### PR TITLE
Fix  WC_Stripe_API::request PHP doc

### DIFF
--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -96,8 +96,10 @@ class WC_Stripe_API {
 	 * @version 4.0.6
 	 * @param array $request
 	 * @param string $api
+	 * @param string $method
 	 * @param bool $with_headers To get the response with headers.
-	 * @return array|WP_Error
+	 * @return stdClass|array
+	 * @throws WC_Stripe_Exception
 	 */
 	public static function request( $request, $api = 'charges', $method = 'POST', $with_headers = false ) {
 		WC_Stripe_Logger::log( "{$api} request: " . print_r( $request, true ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- Fixes the `WC_Stripe_API::request` method PHP docs.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

