### PR TITLE
Fix 3DS sometimes causes second payment retry closes #683 #684

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.1.8 - 2018-xx-xx =
+* Fix - 3DS payment sometimes will create additional transaction in Stripe.
+
 = 4.1.7 - 2018-06-06 =
 * Fix - Asynchronous payment methods such as SEPA, did not show order Stripe fees/net after payment succeed.
 * Fix - Missing semicolon on a CSS style value which causes display issues in some browsers.

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -105,6 +105,17 @@ class WC_Stripe_Customer {
 		if ( $user ) {
 			$billing_first_name = get_user_meta( $user->ID, 'billing_first_name', true );
 			$billing_last_name  = get_user_meta( $user->ID, 'billing_last_name', true );
+
+			// If billing first name does not exists try the user first name.
+			if ( empty( $billing_first_name ) ) {
+				$billing_first_name = get_user_meta( $user->ID, 'first_name', true );
+			}
+
+			// If billing last name does not exists try the user last name.
+			if ( empty( $billing_last_name ) ) {
+				$billing_last_name = get_user_meta( $user->ID, 'last_name', true );
+			}
+
 			$description        = __( 'Name', 'woocommerce-gateway-stripe' ) . ': ' . $billing_first_name . ' ' . $billing_last_name . ' ' . __( 'Username', 'woocommerce-gateway-stripe' ) . ': ' . $user->user_login;
 
 			$defaults = array(

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -122,8 +122,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param bool $retry
 	 */
 	public function process_webhook_payment( $notification, $retry = true ) {
-		// The following 2 payment methods are synchronous so does not need to be handle via webhook.
-		if ( 'card' === $notification->data->object->type || 'sepa_debit' === $notification->data->object->type ) {
+		// The following 3 payment methods are synchronous so does not need to be handle via webhook.
+		if ( 'card' === $notification->data->object->type || 'sepa_debit' === $notification->data->object->type || 'three_d_secure' === $notification->data->object->type ) {
 			return;
 		}
 

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: WooCommerce Stripe Gateway 4.1.7\n"
 "Report-Msgid-Bugs-To: "
 "https://github.com/woocommerce/woocommerce-gateway-stripe/issues\n"
-"POT-Creation-Date: 2018-06-06 15:36:21+00:00\n"
+"POT-Creation-Date: 2018-06-08 21:19:13+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -55,7 +55,7 @@ msgid "Stripe charge awaiting payment: %s."
 msgstr ""
 
 #: includes/abstracts/abstract-wc-stripe-payment-gateway.php:459
-#: includes/class-wc-stripe-order-handler.php:245
+#: includes/class-wc-stripe-order-handler.php:249
 #: includes/class-wc-stripe-webhook-handler.php:314
 #: includes/class-wc-stripe-webhook-handler.php:362
 #. translators: transaction id
@@ -850,14 +850,14 @@ msgid "Place Order"
 msgstr ""
 
 #: includes/class-wc-gateway-stripe.php:785
-#: includes/class-wc-stripe-order-handler.php:140
+#: includes/class-wc-stripe-order-handler.php:144
 #: includes/class-wc-stripe-webhook-handler.php:187
 #: includes/payment-methods/class-wc-gateway-stripe-sepa.php:348
 msgid "This card is no longer available and has been removed."
 msgstr ""
 
 #: includes/class-wc-gateway-stripe.php:804
-#: includes/class-wc-stripe-order-handler.php:158
+#: includes/class-wc-stripe-order-handler.php:162
 #: includes/class-wc-stripe-webhook-handler.php:206
 #: includes/compat/class-wc-stripe-sepa-subs-compat.php:222
 #: includes/compat/class-wc-stripe-subs-compat.php:237
@@ -988,7 +988,7 @@ msgid "An error occurred while processing the card."
 msgstr ""
 
 #: includes/class-wc-stripe-helper.php:222
-#: includes/class-wc-stripe-order-handler.php:92
+#: includes/class-wc-stripe-order-handler.php:95
 msgid "Unable to process this payment, please try again or use alternative method."
 msgstr ""
 
@@ -996,12 +996,12 @@ msgstr ""
 msgid "The billing country is not accepted by SOFORT. Please try another country."
 msgstr ""
 
-#: includes/class-wc-stripe-order-handler.php:190
+#: includes/class-wc-stripe-order-handler.php:194
 #. translators: error message
 msgid "Stripe payment failed: %s"
 msgstr ""
 
-#: includes/class-wc-stripe-order-handler.php:242
+#: includes/class-wc-stripe-order-handler.php:246
 #. translators: error message
 msgid "Unable to capture charge! %s"
 msgstr ""


### PR DESCRIPTION
Fixes #683 #684

#### Changes proposed in this Pull Request:
* Fix - 3DS payment sometimes will create additional transaction in Stripe.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

