### PR TITLE
Add a notice for SCA readiness

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -332,6 +332,11 @@ class WC_Stripe_Admin_Notices {
 		if ( empty( $previous_version ) || version_compare( $previous_version, '4.1.4', 'ge' ) ) {
 			update_option( 'wc_stripe_show_style_notice', 'no' );
 		}
+
+		// Only show the SCA notice on pre-4.3.0 installs.
+		if ( empty( $previous_version ) || version_compare( $previous_version, '4.3.0', 'ge' ) ) {
+			update_option( 'wc_stripe_show_sca_notice', 'no' );
+		}
 	}
 }
 

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -107,6 +107,7 @@ class WC_Stripe_Admin_Notices {
 		$show_phpver_notice = get_option( 'wc_stripe_show_phpver_notice' );
 		$show_wcver_notice  = get_option( 'wc_stripe_show_wcver_notice' );
 		$show_curl_notice   = get_option( 'wc_stripe_show_curl_notice' );
+		$show_sca_notice    = get_option( 'wc_stripe_show_sca_notice' );
 		$options            = get_option( 'woocommerce_stripe_settings' );
 		$testmode           = ( isset( $options['testmode'] ) && 'yes' === $options['testmode'] ) ? true : false;
 		$test_pub_key       = isset( $options['test_publishable_key'] ) ? $options['test_publishable_key'] : '';
@@ -200,6 +201,10 @@ class WC_Stripe_Admin_Notices {
 					$this->add_admin_notice( 'ssl', 'notice notice-warning', sprintf( __( 'Stripe is enabled, but a SSL certificate is not detected. Your checkout may not be secure! Please ensure your server has a valid <a href="%1$s" target="_blank">SSL certificate</a>', 'woocommerce-gateway-stripe' ), 'https://en.wikipedia.org/wiki/Transport_Layer_Security' ), true );
 				}
 			}
+
+			if ( empty( $show_sca_notice ) ) {
+				$this->add_admin_notice( 'sca', 'notice notice-success', sprintf( __( 'Stripe is now ready for Strong Customer Authentication (SCA) and 3D Secure 2! <a href="%1$s" target="_blank">Read about SCA</a>', 'woocommerce-gateway-stripe' ), 'https://woocommerce.com/posts/introducing-strong-customer-authentication-sca/' ), true );
+			}
 		}
 	}
 
@@ -292,6 +297,9 @@ class WC_Stripe_Admin_Notices {
 					break;
 				case 'SOFORT':
 					update_option( 'wc_stripe_show_sofort_notice', 'no' );
+					break;
+				case 'sca':
+					update_option( 'wc_stripe_show_sca_notice', 'no' );
 					break;
 			}
 		}


### PR DESCRIPTION
Fixes #982.

#### Changes proposed in this Pull Request:

Introduce a dismissable notice to tell the merchant that the extension is SCA-ready. Per @allendav 's advice there are no mentions of compliance.

#### Testing instructions

1. Check out this branch.
2. Open the admin and make sure you see a notice like this:

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/5311119/65782774-a9900f00-e14e-11e9-9ba1-7545161ec498.png">

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Run `npm run build` to re-generate the POT file.
- [ ] Eventually rebase on #1012 and only show the notice after upgrade, instead of new installations?