### PR TITLE
Don't send the "Order failed" e-mail twice

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1015,7 +1015,5 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			? sprintf( __( 'Stripe SCA authentication failed. Reason: %s', 'woocommerce-gateway-stripe' ), $intent->last_payment_error->message )
 			: __( 'Stripe SCA authentication failed.', 'woocommerce-gateway-stripe' );
 		$order->update_status( 'failed', $status_message );
-
-		$this->send_failed_order_email( $order->get_id() );
 	}
 }

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -269,9 +269,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification, $e );
 
-			$statuses = array( 'pending', 'failed' );
-
-			if ( $order->has_status( $statuses ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 		}
@@ -686,8 +684,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$order->update_status( 'failed', sprintf( __( 'Stripe SCA authentication failed. Reason: %s', 'woocommerce-gateway-stripe' ), $error_message ) );
 
 			do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
-
-			$this->send_failed_order_email( $order_id );
 		}
 
 		$this->unlock_order_payment( $order );

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -268,7 +268,6 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
 
-			/* translators: error message */
 			$renewal_order->update_status( 'failed' );
 		}
 	}

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -283,9 +283,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			$statuses = array( 'pending', 'failed' );
-
-			if ( $order->has_status( $statuses ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
@@ -277,7 +277,7 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-eps.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-eps.php
@@ -276,7 +276,7 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-giropay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-giropay.php
@@ -276,7 +276,7 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-ideal.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-ideal.php
@@ -276,7 +276,7 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -383,7 +383,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-p24.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-p24.php
@@ -273,7 +273,7 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -412,7 +412,7 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-sofort.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sofort.php
@@ -288,7 +288,7 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
+			if ( $order->has_status( 'pending' ) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 


### PR DESCRIPTION
In my testing for SCA, I noticed that I received a lot of duplicated e-mails. Turns out, when transitioning an order to `failed` status, an "Order Failed" e-mail is automatically sent by WooCommerce. So, I removed all the redundant calls to `$stripe_gateway->send_failed_order_email( $order_id )` if they come inmediately after setting the order status to `failed`.

To test:
- Purchase an item with a test credit card that will fail (or fail the SCA challenge).
- Notice that you only receive one "Failed order" e-mail on the admin inbox, and one e-mail on the customer's inbox.