### PR TITLE
Updating the link in the 3DS notice.

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -66,7 +66,7 @@ class WC_Stripe_Admin_Notices {
 			}
 
 			echo '<p>';
-			echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) );
+			echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array(), 'target' => array() ) ) );
 			echo '</p></div>';
 		}
 	}
@@ -119,7 +119,7 @@ class WC_Stripe_Admin_Notices {
 				$url = 'https://stripe.com/docs/payments/3d-secure#three-ds-radar';
 
 				/* translators: 1) A URL that explains Stripe Radar. */
-				$message = __( 'WooCommerce Stripe - We see that you had the "Require 3D secure when applicable" setting turned on. This setting is not available here anymore, because it is now replaced by Stripe Radar. You can learn more about it <a href="%s">here</a>.', 'woocommerce-gateway-stripe' );
+				$message = __( 'WooCommerce Stripe - We see that you had the "Require 3D secure when applicable" setting turned on. This setting is not available here anymore, because it is now replaced by Stripe Radar. You can learn more about it <a href="%s" target="_blank">here</a>.', 'woocommerce-gateway-stripe' );
 
 				$this->add_admin_notice( '3ds', 'notice notice-warning', sprintf( $message, $url ), true );
 			}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -116,7 +116,7 @@ class WC_Stripe_Admin_Notices {
 
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
 			if ( empty( $show_3ds_notice ) && $three_d_secure ) {
-				$url = 'https://stripe.com/docs/payments/dynamic-3ds';
+				$url = 'https://stripe.com/docs/payments/3d-secure#three-ds-radar';
 
 				/* translators: 1) A URL that explains Stripe Radar. */
 				$message = __( 'WooCommerce Stripe - We see that you had the "Require 3D secure when applicable" setting turned on. This setting is not available here anymore, because it is now replaced by Stripe Radar. You can learn more about it <a href="%s">here</a>.', 'woocommerce-gateway-stripe' );


### PR DESCRIPTION
Fixes #881 .

#### Changes proposed in this Pull Request:

As @dechov suggested in #881, replaced `https://stripe.com/docs/payments/dynamic-3ds` with `https://stripe.com/docs/payments/3d-secure#three-ds-radar` in the 3DS notice.

#### Testing instructions

It's a simple link change, so no real tests are needed. If you still need to see the notice:

1. Install a pre-`4.2.0` version of Stripe.
2. Enable 3DS in the gateway's settings.
3. Check out the branch of this PR.
4. See the notice.