### PR TITLE
Add filter to change the refund request sent to the server.

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -721,6 +721,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		$request['charge'] = $order->get_transaction_id();
 
+		$request = apply_filters( 'wc_stripe_generate_refund_request', $request, $order, $amount, $reason );
+
 		WC_Stripe_Logger::log( "Info: Beginning refund for order {$order->get_transaction_id()} for the amount of {$amount}" );
 
 		$response = WC_Stripe_API::request( $request, 'refunds' );


### PR DESCRIPTION
Simple proposal. Not related to any issues.

#### Changes proposed in this Pull Request:
-We're adding the `wc_stripe_generate_refund_request` filter to allow filtering of the request sent to stripe at the time of the refund. It's useful when you implement "destination" parameters on the charge (with the `wc_stripe_generate_payment_request` filter).

