### PR TITLE
SCA/FIX: Prevent multiple error messages because of saved cards

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -610,8 +610,14 @@ jQuery( function( $ ) {
 		 * @param {Object} result The result of Stripe call.
 		 */
 		onError: function( e, result ) {
-			var message = result.error.message,
-				errorContainer = wc_stripe_form.getSelectedPaymentElement().parents( 'li' ).eq(0).find( '.stripe-source-errors' );
+			var message = result.error.message;
+
+			var selectedMethodElement = wc_stripe_form.getSelectedPaymentElement().closest( 'li' );
+
+			// Use the right error wrapper if there are saved cards.
+			var errorContainer = selectedMethodElement.find( '.woocommerce-SavedPaymentMethods-tokenInput' ).length
+				? selectedMethodElement.find( '.woocommerce-SavedPaymentMethods-tokenInput:checked' ).closest( 'li' ).find( '.stripe-source-errors' )
+				: selectedMethodElement.find( '.stripe-source-errors' );
 
 			/*
 			 * If payment method is SEPA and owner name is not completed,

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -611,13 +611,21 @@ jQuery( function( $ ) {
 		 */
 		onError: function( e, result ) {
 			var message = result.error.message;
-
 			var selectedMethodElement = wc_stripe_form.getSelectedPaymentElement().closest( 'li' );
+			var savedTokens = selectedMethodElement.find( '.woocommerce-SavedPaymentMethods-tokenInput' );
+			var errorContainer;
 
-			// Use the right error wrapper if there are saved cards.
-			var errorContainer = selectedMethodElement.find( '.woocommerce-SavedPaymentMethods-tokenInput' ).length
-				? selectedMethodElement.find( '.woocommerce-SavedPaymentMethods-tokenInput:checked' ).closest( 'li' ).find( '.stripe-source-errors' )
-				: selectedMethodElement.find( '.stripe-source-errors' );
+			if ( savedTokens.length ) {
+				var selectedToken = savedTokens.filter( ':checked' );
+
+				if ( selectedToken.closest( '.woocommerce-SavedPaymentMethods-new' ).length ) {
+					errorContainer = $( '#wc-stripe-cc-form .stripe-source-errors' );
+				} else {
+					errorContainer = selectedToken.closest( 'li' ).find( '.stripe-source-errors' );
+				}
+			} else {
+				errorContainer = selectedMethodElement.find( '.stripe-source-errors' );
+			}
 
 			/*
 			 * If payment method is SEPA and owner name is not completed,

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -616,14 +616,18 @@ jQuery( function( $ ) {
 			var errorContainer;
 
 			if ( savedTokens.length ) {
+				// In case there are saved cards too, display the message next to the correct one.
 				var selectedToken = savedTokens.filter( ':checked' );
 
 				if ( selectedToken.closest( '.woocommerce-SavedPaymentMethods-new' ).length ) {
+					// Display the error next to the CC fields if a new card is being entered.
 					errorContainer = $( '#wc-stripe-cc-form .stripe-source-errors' );
 				} else {
+					// Display the error next to the chosen saved card.
 					errorContainer = selectedToken.closest( 'li' ).find( '.stripe-source-errors' );
 				}
 			} else {
+				// When no saved cards are available, display the error next to CC fields.
 				errorContainer = selectedMethodElement.find( '.stripe-source-errors' );
 			}
 


### PR DESCRIPTION
When handling errors, the extension selects all `.stripe-source-errors` elements and fills them with the error message, which might cause a state like this:

__Broken state:__
<img width="334" alt="erroneous-state" src="https://user-images.githubusercontent.com/5311119/57958950-9aab6d00-78cf-11e9-8140-c80e79219923.png">

## Changes proposed in this PR

In this PR I'm selecting the correct element:

- Just `.stripe-source-errors` if there are no saved cards.
- The element within the current saved card `li` if one is chosen.
- The element within `#wc-stripe-cc-form` for freshly entered cards.

__Saved card:__
<img width="336" alt="saved-card" src="https://user-images.githubusercontent.com/5311119/57958949-9aab6d00-78cf-11e9-9a5a-813e3d3baf8a.png">

__New card:__
<img width="334" alt="new-card" src="https://user-images.githubusercontent.com/5311119/57958951-9aab6d00-78cf-11e9-8478-32d9ad9e0083.png">

## Testing instructions

1. Add multiple saved cards
2. Force an error (ex. failed SCA auth)
3. Ensure that no matter what is chosen, only one message appears and it appears in the right place.