### PR TITLE
Show Apple Pay holiday marketing note on setup success

### DIFF
--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -19,6 +19,9 @@ class WC_Stripe_Inbox_Notes {
 		add_action( 'wc_stripe_apple_pay_post_setup_success', array( self::class, 'create_marketing_note' ) );
 	}
 
+	/**
+	 * Manage notes to show after Apple Pay domain verification.
+	 */
 	public static function notify_on_apple_pay_domain_verification( $verification_complete ) {
 		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
 			return;
@@ -51,6 +54,9 @@ class WC_Stripe_Inbox_Notes {
 		}
 	}
 
+	/**
+	 * Whether conditions are right for the marketing note.
+	 */
 	public static function should_show_marketing_note() {
 		// Display to US merchants only.
 		$base_location = wc_get_base_location();
@@ -77,6 +83,9 @@ class WC_Stripe_Inbox_Notes {
 		return true;
 	}
 
+	/**
+	 * If conditions are right, show note promoting Apple Pay marketing guide.
+	 */
 	public static function create_marketing_note() {
 		// Make sure conditions for this note still hold.
 		if ( ! self::should_show_marketing_note() ) {
@@ -97,6 +106,9 @@ class WC_Stripe_Inbox_Notes {
 		$note->save();
 	}
 
+	/**
+	 * Show note indicating domain verification failure.
+	 */
 	public static function create_failure_note() {
 		$note = new WC_Admin_Note();
 		$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-gateway-stripe' ) );

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -31,22 +31,25 @@ class WC_Stripe_Inbox_Notes {
 
 		$failure_note_ids = $data_store->get_notes_with_name( self::FAILURE_NOTE_NAME );
 
-		if ( ! empty( $failure_note_ids ) ) {
-			$note_id = array_pop( $failure_note_ids );
-			$note    = WC_Admin_Notes::get_note( $note_id );
-			if ( false === $note ) {
-				return;
-			}
+		if ( $verification_complete ) {
+			if ( ! empty( $failure_note_ids ) ) {
+				$note_id = array_pop( $failure_note_ids );
+				$note    = WC_Admin_Notes::get_note( $note_id );
+				if ( false === $note ) {
+					return;
+				}
 
-			// If the domain verification completed after failure note was created, make sure it's marked as actioned.
-			if ( $verification_complete && WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
-				$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
-				$note->save();
+				// If the domain verification completed after failure note was created, make sure it's marked as actioned.
+				if ( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
+					$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+					$note->save();
+				}
 			}
-			return;
+		} else {
+			if ( empty( $failure_note_ids ) ) {
+				self::create_failure_note();
+			}
 		}
-
-		self::create_failure_note();
 	}
 
 	public static function create_failure_note() {

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
  * @since 4.5.4
  */
 class WC_Stripe_Inbox_Notes {
+	const SUCCESS_NOTE_NAME = 'stripe-apple-pay-marketing-guide-holiday-2020';
 	const FAILURE_NOTE_NAME = 'stripe-apple-pay-domain-verification-needed';
 
 	public static function notify_on_apple_pay_domain_verification() {
@@ -29,9 +30,14 @@ class WC_Stripe_Inbox_Notes {
 
 		$data_store = WC_Data_Store::load( 'admin-note' );
 
+		$success_note_ids = $data_store->get_notes_with_name( self::SUCCESS_NOTE_NAME );
 		$failure_note_ids = $data_store->get_notes_with_name( self::FAILURE_NOTE_NAME );
 
 		if ( $verification_complete ) {
+			if ( empty( $success_note_ids ) ) {
+				self::create_success_note();
+			}
+
 			if ( ! empty( $failure_note_ids ) ) {
 				$note_id = array_pop( $failure_note_ids );
 				$note    = WC_Admin_Notes::get_note( $note_id );
@@ -50,6 +56,21 @@ class WC_Stripe_Inbox_Notes {
 				self::create_failure_note();
 			}
 		}
+	}
+
+	public static function create_success_note() {
+		$note = new WC_Admin_Note();
+		$note->set_title( __( 'Boost sales this holiday season with Apple Pay!', 'woocommerce-gateway-stripe' ) );
+		$note->set_content( __( 'Now that you accept Apple Pay® with Stripe, you can increase conversion rates by letting your customers know that Apple Pay is available. Here’s a marketing guide to help you get started.', 'woocommerce-gateway-stripe' ) );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_name( self::SUCCESS_NOTE_NAME );
+		$note->set_source( 'woocommerce-gateway-stripe' );
+		$note->add_action(
+			'marketing-guide',
+			__( 'See marketing guide', 'woocommerce-gateway-stripe' ),
+			'https://developer.apple.com/apple-pay/marketing/'
+		);
+		$note->save();
 	}
 
 	public static function create_failure_note() {

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -54,14 +54,14 @@ class WC_Stripe_Inbox_Notes {
 
 	public static function create_failure_note() {
 		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-admin' ) );
-		$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This must be resolved before Apple Pay can be offered to your customers.', 'woocommerce-admin' ) );
+		$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-gateway-stripe' ) );
+		$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This must be resolved before Apple Pay can be offered to your customers.', 'woocommerce-gateway-stripe' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::FAILURE_NOTE_NAME );
-		$note->set_source( 'woocommerce-admin' );
+		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			'learn-more',
-			__( 'Learn more', 'woocommerce-admin' ),
+			__( 'Learn more', 'woocommerce-gateway-stripe' ),
 			'https://docs.woocommerce.com/document/stripe/#apple-pay'
 		);
 		$note->save();

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -15,7 +15,7 @@ class WC_Stripe_Inbox_Notes {
 	const SUCCESS_NOTE_NAME = 'stripe-apple-pay-marketing-guide-holiday-2020';
 	const FAILURE_NOTE_NAME = 'stripe-apple-pay-domain-verification-needed';
 
-	public static function notify_on_apple_pay_domain_verification() {
+	public static function notify_on_apple_pay_domain_verification( $verification_complete ) {
 		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
 			return;
 		}
@@ -23,10 +23,6 @@ class WC_Stripe_Inbox_Notes {
 		if ( ! class_exists( 'WC_Data_Store' ) ) {
 			return;
 		}
-
-		$stripe_settings       = get_option( 'woocommerce_stripe_settings', array() );
-		$domain_flag_key       = 'apple_pay_domain_set';
-		$verification_complete = isset( $stripe_settings[ $domain_flag_key ] ) && 'yes' === $stripe_settings[ $domain_flag_key ];
 
 		$data_store = WC_Data_Store::load( 'admin-note' );
 
@@ -42,15 +38,11 @@ class WC_Stripe_Inbox_Notes {
 				}
 			}
 
+			// If the domain verification completed after failure note was created, make sure it's marked as actioned.
 			if ( ! empty( $failure_note_ids ) ) {
 				$note_id = array_pop( $failure_note_ids );
 				$note    = WC_Admin_Notes::get_note( $note_id );
-				if ( false === $note ) {
-					return;
-				}
-
-				// If the domain verification completed after failure note was created, make sure it's marked as actioned.
-				if ( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
+				if ( false !== $note && WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
 					$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
 					$note->save();
 				}

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -15,8 +15,10 @@ class WC_Stripe_Inbox_Notes {
 	const SUCCESS_NOTE_NAME = 'stripe-apple-pay-marketing-guide-holiday-2020';
 	const FAILURE_NOTE_NAME = 'stripe-apple-pay-domain-verification-needed';
 
+	const POST_SETUP_SUCCESS_ACTION = 'wc_stripe_apple_pay_post_setup_success';
+
 	public function __construct() {
-		add_action( 'wc_stripe_apple_pay_post_setup_success', array( self::class, 'create_marketing_note' ) );
+		add_action( self::POST_SETUP_SUCCESS_ACTION, array( self::class, 'create_marketing_note' ) );
 	}
 
 	/**
@@ -32,8 +34,8 @@ class WC_Stripe_Inbox_Notes {
 		}
 
 		if ( $verification_complete ) {
-			if ( self::should_show_marketing_note() && ! wp_next_scheduled( 'wc_stripe_apple_pay_post_setup_success' ) ) {
-				wp_schedule_single_event( time() + DAY_IN_SECONDS, 'wc_stripe_apple_pay_post_setup_success' );
+			if ( self::should_show_marketing_note() && ! wp_next_scheduled( self::POST_SETUP_SUCCESS_ACTION ) ) {
+				wp_schedule_single_event( time() + DAY_IN_SECONDS, self::POST_SETUP_SUCCESS_ACTION );
 			}
 
 			// If the domain verification completed after failure note was created, make sure it's marked as actioned.

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -34,8 +34,12 @@ class WC_Stripe_Inbox_Notes {
 		$failure_note_ids = $data_store->get_notes_with_name( self::FAILURE_NOTE_NAME );
 
 		if ( $verification_complete ) {
-			if ( empty( $success_note_ids ) ) {
-				self::create_success_note();
+			// Display success note to US merchants only.
+			$base_location = wc_get_base_location();
+			if ( is_array( $base_location ) && 'US' === $base_location['country'] ) {
+				if ( empty( $success_note_ids ) ) {
+					self::create_success_note();
+				}
 			}
 
 			if ( ! empty( $failure_note_ids ) ) {

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -226,8 +226,8 @@ class WC_Stripe_Apple_Pay_Registration {
 		// Register the domain with Apple Pay.
 		$this->register_domain_with_apple( $secret_key );
 
-		// Show/hide failure note if necessary.
-		WC_Stripe_Inbox_Notes::notify_of_apple_pay_domain_verification_if_needed();
+		// Show/hide notes if necessary.
+		WC_Stripe_Inbox_Notes::notify_on_apple_pay_domain_verification();
 	}
 
 	/**

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -183,6 +183,8 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * @version 4.5.4
 	 *
 	 * @param string $secret_key
+	 *
+	 * @return bool Whether domain verification succeeded.
 	 */
 	public function register_domain_with_apple( $secret_key ) {
 		try {
@@ -196,6 +198,8 @@ class WC_Stripe_Apple_Pay_Registration {
 
 			WC_Stripe_Logger::log( 'Your domain has been verified with Apple Pay!' );
 
+			return true;
+
 		} catch ( Exception $e ) {
 			$this->stripe_settings['apple_pay_domain_set'] = 'no';
 			$this->apple_pay_domain_set                    = false;
@@ -203,9 +207,10 @@ class WC_Stripe_Apple_Pay_Registration {
 			update_option( 'woocommerce_stripe_settings', $this->stripe_settings );
 
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+
+			return false;
 		}
 	}
-
 
 	/**
 	 * Process the Apple Pay domain verification if proper settings are configured.
@@ -224,10 +229,10 @@ class WC_Stripe_Apple_Pay_Registration {
 		flush_rewrite_rules();
 
 		// Register the domain with Apple Pay.
-		$this->register_domain_with_apple( $secret_key );
+		$verification_complete = $this->register_domain_with_apple( $secret_key );
 
 		// Show/hide notes if necessary.
-		WC_Stripe_Inbox_Notes::notify_on_apple_pay_domain_verification();
+		WC_Stripe_Inbox_Notes::notify_on_apple_pay_domain_verification( $verification_complete );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1351

#### Changes proposed in this Pull Request:

Shows a marketing Inbox note **a day after** successfully enabling Apple Pay and automatic domain verification (for US):

<img width="517" src="https://user-images.githubusercontent.com/1867547/98954064-6700d180-24cb-11eb-9e6c-bf283c554f4e.png">

The "Apple Pay domain verification needed" note (implemented previously in #1350) is now referred to in code as the "failure note", while the "Boost sales this holiday season with Apple Pay!" is called the "success note" or "marketing note". A subsequent release (after the holidays) will replace the success note with a different one.

Note: https://github.com/woocommerce/woocommerce-gateway-stripe/commit/ee65be12f80eec98286d5244cba3862646fb35c2 fixes a bug where the failure note shows even in success case, overlooked in #1337.

#### Scenarios to test:

For testing, I changed the delay from `DAY_IN_SECONDS` to `45` so that I could verify the appearance of the note in under a minute (while having a chance to prevent it from appearing by changing something).

- Nominal case
  - On fresh install, with store country set to US…
  - Set up Apple Pay (e.g. go through Task List » Set up payments » Stripe "Set up" flow)
  - Verify that marketing note appears (after delay + refresh)
- Non-US
  - On fresh install, with store country set to something other than US…
  - Set up Apple Pay (e.g. go through Task List » Set up payments » Stripe "Set up" flow)
  - Verify that marketing note does not appear (even after delay + refresh)
  - (Can also change to non-US after setting up Apple Pay, and the note shouldn't appear)
- Failure case, followed by nominal case
  - On fresh install, with store country set to US…
  - Set up Apple Pay but make domain verification fail (e.g. by providing wrong secret key)
  - Verify that failure note appears
  - Make domain verification succeed (say, by providing correct secret key)
  - Verify that failure note disappears (after refresh) and marketing note appears (after delay + refresh)
- Show note to upgrading merchants with Apple Pay enabled
  - On fresh install, with store country set to US…
  - Set up Apple Pay on an earlier extension version (e.g. 4.5.2)
  - Upgrade to version with this change
  - Verify that marketing note appears in Inbox (after delay + refresh)

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

