### PR TITLE
Add: Declare WooCommerce version support in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,8 @@ Requires at least: 4.4
 Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: 4.5.0
+WC requires at least: 2.6
+WC tested up to: 4.3.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe


### PR DESCRIPTION
Fixes #1282 .

#### Changes proposed in this Pull Request:
Added 

`WC requires at least: 2.6`
`WC tested up to: 4.3.2`

in plugin header. 
-------------------
- [✅] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [-] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

