### PR TITLE
Upgrading to API version 2019-09-09

### DIFF
--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -14,7 +14,7 @@ class WC_Stripe_API {
 	 * Stripe API Endpoint
 	 */
 	const ENDPOINT           = 'https://api.stripe.com/v1/';
-	const STRIPE_API_VERSION = '2019-02-19';
+	const STRIPE_API_VERSION = '2019-09-09';
 
 	/**
 	 * Secret API Key.


### PR DESCRIPTION
Fixes #1021.

#### Changes proposed in this Pull Request:

As @dougaitken suggested in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1021, this PR updates the Stripe API version we are using to the latest, `2019-09-09`.

I looked at [the changelog](https://stripe.com/docs/upgrades#api-changelog), as far as I can tell, there are no upgrades since the previous version, which could interfere with the plugin's functionality. A few smoke tests proved that to be right.

_Note:_ This PR is not too important, so if you think it we should, we can move it to a later version, instead of 4.3.0.

@dougaitken I'm adding you as a reviewer because this change mainly requires smoke tests, and we have some higher-priority PRs which need review at the moment. Any additional help would be appreciated.