### PR TITLE
Allow other product types to add to cart.

### DIFF
--- a/includes/class-wc-stripe-apple-pay.php
+++ b/includes/class-wc-stripe-apple-pay.php
@@ -486,6 +486,9 @@ class WC_Stripe_Apple_Pay extends WC_Gateway_Stripe {
 			if ( 'simple' === ( version_compare( WC_VERSION, '3.0.0', '<' ) ? $product->product_type : $product->get_type() ) ) {
 				WC()->cart->add_to_cart( $product->get_id(), $qty );
 			}
+
+			// Allow other product types to add to cart.
+			do_action( 'woocommerce_add_to_apple_cart', $product, $qty );
 		}
 
 		WC()->cart->calculate_totals();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Allow other product types to add to cart. You have a filter `wc_stripe_apple_pay_supported_types` to allow other product types to be supported but do not have the ability to add the item to the cart for other product types. This should be enough to allow that.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

