### PR TITLE
fix: return early from check intent status if no order.

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -906,6 +906,11 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		$order = wc_get_order( absint( $order_id ) );
+
+		if ( ! $order ) {
+			return;
+		}
+
 		$this->verify_intent_after_checkout( $order );
 	}
 


### PR DESCRIPTION
Fixes #965  .

#### Changes proposed in this Pull Request:
- return early from check intent status if no order

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

