### PR TITLE
Do not return WP_Error when processing sub renewals

### DIFF
--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -234,7 +234,7 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 
 			if ( ! $prepared_source->customer ) {
 				throw new WC_Stripe_Exception(
-					'Customer not found while processing renewal for order ' . $renewal_order->get_id(),
+					'Failed to process renewal for order ' . $renewal_order->get_id() . '. Stripe customer id is missing in the order',
 					__( 'Customer not found', 'woocommerce-gateway-stripe' )
 				);
 			}

--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -219,7 +219,11 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 		try {
 			if ( $amount * 100 < WC_Stripe_Helper::get_minimum_amount() ) {
 				/* translators: minimum amount */
-				return new WP_Error( 'stripe_error', sprintf( __( 'Sorry, the minimum allowed order total is %1$s to use this payment method.', 'woocommerce-gateway-stripe' ), wc_price( WC_Stripe_Helper::get_minimum_amount() / 100 ) ) );
+				$message = sprintf( __( 'Sorry, the minimum allowed order total is %1$s to use this payment method.', 'woocommerce-gateway-stripe' ), wc_price( WC_Stripe_Helper::get_minimum_amount() / 100 ) );
+				throw new WC_Stripe_Exception(
+					'Error while processing renewal order ' . $renewal_order->get_id() . ' : ' . $message,
+					$message
+				);
 			}
 
 			$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id();
@@ -229,7 +233,10 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 			$source_object   = $prepared_source->source_object;
 
 			if ( ! $prepared_source->customer ) {
-				return new WP_Error( 'stripe_error', __( 'Customer not found', 'woocommerce-gateway-stripe' ) );
+				throw new WC_Stripe_Exception(
+					'Customer not found while processing renewal for order ' . $renewal_order->get_id(),
+					__( 'Customer not found', 'woocommerce-gateway-stripe' )
+				);
 			}
 
 			WC_Stripe_Logger::log( "Info: Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -272,7 +272,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 			if ( ! $prepared_source->customer ) {
 				throw new WC_Stripe_Exception(
-					'Customer not found while processing renewal for order ' . $renewal_order->get_id(),
+					'Failed to process renewal for order ' . $renewal_order->get_id() . '. Stripe customer id is missing in the order',
 					__( 'Customer not found', 'woocommerce-gateway-stripe' )
 				);
 			}

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -221,7 +221,11 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		try {
 			if ( $amount * 100 < WC_Stripe_Helper::get_minimum_amount() ) {
 				/* translators: minimum amount */
-				return new WP_Error( 'stripe_error', sprintf( __( 'Sorry, the minimum allowed order total is %1$s to use this payment method.', 'woocommerce-gateway-stripe' ), wc_price( WC_Stripe_Helper::get_minimum_amount() / 100 ) ) );
+				$message = sprintf( __( 'Sorry, the minimum allowed order total is %1$s to use this payment method.', 'woocommerce-gateway-stripe' ), wc_price( WC_Stripe_Helper::get_minimum_amount() / 100 ) );
+				throw new WC_Stripe_Exception(
+					'Error while processing renewal order ' . $renewal_order->get_id() . ' : ' . $message,
+					$message
+				);
 			}
 
 			$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id();
@@ -267,7 +271,10 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			$source_object   = $prepared_source->source_object;
 
 			if ( ! $prepared_source->customer ) {
-				return new WP_Error( 'stripe_error', __( 'Customer not found', 'woocommerce-gateway-stripe' ) );
+				throw new WC_Stripe_Exception(
+					'Customer not found while processing renewal for order ' . $renewal_order->get_id(),
+					__( 'Customer not found', 'woocommerce-gateway-stripe' )
+				);
 			}
 
 			WC_Stripe_Logger::log( "Info: Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );


### PR DESCRIPTION
Fixes #1094 

#### Changes proposed in this Pull Request:
- Replaced `WP_Error` with `WC_Stripe_Exception` to be in line with the rest of the function

Despite the scary repro steps below, this PR is just bringing the code in line with the rest of the function. WP_Errors would not be handled at all and are just an early return, while the Exceptions would be logged in [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/323cf377574cd942b48647436bc3af315c4e5449/includes/compat/class-wc-stripe-subs-compat.php#L361) and the order would be marked as failed.

#### Test steps:
* Enable logging in this extension
* Purchase a subscription
* In wp-admin, open the subscription
* Under actions, select "Create pending renewal order"
* In the database, delete `_stripe_customer_id` from `wp_postmeta` for that new renewal order ID
* Go back to the pending renewal order and select `Retry renewal payment` action
* The order should be marked as failed and a message like `Customer not found while processing renewal for order ***` should appear in the logs.

