### PR TITLE
Fix Payment Request issue when product attribute has quotes

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -241,11 +241,15 @@ class WC_Stripe_Payment_Request {
 
 		$product = wc_get_product( $post->ID );
 
-		if ( 'variable' === $product->get_type() ) {
+		if ( 'variable' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $product->product_type : $product->get_type() ) ) {
 			$attributes = wc_clean( wp_unslash( $_GET ) );
 
-			$data_store   = WC_Data_Store::load( 'product' );
-			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+				$variation_id = $product->get_matching_variation( $attributes );
+			} else {
+				$data_store   = WC_Data_Store::load( 'product' );
+				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+			}
 
 			if ( ! empty( $variation_id ) ) {
 				$product = wc_get_product( $variation_id );
@@ -825,11 +829,15 @@ class WC_Stripe_Payment_Request {
 				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
 
-			if ( 'variable' === $product->get_type() && isset( $_POST['attributes'] ) ) {
+			if ( 'variable' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $product->product_type : $product->get_type() ) && isset( $_POST['attributes'] ) ) {
 				$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
 
-				$data_store   = WC_Data_Store::load( 'product' );
-				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+				if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
+					$variation_id = $product->get_matching_variation( $attributes );
+				} else {
+					$data_store   = WC_Data_Store::load( 'product' );
+					$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+				}
 
 				if ( ! empty( $variation_id ) ) {
 					$product = wc_get_product( $variation_id );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -241,6 +241,17 @@ class WC_Stripe_Payment_Request {
 
 		$product = wc_get_product( $post->ID );
 
+		if ( 'variable' === $product->get_type() ) {
+			$attributes = wc_clean( wp_unslash( $_GET ) );
+
+			$data_store   = WC_Data_Store::load( 'product' );
+			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+
+			if ( ! empty( $variation_id ) ) {
+				$product = wc_get_product( $variation_id );
+			}
+		}
+
 		$data  = array();
 		$items = array();
 
@@ -814,21 +825,15 @@ class WC_Stripe_Payment_Request {
 				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
 
-			if ( 'variable' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $product->product_type : $product->get_type() ) && isset( $_POST['attributes'] ) ) {
-				$attributes = array_map( 'wc_clean', $_POST['attributes'] );
+			if ( 'variable' === $product->get_type() && isset( $_POST['attributes'] ) ) {
+				$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
 
-				if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-					$variation_id = $product->get_matching_variation( $attributes );
-				} else {
-					$data_store   = WC_Data_Store::load( 'product' );
-					$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
-				}
+				$data_store   = WC_Data_Store::load( 'product' );
+				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 				if ( ! empty( $variation_id ) ) {
 					$product = wc_get_product( $variation_id );
 				}
-			} elseif ( 'simple' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $product->product_type : $product->get_type() ) ) {
-				$product = wc_get_product( $product_id );
 			}
 
 			// Force quantity to 1 if sold individually and check for existing item in cart.
@@ -918,7 +923,7 @@ class WC_Stripe_Payment_Request {
 		WC()->cart->empty_cart();
 
 		if ( ( 'variable' === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
-			$attributes = array_map( 'wc_clean', $_POST['attributes'] );
+			$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
 
 			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
 				$variation_id = $product->get_matching_variation( $attributes );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1138

In this PR:
- I removed some `< WC 3.0` checks while I was at it, it's long overdue.
- Properly unescape attributes that come in the `$_POST` payload before using them to find a product variation.
- Correctly configure the payment request with the correct product variation on first page load (not only on AJAX updates).

Testing instructions in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1138

@vbelolapotkov 

Thanks @hardipparmar-multidots for your contribution! It was much easier to tweak your solution than to having to figure out what's wrong for ourselves :) Would you mind checking if these changes fix your issue?