### PR TITLE
Add a filter so the checkbox for updating the payment method used in all subscriptions can be checked by default

### DIFF
--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -79,13 +79,15 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 			wcs_user_has_subscription( get_current_user_id(), '', 'active' ) &&
 			is_add_payment_method_page()
 		) {
-			printf(
-				'<p class="form-row">
-					<input id="wc-%1$s-update-subs-payment-method-card" name="wc-%1$s-update-subs-payment-method-card" type="checkbox" value="true" style="width:auto;" />
-					<label for="wc-%1$s-update-subs-payment-method-card" style="display:inline;">%2$s</label>
-				</p>',
-				esc_attr( $this->id ),
-				esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions (optional).', 'woocommerce-gateway-stripe' ) ) )
+			$label = esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions.', 'woocommerce-gateway-stripe' ) ) );
+			$id    = sprintf( 'wc-%1$s-update-subs-payment-method-card', $this->id );
+			woocommerce_form_field(
+				$id,
+				array(
+					'type'    => 'checkbox',
+					'label'   => $label,
+					'default' => apply_filters( 'wc_stripe_save_to_subs_checked', false ),
+				)
 			);
 		}
 	}

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -88,13 +88,15 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			wcs_user_has_subscription( get_current_user_id(), '', 'active' ) &&
 			is_add_payment_method_page()
 		) {
-			printf(
-				'<p class="form-row">
-					<input id="wc-%1$s-update-subs-payment-method-card" name="wc-%1$s-update-subs-payment-method-card" type="checkbox" value="true" style="width:auto;" />
-					<label for="wc-%1$s-update-subs-payment-method-card" style="display:inline;">%2$s</label>
-				</p>',
-				esc_attr( $this->id ),
-				esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions (optional).', 'woocommerce-gateway-stripe' ) ) )
+			$label = esc_html( apply_filters( 'wc_stripe_save_to_subs_text', __( 'Update the Payment Method used for all of my active subscriptions.', 'woocommerce-gateway-stripe' ) ) );
+			$id    = sprintf( 'wc-%1$s-update-subs-payment-method-card', $this->id );
+			woocommerce_form_field(
+				$id,
+				array(
+					'type'    => 'checkbox',
+					'label'   => $label,
+					'default' => apply_filters( 'wc_stripe_save_to_subs_checked', false ),
+				)
 			);
 		}
 	}


### PR DESCRIPTION
Fixes #764 

I've split https://github.com/woocommerce/woocommerce-gateway-stripe/pull/874 into 2 PRs, to make it easier to review.

This one refactors a bit how the "`Update the Payment Method used for all of my active subscriptions`" checkbox is displayed in the `Add Payment Method` screen, to use the `woocommerce_form_field` helper function.

It also adds a `wc_stripe_save_to_subs_checked` filter (`false` by default) that controls if said checkbox should be checked/unchecked by default.

To test:
- Have some active subscriptions in your account.
- Go to `My Account -> Payment Methods -> Add payment method`.
- See that the checkbox is unchecked.
- Add this filter anywhere that's run on every page load (like `functions.php`): `add_filter( 'wc_stripe_save_to_subs_checked', '__return_true' );`
- Reload the page, see that the checkbox is now checked.

@glagonikas I didn't include the `wc_stripe_save_to_subs_class` filter from your PR, the field can already be styled by `id` or by `name`. I hope that's ok.