### PR TITLE
Update payment request button description to include link to dashboard

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.5.3 - 2020-09-29 =
+* Add - Link from Payment Request button setting to Apple Pay settings in Stripe dashboard
+
 = 4.5.2 - 2020-08-19 =
 * Fix - Allow extension to attempt to run in all countries, not just officially supported ones
 

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -114,7 +114,7 @@ return apply_filters(
 				'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
 				'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>',
 				'<a href="https://dashboard.stripe.com/settings/payments/apple_pay" target="_blank">',
-				'</a>',
+				'</a>'
 			),
 			'type'        => 'checkbox',
 			'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-gateway-stripe' ),

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -107,8 +107,15 @@ return apply_filters(
 		),
 		'payment_request'               => array(
 			'title'       => __( 'Payment Request Buttons', 'woocommerce-gateway-stripe' ),
-			/* translators: 1) br tag 2) opening anchor tag 3) closing anchor tag */
-			'label'       => sprintf( __( 'Enable Payment Request Buttons. (Apple Pay/Chrome Payment Request API) %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service.', 'woocommerce-gateway-stripe' ), '<br />', '<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>', '<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>' ),
+			/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe dashboard opening anchor tag 5) Stripe dashboard closing anchor tag */
+			'label'       => sprintf(
+				__( 'Enable Payment Request Buttons. (Apple Pay/Google Pay) %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service. %4$sLog into your Stripe dashboard%5$s to complete or update your Apple Pay setup.', 'woocommerce-gateway-stripe' ),
+				'<br />',
+				'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
+				'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>',
+				'<a href="https://dashboard.stripe.com/settings/payments/apple_pay" target="_blank">',
+				'</a>',
+			),
 			'type'        => 'checkbox',
 			'description' => __( 'If enabled, users will be able to pay using Apple Pay or Chrome Payment Request if supported by the browser.', 'woocommerce-gateway-stripe' ),
 			'default'     => 'yes',

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.5.2\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.5.3\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2020-08-19 19:45:47+00:00\n"
+"POT-Creation-Date: 2020-09-30 21:58:11+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -661,148 +661,150 @@ msgstr ""
 msgid "Payment Request Buttons"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:111
-#. translators: 1) br tag 2) opening anchor tag 3) closing anchor tag
+#: includes/admin/stripe-settings.php:112
+#. translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe
+#. dashboard opening anchor tag 5) Stripe dashboard closing anchor tag
 msgid ""
-"Enable Payment Request Buttons. (Apple Pay/Chrome Payment Request API) "
-"%1$sBy using Apple Pay, you agree to %2$s and %3$s's terms of service."
+"Enable Payment Request Buttons. (Apple Pay/Google Pay) %1$sBy using Apple "
+"Pay, you agree to %2$s and %3$s's terms of service. %4$sLog into your "
+"Stripe dashboard%5$s to complete or update your Apple Pay setup."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:113
+#: includes/admin/stripe-settings.php:120
 msgid ""
 "If enabled, users will be able to pay using Apple Pay or Chrome Payment "
 "Request if supported by the browser."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:118
+#: includes/admin/stripe-settings.php:125
 msgid "Payment Request Button Type"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:119
+#: includes/admin/stripe-settings.php:126
 msgid "Button Type"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:121
+#: includes/admin/stripe-settings.php:128
 msgid "Select the button type you would like to show."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:125
+#: includes/admin/stripe-settings.php:132
 msgid "Default"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:126
+#: includes/admin/stripe-settings.php:133
 msgid "Buy"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:127
+#: includes/admin/stripe-settings.php:134
 msgid "Donate"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:128
+#: includes/admin/stripe-settings.php:135
 msgid "Branded"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:129
+#: includes/admin/stripe-settings.php:136
 msgid "Custom"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:133
+#: includes/admin/stripe-settings.php:140
 msgid "Payment Request Button Theme"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:134
+#: includes/admin/stripe-settings.php:141
 msgid "Button Theme"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:136
+#: includes/admin/stripe-settings.php:143
 msgid "Select the button theme you would like to show."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:140
+#: includes/admin/stripe-settings.php:147
 msgid "Dark"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:141
+#: includes/admin/stripe-settings.php:148
 msgid "Light"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:142
+#: includes/admin/stripe-settings.php:149
 msgid "Light-Outline"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:146
+#: includes/admin/stripe-settings.php:153
 msgid "Payment Request Button Height"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:147
+#: includes/admin/stripe-settings.php:154
 msgid "Button Height"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:149
+#: includes/admin/stripe-settings.php:156
 msgid ""
 "Enter the height you would like the button to be in pixels. Width will "
 "always be 100%."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:154
+#: includes/admin/stripe-settings.php:161
 msgid "Payment Request Button Label"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:155
+#: includes/admin/stripe-settings.php:162
 msgid "Button Label"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:157
+#: includes/admin/stripe-settings.php:164
 msgid "Enter the custom text you would like the button to have."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:158
+#: includes/admin/stripe-settings.php:165
 msgid "Buy now"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:162
+#: includes/admin/stripe-settings.php:169
 msgid "Payment Request Branded Button Label Format"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:163
+#: includes/admin/stripe-settings.php:170
 msgid "Branded Button Label Format"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:165
+#: includes/admin/stripe-settings.php:172
 msgid "Select the branded button label format."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:169
+#: includes/admin/stripe-settings.php:176
 msgid "Logo only"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:170
+#: includes/admin/stripe-settings.php:177
 msgid "Text and logo"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:174
+#: includes/admin/stripe-settings.php:181
 msgid "Saved Cards"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:175
+#: includes/admin/stripe-settings.php:182
 msgid "Enable Payment via Saved Cards"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:177
+#: includes/admin/stripe-settings.php:184
 msgid ""
 "If enabled, users will be able to pay with a saved card during checkout. "
 "Card details are saved on Stripe servers, not on your store."
 msgstr ""
 
-#: includes/admin/stripe-settings.php:182
+#: includes/admin/stripe-settings.php:189
 msgid "Logging"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:183
+#: includes/admin/stripe-settings.php:190
 msgid "Log debug messages"
 msgstr ""
 
-#: includes/admin/stripe-settings.php:185
+#: includes/admin/stripe-settings.php:192
 msgid "Save debug messages to the WooCommerce System Status log."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "4.5.2",
+  "version": "4.5.3",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort,
 Requires at least: 4.4
 Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 4.5.2
+Stable tag: 4.5.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe
@@ -126,8 +126,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.5.2 - 2020-08-19 =
-* Fix - Allow extension to attempt to run in all countries, not just officially supported ones
+= 4.5.3 - 2020-09-29 =
+* Add - Link from Payment Request button setting to Apple Pay settings in Stripe dashboard
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 4.5.2
+ * Version: 4.5.3
  * Requires at least: 4.4
  * Tested up to: 5.5
  * WC requires at least: 3.0
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_STRIPE_VERSION', '4.5.2' );
+define( 'WC_STRIPE_VERSION', '4.5.3' );
 define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 define( 'WC_STRIPE_MIN_WC_VER', '3.0' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.0' );


### PR DESCRIPTION
Fixes #1308

#### Changes proposed in this Pull Request:
- Updates the payment request setting description to include a deep link to the Apple Pay settings on the merchant's Stripe dashboard
- Bumps the versions to 4.5.3

#### Testing
- Make sure all links function correctly in the description, not just the new one
- Make sure the new link drops you on https://dashboard.stripe.com/settings/payments/apple_pay (you may need to log in, and then it will take you there if you weren't logged in already)

cc @bmccotter 

<img width="1125" alt="Screen Shot 2020-09-28 at 3 10 01 PM" src="https://user-images.githubusercontent.com/1595739/94491328-de3d0900-019c-11eb-8e30-3f6fbcdd08e2.png">


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

