### PR TITLE
Returns a caching layer to WC_Stripe_Customer::get_sources()

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -268,20 +268,24 @@ class WC_Stripe_Customer {
 
 		$sources = get_transient( 'stripe_sources_' . $this->get_id() );
 
-		$response = WC_Stripe_API::request(
-			array(
-				'limit' => 100,
-			),
-			'customers/' . $this->get_id() . '/sources',
-			'GET'
-		);
+		if ( false === $sources ) {
+			$response = WC_Stripe_API::request(
+				array(
+					'limit' => 100,
+				),
+				'customers/' . $this->get_id() . '/sources',
+				'GET'
+			);
 
-		if ( ! empty( $response->error ) ) {
-			return array();
-		}
+			if ( ! empty( $response->error ) ) {
+				return array();
+			}
 
-		if ( is_array( $response->data ) ) {
-			$sources = $response->data;
+			if ( is_array( $response->data ) ) {
+				$sources = $response->data;
+			}
+
+			set_transient( 'stripe_sources_' . $this->get_id(), $sources, DAY_IN_SECONDS );
 		}
 
 		return empty( $sources ) ? array() : $sources;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
Returns the caching layer to the `WC_Stripe_Customer::get_sources()` function.

This function used to cache the response in a transient, but it was removed in commit [`0c3c1be`](https://github.com/woocommerce/woocommerce-gateway-stripe/commit/0c3c1be41987a9d9976c50cf6560c7d41e409ec7#diff-f8dd0b04c52dc566825dead0a3b8b84c). It wasn't fully removed though; there is still a `get_transient()` which remained and the `clear_cache()` function which still runs. 

Looking at the issue that 0c3c1be fixed (#478 ), I don't think the cache layer was the problem. Please correct me if I'm wrong 🙂 

#### Background:
I noticed on the **My Account > Subscriptions tab**, it was taking about 8-10 seconds to load the page. Looking into why it was taking that long, I noticed there were 8 HTTP requests all retrieving information from Stripe totalling ~6-8 seconds. 

<img width="1149" alt="Screen Shot 2019-10-28 at 2 54 26 pm" src="https://user-images.githubusercontent.com/8490476/67652945-04599800-f993-11e9-8026-be5502bfb8e0.png">

As you can see from the screenshot, all the requests are for the same thing - to get the customer's sources from Stripe. For your reference in this case it's the  `WC_Stripe_Subs_Compat::maybe_render_subscription_payment_method()` function which is calling `get_sources()` multiple times.

By re-adding the caching layer, the sources are only retrieved from Stripe once a day. Please let me know if there are issues this might cause that I'm not aware of. 🙂 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

