### PR TITLE
Allow Alipay when store currency is set to CNY

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.5.4 - 2020-xx-xx =
 * Add - Security.md with security and vulnerability reporting guidelines.
+* Add - Accept payments via AliPay when store currency is set to CNY.
 
 = 4.5.3 - 2020-10-06 =
 * Fix   - Apple Pay now requires a buyer's phone number only if it's required in Appearance > Customize > WooCommerce > Checkout.

--- a/includes/admin/stripe-alipay-settings.php
+++ b/includes/admin/stripe-alipay-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_alipay_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: China', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: China', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'guide'       => array(

--- a/includes/admin/stripe-bancontact-settings.php
+++ b/includes/admin/stripe-bancontact-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_bancontact_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: Belgium', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: Belgium', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'guide'       => array(

--- a/includes/admin/stripe-eps-settings.php
+++ b/includes/admin/stripe-eps-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_eps_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: Austria', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: Austria', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'activation'  => array(

--- a/includes/admin/stripe-giropay-settings.php
+++ b/includes/admin/stripe-giropay-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_giropay_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: Germany', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: Germany', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'guide'       => array(

--- a/includes/admin/stripe-ideal-settings.php
+++ b/includes/admin/stripe-ideal-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_ideal_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: The Netherlands', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: The Netherlands', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'guide'       => array(

--- a/includes/admin/stripe-multibanco-settings.php
+++ b/includes/admin/stripe-multibanco-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_multibanco_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: Portugal', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: Portugal', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'activation'  => array(

--- a/includes/admin/stripe-p24-settings.php
+++ b/includes/admin/stripe-p24-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_p24_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: Poland', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: Poland', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'activation'  => array(

--- a/includes/admin/stripe-sepa-settings.php
+++ b/includes/admin/stripe-sepa-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_sepa_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: France, Germany, Spain, Belgium, Netherlands, Luxembourg, Italy, Portugal, Austria, Ireland', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: France, Germany, Spain, Belgium, Netherlands, Luxembourg, Italy, Portugal, Austria, Ireland', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'guide'       => array(

--- a/includes/admin/stripe-sofort-settings.php
+++ b/includes/admin/stripe-sofort-settings.php
@@ -7,7 +7,7 @@ return apply_filters(
 	'wc_stripe_sofort_settings',
 	array(
 		'geo_target'  => array(
-			'description' => __( 'Relevant Payer Geography: Germany, Austria', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'Customer Geography: Germany, Austria', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 		),
 		'guide'       => array(

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -104,6 +104,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 				'EUR',
 				'AUD',
 				'CAD',
+				'CNY',
 				'GBP',
 				'HKD',
 				'JPY',


### PR DESCRIPTION
Fixes #1340

#### Changes proposed in this Pull Request:
- Allow Alipay when store currency is set to CNY

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

