### PR TITLE
Separator format

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -610,7 +610,7 @@ class WC_Stripe_Payment_Request {
 			}
 		}
 		?>
-		<p id="wc-stripe-payment-request-button-separator" style="margin-top:1.5em;text-align:center;display:none;">- <?php esc_html_e( 'OR', 'woocommerce-gateway-stripe' ); ?> -</p>
+		<p id="wc-stripe-payment-request-button-separator" style="margin-top:1.5em;text-align:center;display:none;">&mdash; <?php esc_html_e( 'or', 'woocommerce-gateway-stripe' ); ?> &mdash;</p>
 		<?php
 	}
 

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -1100,7 +1100,7 @@ msgid "Unknown shipping option \"[option]\"."
 msgstr ""
 
 #: includes/payment-methods/class-wc-stripe-payment-request.php:609
-msgid "OR"
+msgid "or"
 msgstr ""
 
 #: includes/payment-methods/class-wc-stripe-payment-request.php:700


### PR DESCRIPTION
Changes the format of the payment request button separator to match the paypal express separator.

This includes changing `OR` to lowercase and wrapping it with `&mdash;` instead of dashes.

See: 
https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/blame/master/includes/class-wc-gateway-ppec-cart-handler.php#L166

Current Implementation:
<img width="495" alt="checkout" src="https://user-images.githubusercontent.com/15932045/36707322-bba5250c-1bbd-11e8-8eaa-a2ab3eebabd8.png">
