### PR TITLE
Setting: Retain Stripe Data, place in correct spot settings array

### DIFF
--- a/includes/admin/class-wc-stripe-privacy.php
+++ b/includes/admin/class-wc-stripe-privacy.php
@@ -44,7 +44,18 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 			),
 		);
 
-		array_splice( $settings, ( count( $settings ) - 1 ), 0, $insert_setting );
+		$index = null;
+
+		foreach ( $settings as $key => $value) {
+			if ( 'sectionend' === $value[ 'type' ] && 'personal_data_retention' === $value[ 'id' ] ) {
+				$index = $key;
+				break;
+			}
+		}
+
+		if ( ! is_null( $index ) ) {
+			array_splice( $settings, $index, 0, $insert_setting );
+		}
 
 		return $settings;
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "4.1.10",
+  "version": "4.1.15",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -101,6 +101,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 4.1.15 - 2019-03-10 =
+* Fix - "Retain Stripe Data" setting placement on WooCommerce settings page.
+
 = 4.1.14 - 2019-01-10 =
 * Remove - Stripe specific styling to allow themes to style accordingly.
 * Tweak  - Handle error if product is not found in payment request.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Explicitly place the "Retain Stripe Data" setting at the end of the `personal_data_retention` section of settings instead of appending it as the second to last entry in the settings array. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

#### Avoids this issue when Core adds additional settings

![screen shot 2019-03-05 at 11 04 50 am](https://user-images.githubusercontent.com/1922453/53767529-f86c2200-3f3a-11e9-8512-bcab4dc0f06f.png)

#### Test instruction

1. WooCommerce > Settings > Accounts & Privacy
2. The "Retain Stripe Data" should be the last entry in the "Personal data retention" section. 
