### PR TITLE
Proposal Updater + Update meta_key name

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -11,8 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0.0
  */
 abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
-	const META_NAME_FEE = 'Stripe Fee';
-	const META_NAME_NET = 'Net Revenue From Stripe';
+	const META_NAME_FEE = '_stripe_fee';
+	const META_NAME_NET = '_stripe_net';
 
 	/**
 	 * Checks to see if request is invalid and that

--- a/includes/compat/class-wc-stripe-compat.php
+++ b/includes/compat/class-wc-stripe-compat.php
@@ -266,8 +266,8 @@ class WC_Stripe_Compat extends WC_Gateway_Stripe {
 	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_renewal_meta( $renewal_order ) {
-		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), 'Stripe Fee' );
-		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), 'Net Revenue From Stripe' );
+		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), self::META_NAME_FEE );
+		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), self::META_NAME_NET );
 		return $renewal_order;
 	}
 

--- a/includes/compat/class-wc-stripe-sepa-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-compat.php
@@ -199,8 +199,8 @@ class WC_Stripe_Sepa_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_renewal_meta( $renewal_order ) {
-		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), 'Stripe Fee' );
-		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), 'Net Revenue From Stripe' );
+		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), self::META_NAME_FEE );
+		delete_post_meta( ( WC_Stripe_Helper::is_pre_30() ? $renewal_order->id : $renewal_order->get_id() ), self::META_NAME_NET );
 		return $renewal_order;
 	}
 

--- a/includes/updates/class-wc-stripe-updater.php
+++ b/includes/updates/class-wc-stripe-updater.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Class WC_Stripe_Updater
+ *
+ * @since: 4.1.0
+ **/
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'WC_STRIPE_VERSION' ) ) {
+	exit;
+}
+
+/**
+ * Class WC_Stripe_Updater
+ *
+ * Execute the functions if needed to update.
+ */
+final class WC_Stripe_Updater {
+
+	/**
+	 * WC_Stripe_Updater constructor.
+	 */
+	public function __construct() {
+		$this->check_update();
+	}
+
+	/**
+	 * Check if the wc-stripe-functions file has a function called 'wc_stripe_update_%WC_STRIPE_VERSION%'.
+	 * Execute the function.
+	 * Has hooks 'wc_stripe_update_%WC_STRIPE_VERSION%_before' and 'wc_stripe_update_%WC_STRIPE_VERSION%_after'.
+	 * %WC_STRIPE_VERSION% to be replaced by the version number without a dot.
+	 */
+	public function check_update() {
+
+		include_once dirname( __FILE__ ) . '/wc-stripe-update-functions.php';
+
+		if ( function_exists( $this->update_function() ) ) {
+
+			// Before.
+			do_action( $this->update_function() . '_before' );
+
+			// Update.
+			$this->update_function()();
+
+			// After.
+			do_action( $this->update_function() . '_after' );
+
+			// Clean Cache.
+			wp_cache_delete();
+		}
+	}
+
+	/**
+	 * Returns the function name of the update of this version
+	 *
+	 * @return string
+	 */
+	private function update_function() {
+		return sprintf(
+			'wc_stripe_update_%d',
+			str_replace( '.', '', WC_STRIPE_VERSION )
+		);
+	}
+}

--- a/includes/updates/wc-stripe-update-functions.php
+++ b/includes/updates/wc-stripe-update-functions.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Functions for update Stripe
+ *
+ * @since: 4.1.0
+ **/
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+if ( ! defined( 'WC_STRIPE_VERSION' ) ) {
+	exit;
+}

--- a/includes/updates/wc-stripe-update-functions.php
+++ b/includes/updates/wc-stripe-update-functions.php
@@ -11,3 +11,31 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( ! defined( 'WC_STRIPE_VERSION' ) ) {
 	exit;
 }
+
+/**
+ * 4.1.0 UPDATE
+ */
+function wc_stripe_update_410() {
+	wc_stripe_update_410_metaname();
+}
+
+/**
+ * Update meta_key name for "fee" & "net revenue".
+ */
+function wc_stripe_update_410_metaname() {
+	global $wpdb;
+
+	// Fees.
+	$wpdb->query( "
+		UPDATE $wpdb->postmeta
+		SET `meta_key` = '_stripe_fee'
+		WHERE `meta_key` = 'Stripe Fee'
+	" );
+
+	// Net.
+	$wpdb->query( "
+		UPDATE $wpdb->postmeta
+		SET `meta_key` = '_stripe_net'
+		WHERE `meta_key` = 'Net Revenue From Stripe'
+	" );
+}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -256,11 +256,13 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 		 * or the environment changes after activation. Also handles upgrade routines.
 		 *
 		 * @since 1.0.0
-		 * @version 4.0.0
+		 * @version 4.1.0
 		 */
 		public function check_environment() {
 			if ( ! defined( 'IFRAME_REQUEST' ) && ( WC_STRIPE_VERSION !== get_option( 'wc_stripe_version' ) ) ) {
 				$this->install();
+
+				$this->update();
 
 				do_action( 'woocommerce_stripe_updated' );
 			}
@@ -345,6 +347,16 @@ if ( ! class_exists( 'WC_Stripe' ) ) :
 			}
 
 			$this->update_plugin_version();
+		}
+
+		/**
+		 * Execute the class for the specific upgrade.
+		 *
+		 * @since 4.1.0
+		 */
+		public function update() {
+			require_once dirname( __FILE__ ) . '/includes/updates/class-wc-stripe-updater.php';
+			new WC_Stripe_Updater();
 		}
 
 		/**


### PR DESCRIPTION
Hello team and hello @roykho

Before quickly closing my PR, I ask you to try to look calmly.

Indeed, the extension Stripe really use a bad name meta_key to save the Fees and Net.

I wondered how to evolve this, for something more conventional.

I then create the "bases" of a class Updater, which would also allow in the future of this extension to be able to modify certain data in SQL.

I ask you to judge the relevance of this PR, and to guide me to improve this code.

I first made the conventions of WordPress writing.
-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

