### PR TITLE
Make the stripe logger overridable.

### DIFF
--- a/includes/class-wc-stripe-logger.php
+++ b/includes/class-wc-stripe-logger.php
@@ -27,7 +27,7 @@ class WC_Stripe_Logger {
 
 		if ( apply_filters( 'wc_stripe_logging', true, $message ) ) {
 			if ( empty( self::$logger ) ) {
-				self::$logger = new WC_Logger();
+				self::$logger = wc_get_logger();
 			}
 
 			$settings = get_option( 'woocommerce_stripe_settings' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This updates the stripe logger's internal log instance creation.

The change makes use of the shared `WC_Logger` instance instead of how it currently is: a new WC_Logger instance is created specifically for stripe.

We need to add this to allow for the class to be filtered out and replaced by a custom class, in our case WooCommerce.com, but this will help all other large scale sites.

The default from `wc_get_logger` is simply an instance of WC_Logger, but anyone can replace this.

For more detail see:
https://alphamattic.wordpress.com/2018/06/01/double-charging-customers/#comment-4994
https://a8c.slack.com/archives/C4E0DVDB2/p1528186755000071


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

