### PR TITLE
Buffer the output of payment form until entire enclosing div is rende…

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -402,6 +402,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$pay_button_text = '';
 		}
 
+		// Buffer the output until entire div is rendered before transmitting over the network.
+		// Prevents browser rendering unclosed div which is visible to user for a second.
+		ob_start();
+
 		echo '<div
 			id="stripe-payment-data"
 			data-panel-label="' . esc_attr( $pay_button_text ) . '"
@@ -444,6 +448,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		echo '</div>';
+
+		ob_end_flush();
 	}
 
 	/**


### PR DESCRIPTION
…red before actually transmitting anything over the network.

This prevents browser rendering the unclosed div and data-* atributes which are visible to visitor for a second.

Fixes #458 .

#### Changes proposed in this Pull Request:
- Enclose rendering of checkout form with ob_start() and ob_end_flush()

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
