### PR TITLE
Added migration to fix missing cards when using WC > 2.6.

### DIFF
--- a/includes/class-wc-stripe-background-updater.php
+++ b/includes/class-wc-stripe-background-updater.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Background Updater for WooCommerce Stripe
+  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Background_Updater Class.
+ */
+class WC_Stripe_Background_Updater extends WC_Background_Updater {
+
+	/**
+	 * @var string
+	 */
+	protected $action = 'wc_stripe_updater';
+
+	/**
+	 * Dispatch updater.
+	 *
+	 * Updater will still run via cron job if this fails for any reason.
+	 */
+	public function dispatch() {
+		$dispatched = parent::dispatch();
+
+		if ( is_wp_error( $dispatched ) ) {
+			WC_Stripe::log( sprintf( 'DB updater - Unable to dispatch WooCommerce Stripe updater: %s', $dispatched->get_error_message() ) );
+		}
+	}
+
+	/**
+	 * Task
+	 *
+	 * Override this method to perform any actions required on each
+	 * queue item. Return the modified item for further processing
+	 * in the next pass through. Or, return false to remove the
+	 * item from the queue.
+	 *
+	 * @param string $callback Update callback function
+	 * @return mixed
+	 */
+	protected function task( $callback ) {
+
+		include_once( 'wc-stripe-update-functions.php' );
+
+		if ( is_callable( $callback ) ) {
+			WC_Stripe::log( sprintf( 'DB updater - Running %s callback', $callback ) );
+			call_user_func( $callback );
+			WC_Stripe::log( sprintf( 'DB updater - Finished %s callback', $callback ) );
+		} else {
+			WC_Stripe::log( sprintf( 'DB updater - Could not find %s callback', $callback ) );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Complete
+	 *
+	 * Override if applicable, but ensure that the below actions are
+	 * performed, or, call parent::complete().
+	 */
+	protected function complete() {
+		WC_Stripe::log( 'Data updater done updating' );
+		parent::complete();
+	}
+}

--- a/includes/views/html-notice-saved-cards-updated.php
+++ b/includes/views/html-notice-saved-cards-updated.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Admin View: Notice - WooCommerce Stripe Updated
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<p>
+	<?php _e( 'WooCommerce Stripe data update complete. Thank you for updating to the latest version!', 'woocommerce-gateway-stripe' ); ?>
+</p>

--- a/includes/views/html-notice-update-saved-cards.php
+++ b/includes/views/html-notice-update-saved-cards.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Admin View: Notice - Stripe Update
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<p><strong><?php _e( 'WooCommerce Stripe Gateway Data Update', 'woocommerce-gateway-stripe' ); ?></strong> &#8211; <?php _e( 'We need to update your store\'s database to the latest version.', 'woocommerce-gateway-stripe' ); ?></p>
+<p class="submit"><a href="<?php echo esc_url( $update_action ); ?>" class="wc-stripe-update-now button-primary"><?php _e( 'Run the updater', 'woocommerce-gateway-stripe' ); ?></a></p>
+

--- a/includes/views/html-notice-updating-saved-cards.php
+++ b/includes/views/html-notice-updating-saved-cards.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Admin View: Notice - WooCommerce Stripe Updating
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<p>
+	<strong><?php _e( 'WooCommerce Data Update', 'woocommerce' ); ?></strong> &#8211; <?php _e( 'Your database is being updated in the background.', 'woocommerce-gateway-stripe' ); ?>
+</p>

--- a/includes/wc-stripe-update-functions.php
+++ b/includes/wc-stripe-update-functions.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * WooCommerce Stripe Updates.
+ *
+ * Functions for updating data, used by the background updater.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+function wc_stripe_303_copy_saved_cards_to_token_table() {
+	global $wpdb;
+
+	WC_Stripe::log( 'updating saved cards...' );
+}
+
+function wc_stripe_303_db_version() {
+	$wc_stripe->update_stripe_db_version( '3.0.3' );
+}


### PR DESCRIPTION
Fixes #19.
#### Changes proposed in this Pull Request:
- Add background updater to update the DB for saved cards.

---
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
