### PR TITLE
Preorders: Prevent double stock reduction

### DIFF
--- a/includes/class-wc-gateway-stripe-addons.php
+++ b/includes/class-wc-gateway-stripe-addons.php
@@ -161,9 +161,6 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 				// Store source to order meta
 				$this->save_source( $order, $source );
 
-				// Reduce stock levels
-				$order->reduce_order_stock();
-
 				// Remove cart
 				WC()->cart->empty_cart();
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/124

This was causing double stock reduction in preorders. Tested with both Upon Release and Charge Up Front orders.

@roykho 