### PR TITLE
Add dot org release config

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
   "engines": {
     "node": ">=8.9.3",
     "npm": ">=5.5.1"
+  },
+  "config": {
+    "wp_org_slug": "woocommerce-gateway-stripe"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-extension-release/issues/22

#### Changes proposed in this Pull Request:
- Add dot org release config

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

