### PR TITLE
Move 3D Secure notice to notices class, replacing Stripe Checkout notice

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -111,15 +111,8 @@ class WC_Stripe_Admin_Notices {
 		$test_secret_key    = isset( $options['test_secret_key'] ) ? $options['test_secret_key'] : '';
 		$live_pub_key       = isset( $options['publishable_key'] ) ? $options['publishable_key'] : '';
 		$live_secret_key    = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
-		$checkout_enabled   = isset( $options['stripe_checkout'] ) && 'yes' === $options['stripe_checkout'];
 
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
-			if ( $checkout_enabled ) {
-				$url = 'https://docs.woocommerce.com/document/stripe/modal-checkout';
-				$message = sprintf( __( 'WooCommerce Stripe - Support for Stripe Modal Checkout will be ending soon. This will impact the appearance of your checkout. <a href="%1$s" target="_blank">Click here to learn more.</a>', 'woocommerce-gateway-stripe' ), $url );
-				$this->add_admin_notice( 'legacy_checkout', 'notice notice-warning', $message );
-			}
-
 			if ( empty( $show_style_notice ) ) {
 				/* translators: 1) int version 2) int version */
 				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://docs.woocommerce.com/document/stripe/#section-45" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -102,6 +102,7 @@ class WC_Stripe_Admin_Notices {
 		$show_style_notice  = get_option( 'wc_stripe_show_style_notice' );
 		$show_ssl_notice    = get_option( 'wc_stripe_show_ssl_notice' );
 		$show_keys_notice   = get_option( 'wc_stripe_show_keys_notice' );
+		$show_3ds_notice    = get_option( 'wc_stripe_show_3ds_notice' );
 		$show_phpver_notice = get_option( 'wc_stripe_show_phpver_notice' );
 		$show_wcver_notice  = get_option( 'wc_stripe_show_wcver_notice' );
 		$show_curl_notice   = get_option( 'wc_stripe_show_curl_notice' );
@@ -111,8 +112,18 @@ class WC_Stripe_Admin_Notices {
 		$test_secret_key    = isset( $options['test_secret_key'] ) ? $options['test_secret_key'] : '';
 		$live_pub_key       = isset( $options['publishable_key'] ) ? $options['publishable_key'] : '';
 		$live_secret_key    = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
+		$three_d_secure     = isset( $options['three_d_secure'] ) && 'yes' === $options['three_d_secure'];
 
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
+			if ( empty( $show_3ds_notice ) && $three_d_secure ) {
+				$url = 'https://stripe.com/docs/payments/dynamic-3ds';
+
+				/* translators: 1) A URL that explains Stripe Radar. */
+				$message = __( 'WooCommerce Stripe - We see that you had the "Require 3D secure when applicable" setting turned on. This setting is not available here anymore, because it is now replaced by Stripe Radar. You can learn more about it <a href="%s">here</a>.', 'woocommerce-gateway-stripe' );
+
+				$this->add_admin_notice( '3ds', 'notice notice-warning', sprintf( $message, $url ), true );
+			}
+
 			if ( empty( $show_style_notice ) ) {
 				/* translators: 1) int version 2) int version */
 				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://docs.woocommerce.com/document/stripe/#section-45" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );
@@ -250,6 +261,9 @@ class WC_Stripe_Admin_Notices {
 					break;
 				case 'keys':
 					update_option( 'wc_stripe_show_keys_notice', 'no' );
+					break;
+				case '3ds':
+					update_option( 'wc_stripe_show_3ds_notice', 'no' );
 					break;
 				case 'Alipay':
 					update_option( 'wc_stripe_show_alipay_notice', 'no' );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -219,14 +219,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		$this->form_fields = require( dirname( __FILE__ ) . '/admin/stripe-settings.php' );
-
-		if ( 'yes' === $this->get_option( 'three_d_secure' ) ) {
-			if ( isset( $_REQUEST['stripe_dismiss_3ds'] ) && wp_verify_nonce( $_REQUEST['stripe_dismiss_3ds'], 'no-3ds' ) ) { // wpcs: sanitization ok.
-				$this->update_option( '3ds_setting_notice_dismissed', true );
-			}
-
-			add_action( 'admin_notices', array( $this, 'display_three_d_secure_notice' ) );
-		}
 	}
 
 	/**
@@ -764,36 +756,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			</td>
 		</tr>
 
-		<?php
-	}
-
-	/**
-	 * Displays a notice that 3DS is not a setting anymore.
-	 *
-	 * @since 4.2.0
-	 */
-	public function display_three_d_secure_notice() {
-		if ( $this->get_option( '3ds_setting_notice_dismissed' ) ) {
-			return;
-		}
-		?>
-		<div data-nonce="<?php echo esc_attr( wp_create_nonce( 'no-3ds' ) ); ?>" class="notice notice-warning is-dismissible wc-stripe-3ds-missing">
-			<p>
-				<?php
-				$url = 'https://stripe.com/docs/payments/dynamic-3ds';
-				/* translators: 1) A URL that explains Stripe Radar. */
-				$message = __( '<strong>WooCommerce Stripe Gateway:</strong> We see that you had the "Require 3D secure when applicable" setting turned on. This setting is not available here anymore, because it is now replaced by Stripe Radar. You can learn more about it <a href="%s">here</a>.', 'woocommerce-gateway-stripe' );
-
-				$allowed_tags = array(
-					'strong' => array(),
-					'a'      => array(
-						'href' => array(),
-					),
-				);
-				printf( wp_kses( $message, $allowed_tags ), esc_url( $url ) );
-				?>
-			</p>
-		</div>
 		<?php
 	}
 


### PR DESCRIPTION
Reverts 3D secure notice (which appeared to cause some anomalous behavior: p1559144950004400-slack-woo-par-hydra-reserve) added in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/795 (https://github.com/woocommerce/woocommerce-gateway-stripe/pull/795/commits/fd458bc7f757de9daf689d03b2ce942c8e0d91c4), in favor of equivalent notice in the `WC_Stripe_Admin_Notices` class.

Also removes Stripe Checkout warning added in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/837, since Stripe Checkout was removed in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/846.