### PR TITLE
Add actions to allow other plugins to be notified of the result of a …

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -468,6 +468,9 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 
 					if ( is_wp_error( $result ) ) {
 						$order->add_order_note( __( 'Unable to capture charge!', 'woocommerce-gateway-stripe' ) . ' ' . $result->get_error_message() );
+						
+						// Allow other plugins to take it from here
+						do_action( 'woocommerce_stripe_capture_failed', $order_id );
 					} else {
 						$order->add_order_note( sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $result->id ) );
 						update_post_meta( $order_id, '_stripe_charge_captured', 'yes' );
@@ -484,6 +487,9 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 							update_post_meta( $order_id, 'Stripe Fee', $fee );
 							update_post_meta( $order_id, 'Net Revenue From Stripe', $net );
 						}
+						
+						// Allow other plugins to take it from here
+						do_action( 'woocommerce_stripe_capture_successed', $order_id );
 					}
 				}
 			}
@@ -507,10 +513,16 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 
 					if ( is_wp_error( $result ) ) {
 						$order->add_order_note( __( 'Unable to refund charge!', 'woocommerce-gateway-stripe' ) . ' ' . $result->get_error_message() );
+						
+						// Allow other plugins to take it from here
+						do_action( 'woocommerce_stripe_refund_failed', $order_id );
 					} else {
 						$order->add_order_note( sprintf( __( 'Stripe charge refunded (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $result->id ) );
 						delete_post_meta( $order_id, '_stripe_charge_captured' );
 						delete_post_meta( $order_id, '_stripe_charge_id' );
+						
+						// Allow other plugins to take it from here
+						do_action( 'woocommerce_stripe_refund_successed', $order_id );
 					}
 				}
 			}


### PR DESCRIPTION
…Stripe API interaction

If a request to the Stripe API to capture or release a payment finishes other plugins should be able to take it from there by hooking into an action. 
This way plugins don't need to hook onto all hooks like "woocommerce_order_status_on-hold_to_completed" on a later priority and run checks them self.

It would help plugins a lot that want to automatically handle failed actions, ex. send a message to admin or shop manager.

Fixes # .

#### Changes proposed in this Pull Request:
-

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

