### PR TITLE
Changed how session are handled to prevent a 2 session situation

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -155,14 +155,7 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
-		$wc_session    = new $session_class();
-
-		if ( version_compare( WC_VERSION, '3.3', '>=' ) ) {
-			$wc_session->init();
-		}
-
-		$wc_session->set_customer_session_cookie( true );
+		WC()->session->set_customer_session_cookie( true );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #819.

#### Changes proposed in this Pull Request:
- Uses the existing WC()->session and instance instead of creating a new one to prevent edge cases and improve plugin compatibility
- Remove version check for WC 3.3+, doesn't _seem_ to be needed

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

