### PR TITLE
Use i18n placeholders whenever possible

### DIFF
--- a/includes/admin/stripe-alipay-settings.php
+++ b/includes/admin/stripe-alipay-settings.php
@@ -8,7 +8,7 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_alipay_settings',
 	array(
 		'geo_target' => array(
-			'description' => __( 'Relevant Payer Geography: China', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'China', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'guide' => array(

--- a/includes/admin/stripe-alipay-settings.php
+++ b/includes/admin/stripe-alipay-settings.php
@@ -12,7 +12,7 @@ return apply_filters( 'wc_stripe_alipay_settings',
 			'type'        => 'title',
 		),
 		'guide' => array(
-			'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#alipay" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( '<a href="%s" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ), 'https://stripe.com/payments/payment-methods-guide#alipay' ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/admin/stripe-bancontact-settings.php
+++ b/includes/admin/stripe-bancontact-settings.php
@@ -12,7 +12,7 @@ return apply_filters( 'wc_stripe_bancontact_settings',
 			'type'        => 'title',
 		),
 		'guide' => array(
-			'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#bancontact" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( '<a href="%s" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ), 'https://stripe.com/payments/payment-methods-guide#bancontact' ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/admin/stripe-bancontact-settings.php
+++ b/includes/admin/stripe-bancontact-settings.php
@@ -8,7 +8,7 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_bancontact_settings',
 	array(
 		'geo_target' => array(
-			'description' => __( 'Relevant Payer Geography: Belgium', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'Belgium', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'guide' => array(

--- a/includes/admin/stripe-bitcoin-settings.php
+++ b/includes/admin/stripe-bitcoin-settings.php
@@ -12,7 +12,7 @@ return apply_filters( 'wc_stripe_bitcoin_settings',
 			'type'        => 'title',
 		),
 		'guide' => array(
-			'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#bitcoin" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( '<a href="%s" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ), 'https://stripe.com/payments/payment-methods-guide#bitcoin' ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/admin/stripe-bitcoin-settings.php
+++ b/includes/admin/stripe-bitcoin-settings.php
@@ -8,7 +8,7 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_bitcoin_settings',
 	array(
 		'geo_target' => array(
-			'description' => __( 'Relevant Payer Geography: Global', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'Global', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'guide' => array(

--- a/includes/admin/stripe-giropay-settings.php
+++ b/includes/admin/stripe-giropay-settings.php
@@ -8,7 +8,7 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_giropay_settings',
 	array(
 		'geo_target' => array(
-			'description' => __( 'Relevant Payer Geography: Germany', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'Germany', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'guide' => array(

--- a/includes/admin/stripe-giropay-settings.php
+++ b/includes/admin/stripe-giropay-settings.php
@@ -8,7 +8,7 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_giropay_settings',
 	array(
 		'geo_target' => array(
-			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'Germany', 'woocommerce-gateway-stripe' ) ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'The Netherlands', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'guide' => array(

--- a/includes/admin/stripe-giropay-settings.php
+++ b/includes/admin/stripe-giropay-settings.php
@@ -12,7 +12,7 @@ return apply_filters( 'wc_stripe_giropay_settings',
 			'type'        => 'title',
 		),
 		'guide' => array(
-			'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#giropay" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( '<a href="%s" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ), 'https://stripe.com/payments/payment-methods-guide#giropay' ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/admin/stripe-ideal-settings.php
+++ b/includes/admin/stripe-ideal-settings.php
@@ -12,7 +12,7 @@ return apply_filters( 'wc_stripe_ideal_settings',
 			'type'        => 'title',
 		),
 		'guide' => array(
-			'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#ideal" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( '<a href="%s" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ), 'https://stripe.com/payments/payment-methods-guide#ideal' ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/admin/stripe-p24-settings.php
+++ b/includes/admin/stripe-p24-settings.php
@@ -8,7 +8,7 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_p24_settings',
 	array(
 		'geo_target' => array(
-			'description' => __( 'Relevant Payer Geography: Poland', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'Poland', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/admin/stripe-sepa-settings.php
+++ b/includes/admin/stripe-sepa-settings.php
@@ -8,11 +8,11 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_sepa_settings',
 	array(
 		'geo_target' => array(
-			'description' => __( 'Relevant Payer Geography: France, Germany, Spain, Belgium, Netherlands, Luxembourg, Italy, Portugal, Austria, Ireland', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'France, Germany, Spain, Belgium, Netherlands, Luxembourg, Italy, Portugal, Austria, Ireland', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'guide' => array(
-			'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#sepa-direct-debit" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( '<a href="%s" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ), 'https://stripe.com/payments/payment-methods-guide#sepa-direct-debit' ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/admin/stripe-sofort-settings.php
+++ b/includes/admin/stripe-sofort-settings.php
@@ -8,11 +8,11 @@ $webhook_url = WC_Stripe_Helper::get_webhook_url();
 return apply_filters( 'wc_stripe_sofort_settings',
 	array(
 		'geo_target' => array(
-			'description' => __( 'Relevant Payer Geography: Germany, Austria', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( 'Relevant Payer Geography: %s', 'woocommerce-gateway-stripe' ), __( 'Germany, Austria', 'woocommerce-gateway-stripe' ) ),
 			'type'        => 'title',
 		),
 		'guide' => array(
-			'description' => __( '<a href="https://stripe.com/payments/payment-methods-guide#sofort" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ),
+			'description' => sprintf( __( '<a href="%s" target="_blank">Payment Method Guide</a>', 'woocommerce-gateway-stripe' ), 'https://stripe.com/payments/payment-methods-guide#sofort' ),
 			'type'        => 'title',
 		),
 		'activation' => array(

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -128,7 +128,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 			'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() )
 		) {
 			/* translators: supported currency list */
-			$message = sprintf( __( 'Alipay is enabled - it requires store currency to be set to %s', 'woocommerce-gateway-stripe' ), implode( ', ', $this->get_supported_currency() ) );
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'Alipay', 'woocommerce-gateway-stripe' ), implode( ', ', $this->get_supported_currency() ) );
 
 			return $message;
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
@@ -125,7 +125,7 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_environment_warning() {
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
-			$message = __( 'Bancontact is enabled - it requires store currency to be set to Euros.', 'woocommerce-gateway-stripe' );
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'Bancontact', 'woocommerce-gateway-stripe' ), __( 'Euros', 'woocommerce-gateway-stripe' ) );
 
 			return $message;
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-bitcoin.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-bitcoin.php
@@ -141,7 +141,7 @@ class WC_Gateway_Stripe_Bitcoin extends WC_Stripe_Payment_Gateway {
 		}
 
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
-			$message = __( 'Bitcoin is enabled - it requires store currency to be set to USD.', 'woocommerce-gateway-stripe' );
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'Bitcoin', 'woocommerce-gateway-stripe' ), __( 'USD', 'woocommerce-gateway-stripe' ) );
 
 			return $message;
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-giropay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-giropay.php
@@ -125,7 +125,7 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_environment_warning() {
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
-			$message = __( 'Giropay is enabled - it requires store currency to be set to Euros.', 'woocommerce-gateway-stripe' );
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'Giropay', 'woocommerce-gateway-stripe' ), __( 'Euros', 'woocommerce-gateway-stripe' ) );
 
 			return $message;
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-ideal.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-ideal.php
@@ -125,7 +125,8 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_environment_warning() {
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
-			$message = __( 'iDeal is enabled - it requires store currency to be set to Euros.', 'woocommerce-gateway-stripe' );
+			
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'iDeal', 'woocommerce-gateway-stripe' ), __( 'Euros', 'woocommerce-gateway-stripe' ) );
 
 			return $message;
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-p24.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-p24.php
@@ -125,7 +125,7 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_environment_warning() {
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
-			$message = __( 'P24 is enabled - it requires store currency to be set to Euros or Polish Zloty.', 'woocommerce-gateway-stripe' );
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'P24', 'woocommerce-gateway-stripe' ), __( 'Euros or Polish Zloty', 'woocommerce-gateway-stripe' ) );
 
 			return $message;
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -146,7 +146,7 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_environment_warning() {
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
-			$message = __( 'SEPA is enabled - it requires store currency to be set to Euros.', 'woocommerce-gateway-stripe' );
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'SEPA', 'woocommerce-gateway-stripe' ), __( 'Euros', 'woocommerce-gateway-stripe' ) );
 
 			return $message;
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-sofort.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sofort.php
@@ -125,7 +125,7 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_environment_warning() {
 		if ( 'yes' === $this->enabled && ! in_array( get_woocommerce_currency(), $this->get_supported_currency() ) ) {
-			$message = __( 'SOFORT is enabled - it requires store currency to be set to Euros.', 'woocommerce-gateway-stripe' );
+			$message = sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s.', 'woocommerce-gateway-stripe' ), __( 'SOFORT', 'woocommerce-gateway-stripe' ), __( 'Euros', 'woocommerce-gateway-stripe' ) );
 
 			return $message;
 		}


### PR DESCRIPTION
- Solves #595 

#### Changes proposed in this Pull Request:
- Use i18n placeholders on similar strings. 3 strings were changed so far: `Relevant Payer Geography: %s`, `<a href="%s" target="_blank">Payment Method Guide</a>` and `%1$s is enabled - it requires store currency to be set to %2$s.`

