### PR TITLE
Add apple association and uninstall files

### DIFF
--- a/tasks/release.js
+++ b/tasks/release.js
@@ -19,6 +19,8 @@ const filesToCopy = [
 	'woocommerce-gateway-stripe.php',
 	'changelog.txt',
 	'readme.txt',
+	'apple-developer-merchantid-domain-association',
+	'uninstall.php',
 ];
 
 // run npm dist


### PR DESCRIPTION
Fixes #1311 

#### Changes proposed in this Pull Request:
- Adds the apple association file to the build ZIP
- Adds the uninstall file to the build ZIP

#### To test:
- composer install
- composer update
- npm install
- npm run prebuild
- npm run build
- npm run build:release
- Make sure release/woocommerce-gateway-stripe.zip includes both files (in the root of the ZIP)
-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

