### PR TITLE
Add function to generate level 3 data from order

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1150,7 +1150,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return $intent;
 		}
 
-		return WC_Stripe_API::request( $request, "payment_intents/$intent->id" );
+		$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+		return WC_Stripe_API::request_with_level3_data(
+			$request,
+			"payment_intents/$intent->id",
+			$level3_data,
+			$order
+		);
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1058,18 +1058,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	/**
 	 * Create the level 3 data array to send to Stripe when making a purchase.
 	 *
-	 * @param WC_Order $order           The order that is being paid for.
-	 * @param string   $store_postcode  The postcode of the store.
-	 * @return array                    The level 3 data to send to Stripe.
+	 * @param WC_Order $order The order that is being paid for.
+	 * @return array          The level 3 data to send to Stripe.
 	 */
-	public function get_level3_data_from_order( $order, $store_postcode ) {
-		// Return an empty array if there's no store postcode (since it's
-		// required for level3 data), or if the version is less than 3.0
-		// (because it's not possible to get a store postcode before WC 3.0).
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) || empty( $store_postcode ) ) {
-			return array();
-		}
-
+	public function get_level3_data_from_order( $order ) {
 		// Get the order items. Don't need their keys, only their values.
 		// Order item IDs are used as keys in the original order items array.
 		$order_items = array_values( $order->get_items() );
@@ -1109,6 +1101,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		// The merchant’s U.S. shipping ZIP code.
+		$store_postcode = get_option( 'woocommerce_store_postcode' );
 		if ( $this->is_valid_us_zip_code( $store_postcode ) ) {
 			$level3_data['shipping_from_zip'] = $store_postcode;
 		}
@@ -1169,7 +1162,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return $intent;
 		}
 
-		$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+		$level3_data = $this->get_level3_data_from_order( $order );
 		return WC_Stripe_API::request_with_level3_data(
 			$request,
 			"payment_intents/$intent->id",
@@ -1197,7 +1190,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'source' => $prepared_source->source,
 		);
 
-		$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+		$level3_data = $this->get_level3_data_from_order( $order );
 		$confirmed_intent = WC_Stripe_API::request_with_level3_data(
 			$confirm_request,
 			"payment_intents/$intent->id/confirm",
@@ -1388,7 +1381,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$request['source'] = $full_request['source'];
 		}
 
-		$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+		$level3_data = $this->get_level3_data_from_order( $order );
 		$intent = WC_Stripe_API::request_with_level3_data(
 			$request,
 			'payment_intents',

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1062,6 +1062,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return array          The level 3 data to send to Stripe.
 	 */
 	public function get_level3_data_from_order( $order ) {
+		// Return an empty array if there's no store postcode (since it's
+		// required for level3 data), or if the version is less than 3.0
+		// (because it's not possible to get a store postcode before WC 3.0).
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			return array();
+		}
+
 		// Get the order items. Don't need their keys, only their values.
 		// Order item IDs are used as keys in the original order items array.
 		$order_items = array_values( $order->get_items() );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1369,7 +1369,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$request['source'] = $full_request['source'];
 		}
 
-		$intent = WC_Stripe_API::request( $request, 'payment_intents' );
+		$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+		$intent = WC_Stripe_API::request_with_level3_data(
+			$request,
+			'payment_intents',
+			$level3_data,
+			$order
+		);
 		$is_authentication_required = $this->is_authentication_required_for_payment( $intent );
 
 		if ( ! empty( $intent->error ) && ! $is_authentication_required ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1178,7 +1178,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'source' => $prepared_source->source,
 		);
 
-		$confirmed_intent = WC_Stripe_API::request( $confirm_request, "payment_intents/$intent->id/confirm" );
+		$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+		$confirmed_intent = WC_Stripe_API::request_with_level3_data(
+			$confirm_request,
+			"payment_intents/$intent->id/confirm",
+			$level3_data,
+			$order
+		);
 
 		if ( ! empty( $confirmed_intent->error ) ) {
 			return $confirmed_intent;

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1063,6 +1063,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return array                    The level 3 data to send to Stripe.
 	 */
 	public function get_level3_data_from_order( $order, $store_postcode ) {
+		// Return an empty array if there's no store postcode (since it's
+		// required for level3 data), or if the version is less than 3.0
+		// (because it's not possible to get a store postcode before WC 3.0).
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) || empty( $store_postcode ) ) {
+			return array();
+		}
+
 		// Get the order items. Don't need their keys, only their values.
 		// Order item IDs are used as keys in the original order items array.
 		$order_items = array_values( $order->get_items() );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1062,9 +1062,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return array          The level 3 data to send to Stripe.
 	 */
 	public function get_level3_data_from_order( $order ) {
-		// Return an empty array if there's no store postcode (since it's
-		// required for level3 data), or if the version is less than 3.0
-		// (because it's not possible to get a store postcode before WC 3.0).
+		// WC Versions before 3.0 don't support postcodes and are
+		// incompatible with level3 data.
 		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
 			return array();
 		}

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -896,9 +896,16 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		if ( 'requires_payment_method' === $intent->status && isset( $intent->last_payment_error )
 		     && 'authentication_required' === $intent->last_payment_error->code ) {
-			$intent = WC_Stripe_API::request( array(
-				'payment_method' => $intent->last_payment_error->source->id,
-			), 'payment_intents/' . $intent->id . '/confirm' );
+			$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+			$intent      = WC_Stripe_API::request_with_level3_data(
+				array(
+					'payment_method' => $intent->last_payment_error->source->id,
+				),
+				'payment_intents/' . $intent->id . '/confirm',
+				$level3_data,
+				$order
+			);
+
 			if ( isset( $intent->error ) ) {
 				throw new WC_Stripe_Exception( print_r( $intent, true ), $intent->error->message );
 			}

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -896,7 +896,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		if ( 'requires_payment_method' === $intent->status && isset( $intent->last_payment_error )
 		     && 'authentication_required' === $intent->last_payment_error->code ) {
-			$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+			$level3_data = $this->get_level3_data_from_order( $order );
 			$intent      = WC_Stripe_API::request_with_level3_data(
 				array(
 					'payment_method' => $intent->last_payment_error->source->id,

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -176,4 +176,32 @@ class WC_Stripe_API {
 
 		return json_decode( $response['body'] );
 	}
+
+	/**
+	 * Send the request to Stripe's API with level 3 data generated
+	 * from the order. If the request fails due to an error related
+	 * to level3 data, make the request again without it to allow
+	 * the payment to go through.
+	 *
+	 * @since 4.3.2
+	 * @version 4.3.2
+	 *
+	 * @param array    $request     Array with request parameters.
+	 * @param string   $api         The API path for the request.
+	 * @param array    $level3_data The level 3 data for this request.
+	 * @param WC_Order $order       The order associated with the payment.
+	 *
+	 * @return stdClass|array The response
+	 */
+	public static function request_with_level3_data( $request, $api, $level3_data, $order ) {
+		// Add level 3 data to the request.
+		$request['level3'] = $level3_data;
+
+		$result = self::request(
+			$request,
+			$api
+		);
+
+		return $result;
+	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -202,6 +202,23 @@ class WC_Stripe_API {
 			$api
 		);
 
+		$is_level3_param_not_allowed = (
+			isset( $result->error )
+			&& isset( $result->error->code )
+			&& 'parameter_unknown' === $result->error->code
+			&& isset( $result->error->param )
+			&& 'level3' === $result->error->param
+		);
+
+		if ( $is_level3_param_not_allowed ) {
+			// Make the request again without level 3 data.
+			unset( $request['level3'] );
+			$result = WC_Stripe_API::request(
+				$request,
+				$api
+			);
+		}
+
 		return $result;
 	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -232,6 +232,33 @@ class WC_Stripe_API {
 			);
 		}
 
+		$is_level_3data_incorrect = (
+			isset( $result->error )
+			&& isset( $result->error->type )
+			&& 'invalid_request_error' === $result->error->type
+		);
+
+		if ( $is_level_3data_incorrect ) {
+			// Log the issue so we could debug it.
+			WC_Stripe_Logger::log(
+				'Level3 data sum incorrect: ' . PHP_EOL
+				. print_r( $result->error->message, true ) . PHP_EOL
+				. print_r( 'Order line items: ', true ) . PHP_EOL
+				. print_r( $order->get_items(), true ) . PHP_EOL
+				. print_r( 'Order shipping amount: ', true ) . PHP_EOL
+				. print_r( $order->get_shipping_total(), true ) . PHP_EOL
+				. print_r( 'Order currency: ', true ) . PHP_EOL
+				. print_r( $order->get_currency(), true )
+			);
+
+			// Make the request again without level 3 data.
+			unset( $request['level3'] );
+			$result = WC_Stripe_API::request(
+				$request,
+				$api
+			);
+		}
+
 		return $result;
 	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -231,8 +231,8 @@ class WC_Stripe_API {
 
 		if ( $is_level3_param_not_allowed ) {
 			// Set a transient so that future requests do not add level 3 data.
-			// Transient is set to never expire, can be manually removed if needed.
-			set_transient( 'wc_stripe_level3_not_allowed', true );
+			// Transient is set to expire in 3 months, can be manually removed if needed.
+			set_transient( 'wc_stripe_level3_not_allowed', true, 3 * MONTH_IN_SECONDS );
 
 			// Make the request again without level 3 data.
 			unset( $request['level3'] );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -194,10 +194,8 @@ class WC_Stripe_API {
 	 * @return stdClass|array The response
 	 */
 	public static function request_with_level3_data( $request, $api, $level3_data, $order ) {
-		// Do not add level3 data for WC versions less than 3.0,
-		// since the store zip code is not available.
 		// Do not add level3 data it's the array is empty.
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) || empty( $level3_data ) ) {
+		if ( empty( $level3_data ) ) {
 			return self::request(
 				$request,
 				$api

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -194,6 +194,16 @@ class WC_Stripe_API {
 	 * @return stdClass|array The response
 	 */
 	public static function request_with_level3_data( $request, $api, $level3_data, $order ) {
+		// Do not add level3 data for WC versions less than 3.0,
+		// since the store zip code is not available.
+		// Do not add level3 data it's the array is empty.
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) || empty( $level3_data ) ) {
+			return self::request(
+				$request,
+				$api
+			);
+		}
+
 		// If there's a transient indicating that level3 data was not accepted by
 		// Stripe in the past for this account, do not try to add level3 data.
 		if ( get_transient( 'wc_stripe_level3_not_allowed' ) ) {

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -261,7 +261,7 @@ class WC_Stripe_API {
 
 			// Make the request again without level 3 data.
 			unset( $request['level3'] );
-			$result = WC_Stripe_API::request(
+			return WC_Stripe_API::request(
 				$request,
 				$api
 			);

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -275,12 +275,15 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 						/* translators: error message */
 						$order->add_order_note( sprintf( __( 'Unable to capture charge! %s', 'woocommerce-gateway-stripe' ), $result->error->message ) );
 					} elseif ( false === $result->captured ) {
-						$result = WC_Stripe_API::request(
+						$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+						$result = WC_Stripe_API::request_with_level3_data(
 							array(
 								'amount'   => WC_Stripe_Helper::get_stripe_amount( $order_total ),
 								'expand[]' => 'balance_transaction',
 							),
-							'charges/' . $charge . '/capture'
+							'charges/' . $charge . '/capture',
+							$level3_data,
+							$order
 						);
 
 						if ( ! empty( $result->error ) ) {

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -244,7 +244,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 						/* translators: error message */
 						$order->add_order_note( sprintf( __( 'Unable to capture charge! %s', 'woocommerce-gateway-stripe' ), $intent->error->message ) );
 					} elseif ( 'requires_capture' === $intent->status ) {
-						$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+						$level3_data = $this->get_level3_data_from_order( $order );
 						$result = WC_Stripe_API::request_with_level3_data(
 							array(
 								'amount'   => WC_Stripe_Helper::get_stripe_amount( $order_total ),
@@ -275,7 +275,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 						/* translators: error message */
 						$order->add_order_note( sprintf( __( 'Unable to capture charge! %s', 'woocommerce-gateway-stripe' ), $result->error->message ) );
 					} elseif ( false === $result->captured ) {
-						$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+						$level3_data = $this->get_level3_data_from_order( $order );
 						$result = WC_Stripe_API::request_with_level3_data(
 							array(
 								'amount'   => WC_Stripe_Helper::get_stripe_amount( $order_total ),

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -244,12 +244,15 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 						/* translators: error message */
 						$order->add_order_note( sprintf( __( 'Unable to capture charge! %s', 'woocommerce-gateway-stripe' ), $intent->error->message ) );
 					} elseif ( 'requires_capture' === $intent->status ) {
-						$result = WC_Stripe_API::request(
+						$level3_data = $this->get_level3_data_from_order( $order, get_option( 'woocommerce_store_postcode' ) );
+						$result = WC_Stripe_API::request_with_level3_data(
 							array(
 								'amount'   => WC_Stripe_Helper::get_stripe_amount( $order_total ),
 								'expand[]' => 'charges.data.balance_transaction',
 							),
-							'payment_intents/' . $intent->id . '/capture'
+							'payment_intents/' . $intent->id . '/capture',
+							$level3_data,
+							$order
 						);
 
 						if ( ! empty( $result->error ) ) {

--- a/tests/phpunit/test-wc-stripe-level-3-data.php
+++ b/tests/phpunit/test-wc-stripe-level-3-data.php
@@ -6,8 +6,10 @@
 
 class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 	public function test_data_for_mutli_item_order() {
-		// Skip this test because of the complexity of creating variable products in WC pre-3.0.
+		// Skip this test because of the complexity of creating products in WC pre-3.0.
 		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			// Dummy assertion.
+			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), true );
 			return;
 		}
 
@@ -41,7 +43,7 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 
 		// Act: Call get_level3_data_from_order().
 		$gateway = new WC_Gateway_Stripe();
-		$result = $gateway->get_level3_data_from_order( $order, $store_postcode );
+		$result = $gateway->get_level3_data_from_order( $order );
 
 		// Assert.
 		$this->assertEquals(
@@ -91,6 +93,13 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 	}
 
 	public function test_non_us_shipping_zip_codes() {
+		// Skip this test because of the complexity of creating products in WC pre-3.0.
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			// Dummy assertion.
+			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), true );
+			return;
+		}
+
 		// Update the store with the right post code.
 		update_option( 'woocommerce_store_postcode', 1040 );
 
@@ -109,7 +118,7 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 		// Act: Call get_level3_data_from_order().
 		$store_postcode = '1100';
 		$gateway = new WC_Gateway_Stripe();
-		$result = $gateway->get_level3_data_from_order( $order, $store_postcode );
+		$result = $gateway->get_level3_data_from_order( $order );
 
 		// Assert.
 		$this->assertEquals(
@@ -129,5 +138,17 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 			),
 			$result
 		);
+	}
+
+	public function test_pre_30_postal_code_omission() {
+		if ( ! WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			// Dummy assertion.
+			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), false );
+			return;
+		}
+
+		$order = new WC_Order();
+		$gateway = new WC_Gateway_Stripe();
+		$this->assertEquals( array(), $gateway->get_level3_data_from_order( $order ) );
 	}
 }

--- a/tests/phpunit/test-wc-stripe-level-3-data.php
+++ b/tests/phpunit/test-wc-stripe-level-3-data.php
@@ -6,11 +6,12 @@
 
 class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 	public function test_data_for_mutli_item_order() {
-		// Store postcode is available only for WC 3.0+.
-		$store_postcode = false;
-		if ( ! WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			$store_postcode = '90210';
+		// Skip this test because of the complexity of creating variable products in WC pre-3.0.
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			return;
 		}
+
+		$store_postcode = '90210';
 		update_option( 'woocommerce_store_postcode', $store_postcode );
 
 		// Arrange: Create a couple of products to use.

--- a/tests/phpunit/test-wc-stripe-level-3-data.php
+++ b/tests/phpunit/test-wc-stripe-level-3-data.php
@@ -6,12 +6,12 @@
 
 class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 	public function test_data_for_mutli_item_order() {
-		// Level 3 data is only for WC 3.0+.
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			// Dummy assertion.
-			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), true );
-			return;
+		// Store postcode is available only for WC 3.0+.
+		$store_postcode = false;
+		if ( ! WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			$store_postcode = '90210';
 		}
+		update_option( 'woocommerce_store_postcode', $store_postcode );
 
 		// Arrange: Create a couple of products to use.
 		$variation_product = WC_Helper_Product::create_variation_product();
@@ -39,7 +39,6 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 		$order->calculate_totals();
 
 		// Act: Call get_level3_data_from_order().
-		$store_postcode = '90210';
 		$gateway = new WC_Gateway_Stripe();
 		$result = $gateway->get_level3_data_from_order( $order, $store_postcode );
 
@@ -90,69 +89,9 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_level3_param_not_added_in_wc26() {
-		// This is a test only for WC version < 3.0.
-		if ( ! WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			// Dummy assertion.
-			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), false );
-			return;
-		}
-
-		// Arrange: A request array and URL path to use in request_with_level3_data().
-		$request = array(
-			'source' => '123',
-		);
-		$api = 'payment_intent';
-
-		// Arrange: Intercept HTTP call so we can test that WC_Stripe_API::request was called.
-		// Two assertions happen here - to make sure we didn't send the level3 parameter to
-		// the Stripe API.
-		// Note: It's unfortunate that we have to test implementation details here, but there
-		// is no way to mock static functions using phpunit - i.e. we could have mocked
-		// WC_Stripe_API::request to make sure that it was called with the correct parameters.
-		$pre_http_request_response_callback = function( $preempt, $request_args, $url ) use (
-			$request,
-			$api
-		) {
-			// Assert: There is no level3 param in API call.
-			$this->assertSame($request_args['body'], $request );
-			// Assert: We're using the same API endpoint as originally
-			// supplied to request_with_level3_data.
-			$this->assertSame( $url, WC_Stripe_API::ENDPOINT . $api); // this assertion should be fixed to use correct url ($x is incorrect)
-
-			// Return dummy content as the response so that an error is not thrown during test.
-			return array(
-				'headers'  => array(),
-				'body'     => 'test',
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'cookies'  => array(),
-				'filename' => null,
-			);
-		};
-		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
-
-		// Act: call request_with_level3_data() in WC 2.6 (it's one of the matrix envs in Travis).
-		// Note: all the assertions happen in pre_http_request_response_callback.
-		WC_Stripe_API::request_with_level3_data(
-			$request,
-			$api,
-			array(
-				'test' => 123,
-			),
-			new WC_Order()
-		);
-	}
-
 	public function test_non_us_shipping_zip_codes() {
-		// Level 3 data is only for WC 3.0+.
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			// Dummy assertion.
-			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), true );
-			return;
-		}
+		// Update the store with the right post code.
+		update_option( 'woocommerce_store_postcode', 1040 );
 
 		// Arrange: Create a couple of products to use.
 		$product = WC_Helper_Product::create_simple_product();

--- a/tests/phpunit/test-wc-stripe-level-3-data.php
+++ b/tests/phpunit/test-wc-stripe-level-3-data.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * These tests assert that get_level3_data_from_order() returns the correct
+ * data.
+ */
+
+class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
+	public function test_data_for_mutli_item_order() {
+		// Arrange: Create a couple of products to use.
+		$variation_product = WC_Helper_Product::create_variation_product();
+		$variation_ids     = $variation_product->get_children();
+
+		$product_1 = wc_get_product ( $variation_ids[0] );
+		$product_1->set_regular_price( 19.19 );
+		$product_1->set_sale_price( 11.83 );
+		$product_1->save();
+
+		$product_2 = wc_get_product( $variation_ids[1] );
+		$product_2->set_regular_price( 20.05 );
+		$product_2->save();
+
+		// Arrange: Set up an order with:
+		// 1) A variation product.
+		// 2) The same product added several times.
+		$order = new WC_Order();
+		$order->add_product( $product_1, 1 ); // Add one item of the first product variation
+		$order->add_product( $product_2, 2 ); // Add two items of the second product variation
+
+		$order->save();
+		$order->calculate_totals();
+
+		// Act: Call get_level3_data_from_order().
+		$store_postcode = '90210';
+		$gateway = new WC_Gateway_Stripe();
+		$result = $gateway->get_level3_data_from_order( $order, $store_postcode );
+
+		// Assert.
+		$this->assertEquals(
+			array(
+				'merchant_reference' => $order->get_id(),
+				'shipping_address_zip' => $order->get_shipping_postcode(),
+				'shipping_from_zip' => $store_postcode,
+				'shipping_amount' => 0,
+				'line_items' => array(
+					(object) array(
+						'product_code'        => (string) $product_1->get_id(),
+						'product_description' => substr( $product_1->get_name(), 0, 26 ),
+						'unit_cost'           => 1183,
+						'quantity'            => 1,
+						'tax_amount'          => 0,
+						'discount_amount'     => 0,
+					),
+					(object) array(
+						'product_code'        => (string) $product_2->get_id(),
+						'product_description' => substr( $product_2->get_name(), 0, 26 ),
+						'unit_cost'           => 2005,
+						'quantity'            => 2,
+						'tax_amount'          => 0,
+						'discount_amount'     => 0,
+					),
+				),
+			),
+			$result
+		);
+
+		// Assert: Check that Stripe's total charge check passes.
+		$total_charged = WC_Stripe_Helper::get_stripe_amount( $order->get_total() );
+		$sum_of_unit_costs = array_reduce( $result['line_items'], function( $sum, $item ) {
+			return $sum + $item->quantity * $item->unit_cost;
+		}  );
+		$sum_of_taxes = array_reduce( $result['line_items'], function( $sum, $item ) {
+			return $sum + $item->tax_amount;
+		}  );
+		$sum_of_discounts = array_reduce( $result['line_items'], function( $sum, $item ) {
+			return $sum + $item->discount_amount;
+		}  );
+		$shipping_amount = $result['shipping_amount'];
+		$this->assertEquals(
+			$total_charged,
+			$sum_of_unit_costs + $sum_of_taxes - $sum_of_discounts + $shipping_amount
+		);
+	}
+}

--- a/tests/phpunit/test-wc-stripe-level-3-data.php
+++ b/tests/phpunit/test-wc-stripe-level-3-data.php
@@ -6,6 +6,13 @@
 
 class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 	public function test_data_for_mutli_item_order() {
+		// Level 3 data is only for WC 3.0+.
+		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			// Dummy assertion.
+			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), true );
+			return;
+		}
+
 		// Arrange: Create a couple of products to use.
 		$variation_product = WC_Helper_Product::create_variation_product();
 		$variation_ids     = $variation_product->get_children();
@@ -78,6 +85,62 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			$total_charged,
 			$sum_of_unit_costs + $sum_of_taxes - $sum_of_discounts + $shipping_amount
+		);
+	}
+
+	public function test_level3_param_not_added_in_wc26() {
+		// This is a test only for WC version < 3.0.
+		if ( ! WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+			// Dummy assertion.
+			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), false );
+			return;
+		}
+
+		// Arrange: A request array and URL path to use in request_with_level3_data().
+		$request = array(
+			'source' => '123',
+		);
+		$api = 'payment_intent';
+
+		// Arrange: Intercept HTTP call so we can test that WC_Stripe_API::request was called.
+		// Two assertions happen here - to make sure we didn't send the level3 parameter to
+		// the Stripe API.
+		// Note: It's unfortunate that we have to test implementation details here, but there
+		// is no way to mock static functions using phpunit - i.e. we could have mocked
+		// WC_Stripe_API::request to make sure that it was called with the correct parameters.
+		$pre_http_request_response_callback = function( $preempt, $request_args, $url ) use (
+			$request,
+			$api
+		) {
+			// Assert: There is no level3 param in API call.
+			$this->assertSame($request_args['body'], $request );
+			// Assert: We're using the same API endpoint as originally
+			// supplied to request_with_level3_data.
+			$this->assertSame( $url, WC_Stripe_API::ENDPOINT . $api); // this assertion should be fixed to use correct url ($x is incorrect)
+
+			// Return dummy content as the response so that an error is not thrown during test.
+			return array(
+				'headers'  => array(),
+				'body'     => 'test',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+
+		// Act: call request_with_level3_data() in WC 2.6 (it's one of the matrix envs in Travis).
+		// Note: all the assertions happen in pre_http_request_response_callback.
+		WC_Stripe_API::request_with_level3_data(
+			$request,
+			$api,
+			array(
+				'test' => 123,
+			),
+			new WC_Order()
 		);
 	}
 }


### PR DESCRIPTION
Fixes #860.

This PR sends level3 data in the following functions:

1. update_existing_intent
   - Can be tested by checking out with a failing credit card (e.g. `4000000000000069`) and then checking out with a working card.
2. confirm_intent
   - Can be tested by checking out normally.
3. create_and_confirm_intent_for_off_session
   - Can be tested by renewal a subscription (Edit Subscription screen > Subscription actions > Renew subscription).
4. prepare_intent_for_order_pay_page
   - Can be tested by purchasing a subscription using card that requires 3DS authentication (e.g. `4000 0027 6000 3184`), then renewing the subscription, and then using the authorize link sent to the customer to authenticate the subscription.
5. capture_payment
   - Can be tested by unchecking the option "Capture charge immediately" in the Stripe settings page at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`

Stripe doc: https://stripe.com/docs/level3

This is what the level 3 data looks like:

```
level3: {
	'merchant_reference', // Order ID
	'shipping_address_zip', // The customer’s U.S. shipping ZIP code.
	'shipping_from_zip', // The merchant’s U.S. shipping ZIP code.
	'shipping_amount', // The shipping cost, in cents, as a non-negative integer.
	'line_items': [ // Object per item in order
		{
			'product_code', // Up to 12 characters that uniquely identify the product.
				'product_description', // Up to 26 characters long describing the product.
				'unit_cost', // Cost of the product, in cents, as a non-negative integer.
				'quantity', // The number of items of this type sold, as a non-negative integer.
				'tax_amount', // The amount of tax this item had added to it, in cents, as a non-negative integer.
				'discount_amount', // The amount an item was discounted—if there was a sale,for example, as a non-negative integer.
		},
	]
}
```

You can test it with an account where level3 is allowed by installing the WooCommerce Services plugin, going through the WC setup wizard, and option to create a new Stripe account (using a new email address that hasn't been used with Stripe before). 

The request with level3 data can fail for a couple of reasons, which are handled by retrying the request without level3 data:

1. If it fails because level3 data is not permitted, level3 data will not be added to all subsequent requests won't using a transient.
2. If it fails because the level3 data we send has an incorrect sum, the request will be tried again without the data, and the error will be logged.

Some notes which have been verified with Stripe:

- Data will be sent for all merchants and customers, not only those in the US. This has been verified with Stripe.
- We can send non-US postal codes in the level3 data object
- The level 3 data should be sent in the currency that's used for the order
- The product code can be the product ID
- Level 3 data should be sent for both digital and shippable products, and for $0 products
- The billing details should be sent using source objects, which we already do.
- We are not going to supply the `customer_reference` parameter (paJDYF-6e-p2#comment-586), which is why it's missing (vs the docs).

Here are some things that are not fully resolved as part of this PR:

- What happens for stores with multiple shipping zipcodes? There isn't a way in WooCommerce to identify which originating zipcode will be used as part of an order. I don't think it should be fixed as part of this PR.
- Unit testing with taxes and shipping