### PR TITLE
added admin option to bypass stripe useragent check, an issue when us…

### DIFF
--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -186,5 +186,13 @@ return apply_filters(
 			'default'     => 'no',
 			'desc_tip'    => true,
 		),
+		'cloudfront_user_agent'                       => array(
+			'title'       => __( 'Cloud Front User Agent', 'woocommerce-gateway-stripe' ),
+			'label'       => __( 'Enable Cloud Front User Agent', 'woocommerce-gateway-stripe' ),
+			'type'        => 'checkbox',
+			'description' => __( 'Disable check for stripe user agent in webhook handles.', 'woocommerce-gateway-stripe' ),
+			'default'     => 'no',
+			'desc_tip'    => true,
+		),
 	)
 );


### PR DESCRIPTION
This fix creates an admin option in the stripes payment settings that allows a bypass to the stripe useragent check. This was discovered to be an issue for sites using cloudfront.

Fixes # 1195.

#### Changes proposed in this Pull Request:
- Added checkbox option called Cloud Front User Agent that will bypass the stripe user agent check in `class-wc-stripe-webhook-handler`

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

