### PR TITLE
Use a customer's default source when none is selected

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -727,14 +727,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function get_default_customer_source_for_order( $order ) {
 		$wc_customer = $order->get_user();
 		if ( ! $wc_customer ) {
-			return false;
+			return null;
 		}
 
 		$stripe_customer = new WC_Stripe_Customer( $wc_customer->ID );
 		$source_object   = $stripe_customer->get_default_source();
 
 		if ( empty( $source_object ) ) {
-			return false;
+			return null;
 		}
 
 		return (object) array(

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -722,10 +722,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * @todo: Check pre-3.0 compatibility.
+	 * Retrieves a source based on an order. Checks for the customer, associated
+	 * with the order and/or the customer which was manually entered in the admin.
 	 *
-	 * @param WC_Order $order
-	 * @return void
+	 * @param WC_Order $order The order to use as a starting point.
+	 * @return stdClass|null  Either an object with the necessary data or null.
 	 */
 	public function get_default_customer_source_for_order( $order ) {
 		$stripe_customer = null;

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -350,7 +350,7 @@ class WC_Stripe_Customer {
 
 			if ( ! empty( $default_token ) && 'stripe' === $default_token->get_gateway_id() ) {
 				$source = WC_Stripe_API::request( array(), 'sources/' . $default_token->get_token(), 'GET' );
-				if ( empty( $source->error ) && $this->id === $source->customer ) {
+				if ( empty( $source->error ) && ! empty( $source->customer ) && $this->id === $source->customer ) {
 					return $source;
 				}
 			}

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -287,8 +287,10 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 			}
 
-			// Either the charge was successfully captured, or it requires further authentication.
+			// By this point the charge _did not fail_. This means that the source and customer objects work, so make sure they are saved.
+			$this->save_source_to_order( $renewal_order, $prepared_source );
 
+			// Either the charge was successfully captured, or it requires further authentication.
 			if ( $is_authentication_required ) {
 				do_action( 'wc_gateway_stripe_process_payment_authentication_required', $renewal_order, $response );
 

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -446,20 +446,20 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	public function validate_subscription_payment_meta( $payment_method_id, $payment_meta ) {
 		if ( $this->id === $payment_method_id ) {
 
-			if ( ! isset( $payment_meta['post_meta']['_stripe_customer_id']['value'] ) || empty( $payment_meta['post_meta']['_stripe_customer_id']['value'] ) ) {
-				throw new Exception( __( 'A "Stripe Customer ID" value is required.', 'woocommerce-gateway-stripe' ) );
-			} elseif ( 0 !== strpos( $payment_meta['post_meta']['_stripe_customer_id']['value'], 'cus_' ) ) {
-				throw new Exception( __( 'Invalid customer ID. A valid "Stripe Customer ID" must begin with "cus_".', 'woocommerce-gateway-stripe' ) );
-			}
+			// if ( ! isset( $payment_meta['post_meta']['_stripe_customer_id']['value'] ) || empty( $payment_meta['post_meta']['_stripe_customer_id']['value'] ) ) {
+			// 	throw new Exception( __( 'A "Stripe Customer ID" value is required.', 'woocommerce-gateway-stripe' ) );
+			// } elseif ( 0 !== strpos( $payment_meta['post_meta']['_stripe_customer_id']['value'], 'cus_' ) ) {
+			// 	throw new Exception( __( 'Invalid customer ID. A valid "Stripe Customer ID" must begin with "cus_".', 'woocommerce-gateway-stripe' ) );
+			// }
 
-			if (
-				( ! empty( $payment_meta['post_meta']['_stripe_source_id']['value'] )
-				&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'card_' ) )
-				&& ( ! empty( $payment_meta['post_meta']['_stripe_source_id']['value'] )
-				&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'src_' ) ) ) {
+			// if (
+			// 	( ! empty( $payment_meta['post_meta']['_stripe_source_id']['value'] )
+			// 	&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'card_' ) )
+			// 	&& ( ! empty( $payment_meta['post_meta']['_stripe_source_id']['value'] )
+			// 	&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'src_' ) ) ) {
 
-				throw new Exception( __( 'Invalid source ID. A valid source "Stripe Source ID" must begin with "src_" or "card_".', 'woocommerce-gateway-stripe' ) );
-			}
+			// 	throw new Exception( __( 'Invalid source ID. A valid source "Stripe Source ID" must begin with "src_" or "card_".', 'woocommerce-gateway-stripe' ) );
+			// }
 		}
 	}
 


### PR DESCRIPTION
Fixes #1028 .

#### The problem

Stripe allows charges (and now payment intents) to be created with empty sources. This way the default card, associated with the customer will be used. However, this behavior is discouraged and might break in the future.

#### Changes proposed in this Pull Request:

As proposed in #1028, this PR implements the loading of the default source, based on an order. As a result, not only is the `Stripe Source ID` field optional, but `Stripe Customer ID` does not need to be populated if a correct customer is chosen (one who already has saved tokens).

The code works in this order:
1. Check for manually entered values in _Stripe Customer ID_ and _Stripe Source ID_. If both are present, no additional steps will be performed.
2. Check for a manually entered value in `Stripe Customer ID`. If one is present, but the source ID 
is empty, the code will try to load the default card of the given Stripe customer.
3. If there is a value in the source field, but none in the customer field, the customer will see a message (because both are required).
4. If both fields are empty, the next source of the truth is the (WooCommerce) customer, associated with the order. If they have already paid with a card, we have their customer ID present and will load the default payment method associated with them.

In any of those cases:

- There will be a notice if a source has not been found.
- If a source was found, it will be saved during the payment process. This will ensure that with time all empty source/customer ID fields will be populated.

#### Testing instructions

1. Create a new subscription and select "Stripe (Credit Card)" in the "Payment Method" field in the "Billing Fields" section. Leave all other (payment) fields empty, and save the subscription.
2. Save the subscription. You should see a notice that `A "Stripe Customer ID" value or a customer with a Stripe account are required.`.
3. Select a customer, which has never paid with a CC through Stripe and save the subscription again. The message should remain.
4. Select a customer, which __has__ paid with a Stripe credit card already. The message should disappear.
5. Force a renewal payment and check the subscription. The subscription should be active and both the "Stripe Customer ID" and "Stripe Source ID" fields should be populated.

Start again with a separate subscription:

1. Create a new subscription and select "Stripe (Credit Card)" in the "Payment Method" field in the "Billing Fields" section. Enter a Source ID in the field.
2. Save the subscription and you should see an error notice, which states `A "Stripe Customer ID" value is required when "Stripe Source ID" is used.`.
3. Delete the source ID and enter a customer ID.
4. Save the subscription and force a renewal payment. 
5. Check the subscription. The subscription should be active and both the "Stripe Customer ID" and "Stripe Source ID" fields should be populated.

Those tests should cover all scenarios and combination.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Load the default source for subscriptions.
- [x] Check if this automatically loads the source for pre-orders.
- [x] Save the source and/or customer after use.