### PR TITLE
Bail if the site is HTTP and testing mode is disabled

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -447,6 +447,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		// If no SSL bail.
 		if ( ! $this->testmode && ! is_ssl() ) {
 			WC_Stripe_Logger::log( 'Stripe live mode requires SSL.' );
+			return;
 		}
 
 		$current_theme = wp_get_theme();


### PR DESCRIPTION
The "return" statement was removed here: https://github.com/woocommerce/woocommerce-gateway-stripe/commit/b2a9812b40c412bdc41297315e65bff526e8acd1#diff-2f62df4143b223ac0f7805c02376412eL456
It looks like its removal was unintended.
