### PR TITLE
Fix / save the Stripe currency during the transaction

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -287,6 +287,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$net = ! empty( $response->balance_transaction->net ) ? WC_Stripe_Helper::format_balance_fee( $response->balance_transaction, 'net' ) : 0;
 			WC_Stripe_Helper::is_pre_30() ? update_post_meta( $order_id, self::META_NAME_FEE, $fee ) : $order->update_meta_data( self::META_NAME_FEE, $fee );
 			WC_Stripe_Helper::is_pre_30() ? update_post_meta( $order_id, self::META_NAME_NET, $net ) : $order->update_meta_data( self::META_NAME_NET, $net );
+
+			// Store currency stripe.
+			$currency = ! empty( $response->balance_transaction->currency ) ? strtoupper( $response->balance_transaction->currency ) : null;
+			WC_Stripe_Helper::is_pre_30() ? update_post_meta( $order_id, '_stripe_currency', $currency ) : $order->update_meta_data( '_stripe_currency', $currency );
 		}
 
 		if ( 'yes' === $captured ) {


### PR DESCRIPTION
Save the currency during the transaction with Stripe.
Thus the PR #527  can display a coherent value.