### PR TITLE
Avoid Apple Pay payment failure on non-required phone field

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -94,7 +94,7 @@ jQuery( function( $ ) {
 				billing_last_name:         null !== name ? name.split( ' ' ).slice( 1 ).join( ' ' ) : '',
 				billing_company:           '',
 				billing_email:             null !== email   ? email : evt.payerEmail,
-				billing_phone:             null !== phone   ? phone : evt.payerPhone.replace( '/[() -]/g', '' ),
+				billing_phone:             null !== phone   ? phone : evt.payerPhone && evt.payerPhone.replace( '/[() -]/g', '' ),
 				billing_country:           null !== billing ? billing.country : '',
 				billing_address_1:         null !== billing ? billing.line1 : '',
 				billing_address_2:         null !== billing ? billing.line2 : '',


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1364

#### Changes proposed in this Pull Request:
Makes sure phone number value is available before processing it for passing to the payment request, so that there is no JS error (and aborted payment request) in the case when the phone number is not required in checkout.

**To test:**

With Apple Pay set up, set Customizer » WooCommerce » Checkout » Phone field to "Optional" or "Hidden" (see also testing instructions in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1317). Go through the whole Apple Pay payment flow and verify that it completes.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

