### PR TITLE
Correctly calculate Stripe fees when doing a partial capture through Stripe Dashboard

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -424,23 +424,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		// Store charge data.
 		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', $captured ) : $order->update_meta_data( '_stripe_charge_captured', $captured );
 
-		$balance_transaction = isset( $response->balance_transaction ) ? $response->balance_transaction : false;
-		if ( is_string( $response->balance_transaction ) ) {
-			$balance_transaction = WC_Stripe_API::request( array(), "balance/history/$response->balance_transaction", 'GET' );
-		}
-
-		// Store other data such as fees.
-		if ( $balance_transaction ) {
-			// Fees and Net needs to both come from Stripe to be accurate as the returned
-			// values are in the local currency of the Stripe account, not from WC.
-			$fee = ! empty( $balance_transaction->fee ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'fee' ) : 0;
-			$net = ! empty( $balance_transaction->net ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'net' ) : 0;
-			WC_Stripe_Helper::update_stripe_fee( $order, $fee );
-			WC_Stripe_Helper::update_stripe_net( $order, $net );
-
-			// Store currency stripe.
-			$currency = ! empty( $balance_transaction->currency ) ? strtoupper( $balance_transaction->currency ) : null;
-			WC_Stripe_Helper::update_stripe_currency( $order, $currency );
+		if ( isset( $response->balance_transaction ) ) {
+			$this->update_fees( $order, is_string( $response->balance_transaction ) ? $response->balance_transaction : $response->balance_transaction->id );
 		}
 
 		if ( 'yes' === $captured ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -305,6 +305,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				if ( $this->is_partial_capture( $notification ) ) {
 					$partial_amount = $this->get_partial_amount_to_charge( $notification );
 					$order->set_total( $partial_amount );
+					$this->update_fees( $order, $notification->data->object->refunds->data[0]->balance_transaction );
 					/* translators: partial captured amount */
 					$order->add_order_note( sprintf( __( 'This charge was partially captured via Stripe Dashboard in the amount of: %s', 'woocommerce-gateway-stripe' ), $partial_amount ) );
 				} else {


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/851

Stripe treats a "partial capture" (capturing a payment for less money that was originally authorized) as a `Charge` object with a partial `Refund` inside it.

When doing a partial capture from the Stripe Dashboard, we rely on the `charge.captured` Webhook to update the order and the Stripe fees. Before, everything worked, except that the fees were being calculated wrong (the resulting fees would be for the whole payment, whereas the correct fees should be `full_payment_fees - partial_refund_fees`). This PR fixes that.

@dechov I haven't been able to fully reproduce the original issue. Apart from the wrong calculation of the fees, everything else seemed to be working fine. This is a screenshor of a `$20.95` order with a partial capture of `$10` made on Stripe Dashboard, on `sca/master`:

<img width="874" alt="Screenshot 2019-05-02 at 14 09 02" src="https://user-images.githubusercontent.com/1715800/57075082-101b1900-6ce6-11e9-8238-8ddcd91ecd37.png">

And here is a similar situation (the order was `$12.95`, `$7.95` captured on Stripe Dashboard) after this fix:

<img width="611" alt="Screenshot 2019-05-02 at 14 16 56" src="https://user-images.githubusercontent.com/1715800/57075164-507a9700-6ce6-11e9-8bfc-748cd48cce1f.png">
