### PR TITLE
Update plugin author to Automattic

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Stripe Gateway
  * Plugin URI: https://wordpress.org/plugins/woocommerce-gateway-stripe/
  * Description: Take credit card payments on your store using Stripe.
- * Author: WooCommerce
+ * Author: Automattic
  * Author URI: https://woocommerce.com/
  * Version: 4.1.4
  * Requires at least: 4.4


### PR DESCRIPTION
Other WooCommerce plugins "Automattic" at the author. For example, WooCommerce: https://github.com/woocommerce/woocommerce/blob/2ad9b00c9c2b55579eb3531cd5eb5d4f03622ab0/woocommerce.php#L7

Update the author to be "Automattic."