### PR TITLE
update wordpress.org contributor list, sync readme with wordpress.org

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === WooCommerce Stripe Payment Gateway ===
-Contributors: automattic, royho, akeda, mattyza, bor0, woothemes
+Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
 Requires at least: 4.4
 Tested up to: 5.5


### PR DESCRIPTION
This PR updates the WordPress.org `readme.txt` to make `woocommerce` the `Developer` of the plugin.

ref: p1596823265254600-sl