### PR TITLE
Update FAQ to reflect the need for an SSL Certificate

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -75,6 +75,10 @@ Automatic updates should work like a charm; as always though, ensure you backup 
 
 Yes!
 
+= Does this require an SSL certificate? =
+
+Yes! In live mode, an SSL certificate must be installed on your site to use Stripe. In addition to SSL encryption, Stripe provides an extra JavaScript method to secure card data.
+
 = Does this support both production mode and sandbox mode for testing? =
 
 Yes it does - production and sandbox mode is driven by the API keys you use.


### PR DESCRIPTION
Based on this question in the forum - https://wordpress.org/support/topic/does-woocommerce-stripe-payment-gateway-require-an-ssl-certificate/ it isn't clear that an SSL certificate is required.

#### Changes proposed in this Pull Request:
-

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

