### PR TITLE
Fix successful retries of 3ds failing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.x.x - 2019-xx-xx =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
+* Fix - Fix successful retries of 3ds failing
 
 = 4.2.2 - 2019-06-26 =
 * Fix - Changing an order status to "Cancelled" or "Refunded" will no longer refund the payment, will only void the payment if it was just authorized.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -985,7 +985,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'succeeded' === $intent->status ) {
+		if ( 'succeeded' === $intent->status || 'requires_capture' === $intent->status ) {
 			// Proceed with the payment completion.
 			$this->process_response( end( $intent->charges->data ), $order );
 		} else if ( 'requires_payment_method' === $intent->status ) {

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 4.x.x - 2019-xx-xx =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
+* Fix - Fix successful retries of 3ds failing
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #913

#### Changes proposed in this Pull Request:
- The payment intent comes back marked as `requires_capture` so we can still process it and the merchant will need to capture it manually

#### To test:
* Follow the repro steps in #913 
* The customer should be shown a success message
* The order should be marked as on hold
* Manually processing the order should successfully capture the transaction

