### PR TITLE
Retry failed subs payments with customer id closes #149

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 3.1.7 =
 * Fix - Additional WC 3.0 compatibility with subscriptions addons.
+* Fix - Retry failed subscription payments with customer ID.
 * Add - Site URL to metadata when charging subscription orders for reference.
 
 = 3.1.6 =


### PR DESCRIPTION
Fixes #149 

#### Changes proposed in this Pull Request:
* Fix - Retry failed subscription payments with customer ID.

Retries can fail if customer has changed/removed their associated credit card on file. This fix will try to process their payment via their customer ID instead if that happens. Don't mind the DRY for now as there are several places that needs to be refactored when I get more time.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

