### PR TITLE
Add Inbox note for Apple Pay domain verification if needed

### DIFF
--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -53,17 +53,16 @@ class WC_Stripe_Inbox_Notes {
 			return;
 		}
 
-		// TODO Adapt note content to specific domain verification case.
 		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Apple Pay is now available on Stripe', 'woocommerce-admin' ) );
-		$note->set_content( __( 'Boost sales by offering a fast, simple, and secure checkout experience with Apple Pay®!', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-admin' ) );
+		$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This will need to be in place before Apple Pay will be functional for your customers.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );
 		$note->add_action(
 			'learn-more',
 			__( 'Learn more', 'woocommerce-admin' ),
-			'https://woocommerce.com/apple-pay/?utm_source=inbox'
+			'https://docs.woocommerce.com/document/stripe/#apple-pay'
 		);
 		$note->save();
 	}

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -49,7 +49,7 @@ class WC_Stripe_Inbox_Notes {
 
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-admin' ) );
-		$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This will need to be in place before Apple Pay will be functional for your customers.', 'woocommerce-admin' ) );
+		$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This must be resolved before Apple Pay can be offered to your customers.', 'woocommerce-admin' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-admin' );

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -28,12 +28,6 @@ class WC_Stripe_Inbox_Notes {
 		$domain_flag_key       = 'apple_pay_domain_set';
 		$verification_complete = isset( $stripe_settings[ $domain_flag_key ] ) && 'yes' === $stripe_settings[ $domain_flag_key ];
 
-		// Only show if in the US.
-		$base_location = wc_get_base_location();
-		if ( ! $base_location || 'US' !== $base_location['country'] ) {
-			return;
-		}
-
 		$data_store = WC_Data_Store::load( 'admin-note' );
 
 		// First, see if we've already created this kind of note so we don't do it again.

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -67,5 +67,3 @@ class WC_Stripe_Inbox_Notes {
 		$note->save();
 	}
 }
-
-new WC_Stripe_Inbox_Notes();

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -1,0 +1,72 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
+/**
+ * Class that adds inbox notifications.
+ *
+ * @since 4.5.4
+ */
+class WC_Stripe_Inbox_Notes {
+	const NOTE_NAME = 'stripe-apple-pay-domain-verification';
+
+	// TODO Call this only after domain verification has a chance to run
+	public static function notify_of_apple_pay_domain_verification_if_needed() {
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
+			return;
+		}
+
+		if ( ! class_exists( 'WC_Data_Store' ) ) {
+			return;
+		}
+
+		$stripe_settings       = get_option( 'woocommerce_stripe_settings', array() );
+		$domain_flag_key       = 'apple_pay_domain_set';
+		$verification_complete = isset( $stripe_settings[ $domain_flag_key ] ) && 'yes' === $stripe_settings[ $domain_flag_key ];
+
+		// Only show if in the US.
+		$base_location = wc_get_base_location();
+		if ( ! $base_location || 'US' !== $base_location['country'] ) {
+			return;
+		}
+
+		$data_store = WC_Data_Store::load( 'admin-note' );
+
+		// First, see if we've already created this kind of note so we don't do it again.
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
+		if ( ! empty( $note_ids ) ) {
+			$note_id = array_pop( $note_ids );
+			$note    = WC_Admin_Notes::get_note( $note_id );
+			if ( false === $note ) {
+				return;
+			}
+
+			// If the domain verification completed after the note was created, make sure it's marked as actioned.
+			if ( $verification_complete && WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
+				$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+				$note->save();
+			}
+			return;
+		}
+
+		// TODO Adapt note content to specific domain verification case.
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Apple Pay is now available on Stripe', 'woocommerce-admin' ) );
+		$note->set_content( __( 'Boost sales by offering a fast, simple, and secure checkout experience with Apple Pay®!', 'woocommerce-admin' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-admin' );
+		$note->add_action(
+			'learn-more',
+			__( 'Learn more', 'woocommerce-admin' ),
+			'https://woocommerce.com/apple-pay/?utm_source=inbox'
+		);
+		$note->save();
+	}
+}
+
+new WC_Stripe_Inbox_Notes();

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -7,14 +7,13 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 /**
- * Class that adds inbox notifications.
+ * Class that adds Inbox notifications.
  *
  * @since 4.5.4
  */
 class WC_Stripe_Inbox_Notes {
 	const NOTE_NAME = 'stripe-apple-pay-domain-verification';
 
-	// TODO Call this only after domain verification has a chance to run
 	public static function notify_of_apple_pay_domain_verification_if_needed() {
 		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
 			return;

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -118,6 +118,7 @@ class WC_Stripe_Apple_Pay_Registration {
 			$this->payment_request
 		) {
 			$this->verify_domain();
+			WC_Stripe_Inbox_Notes::notify_of_apple_pay_domain_verification_if_needed();
 		}
 	}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -124,6 +124,7 @@ function woocommerce_gateway_stripe_init() {
 			public function init() {
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-privacy.php';
+					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-inbox-notes.php';
 				}
 
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-exception.php';


### PR DESCRIPTION
Fixes #1350 

### Changes proposed in this Pull Request:

Adds a WooCommerce inbox note targeting the case when domain verification was attempted but did not succeed.

<img width="540" alt="apple-pay-domain-verification-note" src="https://user-images.githubusercontent.com/1867547/96465797-5d9b8680-11f7-11eb-8d49-522047eb5645.png">

Exact copy TBD. Could perhaps use a bit more thought into the logic for when it appears.

**To test:**
[…]

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

