### PR TITLE
add multibanco payment method

### DIFF
--- a/includes/admin/stripe-multibanco-settings.php
+++ b/includes/admin/stripe-multibanco-settings.php
@@ -11,13 +11,9 @@ return apply_filters( 'wc_stripe_multibanco_settings',
 			'description' => __( 'Relevant Payer Geography: Portugal', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
-		// 'guide' => array(
-		// 	'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#multibanco" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
-		// 	'type'        => 'title',
-		// ),
 		'activation' => array(
 			'description' => __( 'Must be activated from your Stripe Dashboard Settings <a href="https://dashboard.stripe.com/account/payments/settings" target="_blank">here</a>', 'woocommerce-gateway-stripe' ),
-			'type'   => 'title',
+			'type'        => 'title',
 		),
 		'enabled' => array(
 			'title'       => __( 'Enable/Disable', 'woocommerce-gateway-stripe' ),

--- a/includes/admin/stripe-multibanco-settings.php
+++ b/includes/admin/stripe-multibanco-settings.php
@@ -1,0 +1,50 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$webhook_url = WC_Stripe_Helper::get_webhook_url();
+
+return apply_filters( 'wc_stripe_multibanco_settings',
+	array(
+		'geo_target' => array(
+			'description' => __( 'Relevant Payer Geography: Portugal', 'woocommerce-gateway-stripe' ),
+			'type'        => 'title',
+		),
+		// 'guide' => array(
+		// 	'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#multibanco" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+		// 	'type'        => 'title',
+		// ),
+		'activation' => array(
+			'description' => __( 'Must be activated from your Stripe Dashboard Settings <a href="https://dashboard.stripe.com/account/payments/settings" target="_blank">here</a>', 'woocommerce-gateway-stripe' ),
+			'type'   => 'title',
+		),
+		'enabled' => array(
+			'title'       => __( 'Enable/Disable', 'woocommerce-gateway-stripe' ),
+			'label'       => __( 'Enable Stripe Multibanco', 'woocommerce-gateway-stripe' ),
+			'type'        => 'checkbox',
+			'description' => '',
+			'default'     => 'no',
+		),
+		'title' => array(
+			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
+			'type'        => 'text',
+			'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-gateway-stripe' ),
+			'default'     => __( 'Multibanco', 'woocommerce-gateway-stripe' ),
+			'desc_tip'    => true,
+		),
+		'description' => array(
+			'title'       => __( 'Description', 'woocommerce-gateway-stripe' ),
+			'type'        => 'text',
+			'description' => __( 'This controls the description which the user sees during checkout.', 'woocommerce-gateway-stripe' ),
+			'default'     => __( 'You will be redirected to Multibanco.', 'woocommerce-gateway-stripe' ),
+			'desc_tip'    => true,
+		),
+		'webhook' => array(
+			'title'       => __( 'Webhook Enpoints', 'woocommerce-gateway-stripe' ),
+			'type'        => 'title',
+			/* translators: webhook URL */
+			'description' => sprintf( __( 'You must add the webhook endpoint <strong style="background-color:#ddd;">&nbsp;&nbsp;%s&nbsp;&nbsp;</strong> to your Stripe Account Settings <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Here</a> so you can receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ), $webhook_url ),
+		),
+	)
+);

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -8,7 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @extends WC_Gateway_Stripe
  *
- * @since 4.0.0
+ * @since 4.1.0
  */
 class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	/**
@@ -97,8 +97,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Checks to make sure environment is setup correctly to use this payment method.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 */
 	public function check_environment() {
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
@@ -122,8 +122,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 * Checks the environment for compatibility problems. Returns a string with the first incompatibility
 	 * found or false if the environment has no problems.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 */
 	public function get_environment_warning() {
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
@@ -138,8 +138,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Returns all supported currencies for this payment method.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 * @return array
 	 */
 	public function get_supported_currency() {
@@ -151,8 +151,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Checks to see if all criteria is met before showing payment method.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 * @return bool
 	 */
 	public function is_available() {
@@ -166,8 +166,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	/**
 	 * All payment icons that work with Stripe.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 * @return array
 	 */
 	public function payment_icons() {
@@ -180,7 +180,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 * Get_icon function.
 	 *
 	 * @since 1.0.0
-	 * @version 4.0.0
+	 * @version 4.1.0
 	 * @return string
 	 */
 	public function get_icon() {
@@ -251,8 +251,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Add content to the WC emails.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 * @param WC_Order $order
 	 * @param bool $sent_to_admin
 	 * @param bool $plain_text
@@ -270,10 +270,10 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Gets the Bitcoin instructions for customer to pay.
+	 * Gets the Multibanco instructions for customer to pay.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 * @param int $order_id
 	 */
 	public function get_instructions( $order_id, $plain_text = false ) {
@@ -312,10 +312,10 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Saves Bitcoin information to the order meta for later use.
+	 * Saves Multibanco information to the order meta for later use.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 * @param object $order
 	 * @param object $source_object
 	 */
@@ -334,8 +334,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Creates the source for charge.
 	 *
-	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @since 4.1.0
+	 * @version 4.1.0
 	 * @param object $order
 	 * @return mixed
 	 */

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -349,7 +349,10 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 		$post_data['type']                 = 'multibanco';
 		$post_data['owner']                = $this->get_owner_details( $order );
 		$post_data['redirect']             = array( 'return_url' => $return_url );
-		$post_data['statement_descriptor'] = $this->statement_descriptor;
+
+		if ( ! empty( $this->statement_descriptor ) ) {
+			$post_data['statement_descriptor'] = WC_Stripe_Helper::clean_statement_descriptor( $this->statement_descriptor );
+		}
 
 		WC_Stripe_Logger::log( 'Info: Begin creating Multibanco source' );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -1,0 +1,434 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class that handles Multibanco payment method.
+ *
+ * @extends WC_Gateway_Stripe
+ *
+ * @since 4.0.0
+ */
+class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
+	/**
+	 * Notices (array)
+	 * @var array
+	 */
+	public $notices = array();
+
+	/**
+	 * Is test mode active?
+	 *
+	 * @var bool
+	 */
+	public $testmode;
+
+	/**
+	 * Alternate credit card statement name
+	 *
+	 * @var bool
+	 */
+	public $statement_descriptor;
+
+	/**
+	 * API access secret key
+	 *
+	 * @var string
+	 */
+	public $secret_key;
+
+	/**
+	 * Api access publishable key
+	 *
+	 * @var string
+	 */
+	public $publishable_key;
+
+	/**
+	 * Should we store the users credit cards?
+	 *
+	 * @var bool
+	 */
+	public $saved_cards;
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		$this->id                   = 'stripe_multibanco';
+		$this->method_title         = __( 'Stripe Multibanco', 'woocommerce-gateway-stripe' );
+		/* translators: link */
+		$this->method_description   = sprintf( __( 'All other general Stripe settings can be adjusted <a href="%s">here</a>.', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' ) );
+		$this->supports             = array(
+			'products',
+			'refunds',
+		);
+
+		// Load the form fields.
+		$this->init_form_fields();
+
+		// Load the settings.
+		$this->init_settings();
+
+		$main_settings              = get_option( 'woocommerce_stripe_settings' );
+		$this->title                = $this->get_option( 'title' );
+		$this->description          = $this->get_option( 'description' );
+		$this->enabled              = $this->get_option( 'enabled' );
+		$this->testmode             = ( ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'] ) ? true : false;
+		$this->saved_cards          = ( ! empty( $main_settings['saved_cards'] ) && 'yes' === $main_settings['saved_cards'] ) ? true : false;
+		$this->publishable_key      = ! empty( $main_settings['publishable_key'] ) ? $main_settings['publishable_key'] : '';
+		$this->secret_key           = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
+		$this->statement_descriptor = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
+
+		if ( $this->testmode ) {
+			$this->publishable_key = ! empty( $main_settings['test_publishable_key'] ) ? $main_settings['test_publishable_key'] : '';
+			$this->secret_key      = ! empty( $main_settings['test_secret_key'] ) ? $main_settings['test_secret_key'] : '';
+		}
+
+		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
+		add_action( 'admin_notices', array( $this, 'check_environment' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'payment_scripts' ) );
+
+		// Customer Emails
+		add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 3 );
+	}
+
+	/**
+	 * Checks to make sure environment is setup correctly to use this payment method.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 */
+	public function check_environment() {
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		$environment_warning = $this->get_environment_warning();
+
+		if ( $environment_warning ) {
+			$this->add_admin_notice( 'bad_environment', 'error', $environment_warning );
+		}
+
+		foreach ( (array) $this->notices as $notice_key => $notice ) {
+			echo "<div class='" . esc_attr( $notice['class'] ) . "'><p>";
+			echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) );
+			echo '</p></div>';
+		}
+	}
+
+	/**
+	 * Checks the environment for compatibility problems. Returns a string with the first incompatibility
+	 * found or false if the environment has no problems.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 */
+	public function get_environment_warning() {
+		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
+			$message = __( 'Multibanco is enabled - it requires store currency to be set to Euros.', 'woocommerce-gateway-stripe' );
+
+			return $message;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns all supported currencies for this payment method.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @return array
+	 */
+	public function get_supported_currency() {
+		return apply_filters( 'wc_stripe_multibanco_supported_currencies', array(
+			'EUR',
+		) );
+	}
+
+	/**
+	 * Checks to see if all criteria is met before showing payment method.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @return bool
+	 */
+	public function is_available() {
+		if ( ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
+			return false;
+		}
+
+		return parent::is_available();
+	}
+
+	/**
+	 * All payment icons that work with Stripe.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @return array
+	 */
+	public function payment_icons() {
+		return apply_filters( 'wc_stripe_payment_icons', array(
+			'multibanco' => '<i class="stripe-pf stripe-pf-multibanco stripe-pf-right" alt="Multibanco" aria-hidden="true"></i>',
+		) );
+	}
+
+	/**
+	 * Get_icon function.
+	 *
+	 * @since 1.0.0
+	 * @version 4.0.0
+	 * @return string
+	 */
+	public function get_icon() {
+		$icons = $this->payment_icons();
+
+		$icons_str = '';
+
+		$icons_str .= $icons['multibanco'];
+
+		return apply_filters( 'woocommerce_gateway_icon', $icons_str, $this->id );
+	}
+
+	/**
+	 * payment_scripts function.
+	 *
+	 * Outputs scripts used for stripe payment
+	 *
+	 * @access public
+	 */
+	public function payment_scripts() {
+		if ( ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() ) {
+			return;
+		}
+
+		wp_enqueue_style( 'stripe_paymentfonts' );
+		wp_enqueue_script( 'woocommerce_stripe' );
+	}
+
+	/**
+	 * Initialize Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = require( WC_STRIPE_PLUGIN_PATH . '/includes/admin/stripe-multibanco-settings.php' );
+	}
+
+	/**
+	 * Payment form on checkout page
+	 */
+	public function payment_fields() {
+		$user                 = wp_get_current_user();
+		$total                = WC()->cart->total;
+
+		// If paying from order, we need to get total from order not cart.
+		if ( isset( $_GET['pay_for_order'] ) && ! empty( $_GET['key'] ) ) {
+			$order = wc_get_order( wc_get_order_id_by_order_key( wc_clean( $_GET['key'] ) ) );
+			$total = $order->get_total();
+		}
+
+		if ( is_add_payment_method_page() ) {
+			$pay_button_text = __( 'Add Payment', 'woocommerce-gateway-stripe' );
+			$total        = '';
+		} else {
+			$pay_button_text = '';
+		}
+
+		echo '<div
+			id="stripe-multibanco-payment-data"
+			data-amount="' . esc_attr( WC_Stripe_Helper::get_stripe_amount( $total ) ) . '"
+			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '">';
+
+		if ( $this->description ) {
+			echo apply_filters( 'wc_stripe_description', wpautop( wp_kses_post( $this->description ) ) );
+		}
+
+		echo '</div>';
+	}
+
+	/**
+	 * Add content to the WC emails.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @param WC_Order $order
+	 * @param bool $sent_to_admin
+	 * @param bool $plain_text
+	 */
+	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
+		$order_id = WC_Stripe_Helper::is_pre_30() ? $order->id : $order->get_id();
+
+		$payment_method = WC_Stripe_Helper::is_pre_30() ? $order->payment_method : $order->get_payment_method();
+
+		WC_Stripe_Logger::log( 'Multibanco status:' . $order->get_status() );
+		if ( ! $sent_to_admin && 'stripe_multibanco' === $payment_method && $order->has_status( 'on-hold' ) ) {
+			WC_Stripe_Logger::log( 'Sending email for order #' . $order_id );
+			$this->get_instructions( $order_id, $plain_text );
+		}
+	}
+
+	/**
+	 * Gets the Bitcoin instructions for customer to pay.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @param int $order_id
+	 */
+	public function get_instructions( $order_id, $plain_text = false ) {
+		$data = get_post_meta( $order_id, '_stripe_multibanco', true );
+
+		if ( $plain_text ) {
+			esc_html_e( 'MULTIBANCO INFORMAÇÕES DE ENCOMENDA:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+			esc_html_e( 'Montante:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo $data['amount'] . "\n\n";
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+			esc_html_e( 'Entidade:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo $data['entity'] . "\n\n";
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+			esc_html_e( 'Referencia:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo $data['reference'] . "\n\n";
+		} else {
+			?>
+			<h3><?php esc_html_e( 'MULTIBANCO INFORMAÇÕES DE ENCOMENDA:', 'woocommerce-gateway-stripe' ); ?></h3>
+			<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+			<li class="woocommerce-order-overview__order order">
+				<?php esc_html_e( 'Montante:', 'woocommerce-gateway-stripe' ); ?>
+				<strong><?php echo $data['amount']; ?></strong>
+			</li>
+			<li class="woocommerce-order-overview__order order">
+				<?php esc_html_e( 'Entidade:', 'woocommerce-gateway-stripe' ); ?>
+				<strong><?php echo $data['entity']; ?></strong>
+			</li>
+			<li class="woocommerce-order-overview__order order">
+				<?php esc_html_e( 'Referencia:', 'woocommerce-gateway-stripe' ); ?>
+				<strong><?php echo $data['reference']; ?></strong>
+			</li>
+			</ul>
+			<?php
+		}
+	}
+
+	/**
+	 * Saves Bitcoin information to the order meta for later use.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @param object $order
+	 * @param object $source_object
+	 */
+	public function save_instructions( $order, $source_object ) {
+		$data = array(
+			'amount'    => $order->get_formatted_order_total(),
+			'entity'    => $source_object->multibanco->entity,
+			'reference' => $source_object->multibanco->reference,
+		);
+
+		$order_id = WC_Stripe_Helper::is_pre_30() ? $order->id : $order->get_id();
+
+		update_post_meta( $order_id, '_stripe_multibanco', $data );
+	}
+
+	/**
+	 * Creates the source for charge.
+	 *
+	 * @since 4.0.0
+	 * @version 4.0.0
+	 * @param object $order
+	 * @return mixed
+	 */
+	public function create_source( $order ) {
+		$currency                          = WC_Stripe_Helper::is_pre_30() ? $order->get_order_currency() : $order->get_currency();
+		$order_id                          = WC_Stripe_Helper::is_pre_30() ? $order->id : $order->get_id();
+		$return_url                        = $this->get_stripe_return_url( $order );
+		$post_data                         = array();
+		$post_data['amount']               = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
+		$post_data['currency']             = strtolower( $currency );
+		$post_data['type']                 = 'multibanco';
+		$post_data['owner']                = $this->get_owner_details( $order );
+		$post_data['redirect']             = array( 'return_url' => $return_url );
+		$post_data['statement_descriptor'] = $this->statement_descriptor;
+
+		WC_Stripe_Logger::log( 'Info: Begin creating Multibanco source' );
+
+		return WC_Stripe_API::request( $post_data, 'sources' );
+	}
+
+	/**
+	 * Process the payment
+	 *
+	 * @param int  $order_id Reference.
+	 * @param bool $retry Should we retry on fail.
+	 * @param bool $force_save_source Force payment source to be saved.
+	 *
+	 * @throws Exception If payment will not be accepted.
+	 *
+	 * @return array|void
+	 */
+	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
+		try {
+			$order = wc_get_order( $order_id );
+
+			// This will throw exception if not valid.
+			$this->validate_minimum_order_amount( $order );
+
+			// This comes from the create account checkbox in the checkout page.
+			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
+
+			if ( $create_account ) {
+				$new_customer_id     = WC_Stripe_Helper::is_pre_30() ? $order->customer_user : $order->get_customer_id();
+				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
+				$new_stripe_customer->create_customer();
+			}
+
+			$response = $this->create_source( $order );
+
+			if ( ! empty( $response->error ) ) {
+				$order->add_order_note( $response->error->message );
+
+				throw new Exception( $response->error->message );
+			}
+
+			if ( WC_Stripe_Helper::is_pre_30() ) {
+				update_post_meta( $order_id, '_stripe_source_id', $response->id );
+			} else {
+				$order->update_meta_data( '_stripe_source_id', $response->id );
+				$order->save();
+			}
+
+			$this->save_instructions( $order, $response );
+
+			// Mark as on-hold (we're awaiting the payment)
+			$order->update_status( 'on-hold', __( 'Awaiting Multibanco payment', 'woocommerce-gateway-stripe' ) );
+
+			// Reduce stock levels
+			wc_reduce_stock_levels( $order_id );
+
+			// Remove cart
+			WC()->cart->empty_cart();
+
+			WC_Stripe_Logger::log( 'Info: Redirecting to Multibanco...' );
+
+			return array(
+				'result'   => 'success',
+				'redirect' => esc_url_raw( $response->redirect->url ),
+			);
+		} catch ( Exception $e ) {
+			wc_add_notice( $e->getMessage(), 'error' );
+			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+
+			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
+
+			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+				$this->send_failed_order_email( $order_id );
+			}
+
+			return array(
+				'result'   => 'fail',
+				'redirect' => '',
+			);
+		}
+	}
+}

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -89,6 +89,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'admin_notices', array( $this, 'check_environment' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'payment_scripts' ) );
+		add_action( 'woocommerce_thankyou_stripe_multibanco', array( $this, 'thankyou_page' ) );
 
 		// Customer Emails
 		add_action( 'woocommerce_email_before_order_table', array( $this, 'email_instructions' ), 10, 3 );
@@ -246,6 +247,15 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 		}
 
 		echo '</div>';
+	}
+
+	/**
+	 * Output for the order received page.
+	 *
+	 * @param int $order_id
+	 */
+	public function thankyou_page( $order_id ) {
+		$this->get_instructions( $order_id );
 	}
 
 	/**

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -118,6 +118,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-alipay.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-sepa.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-bitcoin.php' );
+			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-multibanco.php' );
 			require_once( dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-payment-request.php' );
 			require_once( dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-compat.php' );
 			require_once( dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-sepa-compat.php' );
@@ -383,6 +384,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			$methods[] = 'WC_Gateway_Stripe_P24';
 			$methods[] = 'WC_Gateway_Stripe_Alipay';
 			$methods[] = 'WC_Gateway_Stripe_Bitcoin';
+			$methods[] = 'WC_Gateway_Stripe_Multibanco';
 
 			return $methods;
 		}
@@ -403,6 +405,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			unset( $sections['stripe_alipay'] );
 			unset( $sections['stripe_sepa'] );
 			unset( $sections['stripe_bitcoin'] );
+			unset( $sections['stripe_multibanco'] );
 
 			$sections['stripe']            = 'Stripe';
 			$sections['stripe_bancontact'] = __( 'Stripe Bancontact', 'woocommerce-gateway-stripe' );
@@ -413,6 +416,7 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			$sections['stripe_alipay']     = __( 'Stripe Alipay', 'woocommerce-gateway-stripe' );
 			$sections['stripe_sepa']       = __( 'Stripe SEPA Direct Debit', 'woocommerce-gateway-stripe' );
 			$sections['stripe_bitcoin']    = __( 'Stripe Bitcoin', 'woocommerce-gateway-stripe' );
+			$sections['stripe_multibanco'] = __( 'Stripe Multibanco', 'woocommerce-gateway-stripe' );
 
 			return $sections;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- adds the receiver flow payment method Multibanco: https://stripe.com/docs/sources/multibanco
- receiver flow information is shown in a redirect / Multibanco hosted page
- Receiver information is added to the on-hold email
- Order is put on hold while we're waiting to receive the funds

@roykho I've reused the way of setting the statement descriptor based on `$main_settings['statement_descriptor']` however, if that's empty an empty string value is provided which will make source creation error. This affects all source creations. Should I open in a separate issue?

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

