### PR TITLE
Handle subs renewal failed payment closes #247

### DIFF
--- a/includes/class-wc-gateway-stripe-addons.php
+++ b/includes/class-wc-gateway-stripe-addons.php
@@ -149,6 +149,8 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 					'site_url'       => esc_url( get_site_url() ),
 				);
 				$response          = WC_Stripe_API::request( $request );
+			} elseif ( ! empty( $response->errors ) ) {
+				return $response; // Default catch all errors.
 			}
 		}
 

--- a/includes/class-wc-gateway-stripe-addons.php
+++ b/includes/class-wc-gateway-stripe-addons.php
@@ -149,7 +149,7 @@ class WC_Gateway_Stripe_Addons extends WC_Gateway_Stripe {
 					'site_url'       => esc_url( get_site_url() ),
 				);
 				$response          = WC_Stripe_API::request( $request );
-			} elseif ( ! empty( $response->errors ) ) {
+			} else {
 				return $response; // Default catch all errors.
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -95,6 +95,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 3.1.11 =
+* Fix - Handle a subscription renewal failed payment order correctly to prevent orders going into onhold status.
+
 = 3.1.10 =
 * Fix - Auto accept terms for Payment Request API to prevent blocker for the checkout.
 * Fix - Add payment method via Stripe checkout button showed pricing.


### PR DESCRIPTION
Fixes #247

#### Changes proposed in this Pull Request:
* Fix - Handle a subscription renewal failed payment order correctly to prevent orders going into onhold status.

When a subs order is renewed, sometimes payment fails. When this happens the order is not handled properly and it first goes into on-hold status and then fail. But doing this, causes order email to be sent to customers again causing confusion.

This patch properly handles the error and prevents the order going into on-hold. Instead it will just fail.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

