### PR TITLE
add 'wc_stripe_customer_args' hook

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -122,6 +122,9 @@ class WC_Stripe_Customer {
 	 * @return WP_Error|int
 	 */
 	public function create_customer( $args = array() ) {
+		// allow for overridability of args
+		$args = apply_filters( 'wc_stripe_customer_args', $args );
+
 		if ( $user = $this->get_user() ) {
 			$billing_first_name = get_user_meta( $user->ID, 'billing_first_name', true );
 			$billing_last_name  = get_user_meta( $user->ID, 'billing_last_name', true );


### PR DESCRIPTION
allow overridability of args in order to attach additional data (such as
email address) to the
Stripe customer object

Fixes # .

#### Changes proposed in this Pull Request:
- Allow user to filter $args passed to create_customer method in order to attach additional data to the Stripe customer object

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

