### PR TITLE
Prevent exposing secret keys in the frontend

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -158,6 +158,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return bool
 	 */
 	public function are_keys_set() {
+		// NOTE: updates to this function should be added to are_keys_set()
+		// in includes/payment-methods/class-wc-stripe-payment-request.php
+
 		if ( $this->testmode ) {
 			return preg_match( '/^pk_test_/', $this->publishable_key )
 				&& preg_match( '/^[rs]k_test_/', $this->secret_key );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -152,16 +152,29 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Checks if keys are set.
+	 *
+	 * @since 4.0.6
+	 * @return bool
+	 */
+	public function are_keys_set() {
+		if ( $this->testmode ) {
+			return preg_match( '/^pk_test_/', $this->publishable_key )
+				&& ( preg_match( '/^sk_test_/', $this->secret_key ) || preg_match( '/^rk_test_/', $this->secret_key ) );
+		} else {
+			return preg_match( '/^pk_live_/', $this->publishable_key )
+			    && ( preg_match( '/^sk_live_/', $this->secret_key ) || preg_match( '/^rk_live_/', $this->secret_key ) );
+		}
+	}
+
+	/**
 	 * Check if we need to make gateways available.
 	 *
 	 * @since 4.1.3
 	 */
 	public function is_available() {
 		if ( 'yes' === $this->enabled ) {
-			if ( ! $this->secret_key || ! $this->publishable_key ) {
-				return false;
-			}
-			return true;
+			return $this->are_keys_set();
 		}
 
 		return parent::is_available();

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -152,11 +152,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Checks if keys are set.
-	 * Side effect: it also returns false if a secret key was set for the publishable key.
+	 * Checks if keys are set and valid.
 	 *
 	 * @since 4.0.6
-	 * @return bool
+	 * @return bool True if the keys are set *and* valid, false otherwise (for example, if keys are empty or the secret key was pasted as publishable key).
 	 */
 	public function are_keys_set() {
 		// NOTE: updates to this function should be added to are_keys_set()

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -160,10 +160,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function are_keys_set() {
 		if ( $this->testmode ) {
 			return preg_match( '/^pk_test_/', $this->publishable_key )
-				&& ( preg_match( '/^sk_test_/', $this->secret_key ) || preg_match( '/^rk_test_/', $this->secret_key ) );
+				&& preg_match( '/^[rs]k_test_/', $this->secret_key );
 		} else {
 			return preg_match( '/^pk_live_/', $this->publishable_key )
-			    && ( preg_match( '/^sk_live_/', $this->secret_key ) || preg_match( '/^rk_live_/', $this->secret_key ) );
+			    && preg_match( '/^[rs]k_live_/', $this->secret_key );
 		}
 	}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -153,6 +153,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 	/**
 	 * Checks if keys are set.
+	 * Side effect: it also returns false if a secret key was set for the publishable key.
 	 *
 	 * @since 4.0.6
 	 * @return bool

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -181,8 +181,7 @@ class WC_Stripe_Admin_Notices {
 				if ( $testmode ) {
 					if (
 						! empty( $test_pub_key ) && ! preg_match( '/^pk_test_/', $test_pub_key )
-						|| ( ! empty( $test_secret_key ) && ! preg_match( '/^sk_test_/', $test_secret_key )
-						&& ! preg_match( '/^rk_test_/', $test_secret_key ) ) ) {
+						|| ! empty( $test_secret_key ) && ! preg_match( '/^[rs]k_test_/', $test_secret_key ) ) {
 						$setting_link = $this->get_setting_link();
 						/* translators: 1) link */
 						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in test mode however your test keys may not be valid. Test keys start with pk_test and sk_test or rk_test. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );
@@ -190,8 +189,7 @@ class WC_Stripe_Admin_Notices {
 				} else {
 					if (
 						! empty( $live_pub_key ) && ! preg_match( '/^pk_live_/', $live_pub_key )
-						|| ( ! empty( $live_secret_key ) && ! preg_match( '/^sk_live_/', $live_secret_key )
-						&& ! preg_match( '/^rk_live_/', $live_secret_key ) ) ) {
+						|| ! empty( $live_secret_key ) && ! preg_match( '/^[rs]k_live_/', $live_secret_key ) ) {
 						$setting_link = $this->get_setting_link();
 						/* translators: 1) link */
 						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in live mode however your live keys may not be valid. Live keys start with pk_live and sk_live or rk_live. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -182,7 +182,7 @@ class WC_Stripe_Admin_Notices {
 					if (
 						! empty( $test_pub_key ) && ! preg_match( '/^pk_test_/', $test_pub_key )
 						|| ( ! empty( $test_secret_key ) && ! preg_match( '/^sk_test_/', $test_secret_key )
-						&& ! empty( $test_secret_key ) && ! preg_match( '/^rk_test_/', $test_secret_key ) ) ) {
+						&& ! preg_match( '/^rk_test_/', $test_secret_key ) ) ) {
 						$setting_link = $this->get_setting_link();
 						/* translators: 1) link */
 						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in test mode however your test keys may not be valid. Test keys start with pk_test and sk_test or rk_test. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );
@@ -191,10 +191,10 @@ class WC_Stripe_Admin_Notices {
 					if (
 						! empty( $live_pub_key ) && ! preg_match( '/^pk_live_/', $live_pub_key )
 						|| ( ! empty( $live_secret_key ) && ! preg_match( '/^sk_live_/', $live_secret_key )
-						&& ! empty( $live_secret_key ) && ! preg_match( '/^rk_live_/', $live_secret_key ) ) ) {
+						&& ! preg_match( '/^rk_live_/', $live_secret_key ) ) ) {
 						$setting_link = $this->get_setting_link();
 						/* translators: 1) link */
-						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in live mode however your test keys may not be valid. Live keys start with pk_live and sk_live or rk_live. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );
+						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in live mode however your live keys may not be valid. Live keys start with pk_live and sk_live or rk_live. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );
 					}
 				}
 			}

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -44,7 +44,7 @@ return apply_filters(
 		'test_publishable_key'          => array(
 			'title'       => __( 'Test Publishable Key', 'woocommerce-gateway-stripe' ),
 			'type'        => 'text',
-			'description' => __( 'Get your API keys from your stripe account.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Get your API keys from your stripe account. Invalid values will be rejected. Only values starting with `pk_` will be saved.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -44,14 +44,14 @@ return apply_filters(
 		'test_publishable_key'          => array(
 			'title'       => __( 'Test Publishable Key', 'woocommerce-gateway-stripe' ),
 			'type'        => 'text',
-			'description' => __( 'Get your API keys from your stripe account. Invalid values will be rejected. Only values starting with `pk_` will be saved.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Get your API keys from your stripe account. Invalid values will be rejected. Only values starting with "pk_test_" will be saved.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
 		'test_secret_key'               => array(
 			'title'       => __( 'Test Secret Key', 'woocommerce-gateway-stripe' ),
 			'type'        => 'password',
-			'description' => __( 'Get your API keys from your stripe account.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Get your API keys from your stripe account. Invalid values will be rejected. Only values starting with "sk_test_" or "rk_test_" will be saved.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
@@ -65,14 +65,14 @@ return apply_filters(
 		'publishable_key'               => array(
 			'title'       => __( 'Live Publishable Key', 'woocommerce-gateway-stripe' ),
 			'type'        => 'text',
-			'description' => __( 'Get your API keys from your stripe account.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Get your API keys from your stripe account. Invalid values will be rejected. Only values starting with "pk_live_" will be saved.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),
 		'secret_key'                    => array(
 			'title'       => __( 'Live Secret Key', 'woocommerce-gateway-stripe' ),
 			'type'        => 'password',
-			'description' => __( 'Get your API keys from your stripe account.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Get your API keys from your stripe account. Invalid values will be rejected. Only values starting with "sk_live_" or "rk_live_" will be saved.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1181,7 +1181,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 	public function validate_secret_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
-		if ( ! empty( $value ) && ! ( preg_match( '/^sk_live_/', $value ) || preg_match( '/^rk_live_/', $value ) ) ) {
+		if ( ! empty( $value ) && ! preg_match( '/^[rs]k_live_/', $value ) ) {
 			throw new Exception( __( 'The "Live Secret Key" should start with "sk_live" or "rk_live", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
 		}
 		return $value;
@@ -1197,7 +1197,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 	public function validate_test_secret_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
-		if ( ! empty( $value ) && ! ( preg_match( '/^sk_test_/', $value ) || preg_match( '/^rk_test_/', $value ) ) ) {
+		if ( ! empty( $value ) && ! preg_match( '/^[rs]k_test_/', $value ) ) {
 			throw new Exception( __( 'The "Test Secret Key" should start with "sk_test" or "rk_test", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
 		}
 		return $value;

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1176,7 +1176,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_publishable_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^pk_live_/', $value ) ) {
-			throw new Exception( __( 'The "Live Publishable Key" should start with "pk_live", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+			throw new Exception( __( 'The "Live Publishable Key" should start with "pk_live", enter the correct key.', 'woocommerce-gateway-stripe' ) );
 		}
 		return $value;
 	}
@@ -1184,7 +1184,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_secret_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^[rs]k_live_/', $value ) ) {
-			throw new Exception( __( 'The "Live Secret Key" should start with "sk_live" or "rk_live", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+			throw new Exception( __( 'The "Live Secret Key" should start with "sk_live" or "rk_live", enter the correct key.', 'woocommerce-gateway-stripe' ) );
 		}
 		return $value;
 	}
@@ -1192,7 +1192,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_test_publishable_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^pk_test_/', $value ) ) {
-			throw new Exception( __( 'The "Test Publishable Key" should start with "pk_test", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+			throw new Exception( __( 'The "Test Publishable Key" should start with "pk_test", enter the correct key.', 'woocommerce-gateway-stripe' ) );
 		}
 		return $value;
 	}
@@ -1200,7 +1200,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_test_secret_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^[rs]k_test_/', $value ) ) {
-			throw new Exception( __( 'The "Test Secret Key" should start with "sk_test" or "rk_test", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+			throw new Exception( __( 'The "Test Secret Key" should start with "sk_test" or "rk_test", enter the correct key.', 'woocommerce-gateway-stripe' ) );
 		}
 		return $value;
 	}

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -140,6 +140,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
 		add_filter( 'woocommerce_get_checkout_payment_url', array( $this, 'get_checkout_payment_url' ), 10, 2 );
+
+		// Note: display error is in the parent class.
 		add_action( 'admin_notices', array( $this, 'display_errors' ), 9999 );
 
 		if ( WC_Stripe_Helper::is_pre_orders_exists() ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -149,20 +149,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Checks if keys are set.
-	 *
-	 * @since 4.0.6
-	 * @return bool
-	 */
-	public function are_keys_set() {
-		if ( empty( $this->secret_key ) || empty( $this->publishable_key ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Checks if gateway should be available to use.
 	 *
 	 * @since 4.0.2

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -140,6 +140,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
 		add_filter( 'woocommerce_get_checkout_payment_url', array( $this, 'get_checkout_payment_url' ), 10, 2 );
+		add_action( 'admin_notices', array( $this, 'display_errors' ), 9999 );
 
 		if ( WC_Stripe_Helper::is_pre_orders_exists() ) {
 			$this->pre_orders = new WC_Stripe_Pre_Orders_Compat();
@@ -1168,5 +1169,37 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		) {
 			update_option( 'wc_stripe_show_changed_keys_notice', 'yes' );
 		}
+	}
+
+	public function validate_publishable_key_field( $key, $value ) {
+		$value = $this->validate_text_field( $key, $value );
+		if ( ! empty( $value ) && ! preg_match( '/^pk_live_/', $value ) ) {
+			throw new Exception( __( 'The "Live Publishable Key" should start with "pk_live", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+		}
+		return $value;
+	}
+
+	public function validate_secret_key_field( $key, $value ) {
+		$value = $this->validate_text_field( $key, $value );
+		if ( ! empty( $value ) && ! ( preg_match( '/^sk_live_/', $value ) || preg_match( '/^rk_live_/', $value ) ) ) {
+			throw new Exception( __( 'The "Live Secret Key" should start with "sk_live" or "rk_live", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+		}
+		return $value;
+	}
+
+	public function validate_test_publishable_key_field( $key, $value ) {
+		$value = $this->validate_text_field( $key, $value );
+		if ( ! empty( $value ) && ! preg_match( '/^pk_test_/', $value ) ) {
+			throw new Exception( __( 'The "Test Publishable Key" should start with "pk_test", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+		}
+		return $value;
+	}
+
+	public function validate_test_secret_key_field( $key, $value ) {
+		$value = $this->validate_text_field( $key, $value );
+		if ( ! empty( $value ) && ! ( preg_match( '/^sk_test_/', $value ) || preg_match( '/^rk_test_/', $value ) ) ) {
+			throw new Exception( __( 'The "Test Secret Key" should start with "sk_test" or "rk_test", please make sure you have entered the correct key.', 'woocommerce-gateway-stripe' ) );
+		}
+		return $value;
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -113,10 +113,10 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Checks if keys are set.
+	 * Checks if keys are set and valid.
 	 *
 	 * @since 4.0.6
-	 * @return bool
+	 * @return bool True if the keys are set *and* valid, false otherwise (for example, if keys are empty or the secret key was pasted as publishable key).
 	 */
 	public function are_keys_set() {
 		// NOTE: updates to this function should be added to are_keys_set()

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -119,11 +119,13 @@ class WC_Stripe_Payment_Request {
 	 * @return bool
 	 */
 	public function are_keys_set() {
-		if ( empty( $this->secret_key ) || empty( $this->publishable_key ) ) {
-			return false;
+		if ( $this->testmode ) {
+			return preg_match( '/^pk_test_/', $this->publishable_key )
+			       && ( preg_match( '/^sk_test_/', $this->secret_key ) || preg_match( '/^rk_test_/', $this->secret_key ) );
+		} else {
+			return preg_match( '/^pk_live_/', $this->publishable_key )
+			       && ( preg_match( '/^sk_live_/', $this->secret_key ) || preg_match( '/^rk_live_/', $this->secret_key ) );
 		}
-
-		return true;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -121,10 +121,10 @@ class WC_Stripe_Payment_Request {
 	public function are_keys_set() {
 		if ( $this->testmode ) {
 			return preg_match( '/^pk_test_/', $this->publishable_key )
-			       && ( preg_match( '/^sk_test_/', $this->secret_key ) || preg_match( '/^rk_test_/', $this->secret_key ) );
+			       && preg_match( '/^[rs]k_test_/', $this->secret_key );
 		} else {
 			return preg_match( '/^pk_live_/', $this->publishable_key )
-			       && ( preg_match( '/^sk_live_/', $this->secret_key ) || preg_match( '/^rk_live_/', $this->secret_key ) );
+			       && preg_match( '/^[rs]k_live_/', $this->secret_key );
 		}
 	}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -119,6 +119,8 @@ class WC_Stripe_Payment_Request {
 	 * @return bool
 	 */
 	public function are_keys_set() {
+		// NOTE: updates to this function should be added to are_keys_set()
+		// in includes/abstracts/abstract-wc-stripe-payment-gateway.php
 		if ( $this->testmode ) {
 			return preg_match( '/^pk_test_/', $this->publishable_key )
 			       && preg_match( '/^[rs]k_test_/', $this->secret_key );


### PR DESCRIPTION
Fixes #1151

### In this PR
- https://github.com/woocommerce/woocommerce-gateway-stripe/commit/e1af6e1dc0f0c1ae1cb8face0ec2a72f23e73021 Don't render anything in the frontend if the keys don't have the expected format.
- https://github.com/woocommerce/woocommerce-gateway-stripe/commit/dd37cd26a6719500f18b074a70deadeda2ec5bc0 Show an error notice when trying to save a key with an incorrect format. Merchants usually have "admin notices blindness", but this was the easiest solution I could come up with. Incorrect keys won't be saved but the rest of the settings will. Can you think of a better approach, like letting the merchant save the keys and having a persistent "WRONG KEYS" admin notice? Or this is fine?
- https://github.com/woocommerce/woocommerce-gateway-stripe/commit/96a7880ba2b627725e2858e1042ab5662bcf909b Some minor cleanup.

### Testing instructions
- **Before** checking out this branch, store some wrong keys. For example, put your "Secret key" in the "Publishable key" field, or type some random garbage.
- Notice that, if you navigate to the checkout, you'll be able to find whatever you entered as "Publishable Key" in the page's source. Oops!
- Checkout this branch, then reload the checkout. You won't see Stripe as a payment option at all, as if it was disabled.
- Go to the Stripe settings and fix your mistake, set the correct keys in the correct fields again. Note that checkout works again.
- Go back to the Stripe settings, try to put incorrect keys again. Note that you won't be able to, and you'll see an error notice when saving explaining your mistake.