### PR TITLE
Adjust styles

### DIFF
--- a/assets/css/stripe-storefront-styles.css
+++ b/assets/css/stripe-storefront-styles.css
@@ -1,0 +1,29 @@
+.woocommerce-checkout #payment .payment_method_stripe label[for=payment_method_stripe] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe label[for=payment_method_stripe] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa] { display: block; padding-left: 1.41575em; }
+
+.woocommerce-checkout #payment .payment_method_stripe_sofort label[for=payment_method_stripe_sofort] { display: block; padding-left: 1.41575em; }
+#add_payment_method #payment .payment_method_stripe_sofort label[for=payment_method_stripe_sofort] { display: block; padding-left: 1.41575em; }

--- a/assets/css/stripe-styles.css
+++ b/assets/css/stripe-styles.css
@@ -1,13 +1,15 @@
-#add_payment_method .woocommerce-PaymentMethod > label { display: block; padding: 1.41575em; padding-top: 0; }
+.wc-stripe-elements-field { border:1px solid #ddd; margin:5px 0; padding:5px; background-color:#fff; outline:0; }
+
+#add_payment_method .woocommerce-PaymentMethod label { margin-left: 10px; }
 #add_payment_method li { clear: right; }
 #add_payment_method #wc-stripe_sepa-form { padding: 10px; }
-form#order_review #payment_method_stripe { margin: 0; }
+form#order_review #payment_method_stripe { margin: 25px 0 25px 25px; }
 form#order_review #payment_method_stripe_sepa { margin: 25px 0 25px 25px; }
 form#order_review .payment_methods label { margin-left: 10px; }
 form#order_review li { clear: right; }
 form#order_review #wc-stripe_sepa-form { padding: 10px; }
-.wc-stripe-elements-field { border:1px solid #ddd; margin:5px 0; padding:5px; background-color:#fff; outline:0; }
-.clear { clear: both; }
+.wc_payment_method .payment_box label { display: inline; }
+
 .woocommerce-checkout #payment .payment_method_stripe,
 #add_payment_method #payment .payment_method_stripe { position: relative; }
 
@@ -39,64 +41,64 @@ form#order_review #wc-stripe_sepa-form { padding: 10px; }
 #add_payment_method #payment .payment_method_stripe_sofort { position: relative; }
 
 .woocommerce-checkout #payment input#payment_method_stripe,
-#add_payment_method #payment input#payment_method_stripe { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_bancontact,
-#add_payment_method #payment input#payment_method_stripe_bancontact { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_bancontact { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_alipay,
-#add_payment_method #payment input#payment_method_stripe_alipay { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_alipay { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_eps,
-#add_payment_method #payment input#payment_method_stripe_eps { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_eps { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_giropay,
-#add_payment_method #payment input#payment_method_stripe_giropay { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_giropay { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_ideal,
-#add_payment_method #payment input#payment_method_stripe_ideal { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_ideal { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_multibanco,
-#add_payment_method #payment input#payment_method_stripe_multibanco { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_multibanco { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_p24,
-#add_payment_method #payment input#payment_method_stripe_p24 { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_p24 { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_sepa,
-#add_payment_method #payment input#payment_method_stripe_sepa { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_sepa { position: absolute; top: 6px; }
 
 .woocommerce-checkout #payment input#payment_method_stripe_sofort,
-#add_payment_method #payment input#payment_method_stripe_sofort { position: absolute; }
+#add_payment_method #payment input#payment_method_stripe_sofort { position: absolute; top: 6px; }
 
-.woocommerce-checkout #payment .payment_method_stripe label[for=payment_method_stripe],
-#add_payment_method #payment .payment_method_stripe label[for=payment_method_stripe] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe label[for=payment_method_stripe] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe label[for=payment_method_stripe] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact],
-#add_payment_method #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay],
-#add_payment_method #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps],
-#add_payment_method #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay],
-#add_payment_method #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal],
-#add_payment_method #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco],
-#add_payment_method #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24],
-#add_payment_method #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24] { display: block; padding-left: 20px; }
 
-.woocommerce-checkout #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa],
-#add_payment_method #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa] { display: block; }
+.woocommerce-checkout #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa] { display: block; padding-left: 32px; }
+#add_payment_method #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa] { display: block; padding-left: 20px; }
 
 .woocommerce-checkout #payment .payment_method_stripe_sofort label[for=payment_method_stripe_sofort],
-#add_payment_method #payment .payment_method_stripe_sofort label[for=payment_method_stripe_sofort] { display: block; }
+#add_payment_method #payment .payment_method_stripe_sofort label[for=payment_method_stripe_sofort] { display: block; padding-left: 32px; }
 
 .woocommerce-checkout #payment ul.payment_methods li img.stripe-icon,
 #add_payment_method #payment ul.payment_methods li img.stripe-icon { float: right; max-width: 40px; padding-left: 3px; margin: 0; }
@@ -129,32 +131,28 @@ form#order_review #wc-stripe_sepa-form { padding: 10px; }
 #add_payment_method #payment ul.payment_methods li img.stripe-giropay-icon { max-width: 50px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-credit-card-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-credit-card-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/credit-card.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-credit-card-brand { position: absolute; top: 50%; margin-top: -10px; right: 10px; background: no-repeat url( '../images/credit-card.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-visa-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-visa-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/visa.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-visa-brand { position: absolute; top: 50%; margin-top: -10px; right: 10px; background: no-repeat url( '../images/visa.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-amex-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-amex-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/amex.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-amex-brand { position: absolute; top: 50%; margin-top: -10px; right: 10px; background: no-repeat url( '../images/amex.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-diners-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-diners-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/diners.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-diners-brand { position: absolute; top: 50%; margin-top: -10px; right: 10px; background: no-repeat url( '../images/diners.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-discover-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-discover-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/discover.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-discover-brand { position: absolute; top: 50%; margin-top: -10px; right: 10px; background: no-repeat url( '../images/discover.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-jcb-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-jcb-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/jcb.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-jcb-brand { position: absolute; top: 50%; margin-top: -10px; right: 10px; background: no-repeat url( '../images/jcb.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-maestro-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-maestro-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/maestro.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-maestro-brand { position: absolute; top: 50%; margin-top: -10px; right: 10px; background: no-repeat url( '../images/maestro.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods li .stripe-mastercard-brand,
-#add_payment_method #payment ul.payment_methods li .stripe-mastercard-brand { position: absolute; top: 6px; right: 10px; background: no-repeat url( '../images/mastercard.svg' ); display: block; width: 30px; height: 24px; }
+#add_payment_method #payment ul.payment_methods li .stripe-mastercard-brand { position: absolute; top: 50%; margin-top: -10px right: 10px; background: no-repeat url( '../images/mastercard.svg' ); display: block; width: 30px; height: 24px; }
 
 .woocommerce-checkout #payment ul.payment_methods .stripe-card-group,
 #add_payment_method #payment ul.payment_methods .stripe-card-group { position: relative; }
-
-.woocommerce-SavedPaymentMethods.wc-saved-payment-methods label { display: inline; }
-
-.woocommerce-PaymentMethods.payment_methods { list-style-type: none; }

--- a/assets/css/stripe-twentyseventeen-styles.css
+++ b/assets/css/stripe-twentyseventeen-styles.css
@@ -1,0 +1,31 @@
+.woocommerce-checkout #payment .payment_method_stripe label[for=payment_method_stripe] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe label[for=payment_method_stripe] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_bancontact label[for=payment_method_stripe_bancontact] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_alipay label[for=payment_method_stripe_alipay] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_eps label[for=payment_method_stripe_eps] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_giropay label[for=payment_method_stripe_giropay] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_ideal label[for=payment_method_stripe_ideal] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_multibanco label[for=payment_method_stripe_multibanco] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_p24 label[for=payment_method_stripe_p24] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_sepa label[for=payment_method_stripe_sepa] { display: block; padding-left: 20px; }
+
+.woocommerce-checkout #payment .payment_method_stripe_sofort label[for=payment_method_stripe_sofort] { display: block; padding-left:0; }
+#add_payment_method #payment .payment_method_stripe_sofort label[for=payment_method_stripe_sofort] { display: block; padding-left: 20px; }
+
+.woocommerce-PaymentMethods li { list-style-type: none; }

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -446,10 +446,23 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Logger::log( 'Stripe live mode requires SSL.' );
 		}
 
+		$current_theme = wp_get_theme();
+
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		wp_register_style( 'stripe_styles', plugins_url( 'assets/css/stripe-styles.css', WC_STRIPE_MAIN_FILE ), array(), WC_STRIPE_VERSION );
 		wp_enqueue_style( 'stripe_styles' );
+
+		if ( 'storefront' === $current_theme->get_template() ) {
+			wp_register_style( 'stripe_storefront_styles', plugins_url( 'assets/css/stripe-storefront-styles.css', WC_STRIPE_MAIN_FILE ), array(), WC_STRIPE_VERSION );
+			wp_enqueue_style( 'stripe_storefront_styles' );
+		}
+
+		if ( 'twentyseventeen' === $current_theme->get_template() ) {
+			wp_register_style( 'stripe_twentyseventeen_styles', plugins_url( 'assets/css/stripe-twentyseventeen-styles.css', WC_STRIPE_MAIN_FILE ), array(), WC_STRIPE_VERSION );
+			wp_enqueue_style( 'stripe_twentyseventeen_styles' );
+		}
+
 		wp_register_script( 'stripe_checkout', 'https://checkout.stripe.com/checkout.js', '', WC_STRIPE_VERSION, true );
 		wp_register_script( 'stripe', 'https://js.stripe.com/v3/', '', '3.0', true );
 		wp_register_script( 'woocommerce_stripe', plugins_url( 'assets/js/stripe' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), array( 'jquery-payment', 'stripe' ), WC_STRIPE_VERSION, true );

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.1.4\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.1.5\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/woocommerce/woocommerce-gateway-stripe/issues\n"
-"POT-Creation-Date: 2018-05-28 21:53:47+00:00\n"
+"POT-Creation-Date: 2018-05-29 21:57:06+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -63,7 +63,7 @@ msgid "Stripe charge complete (Charge ID: %s)"
 msgstr ""
 
 #: includes/abstracts/abstract-wc-stripe-payment-gateway.php:464
-#: includes/class-wc-gateway-stripe.php:690
+#: includes/class-wc-gateway-stripe.php:703
 #: includes/compat/class-wc-stripe-sepa-subs-compat.php:134
 #: includes/compat/class-wc-stripe-subs-compat.php:96
 msgid "Payment processing failed. Please retry."
@@ -821,42 +821,42 @@ msgstr ""
 msgid "Card Code (CVC)"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:459
+#: includes/class-wc-gateway-stripe.php:472
 msgid "Please accept the terms and conditions first"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:460
+#: includes/class-wc-gateway-stripe.php:473
 msgid "Please fill in required checkout fields first"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:478
-#: includes/class-wc-gateway-stripe.php:685
+#: includes/class-wc-gateway-stripe.php:491
+#: includes/class-wc-gateway-stripe.php:698
 #: includes/compat/class-wc-stripe-subs-compat.php:91
 msgid ""
 "Sorry, we're not accepting prepaid cards at this time. Your credit card has "
 "not been charge. Please try with alternative payment method."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:479
+#: includes/class-wc-gateway-stripe.php:492
 msgid "Please enter your IBAN account name."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:480
+#: includes/class-wc-gateway-stripe.php:493
 msgid "Please enter your IBAN account number."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:574
+#: includes/class-wc-gateway-stripe.php:587
 msgid "Place Order"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:772
+#: includes/class-wc-gateway-stripe.php:785
 #: includes/class-wc-stripe-order-handler.php:140
 #: includes/class-wc-stripe-webhook-handler.php:187
 #: includes/payment-methods/class-wc-gateway-stripe-sepa.php:348
 msgid "This card is no longer available and has been removed."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:791
+#: includes/class-wc-gateway-stripe.php:804
 #: includes/class-wc-stripe-order-handler.php:158
 #: includes/class-wc-stripe-webhook-handler.php:206
 #: includes/compat/class-wc-stripe-sepa-subs-compat.php:222
@@ -867,22 +867,22 @@ msgid ""
 "later."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:868
+#: includes/class-wc-gateway-stripe.php:881
 #. translators: error message
 msgid "This represents the fee Stripe collects for the transaction."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:869
+#: includes/class-wc-gateway-stripe.php:882
 msgid "Stripe Fee:"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:905
+#: includes/class-wc-gateway-stripe.php:918
 msgid ""
 "This represents the net total that will be credited to your Stripe bank "
 "account. This may be in the currency that is set in your Stripe account."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:906
+#: includes/class-wc-gateway-stripe.php:919
 msgid "Stripe Payout:"
 msgstr ""
 


### PR DESCRIPTION
Fixes #661

#### Changes proposed in this Pull Request:

Here is one method to get it working is conditional load styles depending on whether the radio button has special styling. So in this case I am just conditionally checking if the themes are Storefront or TwentySeventeen.

Things to check. Make sure alignment is correct on Checkout page AND on Add Payment Method page. Test Storefront, TwentySeventeen and other themes that does NOT have special styling to the radio buttons.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

