### PR TITLE
Add shipping address to payment requests

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -359,6 +359,20 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				break;
 		}
 
+		if ( ! empty( $order->get_shipping_postcode() ) ) {
+			$post_data['shipping'] = array(
+				'name'    => trim( $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name() ),
+				'address' => array(
+					'line1'       => $order->get_shipping_address_1(),
+					'line2'       => $order->get_shipping_address_2(),
+					'city'        => $order->get_shipping_city(),
+					'country'     => $order->get_shipping_country(),
+					'postal_code' => $order->get_shipping_postcode(),
+					'state'       => $order->get_shipping_state(),
+				)
+			);
+		}
+
 		$post_data['expand[]'] = 'balance_transaction';
 
 		$metadata = array(
@@ -1039,6 +1053,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$request['statement_descriptor'] = $full_request['statement_descriptor'];
 		}
 
+		if ( isset( $full_request['shipping'] ) ) {
+			$request['shipping'] = $full_request['shipping'];
+		}
+
 		/**
 		 * Filter the return value of the WC_Payment_Gateway_CC::generate_create_intent_request.
 		 *
@@ -1378,6 +1396,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		if ( isset( $full_request['source'] ) ) {
 			$request['source'] = $full_request['source'];
+		}
+
+		if ( isset( $full_request['shipping'] ) ) {
+			$request['shipping'] = $full_request['shipping'];
 		}
 
 		$level3_data = $this->get_level3_data_from_order( $order );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -359,7 +359,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				break;
 		}
 
-		if ( ! empty( $order->get_shipping_postcode() ) ) {
+		if ( method_exists( $order, 'get_shipping_postcode' ) && ! empty( $order->get_shipping_postcode() ) ) {
 			$post_data['shipping'] = array(
 				'name'    => trim( $order->get_shipping_first_name() . ' ' . $order->get_shipping_last_name() ),
 				'address' => array(


### PR DESCRIPTION
Fixes #1266

#### Changes proposed in this Pull Request:
- Sets the `shipping` property on payment requests when available in the order

#### To test
- Make a payment
- Open the payment in Stripe dashboard
- Confirm the shipping address is present

