### PR TITLE
Add multisite support and notify merchants after acccount changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 4.3.2 2019-x-x =
 * Fix - Add compatibility to payment request buttons with some of the WooCommerce Product Add-ons on the product page
 * Fix - Improved compatibility for free orders with other extensions
+* Add - Support for multisite when sites use different Stripe accounts
 
 = 4.3.1 2019-11-12 =
 * Fix - Overwrite the previous Apple Pay verification file if it has changed.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -254,7 +254,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @version 4.0.0
 	 */
 	public function get_stripe_customer_id( $order ) {
-		$customer = get_user_meta( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id(), '_stripe_customer_id', true );
+		$customer = get_user_option( '_stripe_customer_id', WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id() );
 
 		if ( empty( $customer ) ) {
 			// Try to get it via the order.

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -100,21 +100,22 @@ class WC_Stripe_Admin_Notices {
 	 * @version 4.0.0
 	 */
 	public function stripe_check_environment() {
-		$show_style_notice  = get_option( 'wc_stripe_show_style_notice' );
-		$show_ssl_notice    = get_option( 'wc_stripe_show_ssl_notice' );
-		$show_keys_notice   = get_option( 'wc_stripe_show_keys_notice' );
-		$show_3ds_notice    = get_option( 'wc_stripe_show_3ds_notice' );
-		$show_phpver_notice = get_option( 'wc_stripe_show_phpver_notice' );
-		$show_wcver_notice  = get_option( 'wc_stripe_show_wcver_notice' );
-		$show_curl_notice   = get_option( 'wc_stripe_show_curl_notice' );
-		$show_sca_notice    = get_option( 'wc_stripe_show_sca_notice' );
-		$options            = get_option( 'woocommerce_stripe_settings' );
-		$testmode           = ( isset( $options['testmode'] ) && 'yes' === $options['testmode'] ) ? true : false;
-		$test_pub_key       = isset( $options['test_publishable_key'] ) ? $options['test_publishable_key'] : '';
-		$test_secret_key    = isset( $options['test_secret_key'] ) ? $options['test_secret_key'] : '';
-		$live_pub_key       = isset( $options['publishable_key'] ) ? $options['publishable_key'] : '';
-		$live_secret_key    = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
-		$three_d_secure     = isset( $options['three_d_secure'] ) && 'yes' === $options['three_d_secure'];
+		$show_style_notice   = get_option( 'wc_stripe_show_style_notice' );
+		$show_ssl_notice     = get_option( 'wc_stripe_show_ssl_notice' );
+		$show_keys_notice    = get_option( 'wc_stripe_show_keys_notice' );
+		$show_3ds_notice     = get_option( 'wc_stripe_show_3ds_notice' );
+		$show_phpver_notice  = get_option( 'wc_stripe_show_phpver_notice' );
+		$show_wcver_notice   = get_option( 'wc_stripe_show_wcver_notice' );
+		$show_curl_notice    = get_option( 'wc_stripe_show_curl_notice' );
+		$show_sca_notice     = get_option( 'wc_stripe_show_sca_notice' );
+		$changed_keys_notice = get_option( 'wc_stripe_show_changed_keys_notice' );
+		$options             = get_option( 'woocommerce_stripe_settings' );
+		$testmode            = ( isset( $options['testmode'] ) && 'yes' === $options['testmode'] ) ? true : false;
+		$test_pub_key        = isset( $options['test_publishable_key'] ) ? $options['test_publishable_key'] : '';
+		$test_secret_key     = isset( $options['test_secret_key'] ) ? $options['test_secret_key'] : '';
+		$live_pub_key        = isset( $options['publishable_key'] ) ? $options['publishable_key'] : '';
+		$live_secret_key     = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
+		$three_d_secure      = isset( $options['three_d_secure'] ) && 'yes' === $options['three_d_secure'];
 
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
 			if ( empty( $show_3ds_notice ) && $three_d_secure ) {
@@ -204,6 +205,11 @@ class WC_Stripe_Admin_Notices {
 
 			if ( empty( $show_sca_notice ) ) {
 				$this->add_admin_notice( 'sca', 'notice notice-success', sprintf( __( 'Stripe is now ready for Strong Customer Authentication (SCA) and 3D Secure 2! <a href="%1$s" target="_blank">Read about SCA</a>', 'woocommerce-gateway-stripe' ), 'https://woocommerce.com/posts/introducing-strong-customer-authentication-sca/' ), true );
+			}
+
+			if ( 'yes' === $changed_keys_notice ) {
+				// translators: %s is a the URL for the link.
+				$this->add_admin_notice( 'changed_keys', 'notice notice-warning', sprintf( __( 'The public and/or secret keys for the Stripe gateway have been changed. This might cause errors for existing customers and saved payment methods. <a href="%s" target="_blank">Click here to learn more</a>.', 'woocommerce-gateway-stripe' ), 'https://docs.woocommerce.com/document/stripe-fixing-customer-errors/' ), true );
 			}
 		}
 	}
@@ -301,6 +307,8 @@ class WC_Stripe_Admin_Notices {
 				case 'sca':
 					update_option( 'wc_stripe_show_sca_notice', 'no' );
 					break;
+				case 'changed_keys':
+					update_option( 'wc_stripe_show_changed_keys_notice', 'no' );
 			}
 		}
 	}

--- a/includes/admin/class-wc-stripe-privacy.php
+++ b/includes/admin/class-wc-stripe-privacy.php
@@ -225,7 +225,7 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 				'data'        => array(
 					array(
 						'name'  => __( 'Stripe payment id', 'woocommerce-gateway-stripe' ),
-						'value' => get_user_meta( $user->ID, '_stripe_source_id', true ),
+						'value' => get_user_option( '_stripe_source_id', $user->ID ),
 					),
 					array(
 						'name'  => __( 'Stripe customer id', 'woocommerce-gateway-stripe' ),
@@ -255,8 +255,8 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 		$stripe_source_id   = '';
 
 		if ( $user instanceof WP_User ) {
-			$stripe_customer_id = get_user_meta( $user->ID, '_stripe_customer_id', true );
-			$stripe_source_id   = get_user_meta( $user->ID, '_stripe_source_id', true );
+			$stripe_customer_id = get_user_option( '_stripe_customer_id', $user->ID );
+			$stripe_source_id   = get_user_option( '_stripe_source_id', $user->ID );
 		}
 
 		$items_removed = false;
@@ -264,8 +264,8 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 
 		if ( ! empty( $stripe_customer_id ) || ! empty( $stripe_source_id ) ) {
 			$items_removed = true;
-			delete_user_meta( $user->ID, '_stripe_customer_id' );
-			delete_user_meta( $user->ID, '_stripe_source_id' );
+			delete_user_option( $user->ID, '_stripe_customer_id' );
+			delete_user_option( $user->ID, '_stripe_source_id' );
 			$messages[] = __( 'Stripe User Data Erased.', 'woocommerce-gateway-stripe' );
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1108,12 +1108,17 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$new_test_publishable_key = $this->get_option( 'test_publishable_key' );
 		$new_test_secret_key      = $this->get_option( 'test_secret_key' );
 
+		// Checks whether a value has transitioned from a non-empty value to a new one.
+		$has_changed = function( $old_value, $new_value ) {
+			return ! empty( $old_value ) && ( $old_value !== $new_value );
+		};
+
 		// Look for updates.
 		if (
-			( ! empty( $old_publishable_key ) && $old_publishable_key !== $new_publishable_key )
-			|| ( ! empty( $old_secret_key ) && $old_secret_key !== $new_secret_key )
-			|| ( ! empty( $old_test_publishable_key ) && $old_test_publishable_key !== $new_test_publishable_key )
-			|| ( ! empty( $old_test_secret_key ) && $old_test_secret_key !== $new_test_secret_key )
+			$has_changed( $old_publishable_key, $new_publishable_key )
+			|| $has_changed( $old_secret_key, $new_secret_key )
+			|| $has_changed( $old_test_publishable_key, $new_test_publishable_key )
+			|| $has_changed( $old_test_secret_key, $new_test_secret_key )
 		) {
 			update_option( 'wc_stripe_show_changed_keys_notice', 'yes' );
 		}

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1089,4 +1089,33 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 		return $pay_url;
 	}
+
+	/**
+	 * Checks whether new keys are being entered when saving options.
+	 */
+	public function process_admin_options() {
+		// Load all old values before the new settings get saved.
+		$old_publishable_key      = $this->get_option( 'publishable_key' );
+		$old_secret_key           = $this->get_option( 'secret_key' );
+		$old_test_publishable_key = $this->get_option( 'test_publishable_key' );
+		$old_test_secret_key      = $this->get_option( 'test_secret_key' );
+
+		parent::process_admin_options();
+
+		// Load all old values after the new settings have been saved.
+		$new_publishable_key      = $this->get_option( 'publishable_key' );
+		$new_secret_key           = $this->get_option( 'secret_key' );
+		$new_test_publishable_key = $this->get_option( 'test_publishable_key' );
+		$new_test_secret_key      = $this->get_option( 'test_secret_key' );
+
+		// Look for updates.
+		if (
+			( ! empty( $old_publishable_key ) && $old_publishable_key !== $new_publishable_key )
+			|| ( ! empty( $old_secret_key ) && $old_secret_key !== $new_secret_key )
+			|| ( ! empty( $old_test_publishable_key ) && $old_test_publishable_key !== $new_test_publishable_key )
+			|| ( ! empty( $old_test_secret_key ) && $old_test_secret_key !== $new_test_secret_key )
+		) {
+			update_option( 'wc_stripe_show_changed_keys_notice', 'yes' );
+		}
+	}
 }

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -511,10 +511,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			delete_user_meta( $order->customer_user, '_stripe_customer_id' );
+			delete_user_option( $order->customer_user, '_stripe_customer_id' );
 			delete_post_meta( $order->get_id(), '_stripe_customer_id' );
 		} else {
-			delete_user_meta( $order->get_customer_id(), '_stripe_customer_id' );
+			delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
 			$order->delete_meta_data( '_stripe_customer_id' );
 			$order->save();
 		}

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -35,7 +35,7 @@ class WC_Stripe_Customer {
 	public function __construct( $user_id = 0 ) {
 		if ( $user_id ) {
 			$this->set_user_id( $user_id );
-			$this->set_id( get_user_meta( $user_id, '_stripe_customer_id', true ) );
+			$this->set_id( $this->get_id_from_meta( $user_id ) );
 		}
 	}
 
@@ -56,7 +56,7 @@ class WC_Stripe_Customer {
 		if ( is_array( $id ) && isset( $id['customer_id'] ) ) {
 			$id = $id['customer_id'];
 
-			update_user_meta( $this->get_user_id(), '_stripe_customer_id', $id );
+			$this->update_id_in_meta( $id );
 		}
 
 		$this->id = wc_clean( $id );
@@ -161,7 +161,7 @@ class WC_Stripe_Customer {
 		$this->set_customer_data( $response );
 
 		if ( $this->get_user_id() ) {
-			update_user_meta( $this->get_user_id(), '_stripe_customer_id', $response->id );
+			$this->update_id_in_meta( $response->id );
 		}
 
 		do_action( 'woocommerce_stripe_add_customer', $args, $response );
@@ -175,13 +175,13 @@ class WC_Stripe_Customer {
 	 * @param array $args Additional arguments for the request (optional).
 	 */
 	public function update_customer( $args = array() ) {
-		if ( empty( $this->id ) ) {
+		if ( empty( $this->get_id() ) ) {
 			throw new WC_Stripe_Exception( 'id_required_to_update_user', __( 'Attempting to update a Stripe customer without a customer ID.', 'woocommerce-gateway-stripe' ) );
 		}
 
 		$args     = $this->generate_customer_request( $args );
 		$args     = apply_filters( 'wc_stripe_update_customer_args', $args );
-		$response = WC_Stripe_API::request( $args, 'customers/' . $this->id );
+		$response = WC_Stripe_API::request( $args, 'customers/' . $this->get_id() );
 
 		if ( ! empty( $response->error ) ) {
 			throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
@@ -232,7 +232,7 @@ class WC_Stripe_Customer {
 			// but no longer exists. Instead of failing, lets try to create a
 			// new customer.
 			if ( $this->is_no_such_customer_error( $response->error ) ) {
-				delete_user_meta( $this->get_user_id(), '_stripe_customer_id' );
+				$this->flush_meta( $this->get_id() );
 				$this->create_customer();
 				return $this->add_source( $source_id );
 			} else {
@@ -373,5 +373,74 @@ class WC_Stripe_Customer {
 		delete_transient( 'stripe_sources_' . $this->get_id() );
 		delete_transient( 'stripe_customer_' . $this->get_id() );
 		$this->customer_data = array();
+	}
+
+	/**
+	 * Generates a full meta key based on the current enviroment.
+	 *
+	 * The meta key includes (concatenated):
+	 * - `_stripe_customer_id`
+	 * - The blog ID when using multisite.
+	 * - `_test` if test mode is enabled for the gateway.
+	 *
+	 * @return string
+	 */
+	public function get_full_meta_key() {
+		$meta_key = '_stripe_customer_id';
+		$options  = get_option( 'woocommerce_stripe_settings' );
+
+		if ( is_multisite() ) {
+			$meta_key .= get_current_blog_id();
+		}
+
+		if ( isset( $options['testmode'] ) && 'yes' === $options['testmode'] ) {
+			$meta_key .= '_test';
+		}
+
+		return $meta_key;
+	}
+
+	/**
+	 * Retrieves the Stripe Customer ID from the user meta.
+	 *
+	 * @param  int $user_id The ID of the WordPress user.
+	 * @return string|bool  Either the Stripe ID or false.
+	 */
+	public function get_id_from_meta( $user_id ) {
+		// Look for the new meta key format first: _stripe_customer_id[_{blog_id}][_test].
+		$stripe_id = get_user_meta( $user_id, $this->get_full_meta_key(), true );
+		if ( $stripe_id ) {
+			return $stripe_id;
+		}
+
+		// Fall back to the old format where the same meta key is used in all situations.
+		return get_user_meta( $user_id, '_stripe_customer_id', true );
+	}
+
+	/**
+	 * Updates the current user with the right Stripe ID in the meta table.
+	 *
+	 * @param string $id The Stripe customer ID.
+	 */
+	public function update_id_in_meta( $id ) {
+		update_user_meta( $this->get_user_id(), $this->get_full_meta_key(), $id );
+	}
+
+	/**
+	 * Flushes the user meta whenever a specific user ID is not available.
+	 *
+	 * This method will delete meta values with all possible keys, only when
+	 * the meta value is associated with the (probably missing) customer ID.
+	 *
+	 * @param string $stripe_id The Stripe customer ID.
+	 */
+	public function flush_meta( $stripe_id ) {
+		delete_user_meta( $this->get_user_id(), '_stripe_customer_id', $stripe_id );
+		delete_user_meta( $this->get_user_id(), '_stripe_customer_id_test', $stripe_id );
+
+		if ( is_multisite() ) {
+			delete_user_meta( $this->get_user_id(), '_stripe_customer_id_' . get_current_blog_id(), $stripe_id );
+			delete_user_meta( $this->get_user_id(), '_stripe_customer_id_' . get_current_blog_id() . '_test', $stripe_id );
+		}
 	}
 }

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -128,10 +128,10 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				// Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
 				if ( $this->is_no_such_customer_error( $response->error ) ) {
 					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-						delete_user_meta( $order->customer_user, '_stripe_customer_id' );
+						delete_user_option( $order->customer_user, '_stripe_customer_id' );
 						delete_post_meta( $order_id, '_stripe_customer_id' );
 					} else {
-						delete_user_meta( $order->get_customer_id(), '_stripe_customer_id' );
+						delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
 						$order->delete_meta_data( '_stripe_customer_id' );
 						$order->save();
 					}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -203,10 +203,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				// Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
 				if ( $this->is_no_such_customer_error( $response->error ) ) {
 					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-						delete_user_meta( $order->customer_user, '_stripe_customer_id' );
+						delete_user_option( $order->customer_user, '_stripe_customer_id' );
 						delete_post_meta( $order_id, '_stripe_customer_id' );
 					} else {
-						delete_user_meta( $order->get_customer_id(), '_stripe_customer_id' );
+						delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
 						$order->delete_meta_data( '_stripe_customer_id' );
 						$order->save();
 					}

--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -435,15 +435,15 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 		// If we couldn't find a Stripe customer linked to the subscription, fallback to the user meta data.
 		if ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) {
 			$user_id            = $customer_user;
-			$stripe_customer_id = get_user_meta( $user_id, '_stripe_customer_id', true );
-			$stripe_source_id   = get_user_meta( $user_id, '_stripe_source_id', true );
+			$stripe_customer_id = get_user_option( '_stripe_customer_id', $user_id );
+			$stripe_source_id   = get_user_option( '_stripe_source_id', $user_id );
 
 			// For BW compat will remove in future.
 			if ( empty( $stripe_source_id ) ) {
-				$stripe_source_id = get_user_meta( $user_id, '_stripe_card_id', true );
+				$stripe_source_id = get_user_option( '_stripe_card_id', $user_id );
 
 				// Take this opportunity to update the key name.
-				update_user_meta( $user_id, '_stripe_source_id', $stripe_source_id );
+				update_user_option( $user_id, '_stripe_source_id', $stripe_source_id, false );
 			}
 		}
 

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -502,15 +502,15 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		// If we couldn't find a Stripe customer linked to the subscription, fallback to the user meta data.
 		if ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) {
 			$user_id            = $customer_user;
-			$stripe_customer_id = get_user_meta( $user_id, '_stripe_customer_id', true );
-			$stripe_source_id   = get_user_meta( $user_id, '_stripe_source_id', true );
+			$stripe_customer_id = get_user_option( '_stripe_customer_id', $user_id );
+			$stripe_source_id   = get_user_option( '_stripe_source_id', $user_id );
 
 			// For BW compat will remove in future.
 			if ( empty( $stripe_source_id ) ) {
-				$stripe_source_id = get_user_meta( $user_id, '_stripe_card_id', true );
+				$stripe_source_id = get_user_option( '_stripe_card_id', $user_id );
 
 				// Take this opportunity to update the key name.
-				update_user_meta( $user_id, '_stripe_source_id', $stripe_source_id );
+				update_user_option( $user_id, '_stripe_source_id', $stripe_source_id, false );
 			}
 		}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -337,10 +337,10 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 					// Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
 					if ( $this->is_no_such_customer_error( $response->error ) ) {
 						if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-							delete_user_meta( $order->customer_user, '_stripe_customer_id' );
+							delete_user_option( $order->customer_user, '_stripe_customer_id' );
 							delete_post_meta( $order_id, '_stripe_customer_id' );
 						} else {
-							delete_user_meta( $order->get_customer_id(), '_stripe_customer_id' );
+							delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
 							$order->delete_meta_data( '_stripe_customer_id' );
 							$order->save();
 						}

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2019 WooCommerce
+# Copyright (C) 2020 WooCommerce
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.3.0\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.3.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2019-11-12 11:30:47+00:00\n"
+"POT-Creation-Date: 2020-02-04 16:38:32+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: node-wp-i18n 1.2.1\n"
@@ -29,8 +29,8 @@ msgid "Save payment information to my account for future purchases."
 msgstr ""
 
 #: includes/abstracts/abstract-wc-stripe-payment-gateway.php:230
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:216
-#: includes/compat/class-wc-stripe-subs-compat.php:218
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:220
+#: includes/compat/class-wc-stripe-subs-compat.php:222
 #. translators: 1) dollar amount
 #. translators: minimum amount
 msgid "Sorry, the minimum allowed order total is %1$s to use this payment method."
@@ -64,7 +64,7 @@ msgstr ""
 
 #: includes/abstracts/abstract-wc-stripe-payment-gateway.php:429
 #: includes/class-wc-gateway-stripe.php:495
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:173
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:177
 msgid "Payment processing failed. Please retry."
 msgstr ""
 
@@ -92,7 +92,7 @@ msgstr ""
 msgid "There was a problem adding the payment method."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:124
+#: includes/admin/class-wc-stripe-admin-notices.php:125
 #. translators: 1) A URL that explains Stripe Radar.
 msgid ""
 "WooCommerce Stripe - We see that you had the \"Require 3D secure when "
@@ -101,7 +101,7 @@ msgid ""
 "href=\"%s\" target=\"_blank\">here</a>."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:131
+#: includes/admin/class-wc-stripe-admin-notices.php:132
 #. translators: 1) int version 2) int version
 msgid ""
 "WooCommerce Stripe - We recently made changes to Stripe that may impact the "
@@ -111,32 +111,32 @@ msgid ""
 "target=\"_blank\">instructions</a> to fix."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:141
+#: includes/admin/class-wc-stripe-admin-notices.php:142
 #. translators: 1) int version 2) int version
 msgid ""
 "WooCommerce Stripe - The minimum PHP version required for this plugin is "
 "%1$s. You are running %2$s."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:152
+#: includes/admin/class-wc-stripe-admin-notices.php:153
 #. translators: 1) int version 2) int version
 msgid ""
 "WooCommerce Stripe - The minimum WooCommerce version required for this "
 "plugin is %1$s. You are running %2$s."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:162
+#: includes/admin/class-wc-stripe-admin-notices.php:163
 msgid "WooCommerce Stripe - cURL is not installed."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:172
+#: includes/admin/class-wc-stripe-admin-notices.php:173
 #. translators: 1) link
 msgid ""
 "Stripe is almost ready. To get started, <a href=\"%s\">set your Stripe "
 "account keys</a>."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:183
+#: includes/admin/class-wc-stripe-admin-notices.php:184
 #. translators: 1) link
 msgid ""
 "Stripe is in test mode however your test keys may not be valid. Test keys "
@@ -144,7 +144,7 @@ msgid ""
 "<a href=\"%s\">set your Stripe account keys</a>."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:192
+#: includes/admin/class-wc-stripe-admin-notices.php:193
 #. translators: 1) link
 msgid ""
 "Stripe is in live mode however your test keys may not be valid. Live keys "
@@ -152,7 +152,7 @@ msgid ""
 "<a href=\"%s\">set your Stripe account keys</a>."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:201
+#: includes/admin/class-wc-stripe-admin-notices.php:202
 #. translators: 1) link
 msgid ""
 "Stripe is enabled, but a SSL certificate is not detected. Your checkout may "
@@ -160,22 +160,30 @@ msgid ""
 "target=\"_blank\">SSL certificate</a>"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:206
+#: includes/admin/class-wc-stripe-admin-notices.php:207
 msgid ""
 "Stripe is now ready for Strong Customer Authentication (SCA) and 3D Secure "
 "2! <a href=\"%1$s\" target=\"_blank\">Read about SCA</a>"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:229
+#: includes/admin/class-wc-stripe-admin-notices.php:212
+#. translators: %s is a the URL for the link.
+msgid ""
+"The public and/or secret keys for the Stripe gateway have been changed. "
+"This might cause errors for existing customers and saved payment methods. "
+"<a href=\"%s\" target=\"_blank\">Click here to learn more</a>."
+msgstr ""
+
+#: includes/admin/class-wc-stripe-admin-notices.php:235
 #. translators: %1$s Payment method, %2$s List of supported currencies
 msgid "%1$s is enabled - it requires store currency to be set to %2$s"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:243
+#: includes/admin/class-wc-stripe-admin-notices.php:249
 msgid "Action failed. Please refresh the page and retry."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-admin-notices.php:247
+#: includes/admin/class-wc-stripe-admin-notices.php:253
 msgid "Cheatin&#8217; huh?"
 msgstr ""
 
@@ -210,9 +218,9 @@ msgid "Retains any Stripe data such as Stripe customer ID, source ID."
 msgstr ""
 
 #: includes/admin/class-wc-stripe-privacy.php:41
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:463
-#: includes/compat/class-wc-stripe-subs-compat.php:530
-#: includes/compat/class-wc-stripe-subs-compat.php:545
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:467
+#: includes/compat/class-wc-stripe-subs-compat.php:534
+#: includes/compat/class-wc-stripe-subs-compat.php:549
 msgid "N/A"
 msgstr ""
 
@@ -829,37 +837,37 @@ msgstr ""
 msgid "Billing First Name and Last Name are required."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:720
+#: includes/class-wc-gateway-stripe.php:722
 #. translators: error message
 msgid "This represents the fee Stripe collects for the transaction."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:721
+#: includes/class-wc-gateway-stripe.php:723
 msgid "Stripe Fee:"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:757
+#: includes/class-wc-gateway-stripe.php:759
 msgid ""
 "This represents the net total that will be credited to your Stripe bank "
 "account. This may be in the currency that is set in your Stripe account."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:758
+#: includes/class-wc-gateway-stripe.php:760
 msgid "Stripe Payout:"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:805
+#: includes/class-wc-gateway-stripe.php:807
 #: includes/class-wc-stripe-order-handler.php:162
 #: includes/class-wc-stripe-webhook-handler.php:238
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:263
-#: includes/compat/class-wc-stripe-subs-compat.php:272
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:267
+#: includes/compat/class-wc-stripe-subs-compat.php:276
 #: includes/payment-methods/class-wc-gateway-stripe-sepa.php:373
 msgid ""
 "Sorry, we are unable to process your payment at this time. Please retry "
 "later."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:858
+#: includes/class-wc-gateway-stripe.php:860
 msgid ""
 "Almost there!\n"
 "\n"
@@ -867,14 +875,14 @@ msgid ""
 "done is for you to authorize the payment with your bank."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1070
+#: includes/class-wc-gateway-stripe.php:1072
 #: includes/class-wc-stripe-webhook-handler.php:685
 #: includes/class-wc-stripe-webhook-handler.php:724
 #. translators: 1) The error message that was received from Stripe.
 msgid "Stripe SCA authentication failed. Reason: %s"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1071
+#: includes/class-wc-gateway-stripe.php:1073
 msgid "Stripe SCA authentication failed."
 msgstr ""
 
@@ -921,7 +929,19 @@ msgstr ""
 msgid "Attempting to update a Stripe customer without a customer ID."
 msgstr ""
 
-#: includes/class-wc-stripe-customer.php:242
+#: includes/class-wc-stripe-customer.php:197
+#. Translators: %s is a message, which states that no such customer exists,
+#. without a full stop at the end.
+msgid "%s. Was the customer created in live mode? "
+msgstr ""
+
+#: includes/class-wc-stripe-customer.php:199
+#. Translators: %s is a message, which states that no such customer exists,
+#. without a full stop at the end.
+msgid "%s. Was the customer created in test mode? "
+msgstr ""
+
+#: includes/class-wc-stripe-customer.php:262
 msgid "Unable to add payment source."
 msgstr ""
 
@@ -1155,8 +1175,8 @@ msgid "Unable to store payment details. Please try again."
 msgstr ""
 
 #: includes/compat/class-wc-stripe-pre-orders-compat.php:121
-#: includes/compat/class-wc-stripe-subs-compat.php:304
-#: includes/compat/class-wc-stripe-subs-compat.php:609
+#: includes/compat/class-wc-stripe-subs-compat.php:308
+#: includes/compat/class-wc-stripe-subs-compat.php:613
 msgid "Stripe charge awaiting authentication by user: %s."
 msgstr ""
 
@@ -1165,48 +1185,46 @@ msgstr ""
 msgid "Stripe Transaction Failed (%s)"
 msgstr ""
 
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:88
-#: includes/compat/class-wc-stripe-subs-compat.php:97
-msgid ""
-"Update the Payment Method used for all of my active subscriptions "
-"(optional)."
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:83
+#: includes/compat/class-wc-stripe-subs-compat.php:92
+msgid "Update the Payment Method used for all of my active subscriptions."
 msgstr ""
 
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:226
-#: includes/compat/class-wc-stripe-subs-compat.php:233
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:230
+#: includes/compat/class-wc-stripe-subs-compat.php:237
 msgid "Customer not found"
 msgstr ""
 
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:386
-#: includes/compat/class-wc-stripe-subs-compat.php:453
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:390
+#: includes/compat/class-wc-stripe-subs-compat.php:457
 #. translators: error message
 msgid "A \"Stripe Customer ID\" value is required."
 msgstr ""
 
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:388
-#: includes/compat/class-wc-stripe-subs-compat.php:455
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:392
+#: includes/compat/class-wc-stripe-subs-compat.php:459
 msgid ""
 "Invalid customer ID. A valid \"Stripe Customer ID\" must begin with "
 "\"cus_\"."
 msgstr ""
 
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:397
-#: includes/compat/class-wc-stripe-subs-compat.php:464
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:401
+#: includes/compat/class-wc-stripe-subs-compat.php:468
 msgid ""
 "Invalid source ID. A valid source \"Stripe Source ID\" must begin with "
 "\"src_\" or \"card_\"."
 msgstr ""
 
-#: includes/compat/class-wc-stripe-sepa-subs-compat.php:470
+#: includes/compat/class-wc-stripe-sepa-subs-compat.php:474
 #. translators: 1) last 4 digits of SEPA Direct Debit
 msgid "Via SEPA Direct Debit ending in %1$s"
 msgstr ""
 
-#: includes/compat/class-wc-stripe-subs-compat.php:296
+#: includes/compat/class-wc-stripe-subs-compat.php:300
 msgid "This transaction requires authentication."
 msgstr ""
 
-#: includes/compat/class-wc-stripe-subs-compat.php:545
+#: includes/compat/class-wc-stripe-subs-compat.php:549
 #. translators: 1) card brand 2) last 4 digits
 msgid "Via %1$s card ending in %2$s"
 msgstr ""
@@ -1326,57 +1344,57 @@ msgstr ""
 msgid "Stripe SOFORT"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:261
-#: includes/payment-methods/class-wc-stripe-payment-request.php:866
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1164
+#: includes/payment-methods/class-wc-stripe-payment-request.php:254
+#: includes/payment-methods/class-wc-stripe-payment-request.php:858
+#: includes/payment-methods/class-wc-stripe-payment-request.php:1157
 msgid "Tax"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:269
-#: includes/payment-methods/class-wc-stripe-payment-request.php:874
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1171
+#: includes/payment-methods/class-wc-stripe-payment-request.php:262
+#: includes/payment-methods/class-wc-stripe-payment-request.php:866
+#: includes/payment-methods/class-wc-stripe-payment-request.php:1164
 msgid "Shipping"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:276
-#: includes/payment-methods/class-wc-stripe-payment-request.php:881
+#: includes/payment-methods/class-wc-stripe-payment-request.php:269
+#: includes/payment-methods/class-wc-stripe-payment-request.php:873
 msgid "Pending"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:503
+#: includes/payment-methods/class-wc-stripe-payment-request.php:486
 msgid "Sorry, we're not accepting prepaid cards at this time."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:505
+#: includes/payment-methods/class-wc-stripe-payment-request.php:488
 #. translators: Do not translate the [option] placeholder
 msgid "Unknown shipping option \"[option]\"."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:646
+#: includes/payment-methods/class-wc-stripe-payment-request.php:591
 msgid "OR"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:740
-#: includes/payment-methods/class-wc-stripe-payment-request.php:753
+#: includes/payment-methods/class-wc-stripe-payment-request.php:731
+#: includes/payment-methods/class-wc-stripe-payment-request.php:744
 msgid "Unable to find shipping method for address."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:822
+#: includes/payment-methods/class-wc-stripe-payment-request.php:814
 msgid "Product with the ID (%d) cannot be found."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:849
+#: includes/payment-methods/class-wc-stripe-payment-request.php:841
 #. translators: 1: product name 2: quantity in stock
 msgid ""
 "You cannot add that amount of \"%1$s\"; to the cart because there is not "
 "enough stock (%2$s remaining)."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1003
+#: includes/payment-methods/class-wc-stripe-payment-request.php:996
 msgid "Empty cart"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1178
+#: includes/payment-methods/class-wc-stripe-payment-request.php:1171
 msgid "Discount"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 4.3.2 2019-x-x =
 * Fix - Add compatibility to payment request buttons with some of the WooCommerce Product Add-ons on the product page
 * Fix - Improved compatibility for free orders with other extensions
+* Add - Support for multisite when sites use different Stripe accounts
 
 = 4.3.1 2019-11-12 =
 * Fix - Overwrite the previous Apple Pay verification file if it has changed.


### PR DESCRIPTION
Fixes #1092.

## Changes proposed in this Pull Request:

Many merchants are experiencing errors, related to missing customers. Those errors can be caused by multiple factors:

1. The Stripe account was changed.
2. The customer was manually deleted in Stripe.
3. The extension is used in a multisite network.

While No. 2 is a conscious decision, 1 & 3 are addressed by this PR by the following changes:

### Switching to `*_user_option` instead of `*_user_meta`

H/T @thenbrent for suggesting those APIs!

The `*_user_option` APIs are built on top of user meta APIs, but add blog-specific prefixes to meta keys in order to isolate bits of data for a specific site.

`get_user_option()` also has a built-in fallback in case a setting is specified globally, but not for the given site. This means that the new version of the gateway will not degrade UX any further, but might improve it with time. There is also [a section in this doc](https://docs.woocommerce.com/document/stripe-fixing-customer-errors/#section-5), which describes how to transfer the existing values to the main site.

### Adding a notice upon changes in API keys

The new `WC_Gateway_Stripe::process_admin_options` method (which overloads the one from `WC_Settings_API`) compares the keys before & after saving them, and adds a notice to the admin. The notice will not be displayed when those values are added for the first time (when transitioning from an empty string).

The content of the notice leads merchants to https://docs.woocommerce.com/document/stripe-fixing-customer-errors/#section-1, where I've described how to clean up the database if necessary.

### Improving the content of "no such customer" messages

[Here](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1131/files#diff-f8dd0b04c52dc566825dead0a3b8b84cR187) I've added additional strings to the message, which suggest that there might be changes in the Stripe environment.

Please note that those are relatively redundant, since Stripe already changes their message if a test/live user exists with the same ID. Still, this should customers to consider whether they have changed something.

## Testing instructions

There are no particular instructions, you need to make purchases with new & existing customers and everything should keep on working well.

While doing so, please make sure to:

- Try it with different accounts. This will trigger the new notice, as well as some "No such customer" errors.
- Try it within a multisite environment, as well as a single site.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

