### PR TITLE
Localize error message for save card on checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Add compatibility to payment request buttons with some of the WooCommerce Product Add-ons on the product page
 * Fix - Improved compatibility for free orders with other extensions
 * Add - Support for multisite when sites use different Stripe accounts
+* Fix - Display a localized error message when a customer tries to save a card during checkout, but there's an error
 
 = 4.3.1 2019-11-12 =
 * Fix - Overwrite the previous Apple Pay verification file if it has changed.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -606,7 +606,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				$response = $customer->add_source( $source_object->id );
 
 				if ( ! empty( $response->error ) ) {
-					throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+					throw new WC_Stripe_Exception( print_r( $response, true ), $this->get_localized_error_message_from_response( $response ) );
 				}
 			}
 		} elseif ( $this->is_using_saved_payment_method() ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -784,14 +784,15 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Generates a localized message for an error, adds it as a note and throws it.
+	 * Generates a localized message for an error from a response.
 	 *
-	 * @since 4.2.0
-	 * @param  stdClass $response  The response from the Stripe API.
-	 * @param  WC_Order $order     The order to add a note to.
-	 * @throws WC_Stripe_Exception An exception with the right message.
+	 * @since 4.3.2
+	 *
+	 * @param stdClass $response The response from the Stripe API.
+	 *
+	 * @return string The localized error message.
 	 */
-	public function throw_localized_message( $response, $order ) {
+	public function get_localized_error_message_from_response( $response ) {
 		$localized_messages = WC_Stripe_Helper::get_localized_messages();
 
 		if ( 'card_error' === $response->error->type ) {
@@ -799,6 +800,20 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		} else {
 			$localized_message = isset( $localized_messages[ $response->error->type ] ) ? $localized_messages[ $response->error->type ] : $response->error->message;
 		}
+
+		return $localized_message;
+	}
+
+	/**
+	 * Gets a localized message for an error from a response, adds it as a note to the order, and throws it.
+	 *
+	 * @since 4.2.0
+	 * @param  stdClass $response  The response from the Stripe API.
+	 * @param  WC_Order $order     The order to add a note to.
+	 * @throws WC_Stripe_Exception An exception with the right message.
+	 */
+	public function throw_localized_message( $response, $order ) {
+		$localized_message = $this->get_localized_error_message_from_response( $response );
 
 		$order->add_order_note( $localized_message );
 

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Add compatibility to payment request buttons with some of the WooCommerce Product Add-ons on the product page
 * Fix - Improved compatibility for free orders with other extensions
 * Add - Support for multisite when sites use different Stripe accounts
+* Fix - Display a localized error message when a customer tries to save a card during checkout, but there's an error
 
 = 4.3.1 2019-11-12 =
 * Fix - Overwrite the previous Apple Pay verification file if it has changed.


### PR DESCRIPTION
Fixes #1110.

When a user is logged in during checkout and saving a card to the account using the checkbox "Save payment information to my account for future purchases.", an error can happen while we `prepare_source`.

If we get an error back from Stripe during `prepare_source`, we'll throw an exception using the localized error message instead of the original error message we get back from Stripe.

