### PR TITLE
Fixing a deprecated call to `woocommerce_get_page_id`.

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -92,7 +92,7 @@ class WC_Stripe_Intent_Controller {
 			wc_add_notice( esc_html( $message ), 'error' );
 
 			$redirect_url = $woocommerce->cart->is_empty()
-				? get_permalink( woocommerce_get_page_id( 'shop' ) )
+				? get_permalink( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? woocommerce_get_page_id( 'shop' ) : wc_get_page_id( 'shop' ) )
 				: wc_get_checkout_url();
 
 			$this->handle_error( $e, $redirect_url );


### PR DESCRIPTION
Fixes #932

#### Changes proposed in this Pull Request:

When introducing `WC_Stripe_Intent_Controller::verify_intent`, I used `woocommerce_get_page_id`, which is deprecated. I did not see a deprecation notice because during AJAX WordPress turns error display off.

After the issue was reported in #932, this PR checks which WooCommerce version is being used and if it is newer than 3.0 or 3.0, the method uses the new `wc_get_page_id` function.

#### Testing instructions

1. Open `<your-website-url>/?wc-ajax=wc_stripe_verify_intent&order=999999`
2. Ensure that the error logs do not contain any deprecated function notices.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

