### PR TITLE
Fix the Radar-related webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.x.x - 2019-xx-xx =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
+* Fix - Correctly transition an order to "On Hold" if the payment was put under review by Stripe Radar, and back to "Processing" when the review is approved.
 
 = 4.2.2 - 2019-06-26 =
 * Fix - Changing an order status to "Cancelled" or "Refunded" will no longer refund the payment, will only void the payment if it was just authorized.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -506,7 +506,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via intent ID: ' . $notification->data->object->payment_intent );
+			WC_Stripe_Logger::log( '[Review Opened] Could not find order via intent ID: ' . $notification->data->object->payment_intent );
 			return;
 		}
 
@@ -530,7 +530,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via intent ID: ' . $notification->data->object->payment_intent );
+			WC_Stripe_Logger::log( '[Review Closed] Could not find order via intent ID: ' . $notification->data->object->payment_intent );
 			return;
 		}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -503,10 +503,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_review_opened( $notification ) {
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
+		$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->charge );
+			WC_Stripe_Logger::log( 'Could not find order via intent ID: ' . $notification->data->object->payment_intent );
 			return;
 		}
 
@@ -527,10 +527,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_review_closed( $notification ) {
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
+		$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->charge );
+			WC_Stripe_Logger::log( 'Could not find order via intent ID: ' . $notification->data->object->payment_intent );
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 4.x.x - 2019-xx-xx =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
+* Fix - Correctly transition an order to "On Hold" if the payment was put under review by Stripe Radar, and back to "Processing" when the review is approved.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #818

Sorry this issue flew under our radar (pun absolutely intended) for so long.

When a payment triggers a Stripe Radar rule and it's placed "under review", the merchant's site is notified woth a webhook. When the merchant goes to Stripe Dashboard and approves the review ("unlocking" the payment), there's another webhook.

The webhooks `review.opened` and `review.closed` previously had a property `object.charge` with the Charge ID that triggered the review. Now, with the Payment Intent logic, that property is `null`, and instead the webhook includes the Intent ID in `object.payment_intent`. This PR fixes the webhook logic to look for the `payment_intent` property.

To test:
- Make a payment using this CC: `4000000000009235`
- On the order screen, you'll see that it has been pun "On Hold" and there's an order note prompting you to review the payment
- Follow the link in the order note, and approve the payment
- Refresh the order page, it should go to "Processing" state and there's an order note indicating why

These are my order notes after the whole process:
![Screenshot 2019-07-02 at 15 29 54](https://user-images.githubusercontent.com/1715800/60521017-5688f600-9cde-11e9-9eff-ca2d289fe19a.png)


Question: Can you imagine any use case where the `charge` property would still be used instead of `payment_intent`? I can't think of anything, so keeping the old logic in case `charge` isn't `null` seemed pointless.