### PR TITLE
SCA: JavaScript inline docs & cleanup

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -721,7 +721,6 @@ jQuery( function( $ ) {
 				return true; // The checkout form will be sumitted if this is !== false.
 			}
 
-			e.preventDefault();
 			wc_stripe_form.block();
 			wc_stripe_form.createSource();
 

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -583,7 +583,7 @@ jQuery( function( $ ) {
 
 			// Handle SEPA Direct Debit payments.
 			if ( wc_stripe_form.isSepaChosen() ) {
-				extra_details.currency = $( '#stripe-sepa_debig-payment-data' ).data( 'currency' );
+				extra_details.currency = $( '#stripe-sepa_debit-payment-data' ).data( 'currency' );
 				extra_details.mandate  = { notification_method: wc_stripe_params.sepa_mandate_notification };
 				extra_details.type     = 'sepa_debit';
 

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -378,18 +378,6 @@ jQuery( function( $ ) {
 		},
 
 		/**
-		 * Checks if a legacy token ID is present as a hidden input.
-		 *
-		 * ToDo: Check whether such inputs would appear from PHP and either
-		 * remove this check or make sure that the needed PHP logic is in place.
-		 *
-		 * @return {boolean}
-		 */
-		hasToken: function() {
-			return 0 < $( 'input.stripe_token' ).length;
-		},
-
-		/**
 		 * Checks whether a payment intent ID is present as a hidden input.
 		 * Only used in combination with credit cards.
 		 *
@@ -419,10 +407,7 @@ jQuery( function( $ ) {
 		 * @return {boolean}
 		 */
 		isStripeModalNeeded: function() {
-			var token = wc_stripe_form.form.find( 'input.stripe_token' );
-
-			// If this is a stripe submission (after modal) and token exists, allow submit.
-			if ( wc_stripe_form.stripe_submit && token ) {
+			if ( 'yes' !== wc_stripe_params.is_stripe_checkout ) {
 				return false;
 			}
 
@@ -671,13 +656,13 @@ jQuery( function( $ ) {
 			 * ToDo: The logic here was restructured a bit, make sure it still works well.
 			 */
 
-			// If a source, token, or an intent is already in place, submit the form as usual.
-			if ( wc_stripe_form.isStripeSaveCardChosen() || wc_stripe_form.hasSource() || wc_stripe_form.hasToken() || wc_stripe_form.hasIntent() ) {
+			// If a source, or an intent is already in place, submit the form as usual.
+			if ( wc_stripe_form.isStripeSaveCardChosen() || wc_stripe_form.hasSource() || wc_stripe_form.hasIntent() ) {
 				return true;
 			}
 
 			// Open the Stripe Checkout modal.
-			if ( 'yes' === wc_stripe_params.is_stripe_checkout && wc_stripe_form.isStripeModalNeeded() && wc_stripe_form.isStripeCardChosen() ) {
+			if ( wc_stripe_form.isStripeModalNeeded() && wc_stripe_form.isStripeCardChosen() ) {
 				if ( 'yes' === wc_stripe_params.is_checkout ) {
 					return true;
 				} else {
@@ -732,7 +717,7 @@ jQuery( function( $ ) {
 		},
 
 		/**
-		 * If a new credit card is entered, reset sources, tokens, and intents.
+		 * If a new credit card is entered, reset sources, and intents.
 		 */
 		onCCFormChange: function() {
 			wc_stripe_form.reset();
@@ -742,7 +727,7 @@ jQuery( function( $ ) {
 		 * Removes all Stripe errors and hidden fields with IDs from the form.
 		 */
 		reset: function() {
-			$( '.wc-stripe-error, .stripe-source, .stripe_token, .stripe-intent' ).remove();
+			$( '.wc-stripe-error, .stripe-source, .stripe-intent' ).remove();
 		},
 
 		/**

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -245,6 +245,7 @@ jQuery( function( $ ) {
 
 			if ( 'yes' === wc_stripe_params.is_stripe_checkout ) {
 				$( document.body ).on( 'click', '.wc-stripe-checkout-button', function() {
+					wc_stripe_form.block();
 					wc_stripe_form.openModal();
 					return false;
 				} );
@@ -491,7 +492,7 @@ jQuery( function( $ ) {
 				panelLabel        : $data.data( 'panel-label' ),
 				allowRememberMe   : $data.data( 'allow-remember-me' ),
 				token             : token_action,
-				closed            : wc_stripe_form.onClose()
+				closed            : wc_stripe_form.onClose,
 			} );
 		},
 
@@ -657,16 +658,13 @@ jQuery( function( $ ) {
 		/**
 		 * Performs payment-related actions when a checkout/payment form is being submitted.
 		 *
-		 * @param {Event} e A form submission event.
+		 * @return {boolean} An indicator whether the submission should proceed.
+		 *                   WooCommerce's checkout.js stops only on `false`, so this needs to be explicit.
 		 */
-		onSubmit: function( e ) {
+		onSubmit: function() {
 			if ( ! wc_stripe_form.isStripeChosen() ) {
-				return;
+				return true;
 			}
-
-			/**
-			 * ToDo: The logic here was restructured a bit, make sure it still works well.
-			 */
 
 			// If a source, or an intent is already in place, submit the form as usual.
 			if ( wc_stripe_form.isStripeSaveCardChosen() || wc_stripe_form.hasSource() || wc_stripe_form.hasIntent() ) {
@@ -678,6 +676,7 @@ jQuery( function( $ ) {
 				if ( 'yes' === wc_stripe_params.is_checkout ) {
 					return true;
 				} else {
+					wc_stripe_form.block();
 					wc_stripe_form.openModal();
 					return false;
 				}
@@ -694,31 +693,7 @@ jQuery( function( $ ) {
 				wc_stripe_form.isEpsChosen() ||
 				wc_stripe_form.isMultibancoChosen()
 			) {
-				if ( $( 'form#order_review' ).length ) {
-					$( 'form#order_review' )
-						.off(
-							'submit',
-							this.onSubmit
-						);
-
-					wc_stripe_form.form.submit();
-
-					return false;
-				}
-
-				if ( $( 'form#add_payment_method' ).length ) {
-					$( 'form#add_payment_method' )
-						.off(
-							'submit',
-							this.onSubmit
-						);
-
-					wc_stripe_form.form.submit();
-
-					return false;
-				}
-
-				return true; // The checkout form will be sumitted if this is !== false.
+				return true;
 			}
 
 			wc_stripe_form.block();

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -603,8 +603,8 @@ jQuery( function( $ ) {
 		/**
 		 * Handles responses, based on source object.
 		 *
-		 * After the switch to payment intents in {PAYMENT_INTENTS_VERSION} this method
-		 * is only applicable to SEPA Direct Debit payments, as cards are handled by
+		 * After the switch to payment intents in 4.2.0 this method is only applicable to
+		 * SEPA Direct Debit payments and the Stripe Checkout modal, as cards are handled by
 		 * intents and all other payment methods require a redirect to an external portal.
 		 *
 		 * @param {Object} response The `stripe.createSource` response.
@@ -615,7 +615,13 @@ jQuery( function( $ ) {
 			}
 
 			wc_stripe_form.reset();
-			wc_stripe_form.addHiddenInput( 'source', response.source.id );
+
+			wc_stripe_form.form.append(
+				$( '<input type="hidden" />' )
+					.addClass( 'stripe-source' )
+					.attr( 'name', 'stripe_source' )
+					.val( response.source.id )
+			);
 
 			if ( $( 'form#add_payment_method' ).length ) {
 				$( wc_stripe_form.form ).off( 'submit', wc_stripe_form.form.onSubmit );
@@ -635,7 +641,13 @@ jQuery( function( $ ) {
 			}
 
 			wc_stripe_form.reset();
-			wc_stripe_form.addHiddenInput( 'intent', response.paymentIntent.id );
+
+			wc_stripe_form.form.append(
+				$( '<input type="hidden" />' )
+					.addClass( 'stripe-intent' )
+					.attr( 'name', 'stripe_intent' )
+					.val( response.paymentIntent.id )
+			);
 
 			// ToDo: Check for `form#add_payment_method` and remove event listeners
 
@@ -728,23 +740,6 @@ jQuery( function( $ ) {
 		 */
 		reset: function() {
 			$( '.wc-stripe-error, .stripe-source, .stripe-intent' ).remove();
-		},
-
-		/**
-		 * Adds a hidden input with the ID of a payment intent or source.
-		 *
-		 * @param {string} type  The type of value that is being added to the form, ex. `source`.
-		 * @param {string} value The ID of the source/payment intent.
-		 */
-		addHiddenInput: function( type, value ) {
-			$( '.stripe-source, .stripe-intent' ).remove();
-
-			wc_stripe_form.form.append(
-				$( '<input type="hidden" />' )
-					.addClass( 'stripe-' + type )
-					.attr( 'name', 'stripe_' + type )
-					.val( value )
-			);
 		},
 
 		/**


### PR DESCRIPTION
I started this PR a while back in order to fully understand the checkout flow in `stripe.js` and what needs to be changed. During the process I did:

1. Add JSDoc comments to every method to clarify what it does both to myself and the next developer that works on the extension.
2. Removed the parts, related to Stripe Checkout (as I thought it's becoming obsolete and will be removed), then restored them, along with comments.
3. *Most importantly,* I realized that most "personalities" (separate payment options like Sofort and etc.) do not involve any JavaScript actions and use follow-up redirects instead. 

#### `createSource()` and `onSubmit()` changes

Most of the changes in those two methods are related to the fact that if either of the following methods returns `true`, the form handler with detach itself and re-submit the form:

- `isBancontactChosen`
- `isGiropayChosen`
- `isIdealChosen`
- `isAlipayChosen`
- `isSofortChosen`
- `isP24Chosen`
- `isEpsChosen`
- `isMultibancoChosen`

This conclusion allowed me to clean up `onSubmit` a bit. Also, a lot of the `switch`es and `if`s in `createSource` are now gong, since they will never be entered.