### PR TITLE
Filter additional metadata for order status changes

### DIFF
--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -344,18 +344,37 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param string Event name, e.g. orders_edit_status_change.
 	 */
 	public function woocommerce_tracks_event_properties( $properties, $prefixed_event_name ) {
-		if ( 'wcadmin_orders_edit_status_change' === $prefixed_event_name ) {
-			$is_live         = true;
-			$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
-			if ( array_key_exists( 'testmode', $stripe_settings ) ) {
-				$is_live = 'no' === $stripe_settings[ 'testmode' ];
-			}
-
-			$properties[ 'admin_email' ]                        = get_option( 'admin_email' );
-			$properties[ 'is_live' ]                            = $is_live;
-			$properties[ 'woocommerce_gateway_stripe_version' ] = WC_STRIPE_VERSION;
-			$properties[ 'woocommerce_default_country' ]        = get_option( 'woocommerce_default_country' );
+		// Not the desired event? Bail.
+		if ( 'wcadmin_orders_edit_status_change' != $prefixed_event_name ) {
+			return $properties;
 		}
+
+		// Properties not an array? Bail.
+		if ( ! is_array( $properties ) ) {
+			return $properties;
+		}
+
+		// No payment_method in properties? Bail.
+		if ( ! array_key_exists( 'payment_method', $properties ) ) {
+			return $properties;
+		}
+
+		// Not stripe? Bail.
+		if ( 'stripe' != $properties[ 'payment_method' ] ) {
+			return $properties;
+		}
+
+		// Due diligence done. Collect the metadata.
+		$is_live         = true;
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+		if ( array_key_exists( 'testmode', $stripe_settings ) ) {
+			$is_live = 'no' === $stripe_settings[ 'testmode' ];
+		}
+
+		$properties[ 'admin_email' ]                        = get_option( 'admin_email' );
+		$properties[ 'is_live' ]                            = $is_live;
+		$properties[ 'woocommerce_gateway_stripe_version' ] = WC_STRIPE_VERSION;
+		$properties[ 'woocommerce_default_country' ]        = get_option( 'woocommerce_default_country' );
 
 		return $properties;
 	}

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -28,6 +28,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 		add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_payment' ) );
 		add_action( 'woocommerce_order_status_refunded', array( $this, 'cancel_payment' ) );
+		add_filter( 'woocommerce_tracks_event_properties', array( $this, 'woocommerce_tracks_event_properties' ), 10, 2 );
 	}
 
 	/**
@@ -332,6 +333,31 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			// This hook fires when admin manually changes order status to cancel.
 			do_action( 'woocommerce_stripe_process_manual_cancel', $order );
 		}
+	}
+
+	/**
+	 * Filter. Adds additional meta data to Tracks events.
+	 * Note that this filter is only called if WC_Site_Tracking::is_tracking_enabled.
+	 *
+	 * @since 4.5.1
+	 * @param array Properties to be appended to.
+	 * @param string Event name, e.g. orders_edit_status_change.
+	 */
+	public function woocommerce_tracks_event_properties( $properties, $prefixed_event_name ) {
+		if ( 'wcadmin_orders_edit_status_change' === $prefixed_event_name ) {
+			$is_live         = true;
+			$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+			if ( array_key_exists( 'testmode', $stripe_settings ) ) {
+				$is_live = 'no' === $stripe_settings[ 'testmode' ];
+			}
+
+			$properties[ 'admin_email' ]                        = get_option( 'admin_email' );
+			$properties[ 'is_live' ]                            = $is_live;
+			$properties[ 'woocommerce_gateway_stripe_version' ] = WC_STRIPE_VERSION;
+			$properties[ 'woocommerce_default_country' ]        = get_option( 'woocommerce_default_country' );
+		}
+
+		return $properties;
 	}
 }
 


### PR DESCRIPTION
Fixes #1260  .

#### Changes proposed in this Pull Request:
- Adds additional metadata to order status changes when using this payment method

#### To test:
- Enable tracking (wp-admin > WooCommerce > Settings > Advanced)
- Complete some orders (test works fine) using the Stripe payment method
- Ensure Tracks receives the wcadmin_orders_edit_status_change  events and the metadata is added (admin email, test/live, default country and plugin version)

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

