### PR TITLE
fix typo

### DIFF
--- a/includes/admin/stripe-eps-settings.php
+++ b/includes/admin/stripe-eps-settings.php
@@ -36,7 +36,7 @@ return apply_filters(
 			'desc_tip'    => true,
 		),
 		'webhook'     => array(
-			'title'       => __( 'Webhook Enpoints', 'woocommerce-gateway-stripe' ),
+			'title'       => __( 'Webhook Endpoints', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 			/* translators: webhook URL */
 			'description' => $this->display_admin_settings_webhook_description(),


### PR DESCRIPTION
unfortunately means re-translations for all but typo is typo. so should be fixed.

Fixes # .

#### Changes proposed in this Pull Request:
- Fixes typo

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

