### PR TITLE
Only show api key notice when stripe is enabled.

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -181,7 +181,15 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 
 			$secret = WC_Stripe_API::get_secret_key();
 
-			if ( empty( $secret ) && ! ( isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 'stripe' === $_GET['section'] ) ) {
+			// Verify Stripe is enabled before showing warning
+			$gateways = WC()->payment_gateways->payment_gateways();
+			$is_enabled = false;
+
+			if ( $gateways && $gateways['stripe'] ) {
+				$is_enabled = 'yes' == $gateways['stripe']->enabled;
+			}
+
+			if ( $is_enabled && empty( $secret ) && ! ( isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 'stripe' === $_GET['section'] ) ) {
 				$setting_link = $this->get_setting_link();
 				$this->add_admin_notice( 'prompt_connect', 'notice notice-warning', sprintf( __( 'Stripe is almost ready. To get started, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ) );
 			}


### PR DESCRIPTION
Related https://github.com/Automattic/wp-calypso/issues/16627

#### Changes proposed in this Pull Request:
While working on the above issue for the Store on wpcom - I have been looking for ways to reduce the large quantity of woo-related notices that are displayed on a fresh install in `wp-admin`. We have been able to hide some of the other notices [#](https://github.com/Automattic/wc-calypso-bridge/pull/3) from the stripe plugin, but I couldn't find an easy way to hide the "Almost ready" notice which prompts users to enter in an API key.

The suggested change I have here is to only show this notice if the Stripe Payment type is enabled... while I realize this might go against the initial intentions of the notice, I figured this would be a good way to at least get a discussion going on about the topic 😆 - another route is to possibly check an option like the Apple/Google Payments notices so we could supress the notice via our `wc-calypso-bridge` plugin. Anyhow curious to hear your thoughts! Thanks!

