### PR TITLE
Update the Stripe's API version we support

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -843,7 +843,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				$response = end( $intent->charges->data );
 
 				// If the intent requires a 3DS flow, redirect to it.
-				if ( 'requires_source_action' === $intent->status ) {
+				if ( 'requires_action' === $intent->status ) {
 					if ( is_wc_endpoint_url( 'order-pay' ) ) {
 						$redirect_url = add_query_arg( 'wc-stripe-confirmation', 1, $order->get_checkout_payment_url( false ) );
 					} else {
@@ -1086,7 +1086,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			'description'          => $full_request['description'],
 			'metadata'             => $full_request['metadata'],
 			'statement_descriptor' => $full_request['statement_descriptor'],
-			'allowed_source_types' => array(
+			'payment_method_types' => array(
 				'card',
 			),
 		);
@@ -1120,7 +1120,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		// Save a note about the status of the intent.
 		if ( 'succeeded' === $confirmed_intent->status ) {
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
-		} elseif ( 'requires_source_action' === $confirmed_intent->status ) {
+		} elseif ( 'requires_action' === $confirmed_intent->status ) {
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id requires authentication for order $order_id" );
 		}
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -14,7 +14,7 @@ class WC_Stripe_API {
 	 * Stripe API Endpoint
 	 */
 	const ENDPOINT           = 'https://api.stripe.com/v1/';
-	const STRIPE_API_VERSION = '2018-09-24';
+	const STRIPE_API_VERSION = '2019-02-19';
 
 	/**
 	 * Secret API Key.


### PR DESCRIPTION
The Stripe API version has been bumped to `2019-02-19` in `master` here: https://github.com/woocommerce/woocommerce-gateway-stripe/commit/7b32ad1710f6693d73fc8f4c1bdb064a8420a0fa

This PR makes the same change for the SCA feature branch. There were some minor naming changes related to Payment Intents, described here: https://stripe.com/docs/upgrades#2019-02-11
