### PR TITLE
Use site locale as locale for Stripe elements

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -426,6 +426,13 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
+		$elements_options = apply_filters(
+			'wc_stripe_elements_options',
+			array(
+				'locale' => get_locale(),
+			)
+		);
+
 		$sepa_elements_options = apply_filters(
 			'wc_stripe_sepa_elements_options',
 			array(
@@ -447,7 +454,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$stripe_params['ajaxurl']                   = WC_AJAX::get_endpoint( '%%endpoint%%' );
 		$stripe_params['stripe_nonce']              = wp_create_nonce( '_wc_stripe_nonce' );
 		$stripe_params['statement_descriptor']      = $this->statement_descriptor;
-		$stripe_params['elements_options']          = apply_filters( 'wc_stripe_elements_options', array() );
+		$stripe_params['elements_options']          = $elements_options;
 		$stripe_params['sepa_elements_options']     = $sepa_elements_options;
 		$stripe_params['invalid_owner_name']        = __( 'Billing First Name and Last Name are required.', 'woocommerce-gateway-stripe' );
 		$stripe_params['is_change_payment_page']    = isset( $_GET['change_payment_method'] ) ? 'yes' : 'no'; // wpcs: csrf ok.


### PR DESCRIPTION
Fixes #521.

#### Changes proposed in this Pull Request:
Use the site locale (`get_locale()`) for the value of `locale` when using Stripe elements.

Notes:
- The site locale string is something like `fr_FR` whereas Stripe notes two-character strings in their docs: `fr`. Stripe will correctly use the longer string. 
- If a string is used that's not supported, it will not cause an error, and instead will use `en` as the locale.

Testing instructions:
1. Set a site language at `/wp-admin/options-general.php`
2. See that the correct placeholder strings for that language are used for Stripe elements at checkout

#### Docs that need updating:
https://docs.woocommerce.com/document/stripe/#section-32

This needs to be updated to use a specific locale string instead of the site locale, and that the default behaviour is to use the site language if it's available from Stripe.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

