### PR TITLE
Add webhooks for review open/closed Radar closes #261

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -824,4 +824,16 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		return $locale;
 	}
+
+	/**
+	 * A wrapper to update order status so it can be filtered.
+	 *
+	 * @since 4.0.6
+	 * @param object $order The order
+	 * @param string $status The status you want to change to.
+	 * @param string $message The order note to add.
+	 */
+	public function update_order_status( $order, $status, $message = '' ) {
+
+	}
 }

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -466,9 +466,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		$message = sprintf( __( 'A review has been opened for this order. Action is needed. Please go to your Stripe Dashboard to review the issue. Reason: (%s)', 'woocommerce-gateway-stripe' ), $notification->data->object->reason );
+
 		if ( apply_filters( 'wc_stripe_webhook_review_change_order_status', true, $order, $notification ) ) {
 			/* translators: token is the reason returned. */
-			$order->update_status( 'on-hold', sprintf( __( 'A review has been opened for this order. Action is needed. Please go to your Stripe Dashboard to review the issue. Reason: (%s)', 'woocommerce-gateway-stripe' ), $notification->data->object->reason ) );
+			$order->update_status( 'on-hold', $message );
+		} else {
+			$order->add_order_note( $message );
 		}
 	}
 
@@ -492,6 +496,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		if ( 'on-hold' === $order->get_status() ) {
 			if ( apply_filters( 'wc_stripe_webhook_review_change_order_status', true, $order, $notification ) ) {
 				$order->update_status( 'processing', $message );
+			} else {
+				$order->add_order_note( $message );
 			}
 		} else {
 			$order->add_order_note( $message );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -83,11 +83,6 @@ class WC_Stripe_Payment_Request {
 			$this->secret_key      = ! empty( $this->stripe_settings['test_secret_key'] ) ? $this->stripe_settings['test_secret_key'] : '';
 		}
 
-		// If both site title and statement descriptor is not set. Fallback.
-		if ( empty( $this->total_label ) ) {
-			$this->total_label = $_SERVER['SERVER_NAME'];
-		}
-
 		$this->total_label = str_replace( "'", '', $this->total_label ) . apply_filters( 'wc_stripe_payment_request_total_label_suffix', ' (via WooCommerce)' );
 
 		// Checks if Stripe Gateway is enabled.

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ We will completely remove the older form by version 4.1.0.
 * Fix - Refund fees may not accurately reflect net fees. Props @rvola.
 * Tweak - Pre checkout validation now happens only with Stripe Modal.
 * Update - Stripe API version to 2018-02-06.
+* Add - Webhooks for review open/closed for Radar.
 
 = 4.0.5 - 2018-02-02 =
 * Fix - Illegal offset error on settings when non is defined or saved.

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,7 @@ We will completely remove the older form by version 4.1.0.
 * Fix - Subs renewal sometimes failed due to parameters being different.
 * Fix - Stripe accepts only NO for Norwegian language on Stripe Checkout.
 * Fix - Refund fees may not accurately reflect net fees. Props @rvola.
+* Fix - Undefined SERVERNAME property in some cases.
 * Tweak - Pre checkout validation now happens only with Stripe Modal.
 * Update - Stripe API version to 2018-02-06.
 * Add - Webhooks for review open/closed for Radar.


### PR DESCRIPTION
Fixes #261

#### Changes proposed in this Pull Request:
* Add - Webhooks for review open/closed for Radar.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

