### PR TITLE
Fix duplicate intent actions when webhooks are enabled.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,9 @@
 *** Changelog ***
 
-= 4.2.1 - 2019-xx-xx =
+= 4.2.1 - 2019-06-17 =
 * Update - Add UGX (Ugandan Shilling) to zero decimal currency list.
 * Fix - CSRF verification error upon creating account on checkout.
+* Fix - Duplicate emails and order notes after successful transactions.
 
 = 4.2.0 - 2019-05-29 =
 * Update - Enable Payment Request buttons for Puerto Rico based stores.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -614,19 +614,25 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			if ( $intent ) {
 				$intent = $this->update_existing_intent( $intent, $order, $prepared_source );
 			} else {
-				$intent   = $this->create_and_confirm_intent( $order, $prepared_source );
-				$response = $intent;
+				$intent = $this->create_intent( $order, $prepared_source );
 			}
 
-			if ( ! empty( $response->error ) ) {
-				$this->maybe_remove_non_existent_customer( $response->error, $order );
+			// Confirm the intent after locking the order to make sure webhooks will not interfere.
+			if ( empty( $intent->error ) ) {
+				$this->lock_order_payment( $order, $intent );
+				$intent = $this->confirm_intent( $intent, $order, $prepared_source );
+			}
+
+			if ( ! empty( $intent->error ) ) {
+				$this->maybe_remove_non_existent_customer( $intent->error, $order );
 
 				// We want to retry.
-				if ( $this->is_retryable_error( $response->error ) ) {
-					return $this->retry_after_error( $response, $order, $retry, $force_save_source, $previous_error );
+				if ( $this->is_retryable_error( $intent->error ) ) {
+					return $this->retry_after_error( $intent, $order, $retry, $force_save_source, $previous_error );
 				}
 
-				$this->throw_localized_message( $response, $order );
+				$this->unlock_order_payment( $order );
+				$this->throw_localized_message( $intent, $order );
 			}
 
 			if ( ! empty( $intent ) ) {
@@ -635,6 +641,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 				// If the intent requires a 3DS flow, redirect to it.
 				if ( 'requires_action' === $intent->status ) {
+					$this->unlock_order_payment( $order );
+
 					if ( is_wc_endpoint_url( 'order-pay' ) ) {
 						$redirect_url = add_query_arg( 'wc-stripe-confirmation', 1, $order->get_checkout_payment_url( false ) );
 
@@ -650,9 +658,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 						 */
 
 						return array(
-							'result'           => 'success',
-							'redirect'         => $this->get_return_url( $order ),
-							'intent_secret'    => $intent->client_secret,
+							'result'        => 'success',
+							'redirect'      => $this->get_return_url( $order ),
+							'intent_secret' => $intent->client_secret,
 						);
 					}
 				}
@@ -663,6 +671,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 			// Remove cart.
 			WC()->cart->empty_cart();
+
+			// Unlock the order.
+			$this->unlock_order_payment( $order );
 
 			// Return thank you page redirect.
 			return array(

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -294,15 +294,14 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				if ( $is_stripe_captured ) {
 					/* translators: transaction id */
 					$order->add_order_note( sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $result->id ) );
-					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-						update_post_meta( $order_id, '_stripe_charge_captured', 'yes' );
-					} else {
-						$order->update_meta_data( '_stripe_charge_captured', 'yes' );
-						$order->save();
-					}
+					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', 'yes' ) : $order->update_meta_data( '_stripe_charge_captured', 'yes' );
 
 					// Store other data such as fees
 					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $result->id ) : $order->set_transaction_id( $result->id );
+
+					if ( is_callable( array( $order, 'save' ) ) ) {
+						$order->save();
+					}
 
 					$this->update_fees( $order, $result->balance_transaction->id );
 				}

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -294,7 +294,12 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				if ( $is_stripe_captured ) {
 					/* translators: transaction id */
 					$order->add_order_note( sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $result->id ) );
-					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', 'yes' ) : $order->update_meta_data( '_stripe_charge_captured', 'yes' );
+					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+						update_post_meta( $order_id, '_stripe_charge_captured', 'yes' );
+					} else {
+						$order->update_meta_data( '_stripe_charge_captured', 'yes' );
+						$order->save();
+					}
 
 					// Store other data such as fees
 					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $result->id ) : $order->set_transaction_id( $result->id );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -295,7 +295,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', 'yes' ) : $order->update_meta_data( '_stripe_charge_captured', 'yes' );
 
 				// Store other data such as fees
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $notification->data->object->id ) : $order->set_transaction_id( $notification->data->object->id );
+				if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+					update_post_meta( $order_id, '_transaction_id', $notification->data->object->id );
+				} else {
+					$order->set_transaction_id( $notification->data->object->id );
+					$order->save();
+				}
 
 				if ( isset( $notification->data->object->balance_transaction ) ) {
 					$this->update_fees( $order, $notification->data->object->balance_transaction );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -295,12 +295,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', 'yes' ) : $order->update_meta_data( '_stripe_charge_captured', 'yes' );
 
 				// Store other data such as fees
-				if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-					update_post_meta( $order_id, '_transaction_id', $notification->data->object->id );
-				} else {
-					$order->set_transaction_id( $notification->data->object->id );
-					$order->save();
-				}
+				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $notification->data->object->id ) : $order->set_transaction_id( $notification->data->object->id );
 
 				if ( isset( $notification->data->object->balance_transaction ) ) {
 					$this->update_fees( $order, $notification->data->object->balance_transaction );

--- a/readme.txt
+++ b/readme.txt
@@ -113,8 +113,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.2.1 - xxxx-xx-xx =
+= 4.2.1 - 2019-06-17 =
 * Fix - CSRF verification error upon creating account on checkout.
+* Fix - Duplicate emails and order notes after successful transactions.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #889

#### Changes proposed in this Pull Request:

`WC_Gateway_Stripe::verify_intent_after_checkout` (called during the redirect from Checkout to Thank You) contains something like this:

```php
if ( 'pending' !== $order->get_status() && 'failed' !== $order->get_status() ) {
	// If payment has already been completed, this function is redundant.
	return;
}

$intent = $this->get_intent_from_order( $order ); // A slow function, because of remote calls

if ( $this->lock_order_payment( $order, $intent ) ) {
	// Do not proceed if the order is being handled by a webhook at the moment.
	return;
}
```

The locking mechanism works fine __if__ this method gets entered __while__ a webhook is handling the intent confirmation. However, if the webhook is much faster, or retrieving the intent in this method takes a while, it does not. The reason for this is that the webhook handler might have already completed the confirmation/verification process *and* unlocked the order. At this point `WC_Gateway_Stripe::verify_intent_after_checkout` will proceed, because the order status check was performed too early.

This PR moves the order status checks after the retrieval of the PaymentIntent, but also reloads the order before checking the status, to ensure that it has not been completed already.

#### Testing instructions

0. Enable all webhooks.
1. Checkout `master`.
2. Put a timer (`sleep( 10 );`) right after `$intent = $this->get_intent_from_order( $order );` in `verify_intent_after_checkout`. This will simulate a slow PaymentIntent retrival.
3. Create an order. You will see double status changes, and duplicate emails.
4. Checkout this branch.
5. Put the same timer after `$intent = $this->get_intent_from_order( $order );`.
6. A single set of emails should've gone out, and a single order note should be present.