### PR TITLE
Fix more WC 30 notices closes #239

### DIFF
--- a/includes/class-wc-gateway-stripe-addons.php
+++ b/includes/class-wc-gateway-stripe-addons.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 
+	public $wc_pre_30;
+
 	/**
 	 * Constructor
 	 */
@@ -33,6 +35,8 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 		if ( class_exists( 'WC_Pre_Orders_Order' ) ) {
 			add_action( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->id, array( $this, 'process_pre_order_release_payment' ) );
 		}
+
+		$this->wc_pre_30 = version_compare( WC_VERSION, '3.0.0', '<' );
 	}
 
 	/**
@@ -77,8 +81,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	protected function save_source( $order, $source ) {
 		parent::save_source( $order, $source );
 
-		$wc_pre_30 = version_compare( WC_VERSION, '3.0.0', '<' );
-		$order_id  = $wc_pre_30 ? $order->id : $order->get_id();
+		$order_id  = $this->wc_pre_30 ? $order->id : $order->get_id();
 
 		// Also store it on the subscriptions being purchased or paid for in the order
 		if ( function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order_id ) ) {
@@ -90,7 +93,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 		}
 
 		foreach ( $subscriptions as $subscription ) {
-			$subscription_id = $wc_pre_30 ? $subscription->id : $subscription->get_id();
+			$subscription_id = $this->wc_pre_30 ? $subscription->id : $subscription->get_id();
 			update_post_meta( $subscription_id, '_stripe_customer_id', $source->customer );
 			update_post_meta( $subscription_id, '_stripe_card_id', $source->source );
 		}
@@ -113,7 +116,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 
 		// If no order source was defined, use user source instead.
 		if ( ! $source->customer ) {
-			$source = $this->get_source( $order->customer_user );
+			$source = $this->get_source( ( $this->wc_pre_30 ? $order->customer_user : $order->get_customer_id() ) );
 		}
 
 		// Or fail :(
@@ -121,7 +124,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 			return new WP_Error( 'stripe_error', __( 'Customer not found', 'woocommerce-gateway-stripe' ) );
 		}
 
-		$order_id = version_compare( WC_VERSION, '3.0.0', '<' ) ? $order->id : $order->get_id();
+		$order_id = $this->wc_pre_30 ? $order->id : $order->get_id();
 		$this->log( "Info: Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );
 
 		// Make the request
@@ -138,7 +141,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 		if ( is_wp_error( $response ) ) {
 			if ( 'missing' === $response->get_error_code() ) {
 				// If we can't link customer to a card, we try to charge by customer ID.
-				$request             = $this->generate_payment_request( $order, $this->get_source( $order->customer_user ) );
+				$request             = $this->generate_payment_request( $order, $this->get_source( ( $this->wc_pre_30 ? $order->customer_user : $order->get_customer_id() ) ) );
 				$request['capture']  = 'true';
 				$request['amount']   = $this->get_stripe_amount( $amount, $request['currency'] );
 				$request['metadata'] = array(
@@ -246,8 +249,8 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_resubscribe_meta( $resubscribe_order ) {
-		delete_post_meta( $resubscribe_order->id, '_stripe_customer_id' );
-		delete_post_meta( $resubscribe_order->id, '_stripe_card_id' );
+		delete_post_meta( ( $this->wc_pre_30 ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_customer_id' );
+		delete_post_meta( ( $this->wc_pre_30 ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_card_id' );
 		$this->delete_renewal_meta( $resubscribe_order );
 	}
 
@@ -256,9 +259,9 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_renewal_meta( $renewal_order ) {
-		delete_post_meta( $renewal_order->id, 'Stripe Fee' );
-		delete_post_meta( $renewal_order->id, 'Net Revenue From Stripe' );
-		delete_post_meta( $renewal_order->id, 'Stripe Payment ID' );
+		delete_post_meta( ( $this->wc_pre_30 ? $renewal_order->id : $renewal_order->get_id() ), 'Stripe Fee' );
+		delete_post_meta( ( $this->wc_pre_30 ? $renewal_order->id : $renewal_order->get_id() ), 'Net Revenue From Stripe' );
+		delete_post_meta( ( $this->wc_pre_30 ? $renewal_order->id : $renewal_order->get_id() ), 'Stripe Payment ID' );
 		return $renewal_order;
 	}
 
@@ -281,7 +284,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	 * @param  object $order
 	 */
 	public function remove_order_source_before_retry( $order ) {
-		$order_id = version_compare( WC_VERSION, '3.0.0', '<' ) ? $order->id : $order->get_id();
+		$order_id = $this->wc_pre_30 ? $order->id : $order->get_id();
 		delete_post_meta( $order_id, '_stripe_card_id' );
 	}
 
@@ -290,7 +293,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	 * @param  object $order
 	 */
 	public function remove_order_customer_before_retry( $order ) {
-		$order_id = version_compare( WC_VERSION, '3.0.0', '<' ) ? $order->id : $order->get_id();
+		$order_id = $this->wc_pre_30 ? $order->id : $order->get_id();
 		delete_post_meta( $order_id, '_stripe_customer_id' );
 	}
 
@@ -304,8 +307,8 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	 * @return void
 	 */
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
-		update_post_meta( $subscription->id, '_stripe_customer_id', $renewal_order->stripe_customer_id );
-		update_post_meta( $subscription->id, '_stripe_card_id', $renewal_order->stripe_card_id );
+		update_post_meta( ( $this->wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_customer_id', $renewal_order->stripe_customer_id );
+		update_post_meta( ( $this->wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_card_id', $renewal_order->stripe_card_id );
 	}
 
 	/**
@@ -321,11 +324,11 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 		$payment_meta[ $this->id ] = array(
 			'post_meta' => array(
 				'_stripe_customer_id' => array(
-					'value' => get_post_meta( $subscription->id, '_stripe_customer_id', true ),
+					'value' => get_post_meta( ( $this->wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_customer_id', true ),
 					'label' => 'Stripe Customer ID',
 				),
 				'_stripe_card_id' => array(
-					'value' => get_post_meta( $subscription->id, '_stripe_card_id', true ),
+					'value' => get_post_meta( ( $this->wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_card_id', true ),
 					'label' => 'Stripe Card ID',
 				),
 			),
@@ -366,18 +369,16 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 	 * @return string the subscription payment method
 	 */
 	public function maybe_render_subscription_payment_method( $payment_method_to_display, $subscription ) {
-		$wc_pre_30 = version_compare( WC_VERSION, '3.0', '<' );
-
-		$customer_user = $wc_pre_30 ? $subscription->customer_user : $subscription->get_customer_id();
+		$customer_user = $this->wc_pre_30 ? $subscription->customer_user : $subscription->get_customer_id();
 
 		// bail for other payment methods
-		if ( $this->id !== ( $wc_pre_30 ? $subscription->payment_method : $subscription->get_payment_method() ) || ! $customer_user ) {
+		if ( $this->id !== ( $this->wc_pre_30 ? $subscription->payment_method : $subscription->get_payment_method() ) || ! $customer_user ) {
 			return $payment_method_to_display;
 		}
 
 		$stripe_customer    = new WC_Stripe_Customer();
-		$stripe_customer_id = get_post_meta( ( $wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_customer_id', true );
-		$stripe_card_id     = get_post_meta( ( $wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_card_id', true );
+		$stripe_customer_id = get_post_meta( ( $this->wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_customer_id', true );
+		$stripe_card_id     = get_post_meta( ( $this->wc_pre_30 ? $subscription->id : $subscription->get_id() ), '_stripe_card_id', true );
 
 		// If we couldn't find a Stripe customer linked to the subscription, fallback to the user meta data.
 		if ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) {
@@ -388,8 +389,8 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 
 		// If we couldn't find a Stripe customer linked to the account, fallback to the order meta data.
 		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->order ) {
-			$stripe_customer_id = get_post_meta( ( $wc_pre_30 ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_customer_id', true );
-			$stripe_card_id     = get_post_meta( ( $wc_pre_30 ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_card_id', true );
+			$stripe_customer_id = get_post_meta( ( $this->wc_pre_30 ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_customer_id', true );
+			$stripe_card_id     = get_post_meta( ( $this->wc_pre_30 ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_card_id', true );
 		}
 
 		$stripe_customer->set_id( $stripe_customer_id );


### PR DESCRIPTION
Fixes #239

#### Changes proposed in this Pull Request:
Fix more notices for WC 30 on addons. 

@gedex did you also get this notice when testing `PHP Notice:  Undefined variable: item_array in /srv/www/gitwooplugins/wp-content/plugins/woocommerce/includes/wc-order-item-functions.php on line 32`

I am not sure where that is coming from.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

