### PR TITLE
Tweak wording of Apple Pay Stripe Dashboard link

### DIFF
--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -109,7 +109,7 @@ return apply_filters(
 			'title'       => __( 'Payment Request Buttons', 'woocommerce-gateway-stripe' ),
 			'label'       => sprintf(
 				/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe dashboard opening anchor tag 5) Stripe dashboard closing anchor tag */
-				__( 'Enable Payment Request Buttons. (Apple Pay/Google Pay) %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service. %4$sLog into your Stripe dashboard%5$s to complete or update your Apple Pay setup.', 'woocommerce-gateway-stripe' ),
+				__( 'Enable Payment Request Buttons. (Apple Pay/Google Pay) %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service. (Apple Pay domain verification is performed automatically; configuration can be found on the %4$sStripe dashboard%5$s.)', 'woocommerce-gateway-stripe' ),
 				'<br />',
 				'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
 				'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Reworks the Apple Pay configuration link in the Payment Request description as a parenthetical (but keeping the Dashboard link), as domain verification is done automatically.

`master` branch:

<img width="941" src="https://user-images.githubusercontent.com/1867547/95330627-cd645580-0876-11eb-973a-0d84f994d347.png">

This branch:

<img width="955" src="https://user-images.githubusercontent.com/1867547/95330635-d1907300-0876-11eb-9d2e-c7bffc27a764.png">

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

