### PR TITLE
Declare WordPress 5.3 and WooCommerce 3.8 compatibility

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
 Requires at least: 4.4
-Tested up to: 5.2.4
+Tested up to: 5.3.0
 Requires PHP: 5.6
 Stable tag: 4.3.0
 License: GPLv3

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Version: 4.3.0
  * Requires at least: 4.4
- * Tested up to: 5.2.4
+ * Tested up to: 5.3.0
  * WC requires at least: 2.6
- * WC tested up to: 3.7.1
+ * WC tested up to: 3.8
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  *


### PR DESCRIPTION
Fixes #999

I did a basic smoke test (buying a product using an SCA-required card, a regular card, buying a subscription) using WooCommerce 3.8 and WordPress 5.3 RC4 (the latest version at the moment of writing this). Everything worked.

I've taken a look at WooCommerce 3.8's changelog, and I don't see anything that could potentially impact us. There's some CSS tweaks in WP-Admin, but that just means that the Setting pages look prettier.