### PR TITLE
SCA Subs: Use SetupIntent for Pre-Orders

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1193,4 +1193,33 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 		delete_transient( 'wc_stripe_processing_intent_' . $order_id );
 	}
+
+	/**
+	 * Creates a SetupIntent for future payments, and saves it to the order.
+	 *
+	 * @param WC_Order $order           The ID of the (free/pre- order).
+	 * @param object   $prepared_source The source, entered/chosen by the customer.
+	 * @return string                   The client secret of the intent, used for confirmation in JS.
+	 */
+	public function setup_intent( $order, $prepared_source ) {
+		$order_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$setup_intent = WC_Stripe_API::request( array(
+			'payment_method' => $prepared_source->source,
+			'customer'       => $prepared_source->customer,
+			'confirm'        => 'true',
+		), 'setup_intents' );
+
+		if ( is_wp_error( $setup_intent ) ) {
+			WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
+		} elseif ( 'requires_action' === $setup_intent->status ) {
+			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+				update_post_meta( $order_id, '_stripe_setup_intent', $setup_intent->id );
+			} else {
+				$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
+				$order->save();
+			}
+
+			return $setup_intent->client_secret;
+		}
+	}
 }

--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -61,19 +61,28 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( __( 'Unable to store payment details. Please try again.', 'woocommerce-gateway-stripe' ) );
 			}
 
+			// Setup the response early to allow later modifications.
+			$response = array(
+				'result'   => 'success',
+				'redirect' => $this->get_return_url( $order ),
+			);
+
 			$this->save_source_to_order( $order, $prepared_source );
 
-			// Remove cart
+			// Try setting up a payment intent.
+			$intent_secret = $this->setup_intent( $order, $prepared_source );
+			if ( ! empty( $intent_secret ) ) {
+				$response['setup_intent_secret'] = $intent_secret;
+			}
+
+			// Remove cart.
 			WC()->cart->empty_cart();
 
 			// Is pre ordered!
 			WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );
 
 			// Return thank you page redirect
-			return array(
-				'result'   => 'success',
-				'redirect' => $this->get_return_url( $order ),
-			);
+			return $response;
 		} catch ( WC_Stripe_Exception $e ) {
 			wc_add_notice( $e->getLocalizedMessage(), 'error' );
 			WC_Stripe_Logger::log( 'Pre Orders Error: ' . $e->getMessage() );


### PR DESCRIPTION
Fixes #941.

#### Changes proposed in this Pull Request:

- Extracted the creation of SetupIntents into a separate method within the abstract class, rather than the CC one.
- `setup_intent` is now used within Pre-Orders too.

This PR is based on #961, which handles all needed actions like dialogs, thank you page, and etc.

## Testing instructions

Try to pre-order a pre-order (xD) with `4000000000003220`. You should see a modal that requires you to confirm the new SetupIntent (looks significantly different from normal SCA/PaymentIntent modal).

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
