### PR TITLE
Allow migrated Payment Methods to be charged on subscription renewal

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1377,7 +1377,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		if ( isset( $full_request['source'] ) ) {
-			$request['source'] = $full_request['source'];
+			$is_source = 'src_' === substr( $full_request['source'], 0, 4 );
+			$request[ $is_source ? 'source' : 'payment_method' ] = $full_request['source'];
 		}
 	
 		/**

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -499,12 +499,13 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			}
 
 			if (
-				( ! empty( $payment_meta['post_meta']['_stripe_source_id']['value'] )
-				&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'card_' ) )
-				&& ( ! empty( $payment_meta['post_meta']['_stripe_source_id']['value'] )
-				&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'src_' ) ) ) {
-
-				throw new Exception( __( 'Invalid source ID. A valid source "Stripe Source ID" must begin with "src_" or "card_".', 'woocommerce-gateway-stripe' ) );
+				! empty( $payment_meta['post_meta']['_stripe_source_id']['value'] ) && (
+					0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'card_' )
+					&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'src_' )
+					&& 0 !== strpos( $payment_meta['post_meta']['_stripe_source_id']['value'], 'pm_' )
+				)
+			) {
+				throw new Exception( __( 'Invalid source ID. A valid source "Stripe Source ID" must begin with "src_", "pm_", or "card_".', 'woocommerce-gateway-stripe' ) );
 			}
 		}
 	}


### PR DESCRIPTION
Fixes (edit: _not entirely_) https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1102
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1181

#### Changes proposed in this Pull Request:

Allows `pm_` payment method IDs to be submitted as subscription payment method source (on Edit Subscription screen) and charged for renewals. (Other behaviors depending on `src_` IDs are unchanged.)

Adapted from solution offered in the comments of https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1181 (thanks @nsandrew).

To test:
- With WooCommerce Subscriptions activated…
- Create Customer with attached Payment Method, e.g. with cURL:
```bash
curl https://api.stripe.com/v1/payment_methods \
  -u sk_test_****: \
  -d type=card \
  -d "card[number]"=4242424242424242 \
  -d "card[exp_month]"=02 \
  -d "card[exp_year]"=2042 \
  -d "card[cvc]"=424
curl https://api.stripe.com/v1/customers \
  -u sk_test_****: \
  -d payment_method="pm_****"
```
- Navigate to the Edit Subscription screen for a new or existing active subscription
- Edit the Billing section, and change "Stripe Customer ID" and "Stripe Source ID" to the Customer and Payment Method IDs (respectively) created above
- Select "Process renewal" action, Update, and Verify that the payment went through

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

