### PR TITLE
Add warning notice for merchants that use the Modal checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
-= 4.1.16 - 2019-xx-xx =
+= 4.1.16 - 2019-04-15 =
+* Deprecate - Warn about the future removal of the Modal Checkout option.
 * Tweak - WC 3.6 compatibility.
 
 = 4.1.15 - 2019-03-12 =

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -200,20 +200,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Allow this class and other classes to add slug keyed notices (to avoid duplication).
-	 *
-	 * @since 1.0.0
-	 * @version 4.0.0
-	 */
-	public function add_admin_notice( $slug, $class, $message, $dismissible = false ) {
-		$this->notices[ $slug ] = array(
-			'class'       => $class,
-			'message'     => $message,
-			'dismissible' => $dismissible,
-		);
-	}
-
-	/**
 	 * All payment icons that work with Stripe. Some icons references
 	 * WC core icons.
 	 *

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -111,6 +111,7 @@ class WC_Stripe_Admin_Notices {
 		$test_secret_key    = isset( $options['test_secret_key'] ) ? $options['test_secret_key'] : '';
 		$live_pub_key       = isset( $options['publishable_key'] ) ? $options['publishable_key'] : '';
 		$live_secret_key    = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
+		$checkout_enabled = isset( $options['stripe_checkout'] ) && 'yes' === $options['stripe_checkout'];
 
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
 			if ( empty( $show_style_notice ) ) {
@@ -187,6 +188,12 @@ class WC_Stripe_Admin_Notices {
 					/* translators: 1) link */
 					$this->add_admin_notice( 'ssl', 'notice notice-warning', sprintf( __( 'Stripe is enabled, but a SSL certificate is not detected. Your checkout may not be secure! Please ensure your server has a valid <a href="%1$s" target="_blank">SSL certificate</a>', 'woocommerce-gateway-stripe' ), 'https://en.wikipedia.org/wiki/Transport_Layer_Security' ), true );
 				}
+			}
+
+			if ( $checkout_enabled ) {
+				$url = 'https://docs.woocommerce.com/document/stripe/modal-checkout';
+				$message = sprintf( __( 'WooCommerce Stripe - Support for Stripe Modal Checkout will be ending soon. This will impact the appearance of your checkout. <a href="%1$s" target="_blank">Click here to learn more.</a>', 'woocommerce-gateway-stripe' ), $url );
+				$this->add_admin_notice( 'legacy_checkout', 'notice notice-warning', $message );
 			}
 		}
 	}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -111,9 +111,15 @@ class WC_Stripe_Admin_Notices {
 		$test_secret_key    = isset( $options['test_secret_key'] ) ? $options['test_secret_key'] : '';
 		$live_pub_key       = isset( $options['publishable_key'] ) ? $options['publishable_key'] : '';
 		$live_secret_key    = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
-		$checkout_enabled = isset( $options['stripe_checkout'] ) && 'yes' === $options['stripe_checkout'];
+		$checkout_enabled   = isset( $options['stripe_checkout'] ) && 'yes' === $options['stripe_checkout'];
 
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
+			if ( $checkout_enabled ) {
+				$url = 'https://docs.woocommerce.com/document/stripe/modal-checkout';
+				$message = sprintf( __( 'WooCommerce Stripe - Support for Stripe Modal Checkout will be ending soon. This will impact the appearance of your checkout. <a href="%1$s" target="_blank">Click here to learn more.</a>', 'woocommerce-gateway-stripe' ), $url );
+				$this->add_admin_notice( 'legacy_checkout', 'notice notice-warning', $message );
+			}
+
 			if ( empty( $show_style_notice ) ) {
 				/* translators: 1) int version 2) int version */
 				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://docs.woocommerce.com/document/stripe/#section-45" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );
@@ -188,12 +194,6 @@ class WC_Stripe_Admin_Notices {
 					/* translators: 1) link */
 					$this->add_admin_notice( 'ssl', 'notice notice-warning', sprintf( __( 'Stripe is enabled, but a SSL certificate is not detected. Your checkout may not be secure! Please ensure your server has a valid <a href="%1$s" target="_blank">SSL certificate</a>', 'woocommerce-gateway-stripe' ), 'https://en.wikipedia.org/wiki/Transport_Layer_Security' ), true );
 				}
-			}
-
-			if ( $checkout_enabled ) {
-				$url = 'https://docs.woocommerce.com/document/stripe/modal-checkout';
-				$message = sprintf( __( 'WooCommerce Stripe - Support for Stripe Modal Checkout will be ending soon. This will impact the appearance of your checkout. <a href="%1$s" target="_blank">Click here to learn more.</a>', 'woocommerce-gateway-stripe' ), $url );
-				$this->add_admin_notice( 'legacy_checkout', 'notice notice-warning', $message );
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "4.1.15",
+  "version": "4.1.16",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort,
 Requires at least: 4.4
 Tested up to: 5.0
 Requires PHP: 5.6
-Stable tag: 4.1.15
+Stable tag: 4.1.16
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 4.1.15
+ * Version: 4.1.16
  * Requires at least: 4.4
  * Tested up to: 5.0
  * WC requires at least: 2.6
@@ -46,7 +46,7 @@ function woocommerce_gateway_stripe_init() {
 		/**
 		 * Required minimums and constants
 		 */
-		define( 'WC_STRIPE_VERSION', '4.1.15' );
+		define( 'WC_STRIPE_VERSION', '4.1.16' );
 		define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 		define( 'WC_STRIPE_MIN_WC_VER', '2.6.0' );
 		define( 'WC_STRIPE_MAIN_FILE', __FILE__ );


### PR DESCRIPTION
Fixes #835 (see the issue for more context)

The notice is a `warning`, non-dismissable, and it only appears if the `Stripe Modal Checkout` option is checked. The notice has a link to this page, which will have relevant info by Monday: https://docs.woocommerce.com/document/stripe/modal-checkout

I also took the liberty of getting the plugin ready to cut the `4.1.16` release on Monday.