### PR TITLE
add a new constant that other extensions can use to figure out if we …

### DIFF
--- a/includes/legacy/class-wc-gateway-stripe.php
+++ b/includes/legacy/class-wc-gateway-stripe.php
@@ -326,10 +326,18 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway {
 	 */
 	protected function generate_payment_request( $order, $source ) {
 		$post_data                = array();
+
+		$post_data['capture']     = $this->capture ? 'true' : 'false';
+		if ( 'true' == $post_data['capture'] ) {
+			if ( ! defined( 'WOOCOMMERCE_STRIPE_DOING_CAPTURE' ) ) {
+				// Allow other extensions hooking the process to know that we're capturing.
+				define( 'WOOCOMMERCE_STRIPE_DOING_CAPTURE', true );
+			}
+		}
+
+		$post_data['description'] = sprintf( __( '%s - Order %s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
 		$post_data['currency']    = strtolower( $order->get_order_currency() ? $order->get_order_currency() : get_woocommerce_currency() );
 		$post_data['amount']      = $this->get_stripe_amount( $order->get_total(), $post_data['currency'] );
-		$post_data['description'] = sprintf( __( '%s - Order %s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
-		$post_data['capture']     = $this->capture ? 'true' : 'false';
 
 		if ( ! empty( $order->billing_email ) && apply_filters( 'wc_stripe_send_stripe_receipt', false ) ) {
 			$post_data['receipt_email'] = $order->billing_email;

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -308,6 +308,10 @@ class WC_Stripe {
 			$captured = get_post_meta( $order_id, '_stripe_charge_captured', true );
 
 			if ( $charge && 'no' === $captured ) {
+				if ( ! defined( 'WOOCOMMERCE_STRIPE_DOING_CAPTURE' ) ) {
+					// Allow other extensions hooking the process to know that we're capturing.
+					define( 'WOOCOMMERCE_STRIPE_DOING_CAPTURE', true );
+				}
 				$result = WC_Stripe_API::request( array(
 					'amount'   => $order->get_total() * 100,
 					'expand[]' => 'balance_transaction'


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Within account funds, we need a way to determine if the current process will be capturing payment as well. This is not very easy to establish without it explicitly being set.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


…are in a capture process.