### PR TITLE
SCA: Add compatibility back to WooCommerce 2.6

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1170,7 +1170,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return bool            A flag that indicates whether the order is already locked.
 	 */
 	public function lock_order_payment( $order, $intent ) {
-		$transient_name = 'wc_stripe_processing_intent_' . $order->get_id();
+		$order_id       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$transient_name = 'wc_stripe_processing_intent_' . $order_id;
 		$processing     = get_transient( $transient_name );
 
 		// Block the process if the same intent is already being handled.
@@ -1191,6 +1192,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param WC_Order $order The order that is being unlocked.
 	 */
 	public function unlock_order_payment( $order ) {
-		delete_transient( 'wc_stripe_processing_intent_' . $order->get_id() );
+		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		delete_transient( 'wc_stripe_processing_intent_' . $order_id );
 	}
 }

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -984,7 +984,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( $order->get_payment_method() !== $this->id ) {
+		$payment_method = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method();
+		if ( $payment_method !== $this->id ) {
 			// If this is not the payment method, an intent would not be available.
 			return;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR ensures that the gateway works correctly back to WooCommerce 2.6. The amount of needed changes is surprisingly small based on the fact that we have 1000+ additions in `sca/master`.

#### Testing instructions

Checkout WooCommerce 2.6 and do a couple of tests with the gateway:

- With a standard (non-3DS card)
- With a 3DS card
- With webhooks enabled (and check the response of webhooks in Stripe Dashboard)