### PR TITLE
Fix order not showing stripe fees for asynchronous payments closes #671

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.1.7 - 2018-xx-xx =
+* Fix - Asynchronous payment methods such as SEPA, did not show order Stripe fees/net after payment succeed.
+
 = 4.1.6 - 2018-05-31 =
 * Fix - Radio buttons on checkout on some themes are not aligned properly.
 * Fix - False negative on SSL warning notice in admin.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -894,6 +894,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( empty( $balance_transaction->error ) ) {
 			$currency = ! empty( $balance_transaction->currency ) ? strtoupper( $balance_transaction->currency ) : null;
 			WC_Stripe_Helper::update_stripe_currency( $order, $currency );
+
+			if ( is_callable( array( $order, 'save' ) ) ) {
+				$order->save();
+			}
 		} else {
 			WC_Stripe_Logger::log( "Unable to update currency meta for order: {$order_id}" );
 		}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -880,6 +880,26 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Updates Stripe currency in order meta.
+	 *
+	 * @since 4.1.7
+	 * @param object $order The order object
+	 * @param int $balance_transaction_id
+	 */
+	public function update_currency( $order, $balance_transaction_id ) {
+		$order_id = WC_Stripe_Helper::is_pre_30() ? $order->id : $order->get_id();
+
+		$balance_transaction = WC_Stripe_API::retrieve( 'balance/history/' . $balance_transaction_id );
+
+		if ( empty( $balance_transaction->error ) ) {
+			$currency = ! empty( $balance_transaction->currency ) ? strtoupper( $balance_transaction->currency ) : null;
+			WC_Stripe_Helper::update_stripe_currency( $order, $currency );
+		} else {
+			WC_Stripe_Logger::log( "Unable to update currency meta for order: {$order_id}" );
+		}
+	}
+
+	/**
 	 * Refund a charge.
 	 *
 	 * @since 3.1.0

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -353,6 +353,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( isset( $notification->data->object->balance_transaction ) ) {
 			$this->update_fees( $order, $notification->data->object->balance_transaction );
+			$this->update_currency( $order, $notification->data->object->balance_transaction );
 		}
 
 		$order->payment_complete( $notification->data->object->id );


### PR DESCRIPTION
Fixes #671

#### Changes proposed in this Pull Request:
* Fix - Asynchronous payment methods such as SEPA, did not show order Stripe fees/net after payment succeed.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

