### PR TITLE
Avoid Notice: Undefined index

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -310,7 +310,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 			$file     = 'apple-developer-merchantid-domain-association';
 			$fullpath = $path . '/' . $dir . '/' . $file;
 
-			if ( 'yes' === $gateway_settings['apple_pay_domain_set'] && file_exists( $fullpath ) ) {
+			if ( isset($gateway_settings['apple_pay_domain_set']) && 'yes' === $gateway_settings['apple_pay_domain_set'] && file_exists( $fullpath ) ) {
 				return;
 			}
 


### PR DESCRIPTION
Avoid Notice: Undefined index: apple_pay_domain_set

Fixes # .

#### Changes proposed in this Pull Request:
-

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

