### PR TITLE
Add two filters to control whether or not to save cards and to display the save payment method checkbox

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -474,7 +474,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 		if ( ! $this->stripe_checkout ) {
 			$this->form();
 
-			if ( $display_tokenization ) {
+			if ( apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) ) {
 				$this->save_payment_method_checkbox();
 			}
 		}
@@ -650,6 +650,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 	 */
 	protected function get_source( $user_id, $force_customer = false ) {
 		$stripe_customer = new WC_Stripe_Customer( $user_id );
+		$force_customer  = apply_filters( 'wc_stripe_force_customer_creation', $force_customer, $stripe_customer );
 		$stripe_source   = false;
 		$token_id        = false;
 


### PR DESCRIPTION
As discussed with @roykho, this PR adds two new filters:

- `wc_stripe_display_save_payment_method_checkbox` is used to control whether or not to display the checkbox to let users save their credit card.
- `wc_stripe_force_customer_creation` is used to allow sites to always save credit cards without first asking the user.

With those two filters, sites will be able to save customers credit cards without asking.