### PR TITLE
SCA: Create the PaymentIntent just when the checkout form is submitted 

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -496,15 +496,15 @@ jQuery( function( $ ) {
 
 			if ( 'card' === source_type ) {
 				wc_stripe_form.getIntent()
-					.catch( function( error ) {
-						$( document.body ).trigger( 'stripeError', { error: error } );
-					} )
 					.then( function( intent ) {
 						return stripe.handleCardPayment( intent.client_secret, stripe_card, {
 							source_data: extra_details,
 						} );
 					} )
-					.then( wc_stripe_form.intentResponse );
+					.then( wc_stripe_form.intentResponse )
+					.catch( function( error ) {
+						$( document.body ).trigger( 'stripeError', { error: error } );
+					} );
 				;
 			} else {
 				switch ( source_type ) {

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -24,6 +24,8 @@ jQuery( function( $ ) {
 	 * Object to handle Stripe elements payment form.
 	 */
 	var wc_stripe_form = {
+		paymentIntent: null,
+
 		/**
 		 * Get WC AJAX endpoint URL.
 		 *
@@ -466,8 +468,7 @@ jQuery( function( $ ) {
 
 		createSource: function() {
 			var extra_details = wc_stripe_form.getOwnerDetails(),
-				source_type   = 'card',
-				client_secret = $( '#stripe-payment-data' ).data( 'client-secret' );
+				source_type   = 'card';
 
 			if ( wc_stripe_form.isBancontactChosen() ) {
 				source_type = 'bancontact';
@@ -494,10 +495,17 @@ jQuery( function( $ ) {
 			}
 
 			if ( 'card' === source_type ) {
-				stripe.handleCardPayment( client_secret, stripe_card, {
-					source_data: extra_details,
-				} )
-				.then( wc_stripe_form.intentResponse );
+				wc_stripe_form.getIntent()
+					.catch( function( error ) {
+						$( document.body ).trigger( 'stripeError', { error: error } );
+					} )
+					.then( function( intent ) {
+						return stripe.handleCardPayment( intent.client_secret, stripe_card, {
+							source_data: extra_details,
+						} );
+					} )
+					.then( wc_stripe_form.intentResponse );
+				;
 			} else {
 				switch ( source_type ) {
 					case 'bancontact':
@@ -778,7 +786,40 @@ jQuery( function( $ ) {
 
 			$( document.body ).trigger( 'checkout_error' );
 			wc_stripe_form.unblock();
-		}
+		},
+
+		/**
+		 * Queries the server for a PaymentIntent.
+		 *
+		 * @return {Promise} A promise that resolves to a payment intent.
+		 */
+		getIntent: function() {
+			return new Promise( function( resolve, reject ) {
+				if ( wc_stripe_form.paymentIntent ) {
+					return resolve( wc_stripe_form.paymentIntent );
+				}
+
+				$.ajax( {
+					url: wc_stripe_form.getAjaxURL( 'create_intent' ),
+					type: 'post',
+					dataType: 'json',
+					success: function( result ) {
+						if ( result.error ) {
+							reject( result.error );
+						}
+
+						wc_stripe_form.paymentIntent = result;
+						resolve( result );
+					},
+					error: function() {
+						reject( {
+							code   : 'ajax_failed',
+							message: wc_stripe_params.payment_intent_error,
+						} );
+					},
+				} );
+			} );
+		},
 	};
 
 	wc_stripe_form.init();

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -487,7 +487,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$stripe_params['no_prepaid_card_msg']                     = __( 'Sorry, we\'re not accepting prepaid cards at this time. Your credit card has not been charged. Please try with alternative payment method.', 'woocommerce-gateway-stripe' );
 		$stripe_params['no_sepa_owner_msg']                       = __( 'Please enter your IBAN account name.', 'woocommerce-gateway-stripe' );
 		$stripe_params['no_sepa_iban_msg']                        = __( 'Please enter your IBAN account number.', 'woocommerce-gateway-stripe' );
-		$stripe_params['payment_intent_error']                    = __( 'We could not initiate the payment. Please try again!', 'woocommerce-gateway-stripe' );
+		$stripe_params['payment_intent_error']                    = __( 'We couldn\'t initiate the payment. Please try again.', 'woocommerce-gateway-stripe' );
 		$stripe_params['sepa_mandate_notification']               = apply_filters( 'wc_stripe_sepa_mandate_notification', 'email' );
 		$stripe_params['allow_prepaid_card']                      = apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no';
 		$stripe_params['inline_cc_form']                          = $this->inline_cc_form ? 'yes' : 'no';

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -294,24 +294,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$pay_button_text = '';
 		}
 
-		/**
-		 * Start a payment intent.
-		 *
-		 * @see https://stripe.com/docs/payments/payment-intents/quickstart
-		 */
-		$request = array(
-			'amount'               => WC_Stripe_Helper::get_stripe_amount( $total ),
-			'capture_method'       => 'manual',
-			'currency'             => get_woocommerce_currency(),
-			'allowed_source_types' => array(
-				'card',
-			),
-		);
-
-		// ToDo: Extract this into an ajax call that is performed just before `handleCardPayment` in JS.
-		$intent        = WC_Stripe_API::request( $request, 'payment_intents' );
-		$client_secret = $intent->client_secret;
-
 		ob_start();
 
 		echo '<div
@@ -330,7 +312,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			data-locale="' . esc_attr( apply_filters( 'wc_stripe_checkout_locale', $this->get_locale() ) ) . '"
 			data-three-d-secure="' . esc_attr( $this->three_d_secure ? 'true' : 'false' ) . /* ToDo: three_d_secure should be obsolete */ '"
 			data-allow-remember-me="' . esc_attr( apply_filters( 'wc_stripe_allow_remember_me', true ) ? 'true' : 'false' ) . '"
-			data-client-secret="' . esc_attr( $client_secret ) . '"
 		>';
 
 		if ( $this->testmode ) {
@@ -506,6 +487,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$stripe_params['no_prepaid_card_msg']                     = __( 'Sorry, we\'re not accepting prepaid cards at this time. Your credit card has not been charged. Please try with alternative payment method.', 'woocommerce-gateway-stripe' );
 		$stripe_params['no_sepa_owner_msg']                       = __( 'Please enter your IBAN account name.', 'woocommerce-gateway-stripe' );
 		$stripe_params['no_sepa_iban_msg']                        = __( 'Please enter your IBAN account number.', 'woocommerce-gateway-stripe' );
+		$stripe_params['payment_intent_error']                    = __( 'We could not initiate the payment. Please try again!', 'woocommerce-gateway-stripe' );
 		$stripe_params['sepa_mandate_notification']               = apply_filters( 'wc_stripe_sepa_mandate_notification', 'email' );
 		$stripe_params['allow_prepaid_card']                      = apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no';
 		$stripe_params['inline_cc_form']                          = $this->inline_cc_form ? 'yes' : 'no';
@@ -1014,5 +996,36 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		return $intent_object;
+	}
+
+	/**
+	 * Prepares and retrieves a new PaymentIntent from Stripe's API.
+	 *
+	 * @see https://stripe.com/docs/payments/payment-intents/quickstart
+	 * @return array An array with the intent `id` and `client_secret`.
+	 */
+	public function get_intent_and_secret() {
+		$total = WC()->cart->total;
+
+		if ( empty( WC()->cart->get_cart_contents() ) ) {
+			$message = __( 'Your cart is empty.', 'woocommerce-gateway-stripe' );
+			throw new WC_Stripe_Exception( 'empty_cart', $message );
+		}
+
+		$request = array(
+			'amount'               => WC_Stripe_Helper::get_stripe_amount( $total ),
+			'capture_method'       => 'manual',
+			'currency'             => get_woocommerce_currency(),
+			'allowed_source_types' => array(
+				'card',
+			),
+		);
+
+		$intent = WC_Stripe_API::request( $request, 'payment_intents' );
+
+		return array(
+			'id'            => $intent->id,
+			'client_secret' => $intent->client_secret,
+		);
 	}
 }

--- a/includes/class-wc-stripe-intent-generator.php
+++ b/includes/class-wc-stripe-intent-generator.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Stripe_Intent_Generator class.
+ *
+ * Handles in-checkout AJAX calls, which generate PaymentIntents.
+ */
+class WC_Stripe_Intent_Generator {
+	/**
+	 * Class constructor.
+	 *
+	 * Adds the necessary hooks.
+	 */
+	public function __construct() {
+		add_action( 'wc_ajax_wc_stripe_create_intent', array( $this, 'create_intent' ) );
+	}
+
+	/**
+	 * Handles the "create_event" AJAX action.
+	 */
+	public function create_intent() {
+		$gateway = new WC_Gateway_Stripe;
+
+		try {
+			$intent = $gateway->get_intent_and_secret();
+		} catch ( WC_Stripe_Exception $e ) {
+			$intent = array(
+				'error' => array(
+					'error'   => $e->getMessage(),
+					'message' => $e->getLocalizedMessage(),
+				),
+			);
+		}
+
+		echo wp_json_encode( $intent );
+		exit;
+	}
+}
+
+new WC_Stripe_Intent_Generator;

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -133,6 +133,7 @@ function woocommerce_gateway_stripe_init() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-order-handler.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-payment-tokens.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-customer.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-intent-generator.php';
 
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';


### PR DESCRIPTION
Fixes #787.

#### Changes proposed in this Pull Request:

This PR introduces the `WC_Stripe_Intent_Generator`, which uses the new `get_intent_and_secret` method of `WC_Gateway_Stripe` in order to only generate payment intents when the checkout form is being submitted.

With this change, payment intents will not be generated on every visit of the checkout page. This way merchants will not see empty payment intents in their dashboards and the checkout page loads faster.

To prevent unintended direct access to the new AJAX endpoint, `WC_Stripe_Intent_Generator` will check if the cart has contents, and only create a payment intent when the cart is not empty. This is why a standard WC_AJAX action is used, instead of a REST API endpoint.

#### Testing instructions:

Try creating an order with a credit card. The process should start with a local AJAX request before Stripe's `handleCardPayment` is called.