### PR TITLE
Extend webhook time window from 1 to 5 minutes to match Stripe client

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -104,7 +104,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 			// Verify the timestamp.
 			$timestamp = intval( $matches['timestamp'] );
-			if ( abs( $timestamp - time() ) > MINUTE_IN_SECONDS ) {
+			if ( abs( $timestamp - time() ) > 5 * MINUTE_IN_SECONDS ) {
 				return;
 			}
 


### PR DESCRIPTION
Fixes #952 

#### Changes proposed in this Pull Request:
- Extend the webhook time delta allowed from 1 to 5 minutes

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

