### PR TITLE
Remove some dead code related with Customer object creation

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -593,7 +593,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function prepare_source( $user_id, $force_save_source = false ) {
 		$customer          = new WC_Stripe_Customer( $user_id );
-		$set_customer      = true;
 		$force_save_source = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $customer );
 		$source_object     = '';
 		$source_id         = '';
@@ -648,7 +647,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 					throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 				}
 			} else {
-				$set_customer = false;
 				$source_id    = $stripe_token;
 				$is_token     = true;
 			}

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -477,23 +477,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Creates a new WC_Stripe_Customer if the visitor chooses to.
-	 *
-	 * @since 4.2.0
-	 * @param WC_Order $order The order that is being created.
-	 */
-	public function maybe_create_customer( $order ) {
-		// This comes from the create account checkbox in the checkout page.
-		if ( empty( $_POST['createaccount'] ) ) { // wpcs: csrf ok.
-			return;
-		}
-
-		$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
-		$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
-		$new_stripe_customer->create_customer();
-	}
-
-	/**
 	 * Checks if a source object represents a prepaid credit card and
 	 * throws an exception if it is one, but that is not allowed.
 	 *
@@ -593,8 +576,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				return $this->pre_orders->process_pre_order( $order_id );
 			}
 
-			$this->maybe_create_customer( $order );
-
 			$prepared_source = $this->prepare_source( get_current_user_id(), $force_save_source );
 
 			$this->maybe_disallow_prepaid_card( $prepared_source );
@@ -673,7 +654,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			if ( isset( WC()->cart ) ) {
 				WC()->cart->empty_cart();
 			}
-			
+
 			// Unlock the order.
 			$this->unlock_order_payment( $order );
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -178,10 +178,9 @@ class WC_Stripe_Customer {
 	/**
 	 * Add a source for this stripe customer.
 	 * @param string $source_id
-	 * @param bool $retry
 	 * @return WP_Error|int
 	 */
-	public function add_source( $source_id, $retry = true ) {
+	public function add_source( $source_id ) {
 		if ( ! $this->get_id() ) {
 			$this->set_id( $this->create_customer() );
 		}
@@ -202,7 +201,7 @@ class WC_Stripe_Customer {
 			if ( $this->is_no_such_customer_error( $response->error ) ) {
 				delete_user_meta( $this->get_user_id(), '_stripe_customer_id' );
 				$this->create_customer();
-				return $this->add_source( $source_id, false );
+				return $this->add_source( $source_id );
 			} else {
 				return $response;
 			}


### PR DESCRIPTION
I was looking at a semi-related issue and I found some code that, after https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1013, is no longer needed.
- The `$set_customer` boolean is unused.
- The `$retry` optional argument on `add_source` is unused.
- The `maybe_create_customer` function is redundant, because a customer object will always be created in the `prepare_source` function, which is called literally one line after `maybe_create_customer`.