### PR TITLE
Payment Request API on by default in settings

### DIFF
--- a/includes/settings-stripe.php
+++ b/includes/settings-stripe.php
@@ -128,7 +128,7 @@ return apply_filters( 'wc_stripe_settings',
 			'label'       => __( 'Enable Payment Request API', 'woocommerce-gateway-stripe' ),
 			'type'        => 'checkbox',
 			'description' => __( 'If enabled, users will be able to pay using the Payment Request API if supported by the browser.', 'woocommerce-gateway-stripe' ),
-			'default'     => 'no',
+			'default'     => 'yes',
 			'desc_tip'    => true,
 		),
 		'apple_pay' => array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Payment Request API on by default in settings.

-------------------
- [X] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [X] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

