### PR TITLE
[4.0] User Agent changes for better tracking

### DIFF
--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -56,7 +56,7 @@ class WC_Stripe_API {
     $php_version = phpversion();
     $uname = php_uname();
     $app_info = array(
-			'name' => 'WooCommerce Gateway Stripe',
+			'name' => 'WooCommerce Stripe Gateway',
 			'version' => WC_STRIPE_VERSION,
 			'url' => 'https://woocommerce.com/products/stripe/',
 		);

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -56,7 +56,7 @@ class WC_Stripe_API {
     $php_version = phpversion();
     $uname = php_uname();
     $app_info = array(
-			'name' => 'woocommerce-gateway-stripe',
+			'name' => 'WooCommerce Gateway Stripe',
 			'version' => WC_STRIPE_VERSION,
 			'url' => 'https://woocommerce.com/products/stripe/',
 		);
@@ -77,11 +77,14 @@ class WC_Stripe_API {
 	 * @version 4.0.0
 	 */
 	public static function get_headers() {
+		$user_agent = self::get_user_agent();
+		$app_info = $user_agent['application'];
+		$user_agent_string = $app_info['name'] . '/' . $app_info['version'] . ' (' . $app_info['url'] . ')';
 		return array(
 			'Authorization'              => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
 			'Stripe-Version'             => self::STRIPE_API_VERSION,
-			'User-Agent'                 => 'woocommerce-gateway-stripe/' . WC_STRIPE_VERSION,
-			'X-Stripe-Client-User-Agent' => json_encode( self::get_user_agent() ),
+			'User-Agent'                 => $user_agent_string,
+			'X-Stripe-Client-User-Agent' => json_encode( $user_agent ),
 		);
 	}
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -53,11 +53,21 @@ class WC_Stripe_API {
 	 * @version 4.0.0
 	 */
 	public static function get_user_agent() {
-		return array(
-			'name' => 'WooCommerce ' . WC()->version,
+    $langVersion = phpversion();
+    $uname = php_uname();
+    $appInfo = array(
+			'name' => 'woocommerce-gateway-stripe',
 			'version' => WC_STRIPE_VERSION,
-			'url' => 'https://woocommerce.com',
+			'url' => 'https://woocommerce.com/products/stripe/',
 		);
+    $ua = array(
+        'lang' => 'php',
+        'lang_version' => $langVersion,
+        'publisher' => 'woocommerce',
+        'uname' => $uname,
+				'application' => $appInfo
+    );
+		return $ua;
 	}
 
 	/**
@@ -70,6 +80,7 @@ class WC_Stripe_API {
 		return array(
 			'Authorization'              => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
 			'Stripe-Version'             => self::STRIPE_API_VERSION,
+			'User-Agent' 								 => 'woocommerce-gateway-stripe/' . WC_STRIPE_VERSION,
 			'X-Stripe-Client-User-Agent' => json_encode( self::get_user_agent() ),
 		);
 	}
@@ -99,7 +110,6 @@ class WC_Stripe_API {
 				'headers'       => self::get_headers(),
 				'body'       => apply_filters( 'woocommerce_stripe_request_body', $request, $api ),
 				'timeout'    => 70,
-				'user-agent' => 'WooCommerce ' . WC()->version,
 			)
 		);
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -53,21 +53,21 @@ class WC_Stripe_API {
 	 * @version 4.0.0
 	 */
 	public static function get_user_agent() {
-    $langVersion = phpversion();
+    $php_version = phpversion();
     $uname = php_uname();
-    $appInfo = array(
+    $app_info = array(
 			'name' => 'woocommerce-gateway-stripe',
 			'version' => WC_STRIPE_VERSION,
 			'url' => 'https://woocommerce.com/products/stripe/',
 		);
-    $ua = array(
+    $user_agent = array(
 			'lang' => 'php',
-			'lang_version' => $langVersion,
+			'lang_version' => $php_version,
 			'publisher' => 'woocommerce',
 			'uname' => $uname,
-			'application' => $appInfo,
+			'application' => $app_info,
     );
-		return $ua;
+		return $user_agent;
 	}
 
 	/**
@@ -151,7 +151,6 @@ class WC_Stripe_API {
 				'method'        => 'GET',
 				'headers'       => self::get_headers(),
 				'timeout'    => 70,
-				'user-agent' => 'WooCommerce ' . WC()->version,
 			)
 		);
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -61,11 +61,11 @@ class WC_Stripe_API {
 			'url' => 'https://woocommerce.com/products/stripe/',
 		);
     $ua = array(
-        'lang' => 'php',
-        'lang_version' => $langVersion,
-        'publisher' => 'woocommerce',
-        'uname' => $uname,
-				'application' => $appInfo
+			'lang' => 'php',
+			'lang_version' => $langVersion,
+			'publisher' => 'woocommerce',
+			'uname' => $uname,
+			'application' => $appInfo,
     );
 		return $ua;
 	}
@@ -80,7 +80,7 @@ class WC_Stripe_API {
 		return array(
 			'Authorization'              => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
 			'Stripe-Version'             => self::STRIPE_API_VERSION,
-			'User-Agent' 								 => 'woocommerce-gateway-stripe/' . WC_STRIPE_VERSION,
+			'User-Agent'                 => 'woocommerce-gateway-stripe/' . WC_STRIPE_VERSION,
 			'X-Stripe-Client-User-Agent' => json_encode( self::get_user_agent() ),
 		);
 	}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 3.2.2
+ * Version: 4.0.0
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  *
@@ -19,7 +19,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 	/**
 	 * Required minimums and constants
 	 */
-	define( 'WC_STRIPE_VERSION', '3.2.2' );
+	define( 'WC_STRIPE_VERSION', '4.0.0' );
 	define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 	define( 'WC_STRIPE_MIN_WC_VER', '2.5.0' );
 	define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
@@ -428,7 +428,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 				$sections['stripe_sepa']       = 'Stripe SEPA';
 				$sections['stripe_bitcoin']    = 'Stripe Bitcoin';
 			}
-			
+
 			return $sections;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Changes to User-Agent header to be more similar with the Stripe bindings[0] which will allow for better tracking.

[0] https://github.com/stripe/stripe-php/blob/master/lib/ApiRequestor.php#L174-L203

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

