### PR TITLE
Always creating a customer object on checkout.

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -650,10 +650,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			}
 		}
 
-		if ( ! $set_customer ) {
-			$customer_id = false;
-		} else {
-			$customer_id = $customer->get_id() ? $customer->get_id() : false;
+		$customer_id = $customer->get_id();
+		if ( ! $customer_id ) {
+			$customer->set_id( $customer->create_customer() );
+			$customer_id = $customer->get_id();
 		}
 
 		if ( empty( $source_object ) && ! $is_token ) {

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -123,9 +123,14 @@ class WC_Stripe_Customer {
 				'description' => $description,
 			);
 		} else {
+			$billing_first_name = isset( $_POST['billing_first_name'] ) ? filter_var( wp_unslash( $_POST['billing_first_name'] ), FILTER_SANITIZE_STRING ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+			$billing_last_name  = isset( $_POST['billing_last_name'] ) ? filter_var( wp_unslash( $_POST['billing_last_name'] ), FILTER_SANITIZE_STRING ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+
+			$description = __( 'Name', 'woocommerce-gateway-stripe' ) . ': ' . $billing_first_name . ' ' . $billing_last_name . ' ' . __( ', Guest', 'woocommerce-gateway-stripe' );
+
 			$defaults = array(
 				'email'       => $billing_email,
-				'description' => '',
+				'description' => $description,
 			);
 		}
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -116,7 +116,8 @@ class WC_Stripe_Customer {
 				$billing_last_name = get_user_meta( $user->ID, 'last_name', true );
 			}
 
-			$description = __( 'Name', 'woocommerce-gateway-stripe' ) . ': ' . $billing_first_name . ' ' . $billing_last_name . ' ' . __( 'Username', 'woocommerce-gateway-stripe' ) . ': ' . $user->user_login;
+			// translators: %1$s First name, %2$s Second name, %3$s Username.
+			$description = sprintf( __( 'Name: %1$s %2$s, Username: %s', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name, $user->user_login );
 
 			$defaults = array(
 				'email'       => $user->user_email,
@@ -126,7 +127,8 @@ class WC_Stripe_Customer {
 			$billing_first_name = isset( $_POST['billing_first_name'] ) ? filter_var( wp_unslash( $_POST['billing_first_name'] ), FILTER_SANITIZE_STRING ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 			$billing_last_name  = isset( $_POST['billing_last_name'] ) ? filter_var( wp_unslash( $_POST['billing_last_name'] ), FILTER_SANITIZE_STRING ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
-			$description = __( 'Name', 'woocommerce-gateway-stripe' ) . ': ' . $billing_first_name . ' ' . $billing_last_name . ' ' . __( ', Guest', 'woocommerce-gateway-stripe' );
+			// translators: %1$s First name, %2$s Second name.
+			$description = sprintf( __( 'Name: %1$s %2$s, Guest', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name );
 
 			$defaults = array(
 				'email'       => $billing_email,


### PR DESCRIPTION
Fixes #866 

#### Changes proposed in this Pull Request:

- Within `prepare_source`, make sure that a Stripe customer always exists. If missing, create one.
- Because a customer object might even be created without a logged in user, gather customer details (first and last billing names) from `$_POST` too.

#### Testing instructions

1. Open an incognito window and add a product to the cart.
2. Check out with a specific email address, which is not in Stripe as a customer yet. Do not register.
3. Go to Stripe Dashboard and check if the customer exists, based on the email. The description of the customer should be like "Name: John Doe , Guest"

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).

