### PR TITLE
Update readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, woothemes, mikejolley, akeda, royho, slash1andy, woosteve, spraveenitpro, mikedmoore, fernashes, shellbeezy, danieldudzic, mikaey, dsmithweb, fullysupportedphil, corsonr
 Tags: credit card, stripe, woocommerce
 Requires at least: 4.4
-Tested up to: 4.5
+Tested up to: 4.6.1
 Stable tag: 3.0.6
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
Fixes: 

People were asking if the actual / real / correct / proper / official / **RIGHT** plugin when searching for _"WooCommerce Stripe"_ is compatible with the current version of WordPress, then installing a completely different plugin simple b/c no one {cough} @claudiosanches 😉 might have inadvertently forgotten to update the compatibility version number 😜 

#### Changes proposed in this Pull Request: Updated Line 5 to 4.6.1 _that's all_ ❤️ 