### PR TITLE
Adding filters to control default status of update_subs_payment_method_card checkbox

### DIFF
--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -85,17 +85,21 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	public function display_update_subs_payment_checkout() {
 		if (
 			apply_filters( 'wc_stripe_display_update_subs_payment_method_card_checkbox', true ) &&
-			wcs_user_has_subscription( get_current_user_id(), '', 'active' ) &&
+			wcs_user_has_subscription( get_current_user_id(), '', apply_filters( 'wc_stripe_display_update_subs_payment_method_card_statuses', array( 'active' ) ) ) &&
 			is_add_payment_method_page()
 		) {
-			printf(
-				'<p class="form-row">
-					<input id="wc-%1$s-update-subs-payment-method-card" name="wc-%1$s-update-subs-payment-method-card" type="checkbox" value="true" style="width:auto;" />
-					<label for="wc-%1$s-update-subs-payment-method-card" style="display:inline;">%2$s</label>
-				</p>',
-				esc_attr( $this->id ),
-				esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions (optional).', 'woocommerce-gateway-stripe' ) ) )
-			);
+			$label = esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions.', 'woocommerce-gateway-stripe' ) ) );
+			$id    = sprintf( 'wc-%1$s-update-subs-payment-method-card', $this->id );
+
+            woocommerce_form_field(
+                    $id,
+                    array(
+                            'type'    => 'checkbox',
+                            'class'   => apply_filters( 'wc_stripe_save_to_subs_class', array() ),
+                            'label'   => $label,
+                            'default' => apply_filters( 'wc_stripe_save_to_subs_checked', false ),
+                    )
+            );
 		}
 	}
 

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -85,17 +85,21 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	public function display_update_subs_payment_checkout() {
 		if (
 			apply_filters( 'wc_stripe_display_update_subs_payment_method_card_checkbox', true ) &&
-			wcs_user_has_subscription( get_current_user_id(), '', 'active' ) &&
+			wcs_user_has_subscription( get_current_user_id(), '', apply_filters( 'wc_stripe_display_update_subs_payment_method_card_statuses', array( 'active' ) ) ) &&
 			is_add_payment_method_page()
 		) {
-			printf(
-				'<p class="form-row">
-					<input id="wc-%1$s-update-subs-payment-method-card" name="wc-%1$s-update-subs-payment-method-card" type="checkbox" value="true" style="width:auto;" />
-					<label for="wc-%1$s-update-subs-payment-method-card" style="display:inline;">%2$s</label>
-				</p>',
-				esc_attr( $this->id ),
-				esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions (optional).', 'woocommerce-gateway-stripe' ) ) )
-			);
+			$label = esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions.', 'woocommerce-gateway-stripe' ) ) );
+			$id    = sprintf( 'wc-%1$s-update-subs-payment-method-card', $this->id );
+
+            woocommerce_form_field(
+                    $id,
+                    array(
+                            'type'    => 'checkbox',
+                            'class'   => apply_filters( 'wc_stripe_save_to_subs_class', array() ),
+                            'label'   => $label,
+                            'default' => apply_filters( 'wc_stripe_save_to_subs_checked', false ),
+                    )
+            );
 		}
 	}
 


### PR DESCRIPTION
Fixes #764 .

#### Changes proposed in this Pull Request:
- Add more filters to control the default state of the update_subs_payment_method_card checkbox
- Use woocommerce_form_field to create the checkbox
- Add new filter to control the subscription statuses that are eligible for displaying this checkbox. This could possibly be a step towards #728 and allow admins to update non-active subscriptions too.