### PR TITLE
Fix when adding declined cards, fatal error is thrown fixes #72

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -87,6 +87,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 3.0.6 =
+* Fix - When adding declined cards, fatal error is thrown.
+
 = 3.0.5 =
 * Fix - Previous upload of files didn't take. Retry.
 


### PR DESCRIPTION
Fixes #72 

cc @dwainm for review.

#### Changes proposed in this Pull Request:
Fix - When adding declined cards, fatal error is thrown.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


