### PR TITLE
Remove country check, roll version to 4.5.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.5.2 - 2020-08-19 =
+* Fix - Allow extension to attempt to run in all countries, not just officially supported ones
+
 = 4.5.1 - 2020-08-12 =
 * Add - Support for Bulgaria, Czech Republic, Greece, Cyprus, Malta, Slovenia
 * Add - Additional metadata for order status change events when tracking is permitted

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.5.1\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.5.2\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2020-08-12 19:35:17+00:00\n"
+"POT-Creation-Date: 2020-08-19 19:45:47+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1315,7 +1315,7 @@ msgid ""
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-alipay.php:60
-#: woocommerce-gateway-stripe.php:364
+#: woocommerce-gateway-stripe.php:292
 msgid "Stripe Alipay"
 msgstr ""
 
@@ -1344,27 +1344,27 @@ msgid "Add Payment"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-bancontact.php:60
-#: woocommerce-gateway-stripe.php:358
+#: woocommerce-gateway-stripe.php:286
 msgid "Stripe Bancontact"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-eps.php:60
-#: woocommerce-gateway-stripe.php:361
+#: woocommerce-gateway-stripe.php:289
 msgid "Stripe EPS"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-giropay.php:60
-#: woocommerce-gateway-stripe.php:360
+#: woocommerce-gateway-stripe.php:288
 msgid "Stripe Giropay"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-ideal.php:60
-#: woocommerce-gateway-stripe.php:362
+#: woocommerce-gateway-stripe.php:290
 msgid "Stripe iDeal"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-multibanco.php:60
-#: woocommerce-gateway-stripe.php:366
+#: woocommerce-gateway-stripe.php:294
 msgid "Stripe Multibanco"
 msgstr ""
 
@@ -1393,12 +1393,12 @@ msgid "Awaiting Multibanco payment"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-p24.php:60
-#: woocommerce-gateway-stripe.php:363
+#: woocommerce-gateway-stripe.php:291
 msgid "Stripe P24"
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-sepa.php:75
-#: woocommerce-gateway-stripe.php:365
+#: woocommerce-gateway-stripe.php:293
 msgid "Stripe SEPA Direct Debit"
 msgstr ""
 
@@ -1425,7 +1425,7 @@ msgid ""
 msgstr ""
 
 #: includes/payment-methods/class-wc-gateway-stripe-sofort.php:60
-#: woocommerce-gateway-stripe.php:359
+#: woocommerce-gateway-stripe.php:287
 msgid "Stripe SOFORT"
 msgstr ""
 
@@ -1515,29 +1515,23 @@ msgid ""
 "WooCommerce %2$s is no longer supported."
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:64
-msgid ""
-"Stripe is not available in your store's country and will not be available "
-"for buyers to choose during checkout."
-msgstr ""
-
-#: woocommerce-gateway-stripe.php:288
+#: woocommerce-gateway-stripe.php:216
 msgid "Settings"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:304
+#: woocommerce-gateway-stripe.php:232
 msgid "View Documentation"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:304
+#: woocommerce-gateway-stripe.php:232
 msgid "Docs"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:305
+#: woocommerce-gateway-stripe.php:233
 msgid "Open a support request at WooCommerce.com"
 msgstr ""
 
-#: woocommerce-gateway-stripe.php:305
+#: woocommerce-gateway-stripe.php:233
 msgid "Support"
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort,
 Requires at least: 4.4
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 4.5.1
+Stable tag: 4.5.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe
@@ -126,9 +126,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.5.1 - 2020-08-12 =
-* Add - Support for Bulgaria, Czech Republic, Greece, Cyprus, Malta, Slovenia
-* Add - Additional metadata for order status change events when tracking is permitted
+= 4.5.2 - 2020-08-19 =
+* Fix - Allow extension to attempt to run in all countries, not just officially supported ones
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 4.5.1
+ * Version: 4.5.2
  * Requires at least: 4.4
  * Tested up to: 5.5
  * WC requires at least: 3.0
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_STRIPE_VERSION', '4.5.1' );
+define( 'WC_STRIPE_VERSION', '4.5.2' );
 define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 define( 'WC_STRIPE_MIN_WC_VER', '3.0' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );
@@ -54,73 +54,6 @@ function woocommerce_stripe_wc_not_supported() {
 	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_STRIPE_MIN_WC_VER, WC_VERSION ) . '</strong></p></div>';
 }
 
-/**
- * WooCommerce country not supported notice.
- *
- * @since 4.5.1
- * @return string
- */
-function woocommerce_stripe_wc_country_not_supported() {
-	echo '<div class="error"><p><strong>' . __( 'Stripe is not available in your store\'s country and will not be available for buyers to choose during checkout.', 'woocommerce-gateway-stripe' ) . '</strong></p></div>';
-}
-
-/**
- * Check that the WooCommerce country is supported by Stripe.
- * See https://stripe.com/global for list.
- *
- * @since 4.5.1
- * @return bool
- */
-function woocommerce_stripe_wc_country_is_supported_country() {
-	$wc_default_country = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
-
-	$supported_countries = apply_filters(
-		'wc_stripe_supported_countries',
-		array(
-			'AT', // Austria
-			'AU', // Australia
-			'BE', // Belgium
-			'BG', // Bulgaria
-			'CA', // Canada
-			'CY', // Cyprus
-			'CZ', // Czech Republic
-			'DK', // Denmark
-			'EE', // Estonia
-			'FI', // Finland
-			'FR', // France
-			'DE', // Germany
-			'GR', // Greece
-			'HK', // Hong Kong
-			'IE', // Ireland
-			'IT', // Italy
-			'JP', // Japan
-			'LV', // Latvia
-			'LT', // Lithuania
-			'LU', // Luxembourg
-			'MY', // Malaysia
-			'MT', // Malta
-			'MX', // Mexico
-			'NL', // Netherlands
-			'NZ', // New Zealand
-			'NO', // Norway
-			'PL', // Poland
-			'PR', // Puerto Rico #1203
-			'PT', // Portugal
-			'RO', // Romania
-			'SG', // Singapore
-			'SK', // Slovakia
-			'SI', // Slovenia
-			'ES', // Spain
-			'SE', // Sweden
-			'CH', // Switzerland
-			'GB', // United Kingdom (UK)
-			'US'  // United States (US)
-		)
-	);
-
-	return in_array( $wc_default_country, $supported_countries );
-}
-
 add_action( 'plugins_loaded', 'woocommerce_gateway_stripe_init' );
 
 function woocommerce_gateway_stripe_init() {
@@ -133,11 +66,6 @@ function woocommerce_gateway_stripe_init() {
 
 	if ( version_compare( WC_VERSION, WC_STRIPE_MIN_WC_VER, '<' ) ) {
 		add_action( 'admin_notices', 'woocommerce_stripe_wc_not_supported' );
-		return;
-	}
-
-	if ( ! woocommerce_stripe_wc_country_is_supported_country() ) {
-		add_action( 'admin_notices', 'woocommerce_stripe_wc_country_not_supported' );
 		return;
 	}
 


### PR DESCRIPTION
Fixes #1286 
Fixes #1284 

#### Changes proposed in this Pull Request:
- Remove the country check
- Roll to 4.5.2

#### Recommended minimum testing:
- `npm run build`
- Install the resulting plugin ZIP on a test site for an not-yet-officially supported country, e.g. India
- Ensure the plugin shows "4.5.2" as its release version
- Ensure the payment form displays on checkout
- Change the store location to an officially supported country, e.g. the United States
- Ensure you can complete a test purchase.

fyi @bmccotter 

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

