### PR TITLE
Bump "tested up to" headers

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
 Requires at least: 4.4
-Tested up to: 5.3.2
+Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: 4.3.2
 License: GPLv3

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Version: 4.3.2
  * Requires at least: 4.4
- * Tested up to: 5.3.2
+ * Tested up to: 5.4
  * WC requires at least: 2.6
- * WC tested up to: 3.9.2
+ * WC tested up to: 4.0
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  *


### PR DESCRIPTION
Fixes #1123 
Fixes #1148

I updated WP to 5.4 and Woo to 4.0.1 and did some smoke testing (new transactions, subs renewal, refunds) and everything worked.

