### PR TITLE
Fix Pre-Order retries

### DIFF
--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -40,19 +40,6 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Remove order meta
-	 * @param  object $order
-	 */
-	public function remove_order_customer_before_retry( $order ) {
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			delete_post_meta( $order->id, '_stripe_customer_id' );
-		} else {
-			$order->delete_meta_data( '_stripe_customer_id' );
-			$order->save();
-		}
-	}
-
-	/**
 	 * Process the pre-order when pay upon release is used.
 	 * @param int $order_id
 	 */
@@ -114,7 +101,6 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 			// Define some callbacks if the first attempt fails.
 			$retry_callbacks = array(
 				'remove_order_source_before_retry',
-				'remove_order_customer_before_retry',
 			);
 
 			while ( 1 ) {

--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -93,50 +93,44 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 
 	/**
 	 * Process a pre-order payment when the pre-order is released.
+	 *
 	 * @param WC_Order $order
+	 * @param bool $retry
+	 *
 	 * @return void
 	 */
-	public function process_pre_order_release_payment( $order ) {
+	public function process_pre_order_release_payment( $order, $retry = true ) {
 		try {
-			// Define some callbacks if the first attempt fails.
-			$retry_callbacks = array(
-				'remove_order_source_before_retry',
-			);
+			$source   = $this->prepare_order_source( $order );
+			$response = $this->create_and_confirm_intent_for_off_session( $order, $source );
 
-			while ( 1 ) {
-				$source   = $this->prepare_order_source( $order );
-				$response = $this->create_and_confirm_intent_for_off_session( $order, $source );
+			$is_authentication_required = $this->is_authentication_required_for_payment( $response );
 
-				$is_authentication_required = $this->is_authentication_required_for_payment( $response );
-
-				if ( ! empty( $response->error ) && ! $is_authentication_required ) {
-					if ( 0 === sizeof( $retry_callbacks ) ) {
-						throw new Exception( $response->error->message );
-					} else {
-						$retry_callback = array_shift( $retry_callbacks );
-						call_user_func( array( $this, $retry_callback ), $order );
-					}
-				} else if ( $is_authentication_required ) {
-					$charge = end( $response->error->payment_intent->charges->data );
-					$id = $charge->id;
-					$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-
-					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $id ) : $order->set_transaction_id( $id );
-					$order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
-					if ( is_callable( array( $order, 'save' ) ) ) {
-						$order->save();
-					}
-
-					WC_Emails::instance();
-
-					do_action( 'wc_gateway_stripe_process_payment_authentication_required', $order );
-
-					throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
-				} else {
-					// Successful
-					$this->process_response( end( $response->charges->data ), $order );
-					break;
+			if ( ! empty( $response->error ) && ! $is_authentication_required ) {
+				if ( ! $retry ) {
+					throw new Exception( $response->error->message );
 				}
+				$this->remove_order_source_before_retry( $order );
+				$this->process_pre_order_release_payment( $order, false );
+			} else if ( $is_authentication_required ) {
+				$charge = end( $response->error->payment_intent->charges->data );
+				$id = $charge->id;
+				$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+
+				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $id ) : $order->set_transaction_id( $id );
+				$order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
+				if ( is_callable( array( $order, 'save' ) ) ) {
+					$order->save();
+				}
+
+				WC_Emails::instance();
+
+				do_action( 'wc_gateway_stripe_process_payment_authentication_required', $order );
+
+				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+			} else {
+				// Successful
+				$this->process_response( end( $response->charges->data ), $order );
 			}
 		} catch ( Exception $e ) {
 			$error_message = is_callable( array( $e, 'getLocalizedMessage' ) ) ? $e->getLocalizedMessage() : $e->getMessage();

--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -28,10 +28,15 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 	 * @param object $order
 	 */
 	public function remove_order_source_before_retry( $order ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-		delete_post_meta( $order_id, '_stripe_source_id' );
-		// For BW compat will remove in the future.
-		delete_post_meta( $order_id, '_stripe_card_id' );
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			delete_post_meta( $order->id, '_stripe_source_id' );
+			// For BW compat will remove in the future.
+			delete_post_meta( $order->id, '_stripe_card_id' );
+		} else {
+			$order->delete_meta_data( '_stripe_source_id' );
+			$order->delete_meta_data( '_stripe_card_id' );
+			$order->save();
+		}
 	}
 
 	/**
@@ -39,8 +44,12 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 	 * @param  object $order
 	 */
 	public function remove_order_customer_before_retry( $order ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-		delete_post_meta( $order_id, '_stripe_customer_id' );
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			delete_post_meta( $order->id, '_stripe_customer_id' );
+		} else {
+			$order->delete_meta_data( '_stripe_customer_id' );
+			$order->save();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes #949.

#### Background

This is a follow-up of https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1015, which will be shortly closed.

@tommyshellberg reported that the following error was happening when completing Pre-Orders:
> Stripe Transaction Failed (Keys for idempotent requests can only be used with the same parameters they were first used with. Try using a key other than ...

Initially I opened #1015 in order to fix the issue, but upon further investigation it turned out that I was merely fixing a symptom. Pre-Orders has the following logic when processing payments (off-session):

1. Try payment based on the source, saved in the order's meta.
2. If 1. fails, delete the saved source (or card) ID and retry based on customer ID only, without a source. This should charge the customer's default card.
3. If 2. fails, delete the customer ID and try again.

The message was caused because the idempotency key was not updated with the right values after each retry. There were other issues with the particular implementation of this approach though:

1.  `remove_order_source_before_retry` and `remove_order_customer_before_retry` both used only `delete_post_meta`, which is ineffective in WooCommerce 3.0, because the order is already cached and the cache is never flushed.
2. In the current state of the code, `remove_order_customer_before_retry` does not make any sense. It is called _after_ the source is already deleted, so the order ends up having neither a customer, nor a source, and a payment this way would never work.
I assume that at some point in the past, this would've attempted to use the customer object, associated with the order's user (too many nouns, sorry), but this is not happening now.

#### Changes proposed in this Pull Request:

To fix the issues mentioned above, I:

1. Reformatted `remove_order_source_before_retry` to call `$order->save()` in order to update the right caches.
2. Removed `remove_order_customer_before_retry`, because it is not useful at the moment.

#1015 is now redundant, because it was used to include the `customer_id` in the idempotency key, but `customer_id` will not be changed anymore.

#### Testing instructions

0. I recommend starting with a private/incognito window in order to avoid interference from existing orders.
1. Register as a new customer.
2. Purchase a product, which is pre-ordered with one card (ex. 4242 4242 4242 4242).
3. Go to My Account -> Payment methods
   1. Add a different, new card (ex. 5555 5555 5555 4444).
   2. Set the new card as default.
   3. Delete the old card.
4. As an administrator, go to WooCommerce -> Pre-Orders -> Actions -> Complete, select the product, and try to complete all associated pre-orders.

Follow those instructions:

1. Without this PR.
    - If you use `master`, you will see the idempotency error mentioned above.
    - If you use `sca/master`, you should see something like `The PaymentIntent was confirmed with the 'off_session' option, but the attached Source is not chargeable.`.
2. With this PR.
It should work. If you check the logs in Stripe, there will be an erroneous call first, but then a good one. The request of the second one will be almost the same, but will not include a `source`.

#### Further actions

@thenbrent opened https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1028 to use the default customer's source. Because Stripe does not recommend __not__ sending a source, in order to use the default customer's card, I'll shortly check whether I can use `WC_Stripe_Payment_Gateway::prepare_order_source` to load the customer's default card. Considering we _should_ (fully described in the future PR) have all of the customer's payment methods synchronized already, this should not be a heavy task.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).

__P.S.__ This is the highest PR description / code changes ratio among my PRs so far :D