### PR TITLE
Add filter so the payment method can be updated for all subscriptions, not only active ones

### DIFF
--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -74,9 +74,10 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @since 4.1.11
 	 */
 	public function display_update_subs_payment_checkout() {
+		$subs_statuses = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
 		if (
 			apply_filters( 'wc_stripe_display_update_subs_payment_method_card_checkbox', true ) &&
-			wcs_user_has_subscription( get_current_user_id(), '', 'active' ) &&
+			wcs_user_has_subscription( get_current_user_id(), '', $subs_statuses ) &&
 			is_add_payment_method_page()
 		) {
 			printf(
@@ -100,10 +101,11 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	public function handle_add_payment_method_success( $source_id, $source_object ) {
 		if ( isset( $_POST[ 'wc-' . $this->id . '-update-subs-payment-method-card' ] ) ) {
 			$all_subs = wcs_get_users_subscriptions();
+			$subs_statuses = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
 
 			if ( ! empty( $all_subs ) ) {
 				foreach ( $all_subs as $sub ) {
-					if ( 'active' === $sub->get_status() ) {
+					if ( $sub->has_status( $subs_statuses ) ) {
 						update_post_meta( $sub->get_id(), '_stripe_source_id', $source_id );
 						update_post_meta( $sub->get_id(), '_payment_method', $this->id );
 						update_post_meta( $sub->get_id(), '_payment_method_title', $this->method_title );

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -83,9 +83,10 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 * @since 4.1.11
 	 */
 	public function display_update_subs_payment_checkout() {
+		$subs_statuses = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
 		if (
 			apply_filters( 'wc_stripe_display_update_subs_payment_method_card_checkbox', true ) &&
-			wcs_user_has_subscription( get_current_user_id(), '', 'active' ) &&
+			wcs_user_has_subscription( get_current_user_id(), '', $subs_statuses ) &&
 			is_add_payment_method_page()
 		) {
 			printf(
@@ -109,10 +110,11 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	public function handle_add_payment_method_success( $source_id, $source_object ) {
 		if ( isset( $_POST[ 'wc-' . $this->id . '-update-subs-payment-method-card' ] ) ) {
 			$all_subs = wcs_get_users_subscriptions();
+			$subs_statuses = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
 
 			if ( ! empty( $all_subs ) ) {
 				foreach ( $all_subs as $sub ) {
-					if ( 'active' === $sub->get_status() ) {
+					if ( $sub->has_status( $subs_statuses ) ) {
 						update_post_meta( $sub->get_id(), '_stripe_source_id', $source_id );
 						update_post_meta( $sub->get_id(), '_payment_method', $this->id );
 						update_post_meta( $sub->get_id(), '_payment_method_title', $this->method_title );


### PR DESCRIPTION
I've split #874 into 2 PRs, to make it easier to review.

By default, only active subscriptions' payment methods are updated when you add a new payment method and tick the "`Update the Payment Method used for all of my active subscriptions`" checkbox. This PR adds a filter so the change can affect subscriptions on other statuses.

To test:
- Have some active, on-hold, or pending subscriptions in your account.
- Go to `My Account -> Payment Methods -> Add payment method`.
- Add a new payment method, remember to tick the checkbox.
- See that only active subscriptions have the new payment method.
- Add this filter anywhere that's run on every page load (like `functions.php`): `add_filter( 'wc_stripe_update_subs_payment_method_card_statuses', function( $statuses ) { return [ 'active', 'on-hold', 'pending' ]; } );`
- Go add a payment method again, remember to tick the checkbox.
- See that now the `on-hold` and `pending` subcriptions have also been updated.

cc/ @glagonikas