### PR TITLE
Replaced all the $order->get_status() comparisons with $order->has_status(...) because it's filterable

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1018,7 +1018,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		clean_post_cache( $order->get_id() );
 		$order = wc_get_order( $order->get_id() );
 
-		if ( 'pending' !== $order->get_status() && 'failed' !== $order->get_status() ) {
+		if ( ! $order->has_status( array( 'pending', 'failed' ) ) ) {
 			// If payment has already been completed, this function is redundant.
 			return;
 		}
@@ -1054,7 +1054,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function failed_sca_auth( $order, $intent ) {
 		// If the order has already failed, do not repeat the same message.
-		if ( 'failed' === $order->get_status() ) {
+		if ( $order->has_status( 'failed' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -69,7 +69,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				return;
 			}
 
-			if ( 'processing' === $order->get_status() || 'completed' === $order->get_status() || 'on-hold' === $order->get_status() ) {
+			if ( $order->has_status( array( 'processing', 'completed', 'on-hold' ) ) ) {
 				return;
 			}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -172,11 +172,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$is_pending_receiver = ( 'receiver' === $notification->data->object->flow );
 
 		try {
-			if ( 'processing' === $order->get_status() || 'completed' === $order->get_status() ) {
+			if ( $order->has_status( array( 'processing', 'completed' ) ) ) {
 				return;
 			}
 
-			if ( 'on-hold' === $order->get_status() && ! $is_pending_receiver ) {
+			if ( $order->has_status( 'on-hold' ) && ! $is_pending_receiver ) {
 				return;
 			}
 
@@ -382,7 +382,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 
-		if ( 'on-hold' !== $order->get_status() ) {
+		if ( ! $order->has_status( 'on-hold' ) ) {
 			return;
 		}
 
@@ -421,7 +421,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 
 		// If order status is already in failed status don't continue.
-		if ( 'failed' === $order->get_status() ) {
+		if ( $order->has_status( 'failed' ) ) {
 			return;
 		}
 
@@ -457,7 +457,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'cancelled' !== $order->get_status() ) {
+		if ( ! $order->has_status( 'cancelled' ) ) {
 			$order->update_status( 'cancelled', __( 'This payment has cancelled.', 'woocommerce-gateway-stripe' ) );
 		}
 
@@ -587,7 +587,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		/* translators: 1) The reason type. */
 		$message = sprintf( __( 'The opened review for this order is now closed. Reason: (%s)', 'woocommerce-gateway-stripe' ), $notification->data->object->reason );
 
-		if ( 'on-hold' === $order->get_status() ) {
+		if ( $order->has_status( 'on-hold' ) ) {
 			if ( apply_filters( 'wc_stripe_webhook_review_change_order_status', true, $order, $notification ) ) {
 				$order->update_status( 'processing', $message );
 			} else {
@@ -660,7 +660,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'pending' !== $order->get_status() && 'failed' !== $order->get_status() ) {
+		if ( ! $order->has_status( array( 'pending', 'failed' ) ) ) {
 			return;
 		}
 
@@ -701,7 +701,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'pending' !== $order->get_status() && 'failed' !== $order->get_status() ) {
+		if ( ! $order->has_status( array( 'pending', 'failed' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The rationale and more context is in https://github.com/woocommerce/woocommerce-deposits/pull/306

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/943 (partially at least)

The change itself is simple. I've changed all the `'blah' === $order->get_status()` checks with the equivalent `$order->has_status('blah')`. That way, the result of that function is filterable so extensions that define their own custom statuses can make it behave the way it should. I don't know which changes are strictly required to make Deposits work, but I don't care, this refactor is simple enough that I just changed all of them.

To test:
- Make sure you have Deposits installed with https://github.com/woocommerce/woocommerce-deposits/pull/306 included.
- Follow the testing steps on https://github.com/woocommerce/woocommerce-gateway-stripe/issues/943#issuecomment-541091369
- At the end, everything should work. The second installment of the deposit should be marked as paid in `wp-admin`.