### PR TITLE
Fixed Call to a member function empty_cart() on null

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -670,8 +670,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$this->process_response( $response, $order );
 
 			// Remove cart.
-			WC()->cart->empty_cart();
-
+			if ( isset( WC()->cart ) ) {
+				WC()->cart->empty_cart();
+			}
+			
 			// Unlock the order.
 			$this->unlock_order_payment( $order );
 


### PR DESCRIPTION
Fixes # .

#### Changes proposed in this Pull Request:
-
I write a module to handle payment progress for my mobile app, but throw error "Call to a member function empty_cart() on null". So a do a bit fix, please merge a release it.  

`$wc_gateway_stripe                = new WC_Gateway_Stripe();

        $_POST['stripe_source']            = $stripe_source;
        $_POST['payment_method']            = "stripe";

        $payment_result               = $wc_gateway_stripe->process_payment( $order_id );`

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).

