### PR TITLE
Code tweaks for PHP 8 compatibility

### DIFF
--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -90,7 +90,7 @@ class WC_Stripe_Payment_Tokens {
 	 * @param array $tokens
 	 * @return array
 	 */
-	public function woocommerce_get_customer_payment_tokens( $tokens = array(), $customer_id, $gateway_id ) {
+	public function woocommerce_get_customer_payment_tokens( $tokens, $customer_id, $gateway_id ) {
 		if ( is_user_logged_in() && class_exists( 'WC_Payment_Token_CC' ) ) {
 			$stored_tokens = array();
 

--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -215,7 +215,7 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 	 * @param bool $retry Should we retry the process?
 	 * @param object $previous_error
 	 */
-	public function process_subscription_payment( $amount = 0.0, $renewal_order, $retry = true, $previous_error ) {
+	public function process_subscription_payment( $amount, $renewal_order, $retry = true, $previous_error = false ) {
 		try {
 			if ( $amount * 100 < WC_Stripe_Helper::get_minimum_amount() ) {
 				/* translators: minimum amount */

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -217,7 +217,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 	 * @param bool $retry Should we retry the process?
 	 * @param object $previous_error
 	 */
-	public function process_subscription_payment( $amount = 0.0, $renewal_order, $retry = true, $previous_error ) {
+	public function process_subscription_payment( $amount, $renewal_order, $retry = true, $previous_error = false ) {
 		try {
 			if ( $amount * 100 < WC_Stripe_Helper::get_minimum_amount() ) {
 				/* translators: minimum amount */

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -99,7 +99,7 @@ function wc_stripe() {
 			 *
 			 * @return void
 			 */
-			private function __clone() {}
+			public function __clone() {}
 
 			/**
 			 * Private unserialize method to prevent unserializing of the *Singleton*
@@ -107,13 +107,13 @@ function wc_stripe() {
 			 *
 			 * @return void
 			 */
-			private function __wakeup() {}
+			public function __wakeup() {}
 
 			/**
 			 * Protected constructor to prevent creating a new instance of the
 			 * *Singleton* via the `new` operator from outside of this class.
 			 */
-			private function __construct() {
+			public function __construct() {
 				add_action( 'admin_init', array( $this, 'install' ) );
 
 				$this->init();


### PR DESCRIPTION
Fixes #1353 

#### Changes proposed in this Pull Request:
- Ensure that optional function arguments follow required ones (https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1356/commits/3b18c73cda6a0c1af7482d35aa3eb2422157c3be)
- Avoid "magic method must have public visibility" warning (https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1356/commits/a94ead617160a9cff8501f4ead962804409a860d)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

