### PR TITLE
Payment request button/variable subs compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 4.2.4 - 2019-XX-XX =
 * Fix - Unclear error message when email address not completely filled in.
 * Fix - Add payment request button compatibility with variable subscriptions
+* Tweak - Do not show payment request button for shippable trial subscription products
 
 = 4.2.3 - 2019-07-18 =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.2.4 - 2019-XX-XX =
 * Fix - Unclear error message when email address not completely filled in.
+* Fix - Add payment request button compatibility with variable subscriptions
 
 = 4.2.3 - 2019-07-18 =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -430,6 +430,11 @@ class WC_Stripe_Payment_Request {
 				return false;
 			}
 
+			// Trial subscriptions with shipping are not supported
+			if ( class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Cart::cart_contains_subscription() && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
+				return false;
+			}
+
 			// Pre Orders compatbility where we don't support charge upon release.
 			if ( class_exists( 'WC_Pre_Orders_Order' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() ) ) {
 				return false;
@@ -562,6 +567,11 @@ class WC_Stripe_Payment_Request {
 				return;
 			}
 
+			// Trial subscriptions with shipping are not supported
+			if ( class_exists( 'WC_Subscriptions_Order' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+				return;
+			}
+
 			// Pre Orders charge upon release not supported.
 			if ( class_exists( 'WC_Pre_Orders_Order' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
 				WC_Stripe_Logger::log( 'Pre Order charge upon release is not supported. ( Payment Request button disabled )' );
@@ -613,6 +623,11 @@ class WC_Stripe_Payment_Request {
 			$product = wc_get_product( $post->ID );
 
 			if ( ! is_object( $product ) || ! in_array( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $product->product_type : $product->get_type() ), $this->supported_product_types() ) ) {
+				return;
+			}
+
+			// Trial subscriptions with shipping are not supported
+			if ( class_exists( 'WC_Subscriptions_Order' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
 				return;
 			}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -405,6 +405,8 @@ class WC_Stripe_Payment_Request {
 				'variable',
 				'variation',
 				'subscription',
+				'variable-subscription',
+				'subscription_variation',
 				'booking',
 				'bundle',
 				'composite',

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 4.x.x - 2019-x-x =
 * Fix - Add payment request button compatibility with variable subscriptions
+* Tweak - Do not show payment request button for shippable trial subscription products
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,11 +113,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.2.3 - 2019-07-18 =
-* Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.
-* Fix - Correctly transition an order to "On Hold" if the payment was put under review by Stripe Radar, and back to "Processing" when the review is approved.
-* Tweak - Make the publishable key fields be plain text instead of "password".
-* Fix - Fix successful retries of 3ds failing.
+= 4.x.x - 2019-x-x =
+* Fix - Add payment request button compatibility with variable subscriptions
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
See p7bbVw-3f3-p2

#### Changes proposed in this Pull Request:
- Show payment request button when checking out a variable sub

#### To test:
* Install woo subs and this gateway on a site with https
* Add a card to chrome or use a different method [(see here for docs)](https://stripe.com/docs/stripe-js/elements/payment-request-button#testing)
* The payment button should appear in the cart when checking out a variable subscription
