### PR TITLE
Allowing state abbreviations to be used in payment requests

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1053,7 +1053,7 @@ class WC_Stripe_Payment_Request {
 		 * In some versions of Chrome, state can be a full name. So we need
 		 * to convert that to abbreviation as WC is expecting that.
 		 */
-		if ( 2 < strlen( $state ) && ! empty( $wc_states ) ) {
+		if ( 2 < strlen( $state ) && ! empty( $wc_states ) && ! isset( $wc_states[ $state ] ) ) {
 			$state = array_search( ucwords( strtolower( $state ) ), $wc_states, true );
 		}
 


### PR DESCRIPTION
Fixes #1033 .

#### Changes proposed in this Pull Request:

The change is extremely small, but allows customers to use the abbreviation of their state when using payment requests. To understand this:

So far the request class was always expecting full state names, which would then get converted to the abbreviation. With this change, it will detect that the value is already an abbreviation and not try to convert it.

#### Testing instructions

Perfectly described in [the issue](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1033) by @dougaitken!