### PR TITLE
apply_filters wc_stripe_generate_payment_request for backwards compat…

### DIFF
--- a/includes/legacy/class-wc-gateway-stripe.php
+++ b/includes/legacy/class-wc-gateway-stripe.php
@@ -345,7 +345,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway {
 			$post_data['source'] = $source->source;
 		}
 
-		return $post_data;
+		return apply_filters( 'wc_stripe_generate_payment_request', $post_data, $order, $source );
 	}
 
 	/**


### PR DESCRIPTION
Fixes # .

#### Changes proposed in this Pull Request:
- Currently some plugins are hooking into the wc_stripe_generate_payment_request filter to add some metadata before the request is send to Stripe. In the case the user store fallback into the legacy code these plugins would fail because of the missing apply_filters call.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


…ibility of plugins that depend on it.