### PR TITLE
Display time of last webhook in settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** Changelog ***
+= 5.0.0 - 2021-xx-xx =
+* Add - Display time of last Stripe webhook in settings.
+
 = 4.9.0 - 2021-02-24 =
 * Fix    - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix    - Adding a SEPA payment method doesn't work.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -21,21 +21,72 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function display_admin_settings_webhook_description() {
 		/* translators: 1) webhook url */
-		$must_add = sprintf( __( 'You must add the following webhook endpoint <strong style="background-color:#ddd;">&nbsp;%s&nbsp;</strong> to your <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Stripe account settings</a> (if there isn\'t one already enabled). This will enable you to receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ), WC_Stripe_Helper::get_webhook_url() );
+		$description = sprintf( __( 'You must add the following webhook endpoint <strong style="background-color:#ddd;">&nbsp;%s&nbsp;</strong> to your <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Stripe account settings</a> (if there isn\'t one already enabled). This will enable you to receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ), WC_Stripe_Helper::get_webhook_url() );
 
-		$last_event_time = get_option( 'wc_stripe_last_event_time', null );
-		if ( $last_event_time ) {
-			$webhook_status = sprintf(
-				/* translators: 1) time of last event received */
-				__(
-					'Event time of last webhook received: %s',
-					'woocommerce-gateway-stripe'
-				),
-				date( 'Y-m-d H:i:s e', $last_event_time )
+		$webhook_status = $this->get_webhook_status_message();
+
+		return $description . '<br><br>' . $webhook_status;
+	}
+
+	/**
+	 * Gets the state of webhook processing in a human readable format.
+	 *
+	 * @since 4.4.2
+	 * @return string Details on recent webhook successes and failures.
+	 */
+	protected function get_webhook_status_message() {
+		$monitoring_began_at = WC_Stripe_Webhook_Handler::get_monitoring_began_at();
+		$last_success_at     = WC_Stripe_Webhook_Handler::get_last_webhook_success_at();
+		$last_failure_at     = WC_Stripe_Webhook_Handler::get_last_webhook_failure_at();
+		$last_error          = WC_Stripe_Webhook_Handler::get_last_error_reason();
+
+		$date_format = 'Y-m-d H:i:s e';
+
+		// Case 1 (Nominal case): Most recent = success
+		if ( last_success_at > $last_failure_at ) {
+			$message = sprintf(
+				/* translators: 1) date and time of last webhook received, e.g. 2020-06-28 10:30:50 UTC */
+				__( 'The most recent webhook, timestamped %s, was processed succesfully.', 'woocommerce-gateway-stripe' ),
+				date( $date_format, $last_success_at )
 			);
+			return $message;
 		}
 
-		return isset( $webhook_status ) ? $must_add . '<br><br>' . $webhook_status : $must_add;
+		// Case 2: No webhooks received yet
+		if ( ( 0 == $last_success_at ) && ( 0 == $last_failure_at ) ) {
+			$message = sprintf(
+				/* translators: 1) date and time webhook monitoring began, e.g. 2020-06-28 10:30:50 UTC */
+				__( 'No webhooks have been received since monitoring began at %s.', 'woocommerce-gateway-stripe' ),
+				date( $date_format, $monitoring_began_at )
+			);
+			return $message;
+		}
+
+		// Case 3: Failure after success
+		if ( $last_success_at > 0 ) {
+			$message = sprintf(
+				/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
+				/* translators: 2) reason webhook failed */
+				/* translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC */
+				__( 'Warning: The most recent webhook, received at %s, could not be processed. Reason: %s. (The last webhook to process successfully was timestamped %s.)', 'woocommerce-gateway-stripe' ),
+				date( $date_format, $last_failure_at ),
+				$last_error,
+				date( $date_format, $last_success_at )
+			);
+			return $message;
+		}
+
+		// Case 4: Failure with no prior success
+		$message = sprintf(
+			/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
+			/* translators: 2) reason webhook failed */
+			/* translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC */
+			__( 'Warning: The most recent webhook, received at %s, could not be processed. Reason: %s. (No webhooks have been processed successfully since monitoring began at %s.)', 'woocommerce-gateway-stripe' ),
+			date( $date_format, $last_failure_at ),
+			$last_error,
+			date( $date_format, $monitoring_began_at )
+		);
+		return $message;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -21,7 +21,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function display_admin_settings_webhook_description() {
 		/* translators: 1) webhook url */
-		$must_add = sprintf( __( 'You must add the following webhook endpoint <strong style="background-color:#ddd;">&nbsp;%s&nbsp;</strong> to your <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Stripe account settings</a>. This will enable you to receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ), WC_Stripe_Helper::get_webhook_url() );
+		$must_add = sprintf( __( 'You must add the following webhook endpoint <strong style="background-color:#ddd;">&nbsp;%s&nbsp;</strong> to your <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Stripe account settings</a> (if there isn\'t one already enabled). This will enable you to receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ), WC_Stripe_Helper::get_webhook_url() );
 
 		$last_event_time = get_option( 'wc_stripe_last_event_time', null );
 		if ( $last_event_time ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -43,7 +43,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$date_format = 'Y-m-d H:i:s e';
 
 		// Case 1 (Nominal case): Most recent = success
-		if ( last_success_at > $last_failure_at ) {
+		if ( $last_success_at > $last_failure_at ) {
 			$message = sprintf(
 				/* translators: 1) date and time of last webhook received, e.g. 2020-06-28 10:30:50 UTC */
 				__( 'The most recent webhook, timestamped %s, was processed succesfully.', 'woocommerce-gateway-stripe' ),

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -17,6 +17,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Displays the admin settings webhook description.
 	 *
 	 * @since 4.1.0
+	 * @version 5.0.0
 	 * @return mixed
 	 */
 	public function display_admin_settings_webhook_description() {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -21,7 +21,21 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function display_admin_settings_webhook_description() {
 		/* translators: 1) webhook url */
-		return sprintf( __( 'You must add the following webhook endpoint <strong style="background-color:#ddd;">&nbsp;%s&nbsp;</strong> to your <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Stripe account settings</a>. This will enable you to receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ), WC_Stripe_Helper::get_webhook_url() );
+		$must_add = sprintf( __( 'You must add the following webhook endpoint <strong style="background-color:#ddd;">&nbsp;%s&nbsp;</strong> to your <a href="https://dashboard.stripe.com/account/webhooks" target="_blank">Stripe account settings</a>. This will enable you to receive notifications on the charge statuses.', 'woocommerce-gateway-stripe' ), WC_Stripe_Helper::get_webhook_url() );
+
+		$last_event_time = get_option( 'wc_stripe_last_event_time', null );
+		if ( $last_event_time ) {
+			$webhook_status = sprintf(
+				/* translators: 1) time of last event received */
+				__(
+					'Event time of last webhook received: %s',
+					'woocommerce-gateway-stripe'
+				),
+				date( 'Y-m-d H:i:s e', $last_event_time )
+			);
+		}
+
+		return isset( $webhook_status ) ? $must_add . '<br><br>' . $webhook_status : $must_add;
 	}
 
 	/**

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -59,12 +59,6 @@ return apply_filters(
 			'default'     => __( 'Pay with your credit card via Stripe.', 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,
 		),
-		'webhook'                       => array(
-			'title'       => __( 'Webhook Endpoints', 'woocommerce-gateway-stripe' ),
-			'type'        => 'title',
-			/* translators: webhook URL */
-			'description' => $this->display_admin_settings_webhook_description(),
-		),
 		'api_credentials'               => array(
 			'title'       => __( 'Stripe Account Keys', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
@@ -92,13 +86,6 @@ return apply_filters(
 			'default'     => '',
 			'desc_tip'    => true,
 		),
-		'test_webhook_secret'           => array(
-			'title'       => __( 'Test Webhook Secret', 'woocommerce-gateway-stripe' ),
-			'type'        => 'password',
-			'description' => __( 'Get your webhook signing secret from the webhooks section in your stripe account.', 'woocommerce-gateway-stripe' ),
-			'default'     => '',
-			'desc_tip'    => true,
-		),
 		'publishable_key'               => array(
 			'title'       => __( 'Live Publishable Key', 'woocommerce-gateway-stripe' ),
 			'type'        => 'text',
@@ -110,6 +97,19 @@ return apply_filters(
 			'title'       => __( 'Live Secret Key', 'woocommerce-gateway-stripe' ),
 			'type'        => 'password',
 			'description' => __( 'Get your API keys from your stripe account. Invalid values will be rejected. Only values starting with "sk_live_" or "rk_live_" will be saved.', 'woocommerce-gateway-stripe' ),
+			'default'     => '',
+			'desc_tip'    => true,
+		),
+		'webhook'                       => array(
+			'title'       => __( 'Webhook Endpoints', 'woocommerce-gateway-stripe' ),
+			'type'        => 'title',
+			/* translators: webhook URL */
+			'description' => $this->display_admin_settings_webhook_description(),
+		),
+		'test_webhook_secret'           => array(
+			'title'       => __( 'Test Webhook Secret', 'woocommerce-gateway-stripe' ),
+			'type'        => 'password',
+			'description' => __( 'Get your webhook signing secret from the webhooks section in your stripe account.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -146,12 +146,12 @@ class WC_Stripe_Apple_Pay_Registration {
 
 		if ( ! file_exists( $well_known_dir ) ) {
 			if ( ! @mkdir( $well_known_dir, 0755 ) ) { // @codingStandardsIgnoreLine
-				return __( 'Unable to create domain association folder to domain root.', 'woocommerce-payments' );
+				return __( 'Unable to create domain association folder to domain root.', 'woocommerce-gateway-stripe' );
 			}
 		}
 
 		if ( ! @copy( WC_STRIPE_PLUGIN_PATH . '/' . self::DOMAIN_ASSOCIATION_FILE_NAME, $fullpath ) ) { // @codingStandardsIgnoreLine
-			return __( 'Unable to copy domain association file to domain root.', 'woocommerce-payments' );
+			return __( 'Unable to copy domain association file to domain root.', 'woocommerce-gateway-stripe' );
 		}
 	}
 
@@ -173,10 +173,10 @@ class WC_Stripe_Apple_Pay_Registration {
 			WC_Stripe_Logger::log(
 				'Error: ' . $error_message . ' ' .
 				/* translators: expected domain association file URL */
-				sprintf( __( 'To enable Apple Pay, domain association file must be hosted at %s.', 'woocommerce-payments' ), $url )
+				sprintf( __( 'To enable Apple Pay, domain association file must be hosted at %s.', 'woocommerce-gateway-stripe' ), $url )
 			);
 		} else {
-			WC_Stripe_Logger::log( __( 'Domain association file updated.', 'woocommerce-payments' ) );
+			WC_Stripe_Logger::log( __( 'Domain association file updated.', 'woocommerce-gateway-stripe' ) );
 		}
 	}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -10,19 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0.0
  */
 class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
-	const OPTION_MONITORING_BEGAN_AT = 'wc_stripe_webhook_monitoring_began_at';
-	const OPTION_LAST_SUCCESS_AT     = 'wc_stripe_webhook_last_success_at';
-	const OPTION_LAST_FAILURE_AT     = 'wc_stripe_webhook_last_failure_at';
-	const OPTION_LAST_ERROR          = 'wc_stripe_webhook_last_error';
-
-	const VALIDATION_SUCCEEDED                 = 'validation_succeeded';
-	const VALIDATION_FAILED_HEADERS_NULL       = 'headers_null';
-	const VALIDATION_FAILED_BODY_NULL          = 'body_null';
-	const VALIDATION_FAILED_USER_AGENT_INVALID = 'user_agent_invalid';
-	const VALIDATION_FAILED_SIGNATURE_INVALID  = 'signature_invalid';
-	const VALIDATION_FAILED_TIMESTAMP_MISMATCH = 'timestamp_out_of_range';
-	const VALIDATION_FAILED_SIGNATURE_MISMATCH = 'signature_mismatch';
-
 	/**
 	 * Delay of retries.
 	 *
@@ -62,7 +49,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// Get/set the time we began monitoring the health of webhooks by fetching it.
 		// This should be roughly the same as the activation time of the version of the
 		// plugin when this code first appears.
-		self::get_monitoring_began_at();
+		WC_Stripe_Webhook_State::get_monitoring_began_at();
 	}
 
 	/**
@@ -84,18 +71,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		// Validate it to make sure it is legit.
 		$validation_result = $this->validate_request( $request_headers, $request_body );
-		if ( self::VALIDATION_SUCCEEDED === $validation_result ) {
+		if ( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED === $validation_result ) {
 			$this->process_webhook( $request_body );
 
 			$notification = json_decode( $request_body );
-			update_option( self::OPTION_LAST_SUCCESS_AT, $notification->created );
+			WC_Stripe_Webhook_State::set_last_webhook_success_at( $notification->created );
 
 			status_header( 200 );
 			exit;
 		} else {
 			WC_Stripe_Logger::log( 'Incoming webhook failed validation: ' . print_r( $request_body, true ) );
-			update_option( self::OPTION_LAST_FAILURE_AT, current_time( 'timestamp', true ) );
-			update_option( self::OPTION_LAST_ERROR, $validation_result );
+			WC_Stripe_Webhook_State::set_last_webhook_failure_at( current_time( 'timestamp', true ) );
+			WC_Stripe_Webhook_State::set_last_error_reason( $validation_result );
 
 			status_header( 400 );
 			exit;
@@ -113,27 +100,27 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function validate_request( $request_headers = null, $request_body = null ) {
 		if ( null === $request_headers ) {
-			return self::VALIDATION_FAILED_HEADERS_NULL;
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_HEADERS_NULL;
 		}
 		if ( null === $request_body ) {
-			return self::VALIDATION_FAILED_BODY_NULL;
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_BODY_NULL;
 		}
 
 		if ( ! empty( $request_headers['USER-AGENT'] ) && ! preg_match( '/Stripe/', $request_headers['USER-AGENT'] ) ) {
-			return self::VALIDATION_FAILED_USER_AGENT_INVALID;
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_USER_AGENT_INVALID;
 		}
 
 		if ( ! empty( $this->secret ) ) {
 			// Check for a valid signature.
 			$signature_format = '/^t=(?P<timestamp>\d+)(?P<signatures>(,v\d+=[a-z0-9]+){1,2})$/';
 			if ( empty( $request_headers['STRIPE-SIGNATURE'] ) || ! preg_match( $signature_format, $request_headers['STRIPE-SIGNATURE'], $matches ) ) {
-				return self::VALIDATION_FAILED_SIGNATURE_INVALID;
+				return WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_INVALID;
 			}
 
 			// Verify the timestamp.
 			$timestamp = intval( $matches['timestamp'] );
 			if ( abs( $timestamp - time() ) > 5 * MINUTE_IN_SECONDS ) {
-				return self::VALIDATION_FAILED_TIMESTAMP_MISMATCH;
+				return WC_Stripe_Webhook_State::VALIDATION_FAILED_TIMESTAMP_MISMATCH;
 			}
 
 			// Generate the expected signature.
@@ -142,11 +129,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 			// Check if the expected signature is present.
 			if ( ! preg_match( '/,v\d+=' . preg_quote( $expected_signature, '/' ) . '/', $matches['signatures'] ) ) {
-				return self::VALIDATION_FAILED_SIGNATURE_MISMATCH;
+				return WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH;
 			}
 		}
 
-		return self::VALIDATION_SUCCEEDED;
+		return WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED;
 	}
 
 	/**
@@ -884,91 +871,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$this->process_setup_intent( $notification );
 
 		}
-	}
-
-	/**
-	 * Gets the timestamp the plugin first
-	 * started tracking webhook failure and successes.
-	 *
-	 * @since 4.4.2
-	 * @return integer UTC seconds since 1970.
-	 */
-	public static function get_monitoring_began_at() {
-		$monitoring_began_at = get_option( self::OPTION_MONITORING_BEGAN_AT, 0 );
-		if ( 0 == $monitoring_began_at ) {
-			$monitoring_began_at = current_time( 'timestamp', true );
-			update_option( self::OPTION_MONITORING_BEGAN_AT, $monitoring_began_at );
-
-			// Enforce database consistency. This should only be needed if the user
-			// has modified the database directly. We should not allow timestamps
-			// before monitoring began.
-			delete_option( self::OPTION_LAST_SUCCESS_AT );
-			delete_option( self::OPTION_LAST_FAILURE_AT );
-			delete_option( self::OPTION_LAST_ERROR );
-		}
-		return $monitoring_began_at;
-	}
-
-	/**
-	 * Gets the timestamp of the last successfully processed webhook,
-	 * or returns 0 if no webhook has ever been successfully processed.
-	 *
-	 * @since 4.4.2
-	 * @return integer UTC seconds since 1970 | 0.
-	 */
-	public static function get_last_webhook_success_at() {
-		return get_option( self::OPTION_LAST_SUCCESS_AT, 0 );
-	}
-
-	/**
-	 * Gets the timestamp of the last failed webhook,
-	 * or returns 0 if no webhook has ever failed to process.
-	 *
-	 * @since 4.4.2
-	 * @return integer UTC seconds since 1970 | 0.
-	 */
-	public static function get_last_webhook_failure_at() {
-		return get_option( self::OPTION_LAST_FAILURE_AT, 0 );
-	}
-
-	/**
-	 * Returns the localized reason the last webhook failed.
-	 *
-	 * @since 4.4.2
-	 * @return string Reason the last webhook failed.
-	 */
-	public static function get_last_error_reason() {
-		$last_error = get_option( self::OPTION_LAST_ERROR, false );
-
-		if ( ! $last_error ) {
-			return( __( 'No error', 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( self::VALIDATION_FAILED_BODY_NULL == $last_error ) {
-			return( __( 'The webhook was missing expected body', 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( self::VALIDATION_FAILED_HEADERS_NULL == $last_error ) {
-			return( __( 'The webhook was missing expected headers', 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( self::VALIDATION_FAILED_SIGNATURE_INVALID == $last_error ) {
-			return( __( 'The webhook signature was missing or was incorrectly formatted', 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( self::VALIDATION_FAILED_SIGNATURE_MISMATCH == $last_error ) {
-			return( __( 'The webhook was not signed with the expected signing secret', 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( self::VALIDATION_FAILED_TIMESTAMP_MISMATCH == $last_error ) {
-			return( __( 'The timestamp in the webhook differed more than five minutes from the site time', 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( self::VALIDATION_FAILED_USER_AGENT_INVALID == $last_error ) {
-			return( __( 'The webhook received did not come from Stripe', 'woocommerce-gateway-stripe' ) );
-		}
-
-		return( __( 'Unknown error.', 'woocommerce-gateway-stripe' ) );
 	}
 }
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -35,7 +35,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Constructor.
 	 *
 	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @version 5.0.0
 	 */
 	public function __construct() {
 		$this->retry_interval = 2;
@@ -56,7 +56,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Check incoming requests for Stripe Webhook data and process them.
 	 *
 	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @version 5.0.0
 	 */
 	public function check_for_webhook() {
 		if ( ( 'POST' !== $_SERVER['REQUEST_METHOD'] )
@@ -93,7 +93,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Verify the incoming webhook notification to make sure it is legit.
 	 *
 	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @version 5.0.0
 	 * @param string $request_headers The request headers from Stripe.
 	 * @param string $request_body The request body from Stripe.
 	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -98,12 +98,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param string $request_body The request body from Stripe.
 	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
 	 */
-	public function validate_request( $request_headers = null, $request_body = null ) {
-		if ( null === $request_headers ) {
-			return WC_Stripe_Webhook_State::VALIDATION_FAILED_HEADERS_NULL;
+	public function validate_request( $request_headers, $request_body ) {
+		if ( empty( $request_headers ) ) {
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_EMPTY_HEADERS;
 		}
-		if ( null === $request_body ) {
-			return WC_Stripe_Webhook_State::VALIDATION_FAILED_BODY_NULL;
+		if ( empty( $request_body ) ) {
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_EMPTY_BODY;
 		}
 
 		if ( ! empty( $request_headers['USER-AGENT'] ) && ! preg_match( '/Stripe/', $request_headers['USER-AGENT'] ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -67,6 +67,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// Validate it to make sure it is legit.
 		if ( $this->is_valid_request( $request_headers, $request_body ) ) {
 			$this->process_webhook( $request_body );
+
+			$notification = json_decode( $request_body );
+			update_option( 'wc_stripe_last_event_time', $notification->created );
+
 			status_header( 200 );
 			exit;
 		} else {

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -1,0 +1,242 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class WC_Stripe_Webhook_State.
+ *
+ * Tracks the most recent successful and unsuccessful webhooks in test and live modes.
+ * @since 4.4.2
+ */
+class WC_Stripe_Webhook_State {
+	const OPTION_LIVE_MONITORING_BEGAN_AT = 'wc_stripe_wh_monitor_began_at';
+	const OPTION_LIVE_LAST_SUCCESS_AT     = 'wc_stripe_wh_last_success_at';
+	const OPTION_LIVE_LAST_FAILURE_AT     = 'wc_stripe_wh_last_failure_at';
+	const OPTION_LIVE_LAST_ERROR          = 'wc_stripe_wh_last_error';
+
+	const OPTION_TEST_MONITORING_BEGAN_AT = 'wc_stripe_wh_test_monitor_began_at';
+	const OPTION_TEST_LAST_SUCCESS_AT     = 'wc_stripe_wh_test_last_success_at';
+	const OPTION_TEST_LAST_FAILURE_AT     = 'wc_stripe_wh_test_last_failure_at';
+	const OPTION_TEST_LAST_ERROR          = 'wc_stripe_wh_test_last_error';
+
+	const VALIDATION_SUCCEEDED                 = 'validation_succeeded';
+	const VALIDATION_FAILED_HEADERS_NULL       = 'headers_null';
+	const VALIDATION_FAILED_BODY_NULL          = 'body_null';
+	const VALIDATION_FAILED_USER_AGENT_INVALID = 'user_agent_invalid';
+	const VALIDATION_FAILED_SIGNATURE_INVALID  = 'signature_invalid';
+	const VALIDATION_FAILED_TIMESTAMP_MISMATCH = 'timestamp_out_of_range';
+	const VALIDATION_FAILED_SIGNATURE_MISMATCH = 'signature_mismatch';
+
+	/**
+	 * Gets whether Stripe is in test mode or not
+	 * 
+	 * @since 4.4.2
+	 * @return bool
+	 */
+	public static function get_testmode() {
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+		return ( ! empty( $stripe_settings['testmode'] ) && 'yes' === $stripe_settings['testmode'] ) ? true : false;
+	}
+
+	/**
+	 * Gets (and sets, if unset) the timestamp the plugin first
+	 * started tracking webhook failure and successes.
+	 *
+	 * @since 4.4.2
+	 * @return integer UTC seconds since 1970.
+	 */
+	public static function get_monitoring_began_at() {
+		$option = self::get_testmode() ? self::OPTION_TEST_MONITORING_BEGAN_AT : self::OPTION_LIVE_MONITORING_BEGAN_AT;
+		$monitoring_began_at = get_option( $option, 0 );
+		if ( 0 == $monitoring_began_at ) {
+			$monitoring_began_at = current_time( 'timestamp', true );
+			update_option( $option, $monitoring_began_at );
+
+			// Enforce database consistency. This should only be needed if the user
+			// has modified the database directly. We should not allow timestamps
+			// before monitoring began.
+			self::set_last_webhook_success_at( 0 );
+			self::set_last_webhook_failure_at( 0 );
+			self::set_last_error_reason( self::VALIDATION_SUCCEEDED );
+		}
+		return $monitoring_began_at;
+	}
+
+	/**
+	 * Sets the timestamp of the last successfully processed webhook.
+	 * 
+	 * @since 4.4.2
+	 * @param integer UTC seconds since 1970.
+	 */
+	public static function set_last_webhook_success_at( $timestamp ) {
+		$option = self::get_testmode() ? self::OPTION_TEST_LAST_SUCCESS_AT : self::OPTION_LIVE_LAST_SUCCESS_AT;
+		update_option( $option, $timestamp );
+	}
+
+	/**
+	 * Gets the timestamp of the last successfully processed webhook,
+	 * or returns 0 if no webhook has ever been successfully processed.
+	 *
+	 * @since 4.4.2
+	 * @return integer UTC seconds since 1970 | 0.
+	 */
+	public static function get_last_webhook_success_at() {
+		$option = self::get_testmode() ? self::OPTION_TEST_LAST_SUCCESS_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
+		return get_option( $option, 0 );
+	}
+
+	/**
+	 * Sets the timestamp of the last failed webhook.
+	 * 
+	 * @since 4.4.2
+	 * @param integer UTC seconds since 1970.
+	 */
+	public static function set_last_webhook_failure_at( $timestamp ) {
+		$option = self::get_testmode() ? self::OPTION_TEST_LAST_FAILURE_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
+		update_option( $option, $timestamp );
+	}
+
+	/**
+	 * Gets the timestamp of the last failed webhook,
+	 * or returns 0 if no webhook has ever failed to process.
+	 *
+	 * @since 4.4.2
+	 * @return integer UTC seconds since 1970 | 0.
+	 */
+	public static function get_last_webhook_failure_at() {
+		$option = self::get_testmode() ? self::OPTION_TEST_LAST_FAILURE_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
+		return get_option( $option, 0 );
+	}
+
+	/**
+	 * Sets the reason for the last failed webhook.
+	 * 
+	 * @since 4.4.2
+	 * @param string Reason code.
+	 * 
+	 */
+	public static function set_last_error_reason( $reason ) {
+		$option = self::get_testmode() ? self::OPTION_TEST_LAST_ERROR : self::OPTION_LIVE_LAST_ERROR;
+		update_option( $option, $reason );
+	}
+
+	/**
+	 * Returns the localized reason the last webhook failed.
+	 *
+	 * @since 4.4.2
+	 * @return string Reason the last webhook failed.
+	 */
+	public static function get_last_error_reason() {
+		$option = self::get_testmode() ? self::OPTION_TEST_LAST_ERROR : self::OPTION_LIVE_LAST_ERROR;
+		$last_error = get_option( $option, false );
+
+		if ( ! $last_error ) {
+			return( __( 'No error', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_BODY_NULL == $last_error ) {
+			return( __( 'The webhook was missing expected body', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_HEADERS_NULL == $last_error ) {
+			return( __( 'The webhook was missing expected headers', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_SIGNATURE_INVALID == $last_error ) {
+			return( __( 'The webhook signature was missing or was incorrectly formatted', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_SIGNATURE_MISMATCH == $last_error ) {
+			return( __( 'The webhook was not signed with the expected signing secret', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_TIMESTAMP_MISMATCH == $last_error ) {
+			return( __( 'The timestamp in the webhook differed more than five minutes from the site time', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_USER_AGENT_INVALID == $last_error ) {
+			return( __( 'The webhook received did not come from Stripe', 'woocommerce-gateway-stripe' ) );
+		}
+
+		return( __( 'Unknown error.', 'woocommerce-gateway-stripe' ) );
+	}
+
+	/**
+	 * Gets the state of webhook processing in a human readable format.
+	 *
+	 * @since 4.4.2
+	 * @return string Details on recent webhook successes and failures.
+	 */
+	public static function get_webhook_status_message() {
+		$monitoring_began_at = self::get_monitoring_began_at();
+		$last_success_at     = self::get_last_webhook_success_at();
+		$last_failure_at     = self::get_last_webhook_failure_at();
+		$last_error          = self::get_last_error_reason();
+		$test_mode           = self::get_testmode();
+
+		$date_format = 'Y-m-d H:i:s e';
+
+		// Case 1 (Nominal case): Most recent = success
+		if ( $last_success_at > $last_failure_at ) {
+			$message = sprintf(
+				$test_mode ?
+					/* translators: 1) date and time of last webhook received, e.g. 2020-06-28 10:30:50 UTC */
+					__( 'The most recent test webhook, timestamped %s, was processed successfully.', 'woocommerce-gateway-stripe' ) :
+					/* translators: 1) date and time of last webhook received, e.g. 2020-06-28 10:30:50 UTC */
+					__( 'The most recent live webhook, timestamped %s, was processed successfully.', 'woocommerce-gateway-stripe' ),
+				date( $date_format, $last_success_at )
+			);
+			return $message;
+		}
+
+		// Case 2: No webhooks received yet
+		if ( ( 0 == $last_success_at ) && ( 0 == $last_failure_at ) ) {
+			$message = sprintf(
+				$test_mode ?
+					/* translators: 1) date and time webhook monitoring began, e.g. 2020-06-28 10:30:50 UTC */
+					__( 'No test webhooks have been received since monitoring began at %s.', 'woocommerce-gateway-stripe' ) :
+					/* translators: 1) date and time webhook monitoring began, e.g. 2020-06-28 10:30:50 UTC */
+					__( 'No live webhooks have been received since monitoring began at %s.', 'woocommerce-gateway-stripe' ),
+				date( $date_format, $monitoring_began_at )
+			);
+			return $message;
+		}
+
+		// Case 3: Failure after success
+		if ( $last_success_at > 0 ) {
+			$message = sprintf(
+				$test_mode ?
+					/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
+					/* translators: 2) reason webhook failed */
+					/* translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC */
+					__( 'Warning: The most recent test webhook, received at %s, could not be processed. Reason: %s. (The last test webhook to process successfully was timestamped %s.)', 'woocommerce-gateway-stripe' ) :
+					/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
+					/* translators: 2) reason webhook failed */
+					/* translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC */
+					__( 'Warning: The most recent live webhook, received at %s, could not be processed. Reason: %s. (The last live webhook to process successfully was timestamped %s.)', 'woocommerce-gateway-stripe' ),
+				date( $date_format, $last_failure_at ),
+				$last_error,
+				date( $date_format, $last_success_at )
+			);
+			return $message;
+		}
+
+		// Case 4: Failure with no prior success
+		$message = sprintf(
+			$test_mode ?
+				/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
+				/* translators: 2) reason webhook failed */
+				/* translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC */
+				__( 'Warning: The most recent test webhook, received at %s, could not be processed. Reason: %s. (No test webhooks have been processed successfully since monitoring began at %s.)', 'woocommerce-gateway-stripe' ) :
+				/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
+				/* translators: 2) reason webhook failed */
+				/* translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC */
+				__( 'Warning: The most recent live webhook, received at %s, could not be processed. Reason: %s. (No live webhooks have been processed successfully since monitoring began at %s.)', 'woocommerce-gateway-stripe' ),
+			date( $date_format, $last_failure_at ),
+			$last_error,
+			date( $date_format, $monitoring_began_at )
+		);
+		return $message;
+	}
+};

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -30,7 +30,7 @@ class WC_Stripe_Webhook_State {
 
 	/**
 	 * Gets whether Stripe is in test mode or not
-	 * 
+	 *
 	 * @since 4.4.2
 	 * @return bool
 	 */
@@ -65,7 +65,7 @@ class WC_Stripe_Webhook_State {
 
 	/**
 	 * Sets the timestamp of the last successfully processed webhook.
-	 * 
+	 *
 	 * @since 4.4.2
 	 * @param integer UTC seconds since 1970.
 	 */
@@ -82,13 +82,13 @@ class WC_Stripe_Webhook_State {
 	 * @return integer UTC seconds since 1970 | 0.
 	 */
 	public static function get_last_webhook_success_at() {
-		$option = self::get_testmode() ? self::OPTION_TEST_LAST_SUCCESS_AT : self::OPTION_LIVE_LAST_FAILURE_AT;
+		$option = self::get_testmode() ? self::OPTION_TEST_LAST_SUCCESS_AT : self::OPTION_LIVE_LAST_SUCCESS_AT;
 		return get_option( $option, 0 );
 	}
 
 	/**
 	 * Sets the timestamp of the last failed webhook.
-	 * 
+	 *
 	 * @since 4.4.2
 	 * @param integer UTC seconds since 1970.
 	 */
@@ -111,10 +111,10 @@ class WC_Stripe_Webhook_State {
 
 	/**
 	 * Sets the reason for the last failed webhook.
-	 * 
+	 *
 	 * @since 4.4.2
 	 * @param string Reason code.
-	 * 
+	 *
 	 */
 	public static function set_last_error_reason( $reason ) {
 		$option = self::get_testmode() ? self::OPTION_TEST_LAST_ERROR : self::OPTION_LIVE_LAST_ERROR;

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -131,32 +131,32 @@ class WC_Stripe_Webhook_State {
 		$option = self::get_testmode() ? self::OPTION_TEST_LAST_ERROR : self::OPTION_LIVE_LAST_ERROR;
 		$last_error = get_option( $option, false );
 
-		if ( ! $last_error ) {
+		if ( self::VALIDATION_SUCCEEDED == $last_error ) {
 			return( __( 'No error', 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( self::VALIDATION_FAILED_EMPTY_BODY == $last_error ) {
-			return( __( 'The webhook was missing expected body', 'woocommerce-gateway-stripe' ) );
 		}
 
 		if ( self::VALIDATION_FAILED_EMPTY_HEADERS == $last_error ) {
 			return( __( 'The webhook was missing expected headers', 'woocommerce-gateway-stripe' ) );
 		}
 
-		if ( self::VALIDATION_FAILED_SIGNATURE_INVALID == $last_error ) {
-			return( __( 'The webhook signature was missing or was incorrectly formatted', 'woocommerce-gateway-stripe' ) );
+		if ( self::VALIDATION_FAILED_EMPTY_BODY == $last_error ) {
+			return( __( 'The webhook was missing expected body', 'woocommerce-gateway-stripe' ) );
 		}
 
-		if ( self::VALIDATION_FAILED_SIGNATURE_MISMATCH == $last_error ) {
-			return( __( 'The webhook was not signed with the expected signing secret', 'woocommerce-gateway-stripe' ) );
+		if ( self::VALIDATION_FAILED_USER_AGENT_INVALID == $last_error ) {
+			return( __( 'The webhook received did not come from Stripe', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_SIGNATURE_INVALID == $last_error ) {
+			return( __( 'The webhook signature was missing or was incorrectly formatted', 'woocommerce-gateway-stripe' ) );
 		}
 
 		if ( self::VALIDATION_FAILED_TIMESTAMP_MISMATCH == $last_error ) {
 			return( __( 'The timestamp in the webhook differed more than five minutes from the site time', 'woocommerce-gateway-stripe' ) );
 		}
 
-		if ( self::VALIDATION_FAILED_USER_AGENT_INVALID == $last_error ) {
-			return( __( 'The webhook received did not come from Stripe', 'woocommerce-gateway-stripe' ) );
+		if ( self::VALIDATION_FAILED_SIGNATURE_MISMATCH == $last_error ) {
+			return( __( 'The webhook was not signed with the expected signing secret', 'woocommerce-gateway-stripe' ) );
 		}
 
 		return( __( 'Unknown error.', 'woocommerce-gateway-stripe' ) );

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -21,8 +21,8 @@ class WC_Stripe_Webhook_State {
 	const OPTION_TEST_LAST_ERROR          = 'wc_stripe_wh_test_last_error';
 
 	const VALIDATION_SUCCEEDED                 = 'validation_succeeded';
-	const VALIDATION_FAILED_HEADERS_NULL       = 'headers_null';
-	const VALIDATION_FAILED_BODY_NULL          = 'body_null';
+	const VALIDATION_FAILED_EMPTY_HEADERS      = 'empty_headers';
+	const VALIDATION_FAILED_EMPTY_BODY         = 'empty_body';
 	const VALIDATION_FAILED_USER_AGENT_INVALID = 'user_agent_invalid';
 	const VALIDATION_FAILED_SIGNATURE_INVALID  = 'signature_invalid';
 	const VALIDATION_FAILED_TIMESTAMP_MISMATCH = 'timestamp_out_of_range';
@@ -135,11 +135,11 @@ class WC_Stripe_Webhook_State {
 			return( __( 'No error', 'woocommerce-gateway-stripe' ) );
 		}
 
-		if ( self::VALIDATION_FAILED_BODY_NULL == $last_error ) {
+		if ( self::VALIDATION_FAILED_EMPTY_BODY == $last_error ) {
 			return( __( 'The webhook was missing expected body', 'woocommerce-gateway-stripe' ) );
 		}
 
-		if ( self::VALIDATION_FAILED_HEADERS_NULL == $last_error ) {
+		if ( self::VALIDATION_FAILED_EMPTY_HEADERS == $last_error ) {
 			return( __( 'The webhook was missing expected headers', 'woocommerce-gateway-stripe' ) );
 		}
 

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -207,13 +207,17 @@ class WC_Stripe_Webhook_State {
 		if ( $last_success_at > 0 ) {
 			$message = sprintf(
 				$test_mode ?
-					/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
-					/* translators: 2) reason webhook failed */
-					/* translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC */
+					/*
+					 * translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
+					 * translators: 2) reason webhook failed
+					 * translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
+					 */
 					__( 'Warning: The most recent test webhook, received at %s, could not be processed. Reason: %s. (The last test webhook to process successfully was timestamped %s.)', 'woocommerce-gateway-stripe' ) :
-					/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
-					/* translators: 2) reason webhook failed */
-					/* translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC */
+					/*
+					 * translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
+					 * translators: 2) reason webhook failed
+					 * translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
+					 */
 					__( 'Warning: The most recent live webhook, received at %s, could not be processed. Reason: %s. (The last live webhook to process successfully was timestamped %s.)', 'woocommerce-gateway-stripe' ),
 				date( $date_format, $last_failure_at ),
 				$last_error,
@@ -225,13 +229,15 @@ class WC_Stripe_Webhook_State {
 		// Case 4: Failure with no prior success
 		$message = sprintf(
 			$test_mode ?
-				/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
-				/* translators: 2) reason webhook failed */
-				/* translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC */
+				/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
+				 * translators: 2) reason webhook failed
+				 * translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
+				 */
 				__( 'Warning: The most recent test webhook, received at %s, could not be processed. Reason: %s. (No test webhooks have been processed successfully since monitoring began at %s.)', 'woocommerce-gateway-stripe' ) :
-				/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC */
-				/* translators: 2) reason webhook failed */
-				/* translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC */
+				/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
+				 * translators: 2) reason webhook failed
+				 * translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
+				 */
 				__( 'Warning: The most recent live webhook, received at %s, could not be processed. Reason: %s. (No live webhooks have been processed successfully since monitoring began at %s.)', 'woocommerce-gateway-stripe' ),
 			date( $date_format, $last_failure_at ),
 			$last_error,

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class WC_Stripe_Webhook_State.
  *
  * Tracks the most recent successful and unsuccessful webhooks in test and live modes.
- * @since 4.4.2
+ * @since 5.0.0
  */
 class WC_Stripe_Webhook_State {
 	const OPTION_LIVE_MONITORING_BEGAN_AT = 'wc_stripe_wh_monitor_began_at';
@@ -31,7 +31,7 @@ class WC_Stripe_Webhook_State {
 	/**
 	 * Gets whether Stripe is in test mode or not
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @return bool
 	 */
 	public static function get_testmode() {
@@ -43,7 +43,7 @@ class WC_Stripe_Webhook_State {
 	 * Gets (and sets, if unset) the timestamp the plugin first
 	 * started tracking webhook failure and successes.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @return integer UTC seconds since 1970.
 	 */
 	public static function get_monitoring_began_at() {
@@ -66,7 +66,7 @@ class WC_Stripe_Webhook_State {
 	/**
 	 * Sets the timestamp of the last successfully processed webhook.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @param integer UTC seconds since 1970.
 	 */
 	public static function set_last_webhook_success_at( $timestamp ) {
@@ -78,7 +78,7 @@ class WC_Stripe_Webhook_State {
 	 * Gets the timestamp of the last successfully processed webhook,
 	 * or returns 0 if no webhook has ever been successfully processed.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @return integer UTC seconds since 1970 | 0.
 	 */
 	public static function get_last_webhook_success_at() {
@@ -89,7 +89,7 @@ class WC_Stripe_Webhook_State {
 	/**
 	 * Sets the timestamp of the last failed webhook.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @param integer UTC seconds since 1970.
 	 */
 	public static function set_last_webhook_failure_at( $timestamp ) {
@@ -101,7 +101,7 @@ class WC_Stripe_Webhook_State {
 	 * Gets the timestamp of the last failed webhook,
 	 * or returns 0 if no webhook has ever failed to process.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @return integer UTC seconds since 1970 | 0.
 	 */
 	public static function get_last_webhook_failure_at() {
@@ -112,7 +112,7 @@ class WC_Stripe_Webhook_State {
 	/**
 	 * Sets the reason for the last failed webhook.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @param string Reason code.
 	 *
 	 */
@@ -124,7 +124,7 @@ class WC_Stripe_Webhook_State {
 	/**
 	 * Returns the localized reason the last webhook failed.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @return string Reason the last webhook failed.
 	 */
 	public static function get_last_error_reason() {
@@ -165,7 +165,7 @@ class WC_Stripe_Webhook_State {
 	/**
 	 * Gets the state of webhook processing in a human readable format.
 	 *
-	 * @since 4.4.2
+	 * @since 5.0.0
 	 * @return string Details on recent webhook successes and failures.
 	 */
 	public static function get_webhook_status_message() {

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -20,11 +20,41 @@ msgid ""
 "You must add the following webhook endpoint <strong "
 "style=\"background-color:#ddd;\">&nbsp;%s&nbsp;</strong> to your <a "
 "href=\"https://dashboard.stripe.com/account/webhooks\" "
-"target=\"_blank\">Stripe account settings</a>. This will enable you to "
-"receive notifications on the charge statuses."
+"target=\"_blank\">Stripe account settings</a> (if there isn't one already "
+"enabled). This will enable you to receive notifications on the charge "
+"statuses."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:39
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:49
+#. translators: 1) date and time of last webhook received, e.g. 2020-06-28
+#. 10:30:50 UTC
+msgid "The most recent webhook, timestamped %s, was processed succesfully."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:59
+#. translators: 1) date and time webhook monitoring began, e.g. 2020-06-28
+#. 10:30:50 UTC
+msgid "No webhooks have been received since monitoring began at %s."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:71
+#. translators: 3) date and time of last successful webhook e.g. 2020-05-28
+#. 10:30:50 UTC
+msgid ""
+"Warning: The most recent webhook, received at %s, could not be processed. "
+"Reason: %s. (The last webhook to process successfully was timestamped %s.)"
+msgstr ""
+
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:84
+#. translators: 3) date and time webhook monitoring began e.g. 2020-05-28
+#. 10:30:50 UTC
+msgid ""
+"Warning: The most recent webhook, received at %s, could not be processed. "
+"Reason: %s. (No webhooks have been processed successfully since monitoring "
+"began at %s.)"
+msgstr ""
+
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:104
 msgid "Save payment information to my account for future purchases."
 msgstr ""
 
@@ -36,7 +66,7 @@ msgstr ""
 msgid "Sorry, the minimum allowed order total is %1$s to use this payment method."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:338
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:403
 #. translators: 1) blog name 2) order number
 msgid "%1$s - Order %2$s"
 msgstr ""
@@ -1277,6 +1307,40 @@ msgstr ""
 #: includes/class-wc-stripe-webhook-handler.php:631
 #. translators: 1) The reason type.
 msgid "The opened review for this order is now closed. Reason: (%s)"
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:865
+msgid "No error."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:869
+msgid "The webhook was missing expected body."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:873
+msgid "The webhook was missing expected headers."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:877
+msgid "The webhook signature was missing or was incorrectly formatted."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:881
+msgid "The webhook signature received did not match expected signature."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:885
+msgid ""
+"The timestamp in the webhook differed more than five minutes from the site "
+"time."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:889
+msgid "The webhook received did not come from Stripe."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:892
+msgid "Unknown error."
 msgstr ""
 
 #: includes/compat/class-wc-stripe-email-failed-authentication-retry.php:29

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -25,36 +25,7 @@ msgid ""
 "statuses."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:49
-#. translators: 1) date and time of last webhook received, e.g. 2020-06-28
-#. 10:30:50 UTC
-msgid "The most recent webhook, timestamped %s, was processed succesfully."
-msgstr ""
-
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:59
-#. translators: 1) date and time webhook monitoring began, e.g. 2020-06-28
-#. 10:30:50 UTC
-msgid "No webhooks have been received since monitoring began at %s."
-msgstr ""
-
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:71
-#. translators: 3) date and time of last successful webhook e.g. 2020-05-28
-#. 10:30:50 UTC
-msgid ""
-"Warning: The most recent webhook, received at %s, could not be processed. "
-"Reason: %s. (The last webhook to process successfully was timestamped %s.)"
-msgstr ""
-
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:84
-#. translators: 3) date and time webhook monitoring began e.g. 2020-05-28
-#. 10:30:50 UTC
-msgid ""
-"Warning: The most recent webhook, received at %s, could not be processed. "
-"Reason: %s. (No webhooks have been processed successfully since monitoring "
-"began at %s.)"
-msgstr ""
-
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:104
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:43
 msgid "Save payment information to my account for future purchases."
 msgstr ""
 
@@ -66,7 +37,7 @@ msgstr ""
 msgid "Sorry, the minimum allowed order total is %1$s to use this payment method."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:403
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:342
 #. translators: 1) blog name 2) order number
 msgid "%1$s - Order %2$s"
 msgstr ""
@@ -1309,38 +1280,98 @@ msgstr ""
 msgid "The opened review for this order is now closed. Reason: (%s)"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:865
-msgid "No error."
+#: includes/class-wc-stripe-webhook-state.php:135
+msgid "No error"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:869
-msgid "The webhook was missing expected body."
+#: includes/class-wc-stripe-webhook-state.php:139
+msgid "The webhook was missing expected body"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:873
-msgid "The webhook was missing expected headers."
+#: includes/class-wc-stripe-webhook-state.php:143
+msgid "The webhook was missing expected headers"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:877
-msgid "The webhook signature was missing or was incorrectly formatted."
+#: includes/class-wc-stripe-webhook-state.php:147
+msgid "The webhook signature was missing or was incorrectly formatted"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:881
-msgid "The webhook signature received did not match expected signature."
+#: includes/class-wc-stripe-webhook-state.php:151
+msgid "The webhook was not signed with the expected signing secret"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:885
+#: includes/class-wc-stripe-webhook-state.php:155
 msgid ""
 "The timestamp in the webhook differed more than five minutes from the site "
-"time."
+"time"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:889
-msgid "The webhook received did not come from Stripe."
+#: includes/class-wc-stripe-webhook-state.php:159
+msgid "The webhook received did not come from Stripe"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:892
+#: includes/class-wc-stripe-webhook-state.php:162
 msgid "Unknown error."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:185
+#. translators: 1) date and time of last webhook received, e.g. 2020-06-28
+#. 10:30:50 UTC
+msgid "The most recent test webhook, timestamped %s, was processed succesfully."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:187
+#. translators: 1) date and time of last webhook received, e.g. 2020-06-28
+#. 10:30:50 UTC
+msgid "The most recent live webhook, timestamped %s, was processed succesfully."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:199
+#. translators: 1) date and time webhook monitoring began, e.g. 2020-06-28
+#. 10:30:50 UTC
+msgid "No test webhooks have been received since monitoring began at %s."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:201
+#. translators: 1) date and time webhook monitoring began, e.g. 2020-06-28
+#. 10:30:50 UTC
+msgid "No live webhooks have been received since monitoring began at %s."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:214
+#. translators: 3) date and time of last successful webhook e.g. 2020-05-28
+#. 10:30:50 UTC
+msgid ""
+"Warning: The most recent test webhook, received at %s, could not be "
+"processed. Reason: %s. (The last test webhook to process successfully was "
+"timestamped %s.)"
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:218
+#. translators: 3) date and time of last successful webhook e.g. 2020-05-28
+#. 10:30:50 UTC
+msgid ""
+"Warning: The most recent live webhook, received at %s, could not be "
+"processed. Reason: %s. (The last live webhook to process successfully was "
+"timestamped %s.)"
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:232
+#. translators: 3) date and time webhook monitoring began e.g. 2020-05-28
+#. 10:30:50 UTC
+msgid ""
+"Warning: The most recent test webhook, received at %s, could not be "
+"processed. Reason: %s. (No test webhooks have been processed successfully "
+"since monitoring began at %s.)"
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-state.php:236
+#. translators: 3) date and time webhook monitoring began e.g. 2020-05-28
+#. 10:30:50 UTC
+msgid ""
+"Warning: The most recent live webhook, received at %s, could not be "
+"processed. Reason: %s. (No live webhooks have been processed successfully "
+"since monitoring began at %s.)"
 msgstr ""
 
 #: includes/compat/class-wc-stripe-email-failed-authentication-retry.php:29

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.8.0\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.9.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2021-02-12 15:12:08+00:00\n"
+"POT-Creation-Date: 2021-03-01 20:45:39+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -29,10 +29,10 @@ msgstr ""
 msgid "Save payment information to my account for future purchases."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:246
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:250
 #: includes/compat/class-wc-stripe-sepa-subs-compat.php:228
 #: includes/compat/class-wc-stripe-subs-compat.php:241
-#. translators: 1) dollar amount
+#. translators: 1) amount (including currency symbol)
 #. translators: minimum amount
 msgid "Sorry, the minimum allowed order total is %1$s to use this payment method."
 msgstr ""
@@ -42,54 +42,63 @@ msgstr ""
 msgid "%1$s - Order %2$s"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:379
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:383
 msgid "customer_name"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:380
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:384
 msgid "customer_email"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:443
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:447
 #. translators: transaction id
 msgid "Stripe charge awaiting payment: %s."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:450
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:454
 #: includes/class-wc-stripe-order-handler.php:298
-#: includes/class-wc-stripe-webhook-handler.php:384
-#: includes/class-wc-stripe-webhook-handler.php:434
+#: includes/class-wc-stripe-webhook-handler.php:400
+#: includes/class-wc-stripe-webhook-handler.php:450
 #. translators: transaction id
 msgid "Stripe charge complete (Charge ID: %s)"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:455
-#: includes/class-wc-gateway-stripe.php:508
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:459
+#: includes/class-wc-gateway-stripe.php:503
 #: includes/compat/class-wc-stripe-sepa-subs-compat.php:185
 msgid "Payment processing failed. Please retry."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:467
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:471
 #. translators: transaction id
 msgid ""
 "Stripe charge authorized (Charge ID: %s). Process order to take payment, or "
-"cancel to remove the pre-authorization."
+"cancel to remove the pre-authorization. Attempting to refund the order in "
+"part or in full will release the authorization and cancel the payment."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:645
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:649
 msgid "Invalid payment method. Please input a new card number."
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:917
-#. translators: 1) dollar amount 2) transaction id 3) refund message
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:918
+#. translators: amount (including currency symbol)
+msgid "Pre-Authorization for %s voided."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:923
+msgid ""
+"The authorization was voided and the order cancelled. Click okay to "
+"continue, then refresh the page."
+msgstr ""
+
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:937
+#. translators: 1) amount (including currency symbol) 2) transaction id 3)
+#. refund message
 msgid "Refunded %1$s - Refund ID: %2$s - Reason: %3$s"
 msgstr ""
 
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:917
-msgid "Pre-Authorization Released"
-msgstr ""
-
-#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:935
+#: includes/abstracts/abstract-wc-stripe-payment-gateway.php:955
 msgid "There was a problem adding the payment method."
 msgstr ""
 
@@ -197,29 +206,29 @@ msgstr ""
 msgid "Boost sales with Apple Pay!"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:130
+#: includes/admin/class-wc-stripe-inbox-notes.php:126
 msgid ""
 "Now that you accept Apple Pay® with Stripe, you can increase conversion "
 "rates by letting your customers know that Apple Pay is available. Here’s a "
 "marketing guide to help you get started."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:136
+#: includes/admin/class-wc-stripe-inbox-notes.php:132
 msgid "See marketing guide"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:149
+#: includes/admin/class-wc-stripe-inbox-notes.php:145
 msgid "Apple Pay domain verification needed"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:150
+#: includes/admin/class-wc-stripe-inbox-notes.php:146
 msgid ""
 "The WooCommerce Stripe Gateway extension attempted to perform domain "
 "verification on behalf of your store, but was unable to do so. This must be "
 "resolved before Apple Pay can be offered to your customers."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:156
+#: includes/admin/class-wc-stripe-inbox-notes.php:152
 msgid "Learn more"
 msgstr ""
 
@@ -430,7 +439,7 @@ msgstr ""
 #: includes/admin/stripe-multibanco-settings.php:39
 #: includes/admin/stripe-p24-settings.php:39
 #: includes/admin/stripe-sepa-settings.php:43
-#: includes/admin/stripe-settings.php:63
+#: includes/admin/stripe-settings.php:104
 #: includes/admin/stripe-sofort-settings.php:43
 msgid "Webhook Endpoints"
 msgstr ""
@@ -603,73 +612,74 @@ msgstr ""
 msgid "Pay with your credit card via Stripe."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:69
-#. translators: webhook URL
+#: includes/admin/stripe-settings.php:63
 msgid "Stripe Account Keys"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:74
+#: includes/admin/stripe-settings.php:68
 msgid "Test mode"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:75
+#: includes/admin/stripe-settings.php:69
 msgid "Enable Test Mode"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:77
+#: includes/admin/stripe-settings.php:71
 msgid "Place the payment gateway in test mode using test API keys."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:82
+#: includes/admin/stripe-settings.php:76
 msgid "Test Publishable Key"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:84
+#: includes/admin/stripe-settings.php:78
 msgid ""
 "Get your API keys from your stripe account. Invalid values will be "
 "rejected. Only values starting with \"pk_test_\" will be saved."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:89
+#: includes/admin/stripe-settings.php:83
 msgid "Test Secret Key"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:91
+#: includes/admin/stripe-settings.php:85
 msgid ""
 "Get your API keys from your stripe account. Invalid values will be "
 "rejected. Only values starting with \"sk_test_\" or \"rk_test_\" will be "
 "saved."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:96
-msgid "Test Webhook Secret"
-msgstr ""
-
-#: includes/admin/stripe-settings.php:98 includes/admin/stripe-settings.php:119
-msgid ""
-"Get your webhook signing secret from the webhooks section in your stripe "
-"account."
-msgstr ""
-
-#: includes/admin/stripe-settings.php:103
+#: includes/admin/stripe-settings.php:90
 msgid "Live Publishable Key"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:105
+#: includes/admin/stripe-settings.php:92
 msgid ""
 "Get your API keys from your stripe account. Invalid values will be "
 "rejected. Only values starting with \"pk_live_\" will be saved."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:110
+#: includes/admin/stripe-settings.php:97
 msgid "Live Secret Key"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:112
+#: includes/admin/stripe-settings.php:99
 msgid ""
 "Get your API keys from your stripe account. Invalid values will be "
 "rejected. Only values starting with \"sk_live_\" or \"rk_live_\" will be "
 "saved."
+msgstr ""
+
+#: includes/admin/stripe-settings.php:110
+#. translators: webhook URL
+msgid "Test Webhook Secret"
+msgstr ""
+
+#: includes/admin/stripe-settings.php:112
+#: includes/admin/stripe-settings.php:119
+msgid ""
+"Get your webhook signing secret from the webhooks section in your stripe "
+"account."
 msgstr ""
 
 #: includes/admin/stripe-settings.php:117
@@ -724,8 +734,8 @@ msgstr ""
 msgid ""
 "Enable Payment Request Buttons. (Apple Pay/Google Pay) %1$sBy using Apple "
 "Pay, you agree to %2$s and %3$s's terms of service. (Apple Pay domain "
-"verification is performed automatically; configuration can be found on the "
-"%4$sStripe dashboard%5$s.)"
+"verification is performed automatically in live mode; configuration can be "
+"found on the %4$sStripe dashboard%5$s.)"
 msgstr ""
 
 #: includes/admin/stripe-settings.php:157
@@ -902,7 +912,7 @@ msgid ""
 "to remove any %1$ssaved payment methods%2$s on file and re-add them."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:258
+#: includes/class-wc-gateway-stripe.php:253
 #. translators: link to Stripe testing page
 msgid ""
 "TEST MODE ENABLED. In test mode, you can use the card number "
@@ -911,23 +921,23 @@ msgid ""
 "card numbers."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:297
+#: includes/class-wc-gateway-stripe.php:292
 msgid "Credit or debit card"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:305
+#: includes/class-wc-gateway-stripe.php:300
 msgid "Card Number"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:316
+#: includes/class-wc-gateway-stripe.php:311
 msgid "Expiry Date"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:324
+#: includes/class-wc-gateway-stripe.php:319
 msgid "Card Code (CVC)"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:359
+#: includes/class-wc-gateway-stripe.php:354
 msgid ""
 "<strong>Warning:</strong> your site's time does not match the time on your "
 "browser and may be incorrect. Some payment methods depend on webhook "
@@ -937,59 +947,59 @@ msgid ""
 "correct the site's time."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:420
+#: includes/class-wc-gateway-stripe.php:415
 msgid "Please accept the terms and conditions first"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:421
+#: includes/class-wc-gateway-stripe.php:416
 msgid "Please fill in required checkout fields first"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:450
-#: includes/class-wc-gateway-stripe.php:495
+#: includes/class-wc-gateway-stripe.php:445
+#: includes/class-wc-gateway-stripe.php:490
 msgid ""
 "Sorry, we're not accepting prepaid cards at this time. Your credit card has "
 "not been charged. Please try with alternative payment method."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:451
+#: includes/class-wc-gateway-stripe.php:446
 msgid "Please enter your IBAN account name."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:452
+#: includes/class-wc-gateway-stripe.php:447
 msgid "Please enter your IBAN account number."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:453
+#: includes/class-wc-gateway-stripe.php:448
 msgid "We couldn't initiate the payment. Please try again."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:464
+#: includes/class-wc-gateway-stripe.php:459
 msgid "Billing First Name and Last Name are required."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:736
+#: includes/class-wc-gateway-stripe.php:731
 #. translators: error message
 msgid "This represents the fee Stripe collects for the transaction."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:737
+#: includes/class-wc-gateway-stripe.php:732
 msgid "Stripe Fee:"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:773
+#: includes/class-wc-gateway-stripe.php:768
 msgid ""
 "This represents the net total that will be credited to your Stripe bank "
 "account. This may be in the currency that is set in your Stripe account."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:774
+#: includes/class-wc-gateway-stripe.php:769
 msgid "Stripe Payout:"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:837
+#: includes/class-wc-gateway-stripe.php:832
 #: includes/class-wc-stripe-order-handler.php:158
-#: includes/class-wc-stripe-webhook-handler.php:233
+#: includes/class-wc-stripe-webhook-handler.php:249
 #: includes/compat/class-wc-stripe-sepa-subs-compat.php:284
 #: includes/compat/class-wc-stripe-subs-compat.php:334
 #: includes/payment-methods/class-wc-gateway-stripe-sepa.php:369
@@ -998,7 +1008,7 @@ msgid ""
 "later."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:890
+#: includes/class-wc-gateway-stripe.php:885
 msgid ""
 "Almost there!\n"
 "\n"
@@ -1006,36 +1016,36 @@ msgid ""
 "done is for you to authorize the payment with your bank."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1131
-#: includes/class-wc-stripe-webhook-handler.php:728
-#: includes/class-wc-stripe-webhook-handler.php:773
+#: includes/class-wc-gateway-stripe.php:1126
+#: includes/class-wc-stripe-webhook-handler.php:753
+#: includes/class-wc-stripe-webhook-handler.php:798
 #. translators: 1) The error message that was received from Stripe.
 msgid "Stripe SCA authentication failed. Reason: %s"
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1132
+#: includes/class-wc-gateway-stripe.php:1127
 msgid "Stripe SCA authentication failed."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1189
+#: includes/class-wc-gateway-stripe.php:1184
 msgid ""
 "The \"Live Publishable Key\" should start with \"pk_live\", enter the "
 "correct key."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1197
+#: includes/class-wc-gateway-stripe.php:1192
 msgid ""
 "The \"Live Secret Key\" should start with \"sk_live\" or \"rk_live\", enter "
 "the correct key."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1205
+#: includes/class-wc-gateway-stripe.php:1200
 msgid ""
 "The \"Test Publishable Key\" should start with \"pk_test\", enter the "
 "correct key."
 msgstr ""
 
-#: includes/class-wc-gateway-stripe.php:1213
+#: includes/class-wc-gateway-stripe.php:1208
 msgid ""
 "The \"Test Secret Key\" should start with \"sk_test\" or \"rk_test\", enter "
 "the correct key."
@@ -1045,25 +1055,42 @@ msgstr ""
 msgid "There was a problem connecting to the Stripe API endpoint."
 msgstr ""
 
-#: includes/class-wc-stripe-apple-pay-registration.php:142
+#: includes/class-wc-stripe-apple-pay-registration.php:149
+msgid "Unable to create domain association folder to domain root."
+msgstr ""
+
+#: includes/class-wc-stripe-apple-pay-registration.php:154
+msgid "Unable to copy domain association file to domain root."
+msgstr ""
+
+#: includes/class-wc-stripe-apple-pay-registration.php:176
+#. translators: expected domain association file URL
+msgid "To enable Apple Pay, domain association file must be hosted at %s."
+msgstr ""
+
+#: includes/class-wc-stripe-apple-pay-registration.php:179
+msgid "Domain association file updated."
+msgstr ""
+
+#: includes/class-wc-stripe-apple-pay-registration.php:232
 msgid "Unable to verify domain - missing secret key."
 msgstr ""
 
-#: includes/class-wc-stripe-apple-pay-registration.php:166
-#: includes/class-wc-stripe-apple-pay-registration.php:175
+#: includes/class-wc-stripe-apple-pay-registration.php:257
+#: includes/class-wc-stripe-apple-pay-registration.php:266
 #. translators: error message
 msgid "Unable to verify domain - %s"
 msgstr ""
 
-#: includes/class-wc-stripe-apple-pay-registration.php:297
+#: includes/class-wc-stripe-apple-pay-registration.php:394
 msgid "Apple Pay domain verification failed."
 msgstr ""
 
-#: includes/class-wc-stripe-apple-pay-registration.php:298
+#: includes/class-wc-stripe-apple-pay-registration.php:395
 msgid "Apple Pay domain verification failed with the following error:"
 msgstr ""
 
-#: includes/class-wc-stripe-apple-pay-registration.php:301
+#: includes/class-wc-stripe-apple-pay-registration.php:398
 #. translators: 1) HTML anchor open tag 2) HTML anchor closing tag
 msgid ""
 "Please check the %1$slogs%2$s for more details on this issue. Logging must "
@@ -1184,16 +1211,16 @@ msgstr ""
 msgid "Unable to verify your request. Please reload the page and try again."
 msgstr ""
 
-#: includes/class-wc-stripe-intent-controller.php:187
+#: includes/class-wc-stripe-intent-controller.php:197
 msgid "Your card could not be set up for future usage."
 msgstr ""
 
-#: includes/class-wc-stripe-intent-controller.php:204
+#: includes/class-wc-stripe-intent-controller.php:214
 msgid "Failed to save payment method."
 msgstr ""
 
 #: includes/class-wc-stripe-order-handler.php:140
-#: includes/class-wc-stripe-webhook-handler.php:214
+#: includes/class-wc-stripe-webhook-handler.php:230
 #: includes/payment-methods/class-wc-gateway-stripe-sepa.php:349
 msgid "This card is no longer available and has been removed."
 msgstr ""
@@ -1220,7 +1247,7 @@ msgstr ""
 msgid "SEPA IBAN ending in %s"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:293
+#: includes/class-wc-stripe-webhook-handler.php:309
 #. translators: 1) The URL to the order.
 msgid ""
 "A dispute was created for this order. Response is needed. Please go to your "
@@ -1228,46 +1255,47 @@ msgid ""
 "Dashboard</a> to review this dispute."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:322
+#: includes/class-wc-stripe-webhook-handler.php:338
 msgid "The dispute was lost or accepted."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:324
+#: includes/class-wc-stripe-webhook-handler.php:340
 msgid "The dispute was resolved in your favor."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:326
+#: includes/class-wc-stripe-webhook-handler.php:342
 msgid "The inquiry or retrieval was closed."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:379
+#: includes/class-wc-stripe-webhook-handler.php:395
 #. translators: partial captured amount
 msgid "This charge was partially captured via Stripe Dashboard in the amount of: %s"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:461
+#: includes/class-wc-stripe-webhook-handler.php:477
 msgid "This payment failed to clear."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:498
+#: includes/class-wc-stripe-webhook-handler.php:514
 msgid "This payment was cancelled."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:537
+#: includes/class-wc-stripe-webhook-handler.php:557
+#. translators: amount (including currency symbol)
+msgid "Pre-Authorization for %s voided from the Stripe Dashboard."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:570
 msgid "Refunded via Stripe Dashboard"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:537
-#: includes/class-wc-stripe-webhook-handler.php:565
-msgid "Pre-Authorization Released via Stripe Dashboard"
-msgstr ""
-
-#: includes/class-wc-stripe-webhook-handler.php:565
-#. translators: 1) dollar amount 2) transaction id 3) refund message
+#: includes/class-wc-stripe-webhook-handler.php:592
+#. translators: 1) amount (including currency symbol) 2) transaction id 3)
+#. refund message
 msgid "Refunded %1$s - Refund ID: %2$s - %3$s"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:598
+#: includes/class-wc-stripe-webhook-handler.php:623
 #. translators: 1) The URL to the order. 2) The reason type.
 msgid ""
 "A review has been opened for this order. Action is needed. Please go to "
@@ -1275,7 +1303,7 @@ msgid ""
 "Dashboard</a> to review the issue. Reason: (%2$s)"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:631
+#: includes/class-wc-stripe-webhook-handler.php:656
 #. translators: 1) The reason type.
 msgid "The opened review for this order is now closed. Reason: (%s)"
 msgstr ""
@@ -1285,19 +1313,19 @@ msgid "No error"
 msgstr ""
 
 #: includes/class-wc-stripe-webhook-state.php:139
-msgid "The webhook was missing expected body"
-msgstr ""
-
-#: includes/class-wc-stripe-webhook-state.php:143
 msgid "The webhook was missing expected headers"
 msgstr ""
 
+#: includes/class-wc-stripe-webhook-state.php:143
+msgid "The webhook was missing expected body"
+msgstr ""
+
 #: includes/class-wc-stripe-webhook-state.php:147
-msgid "The webhook signature was missing or was incorrectly formatted"
+msgid "The webhook received did not come from Stripe"
 msgstr ""
 
 #: includes/class-wc-stripe-webhook-state.php:151
-msgid "The webhook was not signed with the expected signing secret"
+msgid "The webhook signature was missing or was incorrectly formatted"
 msgstr ""
 
 #: includes/class-wc-stripe-webhook-state.php:155
@@ -1307,7 +1335,7 @@ msgid ""
 msgstr ""
 
 #: includes/class-wc-stripe-webhook-state.php:159
-msgid "The webhook received did not come from Stripe"
+msgid "The webhook was not signed with the expected signing secret"
 msgstr ""
 
 #: includes/class-wc-stripe-webhook-state.php:162
@@ -1317,57 +1345,61 @@ msgstr ""
 #: includes/class-wc-stripe-webhook-state.php:185
 #. translators: 1) date and time of last webhook received, e.g. 2020-06-28
 #. 10:30:50 UTC
-msgid "The most recent test webhook, timestamped %s, was processed succesfully."
+msgid "The most recent test webhook, timestamped %s, was processed successfully."
 msgstr ""
 
 #: includes/class-wc-stripe-webhook-state.php:187
 #. translators: 1) date and time of last webhook received, e.g. 2020-06-28
 #. 10:30:50 UTC
-msgid "The most recent live webhook, timestamped %s, was processed succesfully."
+msgid "The most recent live webhook, timestamped %s, was processed successfully."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-state.php:199
+#: includes/class-wc-stripe-webhook-state.php:198
 #. translators: 1) date and time webhook monitoring began, e.g. 2020-06-28
 #. 10:30:50 UTC
 msgid "No test webhooks have been received since monitoring began at %s."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-state.php:201
+#: includes/class-wc-stripe-webhook-state.php:200
 #. translators: 1) date and time webhook monitoring began, e.g. 2020-06-28
 #. 10:30:50 UTC
 msgid "No live webhooks have been received since monitoring began at %s."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-state.php:214
-#. translators: 3) date and time of last successful webhook e.g. 2020-05-28
-#. 10:30:50 UTC
+#: includes/class-wc-stripe-webhook-state.php:215
+#. translators: 1) date and time of last failed webhook e.g. 2020-06-28
+#. 10:30:50 UTC translators: 2) reason webhook failed translators: 3) date and
+#. time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
 msgid ""
 "Warning: The most recent test webhook, received at %s, could not be "
 "processed. Reason: %s. (The last test webhook to process successfully was "
 "timestamped %s.)"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-state.php:218
-#. translators: 3) date and time of last successful webhook e.g. 2020-05-28
-#. 10:30:50 UTC
+#: includes/class-wc-stripe-webhook-state.php:221
+#. translators: 1) date and time of last failed webhook e.g. 2020-06-28
+#. 10:30:50 UTC translators: 2) reason webhook failed translators: 3) date and
+#. time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
 msgid ""
 "Warning: The most recent live webhook, received at %s, could not be "
 "processed. Reason: %s. (The last live webhook to process successfully was "
 "timestamped %s.)"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-state.php:232
-#. translators: 3) date and time webhook monitoring began e.g. 2020-05-28
-#. 10:30:50 UTC
+#: includes/class-wc-stripe-webhook-state.php:236
+#. translators: 1) date and time of last failed webhook e.g. 2020-06-28
+#. 10:30:50 UTC translators: 2) reason webhook failed translators: 3) date and
+#. time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
 msgid ""
 "Warning: The most recent test webhook, received at %s, could not be "
 "processed. Reason: %s. (No test webhooks have been processed successfully "
 "since monitoring began at %s.)"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-state.php:236
-#. translators: 3) date and time webhook monitoring began e.g. 2020-05-28
-#. 10:30:50 UTC
+#: includes/class-wc-stripe-webhook-state.php:241
+#. translators: 1) date and time of last failed webhook e.g. 2020-06-28
+#. 10:30:50 UTC translators: 2) reason webhook failed translators: 3) date and
+#. time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
 msgid ""
 "Warning: The most recent live webhook, received at %s, could not be "
 "processed. Reason: %s. (No live webhooks have been processed successfully "
@@ -1552,7 +1584,7 @@ msgid "You are not authorized to clear Stripe account keys."
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-alipay.php:60
-#: woocommerce-gateway-stripe.php:305
+#: woocommerce-gateway-stripe.php:306
 msgid "Stripe Alipay"
 msgstr ""
 
@@ -1581,27 +1613,27 @@ msgid "Add Payment"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-bancontact.php:60
-#: woocommerce-gateway-stripe.php:299
+#: woocommerce-gateway-stripe.php:300
 msgid "Stripe Bancontact"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-eps.php:60
-#: woocommerce-gateway-stripe.php:302
+#: woocommerce-gateway-stripe.php:303
 msgid "Stripe EPS"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-giropay.php:60
-#: woocommerce-gateway-stripe.php:301
+#: woocommerce-gateway-stripe.php:302
 msgid "Stripe Giropay"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-ideal.php:60
-#: woocommerce-gateway-stripe.php:303
+#: woocommerce-gateway-stripe.php:304
 msgid "Stripe iDeal"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-multibanco.php:60
-#: woocommerce-gateway-stripe.php:307
+#: woocommerce-gateway-stripe.php:308
 msgid "Stripe Multibanco"
 msgstr ""
 
@@ -1630,12 +1662,12 @@ msgid "Awaiting Multibanco payment"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-p24.php:60
-#: woocommerce-gateway-stripe.php:304
+#: woocommerce-gateway-stripe.php:305
 msgid "Stripe P24"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-sepa.php:75
-#: woocommerce-gateway-stripe.php:306
+#: woocommerce-gateway-stripe.php:307
 msgid "Stripe SEPA Direct Debit"
 msgstr ""
 
@@ -1662,7 +1694,7 @@ msgid ""
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-sofort.php:60
-#: woocommerce-gateway-stripe.php:300
+#: woocommerce-gateway-stripe.php:301
 msgid "Stripe SOFORT"
 msgstr ""
 
@@ -1752,23 +1784,23 @@ msgid ""
 "WooCommerce %2$s is no longer supported."
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:229
+#: woocommerce-gateway-stripe.php:230
 msgid "Settings"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:245
+#: woocommerce-gateway-stripe.php:246
 msgid "View Documentation"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:245
+#: woocommerce-gateway-stripe.php:246
 msgid "Docs"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:246
+#: woocommerce-gateway-stripe.php:247
 msgid "Open a support request at WooCommerce.com"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:246
+#: woocommerce-gateway-stripe.php:247
 msgid "Support"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -126,14 +126,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.9.0 - 2021-02-24 =
+= 5.0.0 - 2021-xx-xx =
 
-* Fix    - Add fees as line items sent to Stripe to prevent Level 3 errors.
-* Fix    - Adding a SEPA payment method doesn't work.
-* Fix    - Apple Pay domain verification with live secret key.
-* Fix    - Display the correct accepted card branding depending on store currency and location.
-* Fix    - Remove duplicate Apple Pay domain registration Inbox notes.
-* Add    - Copy Apple Pay domain registration file and trigger domain registration on domain name change.
-* Update - Notes and status when refunding order with charge authorization.
+* Add - Display time of last Stripe webhook in settings.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -73,7 +73,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	}
 
 	private function set_valid_request_data( $overwrite_timestamp = null ) {
-		$timestamp = $overwrite_timestamp ?? time();
+		$timestamp = $overwrite_timestamp ? $overwrite_timestamp : time();
 
 		// Body
 		$this->request_body = json_encode(

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -10,247 +10,239 @@
  */
 class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 
-    /**
-	 * System under test.
+	/**
+	 * Webhook handler class.
 	 *
-	 * @var WC_Stripe_Webhook_State
+	 * @var WC_Stripe_Webhook_Handler
 	 */
-    private $wc_stripe_webhook_state;
+	private $wc_stripe_webhook_handler;
 
-    /**
-     * Webhook handler class.
-     *
-     * @var WC_Stripe_Webhook_Handler
-     */
-    private $wc_stripe_webhook_handler;
+	/**
+	 * Request headers.
+	 *
+	 * @var array
+	 */
+	private $request_headers;
 
-    /**
-     * Request headers.
-     *
-     * @var array
-     */
-    private $request_headers;
+	/**
+	 * Request body.
+	 *
+	 * @var string
+	 */
+	private $request_body;
 
-    /**
-     * Request body.
-     *
-     * @var string
-     */
-    private $request_body;
+	/**
+	 * Webhook secret key.
+	 *
+	 * @var string
+	 */
+	private $webhook_secret;
 
-    /**
-     * Webhook secret key.
-     *
-     * @var string
-     */
-    private $webhook_secret;
-
-    /**
+	/**
 	 * Sets up things all tests need.
 	 */
-    public function setUp() {
+	public function setUp() {
 		parent::setUp();
-        $this->webhook_secret            = 'whsec_123';
-        $this->wc_stripe_webhook_state   = WC_Stripe_Webhook_State::class;
-        $this->wc_stripe_webhook_handler = new WC_Stripe_Webhook_Handler;
-    }
+		$this->webhook_secret            = 'whsec_123';
+		$this->wc_stripe_webhook_handler = new WC_Stripe_Webhook_Handler;
+	}
 
-    /**
+	/**
 	 * Tears down the stuff we set up.
 	 */
-    public function tearDown() {
+	public function tearDown() {
 		parent::tearDown();
-        $stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
-        $stripe_settings['webhook_secret']      = $this->webhook_secret;
-        $stripe_settings['test_webhook_secret'] = $this->webhook_secret;
-        unset( $stripe_settings['testmode'] );
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+		$stripe_settings['webhook_secret']      = $this->webhook_secret;
+		$stripe_settings['test_webhook_secret'] = $this->webhook_secret;
+		unset( $stripe_settings['testmode'] );
 
-        // Resets settings.
-        update_option( 'woocommerce_stripe_settings', $stripe_settings );
+		// Resets settings.
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 
-        // Deletes all webhook options.
-        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_MONITORING_BEGAN_AT );
-        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_LAST_SUCCESS_AT );
-        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_LAST_FAILURE_AT );
-        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_LAST_ERROR );
+		// Deletes all webhook options.
+		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_MONITORING_BEGAN_AT );
+		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_LAST_SUCCESS_AT );
+		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_LAST_FAILURE_AT );
+		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_LAST_ERROR );
 
-        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_MONITORING_BEGAN_AT );
-        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_LAST_SUCCESS_AT );
-        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_LAST_FAILURE_AT );
-        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_LAST_ERROR );
-    }
+		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_MONITORING_BEGAN_AT );
+		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_SUCCESS_AT );
+		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_FAILURE_AT );
+		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_ERROR );
+	}
 
-    private function set_valid_request_data( $overwrite_timestamp = null ) {
-        $timestamp = $overwrite_timestamp ?? time();
+	private function set_valid_request_data( $overwrite_timestamp = null ) {
+		$timestamp = $overwrite_timestamp ?? time();
 
-        // Body
-        $this->request_body = json_encode(
-            [
-                'type'    => 'payment_intent.succeeded',
-                'created' => $timestamp,
-            ]
-        );
+		// Body
+		$this->request_body = json_encode(
+			[
+				'type'    => 'payment_intent.succeeded',
+				'created' => $timestamp,
+			]
+		);
 
-        $signed_payload = $timestamp . '.' . $this->request_body;
+		$signed_payload = $timestamp . '.' . $this->request_body;
 		$signature      = hash_hmac( 'sha256', $signed_payload, $this->webhook_secret );
 
-        // Headers
-        $this->request_headers = [
-            'USER-AGENT'       => 'Stripe/1.0 (+https://stripe.com/docs/webhooks)',
-            'CONTENT-TYPE'     => 'application/json; charset=utf-8',
-            'STRIPE-SIGNATURE' => 't=' . $timestamp . ',v1=' . $signature,
-        ];
-    }
+		// Headers
+		$this->request_headers = [
+			'USER-AGENT'       => 'Stripe/1.0 (+https://stripe.com/docs/webhooks)',
+			'CONTENT-TYPE'     => 'application/json; charset=utf-8',
+			'STRIPE-SIGNATURE' => 't=' . $timestamp . ',v1=' . $signature,
+		];
+	}
 
-    private function set_testmode() {
-        $stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
-        $stripe_settings['testmode'] = 'yes';
-        update_option( 'woocommerce_stripe_settings', $stripe_settings );
-    }
+	private function set_testmode() {
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+		$stripe_settings['testmode'] = 'yes';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+	}
 
-    /**
-     * This function is intended to mock WC_Stripe_Webhook_Handler check_for_webhook.
-     * We can't use check_for_webhook directly because it exits.
-     */
-    private function process_webhook() {
-        // Fills monitoring, last success and last failure timestamps for current mode.
-        $this->wc_stripe_webhook_state::get_monitoring_began_at();
-        $validation_result = $this->wc_stripe_webhook_handler->validate_request( $this->request_headers, $this->request_body );
+	/**
+	 * This function is intended to mock WC_Stripe_Webhook_Handler check_for_webhook.
+	 * We can't use check_for_webhook directly because it exits.
+	 */
+	private function process_webhook() {
+		// Fills monitoring, last success and last failure timestamps for current mode.
+		WC_Stripe_Webhook_State::get_monitoring_began_at();
+		$validation_result = $this->wc_stripe_webhook_handler->validate_request( $this->request_headers, $this->request_body );
 
-		if ( $this->wc_stripe_webhook_state::VALIDATION_SUCCEEDED === $validation_result ) {
+		if ( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED === $validation_result ) {
 			$notification = json_decode( $this->request_body );
-			$this->wc_stripe_webhook_state::set_last_webhook_success_at( $notification->created );
+			WC_Stripe_Webhook_State::set_last_webhook_success_at( $notification->created );
 		} else {
-			$this->wc_stripe_webhook_state::set_last_webhook_failure_at( current_time( 'timestamp', true ) );
-			$this->wc_stripe_webhook_state::set_last_error_reason( $validation_result );
+			WC_Stripe_Webhook_State::set_last_webhook_failure_at( current_time( 'timestamp', true ) );
+			WC_Stripe_Webhook_State::set_last_error_reason( $validation_result );
 		}
-    }
+	}
 
-    // Case 1 (Nominal case): Most recent = success.
-    public function test_get_webhook_status_message_most_recent_success() {
-        $this->set_valid_request_data();
-        $expected_message = '/The most recent [mode] webhook, timestamped (.*), was processed successfully/';
+	// Case 1 (Nominal case): Most recent = success.
+	public function test_get_webhook_status_message_most_recent_success() {
+		$this->set_valid_request_data();
+		$expected_message = '/The most recent [mode] webhook, timestamped (.*), was processed successfully/';
 
-        // Live
-        $this->process_webhook();
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
-        // Test
-        $this->set_testmode();
-        $this->process_webhook();
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
-    }
+		// Live
+		$this->process_webhook();
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+		// Test
+		$this->set_testmode();
+		$this->process_webhook();
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+	}
 
-    // Case 2: No webhooks received yet.
-    public function test_get_webhook_status_message_no_webhooks_received() {
-        $expected_message = '/No [mode] webhooks have been received since monitoring began at/';
+	// Case 2: No webhooks received yet.
+	public function test_get_webhook_status_message_no_webhooks_received() {
+		$expected_message = '/No [mode] webhooks have been received since monitoring began at/';
 
-        // Live
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
-        // Test
-        $this->set_testmode();
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
-    }
+		// Live
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+		// Test
+		$this->set_testmode();
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+	}
 
-    // Case 3: Failure after success.
-    public function test_get_webhook_status_message_failure_after_success() {
-        $this->set_valid_request_data();
-        $expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(The last [mode] webhook to process successfully was timestamped/';
-        // Live
-        // Process successful webhook.
-        $this->process_webhook();
-        // Fail next webhook.
-        $this->request_headers = [];
-        $this->process_webhook();
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+	// Case 3: Failure after success.
+	public function test_get_webhook_status_message_failure_after_success() {
+		$this->set_valid_request_data();
+		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(The last [mode] webhook to process successfully was timestamped/';
+		// Live
+		// Process successful webhook.
+		$this->process_webhook();
+		// Fail next webhook.
+		$this->request_headers = [];
+		$this->process_webhook();
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
 
-        // Test
-        $this->set_testmode();
-        $this->set_valid_request_data();
-        // Process successful webhook.
-        $this->process_webhook();
-        // Fail next webhook.
-        $this->request_headers = [];
-        $this->process_webhook();
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
-    }
+		// Test
+		$this->set_testmode();
+		$this->set_valid_request_data();
+		// Process successful webhook.
+		$this->process_webhook();
+		// Fail next webhook.
+		$this->request_headers = [];
+		$this->process_webhook();
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+	}
 
-    // Case 4: Failure with no prior success.
-    public function test_get_webhook_status_message_failure_with_no_prior_success() {
-        $this->set_valid_request_data();
-        $expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(No [mode] webhooks have been processed successfully since monitoring began at/';
-        // Live
-        // Fail webhook.
-        $this->request_headers = [];
-        $this->process_webhook();
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+	// Case 4: Failure with no prior success.
+	public function test_get_webhook_status_message_failure_with_no_prior_success() {
+		$this->set_valid_request_data();
+		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(No [mode] webhooks have been processed successfully since monitoring began at/';
+		// Live
+		// Fail webhook.
+		$this->request_headers = [];
+		$this->process_webhook();
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
 
-        // Test
-        $this->set_testmode();
-        // Fail webhook.
-        $this->process_webhook();
-        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
-        $this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
-    }
+		// Test
+		$this->set_testmode();
+		// Fail webhook.
+		$this->process_webhook();
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+	}
 
-    // Test failure reason: no error.
-    public function test_get_error_reason_no_errors() {
-        $this->set_valid_request_data();
-        $this->process_webhook();
-        $this->assertEquals( 'No error', $this->wc_stripe_webhook_state::get_last_error_reason() );
-    }
+	// Test failure reason: no error.
+	public function test_get_error_reason_no_errors() {
+		$this->set_valid_request_data();
+		$this->process_webhook();
+		$this->assertEquals( 'No error', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 
-    // Test failure reason: empty headers.
-    public function test_get_error_reason_empty_headers() {
-        $this->set_valid_request_data();
-        $this->request_headers = [];
-        $this->process_webhook();
-        $this->assertRegExp( '/missing expected headers/', $this->wc_stripe_webhook_state::get_last_error_reason() );
-    }
+	// Test failure reason: empty headers.
+	public function test_get_error_reason_empty_headers() {
+		$this->set_valid_request_data();
+		$this->request_headers = [];
+		$this->process_webhook();
+		$this->assertRegExp( '/missing expected headers/', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 
-    // Test failure reason: empty body.
-    public function test_get_error_reason_empty_body() {
-        $this->set_valid_request_data();
-        $this->request_body = '';
-        $this->process_webhook();
-        $this->assertRegExp( '/missing expected body/', $this->wc_stripe_webhook_state::get_last_error_reason() );
-    }
+	// Test failure reason: empty body.
+	public function test_get_error_reason_empty_body() {
+		$this->set_valid_request_data();
+		$this->request_body = '';
+		$this->process_webhook();
+		$this->assertRegExp( '/missing expected body/', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 
-    // Test failure reason: invalid user agent.
-    public function test_get_error_reason_invalid_user_agent() {
-        $this->set_valid_request_data();
-        $this->request_headers['USER-AGENT'] = 'Other';
-        $this->process_webhook();
-        $this->assertRegExp( '/did not come from Stripe/', $this->wc_stripe_webhook_state::get_last_error_reason() );
-    }
+	// Test failure reason: invalid user agent.
+	public function test_get_error_reason_invalid_user_agent() {
+		$this->set_valid_request_data();
+		$this->request_headers['USER-AGENT'] = 'Other';
+		$this->process_webhook();
+		$this->assertRegExp( '/did not come from Stripe/', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 
-    // Test failure reason: invalid signature.
-    public function test_get_error_reason_invalid_signature() {
-        $this->set_valid_request_data();
-        $this->request_headers['STRIPE-SIGNATURE'] = 'foo';
-        $this->process_webhook();
-        $this->assertRegExp( '/signature was missing or was incorrectly formatted/', $this->wc_stripe_webhook_state::get_last_error_reason() );
-    }
+	// Test failure reason: invalid signature.
+	public function test_get_error_reason_invalid_signature() {
+		$this->set_valid_request_data();
+		$this->request_headers['STRIPE-SIGNATURE'] = 'foo';
+		$this->process_webhook();
+		$this->assertRegExp( '/signature was missing or was incorrectly formatted/', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 
-    // Test failure reason: timestamp mismatch.
-    public function test_get_error_reason_timestamp_mismatch() {
-        $timestamp = time() - 600; // 10 minutes ago.
-        $this->set_valid_request_data( $timestamp );
-        $this->process_webhook();
-        $this->assertRegExp( '/timestamp in the webhook differed more than five minutes/', $this->wc_stripe_webhook_state::get_last_error_reason() );
-    }
+	// Test failure reason: timestamp mismatch.
+	public function test_get_error_reason_timestamp_mismatch() {
+		$timestamp = time() - 600; // 10 minutes ago.
+		$this->set_valid_request_data( $timestamp );
+		$this->process_webhook();
+		$this->assertRegExp( '/timestamp in the webhook differed more than five minutes/', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 
-    // Test failure reason: signature mismatch.
-    public function test_get_error_reason_signature_mismatch() {
-        $this->set_valid_request_data();
-        $this->request_headers['STRIPE-SIGNATURE'] = 't=' . time() . ',v1=0';
-        $this->process_webhook();
-        $this->assertRegExp( '/was not signed with the expected signing secret/', $this->wc_stripe_webhook_state::get_last_error_reason() );
-    }
+	// Test failure reason: signature mismatch.
+	public function test_get_error_reason_signature_mismatch() {
+		$this->set_valid_request_data();
+		$this->request_headers['STRIPE-SIGNATURE'] = 't=' . time() . ',v1=0';
+		$this->process_webhook();
+		$this->assertRegExp( '/was not signed with the expected signing secret/', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 }

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * These tests make assertions against class WC_Stripe_Webhook_State.
+ *
+ * @package WooCommerce_Stripe/Tests/Webhook_State
+ */
+
+/**
+ * WC_Stripe_Webhook_State_Test class.
+ */
+class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
+
+    /**
+	 * System under test.
+	 *
+	 * @var WC_Stripe_Webhook_State
+	 */
+    private $wc_stripe_webhook_state;
+
+    /**
+     * Webhook handler class.
+     *
+     * @var WC_Stripe_Webhook_Handler
+     */
+    private $wc_stripe_webhook_handler;
+
+    /**
+     * Request headers.
+     *
+     * @var array
+     */
+    private $request_headers;
+
+    /**
+     * Request body.
+     *
+     * @var string
+     */
+    private $request_body;
+
+    /**
+	 * Sets up things all tests need.
+	 */
+    public function setUp() {
+		parent::setUp();
+
+        $this->wc_stripe_webhook_state = WC_Stripe_Webhook_State::class;
+        $this->wc_stripe_webhook_handler = new WC_Stripe_Webhook_Handler;
+    }
+
+    /**
+	 * Tears down the stuff we set up.
+	 */
+    public function tearDown() {
+		parent::tearDown();
+
+        $stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+        // Deletes testmode setting
+        unset( $stripe_settings['testmode'] );
+        update_option( 'woocommerce_stripe_settings', $stripe_settings );
+        // Deletes all webhook options
+        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_MONITORING_BEGAN_AT );
+        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_LAST_SUCCESS_AT );
+        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_LAST_FAILURE_AT );
+        delete_option( $this->wc_stripe_webhook_state::OPTION_LIVE_LAST_ERROR );
+
+        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_MONITORING_BEGAN_AT );
+        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_LAST_SUCCESS_AT );
+        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_LAST_FAILURE_AT );
+        delete_option( $this->wc_stripe_webhook_state::OPTION_TEST_LAST_ERROR );
+    }
+
+    private function set_valid_request_data() {
+        // Headers
+        $this->request_headers = [
+            'USER_AGENT'       => 'Stripe/1.0 (+https://stripe.com/docs/webhooks)',
+            'CONTENT_TYPE'     => 'application/json; charset=utf-8',
+            'STRIPE_SIGNATURE' => 't=' . time() . ',v1=1,v0=0',
+        ];
+
+        // Body
+        $this->request_body = json_encode(
+            [
+                'type'    => 'payment_intent.succeeded',
+                'created' => time(),
+            ]
+        );
+    }
+
+    /**
+     * This function is intended to mock WC_Stripe_Webhook_Handler check_for_webhook.
+     * We can't use check_for_webhook directly because it exits.
+     */
+    private function process_webhook() {
+        // Fills monitoring, last success and last failure timestamps for current mode.
+        $this->wc_stripe_webhook_state::get_monitoring_began_at();
+        $validation_result = $this->wc_stripe_webhook_handler->validate_request( $this->request_headers, $this->request_body );
+
+		if ( $this->wc_stripe_webhook_state::VALIDATION_SUCCEEDED === $validation_result ) {
+			$notification = json_decode( $this->request_body );
+			$this->wc_stripe_webhook_state::set_last_webhook_success_at( $notification->created );
+		} else {
+			$this->wc_stripe_webhook_state::set_last_webhook_failure_at( current_time( 'timestamp', true ) );
+			$this->wc_stripe_webhook_state::set_last_error_reason( $validation_result );
+		}
+    }
+
+    public function test_get_webhook_status_message_most_recent_success() {
+        $this->set_valid_request_data();
+        $expected_message = '/The most recent [mode] webhook, timestamped (.*), was processed successfully/';
+
+        $this->process_webhook();
+        $message = $this->wc_stripe_webhook_state::get_webhook_status_message();
+        $this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+    }
+
+}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -128,7 +128,7 @@ function woocommerce_gateway_stripe() {
 			 * Init the plugin after plugins_loaded so environment variables are set.
 			 *
 			 * @since 1.0.0
-			 * @version 4.0.0
+			 * @version 5.0.0
 			 */
 			public function init() {
 				if ( is_admin() ) {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -140,6 +140,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-helper.php';
 				include_once dirname( __FILE__ ) . '/includes/class-wc-stripe-api.php';
 				require_once dirname( __FILE__ ) . '/includes/abstracts/abstract-wc-stripe-payment-gateway.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-state.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-handler.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-sepa-payment-token.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-apple-pay-registration.php';


### PR DESCRIPTION
Fixes #1200

#### Changes proposed in this Pull Request:

Appends a message to the webhook settings description, with the date and time of the most recently received webhook event.

(Also tweaks the order of the settings, to group webhook-related items.)

<img width="788" src="https://user-images.githubusercontent.com/1867547/83553899-f005ec80-a4d9-11ea-94b1-831a789a42bf.png">

## Testing instructions

Unit tests verify test and live mode messages. You can test manually using either test or live mode:

- Use stripe cli to send valid test webhooks: `stripe listen --forward-to "localhost:8082/?wc-api=wc_stripe"`.
- Paste your webhook secret in settings.

**Case 1: (Nominal case): Most recent webhook successful:**

- Run `stripe trigger payment_intent.created` to simulate a successful webhook and notice the following message:

> The most recent [mode] webhook, timestamped [timestamp], was processed successfully.

**Case 2: No webhook ever received (since this version of the plugin was installed):**

- Delete previous webhook options in the database: `DELETE FROM wp_options WHERE option_name LIKE 'wc_stripe_wh_%';`
- Notice the following message:

> No [mode] webhooks have been received since monitoring began at [timestamp].

**Case 3: Most recent webhook unsuccessful with a prior success:**

- Run `stripe trigger payment_intent.created`
- Run `curl -X POST "http://localhost:8082/?wc-api=wc_stripe"`
- Notice the following message:

> Warning: The most recent [mode] webhook, received at [timestamp], could not be processed. Reason: The webhook was missing expected body. (The last [mode] webhook to process successfully was timestamped [timestamp].)

**Case 4: Most recent webhook unsuccessful with no prior successes:**

- Delete previous webhook options in the database: `DELETE FROM wp_options WHERE option_name LIKE 'wc_stripe_wh_%';`
- Run `curl -X POST "http://localhost:8082/?wc-api=wc_stripe"`
- Notice the following message:

> Warning: The most recent [mode] webhook, received at [timestamp], could not be processed. Reason: The webhook was missing expected body. (No [mode] webhooks have been processed successfully since monitoring began at [timestamp].)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

