### PR TITLE
Add filter for checking if subscription in order

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -318,7 +318,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return boolean
 	 */
 	public function has_subscription( $order_id ) {
-		return ( function_exists( 'wcs_order_contains_subscription' ) && ( wcs_order_contains_subscription( $order_id ) || wcs_is_subscription( $order_id ) || wcs_order_contains_renewal( $order_id ) ) );
+		return apply_filters(
+			'wc_stripe_has_subscription',
+			( function_exists( 'wcs_order_contains_subscription' ) && ( wcs_order_contains_subscription( $order_id ) || wcs_is_subscription( $order_id ) || wcs_order_contains_renewal( $order_id ) ) )
+		);
 	}
 
 	/**

--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -54,7 +54,10 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @return boolean
 	 */
 	public function has_subscription( $order_id ) {
-		return ( function_exists( 'wcs_order_contains_subscription' ) && ( wcs_order_contains_subscription( $order_id ) || wcs_is_subscription( $order_id ) || wcs_order_contains_renewal( $order_id ) ) );
+		return apply_filters(
+			'wc_stripe_has_subscription',
+			( function_exists( 'wcs_order_contains_subscription' ) && ( wcs_order_contains_subscription( $order_id ) || wcs_is_subscription( $order_id ) || wcs_order_contains_renewal( $order_id ) ) )
+		);
 	}
 
 	/**

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -54,7 +54,10 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 * @return boolean
 	 */
 	public function has_subscription( $order_id ) {
-		return ( function_exists( 'wcs_order_contains_subscription' ) && ( wcs_order_contains_subscription( $order_id ) || wcs_is_subscription( $order_id ) || wcs_order_contains_renewal( $order_id ) ) );
+		return apply_filters(
+			'wc_stripe_has_subscription',
+			( function_exists( 'wcs_order_contains_subscription' ) && ( wcs_order_contains_subscription( $order_id ) || wcs_is_subscription( $order_id ) || wcs_order_contains_renewal( $order_id ) ) )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Closes #967 .

This filters all return values of the `has_subscription` functions. In progress - there may be more things to be done, like different filters names for different functions.

@dwainm I think this branch can now be tested for your purposes as [outlined here](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/962#issuecomment-524132731) :)

**How to merge**
This should be merged into `sca-subs/master` only after #962 is merged.