### PR TITLE
Don't copy intent id when creating a subs renewal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Unclear error message when email address not completely filled in.
 * Fix - Add payment request button compatibility with variable subscriptions
 * Tweak - Do not show payment request button for shippable trial subscription products
+* Fix - Do not copy the payment intent id when creating a subscription renewal
 
 = 4.2.3 - 2019-07-18 =
 * Fix - Ignore "payment failed" webhooks if they come after another payment has already succeeded for that order.

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -309,6 +309,8 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_source_id' );
 		// For BW compat will remove in future
 		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_card_id' );
+		// delete payment intent ID
+		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_intent_id' );
 		$this->delete_renewal_meta( $resubscribe_order );
 	}
 
@@ -319,6 +321,9 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	public function delete_renewal_meta( $renewal_order ) {
 		WC_Stripe_Helper::delete_stripe_fee( $renewal_order );
 		WC_Stripe_Helper::delete_stripe_net( $renewal_order );
+
+		// delete payment intent ID
+		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id() ), '_stripe_intent_id' );
 
 		return $renewal_order;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 4.x.x - 2019-x-x =
 * Fix - Add payment request button compatibility with variable subscriptions
 * Tweak - Do not show payment request button for shippable trial subscription products
+* Fix - Do not copy the payment intent id when creating a subscription renewal
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #972.

To test:
* Attempt to reproduce the steps from the issue - the payment should go through

CC @v18 @DanReyLop

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

