### PR TITLE
Add filter to override checkout button text

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -607,7 +607,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		do_action( 'wc_stripe_checkout_receipt_page_before_form_submit' );
 
-		echo '<button type="submit" class="wc-stripe-checkout-button">' . __( 'Place Order', 'woocommerce-gateway-stripe' ) . '</button>';
+		echo '<button type="submit" class="wc-stripe-checkout-button button">' . apply_filters( 'wc_stripe_checkout_button_text', __( 'Place Order', 'woocommerce-gateway-stripe' ) ) . '</button>';
 
 		do_action( 'wc_stripe_checkout_receipt_page_after_form_submit' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- add `.button` class for consistency with global WC button styles to the `button.wc-stripe-checkout-button` (`Place Order`) that launches Stripe
- add `wc_stripe_checkout_button_text` filter to override returned text for the button, for greater usability.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] (**N/A**) Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

