### PR TITLE
Update class-wc-gateway-stripe.php

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -322,7 +322,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 		$gateway_settings = get_option( 'woocommerce_stripe_settings', '' );
 
 		try {
-			$path     = untrailingslashit( preg_replace( "!${_SERVER['SCRIPT_NAME']}$!", '', $_SERVER['SCRIPT_FILENAME'] ) );
+			$path     = $_SERVER["DOCUMENT_ROOT"];
 			$dir      = '.well-known';
 			$file     = 'apple-developer-merchantid-domain-association';
 			$fullpath = $path . '/' . $dir . '/' . $file;


### PR DESCRIPTION
On IIS the untrailingslashit( preg_replace( "!${_SERVER['SCRIPT_NAME']}$!", '', $_SERVER['SCRIPT_FILENAME'] ) ); 
returns a path like the following:    C:\inetpub\wwwroot\mywebsite\wp-admin\admin.php 
Replacing with $_SERVER["DOCUMENT_ROOT"] returns the correct path   C:\inetpub\wwwroot\mywebsite
This stops the "Apple Pay verification" failure due to the wrong path to the .well-known/apple-developer-merchantid-domain-association file.

Fixes # .

#### Changes proposed in this Pull Request:
-

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

