### PR TITLE
Fix "no such customer" error on checkout

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -646,7 +646,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$customer->set_id( $customer->create_customer() );
 			$customer_id = $customer->get_id();
 		} else {
-			$customer->update_customer();
+			$customer_id = $customer->update_customer();
 		}
 
 		if ( empty( $source_object ) && ! $is_token ) {

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -175,6 +175,8 @@ class WC_Stripe_Customer {
 	 * @param array $args  Additional arguments for the request (optional).
 	 * @param bool  $retry Number of retries on error (optional, defaults to 0). If greater than 0, then an exception will be thrown instead of further retries on error.
 	 *
+	 * @return string Customer ID
+	 *
 	 * @throws WC_Stripe_Exception
 	 */
 	public function update_customer( $args = array(), $retries = 0 ) {
@@ -222,6 +224,8 @@ class WC_Stripe_Customer {
 		$this->set_customer_data( $response );
 
 		do_action( 'woocommerce_stripe_update_customer', $args, $response );
+
+		return $this->get_id();
 	}
 
 	/**

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -189,32 +189,11 @@ class WC_Stripe_Customer {
 		$response = WC_Stripe_API::request( $args, 'customers/' . $this->get_id() );
 
 		if ( ! empty( $response->error ) ) {
-			if ( $this->is_no_such_customer_error( $response->error ) ) {
+			if ( $this->is_no_such_customer_error( $response->error ) && ! $is_retry ) {
 				// This can happen when switching the main Stripe account or importing users from another site.
-				if ( ! $is_retry ) {
-					// If not already tried, recreate the customer and then update it.
-					$this->delete_id_from_meta();
-					$this->create_customer();
-					return $this->update_customer( $args, true );
-				}
-
-				$message = $response->error->message;
-
-				if ( ! preg_match( '/similar object exists/i', $message ) ) {
-					$options  = get_option( 'woocommerce_stripe_settings' );
-					$testmode = isset( $options['testmode'] ) && 'yes' === $options['testmode'];
-
-					$message = sprintf(
-						( $testmode
-							// Translators: %s is a message, which states that no such customer exists, without a full stop at the end.
-							? __( '%s. Was the customer created in live mode? ', 'woocommerce-gateway-stripe' )
-							// Translators: %s is a message, which states that no such customer exists, without a full stop at the end.
-							: __( '%s. Was the customer created in test mode? ', 'woocommerce-gateway-stripe' ) ),
-						$message
-					);
-				}
-
-				throw new WC_Stripe_Exception( print_r( $response, true ), $message );
+				// If not already retrying, recreate the customer and then try updating it again.
+				$this->recreate_customer();
+				return $this->update_customer( $args, true );
 			}
 
 			throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
@@ -267,8 +246,7 @@ class WC_Stripe_Customer {
 			// but no longer exists. Instead of failing, lets try to create a
 			// new customer.
 			if ( $this->is_no_such_customer_error( $response->error ) ) {
-				$this->delete_id_from_meta();
-				$this->create_customer();
+				$this->recreate_customer();
 				return $this->add_source( $source_id );
 			} else {
 				return $response;
@@ -434,5 +412,15 @@ class WC_Stripe_Customer {
 	 */
 	public function delete_id_from_meta() {
 		delete_user_option( $this->get_user_id(), '_stripe_customer_id', false );
+	}
+
+	/**
+	 * Recreates the customer for this user.
+	 *
+	 * @return string ID of the new Customer object.
+	 */
+	private function recreate_customer() {
+		$this->delete_id_from_meta();
+		return $this->create_customer();
 	}
 }

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -172,14 +172,14 @@ class WC_Stripe_Customer {
 	/**
 	 * Updates the Stripe customer through the API.
 	 *
-	 * @param array $args  Additional arguments for the request (optional).
-	 * @param bool  $retry Number of retries on error (optional, defaults to 0). If greater than 0, then an exception will be thrown instead of further retries on error.
+	 * @param array $args     Additional arguments for the request (optional).
+	 * @param bool  $is_retry Whether the current call is a retry (optional, defaults to false). If true, then an exception will be thrown instead of further retries on error.
 	 *
 	 * @return string Customer ID
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function update_customer( $args = array(), $retries = 0 ) {
+	public function update_customer( $args = array(), $is_retry = false ) {
 		if ( empty( $this->get_id() ) ) {
 			throw new WC_Stripe_Exception( 'id_required_to_update_user', __( 'Attempting to update a Stripe customer without a customer ID.', 'woocommerce-gateway-stripe' ) );
 		}
@@ -191,11 +191,11 @@ class WC_Stripe_Customer {
 		if ( ! empty( $response->error ) ) {
 			if ( $this->is_no_such_customer_error( $response->error ) ) {
 				// This can happen when switching the main Stripe account or importing users from another site.
-				if ( 0 === $retries ) {
+				if ( ! $is_retry ) {
 					// If not already tried, recreate the customer and then update it.
 					$this->delete_id_from_meta();
 					$this->create_customer();
-					return $this->update_customer( $args, $retries++ );
+					return $this->update_customer( $args, true );
 				}
 
 				$message = $response->error->message;


### PR DESCRIPTION
Fixes #1128 .

#### Changes proposed in this Pull Request:
- During Checkout, if a user is logged in and performed the checkout before, the associated customer object ID will be stored in the site DB and the object updated in Stripe.
- If the ID and the merchant's Stripe account mismatch for any reason, the checkout will fail on the update step.
- This PR recreates the customer object in the above scenario rather than failing straight away. 
- If the failure occurs more than once, then the error will be shown.

#### Test/reproduction steps:

1. Have two Stripe accounts ready
1. Create a WP/Woo user account for a customer (you can use incognito mode for convenience)
1. Use the keys from one Stripe account on your site
1. Place an order as the user from step 2.
1. Change the keys to another Stripe account (Check user meta table in your db, it should contain `_stripe_customer_id` field)
1. Attempt to place another order
1. The order should go through (`_stripe_customer_id` should contain a different value than before)
