### PR TITLE
Add to disallowed descriptor character list

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.8.0 - 2021-xx-xx =
+* Fix - Filter more disallowed characters from statement descriptors.
+
 = 4.7.0 - 2020-12-22 =
 * Fix - Updating subscription payment methods from the "My Account" page now adds a note to the subscription.
 * Fix - Link is now correctly formatted in readme.txt.

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -130,7 +130,7 @@ return apply_filters(
 		'statement_descriptor'          => array(
 			'title'       => __( 'Statement Descriptor', 'woocommerce-gateway-stripe' ),
 			'type'        => 'text',
-			'description' => __( 'Statement descriptors are limited to 22 characters, cannot use the special characters >, <, ", \, \', *, and must not consist solely of numbers. This will appear on your customer\'s statement in capital letters.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Statement descriptors are limited to 22 characters, cannot use the special characters >, <, ", \, \', *, /, (, ), {, }, and must not consist solely of numbers. This will appear on your customer\'s statement in capital letters.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
 		),

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -140,6 +140,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_payment_successful_result', array( $this, 'modify_successful_payment_result' ), 99999, 2 );
 		add_action( 'set_logged_in_cookie', array( $this, 'set_cookie_on_current_request' ) );
 		add_filter( 'woocommerce_get_checkout_payment_url', array( $this, 'get_checkout_payment_url' ), 10, 2 );
+		add_filter( 'woocommerce_settings_api_sanitized_fields_' . $this->id, array( $this, 'settings_api_sanitized_fields' ) );
 
 		// Note: display error is in the parent class.
 		add_action( 'admin_notices', array( $this, 'display_errors' ), 9999 );
@@ -1201,5 +1202,21 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			throw new Exception( __( 'The "Test Secret Key" should start with "sk_test" or "rk_test", enter the correct key.', 'woocommerce-gateway-stripe' ) );
 		}
 		return $value;
+	}
+
+	/**
+	 * Ensures the statement descriptor saved to options does not contain any invalid characters.
+	 *
+	 * @since 4.8.0
+	 * @param $settings WC_Settings_API settings to be filtered
+	 * @return Filtered settings
+	 */
+	public function settings_api_sanitized_fields( $settings ) {
+		if ( is_array( $settings ) ) {
+			if ( array_key_exists( 'statement_descriptor', $settings ) ) {
+				$settings['statement_descriptor'] = WC_Stripe_Helper::clean_statement_descriptor( $settings['statement_descriptor']);
+			}
+		}
+		return $settings;
 	}
 }

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1205,7 +1205,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Ensures the statement descriptor saved to options does not contain any invalid characters.
+	 * Ensures the statement descriptor about to be saved to options does not contain any invalid characters.
 	 *
 	 * @since 4.8.0
 	 * @param $settings WC_Settings_API settings to be filtered

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -459,7 +459,7 @@ class WC_Stripe_Helper {
 	 * @return string $statement_descriptor Sanitized statement descriptor
 	 */
 	public static function clean_statement_descriptor( $statement_descriptor = '' ) {
-		$disallowed_characters = array( '<', '>', '"', "'", '/', '(', ')', '{', '}' );
+		$disallowed_characters = array( '<', '>', '\\', '*', '"', "'", '/', '(', ')', '{', '}' );
 
 		// Remove special characters.
 		$statement_descriptor = str_replace( $disallowed_characters, '', $statement_descriptor );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -459,7 +459,7 @@ class WC_Stripe_Helper {
 	 * @return string $statement_descriptor Sanitized statement descriptor
 	 */
 	public static function clean_statement_descriptor( $statement_descriptor = '' ) {
-		$disallowed_characters = array( '<', '>', '"', "'", '{', '}' );
+		$disallowed_characters = array( '<', '>', '"', "'", '/', '(', ')', '{', '}' );
 
 		// Remove special characters.
 		$statement_descriptor = str_replace( $disallowed_characters, '', $statement_descriptor );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -451,8 +451,7 @@ class WC_Stripe_Helper {
 	/**
 	 * Sanitize statement descriptor text.
 	 *
-	 * Stripe requires max of 22 characters and no
-	 * special characters with ><"'.
+	 * Stripe requires max of 22 characters and no special characters.
 	 *
 	 * @since 4.0.0
 	 * @param string $statement_descriptor
@@ -461,9 +460,17 @@ class WC_Stripe_Helper {
 	public static function clean_statement_descriptor( $statement_descriptor = '' ) {
 		$disallowed_characters = array( '<', '>', '\\', '*', '"', "'", '/', '(', ')', '{', '}' );
 
-		// Remove special characters.
+		// Strip any tags.
+		$statement_descriptor = strip_tags( $statement_descriptor );
+
+		// Strip any HTML entities.
+		// Props https://stackoverflow.com/questions/657643/how-to-remove-html-special-chars .
+		$statement_descriptor = preg_replace( "/&#?[a-z0-9]{2,8};/i", "", $statement_descriptor );
+
+		// Next, remove any remaining disallowed characters.
 		$statement_descriptor = str_replace( $disallowed_characters, '', $statement_descriptor );
 
+		// Trim any whitespace at the ends and limit to 22 characters.
 		$statement_descriptor = substr( trim( $statement_descriptor ), 0, 22 );
 
 		return $statement_descriptor;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -459,7 +459,7 @@ class WC_Stripe_Helper {
 	 * @return string $statement_descriptor Sanitized statement descriptor
 	 */
 	public static function clean_statement_descriptor( $statement_descriptor = '' ) {
-		$disallowed_characters = array( '<', '>', '"', "'" );
+		$disallowed_characters = array( '<', '>', '"', "'", '{', '}' );
 
 		// Remove special characters.
 		$statement_descriptor = str_replace( $disallowed_characters, '', $statement_descriptor );

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -689,8 +689,9 @@ msgstr ""
 #: includes/admin/stripe-settings.php:133
 msgid ""
 "Statement descriptors are limited to 22 characters, cannot use the special "
-"characters >, <, \", \\, ', *, and must not consist solely of numbers. This "
-"will appear on your customer's statement in capital letters."
+"characters >, <, \", \\, ', *, /, (, ), {, }, and must not consist solely "
+"of numbers. This will appear on your customer's statement in capital "
+"letters."
 msgstr ""
 
 #: includes/admin/stripe-settings.php:138

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -1,15 +1,15 @@
-# Copyright (C) 2020 WooCommerce
+# Copyright (C) 2021 WooCommerce
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.6.0\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.7.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2020-12-21 22:16:09+00:00\n"
+"POT-Creation-Date: 2021-01-13 19:10:16+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2021-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: node-wp-i18n 1.2.3\n"
@@ -190,6 +190,10 @@ msgstr ""
 
 #: includes/admin/class-wc-stripe-inbox-notes.php:42
 msgid "Boost sales this holiday season with Apple Pay!"
+msgstr ""
+
+#: includes/admin/class-wc-stripe-inbox-notes.php:45
+msgid "Boost sales with Apple Pay!"
 msgstr ""
 
 #: includes/admin/class-wc-stripe-inbox-notes.php:130

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/code-frame": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
       "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
       "dev": true,
       "requires": {
@@ -233,7 +233,7 @@
     },
     "@babel/generator": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
       "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
       "dev": true,
       "requires": {
@@ -254,7 +254,7 @@
     },
     "@babel/helper-function-name": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
       "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
       "dev": true,
       "requires": {
@@ -265,7 +265,7 @@
     },
     "@babel/helper-get-function-arity": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
       "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
       "dev": true,
       "requires": {
@@ -744,7 +744,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
       "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
       "dev": true,
       "requires": {
@@ -940,7 +940,7 @@
     },
     "@babel/highlight": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
       "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
       "dev": true,
       "requires": {
@@ -988,7 +988,7 @@
     },
     "@babel/template": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
       "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
       "dev": true,
       "requires": {
@@ -1000,7 +1000,7 @@
       "dependencies": {
         "babylon": {
           "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
           "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
           "dev": true
         }
@@ -1008,7 +1008,7 @@
     },
     "@babel/traverse": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
       "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
       "dev": true,
       "requires": {
@@ -1026,7 +1026,7 @@
       "dependencies": {
         "babylon": {
           "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
           "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
           "dev": true
         },
@@ -1055,7 +1055,7 @@
     },
     "@babel/types": {
       "version": "7.0.0-beta.44",
-      "resolved": "http://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
       "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
       "dev": true,
       "requires": {
@@ -1372,7 +1372,7 @@
     },
     "array-union": {
       "version": "1.0.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
@@ -1381,7 +1381,7 @@
     },
     "array-uniq": {
       "version": "1.0.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
@@ -1452,7 +1452,7 @@
     },
     "asynckit": {
       "version": "0.4.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
@@ -1643,7 +1643,7 @@
       "dependencies": {
         "babylon": {
           "version": "7.0.0-beta.44",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
           "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
           "dev": true
         }
@@ -2852,7 +2852,7 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
@@ -3268,7 +3268,7 @@
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
@@ -4038,7 +4038,7 @@
     },
     "forever-agent": {
       "version": "0.6.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
       "dev": true
     },
@@ -5416,7 +5416,7 @@
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
@@ -5483,7 +5483,7 @@
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
@@ -5552,7 +5552,7 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
@@ -5598,7 +5598,7 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
@@ -5610,7 +5610,7 @@
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
       "dev": true
     },
@@ -6067,7 +6067,7 @@
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
           "dev": true
         },
@@ -6586,7 +6586,7 @@
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
@@ -6645,19 +6645,19 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
@@ -6911,7 +6911,7 @@
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -7855,7 +7855,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -8651,7 +8651,7 @@
     },
     "typedarray": {
       "version": "0.0.6",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
@@ -9109,7 +9109,7 @@
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": false,
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
     },

--- a/readme.txt
+++ b/readme.txt
@@ -126,13 +126,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.7.0 - 2020-12-22 =
-* Fix - Updating subscription payment methods from the "My Account" page now adds a note to the subscription.
-* Fix - Link is now correctly formatted in readme.txt.
-* Fix - Using SCA cards for subscriptions renewal payments now works as intended.
-* Fix - Cards added under "My Account -> Payment Methods -> Add Payment Method" will now handle SCA properly.
-* Fix - Changing a payment method for a subscription in "My Account -> Subscriptions" will now handle SCA properly.
-* Fix - Missing space causing fatal errors for certain WooCommerce Inbox Note features.
+= 4.8.0 - 2021-xx-xx =
+* Fix - Filter more disallowed characters from statement descriptors.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).
 

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -69,34 +69,28 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 	/**
 	 * Stripe requires statement_descriptor to be no longer than 22 characters.
 	 * In addition, it cannot contain <>"' special characters.
+	 *
+     * @dataProvider statement_descriptor_sanitation_provider
 	 */
-	public function test_statement_descriptor_sanitation() {
-		$statement_descriptor1 = array(
-			'actual'   => 'Test\'s Store',
-			'expected' => 'Tests Store',
-		);
+	public function test_statement_descriptor_sanitation( $original, $expected ) {
+		$this->assertEquals( $expected, WC_Stripe_Helper::clean_statement_descriptor( $original ) );
+	}
 
-		$this->assertEquals( $statement_descriptor1['expected'], WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor1['actual'] ) );
-
-		$statement_descriptor2 = array(
-			'actual'   => 'Test\'s Store > Driving Course Range',
-			'expected' => 'Tests Store  Driving C',
-		);
-
-		$this->assertEquals( $statement_descriptor2['expected'], WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor2['actual'] ) );
-
-		$statement_descriptor3 = array(
-			'actual'   => 'Test\'s Store < Driving Course Range',
-			'expected' => 'Tests Store  Driving C',
-		);
-
-		$this->assertEquals( $statement_descriptor3['expected'], WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor3['actual'] ) );
-
-		$statement_descriptor4 = array(
-			'actual'   => 'Test\'s Store " Driving Course Range',
-			'expected' => 'Tests Store  Driving C',
-		);
-
-		$this->assertEquals( $statement_descriptor4['expected'], WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor4['actual'] ) );
+	public function statement_descriptor_sanitation_provider() {
+		return [
+			'removes \'' => [ 'Test\'s Store', 'Tests Store' ],
+			'removes "' => [ 'Test " Store', 'Test  Store' ],
+			'removes <' => [ 'Test < Store', 'Test  Store' ],
+			'removes >' => [ 'Test > Store', 'Test  Store' ],
+			'removes /' => [ 'Test / Store', 'Test  Store' ],
+			'removes (' => [ 'Test ( Store', 'Test  Store' ],
+			'removes )' => [ 'Test ) Store', 'Test  Store' ],
+			'removes {' => [ 'Test { Store', 'Test  Store' ],
+			'removes }' => [ 'Test } Store', 'Test  Store' ],
+			'keeps at most 22 chars' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
+			'mixed length, \' and >' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
+			'mixed length, \' and <' => [ 'Test\'s Store < Driving Course Range', 'Tests Store  Driving C' ],
+			'mixed length, \' and "' => [ 'Test\'s Store " Driving Course Range', 'Tests Store  Driving C' ]
+		];
 	}
 }

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -87,6 +87,8 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 			'removes )' => [ 'Test ) Store', 'Test  Store' ],
 			'removes {' => [ 'Test { Store', 'Test  Store' ],
 			'removes }' => [ 'Test } Store', 'Test  Store' ],
+			'removes \\' => [ 'Test \\ Store', 'Test  Store' ],
+			'removes *' => [ 'Test * Store', 'Test  Store' ],
 			'keeps at most 22 chars' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
 			'mixed length, \' and >' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
 			'mixed length, \' and <' => [ 'Test\'s Store < Driving Course Range', 'Tests Store  Driving C' ],


### PR DESCRIPTION
Fixes #1262 .

#### Changes proposed in this Pull Request:
- Adds / ( ) { and } to disallowed descriptor character list

#### Testing
- Attempt to add those characters to your descriptor. Ensure they are removed for you.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

