### PR TITLE
Do not use empty string as source for payment intent

### DIFF
--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -300,8 +300,8 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			$request['statement_descriptor'] = $full_request['statement_descriptor'];
 		}
 
-		if ( $prepared_source->customer ) {
-			$request['customer'] = $prepared_source->customer;
+		if ( isset( $full_request['customer'] ) ) {
+			$request['customer'] = $full_request['customer'];
 		}
 
 		if ( isset( $full_request['source'] ) ) {

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -285,7 +285,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 		$request = array(
 			'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, $full_request['currency'] ),
-			'currency'             => strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() ),
+			'currency'             => $full_request['currency'],
 			'description'          => $full_request['description'],
 			'metadata'             => $full_request['metadata'],
 			'payment_method_types' => array(

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -284,7 +284,6 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		$full_request = $this->generate_payment_request( $order, $prepared_source );
 
 		$request = array(
-			'source'               => $prepared_source->source,
 			'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, $full_request['currency'] ),
 			'currency'             => strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() ),
 			'description'          => $full_request['description'],
@@ -303,6 +302,10 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 		if ( $prepared_source->customer ) {
 			$request['customer'] = $prepared_source->customer;
+		}
+
+		if ( isset( $full_request['source'] ) ) {
+			$request['source'] = $full_request['source'];
 		}
 
 		$intent = WC_Stripe_API::request( $request, 'payment_intents' );


### PR DESCRIPTION
Fixes #1010

## Testing instructions from the issue:

1. Make sure that you already have a WC customer with a stripe customer ID (cus_123)
2. Create a new manual subscription using the steps in this video (also listed below as sub-steps of step 2): https://docs.woocommerce.com/document/subscriptions/add-or-modify-a-subscription/
2a. Subscriptions > Create new subscription
2b. Select a customer
2c. Select the Stripe payment method
2d. Enter the customer ID in the customer ID field
2e. Add subscription product
2f. Save
2g. Create parent order
2h. Go to parent order and change status to processing
2i. Renew subscription
3. See that renewing the subscription with just the customer ID entered will work with this branch, but not with plugin v 4.2.4

The problem was that we were sending an empty source string which caused an error, instead of relying on the value of `$full_request['source']` which can be null.

I also fixed some other issues from my original PR in 9652560 and 30b320e.

## Todo:
- [ ] write test to avoid empty source string in payment intent request
- [x] make sure that not sending a source with a payment intent request makes sense... the Stripe docs don't have much to say about default cards and payment intents
- [x] test with a 3ds card that will respond with needs_authentication error. do we leave a good error message for store owners for that?