### PR TITLE
Use 3DS source when redirect status is not required closes #706

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.1.10 - 2018-xx-xx =
+* Fix - When 3DS card redirect status is "not_required", charge the 3DS source.
+
 = 4.1.9 - 2018-08-27 =
 * Fix - Don't display admin notices to user that cannot manage woocommerce.
 * Fix - Fatal error when clicking on order link that doesn't exist.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -696,12 +696,11 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			}
 
 			$prepared_source = $this->prepare_source( get_current_user_id(), $force_save_source );
-			$source_object   = $prepared_source->source_object;
 
 			// Check if we don't allow prepaid credit cards.
-			if ( ! apply_filters( 'wc_stripe_allow_prepaid_card', true ) && $this->is_prepaid_card( $source_object ) ) {
+			if ( ! apply_filters( 'wc_stripe_allow_prepaid_card', true ) && $this->is_prepaid_card( $prepared_source->source_object ) ) {
 				$localized_message = __( 'Sorry, we\'re not accepting prepaid cards at this time. Your credit card has not been charge. Please try with alternative payment method.', 'woocommerce-gateway-stripe' );
-				throw new WC_Stripe_Exception( print_r( $source_object, true ), $localized_message );
+				throw new WC_Stripe_Exception( print_r( $prepared_source->source_object, true ), $localized_message );
 			}
 
 			if ( empty( $prepared_source->source ) ) {
@@ -725,8 +724,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				 * Note that if we need to save source, the original source must be first
 				 * attached to a customer in Stripe before it can be charged.
 				 */
-				if ( $this->is_3ds_required( $source_object ) ) {
-					$response = $this->create_3ds_source( $order, $source_object );
+				if ( $this->is_3ds_required( $prepared_source->source_object ) ) {
+					$response = $this->create_3ds_source( $order, $prepared_source->source_object );
 
 					if ( ! empty( $response->error ) ) {
 						$localized_message = $response->error->message;
@@ -755,6 +754,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 							'result'   => 'success',
 							'redirect' => esc_url_raw( $response->redirect->url ),
 						);
+					} elseif ( 'not_required' === $response->redirect->status && 'chargeable' === $response->status ) {
+						// Override the original source object with 3DS.
+						$prepared_source->source_object = $response;
 					}
 				}
 
@@ -763,7 +765,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				/* If we're doing a retry and source is chargeable, we need to pass
 				 * a different idempotency key and retry for success.
 				 */
-				if ( $this->need_update_idempotency_key( $source_object, $previous_error ) ) {
+				if ( $this->need_update_idempotency_key( $prepared_source->source_object, $previous_error ) ) {
 					add_filter( 'wc_stripe_idempotency_key', array( $this, 'change_idempotency_key' ), 10, 2 );
 				}
 


### PR DESCRIPTION
Fixes #706

#### Changes proposed in this Pull Request:
* Fix - When 3DS card redirect status is "not_required", charge the 3DS source.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

