### PR TITLE
Corrected readme.txt to read Apple Pay Support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -88,7 +88,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 3.1.0 =
-* New - Apply Pay Support.
+* New - Apple Pay Support.
 * New - Option to allow/disallow remember me on Stripe checkout modal.
 * New - Add Google Payment Request API.
 * New - Introduce "wc_stripe_customer_metadata" filter.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
The first line of the Changelog under 3.1.0 reads

* New - **Apply** Pay Support

I've corrected it to read 

* New - **Apple** Pay Support.

Bold emphasis above is mine.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

