### PR TITLE
Disable the "Early renewals via modal" feature until we make it compatible with SCA

### DIFF
--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -39,6 +39,9 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			 */
 			add_action( 'template_redirect', array( $this, 'remove_order_pay_var' ), 99 );
 			add_action( 'template_redirect', array( $this, 'restore_order_pay_var' ), 101 );
+
+			// The SCA flow is not compatible with the "Early manual renew modal" feature
+			add_filter( 'wcs_is_early_renewal_via_modal_enabled', '__return_false' );
 		}
 	}
 


### PR DESCRIPTION
Stopgap fix so the early renewal flow doesn't break. I've created https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1049 to properly fix the flow, but that can wait until after 4.3.0.

WooCommerce Subscriptions 2.6 has introduced a new way for a customer to manually renew a subscription early. The traditional way would take the customer to the checkout, and the new way means that a modal pops-up and renewing can be done with a single click.

See here for a much more eloquent explanation: https://docs.woocommerce.com/document/subscriptions/whats-new-in-subscriptions-2-6/#section-2

The problem is, this "modal" flow doesn't work if there's an SCA challenge. The renewal would just fail. The user would get an unhelpful generic "Payment failed, please try again" error message. The solution is to go to the checkout, but the customer may not even consider trying it, or they may simply not find the link (it's quite small, see the screenshot).

![Screenshot 2019-10-13 at 14 27 32](https://user-images.githubusercontent.com/1715800/66716464-dfc3c480-edc5-11e9-8bf0-9560663f22f9.png)

This PR implements the nuclear option. Using a filter, if Stripe is active, the "Accept Early Renewal Payments via a Modal" feature is effectively disabled.

To test:
- Install WooCommerce Subscriptions 2.6 or newer.
- Go to `WooCommerce > Settings > Subscriptions` and enable both `Accept Early Renewal Payments` and `Accept Early Renewal Payments via Modal`.
- Use a card that will always trigger an SCA challenge, like `4000002760003184`, to purchase a subscription (**without** a free trial).
- As the customer, go to `My account -> Subscriptions`, click `View` in the subscription you've just purchased, and click the `Renew now` button (see screenshot).

![Screenshot 2019-10-13 at 14 33 08](https://user-images.githubusercontent.com/1715800/66716527-84460680-edc6-11e9-96a2-dae04be1553f.png)

Without this change, you would get a modal, you would click `Pay Now`, and the payment would fail. With this change, instead, you will get redirected to the checkout, where you can select the same credit card (or another one) and you'll be able to perform the payment even if it requires SCA.