### PR TITLE
SCA: Use both intents and sources within `process_payment`

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -685,6 +685,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		return (object) array(
+			'is_intent'     => false,
 			'token_id'      => $wc_token_id,
 			'customer'      => $customer_id,
 			'source'        => $source_id,

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -800,7 +800,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		try {
 			$order = wc_get_order( $order_id );
 
-			if ( $this->shoult_redirect_to_stripe_checkout() ) {
+			if ( $this->should_redirect_to_stripe_checkout() ) {
 				return $this->redirect_to_stripe_checkout( $order );
 			}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -641,7 +641,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		if ( WC_Stripe_Helper::is_pre_orders_exists() && $this->pre_orders->is_pre_order( $order_id ) && WC_Pre_Orders_Order::order_requires_payment_tokenization( $order_id ) ) {
 			$result = $this->pre_orders->process_pre_order( $order_id );
 		} else {
-			// ToDo: Do not merge this PR if Stripe checkout remains in place.
 			$result = $this->process_payment( $order_id );
 		}
 
@@ -795,7 +794,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @param mix $previous_error Any error message from previous request.
 	 *
 	 * @throws Exception If payment will not be accepted.
-	 *
 	 * @return array|void
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false, $previous_error = false ) {
@@ -807,7 +805,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			}
 
 			// ToDo: `process_pre_order` saves the source to the order for a later payment.
-			// This would not work well with PaymentIntents.
+			// This might not work well with PaymentIntents.
 			if ( $this->maybe_process_pre_orders( $order_id ) ) {
 				return $this->pre_orders->process_pre_order( $order_id );
 			}
@@ -959,7 +957,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
     /**
      * Charges a source based on an order.
-     *
+	 *
 	 * @since 5.0.0
      * @param  object   $prepared_source An object with everything, related to the source.
      * @param  WC_Order $order           The order that is being paid for.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -731,12 +731,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @throws WC_Stripe_Exception     An exception if the source ID is missing.
 	 */
 	public function check_source( $prepared_source ) {
-		if ( ! empty( $prepared_source->source ) ) {
-			return;
+		if ( empty( $prepared_source->source ) ) {
+			$localized_message = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
+			throw new WC_Stripe_Exception( print_r( $prepared_source, true ), $localized_message );
 		}
-
-		$localized_message = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
-		throw new WC_Stripe_Exception( print_r( $prepared_source, true ), $localized_message );
 	}
 
 	/**

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -743,6 +743,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @since 4.2.0
 	 * @param object   $error The error that was returned from Stripe's API.
 	 * @param WC_Order $order The order those payment is being processed.
+	 * @return bool           A flag that indicates that the customer does not exist and should be removed.
 	 */
 	public function maybe_remove_non_existent_customer( $error, $order ) {
 		if ( ! $this->is_no_such_customer_error( $error ) ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -675,7 +675,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Generates the `process_payment` redirect to Stripe Checkout.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param WC_Order $order The order that needs a payment.
 	 * @return array
 	 */
@@ -691,7 +691,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Creates a new WC_Stripe_Customer if the visitor chooses to.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param WC_Order $order The order that is being created.
 	 */
 	public function maybe_create_customer( $order ) {
@@ -709,7 +709,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * Checks if a source object represents a prepaid credit card and
 	 * throws an exception if it is one, but that is not allowed.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param object   $prepared_source The object with source details.
 	 * @throws WC_Stripe_Exception
 	 */
@@ -726,7 +726,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Checks whether a source exists.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param  object $prepared_source The source that should be verified.
 	 * @throws WC_Stripe_Exception     An exception if the source ID is missing.
 	 */
@@ -742,7 +742,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param object   $error The error that was returned from Stripe's API.
 	 * @param WC_Order $order The order those payment is being processed.
 	 */
@@ -766,7 +766,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Completes an order without a positive value.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param WC_Order $order The order to complete.
 	 * @return array          Redirection data for `process_payment`.
 	 */
@@ -958,7 +958,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
     /**
      * Charges a source based on an order.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
      * @param  object   $prepared_source An object with everything, related to the source.
      * @param  WC_Order $order           The order that is being paid for.
      * @param  mixed    $previous_error  Any error message from a previous request.
@@ -979,7 +979,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Prepares all needed details for an intent.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param int     $user_id            The ID of the current user.
 	 * @param boolean $force_save_source  Should we force save payment source.
 	 *
@@ -1050,7 +1050,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Captures a payment intent.
 	 *
-	 * @since 5.0.0
+	 * @since 4.2.0
 	 * @param object   $prepared_source The already fetched source.
 	 * @param WC_Order $order           The order whose amount is needed.
 	 * @return stdClass                 A response from the API.
@@ -1075,7 +1075,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
     /**
      * Generates a localized message for an error, adds it as a note and throws it.
      *
-	 * @since 5.0.0
+	 * @since 4.2.0
      * @param  stdClass $response  The response from the Stripe API.
      * @param  WC_Order $order     The order to add a note to.
      * @throws WC_Stripe_Exception An exception with the right message.
@@ -1097,7 +1097,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
     /**
      * Retries the payment process once an error occured.
      *
-     * @since 5.0.0
+     * @since 4.2.0
      * @param object   $response          The response from the Stripe API.
      * @param WC_Order $order             An order that is being paid for.
      * @param bool     $retry             A flag that indicates whether another retry should be attempted.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -660,7 +660,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @since 4.1.0
 	 * @return bool
 	 */
-	public function shoult_redirect_to_stripe_checkout() {
+	public function should_redirect_to_stripe_checkout() {
 		$is_payment_request = ( isset( $_POST ) && isset( $_POST['payment_request_type'] ) );
 
 		return (


### PR DESCRIPTION
Fixes #784.

#### Changes proposed in this Pull Request:
- Extracted parts of `process_payment` to separate methods to improve readability.
- Although the initial purpose of this PR was to only use intents within `WC_Gateway_Stripe` and ditch sources, it turned out that this would not work with Stripe Checkout.
- There is a clear separation between intents and sources in terms of loading and processing.

__Note:__ This is a stacked PR that needs to be merged into https://github.com/woocommerce/woocommerce-gateway-stripe/pull/795. Focus on that one first, please.