### PR TITLE
Refresh unactioned Apple Pay notes after 2020 Dec 22

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Tweak - Update packages for Composer 2 compatibility.
 * Tweak - Use full jQuery function calls instead of soon-to-be-deprecated shorthands.
 * Tweak - Use JSON.parse() instead of jQuery.parseJSON().
-* Tweak - Remove holiday messaging from Apple Pay note after Dec 25.
+* Tweak - Remove holiday messaging from Apple Pay note after Dec 22.
 
 = 4.5.5 - 2020-11-17 =
 * Fix - Guard against fatal errors that may occur on inbox data store load.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,10 @@
 *** Changelog ***
 
-= x.x.x - 2020-xx-xx =
+= 4.5.6 - 2020-12-xx =
 * Tweak - Update packages for Composer 2 compatibility.
 * Tweak - Use full jQuery function calls instead of soon-to-be-deprecated shorthands.
 * Tweak - Use JSON.parse() instead of jQuery.parseJSON().
+* Tweak - Remove holiday messaging from Apple Pay note after Dec 25.
 
 = 4.5.5 - 2020-11-17 =
 * Fix - Guard against fatal errors that may occur on inbox data store load.

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -12,13 +12,37 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
  * @since 4.5.4
  */
 class WC_Stripe_Inbox_Notes {
-	const SUCCESS_NOTE_NAME = 'stripe-apple-pay-marketing-guide-holiday-2020';
-	const FAILURE_NOTE_NAME = 'stripe-apple-pay-domain-verification-needed';
+	const SUCCESS_NOTE_NAME    = 'stripe-apple-pay-marketing-guide-holiday-2020';
+	const FAILURE_NOTE_NAME    = 'stripe-apple-pay-domain-verification-needed';
 
-	const POST_SETUP_SUCCESS_ACTION = 'wc_stripe_apple_pay_post_setup_success';
+	const POST_SETUP_SUCCESS_ACTION    = 'wc_stripe_apple_pay_post_setup_success';
+	const CAMPAIGN_2020_CLEANUP_ACTION = 'wc_stripe_apple_pay_2020_cleanup';
 
 	public function __construct() {
 		add_action( self::POST_SETUP_SUCCESS_ACTION, array( self::class, 'create_marketing_note' ) );
+		add_action( self::CAMPAIGN_2020_CLEANUP_ACTION, array( self::class, 'cleanup_campaign_2020' ) );
+
+		// Schedule a 2020 holiday campaign cleanup action if needed.
+		// First, check to see if we are still before the cutoff.
+		// We don't need to (re)schedule this after the cutoff.
+		if ( current_time( 'timestamp', true ) < self::get_campaign_2020_cutoff() ) {
+			// If we don't have the clean up action scheduled, add it.
+			if ( ! wp_next_scheduled( self::CAMPAIGN_2020_CLEANUP_ACTION ) ) {
+				wp_schedule_single_event( self::get_campaign_2020_cutoff(), self::CAMPAIGN_2020_CLEANUP_ACTION );
+			}
+		}
+	}
+
+	public static function get_campaign_2020_cutoff() {
+		return strtotime( '22 December 2020' );
+	}
+
+	public static function get_success_title() {
+		if ( current_time( 'timestamp', true ) < self::get_campaign_2020_cutoff() ) {
+			return __( 'Boost sales this holiday season with Apple Pay!', 'woocommerce-gateway-stripe' );
+		}
+
+		return__( 'Boost sales with Apple Pay!', 'woocommerce-gateway-stripe' );
 	}
 
 	/**
@@ -101,7 +125,7 @@ class WC_Stripe_Inbox_Notes {
 		}
 
 		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Boost sales this holiday season with Apple Pay!', 'woocommerce-gateway-stripe' ) );
+		$note->set_title( self::get_success_title() );
 		$note->set_content( __( 'Now that you accept Apple Pay® with Stripe, you can increase conversion rates by letting your customers know that Apple Pay is available. Here’s a marketing guide to help you get started.', 'woocommerce-gateway-stripe' ) );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::SUCCESS_NOTE_NAME );
@@ -130,6 +154,48 @@ class WC_Stripe_Inbox_Notes {
 			'https://docs.woocommerce.com/document/stripe/#apple-pay'
 		);
 		$note->save();
+	}
+
+	/**
+	 * Destroy unactioned inbox notes from the 2020 holiday campaign, replacing
+	 * them with a non-holiday note promoting Apple Pay. This will be run once
+	 * on/about 2020 Dec 22.
+	 */
+	public static function cleanup_campaign_2020() {
+		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes') ) {
+			return;
+		}
+
+		if ( ! class_exists( 'WC_Data_Store' ) ) {
+			return;
+		}
+
+		$note_ids = array();
+
+		try {
+			$data_store = WC_Data_Store::load( 'admin-note' );
+			$note_ids   = $data_store->get_notes_with_name( self::SUCCESS_NOTE_NAME );
+			if ( empty( $note_ids ) ) {
+				return;
+			}
+		} catch ( Exception $e ) {
+			return;
+		}
+
+		$deleted_an_unactioned_note = false;
+
+		foreach ( (array) $note_ids as $note_id ) {
+			$note = new WC_Admin_Note( $note_id );
+			if ( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED == $note->get_status() ) {
+				$note->delete();
+				$deleted_an_unactioned_note = true;
+			}
+			unset( $note );
+		}
+
+		if ( $deleted_an_unactioned_note ) {
+			self::create_marketing_note();
+		}
 	}
 }
 

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -12,8 +12,8 @@ use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
  * @since 4.5.4
  */
 class WC_Stripe_Inbox_Notes {
-	const SUCCESS_NOTE_NAME    = 'stripe-apple-pay-marketing-guide-holiday-2020';
-	const FAILURE_NOTE_NAME    = 'stripe-apple-pay-domain-verification-needed';
+	const SUCCESS_NOTE_NAME = 'stripe-apple-pay-marketing-guide-holiday-2020';
+	const FAILURE_NOTE_NAME = 'stripe-apple-pay-domain-verification-needed';
 
 	const POST_SETUP_SUCCESS_ACTION    = 'wc_stripe_apple_pay_post_setup_success';
 	const CAMPAIGN_2020_CLEANUP_ACTION = 'wc_stripe_apple_pay_2020_cleanup';

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.5.4\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.5.5\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2020-11-16 20:22:06+00:00\n"
+"POT-Creation-Date: 2020-12-04 22:54:59+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -188,33 +188,33 @@ msgstr ""
 msgid "Cheatin&#8217; huh?"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:98
+#: includes/admin/class-wc-stripe-inbox-notes.php:42
 msgid "Boost sales this holiday season with Apple Pay!"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:99
+#: includes/admin/class-wc-stripe-inbox-notes.php:129
 msgid ""
 "Now that you accept Apple Pay® with Stripe, you can increase conversion "
 "rates by letting your customers know that Apple Pay is available. Here’s a "
 "marketing guide to help you get started."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:105
+#: includes/admin/class-wc-stripe-inbox-notes.php:135
 msgid "See marketing guide"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:116
+#: includes/admin/class-wc-stripe-inbox-notes.php:146
 msgid "Apple Pay domain verification needed"
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:117
+#: includes/admin/class-wc-stripe-inbox-notes.php:147
 msgid ""
 "The WooCommerce Stripe Gateway extension attempted to perform domain "
 "verification on behalf of your store, but was unable to do so. This must be "
 "resolved before Apple Pay can be offered to your customers."
 msgstr ""
 
-#: includes/admin/class-wc-stripe-inbox-notes.php:123
+#: includes/admin/class-wc-stripe-inbox-notes.php:153
 msgid "Learn more"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -126,10 +126,11 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= x.x.x - 2020-xx-xx =
+= 4.5.6 - 2020-12-xx =
 * Tweak - Update packages for Composer 2 compatibility.
 * Tweak - Use full jQuery function calls instead of soon-to-be-deprecated shorthands.
 * Tweak - Use JSON.parse() instead of jQuery.parseJSON().
+* Tweak - Remove holiday messaging from Apple Pay note after Dec 25.
 
 See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 

--- a/readme.txt
+++ b/readme.txt
@@ -130,7 +130,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Update packages for Composer 2 compatibility.
 * Tweak - Use full jQuery function calls instead of soon-to-be-deprecated shorthands.
 * Tweak - Use JSON.parse() instead of jQuery.parseJSON().
-* Tweak - Remove holiday messaging from Apple Pay note after Dec 25.
+* Tweak - Remove holiday messaging from Apple Pay note after Dec 22.
 
 See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: Link to the GitHub issue this PR addresses (if appropriate).
Fixes #1388 

Description: Adds a scheduled event for Dec-22 to refresh the title (dropping the reference to the holiday) on any un-actioned Apple Pay notes.

# Testing instructions

- Navigate to wp-admin > WooCommerce
- Open your inbox
- Verify you have a "Boost sales this holiday season with Apple Pay!" note. Make note of the "x minutes ago / x days ago / whatever"
- Install and activate this branch
- Install and activate the Crontrol plugin
- Navigate to wp-admin > Tools > Cron Events
- Search Hook Names for 2020
- Make sure you have a wc_stripe_apple_pay_2020_cleanup Hook scheduled to run at 2020-12-22 00:00:00 UTC
- Make sure it has an action of WC_Stripe_Inbox_Notes::cleanup_campaign_2020()
- Run it manually (hover over the hook name and select Run Now)
- Navigate to wp-admin > WooCommerce
- Open your inbox again
- Make sure the Apple Pay note has an updated "a minute ago" or something close to that in age
- Note: You won't see "holiday season" removed from the title since the "Run Now" just runs the refresh - the "trigger date" is still Dec 22 after which the titles will drop the holiday bits. If you want, you can hack WC_Stripe_Inbox_Notes::get_success_title to always return the non holiday title

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

(remove me)
- [ ] Did I add a title? A descriptive, yet concise, title.
- [ ] How can this code break?
- [ ] What are we doing to make sure this code doesn't break?
