### PR TITLE
Remove support for WC versions before 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,6 @@ services:
 env:
   - WP_VERSION=latest WP_MULTISITE=0  WC_VERSION=3.4.5
 
-# Additonal tests against stable PHP (min recommended version is 5.6) and past supported versions of WP.
-matrix:
-  include:
-  - php: 5.6
-    env: WP_VERSION=latest WP_MULTISITE=1 WC_VERSION=2.6.14
-  - php: 7.1
-    env: WP_VERSION=latest WP_MULTISITE=0 WC_VERSION=3.4.5
-
 before_script:
   - |
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -752,8 +752,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param int $balance_transaction_id
 	 */
 	public function update_fees( $order, $balance_transaction_id ) {
-		$order_id = $order->get_id();
-
 		$balance_transaction = WC_Stripe_API::retrieve( 'balance/history/' . $balance_transaction_id );
 
 		if ( empty( $balance_transaction->error ) ) {
@@ -782,7 +780,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				}
 			}
 		} else {
-			WC_Stripe_Logger::log( "Unable to update fees/net meta for order: {$order_id}" );
+			WC_Stripe_Logger::log( 'Unable to update fees/net meta for order: ' . $order->get_id() );
 		}
 	}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -254,15 +254,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @version 4.0.0
 	 */
 	public function get_stripe_customer_id( $order ) {
-		$customer = get_user_option( '_stripe_customer_id', WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id() );
+		$customer = get_user_option( '_stripe_customer_id', $order->get_customer_id() );
 
 		if ( empty( $customer ) ) {
 			// Try to get it via the order.
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				return get_post_meta( $order->id, '_stripe_customer_id', true );
-			} else {
-				return $order->get_meta( '_stripe_customer_id', true );
-			}
+			return $order->get_meta( '_stripe_customer_id', true );
 		} else {
 			return $customer;
 		}
@@ -284,7 +280,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				$id = uniqid();
 			}
 
-			$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+			$order_id = $order->get_id();
 
 			$args = array(
 				'utm_nooverride' => '1',
@@ -320,19 +316,19 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$statement_descriptor  = ! empty( $settings['statement_descriptor'] ) ? str_replace( "'", '', $settings['statement_descriptor'] ) : '';
 		$capture               = ! empty( $settings['capture'] ) && 'yes' === $settings['capture'] ? true : false;
 		$post_data             = array();
-		$post_data['currency'] = strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() );
+		$post_data['currency'] = strtolower( $order->get_currency() );
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $post_data['currency'] );
 		/* translators: 1) blog name 2) order number */
 		$post_data['description'] = sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
-		$billing_email            = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_email : $order->get_billing_email();
-		$billing_first_name       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_first_name : $order->get_billing_first_name();
-		$billing_last_name        = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_last_name : $order->get_billing_last_name();
+		$billing_email            = $order->get_billing_email();
+		$billing_first_name       = $order->get_billing_first_name();
+		$billing_last_name        = $order->get_billing_last_name();
 
 		if ( ! empty( $billing_email ) && apply_filters( 'wc_stripe_send_stripe_receipt', false ) ) {
 			$post_data['receipt_email'] = $billing_email;
 		}
 
-		switch ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method() ) {
+		switch ( $order->get_payment_method() ) {
 			case 'stripe':
 				if ( ! empty( $statement_descriptor ) ) {
 					$post_data['statement_descriptor'] = WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor );
@@ -355,7 +351,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'order_id' => $order->get_order_number(),
 		);
 
-		if ( $this->has_subscription( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id() ) ) {
+		if ( $this->has_subscription( $order->get_id() ) ) {
 			$metadata += array(
 				'payment_type' => 'recurring',
 				'site_url'     => esc_url( get_site_url() ),
@@ -389,11 +385,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function process_response( $response, $order ) {
 		WC_Stripe_Logger::log( 'Processing response: ' . print_r( $response, true ) );
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 		$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';
 
 		// Store charge data.
-		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', $captured ) : $order->update_meta_data( '_stripe_charge_captured', $captured );
+		$order->update_meta_data( '_stripe_charge_captured', $captured );
 
 		if ( isset( $response->balance_transaction ) ) {
 			$this->update_fees( $order, is_string( $response->balance_transaction ) ? $response->balance_transaction : $response->balance_transaction->id );
@@ -406,13 +402,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			 * take care of the status changes.
 			 */
 			if ( 'pending' === $response->status ) {
-				$order_stock_reduced = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_order_stock_reduced', true ) : $order->get_meta( '_order_stock_reduced', true );
+				$order_stock_reduced = $order->get_meta( '_order_stock_reduced', true );
 
 				if ( ! $order_stock_reduced ) {
-					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->reduce_order_stock() : wc_reduce_stock_levels( $order_id );
+					wc_reduce_stock_levels( $order_id );
 				}
 
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $response->id ) : $order->set_transaction_id( $response->id );
+				$order->set_transaction_id( $response->id );
 				/* translators: transaction id */
 				$order->update_status( 'on-hold', sprintf( __( 'Stripe charge awaiting payment: %s.', 'woocommerce-gateway-stripe' ), $response->id ) );
 			}
@@ -431,10 +427,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 			}
 		} else {
-			WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $response->id ) : $order->set_transaction_id( $response->id );
+			$order->set_transaction_id( $response->id );
 
 			if ( $order->has_status( array( 'pending', 'failed' ) ) ) {
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->reduce_order_stock() : wc_reduce_stock_levels( $order_id );
+				wc_reduce_stock_levels( $order_id );
 			}
 
 			/* translators: transaction id */
@@ -474,14 +470,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return object $details
 	 */
 	public function get_owner_details( $order ) {
-		$billing_first_name = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_first_name : $order->get_billing_first_name();
-		$billing_last_name  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_last_name : $order->get_billing_last_name();
+		$billing_first_name = $order->get_billing_first_name();
+		$billing_last_name  = $order->get_billing_last_name();
 
 		$details = array();
 
 		$name  = $billing_first_name . ' ' . $billing_last_name;
-		$email = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_email : $order->get_billing_email();
-		$phone = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_phone : $order->get_billing_phone();
+		$email = $order->get_billing_email();
+		$phone = $order->get_billing_phone();
 
 		if ( ! empty( $phone ) ) {
 			$details['phone'] = $phone;
@@ -495,12 +491,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$details['email'] = $email;
 		}
 
-		$details['address']['line1']       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_address_1 : $order->get_billing_address_1();
-		$details['address']['line2']       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_address_2 : $order->get_billing_address_2();
-		$details['address']['state']       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_state : $order->get_billing_state();
-		$details['address']['city']        = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_city : $order->get_billing_city();
-		$details['address']['postal_code'] = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_postcode : $order->get_billing_postcode();
-		$details['address']['country']     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_country : $order->get_billing_country();
+		$details['address']['line1']       = $order->get_billing_address_1();
+		$details['address']['line2']       = $order->get_billing_address_2();
+		$details['address']['state']       = $order->get_billing_state();
+		$details['address']['city']        = $order->get_billing_city();
+		$details['address']['postal_code'] = $order->get_billing_postcode();
+		$details['address']['country']     = $order->get_billing_country();
 
 		return (object) apply_filters( 'wc_stripe_owner_details', $details, $order );
 	}
@@ -681,7 +677,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$source_object   = false;
 
 		if ( $order ) {
-			$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+			$order_id = $order->get_id();
 
 			$stripe_customer_id = get_post_meta( $order_id, '_stripe_customer_id', true );
 
@@ -689,14 +685,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				$stripe_customer->set_id( $stripe_customer_id );
 			}
 
-			$source_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_source_id', true ) : $order->get_meta( '_stripe_source_id', true );
+			$source_id = $order->get_meta( '_stripe_source_id', true );
 
 			// Since 4.0.0, we changed card to source so we need to account for that.
 			if ( empty( $source_id ) ) {
-				$source_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_card_id', true ) : $order->get_meta( '_stripe_card_id', true );
+				$source_id = $order->get_meta( '_stripe_card_id', true );
 
 				// Take this opportunity to update the key name.
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_source_id', $source_id ) : $order->update_meta_data( '_stripe_source_id', $source_id );
+				$order->update_meta_data( '_stripe_source_id', $source_id );
 
 				if ( is_callable( array( $order, 'save' ) ) ) {
 					$order->save();
@@ -732,23 +728,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param stdClass $source Source information.
 	 */
 	public function save_source_to_order( $order, $source ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-
 		// Store source in the order.
 		if ( $source->customer ) {
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_customer_id', $source->customer );
-			} else {
-				$order->update_meta_data( '_stripe_customer_id', $source->customer );
-			}
+			$order->update_meta_data( '_stripe_customer_id', $source->customer );
 		}
 
 		if ( $source->source ) {
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $source->source );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $source->source );
-			}
+			$order->update_meta_data( '_stripe_source_id', $source->source );
 		}
 
 		if ( is_callable( array( $order, 'save' ) ) ) {
@@ -766,7 +752,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param int $balance_transaction_id
 	 */
 	public function update_fees( $order, $balance_transaction_id ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		$balance_transaction = WC_Stripe_API::retrieve( 'balance/history/' . $balance_transaction_id );
 
@@ -818,15 +804,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		$request = array();
 
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			$order_currency = get_post_meta( $order_id, '_order_currency', true );
-			$captured       = get_post_meta( $order_id, '_stripe_charge_captured', true );
-			$charge_id      = get_post_meta( $order_id, '_transaction_id', true );
-		} else {
-			$order_currency = $order->get_currency();
-			$captured       = $order->get_meta( '_stripe_charge_captured', true );
-			$charge_id      = $order->get_transaction_id();
-		}
+		$order_currency = $order->get_currency();
+		$captured       = $order->get_meta( '_stripe_charge_captured', true );
+		$charge_id      = $order->get_transaction_id();
 
 		if ( ! $charge_id ) {
 			return false;
@@ -885,11 +865,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return $response;
 
 		} elseif ( ! empty( $response->id ) ) {
-			WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_refund_id', $response->id ) : $order->update_meta_data( '_stripe_refund_id', $response->id );
+			$order->update_meta_data( '_stripe_refund_id', $response->id );
 
 			$amount = wc_price( $response->amount / 100 );
 
-			if ( in_array( strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() ), WC_Stripe_Helper::no_decimal_currencies() ) ) {
+			if ( in_array( strtolower( $order->get_currency() ), WC_Stripe_Helper::no_decimal_currencies() ) ) {
 				$amount = wc_price( $response->amount );
 			}
 
@@ -1027,7 +1007,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$request = array(
 			'source'               => $prepared_source->source,
 			'amount'               => WC_Stripe_Helper::get_stripe_amount( $order->get_total() ),
-			'currency'             => strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() ),
+			'currency'             => strtolower( $order->get_currency() ),
 			'description'          => $full_request['description'],
 			'metadata'             => $full_request['metadata'],
 			'capture_method'       => ( 'true' === $full_request['capture'] ) ? 'automatic' : 'manual',
@@ -1062,12 +1042,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return array          The level 3 data to send to Stripe.
 	 */
 	public function get_level3_data_from_order( $order ) {
-		// WC Versions before 3.0 don't support postcodes and are
-		// incompatible with level3 data.
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			return array();
-		}
-
 		// Get the order items. Don't need their keys, only their values.
 		// Order item IDs are used as keys in the original order items array.
 		$order_items = array_values( $order->get_items() );
@@ -1131,7 +1105,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return $intent;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 		WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id initiated for order $order_id" );
 
 		// Save the intent ID to the order.
@@ -1209,7 +1183,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		// Save a note about the status of the intent.
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 		if ( 'succeeded' === $confirmed_intent->status ) {
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
 		} elseif ( 'requires_action' === $confirmed_intent->status ) {
@@ -1227,13 +1201,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param stdClass $intent Payment intent information.
 	 */
 	public function save_intent_to_order( $order, $intent ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
-
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			update_post_meta( $order_id, '_stripe_intent_id', $intent->id );
-		} else {
-			$order->update_meta_data( '_stripe_intent_id', $intent->id );
-		}
+		$order->update_meta_data( '_stripe_intent_id', $intent->id );
 
 		if ( is_callable( array( $order, 'save' ) ) ) {
 			$order->save();
@@ -1248,11 +1216,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return obect|bool     Either the intent object or `false`.
 	 */
 	public function get_intent_from_order( $order ) {
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			return $this->pre_3_0_get_intent_from_order( $order );
-		}
-
-		$order_id  = $order->get_id();
 		$intent_id = $order->get_meta( '_stripe_intent_id' );
 
 		if ( $intent_id ) {
@@ -1327,7 +1290,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return bool            A flag that indicates whether the order is already locked.
 	 */
 	public function lock_order_payment( $order, $intent = null ) {
-		$order_id       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id       = $order->get_id();
 		$transient_name = 'wc_stripe_processing_intent_' . $order_id;
 		$processing     = get_transient( $transient_name );
 
@@ -1349,7 +1312,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param WC_Order $order The order that is being unlocked.
 	 */
 	public function unlock_order_payment( $order ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 		delete_transient( 'wc_stripe_processing_intent_' . $order_id );
 	}
 
@@ -1373,7 +1336,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return string                   The client secret of the intent, used for confirmation in JS.
 	 */
 	public function setup_intent( $order, $prepared_source ) {
-		$order_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id     = $order->get_id();
 		$setup_intent = WC_Stripe_API::request( array(
 			'payment_method' => $prepared_source->source,
 			'customer'       => $prepared_source->customer,
@@ -1383,12 +1346,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( is_wp_error( $setup_intent ) ) {
 			WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
 		} elseif ( 'requires_action' === $setup_intent->status ) {
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_setup_intent', $setup_intent->id );
-			} else {
-				$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
+			$order->save();
 
 			return $setup_intent->client_secret;
 		}
@@ -1452,7 +1411,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			? $intent->error->payment_intent
 			: $intent
 		);
-		$order_id       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id       = $order->get_id();
 		WC_Stripe_Logger::log( "Stripe PaymentIntent $intent_id initiated for order $order_id" );
 
 		// Save the intent ID to the order.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1233,30 +1233,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Retrieves the payment intent, associated with an order for WooCommerce < 3.0
-	 *
-	 * @param WC_Order $order The order to retrieve an intent for.
-	 * @return obect|bool     Either the intent object or `false`.
-	 */
-	private function pre_3_0_get_intent_from_order( $order ) {
-		$order_id  = $order->id;
-		$intent_id = get_post_meta( $order_id, '_stripe_intent_id', true );
-
-		if ( $intent_id ) {
-			return $this->get_intent( 'payment_intents', $intent_id );
-		}
-
-		// The order doesn't have a payment intent, but it may have a setup intent.
-		$intent_id = get_post_meta( $order_id, '_stripe_setup_intent', true );
-
-		if ( $intent_id ) {
-			return $this->get_intent( 'setup_intents', $intent_id );
-		}
-
-		return false;
-	}
-
-	/**
 	 * Retrieves intent from Stripe API by intent id.
 	 *
 	 * @param string $intent_type 	Either 'payment_intents' or 'setup_intents'.

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -148,14 +148,7 @@ class WC_Stripe_Admin_Notices {
 			}
 
 			if ( empty( $show_wcver_notice ) ) {
-				if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_MIN_WC_VER ) ) {
-					/* translators: 1) int version 2) int version */
-					$message = __( 'WooCommerce Stripe - The minimum WooCommerce version required for this plugin is %1$s. You are running %2$s.', 'woocommerce-gateway-stripe' );
-
-					$this->add_admin_notice( 'wcver', 'notice notice-warning', sprintf( $message, WC_STRIPE_MIN_WC_VER, WC_VERSION ), true );
-
-					return;
-				} elseif ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
+				if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
 					/* translators: 1) int version 2) int version */
 					$message = __( 'WooCommerce Stripe - This is the last version of the plugin compatible with WooCommerce %1$s. All furture versions of the plugin will require WooCommerce %2$s or greater.', 'woocommerce-gateway-stripe' );
 					$this->add_admin_notice( 'wcver', 'notice notice-warning', sprintf( $message, WC_VERSION, WC_STRIPE_FUTURE_MIN_WC_VER ), true );

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -325,11 +325,7 @@ class WC_Stripe_Admin_Notices {
 	 * @return string Setting link
 	 */
 	public function get_setting_link() {
-		$use_id_as_section = function_exists( 'WC' ) ? version_compare( WC()->version, '2.6', '>=' ) : false;
-
-		$section_slug = $use_id_as_section ? 'stripe' : strtolower( 'WC_Gateway_Stripe' );
-
-		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $section_slug );
+		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
 	}
 
 	/**

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -241,7 +241,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		if ( isset( $_GET['pay_for_order'] ) && ! empty( $_GET['key'] ) ) { // wpcs: csrf ok.
 			$order      = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) ); // wpcs: csrf ok, sanitization ok.
 			$total      = $order->get_total();
-			$user_email = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_email : $order->get_billing_email();
+			$user_email = $order->get_billing_email();
 		} else {
 			if ( $user->ID ) {
 				$user_email = get_user_meta( $user->ID, 'billing_email', true );
@@ -426,14 +426,14 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$order    = wc_get_order( $order_id );
 
 			if ( is_a( $order, 'WC_Order' ) ) {
-				$stripe_params['billing_first_name'] = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_first_name : $order->get_billing_first_name();
-				$stripe_params['billing_last_name']  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_last_name : $order->get_billing_last_name();
-				$stripe_params['billing_address_1']  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_address_1 : $order->get_billing_address_1();
-				$stripe_params['billing_address_2']  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_address_2 : $order->get_billing_address_2();
-				$stripe_params['billing_state']      = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_state : $order->get_billing_state();
-				$stripe_params['billing_city']       = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_city : $order->get_billing_city();
-				$stripe_params['billing_postcode']   = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_postcode : $order->get_billing_postcode();
-				$stripe_params['billing_country']    = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_country : $order->get_billing_country();
+				$stripe_params['billing_first_name'] = $order->get_billing_first_name();
+				$stripe_params['billing_last_name']  = $order->get_billing_last_name();
+				$stripe_params['billing_address_1']  = $order->get_billing_address_1();
+				$stripe_params['billing_address_2']  = $order->get_billing_address_2();
+				$stripe_params['billing_state']      = $order->get_billing_state();
+				$stripe_params['billing_city']       = $order->get_billing_city();
+				$stripe_params['billing_postcode']   = $order->get_billing_postcode();
+				$stripe_params['billing_country']    = $order->get_billing_country();
 			}
 		}
 
@@ -521,14 +521,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return false;
 		}
 
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			delete_user_option( $order->customer_user, '_stripe_customer_id' );
-			delete_post_meta( $order->get_id(), '_stripe_customer_id' );
-		} else {
-			delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
-			$order->delete_meta_data( '_stripe_customer_id' );
-			$order->save();
-		}
+		delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
+		$order->delete_meta_data( '_stripe_customer_id' );
+		$order->save();
 
 		return true;
 	}
@@ -1050,7 +1045,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @param WC_Order $order The order which is in a transitional state.
 	 */
 	public function verify_intent_after_checkout( $order ) {
-		$payment_method = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method();
+		$payment_method = $order->get_payment_method();
 		if ( $payment_method !== $this->id ) {
 			// If this is not the payment method, an intent would not be available.
 			return;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -27,8 +27,6 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = $order->get_id();
-
 		return $order->get_meta( self::META_NAME_STRIPE_CURRENCY, true );
 	}
 
@@ -44,8 +42,6 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = $order->get_id();
-
 		$order->update_meta_data( self::META_NAME_STRIPE_CURRENCY, $currency );
 	}
 
@@ -60,8 +56,6 @@ class WC_Stripe_Helper {
 		if ( is_null( $order ) ) {
 			return false;
 		}
-
-		$order_id = $order->get_id();
 
 		$amount = $order->get_meta( self::META_NAME_FEE, true );
 
@@ -89,8 +83,6 @@ class WC_Stripe_Helper {
 		if ( is_null( $order ) ) {
 			return false;
 		}
-
-		$order_id = $order->get_id();
 
 		$order->update_meta_data( self::META_NAME_FEE, $amount );
 	}
@@ -124,8 +116,6 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = $order->get_id();
-
 		$amount = $order->get_meta( self::META_NAME_NET, true );
 
 		// If not found let's check for legacy name.
@@ -152,8 +142,6 @@ class WC_Stripe_Helper {
 		if ( is_null( $order ) ) {
 			return false;
 		}
-
-		$order_id = $order->get_id();
 
 		$order->update_meta_data( self::META_NAME_NET, $amount );
 	}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -27,9 +27,9 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		return WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, self::META_NAME_STRIPE_CURRENCY, true ) : $order->get_meta( self::META_NAME_STRIPE_CURRENCY, true );
+		return $order->get_meta( self::META_NAME_STRIPE_CURRENCY, true );
 	}
 
 	/**
@@ -44,9 +44,9 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, self::META_NAME_STRIPE_CURRENCY, $currency ) : $order->update_meta_data( self::META_NAME_STRIPE_CURRENCY, $currency );
+		$order->update_meta_data( self::META_NAME_STRIPE_CURRENCY, $currency );
 	}
 
 	/**
@@ -61,13 +61,13 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		$amount = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, self::META_NAME_FEE, true ) : $order->get_meta( self::META_NAME_FEE, true );
+		$amount = $order->get_meta( self::META_NAME_FEE, true );
 
 		// If not found let's check for legacy name.
 		if ( empty( $amount ) ) {
-			$amount = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, self::LEGACY_META_NAME_FEE, true ) : $order->get_meta( self::LEGACY_META_NAME_FEE, true );
+			$amount = $order->get_meta( self::LEGACY_META_NAME_FEE, true );
 
 			// If found update to new name.
 			if ( $amount ) {
@@ -90,9 +90,9 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, self::META_NAME_FEE, $amount ) : $order->update_meta_data( self::META_NAME_FEE, $amount );
+		$order->update_meta_data( self::META_NAME_FEE, $amount );
 	}
 
 	/**
@@ -106,7 +106,7 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		delete_post_meta( $order_id, self::META_NAME_FEE );
 		delete_post_meta( $order_id, self::LEGACY_META_NAME_FEE );
@@ -124,13 +124,13 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		$amount = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, self::META_NAME_NET, true ) : $order->get_meta( self::META_NAME_NET, true );
+		$amount = $order->get_meta( self::META_NAME_NET, true );
 
 		// If not found let's check for legacy name.
 		if ( empty( $amount ) ) {
-			$amount = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, self::LEGACY_META_NAME_NET, true ) : $order->get_meta( self::LEGACY_META_NAME_NET, true );
+			$amount = $order->get_meta( self::LEGACY_META_NAME_NET, true );
 
 			// If found update to new name.
 			if ( $amount ) {
@@ -153,9 +153,9 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, self::META_NAME_NET, $amount ) : $order->update_meta_data( self::META_NAME_NET, $amount );
+		$order->update_meta_data( self::META_NAME_NET, $amount );
 	}
 
 	/**
@@ -169,7 +169,7 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		delete_post_meta( $order_id, self::META_NAME_NET );
 		delete_post_meta( $order_id, self::LEGACY_META_NAME_NET );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -355,20 +355,6 @@ class WC_Stripe_Helper {
 	}
 
 	/**
-	 * Check if WC version is pre 3.0.
-	 *
-	 * @todo Remove in the future.
-	 * @since 4.0.0
-	 * @deprecated 4.1.11
-	 * @return bool
-	 */
-	public static function is_pre_30() {
-		error_log( 'is_pre_30() function has been deprecated since 4.1.11. Please use is_wc_lt( $version ) instead.' );
-
-		return self::is_wc_lt( '3.0' );
-	}
-
-	/**
 	 * Checks if WC version is less than passed in version.
 	 *
 	 * @since 4.1.11

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -92,7 +92,7 @@ class WC_Stripe_Intent_Controller {
 			wc_add_notice( esc_html( $message ), 'error' );
 
 			$redirect_url = $woocommerce->cart->is_empty()
-				? get_permalink( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? woocommerce_get_page_id( 'shop' ) : wc_get_page_id( 'shop' ) )
+				? get_permalink( wc_get_page_id( 'shop' ) )
 				: wc_get_checkout_url();
 
 			$this->handle_error( $e, $redirect_url );

--- a/includes/class-wc-stripe-logger.php
+++ b/includes/class-wc-stripe-logger.php
@@ -27,11 +27,7 @@ class WC_Stripe_Logger {
 
 		if ( apply_filters( 'wc_stripe_logging', true, $message ) ) {
 			if ( empty( self::$logger ) ) {
-				if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-					self::$logger = new WC_Logger();
-				} else {
-					self::$logger = wc_get_logger();
-				}
+				self::$logger = wc_get_logger();
 			}
 
 			$settings = get_option( 'woocommerce_stripe_settings' );
@@ -57,11 +53,7 @@ class WC_Stripe_Logger {
 
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				self::$logger->add( self::WC_LOG_FILENAME, $log_entry );
-			} else {
-				self::$logger->debug( $log_entry, array( 'source' => self::WC_LOG_FILENAME ) );
-			}
+			self::$logger->debug( $log_entry, array( 'source' => self::WC_LOG_FILENAME ) );
 		}
 	}
 }

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -127,14 +127,9 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			if ( ! empty( $response->error ) ) {
 				// Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
 				if ( $this->is_no_such_customer_error( $response->error ) ) {
-					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-						delete_user_option( $order->customer_user, '_stripe_customer_id' );
-						delete_post_meta( $order_id, '_stripe_customer_id' );
-					} else {
-						delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
-						$order->delete_meta_data( '_stripe_customer_id' );
-						$order->save();
-					}
+					delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
+					$order->delete_meta_data( '_stripe_customer_id' );
+					$order->save();
 				}
 
 				if ( $this->is_no_such_token_error( $response->error ) && $prepared_source->token_id ) {
@@ -225,9 +220,9 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	public function capture_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		if ( 'stripe' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method() ) ) {
-			$charge             = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_transaction_id', true ) : $order->get_transaction_id();
-			$captured           = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_charge_captured', true ) : $order->get_meta( '_stripe_charge_captured', true );
+		if ( 'stripe' === $order->get_payment_method() ) {
+			$charge             = $order->get_transaction_id();
+			$captured           = $order->get_meta( '_stripe_charge_captured', true );
 			$is_stripe_captured = false;
 
 			if ( $charge && 'no' === $captured ) {
@@ -300,10 +295,10 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				if ( $is_stripe_captured ) {
 					/* translators: transaction id */
 					$order->add_order_note( sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $result->id ) );
-					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', 'yes' ) : $order->update_meta_data( '_stripe_charge_captured', 'yes' );
+					$order->update_meta_data( '_stripe_charge_captured', 'yes' );
 
 					// Store other data such as fees
-					WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $result->id ) : $order->set_transaction_id( $result->id );
+					$order->set_transaction_id( $result->id );
 
 					if ( is_callable( array( $order, 'save' ) ) ) {
 						$order->save();
@@ -328,10 +323,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	public function cancel_payment( $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		if ( 'stripe' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method() ) ) {
-			$captured = WC_Stripe_Helper::is_wc_lt( '3.0' )
-				? get_post_meta( $order_id, '_stripe_charge_captured', true )
-				: $order->get_meta( '_stripe_charge_captured', true );
+		if ( 'stripe' === $order->get_payment_method() ) {
+			$captured = $order->get_meta( '_stripe_charge_captured', true );
 			if ( 'no' === $captured ) {
 				$this->process_refund( $order_id );
 			}

--- a/includes/class-wc-stripe-sepa-payment-token.php
+++ b/includes/class-wc-stripe-sepa-payment-token.php
@@ -86,7 +86,7 @@ class WC_Payment_Token_SEPA extends WC_Payment_Token {
 	 * @return string Last 4 digits
 	 */
 	public function get_last4( $context = 'view' ) {
-		return WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $this->get_meta( 'last4' ) : $this->get_prop( 'last4', $context );
+		return $this->get_prop( 'last4', $context );
 	}
 
 	/**
@@ -96,6 +96,6 @@ class WC_Payment_Token_SEPA extends WC_Payment_Token {
 	 * @param string $last4
 	 */
 	public function set_last4( $last4 ) {
-		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $this->add_meta_data( 'last4', $last4, true ) : $this->set_prop( 'last4', $last4 );
+		$this->set_prop( 'last4', $last4 );
 	}
 }

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -166,7 +166,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id  = $order->get_id();
 		$source_id = $notification->data->object->id;
 
 		$is_pending_receiver = ( 'receiver' === $notification->data->object->flow );
@@ -202,14 +202,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			if ( ! empty( $response->error ) ) {
 				// Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
 				if ( $this->is_no_such_customer_error( $response->error ) ) {
-					if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-						delete_user_option( $order->customer_user, '_stripe_customer_id' );
-						delete_post_meta( $order_id, '_stripe_customer_id' );
-					} else {
-						delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
-						$order->delete_meta_data( '_stripe_customer_id' );
-						$order->save();
-					}
+					delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
+					$order->delete_meta_data( '_stripe_customer_id' );
+					$order->save();
 				}
 
 				if ( $this->is_no_such_token_error( $response->error ) && $prepared_source->token_id ) {
@@ -297,7 +292,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		do_action( 'wc_gateway_stripe_process_webhook_payment_error', $order, $notification );
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 		$this->send_failed_order_email( $order_id );
 	}
 
@@ -317,17 +312,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		if ( 'stripe' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method() ) ) {
-			$charge   = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_transaction_id', true ) : $order->get_transaction_id();
-			$captured = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_charge_captured', true ) : $order->get_meta( '_stripe_charge_captured', true );
+		if ( 'stripe' === $order->get_payment_method() ) {
+			$charge   = $order->get_transaction_id();
+			$captured = $order->get_meta( '_stripe_charge_captured', true );
 
 			if ( $charge && 'no' === $captured ) {
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_charge_captured', 'yes' ) : $order->update_meta_data( '_stripe_charge_captured', 'yes' );
+				$order->update_meta_data( '_stripe_charge_captured', 'yes' );
 
 				// Store other data such as fees
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $notification->data->object->id ) : $order->set_transaction_id( $notification->data->object->id );
+				$order->set_transaction_id( $notification->data->object->id );
 
 				if ( isset( $notification->data->object->balance_transaction ) ) {
 					$this->update_fees( $order, $notification->data->object->balance_transaction );
@@ -380,14 +375,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		if ( ! $order->has_status( 'on-hold' ) ) {
 			return;
 		}
 
 		// Store other data such as fees
-		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $notification->data->object->id ) : $order->set_transaction_id( $notification->data->object->id );
+		$order->set_transaction_id( $notification->data->object->id );
 
 		if ( isset( $notification->data->object->balance_transaction ) ) {
 			$this->update_fees( $order, $notification->data->object->balance_transaction );
@@ -418,7 +413,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		// If order status is already in failed status don't continue.
 		if ( $order->has_status( 'failed' ) ) {
@@ -479,12 +474,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		if ( 'stripe' === ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method() ) ) {
-			$charge    = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_transaction_id', true ) : $order->get_transaction_id();
-			$captured  = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_charge_captured', true ) : $order->get_meta( '_stripe_charge_captured', true );
-			$refund_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? get_post_meta( $order_id, '_stripe_refund_id', true ) : $order->get_meta( '_stripe_refund_id', true );
+		if ( 'stripe' === $order->get_payment_method() ) {
+			$charge    = $order->get_transaction_id();
+			$captured  = $order->get_meta( '_stripe_charge_captured', true );
+			$refund_id = $order->get_meta( '_stripe_refund_id', true );
 
 			// If the refund ID matches, don't continue to prevent double refunding.
 			if ( $notification->data->object->refunds->data[0]->id === $refund_id ) {
@@ -508,11 +503,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					WC_Stripe_Logger::log( $refund->get_error_message() );
 				}
 
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_stripe_refund_id', $notification->data->object->refunds->data[0]->id ) : $order->update_meta_data( '_stripe_refund_id', $notification->data->object->refunds->data[0]->id );
+				$order->update_meta_data( '_stripe_refund_id', $notification->data->object->refunds->data[0]->id );
 
 				$amount = wc_price( $notification->data->object->refunds->data[0]->amount / 100 );
 
-				if ( in_array( strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency() ), WC_Stripe_Helper::no_decimal_currencies() ) ) {
+				if ( in_array( strtolower( $order->get_currency() ), WC_Stripe_Helper::no_decimal_currencies() ) ) {
 					$amount = wc_price( $notification->data->object->refunds->data[0]->amount );
 				}
 
@@ -668,7 +663,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 		if ( 'payment_intent.succeeded' === $notification->type || 'payment_intent.amount_capturable_updated' === $notification->type ) {
 			$charge = end( $intent->charges->data );
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
@@ -709,7 +704,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 		if ( 'setup_intent.succeeded' === $notification->type ) {
 			WC_Stripe_Logger::log( "Stripe SetupIntent $intent->id succeeded for order $order_id" );
 			if ( WC_Stripe_Helper::is_pre_orders_exists() && WC_Pre_Orders_Order::order_contains_pre_order( $order ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -312,8 +312,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = $order->get_id();
-
 		if ( 'stripe' === $order->get_payment_method() ) {
 			$charge   = $order->get_transaction_id();
 			$captured = $order->get_meta( '_stripe_charge_captured', true );
@@ -375,8 +373,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order_id = $order->get_id();
-
 		if ( ! $order->has_status( 'on-hold' ) ) {
 			return;
 		}
@@ -412,8 +408,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
 			return;
 		}
-
-		$order_id = $order->get_id();
 
 		// If order status is already in failed status don't continue.
 		if ( $order->has_status( 'failed' ) ) {

--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -28,15 +28,9 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 	 * @param object $order
 	 */
 	public function remove_order_source_before_retry( $order ) {
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			delete_post_meta( $order->id, '_stripe_source_id' );
-			// For BW compat will remove in the future.
-			delete_post_meta( $order->id, '_stripe_card_id' );
-		} else {
-			$order->delete_meta_data( '_stripe_source_id' );
-			$order->delete_meta_data( '_stripe_card_id' );
-			$order->save();
-		}
+		$order->delete_meta_data( '_stripe_source_id' );
+		$order->delete_meta_data( '_stripe_card_id' );
+		$order->save();
 	}
 
 	/**
@@ -115,9 +109,9 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 			} else if ( $is_authentication_required ) {
 				$charge = end( $response->error->payment_intent->charges->data );
 				$id = $charge->id;
-				$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+				$order_id = $order->get_id();
 
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $id ) : $order->set_transaction_id( $id );
+				$order->set_transaction_id( $id );
 				$order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
 				if ( is_callable( array( $order, 'save' ) ) ) {
 					$order->save();

--- a/includes/compat/class-wc-stripe-pre-orders-compat.php
+++ b/includes/compat/class-wc-stripe-pre-orders-compat.php
@@ -109,7 +109,6 @@ class WC_Stripe_Pre_Orders_Compat extends WC_Stripe_Payment_Gateway {
 			} else if ( $is_authentication_required ) {
 				$charge = end( $response->error->payment_intent->charges->data );
 				$id = $charge->id;
-				$order_id = $order->get_id();
 
 				$order->set_transaction_id( $id );
 				$order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );

--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -128,7 +128,7 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	public function save_source_to_order( $order, $source ) {
 		parent::save_source_to_order( $order, $source );
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		// Also store it on the subscriptions being purchased or paid for in the order.
 		if ( function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order_id ) ) {
@@ -140,7 +140,7 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 		}
 
 		foreach ( $subscriptions as $subscription ) {
-			$subscription_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id();
+			$subscription_id = $subscription->get_id();
 			update_post_meta( $subscription_id, '_stripe_customer_id', $source->customer );
 			update_post_meta( $subscription_id, '_stripe_source_id', $source->source );
 		}
@@ -226,7 +226,7 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 				);
 			}
 
-			$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id();
+			$order_id = $renewal_order->get_id();
 
 			$this->ensure_subscription_has_customer_id( $order_id );
 
@@ -312,10 +312,10 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_resubscribe_meta( $resubscribe_order ) {
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_customer_id' );
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_source_id' );
+		delete_post_meta( $resubscribe_order->get_id(), '_stripe_customer_id' );
+		delete_post_meta( $resubscribe_order->get_id(), '_stripe_source_id' );
 		// For BW compat will remove in future
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_card_id' );
+		delete_post_meta( $resubscribe_order->get_id(), '_stripe_card_id' );
 		$this->delete_renewal_meta( $resubscribe_order );
 	}
 
@@ -340,14 +340,8 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @return void
 	 */
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			update_post_meta( $subscription->id, '_stripe_customer_id', $renewal_order->stripe_customer_id );
-			update_post_meta( $subscription->id, '_stripe_source_id', $renewal_order->stripe_source_id );
-
-		} else {
-			update_post_meta( $subscription->get_id(), '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
-			update_post_meta( $subscription->get_id(), '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
-		}
+		update_post_meta( $subscription->get_id(), '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
+		update_post_meta( $subscription->get_id(), '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
 	}
 
 	/**
@@ -360,20 +354,20 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @return array
 	 */
 	public function add_subscription_payment_meta( $payment_meta, $subscription ) {
-		$source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_source_id', true );
+		$source_id = get_post_meta( $subscription->get_id(), '_stripe_source_id', true );
 
 		// For BW compat will remove in future.
 		if ( empty( $source_id ) ) {
-			$source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_card_id', true );
+			$source_id = get_post_meta( $subscription->get_id(), '_stripe_card_id', true );
 
 			// Take this opportunity to update the key name.
-			WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $subscription->id, '_stripe_source_id', $source_id ) : update_post_meta( $subscription->get_id(), '_stripe_source_id', $source_id );
+			update_post_meta( $subscription->get_id(), '_stripe_source_id', $source_id );
 		}
 
 		$payment_meta[ $this->id ] = array(
 			'post_meta' => array(
 				'_stripe_customer_id' => array(
-					'value' => get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_customer_id', true ),
+					'value' => get_post_meta( $subscription->get_id(), '_stripe_customer_id', true ),
 					'label' => 'Stripe Customer ID',
 				),
 				'_stripe_source_id'   => array(
@@ -427,25 +421,25 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @return string the subscription payment method
 	 */
 	public function maybe_render_subscription_payment_method( $payment_method_to_display, $subscription ) {
-		$customer_user = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->customer_user : $subscription->get_customer_id();
+		$customer_user = $subscription->get_customer_id();
 
 		// bail for other payment methods
-		if ( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->payment_method : $subscription->get_payment_method() ) !== $this->id || ! $customer_user ) {
+		if ( $subscription->get_payment_method() !== $this->id || ! $customer_user ) {
 			return $payment_method_to_display;
 		}
 
-		$stripe_source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_source_id', true );
+		$stripe_source_id = get_post_meta( $subscription->get_id(), '_stripe_source_id', true );
 
 		// For BW compat will remove in future.
 		if ( empty( $stripe_source_id ) ) {
-			$stripe_source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_card_id', true );
+			$stripe_source_id = get_post_meta( $subscription->get_id(), '_stripe_card_id', true );
 
 			// Take this opportunity to update the key name.
-			WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $subscription->id, '_stripe_source_id', $stripe_source_id ) : update_post_meta( $subscription->get_id(), '_stripe_source_id', $stripe_source_id );
+			update_post_meta( $subscription->get_id(), '_stripe_source_id', $stripe_source_id );
 		}
 
 		$stripe_customer    = new WC_Stripe_Customer();
-		$stripe_customer_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_customer_id', true );
+		$stripe_customer_id = get_post_meta( $subscription->get_id(), '_stripe_customer_id', true );
 
 		// If we couldn't find a Stripe customer linked to the subscription, fallback to the user meta data.
 		if ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) {
@@ -464,15 +458,15 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 
 		// If we couldn't find a Stripe customer linked to the account, fallback to the order meta data.
 		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->order ) {
-			$stripe_customer_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_customer_id', true );
-			$stripe_source_id   = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_source_id', true );
+			$stripe_customer_id = get_post_meta( $subscription->get_parent_id(), '_stripe_customer_id', true );
+			$stripe_source_id   = get_post_meta( $subscription->get_parent_id(), '_stripe_source_id', true );
 
 			// For BW compat will remove in future.
 			if ( empty( $stripe_source_id ) ) {
-				$stripe_source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_card_id', true );
+				$stripe_source_id = get_post_meta( $subscription->get_parent_id(), '_stripe_card_id', true );
 
 				// Take this opportunity to update the key name.
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $subscription->order->id, '_stripe_source_id', $stripe_source_id ) : update_post_meta( $subscription->get_parent_id(), '_stripe_source_id', $stripe_source_id );
+				update_post_meta( $subscription->get_parent_id(), '_stripe_source_id', $stripe_source_id );
 			}
 		}
 

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -228,7 +228,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 				);
 			}
 
-			$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id();
+			$order_id = $renewal_order->get_id();
 
 			$this->ensure_subscription_has_customer_id( $order_id );
 
@@ -343,9 +343,9 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 				$charge = end( $response->error->payment_intent->charges->data );
 				$id = $charge->id;
-				$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id();
+				$order_id = $renewal_order->get_id();
 
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order_id, '_transaction_id', $id ) : $renewal_order->set_transaction_id( $id );
+				$renewal_order->set_transaction_id( $id );
 				$renewal_order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
 				if ( is_callable( array( $renewal_order, 'save' ) ) ) {
 					$renewal_order->save();
@@ -377,7 +377,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	public function save_source_to_order( $order, $source ) {
 		parent::save_source_to_order( $order, $source );
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		// Also store it on the subscriptions being purchased or paid for in the order
 		if ( function_exists( 'wcs_order_contains_subscription' ) && wcs_order_contains_subscription( $order_id ) ) {
@@ -389,7 +389,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		}
 
 		foreach ( $subscriptions as $subscription ) {
-			$subscription_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id();
+			$subscription_id = $subscription->get_id();
 			update_post_meta( $subscription_id, '_stripe_customer_id', $source->customer );
 			update_post_meta( $subscription_id, '_stripe_source_id', $source->source );
 		}
@@ -400,12 +400,12 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_resubscribe_meta( $resubscribe_order ) {
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_customer_id' );
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_source_id' );
+		delete_post_meta( $resubscribe_order->get_id(), '_stripe_customer_id' );
+		delete_post_meta( $resubscribe_order->get_id(), '_stripe_source_id' );
 		// For BW compat will remove in future
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_card_id' );
+		delete_post_meta( $resubscribe_order->get_id(), '_stripe_card_id' );
 		// delete payment intent ID
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $resubscribe_order->id : $resubscribe_order->get_id() ), '_stripe_intent_id' );
+		delete_post_meta( $resubscribe_order->get_id(), '_stripe_intent_id' );
 		$this->delete_renewal_meta( $resubscribe_order );
 	}
 
@@ -418,7 +418,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		WC_Stripe_Helper::delete_stripe_net( $renewal_order );
 
 		// delete payment intent ID
-		delete_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $renewal_order->id : $renewal_order->get_id() ), '_stripe_intent_id' );
+		delete_post_meta( $renewal_order->get_id(), '_stripe_intent_id' );
 
 		return $renewal_order;
 	}
@@ -433,14 +433,8 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 * @return void
 	 */
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			update_post_meta( $subscription->id, '_stripe_customer_id', $renewal_order->stripe_customer_id );
-			update_post_meta( $subscription->id, '_stripe_source_id', $renewal_order->stripe_source_id );
-
-		} else {
-			update_post_meta( $subscription->get_id(), '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
-			update_post_meta( $subscription->get_id(), '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
-		}
+		update_post_meta( $subscription->get_id(), '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
+		update_post_meta( $subscription->get_id(), '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
 	}
 
 	/**
@@ -453,7 +447,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 * @return array
 	 */
 	public function add_subscription_payment_meta( $payment_meta, $subscription ) {
-		$subscription_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id();
+		$subscription_id = $subscription->get_id();
 		$source_id       = get_post_meta( $subscription_id, '_stripe_source_id', true );
 
 		// For BW compat will remove in future.
@@ -524,25 +518,25 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 * @return string the subscription payment method
 	 */
 	public function maybe_render_subscription_payment_method( $payment_method_to_display, $subscription ) {
-		$customer_user = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->customer_user : $subscription->get_customer_id();
+		$customer_user = $subscription->get_customer_id();
 
 		// bail for other payment methods
-		if ( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->payment_method : $subscription->get_payment_method() ) !== $this->id || ! $customer_user ) {
+		if ( $subscription->get_payment_method() !== $this->id || ! $customer_user ) {
 			return $payment_method_to_display;
 		}
 
-		$stripe_source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_source_id', true );
+		$stripe_source_id = get_post_meta( $subscription->get_id(), '_stripe_source_id', true );
 
 		// For BW compat will remove in future.
 		if ( empty( $stripe_source_id ) ) {
-			$stripe_source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_card_id', true );
+			$stripe_source_id = get_post_meta( $subscription->get_id(), '_stripe_card_id', true );
 
 			// Take this opportunity to update the key name.
-			WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $subscription->id, '_stripe_source_id', $stripe_source_id ) : update_post_meta( $subscription->get_id(), '_stripe_source_id', $stripe_source_id );
+			update_post_meta( $subscription->get_id(), '_stripe_source_id', $stripe_source_id );
 		}
 
 		$stripe_customer    = new WC_Stripe_Customer();
-		$stripe_customer_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->id : $subscription->get_id() ), '_stripe_customer_id', true );
+		$stripe_customer_id = get_post_meta( $subscription->get_id(), '_stripe_customer_id', true );
 
 		// If we couldn't find a Stripe customer linked to the subscription, fallback to the user meta data.
 		if ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) {
@@ -561,15 +555,15 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 
 		// If we couldn't find a Stripe customer linked to the account, fallback to the order meta data.
 		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->order ) {
-			$stripe_customer_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_customer_id', true );
-			$stripe_source_id   = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_source_id', true );
+			$stripe_customer_id = get_post_meta( $subscription->get_parent_id(), '_stripe_customer_id', true );
+			$stripe_source_id   = get_post_meta( $subscription->get_parent_id(), '_stripe_source_id', true );
 
 			// For BW compat will remove in future.
 			if ( empty( $stripe_source_id ) ) {
-				$stripe_source_id = get_post_meta( ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $subscription->order->id : $subscription->get_parent_id() ), '_stripe_card_id', true );
+				$stripe_source_id = get_post_meta( $subscription->get_parent_id(), '_stripe_card_id', true );
 
 				// Take this opportunity to update the key name.
-				WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $subscription->order->id, '_stripe_source_id', $stripe_source_id ) : update_post_meta( $subscription->get_parent_id(), '_stripe_source_id', $stripe_source_id );
+				update_post_meta( $subscription->get_parent_id(), '_stripe_source_id', $stripe_source_id );
 			}
 		}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -212,7 +212,6 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 	 */
 	public function create_source( $order ) {
 		$currency              = $order->get_currency();
-		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -211,8 +211,8 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$order_id              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$currency              = $order->get_currency();
+		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -252,7 +252,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -265,12 +265,8 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to Alipay...' );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
@@ -205,7 +205,6 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 	 */
 	public function create_source( $order ) {
 		$currency                = $order->get_currency();
-		$order_id                = $order->get_id();
 		$return_url              = $this->get_stripe_return_url( $order );
 		$post_data               = array();
 		$post_data['amount']     = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );

--- a/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
@@ -204,8 +204,8 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency                = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$order_id                = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$currency                = $order->get_currency();
+		$order_id                = $order->get_id();
 		$return_url              = $this->get_stripe_return_url( $order );
 		$post_data               = array();
 		$post_data['amount']     = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -246,7 +246,7 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -259,12 +259,8 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to Bancontact...' );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-eps.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-eps.php
@@ -205,7 +205,6 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 	 */
 	public function create_source( $order ) {
 		$currency              = $order->get_currency();
-		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );

--- a/includes/payment-methods/class-wc-gateway-stripe-eps.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-eps.php
@@ -204,8 +204,8 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$order_id              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$currency              = $order->get_currency();
+		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -245,7 +245,7 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -258,12 +258,8 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 				throw new Exception( $response->error->message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to EPS...' );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-giropay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-giropay.php
@@ -205,7 +205,6 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 	 */
 	public function create_source( $order ) {
 		$currency              = $order->get_currency();
-		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );

--- a/includes/payment-methods/class-wc-gateway-stripe-giropay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-giropay.php
@@ -204,8 +204,8 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$order_id              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$currency              = $order->get_currency();
+		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -245,7 +245,7 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -258,12 +258,8 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to Giropay...' );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-ideal.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-ideal.php
@@ -205,7 +205,6 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 	 */
 	public function create_source( $order ) {
 		$currency              = $order->get_currency();
-		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );

--- a/includes/payment-methods/class-wc-gateway-stripe-ideal.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-ideal.php
@@ -204,8 +204,8 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$order_id              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$currency              = $order->get_currency();
+		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -245,7 +245,7 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -258,12 +258,8 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to iDeal...' );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -218,9 +218,9 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 * @param bool $plain_text
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
-		$payment_method = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->payment_method : $order->get_payment_method();
+		$payment_method = $order->get_payment_method();
 
 		if ( ! $sent_to_admin && 'stripe_multibanco' === $payment_method && $order->has_status( 'on-hold' ) ) {
 			WC_Stripe_Logger::log( 'Sending multibanco email for order #' . $order_id );
@@ -286,7 +286,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 			'reference' => $source_object->multibanco->reference,
 		);
 
-		$order_id = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$order_id = $order->get_id();
 
 		update_post_meta( $order_id, '_stripe_multibanco', $data );
 	}
@@ -300,8 +300,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$order_id              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$currency              = $order->get_currency();
+		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -341,7 +341,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -354,12 +354,8 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 				throw new Exception( $response->error->message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			$this->save_instructions( $order, $response );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -301,7 +301,6 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 */
 	public function create_source( $order ) {
 		$currency              = $order->get_currency();
-		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );

--- a/includes/payment-methods/class-wc-gateway-stripe-p24.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-p24.php
@@ -205,8 +205,8 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$order_id              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->id : $order->get_id();
+		$currency              = $order->get_currency();
+		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -242,7 +242,7 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -255,12 +255,8 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to P24...' );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-p24.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-p24.php
@@ -206,7 +206,6 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 	 */
 	public function create_source( $order ) {
 		$currency              = $order->get_currency();
-		$order_id              = $order->get_id();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -313,7 +313,7 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -337,14 +337,9 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 				if ( ! empty( $response->error ) ) {
 					// Customer param wrong? The user may have been deleted on stripe's end. Remove customer_id. Can be retried without.
 					if ( $this->is_no_such_customer_error( $response->error ) ) {
-						if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-							delete_user_option( $order->customer_user, '_stripe_customer_id' );
-							delete_post_meta( $order_id, '_stripe_customer_id' );
-						} else {
-							delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
-							$order->delete_meta_data( '_stripe_customer_id' );
-							$order->save();
-						}
+						delete_user_option( $order->get_customer_id(), '_stripe_customer_id' );
+						$order->delete_meta_data( '_stripe_customer_id' );
+						$order->save();
 					}
 
 					if ( $this->is_no_such_token_error( $response->error ) && $prepared_source->token_id ) {

--- a/includes/payment-methods/class-wc-gateway-stripe-sofort.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sofort.php
@@ -204,8 +204,8 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
-		$currency              = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->get_order_currency() : $order->get_currency();
-		$bank_country          = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->billing_country : $order->get_billing_country();
+		$currency              = $order->get_currency();
+		$bank_country          = $order->get_billing_country();
 		$return_url            = $this->get_stripe_return_url( $order );
 		$post_data             = array();
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -249,7 +249,7 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
 
 			if ( $create_account ) {
-				$new_customer_id     = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $order->customer_user : $order->get_customer_id();
+				$new_customer_id     = $order->get_customer_id();
 				$new_stripe_customer = new WC_Stripe_Customer( $new_customer_id );
 				$new_stripe_customer->create_customer();
 			}
@@ -270,12 +270,8 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 			}
 
-			if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-				update_post_meta( $order_id, '_stripe_source_id', $response->id );
-			} else {
-				$order->update_meta_data( '_stripe_source_id', $response->id );
-				$order->save();
-			}
+			$order->update_meta_data( '_stripe_source_id', $response->id );
+			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to SOFORT...' );
 

--- a/templates/emails/failed-preorder-authentication.php
+++ b/templates/emails/failed-preorder-authentication.php
@@ -7,9 +7,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php
-$pre_wc_30 = version_compare( WC_VERSION, '3.0', '<' );
-$billing_email = $pre_wc_30 ? $order->billing_email : $order->get_billing_email();
-$billing_phone = $pre_wc_30 ? $order->billing_phone : $order->get_billing_phone();
+$billing_email = $order->get_billing_email();
+$billing_phone = $order->get_billing_phone();
 
 ?>
 <p><?php

--- a/tests/phpunit/test-wc-stripe-level-3-data.php
+++ b/tests/phpunit/test-wc-stripe-level-3-data.php
@@ -6,13 +6,6 @@
 
 class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 	public function test_data_for_mutli_item_order() {
-		// Skip this test because of the complexity of creating products in WC pre-3.0.
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			// Dummy assertion.
-			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), true );
-			return;
-		}
-
 		$store_postcode = '90210';
 		update_option( 'woocommerce_store_postcode', $store_postcode );
 
@@ -93,13 +86,6 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 	}
 
 	public function test_non_us_shipping_zip_codes() {
-		// Skip this test because of the complexity of creating products in WC pre-3.0.
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			// Dummy assertion.
-			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), true );
-			return;
-		}
-
 		// Update the store with the right post code.
 		update_option( 'woocommerce_store_postcode', 1040 );
 
@@ -138,17 +124,5 @@ class WC_Stripe_level3_Data_Test extends WP_UnitTestCase {
 			),
 			$result
 		);
-	}
-
-	public function test_pre_30_postal_code_omission() {
-		if ( ! WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			// Dummy assertion.
-			$this->assertEquals( WC_Stripe_Helper::is_wc_lt( '3.0' ), false );
-			return;
-		}
-
-		$order = new WC_Order();
-		$gateway = new WC_Gateway_Stripe();
-		$this->assertEquals( array(), $gateway->get_level3_data_from_order( $order ) );
 	}
 }

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -26,7 +26,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	 * Helper function to update test order meta data
 	 */
 	private function updateOrderMeta( $order, $key, $value ) {
-		WC_Stripe_Helper::is_wc_lt( '3.0' ) ? update_post_meta( $order->id, $key, $value ) : $order->update_meta_data( $key, $value );
+		$order->update_meta_data( $key, $value );
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -69,22 +69,17 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 	 */
 	public function test_initial_intent_parameters() {
 		$initial_order        = WC_Helper_Order::create_order();
-		$order_id             = WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $initial_order->id : $initial_order->get_id();
+		$order_id             = $initial_order->get_id();
 		$stripe_amount        = WC_Stripe_Helper::get_stripe_amount( $initial_order->get_total() );
-		$currency             = strtolower( WC_Stripe_Helper::is_wc_lt( '3.0' ) ? $initial_order->get_order_currency() : $initial_order->get_currency() );
+		$currency             = strtolower( $initial_order->get_currency() );
 		$customer             = 'cus_123abc';
 		$source               = 'src_123abc';
 		$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $this->statement_descriptor );
 		$intents_api_endpoint = 'https://api.stripe.com/v1/payment_intents';
 		$urls_used            = array();
 
-		if ( WC_Stripe_Helper::is_wc_lt( '3.0' ) ) {
-			$initial_order->payment_method = 'stripe';
-			update_post_meta( $order_id, '_payment_method', 'stripe' ); // for `wc_get_order()`.
-		} else {
-			$initial_order->set_payment_method( 'stripe' );
-			$initial_order->save();
-		}
+		$initial_order->set_payment_method( 'stripe' );
+		$initial_order->save();
 
 		// Arrange: Mock prepare_source() so that we have a customer and source.
 		$this->wc_stripe_subs_compat
@@ -200,11 +195,7 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'redirect', $result );
 
 		$order      = wc_get_order( $order_id );
-		$order_data = (
-			WC_Stripe_Helper::is_wc_lt( '3.0' )
-				? get_post_meta( $order_id, '_stripe_intent_id', true )
-				: $order->get_meta( '_stripe_intent_id' )
-		);
+		$order_data = $order->get_meta( '_stripe_intent_id' );
 
 		$this->assertEquals( $order_data, 'pi_123abc' );
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -43,6 +43,17 @@ function woocommerce_stripe_missing_wc_notice() {
 	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-gateway-stripe' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
 }
 
+/**
+ * WooCommerce not supported fallback notice.
+ *
+ * @since 4.4.0
+ * @return string
+ */
+function woocommerce_stripe_wc_not_supported() {
+	/* translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version. */
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_STRIPE_MIN_WC_VER, WC_VERSION ) . '</strong></p></div>';
+}
+
 add_action( 'plugins_loaded', 'woocommerce_gateway_stripe_init' );
 
 function woocommerce_gateway_stripe_init() {
@@ -50,6 +61,11 @@ function woocommerce_gateway_stripe_init() {
 
 	if ( ! class_exists( 'WooCommerce' ) ) {
 		add_action( 'admin_notices', 'woocommerce_stripe_missing_wc_notice' );
+		return;
+	}
+
+	if ( version_compare( WC_VERSION, WC_STRIPE_MIN_WC_VER, '<' ) ) {
+		add_action( 'admin_notices', 'woocommerce_stripe_wc_not_supported' );
 		return;
 	}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -19,6 +19,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+/**
+ * Required minimums and constants
+ */
+define( 'WC_STRIPE_VERSION', '4.3.3' );
+define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
+define( 'WC_STRIPE_MIN_WC_VER', '2.6.0' );
+define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );
+define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
+define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
+define( 'WC_STRIPE_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
+
 // phpcs:disable WordPress.Files.FileName
 
 /**
@@ -43,16 +54,6 @@ function woocommerce_gateway_stripe_init() {
 	}
 
 	if ( ! class_exists( 'WC_Stripe' ) ) :
-		/**
-		 * Required minimums and constants
-		 */
-		define( 'WC_STRIPE_VERSION', '4.3.3' );
-		define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
-		define( 'WC_STRIPE_MIN_WC_VER', '2.6.0' );
-		define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );
-		define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
-		define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
-		define( 'WC_STRIPE_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 
 		class WC_Stripe {
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WC_STRIPE_VERSION', '4.3.3' );
 define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
-define( 'WC_STRIPE_MIN_WC_VER', '2.6.0' );
+define( 'WC_STRIPE_MIN_WC_VER', '3.0' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );


### PR DESCRIPTION
Fixes #833.

#### Changes proposed in this Pull Request:

- Display a non-dismissable banner that versions of WooCommerce less than 3.0 are no longer supported and block the plugin from loading when WooCommerce < 3.0
- Remove pre 3.0 compatibility code, including `pre_3_0_get_intent_from_order` and `is_pre_30` functions

*Header and docs will be updated by https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1183* 

#### Testing instructions:

**Using a pre 3.0 version of WC**
1. Make sure this notice is displayed
![image](https://user-images.githubusercontent.com/7714042/81440405-6109ec80-9146-11ea-997f-69bda81ab645.png)
2. Make sure the plugin is not loaded (it should not be available for checkout or be listed under WooCommerce > Settings > Payments)

**Using a post 3.0 version of WC**

1. Make sure the plugin is active
2. Check if automated tests are passing
3. Run purchases using subscriptions and different payment methods

