### PR TITLE
added name support to creating a stripe customer

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -120,7 +120,10 @@ class WC_Stripe_Customer {
 			// translators: %1$s First name, %2$s Second name, %3$s Username.
 			$description = sprintf( __( 'Name: %1$s %2$s, Username: %s', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name, $user->user_login );
 
+			$billing_full_name = "$billing_first_name $billing_last_name";
+			
 			$defaults = array(
+				'name'        => $billing_full_name,
 				'email'       => $user->user_email,
 				'description' => $description,
 			);
@@ -130,8 +133,11 @@ class WC_Stripe_Customer {
 
 			// translators: %1$s First name, %2$s Second name.
 			$description = sprintf( __( 'Name: %1$s %2$s, Guest', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name );
-
+			
+			$billing_full_name = "$billing_first_name $billing_last_name";
+			
 			$defaults = array(
+				'name'        => $billing_full_name,
 				'email'       => $billing_email,
 				'description' => $description,
 			);


### PR DESCRIPTION
Fixes # .

#### Changes proposed in this Pull Request:
- $billing_full_name is derived from $billing_first_name and $billing_last_name filling the "name" field in stripe on the customer object.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

