### PR TITLE
Load Stripe Payment Tokens when to gatway_id is specified

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -386,7 +386,9 @@ class WC_Stripe {
 	 * @return array
 	 */
 	public function woocommerce_get_customer_payment_tokens( $tokens, $customer_id, $gateway_id ) {
-		if ( is_user_logged_in() && 'stripe' === $gateway_id && class_exists( 'WC_Payment_Token_CC' ) ) {
+		$do_api_get = 'stripe' === $gateway_id || '' === $gateway_id;
+
+		if ( is_user_logged_in() && $do_api_get && class_exists( 'WC_Payment_Token_CC' ) ) {
 			$stripe_customer = new WC_Stripe_Customer( $customer_id );
 			$stripe_cards    = $stripe_customer->get_cards();
 			$stored_tokens   = array();


### PR DESCRIPTION
This Fixes #19 for me but appreciate that there is more going on here than I've absorbed yet.
#### Changes proposed in this Pull Request:

Load payment tokens from stripe if the gateway_id is the default empty string '' 
This will allow the payment tokens to be saved and so the users Account->Payment Methods page will be populated.

Currently this will only load payment tokens if the request is made
explicitly for the ’stripe’ gateway_id. Now perhaps the bug is that
this is never set by WC as this method is called twice when loading the
payment methods page.
