### PR TITLE
Don't process any delayed payment failure if the order has already transitioned status

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.x.x - 2019-xx-xx =
+* Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
+
 = 4.2.2 - 2019-06-26 =
 * Fix - Changing an order status to "Cancelled" or "Refunded" will no longer refund the payment, will only void the payment if it was just authorized.
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -610,16 +610,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		if ( 'pending' !== $order->get_status() && 'failed' !== $order->get_status() ) {
+			return;
+		}
+
 		if ( $this->lock_order_payment( $order, $intent ) ) {
 			return;
 		}
 
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 		if ( 'payment_intent.succeeded' === $notification->type || 'payment_intent.amount_capturable_updated' === $notification->type ) {
-			if ( 'pending' !== $order->get_status() && 'failed' !== $order->get_status() ) {
-				return;
-			}
-
 			$charge = end( $intent->charges->data );
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,8 +113,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.2.2 - 2019-06-26 =
-* Fix - Changing an order status to "Cancelled" or "Refunded" will no longer refund the payment, will only void the payment if it was just authorized.
+= 4.x.x - 2019-xx-xx =
+* Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixed #902

Detailed to reproduce are in #902. Basically:
- Payment gets declined
- User tries another card, payment succeeds
- Somehow the first "payment failed" webhook is sent afterwards

With this change, the delayed webhook will be ignored because the order is not on a `pending` or `failed` status, so the order will stay in `processing` status.

