### PR TITLE
Fix the style notice

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -127,7 +127,7 @@ class WC_Stripe_Admin_Notices {
 
 			if ( empty( $show_style_notice ) ) {
 				/* translators: 1) int version 2) int version */
-				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://docs.woocommerce.com/document/stripe/#section-45" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );
+				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://docs.woocommerce.com/document/stripe/#section-48" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );
 
 				$this->add_admin_notice( 'style', 'notice notice-warning', $message, true );
 

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -129,7 +129,7 @@ class WC_Stripe_Admin_Notices {
 				/* translators: 1) int version 2) int version */
 				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://docs.woocommerce.com/document/stripe/#section-45" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );
 
-				$this->add_admin_notice( 'style', 'error', $message, true );
+				$this->add_admin_notice( 'style', 'notice notice-warning', $message, true );
 
 				return;
 			}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -23,6 +23,7 @@ class WC_Stripe_Admin_Notices {
 	public function __construct() {
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 		add_action( 'wp_loaded', array( $this, 'hide_notices' ) );
+		add_action( 'woocommerce_stripe_updated', array( $this, 'stripe_updated' ) );
 	}
 
 	/**
@@ -309,6 +310,20 @@ class WC_Stripe_Admin_Notices {
 		$section_slug = $use_id_as_section ? 'stripe' : strtolower( 'WC_Gateway_Stripe' );
 
 		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $section_slug );
+	}
+
+	/**
+	 * Saves options in order to hide notices based on the gateway's version.
+	 *
+	 * @since 4.3.0
+	 */
+	public function stripe_updated() {
+		$previous_version = get_option( 'wc_stripe_version' );
+
+		// Only show the style notice if the plugin was installed and older than 4.1.4.
+		if ( empty( $previous_version ) || version_compare( $previous_version, '4.1.4', 'ge' ) ) {
+			update_option( 'wc_stripe_show_style_notice', 'no' );
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #891, Fixes #876.

#### Changes proposed in this Pull Request:

- Change the style of the updated styles notice _(WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these instructions to fix.)_ from error to warning.
- Using the `woocommerce_stripe_updated` hook hide the notice
    1. When the plugin just got installed (no `wc_stripe_version` option).
    2. When the last version of the plugin was `4.1.4` (when the notice was added) or newer, assuming that the message has probably already been seen.

#### Testing instructions

With the plugin installed:

- To simulate a new installation:
    1. Navigate to `wp-admin/options.php`
    2. Delete the value of the `wc_stripe_show_style_notice` option to make the plugin think that the notice has not been dismissed yet.
    3. Delete the value of the `wc_stripe_version` option to simulate a fresh install.
    4. Save the options and make sure the notice is __not__ displayed.
- To simulate a version, older than `4.1.4`:
    1. Navigate to `wp-admin/options.php`
    2. Delete the value of the `wc_stripe_show_style_notice` option to make the plugin think that the notice has not been dismissed yet.
    3. Set the value of the `wc_stripe_version` option to `4.1.3` or something older.
    4. Save the options and make sure the notice __is__ displayed.
- To simulate a version, newer than `4.1.4`:
    1. Navigate to `wp-admin/options.php`
    2. Delete the value of the `wc_stripe_show_style_notice` option to make the plugin think that the notice has not been dismissed yet.
    3. Set the value of the `wc_stripe_version` option to `4.2.0`.
    4. Save the options and make sure the notice __is not__ displayed.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
