### PR TITLE
Fix crash when used with WooCommerce Subscriptions <2.6

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -379,7 +379,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			&& ! isset( $_GET['pay_for_order'] ) // wpcs: csrf ok.
 			&& ! is_add_payment_method_page()
 			&& ! isset( $_GET['change_payment_method'] ) // wpcs: csrf ok.
-			&& ! ( ! empty( get_query_var( 'view-subscription' ) ) && class_exists( 'WCS_Early_Renewal_Manager' ) && WCS_Early_Renewal_Manager::is_early_renewal_via_modal_enabled() )
+			&& ! ( ! empty( get_query_var( 'view-subscription' ) ) && is_callable( 'WCS_Early_Renewal_Manager::is_early_renewal_via_modal_enabled' ) && WCS_Early_Renewal_Manager::is_early_renewal_via_modal_enabled() )
 			|| ( is_order_received_page() )
 		) {
 			return;


### PR DESCRIPTION
Fixes #1139 

Quick fix. The issue was not triaged but it was trivial.

To test:
- Downgrade the WooCommerce Subscriptions to a version earlier than `2.6.0`.
- Go to `My Account -> Subscriptions`, and click in a subscription number to go to its details page.

Expected behaviour: 🎉 
Behaviour in `master`: 💥 
Behaviour with this PR: 🎉 