### PR TITLE
Serve Apple Pay domain association file via rewrite rule

### DIFF
--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -179,43 +179,43 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * @return bool True on success, false on failure.
 	 */
 	public function update_domain_association_file( $force = false ) {
-			$path     = untrailingslashit( $_SERVER['DOCUMENT_ROOT'] );
-			$dir      = '.well-known';
-			$file     = 'apple-developer-merchantid-domain-association';
-			$fullpath = $path . '/' . $dir . '/' . $file;
+		$path     = untrailingslashit( $_SERVER['DOCUMENT_ROOT'] );
+		$dir      = '.well-known';
+		$file     = 'apple-developer-merchantid-domain-association';
+		$fullpath = $path . '/' . $dir . '/' . $file;
 
-			$existing_contents = @file_get_contents( $fullpath );
-			$new_contents = @file_get_contents( WC_STRIPE_PLUGIN_PATH . '/' . $file );
-			if ( ( ! $existing_contents && ! $force ) || $existing_contents === $new_contents ) {
-				return true;
-			}
-
-			$error = null;
-			if ( ! file_exists( $path . '/' . $dir ) ) {
-				if ( ! @mkdir( $path . '/' . $dir, 0755 ) ) { // @codingStandardsIgnoreLine
-					$error = __( 'Unable to create domain association folder to domain root.', 'woocommerce-gateway-stripe' );
-				}
-			}
-			if ( ! @copy( WC_STRIPE_PLUGIN_PATH . '/' . $file, $fullpath ) ) { // @codingStandardsIgnoreLine
-				$error = __( 'Unable to copy domain association file to domain root.', 'woocommerce-gateway-stripe' );
-			}
-
-			if ( isset( $error ) ) {
-				$url            = 'https://' . $_SERVER['HTTP_HOST'] . '/' . $dir . '/' . $file;
-				$response       = wp_remote_get( $url );
-				$already_hosted = wp_remote_retrieve_body( $response ) === $new_contents;
-				if ( ! $already_hosted ) {
-					WC_Stripe_Logger::log(
-						'Error: ' . $error . ' ' .
-						/* translators: expected domain association file URL */
-						sprintf( __( 'To enable Apple Pay, domain association file must be hosted at %s.', 'woocommerce-gateway-stripe' ), $url )
-					);
-				}
-				return $already_hosted;
-			}
-
-			WC_Stripe_Logger::log( 'Domain association file updated.' );
+		$existing_contents = @file_get_contents( $fullpath );
+		$new_contents = @file_get_contents( WC_STRIPE_PLUGIN_PATH . '/' . $file );
+		if ( ( ! $existing_contents && ! $force ) || $existing_contents === $new_contents ) {
 			return true;
+		}
+
+		$error = null;
+		if ( ! file_exists( $path . '/' . $dir ) ) {
+			if ( ! @mkdir( $path . '/' . $dir, 0755 ) ) { // @codingStandardsIgnoreLine
+				$error = __( 'Unable to create domain association folder to domain root.', 'woocommerce-gateway-stripe' );
+			}
+		}
+		if ( ! @copy( WC_STRIPE_PLUGIN_PATH . '/' . $file, $fullpath ) ) { // @codingStandardsIgnoreLine
+			$error = __( 'Unable to copy domain association file to domain root.', 'woocommerce-gateway-stripe' );
+		}
+
+		if ( isset( $error ) ) {
+			$url            = 'https://' . $_SERVER['HTTP_HOST'] . '/' . $dir . '/' . $file;
+			$response       = wp_remote_get( $url );
+			$already_hosted = wp_remote_retrieve_body( $response ) === $new_contents;
+			if ( ! $already_hosted ) {
+				WC_Stripe_Logger::log(
+					'Error: ' . $error . ' ' .
+					/* translators: expected domain association file URL */
+					sprintf( __( 'To enable Apple Pay, domain association file must be hosted at %s.', 'woocommerce-gateway-stripe' ), $url )
+				);
+			}
+			return $already_hosted;
+		}
+
+		WC_Stripe_Logger::log( 'Domain association file updated.' );
+		return true;
 	}
 
 	/**

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -66,7 +66,7 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * Whether the gateway and Payment Request Button (prerequisites for Apple Pay) are enabled.
 	 *
 	 * @since 4.5.4
-	 * @return string Secret key.
+	 * @return string Whether Apple Pay required settings are enabled.
 	 */
 	private function is_enabled() {
 		$stripe_enabled                 = 'yes' === $this->get_option( 'enabled', 'no' );

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -37,7 +37,8 @@ class WC_Stripe_Apple_Pay_Registration {
 		add_action( 'parse_request', array( $this, 'parse_domain_association_request' ), 10, 1 );
 
 		add_action( 'woocommerce_stripe_updated', array( $this, 'verify_domain_if_configured' ) );
-		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'verify_domain_on_settings_change' ), 10, 2 );
+		add_action( 'add_option_woocommerce_stripe_settings', array( $this, 'verify_domain_on_new_settings' ), 10, 2 );
+		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'verify_domain_on_updated_settings' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 
 		$this->stripe_settings                 = get_option( 'woocommerce_stripe_settings', array() );
@@ -230,12 +231,22 @@ class WC_Stripe_Apple_Pay_Registration {
 	}
 
 	/**
+	 * Conditionally process the Apple Pay domain verification after settings are initially set.
+	 *
+	 * @since 4.5.4
+	 * @version 4.5.4
+	 */
+	public function verify_domain_on_new_settings( $option, $settings ) {
+		$this->verify_domain_on_updated_settings( array(), $settings );
+	}
+
+	/**
 	 * Conditionally process the Apple Pay domain verification after settings are updated.
 	 *
 	 * @since 4.5.3
 	 * @version 4.5.4
 	 */
-	public function verify_domain_on_settings_change( $prev_settings, $settings ) {
+	public function verify_domain_on_updated_settings( $prev_settings, $settings ) {
 		// Grab previous state and then update cached settings.
 		$this->stripe_settings = $prev_settings;
 		$prev_secret_key       = $this->get_secret_key();

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -94,7 +94,8 @@ class WC_Stripe_Apple_Pay_Registration {
 	 */
 	public function add_domain_association_rewrite_rule() {
 		$regex    = '^\.well-known\/apple-developer-merchantid-domain-association$';
-		$redirect = 'index.php?apple-developer-merchantid-domain-association=1';
+		$redirect = parse_url( WC_STRIPE_PLUGIN_URL, PHP_URL_PATH ) . '/apple-developer-merchantid-domain-association';
+
 		add_rewrite_rule( $regex, $redirect, 'top' );
 	}
 

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -41,9 +41,9 @@ class WC_Stripe_Apple_Pay_Registration {
 		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'verify_domain_on_updated_settings' ), 10, 2 );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 
-		$this->stripe_settings                 = get_option( 'woocommerce_stripe_settings', array() );
-		$this->apple_pay_domain_set            = 'yes' === $this->get_option( 'apple_pay_domain_set', 'no' );
-		$this->apple_pay_verify_notice         = '';
+		$this->stripe_settings         = get_option( 'woocommerce_stripe_settings', array() );
+		$this->apple_pay_domain_set    = 'yes' === $this->get_option( 'apple_pay_domain_set', 'no' );
+		$this->apple_pay_verify_notice = '';
 	}
 
 	/**

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -133,7 +133,6 @@ function wc_stripe() {
 			public function init() {
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-privacy.php';
-					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-inbox-notes.php';
 				}
 
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-exception.php';
@@ -164,6 +163,7 @@ function wc_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-payment-tokens.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-customer.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-intent-controller.php';
+				require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-inbox-notes.php';
 
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';


### PR DESCRIPTION
Fixes #1355 

#### Changes proposed in this Pull Request:

Rather than copying the domain association file (and having to update it if it's changed), add a rewrite rule to serve it from its original location in the plugins directory.

The behavior of this module is modified to only perform the domain verification when settings are updated (and properly configured), and when the plugin is updated. The rewrite rule is flushed right before the domain registration request to ensure the domain association file will be served.

**Testing instructions:**

- On a fresh WooCommerce install, install & activate Stripe plugin on this branch
- Configure gateway
  - (Either…) Go through the Task List » Set up payments » Stripe "Set up" flow
  - (Or…) Enable the Stripe gateway on the WooCommerce » Settings » Payments » Stripe screen (leaving Payment Request Button enabled)
- Verify that the domain has been added on the Stripe dashboard
- Can also disable gateway and/or Payment Request Buttons setting and/or clear (or change) secret key – after re-enabling or restoring, the domain will be added again, even if it was deleted in the meantime
- (Can also test upgrading from previous version and verifying immediate verification)

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

