### PR TITLE
Add site_url to all transactions, not just recurring

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** Changelog ***
 
 = 4.5.4 - 2020-xx-xx =
-* Add - Security.md with security and vulnerability reporting guidelines.
+* Add   - Security.md with security and vulnerability reporting guidelines.
+* Tweak - Add site_url to all transactions, not just recurring ones.
 
 = 4.5.3 - 2020-10-06 =
 * Fix   - Apple Pay now requires a buyer's phone number only if it's required in Appearance > Customize > WooCommerce > Checkout.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -322,7 +322,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Generate the request for the payment.
 	 *
 	 * @since 3.1.0
-	 * @version 4.0.0
+	 * @version 4.5.4
 	 * @param  WC_Order $order
 	 * @param  object $prepared_source
 	 * @return array()
@@ -379,12 +379,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			__( 'customer_name', 'woocommerce-gateway-stripe' ) => sanitize_text_field( $billing_first_name ) . ' ' . sanitize_text_field( $billing_last_name ),
 			__( 'customer_email', 'woocommerce-gateway-stripe' ) => sanitize_email( $billing_email ),
 			'order_id' => $order->get_order_number(),
+			'site_url' => esc_url( get_site_url() ),
 		);
 
 		if ( $this->has_subscription( $order->get_id() ) ) {
 			$metadata += array(
 				'payment_type' => 'recurring',
-				'site_url'     => esc_url( get_site_url() ),
 			);
 		}
 
@@ -1398,7 +1398,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$is_source = 'src_' === substr( $full_request['source'], 0, 4 );
 			$request[ $is_source ? 'source' : 'payment_method' ] = $full_request['source'];
 		}
-	
+
 		/**
 		 * Filter the value of the request.
 		 *


### PR DESCRIPTION

#### Changes proposed in this Pull Request:
- Add `site_url` to all transactions, not just recurring ones.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

