### PR TITLE
Add a way for the user to pass the SCA challenge after a failed renewal

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -872,7 +872,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @since 4.2
 	 */
 	public function render_payment_intent_inputs( $order = null ) {
-		if ( ! isset( $order ) ) {
+		if ( ! isset( $order ) || empty( $order ) ) {
 			$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
 		}
 		$intent = $this->get_intent_from_order( $order );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -845,7 +845,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		add_filter( 'woocommerce_checkout_show_terms', '__return_false' );
 		add_filter( 'woocommerce_pay_order_button_html', '__return_false' );
-		add_filter( 'woocommerce_available_payment_gateways', array( $this, '__return_empty_array' ) );
+		add_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
 		add_filter( 'woocommerce_no_available_payment_methods_message', array( $this, 'change_no_available_methods_message' ) );
 		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'render_payment_intent_inputs' ) );
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -139,14 +139,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_account_view-order_endpoint', array( $this, 'check_intent_status_on_order_page' ), 1 );
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
-		/*
-		 * WC subscriptions hooks into the "template_redirect" hook with priority 100.
-		 * If the screen is "Pay for order" and the order is a subscription renewal, it redirects to the plain checkout.
-		 * See: https://github.com/woocommerce/woocommerce-subscriptions/blob/99a75687e109b64cbc07af6e5518458a6305f366/includes/class-wcs-cart-renewal.php#L165
-		 * If we are in the "You just need to authorize SCA" flow, we don't want that redirection to happen.
-		 */
-		add_action( 'template_redirect', array( $this, 'remove_order_pay_var' ), 99 );
-		add_action( 'template_redirect', array( $this, 'restore_order_pay_var' ), 101 );
 
 		if ( WC_Stripe_Helper::is_pre_orders_exists() ) {
 			$this->pre_orders = new WC_Stripe_Pre_Orders_Compat();
@@ -1051,27 +1043,5 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function process_authentication_required_response( $order ) {
 		$auth_url = add_query_arg( 'wc-stripe-confirmation', 1, $order->get_checkout_payment_url( false ) );
 		$order->add_order_note( '[TODO: send a real e-mail here] Go here to authenticate: ' . $auth_url, true );
-	}
-
-	/**
-	 * If this is the "Pass the SCA challenge" flow, remove a variable that is checked by WC Subscriptions
-	 * so WC Subscriptions doesn't redirect to the checkout
-	 */
-	public function remove_order_pay_var() {
-		global $wp;
-		if ( isset( $_GET['wc-stripe-confirmation'] ) ) {
-			$this->order_pay_var = $wp->query_vars['order-pay'];
-			$wp->query_vars['order-pay'] = null;
-		}
-	}
-
-	/**
-	 * Restore the variable that was removed in remove_order_pay_var()
-	 */
-	public function restore_order_pay_var() {
-		global $wp;
-		if ( isset( $this->order_pay_var ) ) {
-			$wp->query_vars['order-pay'] = $this->order_pay_var;
-		}
 	}
 }

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -279,7 +279,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 					$renewal_order->save();
 				}
 
-				$this->process_authentication_required_response();
+				$this->process_authentication_required_response( $renewal_order );
 			} else {
 				// The charge was successfully captured
 				do_action( 'wc_gateway_stripe_process_payment', $response, $renewal_order );
@@ -352,12 +352,6 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		$this->save_intent_to_order( $order, $payment_intent );
 
 		return $intent;
-	}
-
-	public function process_authentication_required_response() {
-		// TODO: Email the user about the payment requring authentication.
-		// TODO: Make sure that store owner knows not to fulfill this yet.
-		// TODO: Make sure that if authentication is provided, order fails.
 	}
 
 	/**

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -283,7 +283,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 				$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id();
 
 				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $id ) : $renewal_order->set_transaction_id( $id );
-				$renewal_order->update_status( 'on-hold', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
+				$renewal_order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
 				if ( is_callable( array( $renewal_order, 'save' ) ) ) {
 					$renewal_order->save();
 				}


### PR DESCRIPTION
~Marking this as "in progress" because I still need to test this more thoroughly and improve error handling, but it's functionally finished.~ Ready for review now 🎉 

I'm adding some PR comments to point out some potential discussion areas.

To test:
- Create a subscription product.
- Sign up for that subscription using the `4000002760003184` test card.
- After the subscription is active, go to the Edit Order page for the subscription, select `Process Renewal` on `Subscription Actions`, and click the `Update` button.

That should create a renewal order, and attempt to pay for it immediately. SCA will fail, so that renewal order will be in a `failed` state, and will have an `Order Note` telling the user to follow a link. That Order Note will need to be replaced with a real e-mail. because the renewal order "failed", the subscription will transition to an `on-hold` status.

If you follow the link, you'll get to a stripped-down "Pay for order" screen, which will open the SCA challenge modal automatically. After passing the challenge, you'll be redirected to the "Order received" page, the renewal order will be in `processing` status, and the subscription will be `active` again.