### PR TITLE
 Fix - Changing an order status to "Cancelled" will no longer refund the payment.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 4.2.2 - 2019-06-26 =
-* Fix - Changing an order status to "Cancelled" will no longer refund the payment.
+* Fix - Changing an order status to "Cancelled" or "Refunded" will no longer refund the payment, will only void the payment if it was just authorized.
 
 = 4.2.1 - 2019-06-17 =
 * Update - Add UGX (Ugandan Shilling) to zero decimal currency list.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.2.2 - 2019-06-26 =
+* Fix - Changing an order status to "Cancelled" will no longer refund the payment.
+
 = 4.2.1 - 2019-06-17 =
 * Update - Add UGX (Ugandan Shilling) to zero decimal currency list.
 * Fix - CSRF verification error upon creating account on checkout.

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -326,7 +326,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			$captured = WC_Stripe_Helper::is_wc_lt( '3.0' )
 				? get_post_meta( $order_id, '_stripe_charge_captured', true )
 				: $order->get_meta( '_stripe_charge_captured', true );
-			if ( ! $captured ) {
+			if ( 'no' === $captured ) {
 				$this->process_refund( $order_id );
 			}
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -26,8 +26,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		add_action( 'wp', array( $this, 'maybe_process_redirect_order' ) );
 		add_action( 'woocommerce_order_status_processing', array( $this, 'capture_payment' ) );
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
-		add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_authorization' ) );
-		add_action( 'woocommerce_order_status_refunded', array( $this, 'refund_payment' ) );
+		add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_payment' ) );
+		add_action( 'woocommerce_order_status_refunded', array( $this, 'cancel_payment' ) );
 	}
 
 	/**
@@ -313,13 +313,13 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Cancel pre-auth on order cancellation. Does nothing if the payment has already been captured.
+	 * Cancel pre-auth on refund/cancellation.
 	 *
-	 * @since 4.2.2
+	 * @since 3.1.0
 	 * @version 4.2.2
 	 * @param  int $order_id
 	 */
-	public function cancel_authorization( $order_id ) {
+	public function cancel_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 
 		if ( 'stripe' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method() ) ) {
@@ -329,24 +329,6 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			if ( 'no' === $captured ) {
 				$this->process_refund( $order_id );
 			}
-
-			// This hook fires when admin manually changes order status to cancel.
-			do_action( 'woocommerce_stripe_process_manual_cancel', $order );
-		}
-	}
-
-	/**
-	 * Cancel or refund the payment on order cancellation.
-	 *
-	 * @since 4.2.2
-	 * @version 4.2.2
-	 * @param  int $order_id
-	 */
-	public function refund_payment( $order_id ) {
-		$order = wc_get_order( $order_id );
-
-		if ( 'stripe' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method() ) ) {
-			$this->process_refund( $order_id );
 
 			// This hook fires when admin manually changes order status to cancel.
 			do_action( 'woocommerce_stripe_process_manual_cancel', $order );

--- a/readme.txt
+++ b/readme.txt
@@ -114,7 +114,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 4.2.2 - 2019-06-26 =
-* Fix - Changing an order status to "Cancelled" will no longer refund the payment.
+* Fix - Changing an order status to "Cancelled" or "Refunded" will no longer refund the payment, will only void the payment if it was just authorized.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort,
 Requires at least: 4.4
 Tested up to: 5.2.1
 Requires PHP: 5.6
-Stable tag: 4.2.1
+Stable tag: 4.2.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe
@@ -113,14 +113,12 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.2.1 - 2019-06-17 =
-* Update - Add UGX (Ugandan Shilling) to zero decimal currency list.
-* Fix - CSRF verification error upon creating account on checkout.
-* Fix - Duplicate emails and order notes after successful transactions.
+= 4.2.2 - 2019-06-26 =
+* Fix - Changing an order status to "Cancelled" will no longer refund the payment.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 
 == Upgrade Notice ==
 
-= 4.1 =
-4.1 is a minor release. Please do a full site backup and test on a staging site before deploying to a live/production server.
+= 4.2 =
+4.2 is a minor release. Please do a full site backup and test on a staging site before deploying to a live/production server.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 4.2.1
+ * Version: 4.2.2
  * Requires at least: 4.4
  * Tested up to: 5.2.1
  * WC requires at least: 2.6
@@ -46,7 +46,7 @@ function woocommerce_gateway_stripe_init() {
 		/**
 		 * Required minimums and constants
 		 */
-		define( 'WC_STRIPE_VERSION', '4.2.1' );
+		define( 'WC_STRIPE_VERSION', '4.2.2' );
 		define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 		define( 'WC_STRIPE_MIN_WC_VER', '2.6.0' );
 		define( 'WC_STRIPE_MAIN_FILE', __FILE__ );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/900

Old-old behaviour (pre-4.2):
- Moving an order `On-Hold -> Cancelled` would refund/void the payment.
- Moving an order `On-Hold -> Refunded` would refund/void the payment.

That didn't work well if the merchant uses custom order statuses. So...

Current behaviour:
- Moving an order `* -> Cancelled` would refund/void the payment.
- Moving an order `* -> Refunded` would refund/void the payment.

That's worse, because it means that cancelling an order, even if the order was already fulfilled, would refund the payment. That's specially bad with Subscriptions, because a "Cancelled" subscription just means "don't renew it anymore", it shouldn't refund any existing payment.

Proposed behaviour:
- Moving an order `* -> Cancelled` would cancelled an authorized payment, but do nothing if the payment was already captured.
- Moving an order `* -> Refunded` would refund/void the payment (same as before).

The fix itself is in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/8828cdfb7c02530acb9a155cb9adbece2d77e7b7, and in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/e8ed1e3e9268a0cc582186475eb9688e1f3fd188 I prepared everything so we can push a release with this fix ASAP.

cc/ @rynaldos @dougaitken 