### PR TITLE
Set shipping `locality` to City

### DIFF
--- a/includes/class-wc-stripe-apple-pay.php
+++ b/includes/class-wc-stripe-apple-pay.php
@@ -429,7 +429,7 @@ class WC_Stripe_Apple_Pay extends WC_Gateway_Stripe {
 			$shipping_address['phone']      = $data['shippingContact']['phoneNumber'];
 			$shipping_address['country']    = $data['shippingContact']['countryCode'];
 			$shipping_address['address_1']  = $data['shippingContact']['addressLines'][0];
-			$shipping_address['state']      = $data['shippingContact']['locality'];
+			$shipping_address['city']       = $data['shippingContact']['locality'];
 			$shipping_address['state']      = $data['shippingContact']['administrativeArea'];
 			$shipping_address['postcode']   = $data['shippingContact']['postalCode'];
 		} elseif ( ! empty( $data['shippingContact'] ) ) {


### PR DESCRIPTION
Looks like a copy-paste error, because `administrativeArea` is State and `locality` is City