### PR TITLE
Save the customer ID when updating all subscription payment methods

### DIFF
--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -102,13 +102,15 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 */
 	public function handle_add_payment_method_success( $source_id, $source_object ) {
 		if ( isset( $_POST[ 'wc-' . $this->id . '-update-subs-payment-method-card' ] ) ) {
-			$all_subs = wcs_get_users_subscriptions();
-			$subs_statuses = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
+			$all_subs        = wcs_get_users_subscriptions();
+			$subs_statuses   = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
+			$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
 
 			if ( ! empty( $all_subs ) ) {
 				foreach ( $all_subs as $sub ) {
 					if ( $sub->has_status( $subs_statuses ) ) {
 						update_post_meta( $sub->get_id(), '_stripe_source_id', $source_id );
+						update_post_meta( $sub->get_id(), '_stripe_customer_id', $stripe_customer->get_id() );
 						update_post_meta( $sub->get_id(), '_payment_method', $this->id );
 						update_post_meta( $sub->get_id(), '_payment_method_title', $this->method_title );
 					}

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -111,13 +111,15 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 */
 	public function handle_add_payment_method_success( $source_id, $source_object ) {
 		if ( isset( $_POST[ 'wc-' . $this->id . '-update-subs-payment-method-card' ] ) ) {
-			$all_subs = wcs_get_users_subscriptions();
-			$subs_statuses = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
+			$all_subs        = wcs_get_users_subscriptions();
+			$subs_statuses   = apply_filters( 'wc_stripe_update_subs_payment_method_card_statuses', array( 'active' ) );
+			$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
 
 			if ( ! empty( $all_subs ) ) {
 				foreach ( $all_subs as $sub ) {
 					if ( $sub->has_status( $subs_statuses ) ) {
 						update_post_meta( $sub->get_id(), '_stripe_source_id', $source_id );
+						update_post_meta( $sub->get_id(), '_stripe_customer_id', $stripe_customer->get_id() );
 						update_post_meta( $sub->get_id(), '_payment_method', $this->id );
 						update_post_meta( $sub->get_id(), '_payment_method_title', $this->method_title );
 					}


### PR DESCRIPTION
Fixes #1072 

#### Changes proposed in this Pull Request:

Save the Stripe customer ID on the subscription when the customer adds a new payment method via the **My Account > Payment methods** screen and opts to update all their active subscriptions. 

To test: 

1. Purchase a subscription through a non-Stripe payment method (eg PayPal)
2. Go to **My Account > Payment Methods** and add a new Stripe payment method
3. Be sure to select the option for "Update the Payment Method used for all of my active subscriptions (optional)."
4. Go to the subscription and click "Billing Details" to edit
    5. On `master` see that [no Customer ID token has been saved to the subscription.](https://d.pr/i/b9YerW)
    6. After replicating on this branch you should see the [customer token is set](https://d.pr/i/KNW0h8).

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.