### PR TITLE
Fixing a `__return_empty_array` hook

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -838,7 +838,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		add_filter( 'woocommerce_checkout_show_terms', '__return_false' );
 		add_filter( 'woocommerce_pay_order_button_html', '__return_false' );
-		add_filter( 'woocommerce_available_payment_gateways', array( $this, '__return_empty_array' ) );
+		add_filter( 'woocommerce_available_payment_gateways', '__return_empty_array' );
 		add_filter( 'woocommerce_no_available_payment_methods_message', array( $this, 'change_no_available_methods_message' ) );
 		add_action( 'woocommerce_pay_order_after_submit', array( $this, 'render_payment_intent_inputs' ) );
 


### PR DESCRIPTION
Fixes #906.

#### Changes proposed in this Pull Request:

While working on 4.2.0, this line was introduced to `WC_Gateway_Stripe`:

```php
add_filter( 'woocommerce_available_payment_gateways', array( $this, '__return_empty_array' ) );
```

This was done in order not to display any alternative payment methods during SCA confirmations for existing orders, and simplify the page interface. It looks like the plan (or _my_ plan) was to use a local method, but instead I switched to `__return_empty_array` without removing `( $this )`.

This PR simply switches from `array( $this, '__return_empty_array' )` to `'__return_empty_array'` for the callback.

#### Testing instructions:

1. Add an item to the cart
2. Go to the checkout page, fill all necessary fields, and submit the form **with a card, which requires 3DSv2 vefification**.
3. Instead of authorizing the order, navigate to My Account > Orders, and click **Pay** next to   __the newly created order__.
4. Submit the form on the Pay for Order page. You should be redirected to the same page, but an SCA modal should appear.
5. Make sure there are no errors or warnings displayed/in the log.

-------------------
- [+] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
