### PR TITLE
Only show apple pay  admin notice to user who can change options

### DIFF
--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -234,7 +234,7 @@ class WC_Stripe_Apple_Pay_Registration {
 		 * when setting screen is displayed. So if domain verification is not set,
 		 * something went wrong so lets notify user.
 		 */
-		if ( ! empty( $this->secret_key ) && $this->payment_request && ! $this->apple_pay_domain_set ) {
+		if ( current_user_can( 'manage_woocommerce' ) && ! empty( $this->secret_key ) && $this->payment_request && ! $this->apple_pay_domain_set ) {
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			echo '<div class="error stripe-apple-pay-message"><p>' . sprintf( __( 'Apple Pay domain verification failed. Please check the %1$slog%2$s to see the issue. (Logging must be enabled to see recorded logs)', 'woocommerce-gateway-stripe' ), '<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">', '</a>' ) . '</p></div>';
 		}

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -217,6 +217,10 @@ class WC_Stripe_Apple_Pay_Registration {
 		if ( ! $this->stripe_enabled ) {
 			return;
 		}
+		
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
 
 		if ( $this->payment_request && ! empty( $this->apple_pay_verify_notice ) ) {
 			$allowed_html = array(
@@ -234,7 +238,7 @@ class WC_Stripe_Apple_Pay_Registration {
 		 * when setting screen is displayed. So if domain verification is not set,
 		 * something went wrong so lets notify user.
 		 */
-		if ( current_user_can( 'manage_woocommerce' ) && ! empty( $this->secret_key ) && $this->payment_request && ! $this->apple_pay_domain_set ) {
+		if ( ! empty( $this->secret_key ) && $this->payment_request && ! $this->apple_pay_domain_set ) {
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			echo '<div class="error stripe-apple-pay-message"><p>' . sprintf( __( 'Apple Pay domain verification failed. Please check the %1$slog%2$s to see the issue. (Logging must be enabled to see recorded logs)', 'woocommerce-gateway-stripe' ), '<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">', '</a>' ) . '</p></div>';
 		}


### PR DESCRIPTION
The admin notice is show to everybody but only user with special roles can make the change needed. Shop managers can't, for example. So display the notice only to users capable of 'manage_woocommerce'.

Fixes # .

#### Changes proposed in this Pull Request:
-

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

