### PR TITLE
Add SetupIntents so the customer can confirm an SCA-protected payment even on a free order

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -251,23 +251,6 @@ jQuery( function( $ ) {
 			// Listen for hash changes in order to handle payment intents
 			window.addEventListener( 'hashchange', wc_stripe_form.onHashChange );
 			wc_stripe_form.maybeConfirmIntent();
-
-			// Add the "confirm setup intent" button handler on the "Order Received" page
-			var authorizeButtonEnabled = true;
-			$( '#stripe-setup-intent-authorize-button' ).click( function() {
-				if ( ! authorizeButtonEnabled ) {
-					return;
-				}
-				authorizeButtonEnabled = false;
-				stripe.handleCardSetup( $( '#stripe-setup-intent-authorize-button' ).data( 'secret' ) )
-					.then( function( data ) {
-						if ( 'succeeded' === data.setupIntent.status ) {
-							$( '#stripe-setup-intent-authorize-container' ).hide();
-						} else {
-							window.location.reload();
-						}
-					} );
-			} );
 		},
 
 		/**
@@ -759,17 +742,7 @@ jQuery( function( $ ) {
 			// Cleanup the URL
 			window.location.hash = '';
 
-			switch ( type ) {
-				case 'pi': // Payment Intent
-					wc_stripe_form.openIntentModal( intentClientSecret, redirectURL );
-					break;
-				case 'si': // Setup Intent
-					stripe.handleCardSetup( intentClientSecret )
-						.then( function() {
-							window.location = redirectURL;
-						} );
-					break;
-			}
+			wc_stripe_form.openIntentModal( intentClientSecret, redirectURL, false, 'si' === type );
 		},
 
 		maybeConfirmIntent: function() {
@@ -780,7 +753,7 @@ jQuery( function( $ ) {
 			var intentSecret = $( '#stripe-intent-id' ).val();
 			var returnURL    = $( '#stripe-intent-return' ).val();
 
-			wc_stripe_form.openIntentModal( intentSecret, returnURL, true );
+			wc_stripe_form.openIntentModal( intentSecret, returnURL, true, false );
 		},
 
 		/**
@@ -790,15 +763,18 @@ jQuery( function( $ ) {
 		 * @param {string}  redirectURL        The URL to ping on fail or redirect to on success.
 		 * @param {boolean} alwaysRedirect     If set to true, an immediate redirect will happen no matter the result.
 		 *                                     If not, an error will be displayed on failure.
+		 * @param {boolean} isSetupIntent      If set to true, ameans that the flow is handling a Setup Intent.
+		 *                                     If false, it's a Payment Intent.
 		 */
-		openIntentModal: function( intentClientSecret, redirectURL, alwaysRedirect ) {
-			stripe.handleCardPayment( intentClientSecret )
+		openIntentModal: function( intentClientSecret, redirectURL, alwaysRedirect, isSetupIntent ) {
+			stripe[ isSetupIntent ? 'handleCardSetup' : 'handleCardPayment' ]( intentClientSecret )
 				.then( function( response ) {
 					if ( response.error ) {
 						throw response.error;
 					}
 
-					if ( 'requires_capture' !== response.paymentIntent.status && 'succeeded' !== response.paymentIntent.status ) {
+					var intent = response[ isSetupIntent ? 'setupIntent' : 'paymentIntent' ];
+					if ( 'requires_capture' !== intent.status && 'succeeded' !== intent.status ) {
 						return;
 					}
 

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -251,6 +251,23 @@ jQuery( function( $ ) {
 			// Listen for hash changes in order to handle payment intents
 			window.addEventListener( 'hashchange', wc_stripe_form.onHashChange );
 			wc_stripe_form.maybeConfirmIntent();
+
+			// Add the "confirm setup intent" button handler on the "Order Received" page
+			var authorizeButtonEnabled = true;
+			$( '#stripe-setup-intent-authorize-button' ).click( function() {
+				if ( ! authorizeButtonEnabled ) {
+					return;
+				}
+				authorizeButtonEnabled = false;
+				stripe.handleCardSetup( $( '#stripe-setup-intent-authorize-button' ).data( 'secret' ) )
+					.then( function( data ) {
+						if ( 'succeeded' === data.setupIntent.status ) {
+							$( '#stripe-setup-intent-authorize-container' ).hide();
+						} else {
+							window.location.reload();
+						}
+					} );
+			} );
 		},
 
 		/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -74,21 +74,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Checks to see if error is of invalid request
-	 * error and source is already consumed.
-	 *
-	 * @since 4.1.0
-	 * @param array $error
-	 */
-	public function is_source_already_consumed_error( $error ) {
-		return (
-			$error &&
-			'invalid_request_error' === $error->type &&
-			preg_match( '/The reusable source you provided is consumed because it was previously charged without being attached to a customer or was detached from a customer. To charge a reusable source multiple time you must attach it to a customer first./i', $error->message )
-		);
-	}
-
-	/**
-	 * Checks to see if error is of invalid request
 	 * error and it is no such customer.
 	 *
 	 * @since 4.1.0

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1193,4 +1193,33 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 		delete_transient( 'wc_stripe_processing_intent_' . $order_id );
 	}
+
+	/**
+	 * Creates a SetupIntent for future payments, and saves it to the order.
+	 *
+	 * @param WC_Order $order           The ID of the (free/pre- order).
+	 * @param object   $prepared_source The source, entered/chosen by the customer.
+	 * @return string                   The client secret of the intent, used for confirmation in JS.
+	 */
+	public function setup_intent( $order, $prepared_source ) {
+		$order_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$setup_intent = WC_Stripe_API::request( array(
+			'payment_method' => $prepared_source->source,
+			'customer'       => $prepared_source->customer,
+			'confirm'        => 'true',
+		), 'setup_intents' );
+
+		if ( is_wp_error( $setup_intent ) ) {
+			WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
+		} elseif ( 'requires_action' === $setup_intent->status ) {
+			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+				update_post_meta( $order_id, '_stripe_setup_intent', $setup_intent->id );
+			} else {
+				$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
+				$order->save();
+			}
+
+			return $setup_intent->client_secret;
+		}
+	}
 }

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1152,11 +1152,22 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$intent_id = $order->get_meta( '_stripe_intent_id' );
 		}
 
-		if ( ! $intent_id ) {
-			return false;
+		if ( $intent_id ) {
+			return WC_Stripe_API::request( array(), "payment_intents/$intent_id", 'GET' );
 		}
 
-		return WC_Stripe_API::request( array(), "payment_intents/$intent_id", 'GET' );
+		// The order doesn't have a payment intent, but it may have a setup intent
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			$intent_id = get_post_meta( $order_id, '_stripe_setup_intent', true );
+		} else {
+			$intent_id = $order->get_meta( '_stripe_setup_intent' );
+		}
+
+		if ( $intent_id ) {
+			return WC_Stripe_API::request( array(), "setup_intents/$intent_id", 'GET' );
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1156,7 +1156,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return WC_Stripe_API::request( array(), "payment_intents/$intent_id", 'GET' );
 		}
 
-		// The order doesn't have a payment intent, but it may have a setup intent
+		// The order doesn't have a payment intent, but it may have a setup intent.
 		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
 			$intent_id = get_post_meta( $order_id, '_stripe_setup_intent', true );
 		} else {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -139,7 +139,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_account_view-order_endpoint', array( $this, 'check_intent_status_on_order_page' ), 1 );
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
-		add_action( 'woocommerce_thankyou', array( $this, 'thankyou_page' ) );
 
 		if ( WC_Stripe_Helper::is_pre_orders_exists() ) {
 			$this->pre_orders = new WC_Stripe_Pre_Orders_Compat();
@@ -372,8 +371,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @version 4.0.0
 	 */
 	public function payment_scripts() {
-		// TODO: We only need to enqueue stripe.js in the Order Received page if the order has an unresolved Setup Intent
-		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! is_order_received_page() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
+		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
 			return;
 		}
 
@@ -550,11 +548,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @return array                      Redirection data for `process_payment`.
 	 */
 	public function complete_free_order( $order, $prepared_source, $force_save_source ) {
-		$order->payment_complete();
-
-		// Remove cart.
-		WC()->cart->empty_cart();
-
 		$response = array(
 			'result'   => 'success',
 			'redirect' => $this->get_return_url( $order ),
@@ -566,47 +559,15 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			if ( ! empty( $intent_secret ) ) {
 				$response['setup_intent_secret'] = $intent_secret;
 			}
+		} else {
+			// Remove cart.
+			WC()->cart->empty_cart();
+
+			$order->payment_complete();
 		}
 
 		// Return thank you page redirect.
 		return $response;
-	}
-
-	public function thankyou_page( $order_id ) {
-		$order = wc_get_order( $order_id );
-		$setup_intent_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_setup_intent', true ) : $order->get_meta( '_stripe_setup_intent', true );
-
-		if ( $setup_intent_id ) {
-			$setup_intent = WC_Stripe_API::request( array(), 'setup_intents/' . $setup_intent_id, 'GET' );
-
-			// When authentication fails in a SetupIntent, the "payment_method" property is erased. We need to update it again before it's in a "requires_action" state again
-			if ( ! is_wp_error( $setup_intent )
-			     && 'requires_payment_method' === $setup_intent->status
-			     && 'setup_intent_authentication_failure' === $setup_intent->last_setup_error->code ) {
-				$setup_intent = WC_Stripe_API::request( array(
-					'payment_method' => $setup_intent->last_setup_error->payment_method->id,
-				), 'setup_intents/' . $setup_intent_id . '/confirm' );
-			}
-
-			if ( ! is_wp_error( $setup_intent ) ) {
-				if ( 'requires_action' === $setup_intent->status ) {
-					// TODO: Style the hell out of this
-					?>
-					<p id="stripe-setup-intent-authorize-container">
-						We need you to authorize us to charge your credit card in the future. Authorize us now so we won't need to bother you later.
-						<a href="javascript:void(0);" id="stripe-setup-intent-authorize-button" data-secret="<?php echo esc_attr( $setup_intent->client_secret ) ?>">Authorize</a>
-					</p>
-					<?php
-				} else {
-					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-						delete_post_meta( $order_id, '_stripe_setup_intent' );
-					} else {
-						$order->delete_meta_data( '_stripe_setup_intent' );
-						$order->save();
-					}
-				}
-			}
-		}
 	}
 
 	/**
@@ -650,6 +611,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Logger::log( "Info: Begin processing payment for order $order_id for the amount of {$order->get_total()}" );
 
 			$intent = $this->get_intent_from_order( $order );
+			if ( 'setup_intent' === $intent->object ) {
+				$intent = false; // This function can only deal with *payment* intents
+			}
+
 			if ( $intent ) {
 				$intent = $this->update_existing_intent( $intent, $order, $prepared_source );
 			} else {
@@ -697,9 +662,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 						 */
 
 						return array(
-							'result'        => 'success',
-							'redirect'      => $this->get_return_url( $order ),
-							'intent_secret' => $intent->client_secret,
+							'result'                => 'success',
+							'redirect'              => $this->get_return_url( $order ),
+							'payment_intent_secret' => $intent->client_secret,
 						);
 					}
 				}
@@ -951,7 +916,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Attached to `woocommerce_payment_successful_result` with a late priority,
 	 * this method will combine the "naturally" generated redirect URL from
-	 * WooCommerce and a payment intent secret into a hash, which contains both
+	 * WooCommerce and a payment/setup intent secret into a hash, which contains both
 	 * the secret, and a proper URL, which will confirm whether the intent succeeded.
 	 *
 	 * @since 4.2.0
@@ -960,35 +925,31 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @return array
 	 */
 	public function modify_successful_payment_result( $result, $order_id ) {
-		if ( isset( $result['intent_secret'] ) ) {
-			// Put the final thank you page redirect into the verification URL.
-			$verification_url = add_query_arg(
-				array(
-					'order'       => $order_id,
-					'nonce'       => wp_create_nonce( 'wc_stripe_confirm_pi' ),
-					'redirect_to' => rawurlencode( $result['redirect'] ),
-				),
-				WC_AJAX::get_endpoint( 'wc_stripe_verify_intent' )
-			);
-
-			// Combine into a hash.
-			$redirect = sprintf( '#confirm-pi-%s:%s', $result['intent_secret'], rawurlencode( $verification_url ) );
-
-			return array(
-				'result'   => 'success',
-				'redirect' => $redirect,
-			);
-		} elseif ( isset( $result['setup_intent_secret'] ) ) {
-			$redirect = sprintf( '#confirm-si-%s:%s', $result['setup_intent_secret'], rawurlencode( $result['redirect'] ) );
-
-			return array(
-				'result'   => 'success',
-				'redirect' => $redirect,
-			);
+		if ( ! isset( $result['payment_intent_secret'] ) && ! isset( $result['setup_intent_secret'] ) ) {
+			// Only redirects with intents need to be modified.
+			return $result;
 		}
 
-		// Only redirects with intents need to be modified.
-		return $result;
+		// Put the final thank you page redirect into the verification URL.
+		$verification_url = add_query_arg(
+			array(
+				'order'       => $order_id,
+				'nonce'       => wp_create_nonce( 'wc_stripe_confirm_pi' ),
+				'redirect_to' => rawurlencode( $result['redirect'] ),
+			),
+			WC_AJAX::get_endpoint( 'wc_stripe_verify_intent' )
+		);
+
+		if ( isset( $result['payment_intent_secret'] ) ) {
+			$redirect = sprintf( '#confirm-pi-%s:%s', $result['payment_intent_secret'], rawurlencode( $verification_url ) );
+		} else {
+			$redirect = sprintf( '#confirm-si-%s:%s', $result['setup_intent_secret'], rawurlencode( $verification_url ) );
+		}
+
+		return array(
+			'result'   => 'success',
+			'redirect' => $redirect,
+		);
 	}
 
 	/**
@@ -1031,7 +992,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'succeeded' === $intent->status || 'requires_capture' === $intent->status ) {
+		if ( 'setup_intent' === $intent->object && 'succeeded' === $intent->status ) {
+			WC()->cart->empty_cart();
+			$order->payment_complete();
+		} else if ( 'succeeded' === $intent->status || 'requires_capture' === $intent->status ) {
 			// Proceed with the payment completion.
 			$this->process_response( end( $intent->charges->data ), $order );
 		} else if ( 'requires_payment_method' === $intent->status ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -942,7 +942,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		if ( isset( $result['payment_intent_secret'] ) ) {
 			$redirect = sprintf( '#confirm-pi-%s:%s', $result['payment_intent_secret'], rawurlencode( $verification_url ) );
-		} else {
+		} else if ( isset( $result['setup_intent_secret'] ) ) {
 			$redirect = sprintf( '#confirm-si-%s:%s', $result['setup_intent_secret'], rawurlencode( $verification_url ) );
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -139,6 +139,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_account_view-order_endpoint', array( $this, 'check_intent_status_on_order_page' ), 1 );
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
+		add_action( 'woocommerce_thankyou', array( $this, 'thankyou_page' ) );
 
 		if ( WC_Stripe_Helper::is_pre_orders_exists() ) {
 			$this->pre_orders = new WC_Stripe_Pre_Orders_Compat();
@@ -371,7 +372,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @version 4.0.0
 	 */
 	public function payment_scripts() {
-		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
+		// TODO: We only need to enqueue stripe.js in the Order Received page if the order has an unresolved Setup Intent
+		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! is_order_received_page() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
 			return;
 		}
 
@@ -565,15 +567,59 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				'confirm'        => 'true',
 			), 'setup_intents' );
 
+			$order_id  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 			if ( is_wp_error( $setup_intent ) ) {
-				WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order->get_id(): " . print_r( $setup_intent, true ) );
+				WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
 			} elseif ( 'requires_action' === $setup_intent->status ) {
+				if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+					update_post_meta( $order_id, '_stripe_setup_intent', $setup_intent->id );
+				} else {
+					$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
+					$order->save();
+				}
 				$response['setup_intent_secret'] = $setup_intent->client_secret;
 			}
 		}
 
 		// Return thank you page redirect.
 		return $response;
+	}
+
+	public function thankyou_page( $order_id ) {
+		$order = wc_get_order( $order_id );
+		$setup_intent_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_setup_intent', true ) : $order->get_meta( '_stripe_setup_intent', true );
+
+		if ( $setup_intent_id ) {
+			$setup_intent = WC_Stripe_API::request( array(), 'setup_intents/' . $setup_intent_id, 'GET' );
+
+			// When authentication fails in a SetupIntent, the "payment_method" property is erased. We need to update it again before it's in a "requires_action" state again
+			if ( ! is_wp_error( $setup_intent ) && 'succeeded' !== $setup_intent->status ) {
+				if ( 'requires_payment_method' === $setup_intent->status && 'setup_intent_authentication_failure' === $setup_intent->last_setup_error->code ) {
+					$setup_intent = WC_Stripe_API::request( array(
+						'payment_method' => $setup_intent->last_setup_error->payment_method->id,
+					), 'setup_intents/' . $setup_intent_id . '/confirm' );
+				}
+			}
+
+			if ( ! is_wp_error( $setup_intent ) ) {
+				if ( 'requires_action' === $setup_intent->status ) {
+					// TODO: Style the hell out of this
+					?>
+					<p id="stripe-setup-intent-authorize-container">
+						We need you to authorize us to charge your credit card in the future. Authorize us now so we won't need to bother you later.
+						<a href="javascript:void(0);" id="stripe-setup-intent-authorize-button" data-secret="<?php echo esc_attr( $setup_intent->client_secret ) ?>">Authorize</a>
+					</p>
+					<?php
+				} else {
+					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+						delete_post_meta( $order_id, '_stripe_setup_intent' );
+					} else {
+						$order->delete_meta_data( '_stripe_setup_intent' );
+						$order->save();
+					}
+				}
+			}
+		}
 	}
 
 	/**

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1020,7 +1020,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		// Load the right message and update the status.
-		$status_message = ( $intent->last_payment_error )
+		$status_message = isset( $intent->last_payment_error )
 			/* translators: 1) The error message that was received from Stripe. */
 			? sprintf( __( 'Stripe SCA authentication failed. Reason: %s', 'woocommerce-gateway-stripe' ), $intent->last_payment_error->message )
 			: __( 'Stripe SCA authentication failed.', 'woocommerce-gateway-stripe' );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -593,12 +593,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$setup_intent = WC_Stripe_API::request( array(), 'setup_intents/' . $setup_intent_id, 'GET' );
 
 			// When authentication fails in a SetupIntent, the "payment_method" property is erased. We need to update it again before it's in a "requires_action" state again
-			if ( ! is_wp_error( $setup_intent ) && 'succeeded' !== $setup_intent->status ) {
-				if ( 'requires_payment_method' === $setup_intent->status && 'setup_intent_authentication_failure' === $setup_intent->last_setup_error->code ) {
-					$setup_intent = WC_Stripe_API::request( array(
-						'payment_method' => $setup_intent->last_setup_error->payment_method->id,
-					), 'setup_intents/' . $setup_intent_id . '/confirm' );
-				}
+			if ( ! is_wp_error( $setup_intent )
+			     && 'requires_payment_method' === $setup_intent->status
+			     && 'setup_intent_authentication_failure' === $setup_intent->last_setup_error->code ) {
+				$setup_intent = WC_Stripe_API::request( array(
+					'payment_method' => $setup_intent->last_setup_error->payment_method->id,
+				), 'setup_intents/' . $setup_intent_id . '/confirm' );
 			}
 
 			if ( ! is_wp_error( $setup_intent ) ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -995,7 +995,11 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		if ( 'setup_intent' === $intent->object && 'succeeded' === $intent->status ) {
 			WC()->cart->empty_cart();
-			$order->payment_complete();
+			if ( WC_Stripe_Helper::is_pre_orders_exists() && WC_Pre_Orders_Order::order_contains_pre_order( $order ) ) {
+				WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );
+			} else {
+				$order->payment_complete();
+			}
 		} else if ( 'succeeded' === $intent->status || 'requires_capture' === $intent->status ) {
 			// Proceed with the payment completion.
 			$this->process_response( end( $intent->charges->data ), $order );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -248,29 +248,17 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		if ( is_add_payment_method_page() ) {
-			$pay_button_text = __( 'Add Card', 'woocommerce-gateway-stripe' );
-			$total           = '';
 			$firstname       = $user->user_firstname;
 			$lastname        = $user->user_lastname;
-
-		} elseif ( function_exists( 'wcs_order_contains_subscription' ) && isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
-			$pay_button_text = __( 'Change Payment Method', 'woocommerce-gateway-stripe' );
-			$total           = '';
-		} else {
-			$pay_button_text = '';
 		}
 
 		ob_start();
 
 		echo '<div
 			id="stripe-payment-data"
-			data-panel-label="' . esc_attr( $pay_button_text ) . '"
 			data-email="' . esc_attr( $user_email ) . '"
-			data-amount="' . esc_attr( WC_Stripe_Helper::get_stripe_amount( $total ) ) . '"
-			data-name="' . esc_attr( $this->statement_descriptor ) . '"
 			data-full-name="' . esc_attr( $firstname . ' ' . $lastname ) . '"
 			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '"
-			data-allow-remember-me="' . esc_attr( apply_filters( 'wc_stripe_allow_remember_me', true ) ? 'true' : 'false' ) . '"
 		>';
 
 		if ( $this->testmode ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -558,13 +558,14 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 			if ( ! empty( $intent_secret ) ) {
 				$response['setup_intent_secret'] = $intent_secret;
+				return $response;
 			}
-		} else {
-			// Remove cart.
-			WC()->cart->empty_cart();
-
-			$order->payment_complete();
 		}
+
+		// Remove cart.
+		WC()->cart->empty_cart();
+
+		$order->payment_complete();
 
 		// Return thank you page redirect.
 		return $response;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -453,6 +453,25 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Gets the order by Stripe SetupIntent ID.
+	 *
+	 * @since 4.3
+	 * @param string $intent_id The ID of the intent.
+	 * @return WC_Order|bool Either an order or false when not found.
+	 */
+	public static function get_order_by_setup_intent_id( $intent_id ) {
+		global $wpdb;
+
+		$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $intent_id, '_stripe_setup_intent' ) );
+
+		if ( ! empty( $order_id ) ) {
+			return wc_get_order( $order_id );
+		}
+
+		return false;
+	}
+
+	/**
 	 * Sanitize statement descriptor text.
 	 *
 	 * Stripe requires max of 22 characters and no

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -712,7 +712,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 		if ( 'setup_intent.succeeded' === $notification->type ) {
 			WC_Stripe_Logger::log( "Stripe SetupIntent $intent->id succeeded for order $order_id" );
-			$order->payment_complete();
+			if ( WC_Stripe_Helper::is_pre_orders_exists() && WC_Pre_Orders_Order::order_contains_pre_order( $order ) ) {
+				WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );
+			} else {
+				$order->payment_complete();
+			}
 		} else {
 			$error_message = $intent->last_setup_error ? $intent->last_setup_error->message : "";
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -81,7 +81,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @todo Implement proper webhook signature validation. Ref https://stripe.com/docs/webhooks#signatures
 	 * @param string $request_headers The request headers from Stripe.
 	 * @param string $request_body The request body from Stripe.
 	 * @return bool

--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -61,19 +61,28 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( __( 'Unable to store payment details. Please try again.', 'woocommerce-gateway-stripe' ) );
 			}
 
+			// Setup the response early to allow later modifications.
+			$response = array(
+				'result'   => 'success',
+				'redirect' => $this->get_return_url( $order ),
+			);
+
 			$this->save_source_to_order( $order, $prepared_source );
 
-			// Remove cart
+			// Try setting up a payment intent.
+			$intent_secret = $this->setup_intent( $order, $prepared_source );
+			if ( ! empty( $intent_secret ) ) {
+				$response['setup_intent_secret'] = $intent_secret;
+			}
+
+			// Remove cart.
 			WC()->cart->empty_cart();
 
 			// Is pre ordered!
 			WC_Pre_Orders_Order::mark_order_as_pre_ordered( $order );
 
 			// Return thank you page redirect
-			return array(
-				'result'   => 'success',
-				'redirect' => $this->get_return_url( $order ),
-			);
+			return $response;
 		} catch ( WC_Stripe_Exception $e ) {
 			wc_add_notice( $e->getLocalizedMessage(), 'error' );
 			WC_Stripe_Logger::log( 'Pre Orders Error: ' . $e->getMessage() );

--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -73,6 +73,7 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 			$intent_secret = $this->setup_intent( $order, $prepared_source );
 			if ( ! empty( $intent_secret ) ) {
 				$response['setup_intent_secret'] = $intent_secret;
+				return $response;
 			}
 
 			// Remove cart.

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -124,19 +124,9 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		try {
 			$subscription    = wc_get_order( $order_id );
 			$prepared_source = $this->prepare_source( get_current_user_id(), true );
-			$source_object   = $prepared_source->source_object;
 
-			// Check if we don't allow prepaid credit cards.
-			if ( ! apply_filters( 'wc_stripe_allow_prepaid_card', true ) && $this->is_prepaid_card( $source_object ) ) {
-				$localized_message = __( 'Sorry, we\'re not accepting prepaid cards at this time. Your credit card has not been charge. Please try with alternative payment method.', 'woocommerce-gateway-stripe' );
-				throw new WC_Stripe_Exception( print_r( $source_object, true ), $localized_message );
-			}
-
-			if ( empty( $prepared_source->source ) ) {
-				$localized_message = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
-				throw new WC_Stripe_Exception( print_r( $prepared_source, true ), $localized_message );
-			}
-
+			$this->maybe_disallow_prepaid_card( $prepared_source );
+			$this->check_source( $prepared_source );
 			$this->save_source_to_order( $subscription, $prepared_source );
 
 			do_action( 'wc_stripe_change_subs_payment_method_success', $prepared_source->source, $prepared_source );


### PR DESCRIPTION
This PR replaces https://github.com/woocommerce/woocommerce-gateway-stripe/pull/961 and https://github.com/woocommerce/woocommerce-gateway-stripe/pull/997 . Really, it's on top of both those PRs, but because the extensive behaviour change that has been done, I figured this would look better in a single PR, instead of having #961 implement something that this PR would undo.

This PR introduces SetupIntents so the user has a chance to pass a SCA challenge even if the charge is not going to be charged right away. That's important for Subscriptions that have a free trial period, and pre-orders.

Passing the SCA challenge in this way makes it less probable that passing another challenge will be required down the road. We are assuming that most credit cards will behave like this Stripe test card (which is the one I recommend to test this BTW):

NUMBER | AUTHENTICATION | DESCRIPTION
-- | -- | --
4000002500003155 | Required on setup or first transaction | This test card requires authentication for one-time payments. However, if you set up this card using the Setup Intents API and use the saved card for subsequent payments, no further authentication is needed.

The big change for this PR is that **IF THE SCA CHALLENGE IS NOT PASSED, THE ORDER IS MARKED AS FAILED**. So, to sum up, this "optional" SetupIntent SCA challenge is treated as mandatory.

To test:
- Create a subscription with free trial.
- Sign up for that subscription, go to the checkout.
- Use `4242424242424242` credit card, see that the order is created normally and the subscription too.
- Sign up for a subscription again, this time using the `4000002500003155` card. After clicking the `Sign Up Now` button at checkout, you'll get an SCA challenge modal indicating that this is a "non-payment authentication test page". At that moment, the order is in a "Pending payment" status, and so the subscription is not yet active.
- If you pass the challenge, you'll be redirected to the "Thank you" page. The subscription will be active at this point.
- If you fail the challenge, you'll stay in the checkout with an error message, and you'll be able to try again. At this point, the order status is "Failed" and so the subscription is not active.

PS: I haven't made sure that Pre-Orders work, because I found some weird stuff in the compatibility class. I'll take a deeper look tomorrow.

Fixes #936 