### PR TITLE
Improve WC_Stripe_Payment_Request::set_session (compat with custom session handlers)

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -135,18 +135,27 @@ class WC_Stripe_Payment_Request {
 	 * @since 4.0.0
 	 */
 	public function set_session() {
-		if ( ! is_product() ) {
+
+		if ( ! is_product() || is_user_logged_in() ) {
 			return;
 		}
 
-		if ( ! is_user_logged_in() ) {
-			$wc_session = new WC_Session_Handler();
+		if( isset( wc()->session ) ) {
+
+			$wc_session = wc()->session;
+
+		} else {
+
+			$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
+			$wc_session    = new $session_class();
 
 			if ( version_compare( WC_VERSION, '3.3', '>=' ) ) {
 				$wc_session->init();
 			}
+		}
 
-			if ( ! $wc_session->has_session() ) {
+		if ( method_exists($wc_session, 'has_session') && method_exists($wc_session, 'set_customer_session_cookie') ) {
+			if( ! $wc_session->has_session() ) {
 				$wc_session->set_customer_session_cookie( true );
 			}
 		}


### PR DESCRIPTION
Hello there,

My original issue seems to be already fixed with https://github.com/woocommerce/woocommerce-gateway-stripe/commit/717fdd0541f0f35da9e631185aa65a76d3f91684 , but looking at the code, I think there is still some issues with the `set_session` method :

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/717fdd0541f0f35da9e631185aa65a76d3f91684/includes/payment-methods/class-wc-stripe-payment-request.php#L137:L153

- The session object is instantiated even if woocommerce already did it
- The method `session->init()` is called even if woocommerce already did it
- If a custom session handler is used, it could break things because the above code will directly use the native woocommerce handler

Look at https://github.com/woocommerce/woocommerce/blob/master/includes/class-woocommerce.php#L472:L475

This pull request provides the following change :

- Use the woocommerce session object if already instantiated / initialized
- If not, instantiate it the same way woocommerce would have
- Call the methods `has_session` and `set_customer_session_cookie` only if they exist (because they are no part of the abstract class https://github.com/woocommerce/woocommerce/blob/master/includes/abstracts/abstract-wc-session.php )

I made the PR because of side effects, but I'm not aware of the very first reason for the presence of those lines, so I could not check myself that the PR would not break anything, could you check it ?

Bests regards

