### PR TITLE
Fix duplicate payment notifications

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1210,12 +1210,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$processing     = get_transient( $transient_name );
 
 		// Block the process if the same intent is already being handled.
-		if ( -1 == $processing || $processing === $intent->id ) {
+		if ( "-1" === $processing || ( isset( $intent->id ) && $processing === $intent->id ) ) {
 			return true;
 		}
 
 		// Save the new intent as a transient, eventually overwriting another one.
-		set_transient( $transient_name, empty( $intent ) ? -1 : $intent->id, 5 * MINUTE_IN_SECONDS );
+		set_transient( $transient_name, empty( $intent ) ? '-1' : $intent->id, 5 * MINUTE_IN_SECONDS );
 
 		return false;
 	}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1204,18 +1204,18 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param stdClass $intent The intent that is being processed.
 	 * @return bool            A flag that indicates whether the order is already locked.
 	 */
-	public function lock_order_payment( $order, $intent ) {
+	public function lock_order_payment( $order, $intent = null ) {
 		$order_id       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
 		$transient_name = 'wc_stripe_processing_intent_' . $order_id;
 		$processing     = get_transient( $transient_name );
 
 		// Block the process if the same intent is already being handled.
-		if ( $processing === $intent->id ) {
+		if ( -1 == $processing || $processing === $intent->id ) {
 			return true;
 		}
 
 		// Save the new intent as a transient, eventually overwriting another one.
-		set_transient( $transient_name, $intent->id, 5 * MINUTE_IN_SECONDS );
+		set_transient( $transient_name, empty( $intent ) ? -1 : $intent->id, 5 * MINUTE_IN_SECONDS );
 
 		return false;
 	}

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -247,8 +247,9 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 				$prepared_source->source = '';
 			}
 
-			$response = $this->create_and_confirm_intent_for_off_session( $renewal_order, $prepared_source, $amount );
+			$this->lock_order_payment( $renewal_order );
 
+			$response                   = $this->create_and_confirm_intent_for_off_session( $renewal_order, $prepared_source, $amount );
 			$is_authentication_required = $this->is_authentication_required_for_payment( $response );
 
 			// It's only a failed payment if it's an error and it's not of the type 'authentication_required'.
@@ -310,6 +311,8 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 				$this->process_response( end( $response->charges->data ), $renewal_order );
 			}
+
+			$this->unlock_order_payment( $renewal_order );
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 


### PR DESCRIPTION
Fixes #1061. Fixes #1062.

#### Changes proposed in this Pull Request:

1. Use the `lock_order_payment` and `unlock_order_payment` pair of methods to prevent webhooks from interfering with subscription renewal payments.
2. Modify `lock_order_payment` to work without a particular PaymentIntent, needed because the creation and confirmation of renewal intents is a single API-call process.
3. By doing 1. and 2., prevent payment intent success webhooks from interfering with renewal orders completely. This is not needed, because renewals are headless and wouldn't fail because the customer closed their tab or something similar.

#### Testing instructions

1. Prepare the setup.
    1. Create a subscription and purchase it.
    2. Make sure webhooks are enabled.
2. Reproduce the bug
   1. Checkout `master`.
   2. In `WC_Stripe_Subs_Compat::process_subscription_payment`, add a `sleep( 10 )` right after the `create_and_confirm_intent_for_off_session` call.
    3. Process a renewal manually from the subscription screen.
    4. Check the renewal order and notice the duplicate messages.
    5. Remove the `sleep` call.
3. Test
    1. Checkout this branch.
    3. Process a renewal manually from the subscription screen.
    4. Check the renewal order and make sure there are no duplicate messages.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
