### PR TITLE
Introduce a new filter to manage the display of payment request buttons in cart

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -593,11 +593,8 @@ class WC_Stripe_Payment_Request {
 
 		if ( is_product() && ! $this->should_show_payment_button_on_product_page() ) {
 			return;
-		} else {
-			if ( ! $this->allowed_items_in_cart() ) {
-				WC_Stripe_Logger::log( 'Items in the cart has unsupported product type ( Payment Request button disabled )' );
-				return;
-			}
+		} else if ( ! $this->should_show_payment_button_on_cart() ) {
+			return;
 		}
 		?>
 		<div id="wc-stripe-payment-request-wrapper" style="clear:both;padding-top:1.5em;display:none;">
@@ -641,11 +638,8 @@ class WC_Stripe_Payment_Request {
 
 		if ( is_product() && ! $this->should_show_payment_button_on_product_page() ) {
 			return;
-		} else {
-			if ( ! $this->allowed_items_in_cart() ) {
-				WC_Stripe_Logger::log( 'Items in the cart has unsupported product type ( Payment Request button disabled )' );
-				return;
-			}
+		} else if ( ! $this->should_show_payment_button_on_cart() ) {
+			return;
 		}
 		?>
 		<p id="wc-stripe-payment-request-button-separator" style="margin-top:1.5em;text-align:center;display:none;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-gateway-stripe' ); ?> &mdash;</p>
@@ -653,11 +647,27 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
+	 * Whether payment button html should be rendered on the Cart
+	 *
+	 * @since 4.4.1
+	 *
+	 * @return bool
+	 */
+	private function should_show_payment_button_on_cart() {
+		if ( ! apply_filters( 'wc_stripe_show_payment_request_on_cart', true ) ) {
+			return false;
+		}
+		if ( ! $this->allowed_items_in_cart() ) {
+			WC_Stripe_Logger::log( 'Items in the cart has unsupported product type ( Payment Request button disabled )' );
+			return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Whether payment button html should be rendered
 	 *
 	 * @since 4.3.2
-	 *
-	 * @param object $post
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
Fixes #1222

This is an alternative approach to #1223. The end result is exactly the same (the filter name is the same, its behaviour is the same), but it doesn't flood the debug log if the filter returns `false`.

This is just a slightly different approach to an existing PR that occured to me while reviewing it, so I don't think a second review is needed.

### Changes proposed in this Pull Request:
- Added a new filter named `wc_stripe_show_payment_request_on_cart`. If that filter returns `true` (the default), `Payment Request` buttons (G Pay, 🍎 Pay, etc) will be displayed in the cart. If `false`, they won't be displayed in the cart. There are already equivalent filters for the [checkout](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/19e5f4a47d4ad94d4d367a588b3cd4b227c9f80d/includes/payment-methods/class-wc-stripe-payment-request.php#L590) and [product](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/payment-methods/class-wc-stripe-payment-request.php#L669) pages.