### PR TITLE
Update readme file

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -113,7 +113,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.x.x - 2019-09-18 =
+= 4.2.4 - 2019-09-18 =
 * Fix - Unclear error message when email address not completely filled in.
 * Fix - Add payment request button compatibility with variable subscriptions
 * Tweak - Do not show payment request button for shippable trial subscription products


### PR DESCRIPTION
WP.org repo doesn't reflect right version: https://wordpress.org/plugins/woocommerce-gateway-stripe/#developers - not sure if this can be updated on .org without needing to add a new version number

