### PR TITLE
SCA: Use SetupIntent for subscriptions where customer is not charged right away

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -251,6 +251,23 @@ jQuery( function( $ ) {
 			// Listen for hash changes in order to handle payment intents
 			window.addEventListener( 'hashchange', wc_stripe_form.onHashChange );
 			wc_stripe_form.maybeConfirmIntent();
+
+			// Add the "confirm setup intent" button handler on the "Order Received" page
+			var authorizeButtonEnabled = true;
+			$( '#stripe-setup-intent-authorize-button' ).click( function() {
+				if ( ! authorizeButtonEnabled ) {
+					return;
+				}
+				authorizeButtonEnabled = false;
+				stripe.handleCardSetup( $( '#stripe-setup-intent-authorize-button' ).data( 'secret' ) )
+					.then( function( data ) {
+						if ( 'succeeded' === data.setupIntent.status ) {
+							$( '#stripe-setup-intent-authorize-container' ).hide();
+						} else {
+							window.location.reload();
+						}
+					} );
+			} );
 		},
 
 		/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -74,21 +74,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Checks to see if error is of invalid request
-	 * error and source is already consumed.
-	 *
-	 * @since 4.1.0
-	 * @param array $error
-	 */
-	public function is_source_already_consumed_error( $error ) {
-		return (
-			$error &&
-			'invalid_request_error' === $error->type &&
-			preg_match( '/The reusable source you provided is consumed because it was previously charged without being attached to a customer or was detached from a customer. To charge a reusable source multiple time you must attach it to a customer first./i', $error->message )
-		);
-	}
-
-	/**
-	 * Checks to see if error is of invalid request
 	 * error and it is no such customer.
 	 *
 	 * @since 4.1.0

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -139,6 +139,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_account_view-order_endpoint', array( $this, 'check_intent_status_on_order_page' ), 1 );
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
+		add_action( 'woocommerce_thankyou', array( $this, 'thankyou_page' ) );
 
 		if ( WC_Stripe_Helper::is_pre_orders_exists() ) {
 			$this->pre_orders = new WC_Stripe_Pre_Orders_Compat();
@@ -371,7 +372,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @version 4.0.0
 	 */
 	public function payment_scripts() {
-		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
+		// TODO: We only need to enqueue stripe.js in the Order Received page if the order has an unresolved Setup Intent
+		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! is_order_received_page() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
 			return;
 		}
 
@@ -565,15 +567,59 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				'confirm'        => 'true',
 			), 'setup_intents' );
 
+			$order_id  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 			if ( is_wp_error( $setup_intent ) ) {
-				WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order->get_id(): " . print_r( $setup_intent, true ) );
+				WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
 			} elseif ( 'requires_action' === $setup_intent->status ) {
+				if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+					update_post_meta( $order_id, '_stripe_setup_intent', $setup_intent->id );
+				} else {
+					$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
+					$order->save();
+				}
 				$response['setup_intent_secret'] = $setup_intent->client_secret;
 			}
 		}
 
 		// Return thank you page redirect.
 		return $response;
+	}
+
+	public function thankyou_page( $order_id ) {
+		$order = wc_get_order( $order_id );
+		$setup_intent_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_setup_intent', true ) : $order->get_meta( '_stripe_setup_intent', true );
+
+		if ( $setup_intent_id ) {
+			$setup_intent = WC_Stripe_API::request( array(), 'setup_intents/' . $setup_intent_id, 'GET' );
+
+			// When authentication fails in a SetupIntent, the "payment_method" property is erased. We need to update it again before it's in a "requires_action" state again
+			if ( ! is_wp_error( $setup_intent ) && 'succeeded' !== $setup_intent->status ) {
+				if ( 'requires_payment_method' === $setup_intent->status && 'setup_intent_authentication_failure' === $setup_intent->last_setup_error->code ) {
+					$setup_intent = WC_Stripe_API::request( array(
+						'payment_method' => $setup_intent->last_setup_error->payment_method->id,
+					), 'setup_intents/' . $setup_intent_id . '/confirm' );
+				}
+			}
+
+			if ( ! is_wp_error( $setup_intent ) ) {
+				if ( 'requires_action' === $setup_intent->status ) {
+					// TODO: Style the hell out of this
+					?>
+					<p id="stripe-setup-intent-authorize-container">
+						We need you to authorize us to charge your credit card in the future. Authorize us now so we won't need to bother you later.
+						<a href="javascript:void(0);" id="stripe-setup-intent-authorize-button" data-secret="<?php echo esc_attr( $setup_intent->client_secret ) ?>">Authorize</a>
+					</p>
+					<?php
+				} else {
+					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+						delete_post_meta( $order_id, '_stripe_setup_intent' );
+					} else {
+						$order->delete_meta_data( '_stripe_setup_intent' );
+						$order->save();
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -593,12 +593,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$setup_intent = WC_Stripe_API::request( array(), 'setup_intents/' . $setup_intent_id, 'GET' );
 
 			// When authentication fails in a SetupIntent, the "payment_method" property is erased. We need to update it again before it's in a "requires_action" state again
-			if ( ! is_wp_error( $setup_intent ) && 'succeeded' !== $setup_intent->status ) {
-				if ( 'requires_payment_method' === $setup_intent->status && 'setup_intent_authentication_failure' === $setup_intent->last_setup_error->code ) {
-					$setup_intent = WC_Stripe_API::request( array(
-						'payment_method' => $setup_intent->last_setup_error->payment_method->id,
-					), 'setup_intents/' . $setup_intent_id . '/confirm' );
-				}
+			if ( ! is_wp_error( $setup_intent )
+			     && 'requires_payment_method' === $setup_intent->status
+			     && 'setup_intent_authentication_failure' === $setup_intent->last_setup_error->code ) {
+				$setup_intent = WC_Stripe_API::request( array(
+					'payment_method' => $setup_intent->last_setup_error->payment_method->id,
+				), 'setup_intents/' . $setup_intent_id . '/confirm' );
 			}
 
 			if ( ! is_wp_error( $setup_intent ) ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -248,29 +248,17 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		if ( is_add_payment_method_page() ) {
-			$pay_button_text = __( 'Add Card', 'woocommerce-gateway-stripe' );
-			$total           = '';
 			$firstname       = $user->user_firstname;
 			$lastname        = $user->user_lastname;
-
-		} elseif ( function_exists( 'wcs_order_contains_subscription' ) && isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
-			$pay_button_text = __( 'Change Payment Method', 'woocommerce-gateway-stripe' );
-			$total           = '';
-		} else {
-			$pay_button_text = '';
 		}
 
 		ob_start();
 
 		echo '<div
 			id="stripe-payment-data"
-			data-panel-label="' . esc_attr( $pay_button_text ) . '"
 			data-email="' . esc_attr( $user_email ) . '"
-			data-amount="' . esc_attr( WC_Stripe_Helper::get_stripe_amount( $total ) ) . '"
-			data-name="' . esc_attr( $this->statement_descriptor ) . '"
 			data-full-name="' . esc_attr( $firstname . ' ' . $lastname ) . '"
 			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '"
-			data-allow-remember-me="' . esc_attr( apply_filters( 'wc_stripe_allow_remember_me', true ) ? 'true' : 'false' ) . '"
 		>';
 
 		if ( $this->testmode ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -81,7 +81,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @todo Implement proper webhook signature validation. Ref https://stripe.com/docs/webhooks#signatures
 	 * @param string $request_headers The request headers from Stripe.
 	 * @param string $request_body The request body from Stripe.
 	 * @return bool

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -124,19 +124,9 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		try {
 			$subscription    = wc_get_order( $order_id );
 			$prepared_source = $this->prepare_source( get_current_user_id(), true );
-			$source_object   = $prepared_source->source_object;
 
-			// Check if we don't allow prepaid credit cards.
-			if ( ! apply_filters( 'wc_stripe_allow_prepaid_card', true ) && $this->is_prepaid_card( $source_object ) ) {
-				$localized_message = __( 'Sorry, we\'re not accepting prepaid cards at this time. Your credit card has not been charge. Please try with alternative payment method.', 'woocommerce-gateway-stripe' );
-				throw new WC_Stripe_Exception( print_r( $source_object, true ), $localized_message );
-			}
-
-			if ( empty( $prepared_source->source ) ) {
-				$localized_message = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
-				throw new WC_Stripe_Exception( print_r( $prepared_source, true ), $localized_message );
-			}
-
+			$this->maybe_disallow_prepaid_card( $prepared_source );
+			$this->check_source( $prepared_source );
 			$this->save_source_to_order( $subscription, $prepared_source );
 
 			do_action( 'wc_stripe_change_subs_payment_method_success', $prepared_source->source, $prepared_source );


### PR DESCRIPTION
Fixes #936 

cc/ @LevinMedia You can safely skip to the `UX considerations` section.

In hindsight, we probably should have left this issue until the end, since it's merely an optimization. Nothing in this PR is strictly required to launch.

This PR introduces SetupIntents so the user has a chance to pass a SCA challenge even if the charge is not going to be charged right away. That's important for Subscriptions that have a free trial period, and pre-orders.

Passing the SCA challenge in this way makes it less probable that passing another challenge will be required down the road. We are assuming that most credit cards will behave like this Stripe test card (which is the one I recommend to test this BTW):

NUMBER | AUTHENTICATION | DESCRIPTION
-- | -- | --
4000002500003155 | Required on setup or first transaction | This test card requires authentication for one-time payments. However, if you set up this card using the Setup Intents API and use the saved card for subsequent payments, no further authentication is needed.

## Technical considerations

I didn't want for us to migrate everything to `Payment Methods`. I found a way to keep using `sources`. When creating a `SetupIntent`, you can put either a `source` or a `paymentMethod` in the `payment_method` property. However, if you use a `source`, you'll need to also pass a `customer` ID to the `customer` property. We are creating a `customer` object when the user saves the credit card for a subscription, so this was not a problem.

I used a similar (although a bit simpler) approach as with the Payment Intents: I used a `hash`-based URL to allow the JS logic to present the SCA challenge before redirecting to the "Thank You" page.

## UX considerations

The easiest way to test this is to install WooCommerce Subscriptions, create a subscription product with a free trial, and use the `4000002500003155` credit card to purchase it. That credit card won't be charged, but you'll still get a SCA challenge modal.

This is the current flow if the credit card doesn't require SCA at all (like `4242424242424242`):
- User puts the cc in the checkout, clicks `Sign Up Now`
- Spinner...
- Redirected to the `Thank you` page.
- At the same time, the user may receive an `Order Completed` e-mail.

Now, if the credit card requires SCA and the user passes the challenge:
- User puts the cc in the checkout, clicks `Sign Up Now`
- Spinner...
- User is presented with the SCA challenge modal.
- At the same time, the user may receive an `Order Completed` e-mail, since the order is already correctly created in the system.
- User passes the challenge.
- Redirected to the `Thank you` page.

Now, if the user closes the browser before passing the challenge:
- User puts the cc in the checkout, clicks `Sign Up Now`
- Spinner...
- User is presented with the SCA challenge modal.
- At the same time, the user may receive an `Order Completed` e-mail, since the order is already correctly created in the system.
- User closes the browser. Order is still correctly placed in the system even though the user never reached the "Thank You" page.

Now, if the user fails the challenge the first time:
- User puts the cc in the checkout, clicks `Sign Up Now`
- Spinner...
- User is presented with the SCA challenge modal.
- At the same time, the user may receive an `Order Completed` e-mail, since the order is already correctly created in the system.
- User fails the challenge.
- Redirected to the `Thank you` page. Everything seems alright. There's a warning with a button so the user can retry the SCA challenge. That message will dissapear if the challenge is passed, and the whole page will be reloaded if it fails (so it can be re-tried again).

This is how the SCA modal looks:
![Screenshot 2019-08-14 at 21 51 38](https://user-images.githubusercontent.com/1715800/63051681-f2ad3c00-bedd-11e9-9213-0b5d7461d84f.png)

This is how the warning message in the "Thank You" page looks (needs a real copy and some styling, can be moved to the top):
![Screenshot 2019-08-14 at 21 52 04](https://user-images.githubusercontent.com/1715800/63051696-f93bb380-bedd-11e9-8a62-0ec6d0b6712a.png)

The questions I have around UX basically can be summed up in one: Since this flow is not mandatory, how can we provide the least friction possible, considering that if the SCA challenge is not passed, there may be some friction when the time comes to make the first payment?

Everything is on the table. We can, for example:
- Not present the challenge in the checkout, make it pop-up automatically when the "Thank you" page is reached.
- Make the challenge pop-up appear automatically in the Thank You page if it was failed in the Checkout.
- Add just the "warning" message to the Thank You page, without having the challenge disrupt the main checkout/thankyou flow.