### PR TITLE
Fix bitcoin image not showing closes #99

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -165,8 +165,8 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 			$icon .= '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/diners' . $ext ) . '" alt="Diners" width="32" ' . $style . ' />';
 		}
 
-		if ( 'yes' === $this->bitcoin && 'yes' === $this->stripe_checkout ) {
-			$icon .= '<img src="' . WC_HTTPS::force_https_url( plugins_url( '/assets/images/bitcoin' . $ext, WC_STRIPE_MAIN_FILE ) ) . '" alt="Bitcoin" width="32" ' . $style . ' />';
+		if ( $this->bitcoin && $this->stripe_checkout ) {
+			$icon .= '<img src="' . WC_HTTPS::force_https_url( plugins_url( '/assets/images/bitcoin' . $ext, WC_STRIPE_MAIN_FILE ) ) . '" alt="Bitcoin" width="24" ' . $style . ' />';
 		}
 
 		return apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
@@ -432,7 +432,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 		if ( $source->source ) {
 			$post_data['source'] = $source->source;
 		}
-
+		
 		/**
 		 * Filter the return value of the WC_Payment_Gateway_CC::generate_payment_request.
 		 *

--- a/readme.txt
+++ b/readme.txt
@@ -93,6 +93,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - When paying via pay order page/link, billing info is not sent.
 * Fix - Account for all types of errors for proper localization.
 * Fix - Correctly reference Stripe fees/net based on Stripe account locale.
+* Fix - Bitcoin image not showing.
 * New - Introduce "wc_gateway_stripe_process_payment_error" action hook.
 * New - Introduce "wc_gateway_stripe_process_payment" action hook.
 


### PR DESCRIPTION
Fixes #99

cc @gedex for review.

#### Changes proposed in this Pull Request:
* Fix - Bitcoin image not showing.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


