### PR TITLE
Make the publishable key fields be plain text instead of "password"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.x.x - 2019-xx-xx =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
+* Tweak - Make the publishable key fields be plain text instead of "password".
 
 = 4.2.2 - 2019-06-26 =
 * Fix - Changing an order status to "Cancelled" or "Refunded" will no longer refund the payment, will only void the payment if it was just authorized.

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -43,7 +43,7 @@ return apply_filters(
 		),
 		'test_publishable_key'          => array(
 			'title'       => __( 'Test Publishable Key', 'woocommerce-gateway-stripe' ),
-			'type'        => 'password',
+			'type'        => 'text',
 			'description' => __( 'Get your API keys from your stripe account.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
@@ -57,7 +57,7 @@ return apply_filters(
 		),
 		'publishable_key'               => array(
 			'title'       => __( 'Live Publishable Key', 'woocommerce-gateway-stripe' ),
-			'type'        => 'password',
+			'type'        => 'text',
 			'description' => __( 'Get your API keys from your stripe account.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 4.x.x - 2019-xx-xx =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
+* Tweak - Make the publishable key fields be plain text instead of "password".
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #895

The test/live publishable keys aren't "secrets", they are injected into the DOM on the checkout in plain text. There's no need for those fields to be `type=password`, it just makes it more annoying to setup.

To test: Go to the Stripe payment method settings, see that the `Test Publishable Key` / `Live Publishable Key` input fields are displayed in plain text.

