### PR TITLE
add payment method Stripe Przelewy24 (P24)

### DIFF
--- a/includes/admin/stripe-p24-settings.php
+++ b/includes/admin/stripe-p24-settings.php
@@ -1,0 +1,45 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$webhook_url = WC_Stripe_Helper::get_webhook_url();
+
+return apply_filters( 'wc_stripe_p24_settings',
+	array(
+		'geo_target' => array(
+			'description' => __( 'Relevant Payer Geography: Poland', 'woocommerce-gateway-stripe' ),
+			'type'        => 'title',
+		),
+		'activation' => array(
+			'description' => __( 'Must be activated from your Stripe Dashboard Settings <a href="https://dashboard.stripe.com/account/payments/settings" target="_blank">here</a>', 'woocommerce-gateway-stripe' ),
+			'type'   => 'title',
+		),
+		'enabled' => array(
+			'title'       => __( 'Enable/Disable', 'woocommerce-gateway-stripe' ),
+			'label'       => __( 'Enable Stripe P24', 'woocommerce-gateway-stripe' ),
+			'type'        => 'checkbox',
+			'description' => '',
+			'default'     => 'no',
+		),
+		'title' => array(
+			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
+			'type'        => 'text',
+			'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-gateway-stripe' ),
+			'default'     => __( 'Przelewy24 (P24)', 'woocommerce-gateway-stripe' ),
+			'desc_tip'    => true,
+		),
+		'description' => array(
+			'title'       => __( 'Description', 'woocommerce-gateway-stripe' ),
+			'type'        => 'text',
+			'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-gateway-stripe' ),
+			'default'     => __( 'You will be redirected to P24.', 'woocommerce-gateway-stripe' ),
+			'desc_tip'    => true,
+		),
+		'webhook' => array(
+			'title'       => __( 'Webhook Enpoints', 'woocommerce-gateway-stripe' ),
+			'type'        => 'title',
+			'description' => __( 'You must add the webhook endpoint <strong style="background-color:#ddd;">&nbsp;&nbsp;' . $webhook_url . '&nbsp;&nbsp;</strong> to your Stripe Account Settings <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Here</a> so you can receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ),
+		),
+	)
+);

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -199,6 +199,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			'bitcoin'    => '<i class="stripe-pf stripe-pf-bitcoin stripe-pf-right" alt="Bitcoin" aria-hidden="true"></i>',
 			'bancontact' => '<i class="stripe-pf stripe-pf-bancontact-mister-cash stripe-pf-right" alt="Bancontact" aria-hidden="true"></i>',
 			'ideal'      => '<i class="stripe-pf stripe-pf-ideal stripe-pf-right" alt="iDeal" aria-hidden="true"></i>',
+			'p24'   	   => '<i class="stripe-pf stripe-pf-p24 stripe-pf-right" alt="P24" aria-hidden="true"></i>',
 			'giropay'    => '<i class="stripe-pf stripe-pf-giropay stripe-pf-right" alt="Giropay" aria-hidden="true"></i>',
 			'eps'        => '<i class="stripe-pf stripe-pf-eps stripe-pf-right" alt="EPS" aria-hidden="true"></i>',
 			'sofort'     => '<i class="stripe-pf stripe-pf-sofort stripe-pf-right" alt="Sofort" aria-hidden="true"></i>',
@@ -466,7 +467,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			<label for="card-element">
 				<?php esc_html_e( 'Credit or debit card', 'woocommerce-gateway-stripe' ); ?>
 			</label>
-			
+
 			<div id="stripe-card-element" style="background:#f2f2f2;padding:0 1em;box-shadow:inset 0 1px 1px rgba(0,0,0,.125);margin:5px 0;">
 			<!-- a Stripe Element will be inserted here. -->
 			</div>
@@ -594,7 +595,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$currency                    = WC_Stripe_Helper::is_pre_30() ? $order->get_order_currency() : $order->get_currency();
 		$order_id                    = WC_Stripe_Helper::is_pre_30() ? $order->id : $order->get_id();
 		$return_url                  = $this->get_stripe_return_url( $order );
-		
+
 		$post_data                   = array();
 		$post_data['amount']         = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency']       = strtolower( $currency );
@@ -652,7 +653,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$this->validate_minimum_order_amount( $order );
 
 			/**
-			 * Check if card 3DS is required or optional with 3DS setting. 
+			 * Check if card 3DS is required or optional with 3DS setting.
 			 * Will need to first create 3DS source and require redirection
 			 * for customer to login to their credit card company.
 			 * Note that if we need to save source, the original source must be first

--- a/includes/payment-methods/class-wc-gateway-stripe-p24.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-p24.php
@@ -1,0 +1,337 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class that handles P24 payment method.
+ *
+ * @extends WC_Gateway_Stripe
+ *
+ * @since 4.0.0
+ */
+class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
+	/**
+	 * Notices (array)
+	 * @var array
+	 */
+	public $notices = array();
+
+	/**
+	 * Is test mode active?
+	 *
+	 * @var bool
+	 */
+	public $testmode;
+
+	/**
+	 * Alternate credit card statement name
+	 *
+	 * @var bool
+	 */
+	public $statement_descriptor;
+
+	/**
+	 * API access secret key
+	 *
+	 * @var string
+	 */
+	public $secret_key;
+
+	/**
+	 * Api access publishable key
+	 *
+	 * @var string
+	 */
+	public $publishable_key;
+
+	/**
+	 * Should we store the users credit cards?
+	 *
+	 * @var bool
+	 */
+	public $saved_cards;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->id                   = 'stripe_p24';
+		$this->method_title         = __( 'Stripe P24', 'woocommerce-gateway-stripe' );
+		$this->method_description   = sprintf( __( 'All other general Stripe settings can be adjusted <a href="%s">here</a>.', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' ) );
+
+		// Load the form fields.
+		$this->init_form_fields();
+
+		// Load the settings.
+		$this->init_settings();
+
+		$main_settings              = get_option( 'woocommerce_stripe_settings' );
+		$this->title                = $this->get_option( 'title' );
+		$this->description          = $this->get_option( 'description' );
+		$this->enabled              = $this->get_option( 'enabled' );
+		$this->testmode             = ( ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'] ) ? true : false;
+		$this->saved_cards          = ( ! empty( $main_settings['saved_cards'] ) && 'yes' === $main_settings['saved_cards'] ) ? true : false;
+		$this->publishable_key      = ! empty( $main_settings['publishable_key'] ) ? $main_settings['publishable_key'] : '';
+		$this->secret_key           = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
+		$this->statement_descriptor = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
+
+		if ( $this->testmode ) {
+			$this->publishable_key = ! empty( $main_settings['test_publishable_key'] ) ? $main_settings['test_publishable_key'] : '';
+			$this->secret_key      = ! empty( $main_settings['test_secret_key'] ) ? $main_settings['test_secret_key'] : '';
+		}
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action( 'admin_notices', array( $this, 'check_environment' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'payment_scripts' ) );
+	}
+
+	/**
+	 * Checks to make sure environment is setup correctly to use this payment method.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 */
+	public function check_environment() {
+		$environment_warning = $this->get_environment_warning();
+
+		if ( $environment_warning ) {
+			$this->add_admin_notice( 'bad_environment', 'error', $environment_warning );
+		}
+
+		foreach ( (array) $this->notices as $notice_key => $notice ) {
+			echo "<div class='" . esc_attr( $notice['class'] ) . "'><p>";
+			echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) );
+			echo '</p></div>';
+		}
+	}
+
+	/**
+	 * Checks the environment for compatibility problems. Returns a string with the first incompatibility
+	 * found or false if the environment has no problems.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 */
+	public function get_environment_warning() {
+		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
+			$message = __( 'P24 is enabled - it requires store currency to be set to Euros or Polish Zloty.', 'woocommerce-gateway-stripe' );
+
+			return $message;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns all supported currencies for this payment method.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @return array
+	 */
+	public function get_supported_currency() {
+		return apply_filters( 'wc_stripe_p24_supported_currencies', array(
+			'EUR',
+			'PLN',
+		) );
+	}
+
+	/**
+	 * Checks to see if all criteria is met before showing payment method.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @return bool
+	 */
+	public function is_available() {
+		if ( ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
+			return false;
+		}
+
+		return parent::is_available();
+	}
+
+	/**
+	 * All payment icons that work with Stripe.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @return array
+	 */
+	public function payment_icons() {
+		return apply_filters( 'wc_stripe_payment_icons', array(
+			'p24' => '<i class="stripe-pf stripe-pf-p24 stripe-pf-right" alt="P24" aria-hidden="true"></i>',
+		) );
+	}
+
+	/**
+	 * Get_icon function.
+	 *
+	 * @since 1.0.0
+	 * @version 4.0.0
+	 * @return string
+	 */
+	public function get_icon() {
+		$icons = $this->payment_icons();
+
+		$icons_str = '';
+
+		$icons_str .= $icons['p24'];
+
+		return apply_filters( 'woocommerce_gateway_icon', $icons_str, $this->id );
+	}
+
+	/**
+	 * payment_scripts function.
+	 *
+	 * Outputs scripts used for stripe payment
+	 *
+	 * @access public
+	 */
+	public function payment_scripts() {
+		if ( ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() ) {
+			return;
+		}
+
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		wp_enqueue_style( 'stripe_paymentfonts' );
+
+		if ( apply_filters( 'wc_stripe_use_elements_checkout_form', true ) ) {
+			wp_enqueue_script( 'stripev3' );
+			wp_enqueue_script( 'woocommerce_stripe_elements' );
+		} else {
+			wp_enqueue_script( 'woocommerce_stripe' );
+		}
+	}
+
+	/**
+	 * Initialize Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = require( WC_STRIPE_PLUGIN_PATH . '/includes/admin/stripe-p24-settings.php' );
+	}
+
+	/**
+	 * Payment form on checkout page
+	 */
+	public function payment_fields() {
+		$user                 = wp_get_current_user();
+		$total                = WC()->cart->total;
+
+		// If paying from order, we need to get total from order not cart.
+		if ( isset( $_GET['pay_for_order'] ) && ! empty( $_GET['key'] ) ) {
+			$order = wc_get_order( wc_get_order_id_by_order_key( wc_clean( $_GET['key'] ) ) );
+			$total = $order->get_total();
+		}
+
+		if ( is_add_payment_method_page() ) {
+			$pay_button_text = __( 'Add Payment', 'woocommerce-gateway-stripe' );
+			$total        = '';
+		} else {
+			$pay_button_text = '';
+		}
+
+		echo '<div
+			id="stripe-p24-payment-data"
+			data-amount="' . esc_attr( WC_Stripe_Helper::get_stripe_amount( $total ) ) . '"
+			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '">';
+
+		if ( $this->description ) {
+			echo apply_filters( 'wc_stripe_description', wpautop( wp_kses_post( $this->description ) ) );
+		}
+
+		echo '</div>';
+	}
+
+	/**
+	 * Creates the source for charge.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @param object $order
+	 * @return mixed
+	 */
+	public function create_source( $order ) {
+		$currency              = WC_Stripe_Helper::is_pre_30() ? $order->get_order_currency() : $order->get_currency();
+		$order_id              = WC_Stripe_Helper::is_pre_30() ? $order->id : $order->get_id();
+		$return_url            = $this->get_stripe_return_url( $order );
+		$post_data             = array();
+		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
+		$post_data['currency'] = strtolower( $currency );
+		$post_data['type']     = 'p24';
+		$post_data['owner']    = $this->get_owner_details( $order );
+		$post_data['redirect'] = array( 'return_url' => $return_url );
+
+		WC_Stripe_Logger::log( 'Info: Begin creating P24 source' );
+
+		return WC_Stripe_API::request( $post_data, 'sources' );
+	}
+
+	/**
+	 * Process the payment
+	 *
+	 * @param int  $order_id Reference.
+	 * @param bool $retry Should we retry on fail.
+	 * @param bool $force_save_source Force payment source to be saved.
+	 *
+	 * @throws Exception If payment will not be accepted.
+	 *
+	 * @return array|void
+	 */
+	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
+		try {
+			$order = wc_get_order( $order_id );
+
+			if ( $order->get_total() * 100 < WC_Stripe_Helper::get_minimum_amount() ) {
+				throw new Exception( sprintf( __( 'Sorry, the minimum allowed order total is %1$s to use this payment method.', 'woocommerce-gateway-stripe' ), wc_price( WC_Stripe_Helper::get_minimum_amount() / 100 ) ) );
+			}
+
+			// This comes from the create account checkbox in the checkout page.
+			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
+
+			if ( $create_account ) {
+				$new_customer_id     = WC_Stripe_Helper::is_pre_30() ? $order->customer_user : $order->get_customer_id();
+				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
+				$new_stripe_customer->create_customer();
+			}
+
+			$response = $this->create_source( $order );
+
+			if ( ! empty( $response->error ) ) {
+				$order->add_order_note( $response->error->message );
+
+				throw new Exception( $response->error->message );
+			}
+
+			if ( WC_Stripe_Helper::is_pre_30() ) {
+				update_post_meta( $order_id, '_stripe_source_id', $response->id );
+			} else {
+				$order->update_meta_data( '_stripe_source_id', $response->id );
+				$order->save();
+			}
+
+			WC_Stripe_Logger::log( 'Info: Redirecting to P24...' );
+
+			return array(
+				'result'   => 'success',
+				'redirect' => esc_url_raw( $response->redirect->url ),
+			);
+		} catch ( Exception $e ) {
+			wc_add_notice( $e->getMessage(), 'error' );
+			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+
+			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
+
+			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+				$this->send_failed_order_email( $order_id );
+			}
+
+			return array(
+				'result'   => 'fail',
+				'redirect' => '',
+			);
+		}
+	}
+}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -358,6 +358,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			unset( $sections['stripe_sofort'] );
 			unset( $sections['stripe_giropay'] );
 			unset( $sections['stripe_ideal'] );
+			unset( $sections['stripe_p24'] );
 			unset( $sections['stripe_alipay'] );
 			unset( $sections['stripe_sepa'] );
 			unset( $sections['stripe_bitcoin'] );
@@ -367,6 +368,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			$sections['stripe_sofort']     = __( 'Stripe SOFORT', 'woocommerce-gateway-stripe' );
 			$sections['stripe_giropay']    = __( 'Stripe Giropay', 'woocommerce-gateway-stripe' );
 			$sections['stripe_ideal']      = __( 'Stripe iDeal', 'woocommerce-gateway-stripe' );
+			$sections['stripe_p24']      = __( 'Stripe P24', 'woocommerce-gateway-stripe' );
 			$sections['stripe_alipay']     = __( 'Stripe Alipay', 'woocommerce-gateway-stripe' );
 			$sections['stripe_sepa']       = __( 'Stripe SEPA Direct Debit', 'woocommerce-gateway-stripe' );
 			$sections['stripe_bitcoin']    = __( 'Stripe Bitcoin', 'woocommerce-gateway-stripe' );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -111,6 +111,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-sofort.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-giropay.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-ideal.php' );
+			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-p24.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-alipay.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-sepa.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-bitcoin.php' );
@@ -338,6 +339,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			$methods[] = 'WC_Gateway_Stripe_Sofort';
 			$methods[] = 'WC_Gateway_Stripe_Giropay';
 			$methods[] = 'WC_Gateway_Stripe_Ideal';
+			$methods[] = 'WC_Gateway_Stripe_P24';
 			$methods[] = 'WC_Gateway_Stripe_Alipay';
 			$methods[] = 'WC_Gateway_Stripe_Bitcoin';
 


### PR DESCRIPTION
@roykho I wanted to get a feeling for how easy it is to add a new payment method with the example of adding P24 which is very similar to iDEAL in its flow: https://stripe.com/docs/sources/p24

However, I think I'm missing a couple of things, and I would highly appreciate if you could review and assess what I'm missing. From what I can see I'm missing the following bits:

* no P24 logo in payment font (any idea if that's easy to add?)
* "Refund via Stripe P24" is disabled (couldn't find how to enable it)
* Order in the wc-settings (for some reason it's listed before Stripe in the "Checkout options" breadcrumb menu, no idea why)
* missing mentions in `languages/woocommerce-gateway-stripe.pot` file (do I just add any references to lines that "print" some text?)

Am I missing anything else?

But if this would be more work than just trashing this branch and adding P24 yourself I totally understand, and feel free to do exactly that ;)

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

