### PR TITLE
Don’t require test publishable key when using live

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -151,11 +151,11 @@ class WC_Stripe_Payment_Request {
 			return '';
 		}
 
-		if ( empty( $this->stripe_settings['test_publishable_key'] ) ) {
+		if ( 'yes' === $this->stripe_settings['testmode'] && empty( $this->stripe_settings['test_publishable_key'] ) ) {
 			return '';
 		}
 
-		return ( empty( $this->stripe_settings['testmode'] ) || 'yes' === $this->stripe_settings['testmode'] ) ? $this->stripe_settings['test_publishable_key'] : $this->stripe_settings['publishable_key'];
+		return ( 'yes' === $this->stripe_settings['testmode'] ) ? $this->stripe_settings['test_publishable_key'] : $this->stripe_settings['publishable_key'];
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/466

Don't think I did, but wanted to post this here to make sure it doesn't go against it's purpose: https://github.com/woocommerce/woocommerce-gateway-stripe/commit/57c67a52b2875db1619ea440d0266c99125bddf9#diff-5e2a1337dc63b869d573dcd12e633c5f