### PR TITLE
Fixing `is_prepaid_card` to make it work with source objects.

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -548,7 +548,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return bool
 	 */
 	public function is_prepaid_card( $source_object ) {
-		return ( $source_object && 'token' === $source_object->object && 'prepaid' === $source_object->card->funding );
+		return (
+			$source_object
+			&& ( 'token' === $source_object->object || 'source' === $source_object->object )
+			&& 'prepaid' === $source_object->card->funding
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1020.

#### Changes proposed in this Pull Request:

Fix `WC_Stripe_Payment_Gateway::is_prepaid_card` to work both with `card` and `source` objects instead of just `card` objects, like it did until now.

#### Testing instructions

1. Add the following snippet to a file that will be loaded early enough. A good example is the main plugin file of the gateway.
    ```php
    add_filter( 'wc_stripe_allow_prepaid_card', '__return_false' );
    ```
2. Try checking out with `5105105105105100`. You should see an error message.
3. Try checking out with a normal card. It should work as expected.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).