### PR TITLE
Add alert for end of support WC < 3.0 in future releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Thumbs.db
 .settings*
 sftp-config.json
 /deploy/
+.vscode/
 
 # Ignore all log files except for .htaccess
 /logs/*

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -117,12 +117,6 @@ class WC_Stripe_Admin_Notices {
 		$live_secret_key     = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
 		$three_d_secure      = isset( $options['three_d_secure'] ) && 'yes' === $options['three_d_secure'];
 
-		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
-			/* translators: 1) int version 2) int version */
-			$message = __( 'WooCommerce Stripe - This is the last version of the plugin compatible with WooCommerce %1$s. All further versions of the plugin will require WooCommerce %2$s or greater.', 'woocommerce-gateway-stripe' );
-			$this->add_admin_notice( 'wcver', 'notice notice-warning', sprintf( $message, WC_VERSION, WC_STRIPE_FUTURE_MIN_WC_VER ), true );
-		}
-
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
 			if ( empty( $show_3ds_notice ) && $three_d_secure ) {
 				$url = 'https://stripe.com/docs/payments/3d-secure#three-ds-radar';
@@ -154,13 +148,17 @@ class WC_Stripe_Admin_Notices {
 			}
 
 			if ( empty( $show_wcver_notice ) ) {
-				if ( version_compare( WC_VERSION, WC_STRIPE_MIN_WC_VER, '<' ) ) {
+				if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_MIN_WC_VER ) ) {
 					/* translators: 1) int version 2) int version */
 					$message = __( 'WooCommerce Stripe - The minimum WooCommerce version required for this plugin is %1$s. You are running %2$s.', 'woocommerce-gateway-stripe' );
 
 					$this->add_admin_notice( 'wcver', 'notice notice-warning', sprintf( $message, WC_STRIPE_MIN_WC_VER, WC_VERSION ), true );
 
 					return;
+				} elseif ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
+					/* translators: 1) int version 2) int version */
+					$message = __( 'WooCommerce Stripe - This is the last version of the plugin compatible with WooCommerce %1$s. All furture versions of the plugin will require WooCommerce %2$s or greater.', 'woocommerce-gateway-stripe' );
+					$this->add_admin_notice( 'wcver', 'notice notice-warning', sprintf( $message, WC_VERSION, WC_STRIPE_FUTURE_MIN_WC_VER ), true );
 				}
 			}
 

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -117,6 +117,12 @@ class WC_Stripe_Admin_Notices {
 		$live_secret_key     = isset( $options['secret_key'] ) ? $options['secret_key'] : '';
 		$three_d_secure      = isset( $options['three_d_secure'] ) && 'yes' === $options['three_d_secure'];
 
+		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
+			/* translators: 1) int version 2) int version */
+			$message = __( 'WooCommerce Stripe - This is the last version of the plugin compatible with WooCommerce %1$s. All further versions of the plugin will require WooCommerce %2$s or greater.', 'woocommerce-gateway-stripe' );
+			$this->add_admin_notice( 'wcver', 'notice notice-warning', sprintf( $message, WC_VERSION, WC_STRIPE_FUTURE_MIN_WC_VER ), true );
+		}
+
 		if ( isset( $options['enabled'] ) && 'yes' === $options['enabled'] ) {
 			if ( empty( $show_3ds_notice ) && $three_d_secure ) {
 				$url = 'https://stripe.com/docs/payments/3d-secure#three-ds-radar';

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -49,6 +49,7 @@ function woocommerce_gateway_stripe_init() {
 		define( 'WC_STRIPE_VERSION', '4.3.2' );
 		define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 		define( 'WC_STRIPE_MIN_WC_VER', '2.6.0' );
+		define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );
 		define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 		define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 		define( 'WC_STRIPE_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );


### PR DESCRIPTION
Fixes #832 .

#### Changes proposed in this Pull Request:
- Add WP-Admin alert for users running WC < 3.0

#### Testing instructions
1. Install WC < 3.0 and add activate plugin (I was able to download one [here](http://pluginsroom.com/plugins/woocommerce)).
Or update min version in `woocommerce-gateway-stripe.php` => `define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );` to be above current WC version.

2. Go to WP Admin. Alert should be displayed:

![image](https://user-images.githubusercontent.com/3139099/77895228-22e3f800-727f-11ea-8759-6f2169785eb3.png)


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

