### PR TITLE
Creates a complete postcode when calculating shipping

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -991,6 +991,19 @@ class WC_Stripe_Payment_Request {
 		}
 
 		WC()->shipping->reset_shipping();
+		
+		/**
+		 * ApplePay does not return full postcodes, if you have limited delivery
+		 * i.e only N3 area you cannot calculate correct shipping, as a hack add 1AA
+		 * to the partial postcode recieved as postcode does not need to be valid.
+		 * This sepecifcally address this issue in the United Kingdom but similar
+		 * could be applied to other countries were applicable.
+		 */
+		
+		$postcode = trim($postcode);
+		if($country == 'GB' && strlen($postcode) < 5) {
+			$postcode .= " 1AA";
+		}
 
 		if ( $postcode && WC_Validation::is_postcode( $postcode, $country ) ) {
 			$postcode = wc_format_postcode( $postcode, $country );


### PR DESCRIPTION
This addresses a specific issue I had where shipping would be allowed to partial postcode areas like N3, SW11, etc. but woocommerce could not work out the specifics without complete postcodes (ApplePay would only return the first part). As a fix for this issue when a postcode that is too short is received we can fake a complete postcode by adding "1AA" as the postcode does not need to be valid for woocommerce to correctly calculate shipping.

#### Changes proposed in this Pull Request:
- Creates a fake postcode only when the country is the United Kingdom (GB) to allow WooCommerce to correctly calculate shipping.