### PR TITLE
Refactor the prepare_source function, extract the logic to tell if the current request should save the payment method into a new function

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -609,13 +609,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
-		// The payment method in use is already saved.
-		if ( $this->is_using_saved_payment_method() ) {
+		// The customer is not logged in.
+		if ( ! $customer->get_user_id() ) {
 			return false;
 		}
 
-		// The customer is not logged in.
-		if ( ! $customer->get_user_id() ) {
+		// The payment method in use is already saved.
+		if ( $this->is_using_saved_payment_method() ) {
 			return false;
 		}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -648,37 +648,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$customer->set_id( $existing_customer_id );
 		}
 
-		$force_save_source = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $customer );
-		$source_object     = '';
-		$source_id         = '';
-		$wc_token_id       = false;
-		$payment_method    = isset( $_POST['payment_method'] ) ? wc_clean( $_POST['payment_method'] ) : 'stripe';
-		$is_token          = false;
+		$source_object = '';
+		$wc_token_id   = false;
 
-		// New CC info was entered and we have a new source to process.
-		if ( ! empty( $_POST['stripe_source'] ) ) {
-			$source_object = self::get_source_object( wc_clean( $_POST['stripe_source'] ) );
-			$source_id     = $source_object->id;
-
-			// This checks to see if customer opted to save the payment method to file.
-			$maybe_saved_card = isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
-
-			/**
-			 * This is true if the user wants to store the card to their account.
-			 * Criteria to save to file is they are logged in, they opted to save or product requirements and the source is
-			 * actually reusable. Either that or force_save_source is true.
-			 */
-			if ( ( $user_id && $this->saved_cards && $maybe_saved_card && 'reusable' === $source_object->usage ) || $force_save_source ) {
-				$response = $customer->add_source( $source_object->id );
-
-				if ( ! empty( $response->error ) ) {
-					throw new WC_Stripe_Exception( print_r( $response, true ), $this->get_localized_error_message_from_response( $response ) );
-				}
-			}
-		} elseif ( $this->is_using_saved_payment_method() ) {
+		if ( $this->is_using_saved_payment_method() ) {
 			// Use an existing token, and then process the payment.
-			$wc_token_id = wc_clean( $_POST[ 'wc-' . $payment_method . '-payment-token' ] );
-			$wc_token    = WC_Payment_Tokens::get( $wc_token_id );
+			$payment_method = isset( $_POST['payment_method'] ) ? wc_clean( $_POST['payment_method'] ) : 'stripe';
+			$wc_token_id    = wc_clean( $_POST[ 'wc-' . $payment_method . '-payment-token' ] );
+			$wc_token       = WC_Payment_Tokens::get( $wc_token_id );
 
 			if ( ! $wc_token || $wc_token->get_user_id() !== get_current_user_id() ) {
 				WC()->session->set( 'refresh_totals', true );
@@ -687,24 +664,29 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 			$source_id = $wc_token->get_token();
 
-			if ( $this->is_type_legacy_card( $source_id ) ) {
-				$is_token = true;
+			if ( ! $this->is_type_legacy_card( $source_id ) ) {
+				$source_object = self::get_source_object( $source_id );
 			}
-		} elseif ( isset( $_POST['stripe_token'] ) && 'new' !== $_POST['stripe_token'] ) {
-			$stripe_token     = wc_clean( $_POST['stripe_token'] );
-			$maybe_saved_card = isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
+		} else {
+			// New CC info was entered and we have a new source to process.
+			if ( ! empty( $_POST['stripe_source'] ) ) {
+				$source_object = self::get_source_object( wc_clean( $_POST['stripe_source'] ) );
+				$source_id     = $source_object->id;
+			} elseif ( isset( $_POST['stripe_token'] ) && 'new' !== $_POST['stripe_token'] ) {
+				$source_id = wc_clean( $_POST['stripe_token'] );
+			}
 
-			// This is true if the user wants to store the card to their account.
-			if ( ( $user_id && $this->saved_cards && $maybe_saved_card ) || $force_save_source ) {
-				$response = $customer->add_source( $stripe_token );
+			if ( $this->should_save_payment_method( $source_object, $customer, $force_save_source ) ) {
+				$response = $customer->add_source( $source_id );
 
 				if ( ! empty( $response->error ) ) {
-					throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+					throw new WC_Stripe_Exception( print_r( $response, true ), $this->get_localized_error_message_from_response( $response ) );
 				}
-				$source_id    = $response;
-			} else {
-				$source_id    = $stripe_token;
-				$is_token     = true;
+
+				$source_id = $response;
+				if ( empty( $source_object ) ) {
+					$source_object = self::get_source_object( $source_id );
+				}
 			}
 		}
 
@@ -714,10 +696,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$customer_id = $customer->get_id();
 		} else {
 			$customer_id = $customer->update_customer();
-		}
-
-		if ( empty( $source_object ) && ! $is_token ) {
-			$source_object = self::get_source_object( $source_id );
 		}
 
 		return (object) array(


### PR DESCRIPTION
So, after reviewing Paul's other PR, I decided to abandon the changes I made here. However, I had to do some refactors along the way, and I wouldn't want those to get lost. So this PR is just a refactor now. I extracted the logic to check if the current request should save the payment method into a separate function, and reshuffled the `prepare_source` function into something that hopefully is easier to read. Absolutely no functionality should change.

<details>
  <summary>Old PR description</summary>
  
# Changes proposed in this Pull Request:

There's no issue for this, but it's part of our "SCA for subscriptions" umbrella. See pc4etw-6e-p2#comment-296 for more info.

The objective of this PR is in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/3454a74e19b96576359807a3c038bb267ab69aa2 : If a credit card is being saved, in any circumstance (even if it's for buying a regular product), the Payment Intent will be created with the `setup_future_usage=off_session`. That way, if in the future that credit card is used for a subscription renewal, it will have already gone through all the necessary SCA chalenges.

There's a bit of a trade-off: because we're signaling that the card will be used for off-session payments, there may be a higher chance of the SCA algorithm requesting extra authentication. That extra authentication would be pointless if you don't actually plan to use the credit card for off-session payments (for example, if WC Subscriptions isn't installed at all). However, I believe that's an acceptable trade-off.

https://github.com/woocommerce/woocommerce-gateway-stripe/commit/66d66d216babd3d2b15675d6590e066688130feb and https://github.com/woocommerce/woocommerce-gateway-stripe/commit/b2f92f235a930628b33c8ea635331a41bff3ba9a are refactors to support the main change. I also refactored the `prepare_source` function, it was getting a bit scary: https://github.com/woocommerce/woocommerce-gateway-stripe/commit/83fce794daa440daf25226f34412cfb4e920e067 I think reviewing that commit line-by-line is futile, the diff is quite garbled up.

# Testing instructions

- Go purchase a simple product (not a subscription).
- On the checkout, use Stripe to pay, and input a new credit card number (SCA, not SCA, whatever you want).
- Check the "Save card for future payments" box.
- Submit the checkout.
- Go to the Stripe Dashboard, check that the Payment Intent was created with the `"setup_future_usage": "off_session"` parameter.

cc/ @v18 @dechov 
  
</details>

