### PR TITLE
Revert "Update woocommerce-gateway-stripe.php"

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Version: 4.1.15
  * Requires at least: 4.4
- * Tested up to: 5.1.1
+ * Tested up to: 5.0
  * WC requires at least: 2.6
  * WC tested up to: 3.6
  * Text Domain: woocommerce-gateway-stripe


### PR DESCRIPTION
Reverts woocommerce/woocommerce-gateway-stripe#842

This is not a recommended version change. Version 5.1 instead of 5.1.1 should be used.