### PR TITLE
Fix undefined property error on card type in rare cases closes #711

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 4.1.9 - 2018-xx-xx =
 * Fix - Don't display admin notices to user that cannot manage woocommerce.
 * Fix - Fatal error when clicking on order link that doesn't exist.
+* Fix - Undefined property error on card type in rare cases.
 
 = 4.1.8 - 2018-07-19 =
 * Fix - 3DS payment sometimes will create additional transaction in Stripe.

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -466,6 +466,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		if ( $sources ) {
 			$card         = false;
 			$found_source = false;
+
 			foreach ( $sources as $source ) {
 				if ( isset( $source->type ) && 'card' === $source->type ) {
 					$card = $source->card;
@@ -487,7 +488,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			}
 
 			if ( ! $found_source ) {
-				if ( 'card' === $sources[0]->type ) {
+				if ( isset( $sources[0]->type ) && 'card' === $sources[0]->type ) {
 					$card = $sources[0]->card;
 				}
 


### PR DESCRIPTION
Fixes #711

#### Changes proposed in this Pull Request:
* Fix - Undefined property error on card type in rare cases.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

