### PR TITLE
Search through parents to handle possible template overrides

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -354,7 +354,7 @@ jQuery( function( $ ) {
 
 		onError: function( e, result ) {
 			var message = result.error.message,
-				errorContainer = wc_stripe_form.getSelectedPaymentElement().parent( '.wc_payment_method, .woocommerce-PaymentMethod' ).find( '.stripe-source-errors' );
+				errorContainer = wc_stripe_form.getSelectedPaymentElement().parents( '.wc_payment_method, .woocommerce-PaymentMethod' ).find( '.stripe-source-errors' );
 
 			// Customers do not need to know the specifics of the below type of errors
 			// therefore return a generic localizable error message.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Small change to search through all parents in order to handle possible template overrides more gracefully.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

