### PR TITLE
Add handling for closed dispute webhook events

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -323,9 +323,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		// Fail order if dispute is lost, or else revert to pre-dispute status.
-		$order_status = 'lost' === $status ? 'failed' : $order->get_meta( '_stripe_status_before_hold', 'processing' );
-		$order->update_status( $order_status, $message );
+		if ( apply_filters( 'wc_stripe_webhook_dispute_change_order_status', true, $order, $notification ) ) {
+			// Fail order if dispute is lost, or else revert to pre-dispute status.
+			$order_status = 'lost' === $status ? 'failed' : $order->get_meta( '_stripe_status_before_hold', 'processing' );
+			$order->update_status( $order_status, $message );
+		} else {
+			$order->add_order_note( $message );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1098
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1306 (https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1232/commits/b627ac1e447655290cdf0093966927453604fd16)

See also https://github.com/woocommerce/woocommerce-gateway-stripe/issues/128 (h/t @jrick1229), partially addressed by https://github.com/woocommerce/woocommerce-gateway-stripe/commit/cb8d4bfc2e347b6f4a73f2ade5c3959e72eb92ea

#### Changes proposed in this Pull Request:

Manipulates order status in response to `charge.dispute.closed` events. Draws on existing handling for reviews (original issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/261), but restores earlier status when a dispute (or review) is resolved favorably.

When a dispute is closed immediately after the charge (which generally might only happen in test mode but seems plausible [for SEPA Direct Debit](https://stripe.com/docs/payments/sepa-debit#disputed-payments) in live mode as well), the `charge.succeeded event` could be processed _after_ the `charge.dispute.closed` event. The change in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/dfc5ac60391d4d16fee26a5638d2892f63667fdb attempts to ensure that this "final" status change would not be overwritten.
- We could consider a more robust system that aims to generally process webhooks in the correct order when it matters, as touched on in the discussion of https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1108 (cc @DanReyLop @RadoslavGeorgiev @vbelolapotkov). It might require more robust information on what order events are "supposed to" arrive in, but it could also just be a matter of not changing the status if the status has already been updated based on an event with a more recent timestamp?
- Thank you @NickGreen for lending a hand with some webhook testing for SEPA, as I don't personally have an account enabled for it. I'd reproduced the case of `charge.succeeded` arriving after `charge.dispute.closed` before this change, but then couldn't reproduce it after 6-7 times, so then I forced it with a `sleep` in the `charge.succeeded` handling.

Note on [inquiries](https://stripe.com/docs/disputes/how-disputes-work#inquiries-and-retrievals): they're currently treated the same as other disputes, and this PR doesn't change that. We could consider not setting to `'on-hold'` to begin with, and we'd then need to handle `charge.dispute.updated` by updating to `'on-hold'` if it has turned into a chargeback. Worth a separate issue?

Also note: there was a proposal in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1108 was to just always set `'failed'` on new disputes. See pc1FvE-1b-p2 by @jrodger for broader discussion of how order status should work with regard to dispute states, including the WIP introduction of **new statuses to formalize the various dispute states**.

#### Testing instructions

Credit card: check out with card number 4000000000000259 and verify that order has "On Hold" status. Click the order note link to respond to the dispute in the Stripe Dashboard, accept the dispute, then verify that _order has "Failed" status_.

Check out using that card again (with an ordinary physical product), verify "On Hold" status, this time submit evidence in the Stripe Dashboard, with "winning_evidence" as the "Additional information", and verify that _order has "Processing" status_.

Check out using that card again with a product that is virtual and downloadable (so that it skips "Processing" status and goes straight to "Completed" before being disputed), verify "On Hold" status, repeat winning case, and verify that order has "Completed" status.

To (optionally) test SEPA case, see instructions in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1108. Regardless of payment method, can simulate case of `charge.succeeded` event arriving after dispute by commenting out handling of that event, then resending it later via the Stripe Dashboard, and verifying that the "Failed" order stays failed.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

