### PR TITLE
SCA Subs: Prevent payment retries and check for authentication instead

### DIFF
--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -220,6 +220,11 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 			$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id();
 
+			// Check for an existing intent, which is associated with the order.
+			if ( $this->has_authentication_already_failed( $renewal_order ) ) {
+				return;
+			}
+
 			// Get source from order
 			$prepared_source = $this->prepare_order_source( $renewal_order );
 			$source_object   = $prepared_source->source_object;
@@ -565,5 +570,41 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		if ( isset( $this->order_pay_var ) ) {
 			$wp->query_vars['order-pay'] = $this->order_pay_var;
 		}
+	}
+
+	/**
+	 * Checks if a renewal already failed because a manual authentication is required.
+	 *
+	 * @param WC_Order $renewal_order The renewal order.
+	 * @return boolean
+	 */
+	public function has_authentication_already_failed( $renewal_order ) {
+		$existing_intent = $this->get_intent_from_order( $renewal_order );
+
+		if (
+			! $existing_intent
+			|| 'requires_payment_method' !== $existing_intent->status
+			|| empty( $existing_intent->last_payment_error )
+			|| 'authentication_required' !== $existing_intent->last_payment_error->code
+		) {
+			return false;
+		}
+
+		// Make sure all emails are instantiated.
+		WC_Emails::instance();
+
+		/**
+		 * A payment attempt failed because SCA authentication is required.
+		 *
+		 * @param WC_Order $renewal_order The order that is being renewed.
+		 */
+		do_action( 'wc_gateway_stripe_process_payment_authentication_required', $renewal_order );
+
+		// Fail the payment attempt (order would be currently pending because of retry rules).
+		$charge    = end( $existing_intent->charges->data );
+		$charge_id = $charge->id;
+		$renewal_order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $charge_id ) );
+
+		return true;
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Add the `has_authentication_already_failed` method to `WC_Stripe_Subs_Compat`. It is used in `process_subscription_payment` in order to check whether a PaymentIntent is already associated with the order, and if there is one, whether it's awaiting authentication.
- By triggering the `wc_gateway_stripe_process_payment_authentication_required` action in `has_authentication_already_failed`, the `WC_Stripe_Email_Failed_Renewal_Authentication` is being sent during automatic retries.
- `WC_Stripe_Email_Failed_Renewal_Authentication` now prevents all customer-facing emails, sent by automatic retries.

## Testing instructions

1. Create a Mailtrap account, install the WP extension, and connect them.
2. Go to WooCommerce > Settings > Subscriptions and enable "Enable automatic retry of failed recurring payments ".
3. Create a subscription with a free trial.
4. Sign up for the subscription with `4000002760003184`. While doing that, use an email address, which is not the admin email address. This way you'll know whether an email is sent to the admin or the customer.
5. Go to the subscription (in the admin) and try to manually process a renewal.
6. Verify that a single email was sent to the customer, with subject `Payment authorization needed for renewal of Playground order XXX`.
7. Go to WooCommerce > Status > Scheduled Actions. Locate the (probably) one, associated with `woocommerce_scheduled_subscription_payment_retry` and click __Run__.
8. Verify that a single email was sent to the customer, with subject `Payment authorization needed for renewal of Playground order XXX`.

@james-allan I'm setting the `email_template_customer` prop of all raw retry rules to an empty string. Considering this is done only *after* an SCA email gets sent, do you think this is a good strategy?

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).

Edit: Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/995