### PR TITLE
Migrate the Pre-Orders payment logic to PaymentIntents

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1234,6 +1234,18 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Given a response from Stripe, check if it's a card error where authentication is required
+	 * to complete the payment.
+	 *
+	 * @param object $response The response from Stripe.
+	 * @return boolean Whether or not it's a 'authentication_required' error
+	 */
+	public function is_authentication_required_for_payment( $response ) {
+		return ( ! empty( $response->error ) && 'authentication_required' === $response->error->code )
+			|| ( ! empty( $response->last_payment_error ) && 'authentication_required' === $response->last_payment_error->code );
+	}
+
+	/**
 	 * Creates a SetupIntent for future payments, and saves it to the order.
 	 *
 	 * @param WC_Order $order           The ID of the (free/pre- order).
@@ -1260,5 +1272,66 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 			return $setup_intent->client_secret;
 		}
+	}
+
+	/**
+	 * Create and confirm a new PaymentIntent.
+	 *
+	 * @param WC_Order $order           The order that is being paid for.
+	 * @param object   $prepared_source The source that is used for the payment.
+	 * @param float    $amount          The amount to charge. If not specified, it will be read from the order.
+	 * @return object                   An intent or an error.
+	 */
+	public function create_and_confirm_intent_for_off_session( $order, $prepared_source, $amount = NULL ) {
+		// The request for a charge contains metadata for the intent.
+		$full_request = $this->generate_payment_request( $order, $prepared_source );
+
+		$request = array(
+			'amount'               => $amount ? WC_Stripe_Helper::get_stripe_amount( $amount, $full_request['currency'] ) : $full_request['amount'],
+			'currency'             => $full_request['currency'],
+			'description'          => $full_request['description'],
+			'metadata'             => $full_request['metadata'],
+			'payment_method_types' => array(
+				'card',
+			),
+			'off_session'          => 'true',
+			'confirm'              => 'true',
+			'confirmation_method'  => 'automatic',
+		);
+
+		if ( isset( $full_request['statement_descriptor'] ) ) {
+			$request['statement_descriptor'] = $full_request['statement_descriptor'];
+		}
+
+		if ( isset( $full_request['customer'] ) ) {
+			$request['customer'] = $full_request['customer'];
+		}
+
+		if ( isset( $full_request['source'] ) ) {
+			$request['source'] = $full_request['source'];
+		}
+
+		$intent = WC_Stripe_API::request( $request, 'payment_intents' );
+		$is_authentication_required = $this->is_authentication_required_for_payment( $intent );
+
+		if ( ! empty( $intent->error ) && ! $is_authentication_required ) {
+			return $intent;
+		}
+
+		$intent_id      = ( ! empty( $intent->error )
+			? $intent->error->payment_intent->id
+			: $intent->id
+		);
+		$payment_intent = ( ! empty( $intent->error )
+			? $intent->error->payment_intent
+			: $intent
+		);
+		$order_id       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		WC_Stripe_Logger::log( "Stripe PaymentIntent $intent_id initiated for order $order_id" );
+
+		// Save the intent ID to the order.
+		$this->save_intent_to_order( $order, $payment_intent );
+
+		return $intent;
 	}
 }

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -678,7 +678,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			if ( isset( WC()->cart ) ) {
 				WC()->cart->empty_cart();
 			}
-			
+
 			// Unlock the order.
 			$this->unlock_order_payment( $order );
 
@@ -1037,7 +1037,5 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			? sprintf( __( 'Stripe SCA authentication failed. Reason: %s', 'woocommerce-gateway-stripe' ), $intent->last_payment_error->message )
 			: __( 'Stripe SCA authentication failed.', 'woocommerce-gateway-stripe' );
 		$order->update_status( 'failed', $status_message );
-
-		$this->send_failed_order_email( $order->get_id() );
 	}
 }

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -233,7 +233,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 				$prepared_source->source = '';
 			}
 
-			$response = $this->create_and_confirm_intent_for_renewal( $amount, $renewal_order, $prepared_source );
+			$response = $this->create_and_confirm_intent_for_off_session( $renewal_order, $prepared_source, $amount );
 
 			if ( ! empty( $response->error ) ) {
 				// We want to retry.
@@ -281,57 +281,6 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			/* translators: error message */
 			$renewal_order->update_status( 'failed' );
 		}
-	}
-
-	/**
-	 * Create and confirm a new PaymentIntent.
-	 *
-	 * @param float    $amount          The amount to charge.
-	 * @param WC_Order $order           The order that is being paid for.
-	 * @param object   $prepared_source The source that is used for the payment.
-	 * @return object                   An intent or an error.
-	 */
-	public function create_and_confirm_intent_for_renewal( $amount, $order, $prepared_source ) {
-		// The request for a charge contains metadata for the intent.
-		$full_request = $this->generate_payment_request( $order, $prepared_source );
-
-		$request = array(
-			'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, $full_request['currency'] ),
-			'currency'             => $full_request['currency'],
-			'description'          => $full_request['description'],
-			'metadata'             => $full_request['metadata'],
-			'payment_method_types' => array(
-				'card',
-			),
-			'off_session'          => 'true',
-			'confirm'              => 'true',
-			'confirmation_method'  => 'automatic',
-		);
-
-		if ( isset( $full_request['statement_descriptor'] ) ) {
-			$request['statement_descriptor'] = $full_request['statement_descriptor'];
-		}
-
-		if ( isset( $full_request['customer'] ) ) {
-			$request['customer'] = $full_request['customer'];
-		}
-
-		if ( isset( $full_request['source'] ) ) {
-			$request['source'] = $full_request['source'];
-		}
-
-		$intent = WC_Stripe_API::request( $request, 'payment_intents' );
-		if ( ! empty( $intent->error ) ) {
-			return $intent;
-		}
-
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-		WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id initiated for order $order_id" );
-
-		// Save the intent ID to the order.
-		$this->save_intent_to_order( $order, $intent );
-
-		return $intent;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1026

This PR ensures compatibility for Pre-Orders + Stripe + SCA. https://github.com/woocommerce/woocommerce-gateway-stripe/commit/f833dd2bc3b8230c32e121533bd53f175a4bd183 has a little refactor that I needed, https://github.com/woocommerce/woocommerce-gateway-stripe/commit/84161caf84320f3a98d3f987d9c754d48f641fe1 has the actual change.

I based this branch on the `alpha.1` branch so we can test it with the most recent changes possible.

To test:
1. Create a Pre-Orderable Product
2. Pre-order it using the 4000 0025 0000 3155 card (requires authentication, but only if it hasn't been "set up").
3. You should get the SCA non-payment modal at checkout.
4. From `wp-admin > WooCommerce > Pre-Orders > Actions > Complete`, select that product, put whatever message, and hit the `Complete Pre-Orders` button.
5. The Pre-Order release should go through normally, you should get the "Pre-Order available" e-mail, and if you go to the Stripe Dashboard you should see the payment went through.
6. Repeat steps 1 through 4, using the `4000002760003184` card (it will always require authentication).
7. You'll receive the `Payment authorization needed` e-mail, follow the "Authorize payment now" link.
8. You'll arrive to a stripped-down checkout page, the SCA modal will pop-up automatically.
9. After passing the SCA challenge, you'll receive the "Order received" e-mail, and you can see the payment in the Stripe Dashboard.