### PR TITLE
Fix of broken link to stripe-checkout.js

### DIFF
--- a/includes/legacy/class-wc-gateway-stripe.php
+++ b/includes/legacy/class-wc-gateway-stripe.php
@@ -287,7 +287,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway {
 	public function payment_scripts() {
 		if ( $this->stripe_checkout ) {
 			wp_enqueue_script( 'stripe', 'https://checkout.stripe.com/v2/checkout.js', '', '2.0', true );
-			wp_enqueue_script( 'woocommerce_stripe', plugins_url( 'assets/js/stripe_checkout.js', WC_STRIPE_MAIN_FILE ), array( 'stripe' ), WC_STRIPE_VERSION, true );
+			wp_enqueue_script( 'woocommerce_stripe', plugins_url( 'assets/js/stripe-checkout.js', WC_STRIPE_MAIN_FILE ), array( 'stripe' ), WC_STRIPE_VERSION, true );
 		} else {
 			wp_enqueue_script( 'stripe', 'https://js.stripe.com/v2/', '', '1.0', true );
 			wp_enqueue_script( 'woocommerce_stripe', plugins_url( 'assets/js/stripe.js', WC_STRIPE_MAIN_FILE ), array( 'jquery-payment', 'stripe' ), WC_STRIPE_VERSION, true );


### PR DESCRIPTION
Fixes # Cannot use stripe-checkout for legacy version WC2.5 .

#### Changes proposed in this Pull Request:
- Fixed a broken link to renamed stripe-checkout.js

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

