### PR TITLE
Adding basic PaymentIntent support for first-time buyers

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -419,12 +419,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		WC_Stripe_Logger::log( 'Processing response: ' . print_r( $response, true ) );
 
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-
-		if ( 'payment_intent' === $response->object ) {
-			$captured = ( isset( $response->status ) && 'success' === $response->status ) ? 'yes' : 'no';
-		} else {
-			$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';
-		}
+		$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';
 
 		// Store charge data.
 		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', $captured ) : $order->update_meta_data( '_stripe_charge_captured', $captured );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -420,7 +420,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 
-		$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';
+		if ( 'payment_intent' === $response->object ) {
+			$captured = ( isset( $response->status ) && 'success' === $response->status ) ? 'yes' : 'no';
+		} else {
+			$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';
+		}
 
 		// Store charge data.
 		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', $captured ) : $order->update_meta_data( '_stripe_charge_captured', $captured );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -307,6 +307,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				'card',
 			),
 		);
+
+		// ToDo: Extract this into an ajax call that is performed just before `handleCardPayment` in JS.
 		$intent        = WC_Stripe_API::request( $request, 'payment_intents' );
 		$client_secret = $intent->client_secret;
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -294,6 +294,22 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$pay_button_text = '';
 		}
 
+		/**
+		 * Start a payment intent.
+		 *
+		 * @see https://stripe.com/docs/payments/payment-intents/quickstart
+		 */
+		$request = array(
+			'amount'               => round( $total * 100 ),
+			'capture_method'       => 'manual',
+			'currency'             => get_woocommerce_currency(),
+			'allowed_source_types' => array(
+				'card',
+			),
+		);
+		$intent        = WC_Stripe_API::request( $request, 'payment_intents' );
+		$client_secret = $intent->client_secret;
+
 		ob_start();
 
 		echo '<div
@@ -303,15 +319,17 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			data-email="' . esc_attr( $user_email ) . '"
 			data-verify-zip="' . esc_attr( apply_filters( 'wc_stripe_checkout_verify_zip', false ) ? 'true' : 'false' ) . '"
 			data-billing-address="' . esc_attr( apply_filters( 'wc_stripe_checkout_require_billing_address', false ) ? 'true' : 'false' ) . '"
-			data-shipping-address="' . esc_attr( apply_filters( 'wc_stripe_checkout_require_shipping_address', false ) ? 'true' : 'false' ) . '" 
+			data-shipping-address="' . esc_attr( apply_filters( 'wc_stripe_checkout_require_shipping_address', false ) ? 'true' : 'false' ) . '"
 			data-amount="' . esc_attr( WC_Stripe_Helper::get_stripe_amount( $total ) ) . '"
 			data-name="' . esc_attr( $this->statement_descriptor ) . '"
 			data-full-name="' . esc_attr( $firstname . ' ' . $lastname ) . '"
 			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '"
 			data-image="' . esc_attr( $this->stripe_checkout_image ) . '"
 			data-locale="' . esc_attr( apply_filters( 'wc_stripe_checkout_locale', $this->get_locale() ) ) . '"
-			data-three-d-secure="' . esc_attr( $this->three_d_secure ? 'true' : 'false' ) . '"
-			data-allow-remember-me="' . esc_attr( apply_filters( 'wc_stripe_allow_remember_me', true ) ? 'true' : 'false' ) . '">';
+			data-three-d-secure="' . esc_attr( $this->three_d_secure ? 'true' : 'false' ) . /* ToDo: three_d_secure should be obsolete */ '"
+			data-allow-remember-me="' . esc_attr( apply_filters( 'wc_stripe_allow_remember_me', true ) ? 'true' : 'false' ) . '"
+			data-client-secret="' . esc_attr( $client_secret ) . '"
+		>';
 
 		if ( $this->testmode ) {
 			/* translators: link to Stripe testing page */
@@ -454,7 +472,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		wp_register_style( 'stripe_styles', plugins_url( 'assets/css/stripe-styles.css', WC_STRIPE_MAIN_FILE ), array(), WC_STRIPE_VERSION );
-		wp_enqueue_style( 'stripe_styles' );	
+		wp_enqueue_style( 'stripe_styles' );
 
 		wp_register_script( 'stripe_checkout', 'https://checkout.stripe.com/checkout.js', '', WC_STRIPE_VERSION, true );
 		wp_register_script( 'stripe', 'https://js.stripe.com/v3/', '', '3.0', true );
@@ -565,7 +583,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			data-email="' . esc_attr( $user_email ) . '"
 			data-verify-zip="' . esc_attr( apply_filters( 'wc_stripe_checkout_verify_zip', false ) ? 'true' : 'false' ) . '"
 			data-billing-address="' . esc_attr( apply_filters( 'wc_stripe_checkout_require_billing_address', false ) ? 'true' : 'false' ) . '"
-			data-shipping-address="' . esc_attr( apply_filters( 'wc_stripe_checkout_require_shipping_address', false ) ? 'true' : 'false' ) . '" 
+			data-shipping-address="' . esc_attr( apply_filters( 'wc_stripe_checkout_require_shipping_address', false ) ? 'true' : 'false' ) . '"
 			data-amount="' . esc_attr( WC_Stripe_Helper::get_stripe_amount( $total ) ) . '"
 			data-name="' . esc_attr( $this->statement_descriptor ) . '"
 			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '"
@@ -694,7 +712,11 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				$new_stripe_customer->create_customer();
 			}
 
-			$prepared_source = $this->prepare_source( get_current_user_id(), $force_save_source );
+			try {
+				$prepared_source = $this->prepare_source_from_intent( get_current_user_id(), $force_save_source );
+			} catch ( WC_Stripe_Exception $e ) {
+				$prepared_source = $this->prepare_source( get_current_user_id(), $force_save_source );
+			}
 
 			// Check if we don't allow prepaid credit cards.
 			if ( ! apply_filters( 'wc_stripe_allow_prepaid_card', true ) && $this->is_prepaid_card( $prepared_source->source_object ) ) {
@@ -770,7 +792,14 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				}
 
 				// Make the request.
-				$response = WC_Stripe_API::request( $this->generate_payment_request( $order, $prepared_source ) );
+				if ( $prepared_source->is_intent ) {
+					$post_data = array(
+						'amount_to_capture' => WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency ),
+					);
+					$response = WC_Stripe_API::request( $post_data, "payment_intents/{$prepared_source->intent_id}/capture" );
+				} else {
+					$response = WC_Stripe_API::request( $this->generate_payment_request( $order, $prepared_source ) );
+				}
 
 				if ( ! empty( $response->error ) ) {
 					// Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
@@ -932,5 +961,41 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		</tr>
 
 		<?php
+	}
+
+	public function prepare_source_from_intent( $user_id, $force_save_source = false ) {
+		// ToDo: This should either use or mimic WC_Stripe_Payment_Gateway::prepare_source().
+
+		if ( ! isset( $_POST['stripe_intent'] ) || empty( $_POST['stripe_intent'] ) ) { // wpcs: csrf ok.
+			throw new WC_Stripe_Exception( 'missing_intent_id', 'Missing intent ID' );
+		}
+
+		$intent_id     = wc_clean( $_POST['stripe_intent'] );     // wpcs: csrf ok.
+		$intent_object = $this->get_intent_object( $intent_id );
+
+		if ( 'requires_capture' !== $intent_object->status ) {
+			throw new WC_Stripe_Exception( print_r( $intent_object, true ), 'The payment intent is not expecting a capture.' );
+		}
+
+		$response = (object) array(
+			// 'token_id'      => $wc_token_id, // This was in place, investigate where it is used...
+			'customer'      => new WC_Stripe_Customer( $user_id ),
+			'source'        => $intent_object->source,
+			'source_object' => self::get_source_object( $intent_object->source ),
+			'is_intent'     => true,
+			'intent_id'     => $intent_id,
+		);
+
+		return $response;
+	}
+
+	public function get_intent_object( $intent_id = '' ) {
+		$intent_object = WC_Stripe_API::retrieve( 'payment_intents/' . $intent_id );
+
+		if ( ! empty( $intent_object->error ) ) {
+			throw new WC_Stripe_Exception( print_r( $intent_object, true ), $intent_object->error->message );
+		}
+
+		return $intent_object;
 	}
 }


### PR DESCRIPTION
This PR includes a minimal set of changes in order to start supporting Stripe PaymentIntents (currently) in parallel to source objects.

To minimize the proof-of-concept changes required, I did not strip the support for "old-school" sources within `WC_Gateway_Stripe`. Instead, I am using a slightly modified flow in order to extract a source object from payment intents and proceed as usual.

Some of the needed follow-up PRs:

1. Replace all `ToDo` keywords/comments with the proper functionality.
2. Stop accessing sources directly within `WC_Gateway_Stripe` in favor of a PaymentIntent-first approach.
3. Consider eliminating the Stripe Checkout modal and/or check how it works with PaymentIntents.

## Testing instructions

Create a new order and use one of the *3D Secure test card numbers and tokens* from https://stripe.com/docs/testing to see the Stripe's authorization overlay.