### PR TITLE
SCA: Try handleCardAction and manual confirmations

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -389,6 +389,15 @@ jQuery( function( $ ) {
 		},
 
 		/**
+		 * Checks if the currently displayed page is the "Add payment method" one.
+		 *
+		 * @return {boolean}
+		 */
+		isAddPaymentMethodPage() {
+			return 0 < $( 'form#add_payment_method' ).length;
+		},
+
+		/**
 		 * Checks if a source ID is present as a hidden input.
 		 * Only used when SEPA Direct Debit is chosen.
 		 *
@@ -641,6 +650,9 @@ jQuery( function( $ ) {
 			wc_stripe_form.form.submit();
 		},
 
+		/**
+		 * Initiates the creation of a payment method object based on elements.
+		 */
 		createPaymentMethod: function() {
 			var extra_details = wc_stripe_form.getOwnerDetails();
 
@@ -652,6 +664,11 @@ jQuery( function( $ ) {
 				.then( wc_stripe_form.paymentMethodResponse );
 		},
 
+		/**
+		 * Responds to `createPaymentMethod` by adding a hidden input with the method's ID.
+		 *
+		 * @param {Object} response The response from `createPaymentMethod`.
+		 */
 		paymentMethodResponse: function( response ) {
 			if ( response.error ) {
 				return $( document.body ).trigger( 'stripeError', response );
@@ -665,11 +682,6 @@ jQuery( function( $ ) {
 					.attr( 'name', 'stripe_payment_method' )
 					.val( response.paymentMethod.id )
 			);
-
-			 // ToDo: Check if this is even necessary.
-			// if ( $( 'form#add_payment_method' ).length ) {
-				// $( wc_stripe_form.form ).off( 'submit', wc_stripe_form.form.onSubmit );
-			// }
 
 			wc_stripe_form.form.submit();
 		},
@@ -716,7 +728,7 @@ jQuery( function( $ ) {
 			}
 
 			wc_stripe_form.block();
-			if ( wc_stripe_form.isSepaChosen() ) {
+			if ( wc_stripe_form.isSepaChosen() || wc_stripe_form.isAddPaymentMethodPage() ) {
 				wc_stripe_form.createSource();
 			} else {
 				wc_stripe_form.createPaymentMethod();

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -853,7 +853,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			}
 
 			// Process valid response.
-			$this->process_intent_response( $intent, $order );
+			$this->process_response( end( $intent->charges->data ), $order );
 
 			// Remove cart.
 			WC()->cart->empty_cart();
@@ -1070,8 +1070,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$request = array(
 			'payment_method'       => $prepared_source->source,
 			'amount'               => WC_Stripe_Helper::get_stripe_amount( $order->get_total() ),
-			"confirm"              => 'true',
-			"confirmation_method"  => 'manual',
+			'confirm'              => 'true',
+			'confirmation_method'  => 'manual',
 			'currency'             => strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() ),
 			'description'          => $full_request['description'],
 			'metadata'             => $full_request['metadata'],

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -377,8 +377,6 @@ class WC_Stripe_Customer {
 			return false;
 		}
 
-		var_dump( $source_id ); exit;
-
 		$response = WC_Stripe_API::request( array(), 'customers/' . $this->get_id() . '/sources/' . sanitize_text_field( $source_id ), 'DELETE' );
 
 		$this->clear_cache();

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -109,7 +109,7 @@ class WC_Stripe_Payment_Tokens {
 							$token->set_token( $source->id );
 							$token->set_gateway_id( 'stripe' );
 
-							if ( 'source' === $source->object && 'card' === $source->type ) {
+							if ( ( 'source' === $source->object || 'payment_method' === $source->object ) && 'card' === $source->type ) {
 								$token->set_card_type( strtolower( $source->card->brand ) );
 								$token->set_last4( $source->card->last4 );
 								$token->set_expiry_month( $source->card->exp_month );


### PR DESCRIPTION
A spike to try and avoid "no diff" payment intention confirmation requests (i.e. PI confirmation requests where nothing has changed since the last time.)

Combining https://stripe.com/docs/payments/payment-intents/quickstart#flow-manual-confirmation with the current SCA approach, WIP.