### PR TITLE
Bump 'WooCommerce Tested Up To' to version 4.2

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -9,7 +9,7 @@
  * Requires at least: 4.4
  * Tested up to: 5.4
  * WC requires at least: 3.0
- * WC tested up to: 4.0
+ * WC tested up to: 4.2
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  *
@@ -221,7 +221,7 @@ function woocommerce_gateway_stripe_init() {
 			/**
 			 * Add plugin action links.
 			 *
-			 * @since 4.3.4 
+			 * @since 4.3.4
 			 * @param  array  $links Original list of plugin links.
 			 * @param  string $file  Name of current file.
 			 * @return array  $links Update list of plugin links.


### PR DESCRIPTION
Fixes #1221 .

#### Changes proposed in this Pull Request:

- Bumps the tested up to version for WooCommerce to version 4.2.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

