### PR TITLE
Filter User-Agent

### DIFF
--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -64,7 +64,7 @@ class WC_Stripe_API {
 				),
 				'body'       => apply_filters( 'woocommerce_stripe_request_body', $request, $api ),
 				'timeout'    => 70,
-				'user-agent' => 'WooCommerce ' . WC()->version,
+				'user-agent' => apply_filters( 'woocommerce_stripe_request_user_agent', 'WooCommerce ' . WC()->version ),
 			)
 		);
 


### PR DESCRIPTION
Adds `woocommerce_stripe_request_user_agent` filter to allow plugins to modify Stripe API requests' User-Agent header. Will be used to differentiate requests from Stripe Connect accounts in https://github.com/Automattic/woocommerce-services/pull/1199 (cc: @jeffstieler, @pmaiorana)