### PR TITLE
Enqueue woocommerce_stripe script alongside wc_stripe_payment_request script

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -678,6 +678,7 @@ jQuery( function( $ ) {
 				}, 200 );
 			}
 			wc_stripe_form.unblock();
+			$.unblockUI(); // If arriving via Payment Request Button.
 		},
 
 		/**

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -411,7 +411,7 @@ jQuery( function( $ ) {
 		 * Removes overlays from payment forms.
 		 */
 		unblock: function() {
-			wc_stripe_form.form.unblock();
+			wc_stripe_form.form && wc_stripe_form.form.unblock();
 		},
 
 		/**
@@ -780,7 +780,7 @@ jQuery( function( $ ) {
 					}
 
 					$( document.body ).trigger( 'stripeError', { error: error } );
-					wc_stripe_form.form.removeClass( 'processing' );
+					wc_stripe_form.form && wc_stripe_form.form.removeClass( 'processing' );
 
 					// Report back to the server.
 					$.get( redirectURL + '&is_ajax' );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -382,7 +382,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @version 4.0.0
 	 */
 	public function payment_scripts() {
-		if ( ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
+		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -519,6 +519,11 @@ class WC_Stripe_Payment_Request {
 		wp_localize_script( 'wc_stripe_payment_request', 'wc_stripe_payment_request_params', apply_filters( 'wc_stripe_payment_request_params', $stripe_params ) );
 
 		wp_enqueue_script( 'wc_stripe_payment_request' );
+
+		$gateways = WC()->payment_gateways->get_available_payment_gateways();
+		if ( isset( $gateways['stripe'] ) ) {
+			$gateways['stripe']->payment_scripts();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #877

Makes sure payment intent authorization handling (in assets/js/stripe.js) is enqueued whenever Payment Request Button is present, to prevent stalling and allow completion of payment.