### PR TITLE
Refactor `complete_free_order` for compatibilty with other plugins

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.3.2 2019-x-x =
 * Fix - Add compatibility to payment request buttons with some of the WooCommerce Product Add-ons on the product page
+* Fix - Improved compatibility for free orders with other extensions
 
 = 4.3.1 2019-11-12 =
 * Fix - Overwrite the previous Apple Pay verification file if it has changed.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -532,17 +532,16 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @return array                      Redirection data for `process_payment`.
 	 */
 	public function complete_free_order( $order, $prepared_source, $force_save_source ) {
-		$response = array(
-			'result'   => 'success',
-			'redirect' => $this->get_return_url( $order ),
-		);
-
 		if ( $force_save_source ) {
 			$intent_secret = $this->setup_intent( $order, $prepared_source );
 
 			if ( ! empty( $intent_secret ) ) {
-				$response['setup_intent_secret'] = $intent_secret;
-				return $response;
+				// `get_return_url()` must be called immediately before returning a value.
+				return array(
+					'result'              => 'success',
+					'redirect'            => $this->get_return_url( $order ),
+					'setup_intent_secret' => $intent_secret,
+				);
 			}
 		}
 
@@ -552,7 +551,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$order->payment_complete();
 
 		// Return thank you page redirect.
-		return $response;
+		return array(
+			'result'   => 'success',
+			'redirect' => $this->get_return_url( $order ),
+		);
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 4.3.2 2019-x-x =
 * Fix - Add compatibility to payment request buttons with some of the WooCommerce Product Add-ons on the product page
+* Fix - Improved compatibility for free orders with other extensions
 
 = 4.3.1 2019-11-12 =
 * Fix - Overwrite the previous Apple Pay verification file if it has changed.


### PR DESCRIPTION
Fixes #1124 .

#### Changes proposed in this Pull Request:

Refactoring `WC_Gateway_Stripe::complete_free_order()` to call `get_return_url` immediately before returning. This way other WooCommerce extensions can be aware of SetupIntents, which used to be prepared before determining the return URL.

#### Testing instructions

Purchase a subscription with a free trial while using a card, which triggers SCA challenges. It should still be fully functional.

Additionally, feedback and testing from @xlplugins (who reported the issue) are welcome.

-------------------
- [X] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).