### PR TITLE
Add full name to stripe customer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.5.4 - 2020-xx-xx =
 * Add - Security.md with security and vulnerability reporting guidelines.
+* Add - Customer's full name is now included in Stripe Customer object if available.
 
 = 4.5.3 - 2020-10-06 =
 * Fix   - Apple Pay now requires a buyer's phone number only if it's required in Appearance > Customize > WooCommerce > Checkout.

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -120,27 +120,31 @@ class WC_Stripe_Customer {
 			// translators: %1$s First name, %2$s Second name, %3$s Username.
 			$description = sprintf( __( 'Name: %1$s %2$s, Username: %s', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name, $user->user_login );
 
-			$billing_full_name = "$billing_first_name $billing_last_name";
-			
 			$defaults = array(
-				'name'        => $billing_full_name,
 				'email'       => $user->user_email,
 				'description' => $description,
 			);
+
+			$billing_full_name = trim( $billing_first_name . ' ' . $billing_last_name );
+			if ( ! empty( $billing_full_name ) ) {
+				$defaults['name'] = $billing_full_name;
+			}
 		} else {
 			$billing_first_name = isset( $_POST['billing_first_name'] ) ? filter_var( wp_unslash( $_POST['billing_first_name'] ), FILTER_SANITIZE_STRING ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 			$billing_last_name  = isset( $_POST['billing_last_name'] ) ? filter_var( wp_unslash( $_POST['billing_last_name'] ), FILTER_SANITIZE_STRING ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
 
 			// translators: %1$s First name, %2$s Second name.
 			$description = sprintf( __( 'Name: %1$s %2$s, Guest', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name );
-			
-			$billing_full_name = "$billing_first_name $billing_last_name";
-			
+
 			$defaults = array(
-				'name'        => $billing_full_name,
 				'email'       => $billing_email,
 				'description' => $description,
 			);
+
+			$billing_full_name = trim( $billing_first_name . ' ' . $billing_last_name );
+			if ( ! empty( $billing_full_name ) ) {
+				$defaults['name'] = $billing_full_name;
+			}
 		}
 
 		$metadata             = array();

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -120,7 +120,10 @@ class WC_Stripe_Customer {
 			// translators: %1$s First name, %2$s Second name, %3$s Username.
 			$description = sprintf( __( 'Name: %1$s %2$s, Username: %s', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name, $user->user_login );
 
+			$billing_full_name = "$billing_first_name $billing_last_name";
+			
 			$defaults = array(
+				'name'        => $billing_full_name,
 				'email'       => $user->user_email,
 				'description' => $description,
 			);
@@ -130,8 +133,11 @@ class WC_Stripe_Customer {
 
 			// translators: %1$s First name, %2$s Second name.
 			$description = sprintf( __( 'Name: %1$s %2$s, Guest', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name );
-
+			
+			$billing_full_name = "$billing_first_name $billing_last_name";
+			
 			$defaults = array(
+				'name'        => $billing_full_name,
 				'email'       => $billing_email,
 				'description' => $description,
 			);


### PR DESCRIPTION
Supersedes #1304 since I can't make direct changes to that PR. Thank you @mbeinder for your PR!

Description copied from there.

<hr />

#### Changes proposed in this Pull Request:
- `$billing_full_name` is derived from `$billing_first_name` and `$billing_last_name` filling the `name` field in stripe on the customer object.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

