### PR TITLE
Always return the last charge made to a PaymentIntent, instead of the first one

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1094,8 +1094,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return $response;
 		}
 
-		// ToDo: Check whether chrges[] only contains a single charge.
-		return $response->charges->data[0];
+		return end( $response->charges->data );
 	}
 
     /**


### PR DESCRIPTION
Fixes #789 

After calling `/payment_intents/xxxxx/capture`, the returned response is guaranteed to have at least 1 `Charge` object in its list. But, it's possible for a Payment intent to have multiple charges, for example for partial payments or if there have been retries on the same Intent object. It's safer to return the last Charge object instead of the first.