### PR TITLE
Initial addition of the `setup_future_usage` parameter.

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1021,13 +1021,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Create a new PaymentIntent.
+	 * Generates the request when creating a new payment intent.
 	 *
 	 * @param WC_Order $order           The order that is being paid for.
 	 * @param object   $prepared_source The source that is used for the payment.
-	 * @return object                   An intent or an error.
+	 * @return array                    The arguments for the request.
 	 */
-	public function create_intent( $order, $prepared_source ) {
+	public function generate_create_intent_request( $order, $prepared_source ) {
 		// The request for a charge contains metadata for the intent.
 		$full_request = $this->generate_payment_request( $order, $prepared_source );
 
@@ -1047,6 +1047,19 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( $prepared_source->customer ) {
 			$request['customer'] = $prepared_source->customer;
 		}
+
+		return $request;
+	}
+
+	/**
+	 * Create a new PaymentIntent.
+	 *
+	 * @param WC_Order $order           The order that is being paid for.
+	 * @param object   $prepared_source The source that is used for the payment.
+	 * @return object                   An intent or an error.
+	 */
+	public function create_intent( $order, $prepared_source ) {
+		$request = $this->generate_create_intent_request( $order, $prepared_source );
 
 		// Create an intent that awaits an action.
 		$intent = WC_Stripe_API::request( $request, 'payment_intents' );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1037,7 +1037,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'currency'             => strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() ),
 			'description'          => $full_request['description'],
 			'metadata'             => $full_request['metadata'],
-			'statement_descriptor' => $full_request['statement_descriptor'],
 			'capture_method'       => ( 'true' === $full_request['capture'] ) ? 'automatic' : 'manual',
 			'payment_method_types' => array(
 				'card',
@@ -1046,6 +1045,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		if ( $prepared_source->customer ) {
 			$request['customer'] = $prepared_source->customer;
+		}
+
+		if ( isset( $full_request['statement_descriptor'] ) ) {
+			$request['statement_descriptor'] = $full_request['statement_descriptor'];
 		}
 
 		/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1048,7 +1048,15 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$request['customer'] = $prepared_source->customer;
 		}
 
-		return $request;
+		/**
+		 * Filter the return value of the WC_Payment_Gateway_CC::generate_create_intent_request.
+		 *
+		 * @since 3.1.0
+		 * @param array $request
+		 * @param WC_Order $order
+		 * @param object $source
+		 */
+		return apply_filters( 'wc_stripe_generate_create_intent_request', $request, $order, $prepared_source );
 	}
 
 	/**

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -170,6 +170,23 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	}
 
 	/**
+	 * Overloads WC_Stripe_Payment_Gateway::generate_create_intent_request() in order to
+	 * include additional flags, used when setting payment intents up for off-session usage.
+	 *
+	 * @param WC_Order $order           The order that is being paid for.
+	 * @param object   $prepared_source The source that is used for the payment.
+	 * @return array                    The arguments for the request.
+	 */
+	public function generate_create_intent_request( $order, $prepared_source ) {
+		$request = parent::generate_create_intent_request( $order, $prepared_source );
+
+		// Let Stripe know that the payment should be prepared for future usage.
+		$request['setup_future_usage'] = 'off_session';
+
+		return $request;
+	}
+
+	/**
 	 * Scheduled_subscription_payment function.
 	 *
 	 * @param $amount_to_charge float The amount to charge.

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -180,6 +180,11 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	public function generate_create_intent_request( $order, $prepared_source ) {
 		$request = parent::generate_create_intent_request( $order, $prepared_source );
 
+		// Non-subscription orders do not need any additional parameters.
+		if ( ! $this->has_subscription( $order ) ) {
+			return $request;
+		}
+
 		// Let Stripe know that the payment should be prepared for future usage.
 		$request['setup_future_usage'] = 'off_session';
 

--- a/tests/phpunit/dummy-data/subscription_signup_response_success.json
+++ b/tests/phpunit/dummy-data/subscription_signup_response_success.json
@@ -1,0 +1,60 @@
+{
+  "id": "pi_123abc",
+  "object": "payment_intent",
+  "amount": 5000,
+  "amount_capturable": 0,
+  "amount_received": 0,
+  "application": null,
+  "application_fee_amount": null,
+  "canceled_at": null,
+  "cancellation_reason": null,
+  "capture_method": "automatic",
+  "charges": {
+    "object": "list",
+    "data": [
+			{
+				"id": "ch_abc"
+			}
+    ],
+    "has_more": false,
+    "total_count": 0,
+    "url": "/v1/charges?payment_intent=pi_123abc"
+  },
+  "client_secret": "pi_123abc_secret_UaNshLU9SSaLJLtVD6W1V7ndF",
+  "confirmation_method": "automatic",
+  "created": 1566581456,
+  "currency": "eur",
+  "customer": "cus_EgskS2dN4FzgmE",
+  "description": "Playground - Order 1803",
+  "invoice": null,
+  "last_payment_error": null,
+  "livemode": false,
+  "metadata": {
+    "customer_name": "John Smith",
+    "customer_email": "example3@example.com",
+    "order_id": "1803",
+    "payment_type": "recurring",
+    "site_url": "https://localhost/"
+  },
+  "next_action": null,
+  "on_behalf_of": null,
+  "payment_method": null,
+  "payment_method_options": {
+    "card": {
+      "request_three_d_secure": "automatic"
+    }
+  },
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": null,
+  "review": null,
+  "setup_future_usage": "off_session",
+  "shipping": null,
+  "source": "src_1EvP9PIDdSUSdcIrdTMMVT8t",
+  "statement_descriptor": "This is a statement descriptor.",
+  "statement_descriptor_suffix": null,
+  "status": "requires_confirmation",
+  "transfer_data": null,
+  "transfer_group": null
+}

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * These tests assert various things about processing an initial payment for a WooCommerce Subscriptions.
+ *
+ * The responses from HTTP requests are mocked using the WP filter `pre_http_request`.
+ *
+ * There are a few methods that need to be mocked in the class WC_Stripe_Subs_Compat, which is
+ * why that class is mocked even though the method under test is part of that class.
+ *
+ * @package WooCommerce_Stripe/Classes/WC_Stripe_Subscription_Initial_Test
+ */
+
+/**
+ * WC_Stripe_Subscription_Initial_Test
+ */
+class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
+	/**
+	 * System under test, and a mock object with some methods mocked for testing
+	 *
+	 * @var PHPUnit_Framework_MockObject_MockObject
+	 */
+	private $wc_stripe_subs_compat;
+
+	/**
+	 * The statement descriptor we'll use in a test.
+	 *
+	 * @var string
+	 */
+	private $statement_descriptor;
+
+	/**
+	 * Sets up things all tests need.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->wc_stripe_subs_compat = $this->getMockBuilder( 'WC_Stripe_Subs_Compat' )
+			->disableOriginalConstructor()
+			->setMethods( array( 'prepare_source', 'has_subscription' ) )
+			->getMock();
+
+		// Mocked in order to get metadata[payment_type] = recurring in the HTTP request.
+		$this->statement_descriptor = 'This is a statement descriptor.';
+		update_option(
+			'woocommerce_stripe_settings',
+			array(
+				'statement_descriptor' => $this->statement_descriptor,
+			)
+		);
+	}
+
+	/**
+	 * Tears down the stuff we set up.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		delete_option( 'woocommerce_stripe_settings' );
+	}
+
+	/**
+	 * Tests whether the initial payment succeeds and includes the `setup_future_usage` parameter.
+	 *
+	 * 1. Several things are set up or mocked.
+	 * 2. A function that will mock an HTTP response for the payment_intents is created.
+	 * 3. That same function has some assertions about the things we send to the
+	 * payments_intents endpoint.
+	 * 4. The function under test - `process_payment` - is called.
+	 * 5. More assertions are made.
+	 */
+	public function test_initial_intent_parameters() {
+		$initial_order        = WC_Helper_Order::create_order();
+		$order_id             = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $initial_order->id : $initial_order->get_id();
+		$amount               = 50;
+		$stripe_amount        = WC_Stripe_Helper::get_stripe_amount( $amount );
+		$currency             = strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $initial_order->get_order_currency() : $initial_order->get_currency() );
+		$customer             = 'cus_123abc';
+		$source               = 'src_123abc';
+		$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $this->statement_descriptor );
+		$intents_api_endpoint = 'https://api.stripe.com/v1/payment_intents';
+		$urls_used            = array();
+
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			$initial_order->payment_method = 'stripe';
+		} else {
+			$initial_order->set_payment_method( 'stripe' );
+			$initial_order->save();
+		}
+
+		// Arrange: Mock prepare_order_source() so that we have a customer and source.
+		$this->wc_stripe_subs_compat
+			->expects( $this->any() )
+			->method( 'prepare_source' )
+			->will(
+				$this->returnValue(
+					(object) array(
+						'token_id'      => false,
+						'customer'      => $customer,
+						'source'        => $source,
+						'source_object' => (object) array(),
+					)
+				)
+			);
+
+		// Emulate a subscription.
+		$this->wc_stripe_subs_compat
+			->expects( $this->any() )
+			->method( 'has_subscription' )
+			->will( $this->returnValue( true ) );
+
+		$pre_http_request_response_callback = function( $preempt, $request_args, $url ) use (
+			$stripe_amount,
+			$currency,
+			$customer,
+			$source,
+			$intents_api_endpoint,
+			$statement_descriptor,
+			$order_id,
+			&$urls_used
+		) {
+			// Add all urls to array so we can later make assertions about which endpoints were used.
+			array_push( $urls_used, $url );
+			// Continue without mocking the request if it's not the endpoint we care about.
+			if ( 0 !== strpos( $url, $intents_api_endpoint ) ) {
+				return false;
+			}
+
+			// Prepare the response early because it is used for confirmations too.
+			$response = array(
+				'headers'  => array(),
+				// Too bad we aren't dynamically setting things 'cus_123abc' when using this file.
+				'body'     => file_get_contents( 'tests/phpunit/dummy-data/subscription_signup_response_success.json' ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+
+			// Respond with a successfull intent for confirmations.
+			if ( $url !== $intents_api_endpoint ) {
+				$response['body'] = str_replace( 'requires_confirmation', 'succeeded', $response['body'] );
+				return $response;
+			}
+
+			// Assert: the request method is POST.
+			$this->assertArrayHasKey( 'method', $request_args );
+			$this->assertSame( 'POST', $request_args['method'] );
+
+			// Assert: the request has a body.
+			$this->assertArrayHasKey( 'body', $request_args );
+
+			// Assert: the request body contains these values.
+			$expected_request_body_values = array(
+				'source'               => $source,
+				'amount'               => $stripe_amount,
+				'currency'             => $currency,
+				'statement_descriptor' => $statement_descriptor,
+				'customer'             => $customer,
+				'setup_future_usage'   => 'off_session',
+				'payment_method_types' => array( 'card' ),
+			);
+			foreach ( $expected_request_body_values as $key => $value ) {
+				$this->assertArrayHasKey( $key, $request_args['body'] );
+				$this->assertSame( $value, $request_args['body'][ $key ] );
+			}
+
+			// Assert: the request body contains these keys, without checking for their value.
+			$expected_request_body_keys = array(
+				'description',
+				'capture_method',
+			);
+			foreach ( $expected_request_body_keys as $key ) {
+				$this->assertArrayHasKey( $key, $request_args['body'] );
+			}
+
+			// Assert: the body metadata contains the order ID.
+			$this->assertSame( $order_id, absint( $request_args['body']['metadata']['order_id'] ) );
+
+			// // Assert: the body metadata has these keys, without checking for their value.
+			$expected_metadata_keys = array(
+				'customer_name',
+				'customer_email',
+			);
+			foreach ( $expected_metadata_keys as $key ) {
+				$this->assertArrayHasKey( $key, $request_args['body']['metadata'] );
+			}
+
+			// Return dummy content as the response.
+			return $response;
+		};
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+
+		// Act: call process_subscription_payment().
+		// We need to use `wc_stripe_subs_compat` here because we mocked this class earlier.
+		$result = $this->wc_stripe_subs_compat->process_payment( $order_id );
+
+		// Assert: nothing was returned.
+		$this->assertEquals( $result['result'], 'success' );
+		$this->assertArrayHasKey( 'redirect', $result );
+
+		$order      = wc_get_order( $order_id );
+		$order_data = (
+			WC_Stripe_Helper::is_wc_lt( '3.0' )
+				? get_post_meta( $order_id, '_stripe_intent_id', true )
+				: $order->get_meta( '_stripe_intent_id' )
+		);
+
+		$this->assertEquals( $order_data, 'pi_123abc' );
+
+		// Assert: called payment intents.
+		$this->assertTrue( in_array( $intents_api_endpoint, $urls_used, true ) );
+
+		// Clean up.
+		remove_filter( 'pre_http_request', array( $this, 'pre_http_request_response_success' ) );
+	}
+}

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -80,6 +80,7 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 
 		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
 			$initial_order->payment_method = 'stripe';
+			update_post_meta( $order_id, '_payment_method', 'stripe' ); // for `wc_get_order()`.
 		} else {
 			$initial_order->set_payment_method( 'stripe' );
 			$initial_order->save();

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -70,8 +70,7 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 	public function test_initial_intent_parameters() {
 		$initial_order        = WC_Helper_Order::create_order();
 		$order_id             = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $initial_order->id : $initial_order->get_id();
-		$amount               = 50;
-		$stripe_amount        = WC_Stripe_Helper::get_stripe_amount( $amount );
+		$stripe_amount        = WC_Stripe_Helper::get_stripe_amount( $initial_order->get_total() );
 		$currency             = strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $initial_order->get_order_currency() : $initial_order->get_currency() );
 		$customer             = 'cus_123abc';
 		$source               = 'src_123abc';
@@ -86,7 +85,7 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 			$initial_order->save();
 		}
 
-		// Arrange: Mock prepare_order_source() so that we have a customer and source.
+		// Arrange: Mock prepare_source() so that we have a customer and source.
 		$this->wc_stripe_subs_compat
 			->expects( $this->any() )
 			->method( 'prepare_source' )


### PR DESCRIPTION
Fixes #935

#### Changes proposed in this Pull Request:

This PR adds the `setup_future_usage` to intent creation calls when the cart contains a subscription. In order to follow @v18's excellent example of adding tests, I added the `WC_Stripe_Subscription_Initial_Test` test in order to verify the existence of the parameter.

The test covers the `process_payment` method with subscriptions, but only focuses on the PaymentIntent creation call, and not the rest of the method.

#### Testing instructions

1. Add a subscription to the cart and check out.
2. Locate the request log for the payment intent creation in Stripe Dashboard and make sure the 
`setup_future_usage` parameter is set to `off_session`.
3. Add a normal product to the cart and check out.
4. Locate the request log for the payment intent creation in Stripe Dashboard and make sure the 
`setup_future_usage` parameter is __missing__.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- ~[ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.~

