### PR TITLE
PR: Payment Request Buttons: Add Puerto Rico to allowable countries list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 4.1.16 - 2019-04-18 =
 * Deprecate - Warn about the future removal of the Modal Checkout option.
 * Tweak - WC 3.6 compatibility.
-* Update - Add Puerto Rico to supported countries for Payment Requests.
+* Update - Enable Payment Request buttons for Puerto Rico based stores.
 
 = 4.1.15 - 2019-03-12 =
 * Fix - Prevent canceled webhook from processing non Stripe payments.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 4.1.16 - 2019-04-18 =
 * Deprecate - Warn about the future removal of the Modal Checkout option.
 * Tweak - WC 3.6 compatibility.
+* Update - Add Puerto Rico to supported countries for Payment Requests.
 
 = 4.1.15 - 2019-03-12 =
 * Fix - Prevent canceled webhook from processing non Stripe payments.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,11 @@
 *** Changelog ***
 
+= 4.2.0 - 2019-xx-xx =
+* Update - Enable Payment Request buttons for Puerto Rico based stores.
+
 = 4.1.16 - 2019-04-18 =
 * Deprecate - Warn about the future removal of the Modal Checkout option.
 * Tweak - WC 3.6 compatibility.
-* Update - Enable Payment Request buttons for Puerto Rico based stores.
 
 = 4.1.15 - 2019-03-12 =
 * Fix - Prevent canceled webhook from processing non Stripe payments.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -117,7 +117,7 @@ class WC_Stripe_Payment_Request {
 	 * @return array The list of countries.
 	 */
 	public function get_stripe_supported_countries() {
-		return apply_filters( 'wc_stripe_supported_countries', array( 'AT', 'AU', 'BE', 'BR', 'CA', 'CH', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'HK', 'IE', 'IN', 'IT', 'JP', 'LT', 'LU', 'LV', 'MX', 'NL', 'NZ', 'NO', 'PH', 'PL', 'PT', 'RO', 'SE', 'SG', 'SK', 'US' ) );
+		return apply_filters( 'wc_stripe_supported_countries', array( 'AT', 'AU', 'BE', 'BR', 'CA', 'CH', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'HK', 'IE', 'IN', 'IT', 'JP', 'LT', 'LU', 'LV', 'MX', 'NL', 'NZ', 'NO', 'PH', 'PL', 'PR', 'PT', 'RO', 'SE', 'SG', 'SK', 'US' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #844 .

#### Changes proposed in this Pull Request:
- Add Puerto Rico to allowable countries list.

Test:

* Set store's base location to Puerto Rico.
* Enable Payment Request Buttons if not already enabled.
* Visit a product page and note how Stripe Payment Request JS files are not included.
* Checkout this branch and make sure Apple Pay & Google Pay buttons available.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

