### PR TITLE
Fix transactions failing with trailing slash

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1275,7 +1275,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param WC_Order $order The order to retrieve an intent for.
 	 * @return obect|bool     Either the intent object or `false`.
 	 */
-
 	private function pre_3_0_get_intent_from_order( $order ) {
 		$order_id  = $order->id;
 		$intent_id = get_post_meta( $order_id, '_stripe_intent_id', true );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1307,7 +1307,16 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			throw new Exception( "Failed to get intent of type $intent_type. Type is not allowed" );
 		}
 
-		return WC_Stripe_API::request( array(), "$intent_type/$intent_id", 'GET' );
+		$response = WC_Stripe_API::request( array(), "$intent_type/$intent_id", 'GET' );
+
+		if ( $response && isset( $response->{ 'error' } ) ) {
+			$error_response_message = print_r( $response, true );
+			WC_Stripe_Logger::log("Failed to get Stripe intent $intent_type/$intent_id.");
+			WC_Stripe_Logger::log("Response: $error_response_message");
+			return false;
+		}
+
+		return $response;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1248,30 +1248,66 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return obect|bool     Either the intent object or `false`.
 	 */
 	public function get_intent_from_order( $order ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-
 		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			$intent_id = get_post_meta( $order_id, '_stripe_intent_id', true );
-		} else {
-			$intent_id = $order->get_meta( '_stripe_intent_id' );
+			return $this->pre_3_0_get_intent_from_order( $order );
 		}
 
+		$order_id  = $order->get_id();
+		$intent_id = $order->get_meta( '_stripe_intent_id' );
+
 		if ( $intent_id ) {
-			return WC_Stripe_API::request( array(), "payment_intents/$intent_id", 'GET' );
+			return $this->get_intent( 'payment_intents', $intent_id );
 		}
 
 		// The order doesn't have a payment intent, but it may have a setup intent.
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			$intent_id = get_post_meta( $order_id, '_stripe_setup_intent', true );
-		} else {
-			$intent_id = $order->get_meta( '_stripe_setup_intent' );
-		}
+		$intent_id = $order->get_meta( '_stripe_setup_intent' );
 
 		if ( $intent_id ) {
-			return WC_Stripe_API::request( array(), "setup_intents/$intent_id", 'GET' );
+			return $this->get_intent( 'setup_intents', $intent_id );
 		}
 
 		return false;
+	}
+
+	/**
+	 * Retrieves the payment intent, associated with an order for WooCommerce < 3.0
+	 *
+	 * @param WC_Order $order The order to retrieve an intent for.
+	 * @return obect|bool     Either the intent object or `false`.
+	 */
+
+	private function pre_3_0_get_intent_from_order( $order ) {
+		$order_id  = $order->id;
+		$intent_id = get_post_meta( $order_id, '_stripe_intent_id', true );
+
+		if ( $intent_id ) {
+			return $this->get_intent( 'payment_intents', $intent_id );
+		}
+
+		// The order doesn't have a payment intent, but it may have a setup intent.
+		$intent_id = get_post_meta( $order_id, '_stripe_setup_intent', true );
+
+		if ( $intent_id ) {
+			return $this->get_intent( 'setup_intents', $intent_id );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Retrieves intent from Stripe API by intent id.
+	 *
+	 * @param string $intent_type 	Either 'payment_intents' or 'setup_intents'.
+	 * @param string $intent_id		Intent id.
+	 * @return object|bool 			Either the intent object or `false`.
+	 * @throws Exception 			Throws exception for unknown $intent_type.
+	 */
+	private function get_intent( $intent_type, $intent_id ) {
+		if ( ! in_array( $intent_type, [ 'payment_intents', 'setup_intents' ] ) ) {
+			throw new Exception( "Failed to get intent of type $intent_type. Type is not allowed" );
+		}
+
+		return WC_Stripe_API::request( array(), "$intent_type/$intent_id", 'GET' );
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * These tests make assertions against abstract class WC_Stripe_Payment_Gateway
+ *
+ */
+
+
+class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
+	/**
+	 * Gateway under test.
+	 *
+	 * @var WC_Gateway_Stripe
+	 */
+	private $gateway;
+
+	/**
+	 * Sets up things all tests need.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->gateway = new WC_Gateway_Stripe();
+	}
+
+	/**
+	 * Tests false is returned if payment intent is not set in the order.
+	 */
+	public function test_default_get_payment_intent_from_order() {
+		$order = WC_Helper_Order::create_order();
+		$intent = $this->gateway->get_intent_from_order( $order );
+		$this->assertFalse( $intent );
+	}
+
+	/**
+	 * Tests if payment intent is fetched from Stripe API.
+	 */
+	public function test_success_get_payment_intent_from_order() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data('_stripe_intent_id', 'pi_123');
+		$expected_intent = (object) [ 'id' => 'pi_123' ];
+		$callback = function( $preempt, $request_args, $url ) use ( $expected_intent ) {
+			$response = [
+				'headers' 	=> [],
+				'body'		=> json_encode( $expected_intent ),
+				'response'	=> [
+					'code' 		=> 200,
+					'message' 	=> 'OK',
+				],
+			];
+
+			$this->assertEquals( 'GET', $request_args['method'] );
+			$this->assertStringEndsWith( 'payment_intents/pi_123', $url );
+
+			return $response;
+		};
+
+		add_filter( 'pre_http_request', $callback, 10, 3);
+
+		$intent = $this->gateway->get_intent_from_order( $order );
+		$this->assertEquals( $expected_intent, $intent );
+
+		remove_filter( 'pre_http_request', $callback);
+	}
+
+	/**
+	 * Tests if false is returned when error is returned from Stripe API.
+	 */
+	public function test_error_get_payment_intent_from_order() {
+		$order = WC_Helper_Order::create_order();
+		$order->update_meta_data('_stripe_intent_id', 'pi_123');
+		$response_error = (object) [
+			'error' => [
+				'code' 		=> 'resource_missing',
+				'message' 	=> 'error_message'
+			]
+		];
+		$callback = function( $preempt, $request_args, $url ) use ( $response_error ) {
+			$response = [
+				'headers' 	=> [],
+				'body'		=> json_encode( $response_error ),
+				'response'	=> [
+					'code' 		=> 404,
+					'message' 	=> 'ERR',
+				],
+			];
+
+			$this->assertEquals( 'GET', $request_args['method'] );
+			$this->assertStringEndsWith( 'payment_intents/pi_123', $url );
+
+			return $response;
+		};
+
+		add_filter( 'pre_http_request', $callback, 10, 3);
+
+		$intent = $this->gateway->get_intent_from_order( $order );
+		$this->assertFalse( $intent );
+
+		remove_filter( 'pre_http_request', $callback);
+	}
+}

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -23,6 +23,13 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Helper function to update test order meta data
+	 */
+	private function updateOrderMeta( $order, $key, $value ) {
+		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order->id, $key, $value ) : $order->update_meta_data( $key, $value );
+	}
+
+	/**
 	 * Tests false is returned if payment intent is not set in the order.
 	 */
 	public function test_default_get_payment_intent_from_order() {
@@ -36,8 +43,8 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	public function test_success_get_payment_intent_from_order() {
 		$order = WC_Helper_Order::create_order();
-		$order->update_meta_data('_stripe_intent_id', 'pi_123');
-		$expected_intent = (object) [ 'id' => 'pi_123' ];
+		$this->updateOrderMeta( $order, '_stripe_intent_id', 'pi_123' );
+		$expected_intent = ( object ) [ 'id' => 'pi_123' ];
 		$callback = function( $preempt, $request_args, $url ) use ( $expected_intent ) {
 			$response = [
 				'headers' 	=> [],
@@ -59,7 +66,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$intent = $this->gateway->get_intent_from_order( $order );
 		$this->assertEquals( $expected_intent, $intent );
 
-		remove_filter( 'pre_http_request', $callback);
+		remove_filter( 'pre_http_request', $callback );
 	}
 
 	/**
@@ -67,8 +74,8 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	public function test_error_get_payment_intent_from_order() {
 		$order = WC_Helper_Order::create_order();
-		$order->update_meta_data('_stripe_intent_id', 'pi_123');
-		$response_error = (object) [
+		$this->updateOrderMeta( $order, '_stripe_intent_id', 'pi_123' );
+		$response_error = ( object ) [
 			'error' => [
 				'code' 		=> 'resource_missing',
 				'message' 	=> 'error_message'
@@ -95,6 +102,6 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$intent = $this->gateway->get_intent_from_order( $order );
 		$this->assertFalse( $intent );
 
-		remove_filter( 'pre_http_request', $callback);
+		remove_filter( 'pre_http_request', $callback );
 	}
 }


### PR DESCRIPTION
Fixes #1066 .

#### Changes proposed in this Pull Request:
The issue is caused by error object returned from Stripe API when test mode payment intent associated with the order is fetched in the live mode. The error object was mistakenly treated as an intent object (with empty id). Hence further POST request is sent to the wrong URL `payment_intents/` and fails.

To fix the issue extra check of the response object is added. Errors are logged and `false` is returned instead of payment intent in such cases.

#### Testing instructions

There is no known reliable way to reproduce the issue.
Added some unit tests so running PHP unit tests is the only way of testing at the moment.
See #1163 for instructions on setting up and running unit tests.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

