### PR TITLE
Proceed with current request using new login session to ensure consistent nonce

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.2.1 - xxxx-xx-xx =
+* Fix - CSRF verification error upon creating account on checkout.
+
 = 4.2.0 - 2019-05-29 =
 * Update - Enable Payment Request buttons for Puerto Rico based stores.
 * Update - Add support for Strong Customer Authentication (SCA) for user-initiated payments.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -138,6 +138,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_available_payment_gateways', array( $this, 'prepare_order_pay_page' ) );
 		add_action( 'woocommerce_account_view-order_endpoint', array( $this, 'check_intent_status_on_order_page' ), 1 );
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
+		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
 
 		if ( WC_Stripe_Helper::is_pre_orders_exists() ) {
 			$this->pre_orders = new WC_Stripe_Pre_Orders_Compat();
@@ -931,6 +932,13 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			'result'   => 'success',
 			'redirect' => $redirect,
 		);
+	}
+
+	/**
+	 * Proceed with current request using new login session (to ensure consistent nonce).
+	 */
+	public function set_cookie_on_current_request( $cookie ) {
+		$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -113,12 +113,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.2.0 - 2019-05-29 =
-* Update - Enable Payment Request buttons for Puerto Rico based stores.
-* Update - Add support for Strong Customer Authentication (SCA) for user-initiated payments.
-* Remove - Stripe Modal Checkout.
-* Remove - 3D Secure settings are no longer available in the gateway settings. Use Stripe Radar instead.
-* Fix - Display error messages only next to the chosen saved card.
+= 4.2.1 - xxxx-xx-xx =
+* Fix - CSRF verification error upon creating account on checkout.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/882

The verify_intent nonce is created after the processing of the customer, in the same `process_checkout` handler but the session token (a component of the nonce) isn't accessible in `$_COOKIE` until the next page load. Therefore the nonce is obsolete as soon as the response comes back.

This change is to ensure that the newly created and logged in customer is the one reflected in the current session. Is there any reason to not be writing to $_COOKIE directly?

Tested using steps in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/882.

See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/886 for an alternative solution. Kudos to @RadoslavGeorgiev for setting me on the right (after being on the wrong) track.