### PR TITLE
Create release 4.5.0

### DIFF
--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.4.0\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.5.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2020-06-22 13:54:43+00:00\n"
+"POT-Creation-Date: 2020-06-24 03:55:47+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1430,19 +1430,19 @@ msgid "Stripe SOFORT"
 msgstr ""
 
 #: includes/payment-methods/class-wc-stripe-payment-request.php:314
-#: includes/payment-methods/class-wc-stripe-payment-request.php:963
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1254
+#: includes/payment-methods/class-wc-stripe-payment-request.php:969
+#: includes/payment-methods/class-wc-stripe-payment-request.php:1260
 msgid "Tax"
 msgstr ""
 
 #: includes/payment-methods/class-wc-stripe-payment-request.php:322
-#: includes/payment-methods/class-wc-stripe-payment-request.php:971
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1261
+#: includes/payment-methods/class-wc-stripe-payment-request.php:977
+#: includes/payment-methods/class-wc-stripe-payment-request.php:1267
 msgid "Shipping"
 msgstr ""
 
 #: includes/payment-methods/class-wc-stripe-payment-request.php:329
-#: includes/payment-methods/class-wc-stripe-payment-request.php:978
+#: includes/payment-methods/class-wc-stripe-payment-request.php:984
 msgid "Pending"
 msgstr ""
 
@@ -1459,27 +1459,27 @@ msgstr ""
 msgid "OR"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:816
-#: includes/payment-methods/class-wc-stripe-payment-request.php:829
+#: includes/payment-methods/class-wc-stripe-payment-request.php:819
+#: includes/payment-methods/class-wc-stripe-payment-request.php:832
 msgid "Unable to find shipping method for address."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:925
+#: includes/payment-methods/class-wc-stripe-payment-request.php:931
 msgid "Product with the ID (%d) cannot be found."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:946
+#: includes/payment-methods/class-wc-stripe-payment-request.php:952
 #. translators: 1: product name 2: quantity in stock
 msgid ""
 "You cannot add that amount of \"%1$s\"; to the cart because there is not "
 "enough stock (%2$s remaining)."
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1097
+#: includes/payment-methods/class-wc-stripe-payment-request.php:1103
 msgid "Empty cart"
 msgstr ""
 
-#: includes/payment-methods/class-wc-stripe-payment-request.php:1268
+#: includes/payment-methods/class-wc-stripe-payment-request.php:1274
 msgid "Discount"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "4.3.3",
+  "version": "4.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -113,7 +113,12 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 4.5.0 2020-06-24 =
-* TBA
+* Tweak - Improve branded Google Pay button user agent detection.
+* Add   - New filter to manage the display of payment request buttons in cart.
+* Fix   - Display Apple Pay button with text if branded type is text and logo.
+* Fix   - Prevent branded payment request button duplication when checkout is re-calculated.
+* Fix   - Payment request buttons on a single product page now correctly show the product name instead of a subtotal.
+* Fix   - Quotes in variadic product attributes no longer cause payment request buttons to show only the cheapest variation.
 
 = 4.4.0 2020-05-21 =
 * Tweak - Remove support for WooCommerce versions lower than 3.0.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort,
 Requires at least: 4.4
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 4.4.0
+Stable tag: 4.5.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe
@@ -111,6 +111,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 4. Apple Pay and other Payment Request buttons can be used on the Product Page and Checkout for express checkout.
 
 == Changelog ==
+
+= 4.5.0 2020-06-24 =
+* TBA
 
 = 4.4.0 2020-05-21 =
 * Tweak - Remove support for WooCommerce versions lower than 3.0.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 4.4.0
+ * Version: 4.5.0
  * Requires at least: 4.4
  * Tested up to: 5.4
  * WC requires at least: 3.0
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_STRIPE_VERSION', '4.4.0' );
+define( 'WC_STRIPE_VERSION', '4.5.0' );
 define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 define( 'WC_STRIPE_MIN_WC_VER', '3.0' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );


### PR DESCRIPTION
- [x] `npm install`
- [x] Update the Tested Up To (WP version), Stable Tag (plugin version) and Change Log in readme.txt if needed.
- [x] Update the version in the package.json file, this affects the build step.
- [x] npm run build (to minify sources and regenerate the POT file)
- [x] Update version in the POT file.
- [x] Update changelog.txt in readme.txt
- [x] Update “Version” in the main plugin file (woocommerce-gateway-stripe.php) if needed
- [x] Update “Tested up to” in the main plugin file if needed
- [x] Update “WC tested up to” in the main plugin file if needed (as x.x, not x.x.x)
- [x] Update WC_STRIPE_VERSION in the main plugin file if needed
- [x] Update WC_STRIPE_MIN_WC_VER in the main plugin file if needed
- [x] Commit any changes you had to make

I'm still working on merging some of the ready to merge PRs, which is why the changelog and POT files aren't ready yet.