### PR TITLE
Fix the "Not a valid URL" notice

### DIFF
--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -260,26 +260,27 @@ class WC_Stripe_Apple_Pay_Registration {
 		 * when setting screen is displayed. So if domain verification is not set,
 		 * something went wrong so lets notify user.
 		 */
-		$allowed_html = array(
+		$allowed_html                      = array(
 			'a' => array(
 				'href'  => array(),
 				'title' => array(),
 			),
 		);
-
-		echo '<div class="error stripe-apple-pay-message">';
-
-		echo '<p>' . __( 'Apple Pay domain verification failed', 'woocommerce-gateway-stripe' );
-		$reason = $empty_notice ? '' : ' ' . __( 'with the following error:', 'woocommerce-gateway-stripe' ) . '</p><p>' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html );
-		echo $reason . '.</p>';
-
-		echo '<p>' . sprintf(
+		$error_from_stripe                 = $empty_notice ? '' : '<p>' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html ) . '.</p>';
+		$verification_failed_without_error = __( 'Apple Pay domain verification failed.', 'woocommerce-gateway-stripe' );
+		$verification_failed_with_error    = __( 'Apple Pay domain verification failed with the following error:', 'woocommerce-gateway-stripe' );
+		$check_log_text                    = sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
 			'<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
 			'</a>'
-		) . '</p>';
+		);
 
+		$notice_text = $empty_notice ? $verification_failed_without_error : $verification_failed_with_error;
+		echo '<div class="error stripe-apple-pay-message">';
+		echo '<p>' . $notice_text . '</p>';
+		echo $error_from_stripe; // Contains `<p>` tags if an error is present.
+		echo '<p>' . $check_log_text . '</p>';
 		echo '</div>';
 	}
 }

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -281,7 +281,7 @@ class WC_Stripe_Apple_Pay_Registration {
 				<p><?php echo esc_html( $verification_failed_without_error ); ?></p>
 			<?php else : ?>
 				<p><?php echo esc_html( $verification_failed_with_error ); ?></p>
-				<p><?php echo wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ); ?></p>
+				<p><i><?php echo wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ); ?></i></p>
 			<?php endif; ?>
 			<p><?php echo $check_log_text; ?></p>
 		</div>

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -267,20 +267,20 @@ class WC_Stripe_Apple_Pay_Registration {
 			),
 		);
 
-		echo '<div class="error stripe-apple-pay-message"><p>';
+		echo '<div class="error stripe-apple-pay-message">';
 
-		echo 'Apple Pay domain verification failed';
-		$reason = $empty_notice ? '' : ' with the error: ' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html ) . '';
-		echo $reason . '.<br />';
+		echo '<p>Apple Pay domain verification failed';
+		$reason = $empty_notice ? '' : ' with the following error:</p><p>' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html );
+		echo $reason . '.</p>';
 
-		echo sprintf(
+		echo '<p>' . sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			__( 'Please check the %1$slog%2$s to see the issue (logging must be enabled to see recorded logs).', 'woocommerce-gateway-stripe' ),
+			__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
 			 '<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
 			 '</a>'
-		);
+		) . '</p>';
 
-		echo '</p></div>';
+		echo '</div>';
 	}
 }
 

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -266,7 +266,7 @@ class WC_Stripe_Apple_Pay_Registration {
 				'title' => array(),
 			),
 		);
-		$error_from_stripe                 = $empty_notice ? '' : '<p>' . wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ) . '.</p>';
+		$error_from_stripe                 = $empty_notice ? '' : '<p>' . wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ) . '</p>';
 		$verification_failed_without_error = esc_html__( 'Apple Pay domain verification failed.', 'woocommerce-gateway-stripe' );
 		$verification_failed_with_error    = esc_html__( 'Apple Pay domain verification failed with the following error:', 'woocommerce-gateway-stripe' );
 		$check_log_text                    = sprintf(

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -228,6 +228,7 @@ class WC_Stripe_Apple_Pay_Registration {
 
 		} catch ( Exception $e ) {
 			$this->stripe_settings['apple_pay_domain_set'] = 'no';
+			$this->apple_pay_domain_set                    = false;
 
 			update_option( 'woocommerce_stripe_settings', $this->stripe_settings );
 
@@ -241,7 +242,7 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * @since 4.0.6
 	 */
 	public function admin_notices() {
-		if ( ! $this->stripe_enabled ) {
+		if ( ! $this->stripe_enabled || ! $this->payment_request ) {
 			return;
 		}
 
@@ -249,15 +250,9 @@ class WC_Stripe_Apple_Pay_Registration {
 			return;
 		}
 
-		if ( $this->payment_request && ! empty( $this->apple_pay_verify_notice ) ) {
-			$allowed_html = array(
-				'a' => array(
-					'href'  => array(),
-					'title' => array(),
-				),
-			);
-
-			echo '<div class="error stripe-apple-pay-message"><p>' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html ) . '</p></div>';
+		$empty_notice = empty( $this->apple_pay_verify_notice );
+		if ( $empty_notice && ( $this->apple_pay_domain_set || empty( $this->secret_key ) ) ) {
+			return;
 		}
 
 		/**
@@ -265,10 +260,27 @@ class WC_Stripe_Apple_Pay_Registration {
 		 * when setting screen is displayed. So if domain verification is not set,
 		 * something went wrong so lets notify user.
 		 */
-		if ( ! empty( $this->secret_key ) && $this->payment_request && ! $this->apple_pay_domain_set ) {
+		$allowed_html = array(
+			'a' => array(
+				'href'  => array(),
+				'title' => array(),
+			),
+		);
+
+		echo '<div class="error stripe-apple-pay-message"><p>';
+
+		echo 'Apple Pay domain verification failed';
+		$reason = $empty_notice ? '' : ' with the error: ' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html ) . '';
+		echo $reason . '.<br />';
+
+		echo sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			echo '<div class="error stripe-apple-pay-message"><p>' . sprintf( __( 'Apple Pay domain verification failed. Please check the %1$slog%2$s to see the issue. (Logging must be enabled to see recorded logs)', 'woocommerce-gateway-stripe' ), '<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">', '</a>' ) . '</p></div>';
-		}
+			__( 'Please check the %1$slog%2$s to see the issue (logging must be enabled to see recorded logs).', 'woocommerce-gateway-stripe' ),
+			 '<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
+			 '</a>'
+		);
+
+		echo '</p></div>';
 	}
 }
 

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -266,12 +266,12 @@ class WC_Stripe_Apple_Pay_Registration {
 				'title' => array(),
 			),
 		);
-		$error_from_stripe                 = $empty_notice ? '' : '<p>' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html ) . '.</p>';
-		$verification_failed_without_error = __( 'Apple Pay domain verification failed.', 'woocommerce-gateway-stripe' );
-		$verification_failed_with_error    = __( 'Apple Pay domain verification failed with the following error:', 'woocommerce-gateway-stripe' );
+		$error_from_stripe                 = $empty_notice ? '' : '<p>' . wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ) . '.</p>';
+		$verification_failed_without_error = esc_html__( 'Apple Pay domain verification failed.', 'woocommerce-gateway-stripe' );
+		$verification_failed_with_error    = esc_html__( 'Apple Pay domain verification failed with the following error:', 'woocommerce-gateway-stripe' );
 		$check_log_text                    = sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
+			esc_html__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
 			'<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
 			'</a>'
 		);

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -269,15 +269,15 @@ class WC_Stripe_Apple_Pay_Registration {
 
 		echo '<div class="error stripe-apple-pay-message">';
 
-		echo '<p>Apple Pay domain verification failed';
-		$reason = $empty_notice ? '' : ' with the following error:</p><p>' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html );
+		echo '<p>' . __( 'Apple Pay domain verification failed', 'woocommerce-gateway-stripe' );
+		$reason = $empty_notice ? '' : ' ' . __( 'with the following error:', 'woocommerce-gateway-stripe' ) . '</p><p>' . wp_kses( make_clickable( $this->apple_pay_verify_notice ), $allowed_html );
 		echo $reason . '.</p>';
 
 		echo '<p>' . sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
-			 '<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
-			 '</a>'
+			'<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
+			'</a>'
 		) . '</p>';
 
 		echo '</div>';

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -266,9 +266,8 @@ class WC_Stripe_Apple_Pay_Registration {
 				'title' => array(),
 			),
 		);
-		$error_from_stripe                 = $empty_notice ? '' : '<p>' . wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ) . '</p>';
-		$verification_failed_without_error = esc_html__( 'Apple Pay domain verification failed.', 'woocommerce-gateway-stripe' );
-		$verification_failed_with_error    = esc_html__( 'Apple Pay domain verification failed with the following error:', 'woocommerce-gateway-stripe' );
+		$verification_failed_without_error = __( 'Apple Pay domain verification failed.', 'woocommerce-gateway-stripe' );
+		$verification_failed_with_error    = __( 'Apple Pay domain verification failed with the following error:', 'woocommerce-gateway-stripe' );
 		$check_log_text                    = sprintf(
 			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			esc_html__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
@@ -276,12 +275,17 @@ class WC_Stripe_Apple_Pay_Registration {
 			'</a>'
 		);
 
-		$notice_text = $empty_notice ? $verification_failed_without_error : $verification_failed_with_error;
-		echo '<div class="error stripe-apple-pay-message">';
-		echo '<p>' . $notice_text . '</p>';
-		echo $error_from_stripe; // Contains `<p>` tags if an error is present.
-		echo '<p>' . $check_log_text . '</p>';
-		echo '</div>';
+		?>
+		<div class="error stripe-apple-pay-message">
+			<?php if ( $empty_notice ) : ?>
+				<p><?php echo esc_html( $verification_failed_without_error ); ?></p>
+			<?php else : ?>
+				<p><?php echo esc_html( $verification_failed_with_error ); ?></p>
+				<p><?php echo wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ); ?></p>
+			<?php endif; ?>
+			<p><?php echo $check_log_text; ?></p>
+		</div>
+		<?php
 	}
 }
 


### PR DESCRIPTION
Fixes #1240 .

#### Changes proposed in this Pull Request:

- Combines the "Not a valid URL" notice with the "Apple Pay domain verification failed" notice.
- The new notice shows the "Not a valid URL" message in the notice if it exists, otherwise it shows a more generic notice without the message.

![image](https://user-images.githubusercontent.com/13835680/95056543-79972680-0727-11eb-8376-2155a3c645c3.png)


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

