### PR TITLE
Store PaymentIntent nonce in order meta to improve resiliency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.2.1 - 2019-06-XX =
+* Fix - CSRF issues when users are being registered during checkout.
+
 = 4.2.0 - 2019-05-29 =
 * Update - Enable Payment Request buttons for Puerto Rico based stores.
 * Update - Add support for Strong Customer Authentication (SCA) for user-initiated payments.

--- a/readme.txt
+++ b/readme.txt
@@ -113,12 +113,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.2.0 - 2019-05-29 =
-* Update - Enable Payment Request buttons for Puerto Rico based stores.
-* Update - Add support for Strong Customer Authentication (SCA) for user-initiated payments.
-* Remove - Stripe Modal Checkout.
-* Remove - 3D Secure settings are no longer available in the gateway settings. Use Stripe Radar instead.
-* Fix - Display error messages only next to the chosen saved card.
+= 4.2.1 - 2019-06-XX =
+* Fix - CSRF issues when users are being registered during checkout.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
## Changes proposed in this PR

Since 4.2.0 `WC_Stripe_Intent_Controller` and `WC_Gateway_Stripe` use a nonce within the redirect URL after checkout, which is checked in `WC_Stripe_Intent_Controller`.

The problem is that WooCommerce automatically signs newly registered users in, which forces the nonce to be invalidated and even though the purchase and registration are successful, users end up seeing a CSRF message.

## Testing instructions

1. Log out, if logged in
2. Add product(s) to the cart.
3. Check out
    - Remember to check that you'd like to be signed up
    - Use a card that requires 3DS verification
4. Have a successful purchase

Fixes #882