### PR TITLE
Fix/232 and 233

### DIFF
--- a/includes/class-wc-gateway-stripe-addons.php
+++ b/includes/class-wc-gateway-stripe-addons.php
@@ -77,7 +77,8 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	protected function save_source( $order, $source ) {
 		parent::save_source( $order, $source );
 
-		$order_id = version_compare( WC_VERSION, '3.0.0', '<' ) ? $order->id : $order->get_id();
+		$wc_pre_30 = version_compare( WC_VERSION, '3.0.0', '<' );
+		$order_id  = $wc_pre_30 ? $order->id : $order->get_id();
 
 		// Also store it on the subscriptions being purchased or paid for in the order
 		if ( function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order_id ) ) {
@@ -89,8 +90,9 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 		}
 
 		foreach ( $subscriptions as $subscription ) {
-			update_post_meta( $subscription->id, '_stripe_customer_id', $source->customer );
-			update_post_meta( $subscription->id, '_stripe_card_id', $source->source );
+			$subscription_id = $wc_pre_30 ? $subscription->id : $subscription->get_id();
+			update_post_meta( $subscription_id, '_stripe_customer_id', $source->customer );
+			update_post_meta( $subscription_id, '_stripe_card_id', $source->source );
 		}
 	}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -262,9 +262,9 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 	 * @version 3.1.0
 	 */
 	public function init_apple_pay() {
-		if ( 
-			is_admin() && 
-			isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && 
+		if (
+			is_admin() &&
+			isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] &&
 			isset( $_GET['tab'] ) && 'checkout' === $_GET['tab'] &&
 			isset( $_GET['section'] ) && 'stripe' === $_GET['section']
 		) {
@@ -301,7 +301,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 		) );
 
 		if ( is_wp_error( $response ) ) {
-			throw new Exception( sprintf( __( 'Unable to verify domain - %s', 'woocommerce-gateway-stripe' ), $response->get_error_message() ) ); 
+			throw new Exception( sprintf( __( 'Unable to verify domain - %s', 'woocommerce-gateway-stripe' ), $response->get_error_message() ) );
 		}
 
 		if ( 200 !== $response['response']['code'] ) {
@@ -385,7 +385,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 		}
 
 		/**
-		 * Apple pay is enabled by default and domain verification initializes 
+		 * Apple pay is enabled by default and domain verification initializes
 		 * when setting screen is displayed. So if domain verification is not set,
 		 * something went wrong so lets notify user.
 		 */
@@ -529,7 +529,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 				'missing_secret_key'     => __( 'Missing Secret Key. Please set the secret key field above and re-try.', 'woocommerce-gateway-stripe' ),
 			),
 			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
-			'nonce'              => array( 
+			'nonce'              => array(
 				'apple_pay_domain_nonce' => wp_create_nonce( '_wc_stripe_apple_pay_domain_nonce' ),
 			),
 		);
@@ -750,6 +750,9 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 
 			// Store source to order meta.
 			$this->save_source( $order, $source );
+
+			// Result from Stripe API request.
+			$response = null;
 
 			// Handle payment.
 			if ( $order->get_total() > 0 ) {


### PR DESCRIPTION
Fixes #232 
Fixes #233

#### Changes proposed in this Pull Request:
- Use `$subscription->get_id()` when in WC >= 3.0
- Make sure `$response` if declared at the top

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

