### PR TITLE
Set max compression level for zip file produced by build:release.

### DIFF
--- a/tasks/release.js
+++ b/tasks/release.js
@@ -38,7 +38,7 @@ cp( '-Rf', filesToCopy, targetFolder );
 const output = fs.createWriteStream(
 	releaseFolder + '/' + pluginSlug + '.zip'
 );
-const archive = archiver( 'zip' );
+const archive = archiver( 'zip', { zlib: { level: 9 } } );
 
 output.on( 'close', () => {
 	console.log(


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Set maximal compression level for release zip-file (reduces the size from 5 MB to 4.5 MB for WCPay)

#### Testing instructions

* Run `npm run build:release` and ensure you can open the archive and see it's contents

-------------------

- [x] Added changelog entry (or does not apply)
- [x] Covered with tests (or have a good reason not to test in the description ☝️)
- [x] Tested on mobile (or does not apply)