### PR TITLE
Perform Apple Pay domain verification on setup outside of settings screen

### DIFF
--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -53,7 +53,7 @@ class WC_Stripe_Apple_Pay_Registration {
 	public $apple_pay_verify_notice;
 
 	public function __construct() {
-		add_action( 'woocommerce_stripe_updated', array( $this, 'update_domain_association_file' ) );
+		add_action( 'woocommerce_stripe_updated', array( $this, 'verify_domain_if_needed' ) );
 		add_action( 'updated_option', array( $this, 'verify_domain_on_new_secret_key' ), 10, 3 );
 
 		$this->stripe_settings         = get_option( 'woocommerce_stripe_settings', array() );
@@ -257,6 +257,20 @@ class WC_Stripe_Apple_Pay_Registration {
 		$this->secret_key = $this->get_secret_key();
 
 		if ( ! empty( $this->secret_key ) && $this->secret_key !== $prev_secret_key ) {
+			$this->verify_domain();
+		}
+	}
+
+	/**
+	 * Process the Apple Pay domain verification if not already done - otherwise just update the file.
+	 *
+	 * @since 4.5.3
+	 * @version 4.5.3
+	 */
+	public function verify_domain_if_needed() {
+		if ( $this->apple_pay_domain_set ) {
+			$this->update_domain_association_file();
+		} else {
 			$this->verify_domain();
 		}
 	}

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -54,7 +54,7 @@ class WC_Stripe_Apple_Pay_Registration {
 
 	public function __construct() {
 		add_action( 'woocommerce_stripe_updated', array( $this, 'verify_domain_if_needed' ) );
-		add_action( 'updated_option', array( $this, 'verify_domain_on_new_secret_key' ), 10, 3 );
+		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'verify_domain_on_new_secret_key' ), 10, 2 );
 
 		$this->stripe_settings         = get_option( 'woocommerce_stripe_settings', array() );
 		$this->stripe_enabled          = $this->get_option( 'enabled' );
@@ -245,11 +245,7 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * @since 4.5.3
 	 * @version 4.5.3
 	 */
-	public function verify_domain_on_new_secret_key( $option, $prev_settings, $settings ) {
-		if ( 'woocommerce_stripe_settings' !== $option ) {
-			return;
-		}
-
+	public function verify_domain_on_new_secret_key( $prev_settings, $settings ) {
 		$this->stripe_settings = $prev_settings;
 		$prev_secret_key = $this->get_secret_key();
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1313

Hooks into updates of the secret key to **trigger domain verification** even when onboarding is done via an entry point other than the Settings screen (namely the Stripe onboarding task in WooCommerce core).

Also adds this to the plugin update mechanism, for those who already did the setup but are just missing the domain verification piece.

To test, can install this version on a new instance, and then:
- Ensure that domain does not appear [on Dashboard](https://dashboard.stripe.com/settings/payments/apple_pay)
- Connect Jetpack + WooCommerce Services (e.g. via end of Setup Wizard)
- Go to Task List » Set up payments » Stripe (Set up)
- "Connect" Stripe account via OAuth
- Observe that domain now appears [on Dashboard](https://dashboard.stripe.com/settings/payments/apple_pay)

Or, with WC 4.6 ([RC 1](https://github.com/woocommerce/woocommerce/releases/tag/4.6.0-rc.1)), which properly [configures mode without going to the Settings screen](https://github.com/woocommerce/woocommerce-admin/pull/5226):
- Ensure that domain does not appear [on Dashboard](https://dashboard.stripe.com/settings/payments/apple_pay)
- With WooCommerce Services not connected, go to Task List » Set up payments » Stripe (Set up)
- Enter keys
- Observe that domain immediately appears [on Dashboard](https://dashboard.stripe.com/settings/payments/apple_pay)

Also, can go through the either flow with existing Stripe extension version, and then verify that domain only appears registered after upgrading to this branch.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

