### PR TITLE
SCA: Add order meta

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1011,16 +1011,20 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			throw new WC_Stripe_Exception( 'empty_cart', $message );
 		}
 
-		// ToDo: Add meta
-
 		$request = array(
 			'amount'               => WC_Stripe_Helper::get_stripe_amount( $total ),
 			'capture_method'       => 'manual',
 			'currency'             => get_woocommerce_currency(),
+			'description'          => wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ),
+			'statement_descriptor' => '',
 			'allowed_source_types' => array(
 				'card',
 			),
 		);
+
+        if ( ! empty( $this->get_option( 'statement_descriptor' ) ) ) {
+            $request['statement_descriptor'] = WC_Stripe_Helper::clean_statement_descriptor( str_replace( "'", '', $this->get_option( 'statement_descriptor' ) ) );
+        }
 
 		$intent = WC_Stripe_API::request( $request, 'payment_intents' );
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -814,6 +814,15 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 			// Make the request.
 			if ( $prepared_source->is_intent ) {
+				// Update the intent with proper meta and description.
+				$full_request = $this->generate_payment_request( $order, $prepared_source );
+				$updated_data = array(
+					'description' => $full_request['description'],
+					'metadata'    => $full_request['metadata'],
+				);
+				WC_Stripe_API::request( $updated_data, "payment_intents/{$prepared_source->intent_id}" );
+
+				// Capture the intent.
 				$response = $this->capture_intent( $prepared_source, $order );
 			} else {
 				$response = $this->charge_source( $prepared_source, $order, $previous_error );
@@ -824,37 +833,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 					$this->maybe_remove_non_existent_customer( $response->error, $order );
 				}
 
-				// Make the request.
-				if ( $prepared_source->is_intent ) {
-					// Update the intent with proper meta and description.
-					$full_request = $this->generate_payment_request( $order, $prepared_source );
-					$updated_data = array(
-						'description' => $full_request['description'],
-						'metadata'    => $full_request['metadata'],
-					);
-					WC_Stripe_API::request( $updated_data, "payment_intents/{$prepared_source->intent_id}" );
-
-					// Capture the intent.
-					$post_data = array(
-						'amount_to_capture' => WC_Stripe_Helper::get_stripe_amount( $order->get_total() ),
-					);
-					$response = WC_Stripe_API::request( $post_data, "payment_intents/{$prepared_source->intent_id}/capture" );
-
-					if ( ! empty( $response->error ) ) {
-						$response_error = $response->error;
-					} else {
-						// ToDo: Check whether chrges[] only contains a single charge.
-						$charge = $response->charges->data[0];
-					}
-				} else {
-					$response = WC_Stripe_API::request( $this->generate_payment_request( $order, $prepared_source ) );
-
-					if ( ! empty( $response->error ) ) {
-						$response_error = $response->error;
-					} else {
-						// ToDo: Check whether chrges[] only contains a single charge.
-						$charge = $response;
-					}
+				// We want to retry.
+				if ( $this->is_retryable_error( $response->error ) ) {
+					return $this->retry_after_error( $response, $order, $retry, $force_save_source, $previous_error );
 				}
 
 				$this->throw_localized_message( $response, $order );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1011,6 +1011,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			throw new WC_Stripe_Exception( 'empty_cart', $message );
 		}
 
+		// ToDo: Add meta
+
 		$request = array(
 			'amount'               => WC_Stripe_Helper::get_stripe_amount( $total ),
 			'capture_method'       => 'manual',


### PR DESCRIPTION
Fixes #797 .

#### Changes proposed in this Pull Request:
- Add basic `description` and `statement_descriptor` while creating payment intents.
- Update the `description` field of the payment intent and add the necessary `metadata` to it before capturing the payment.

#### Using `generate_payment_request` for the update

This is a part of the PR:

```php
$full_request = $this->generate_payment_request( $order, $prepared_source );
$updated_data = array(
    'description' => $full_request['description'],
    'metadata'    => $full_request['metadata'],
);
```

In order to avoid duplicate code and allow existing filters to work, I am calling `generate_payment_request` even though I am only partially using the data that it generates. Do you consider this an issue?