### PR TITLE
Hash redirect on added payment method if Setup Intent requires action

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -256,6 +256,7 @@ jQuery( function( $ ) {
 
 			// Listen for hash changes in order to handle payment intents
 			window.addEventListener( 'hashchange', wc_stripe_form.onHashChange );
+			wc_stripe_form.onHashChange();
 			wc_stripe_form.maybeConfirmIntent();
 		},
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

This is an initial, minimal attempt at fixing https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1391. It might be insufficient, and is unlikely to be a preferred approach as it stands, but sharing anyway just in case the contrast with the approach in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1398 helps steer towards a viable solution.

<img width="420" alt="hash-redirect-reload-before" src="https://user-images.githubusercontent.com/1867547/101876366-4bd0c280-3b5a-11eb-9928-c1012d3ad1ff.png">
<img width="420" alt="hash-redirect-reload-after" src="https://user-images.githubusercontent.com/1867547/101876370-4c695900-3b5a-11eb-97a5-8f4891c309b2.png">

Note that in this implementation, the payment method is **already saved after the initial form submission**. This doesn't seem ideal, particularly if "Update the Payment Method used for all of my active subscriptions" is opted into since there would be no further opportunity to authenticate on-session until renewals start to fail.

Also note the empty fields after redirect – we _could_ attempt to clean up this screen with hooks just as [the "Pay for order" screen does](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/cf86c635bed9f0f5913077898fb7658a9f8ae5f7/includes/class-wc-gateway-stripe.php#L860-L864) (though we'd need to toss in a query param since the hash can't be read on the server, or else clean up with JS as [WCPay does](https://github.com/Automattic/woocommerce-payments/blob/21c78d32c60c5a3b8a948b3d200cc83f7705c5fb/client/checkout/classic/index.js#L282)).

# Testing instructions

In My account » Payment methods » Add payment method, add a card that requires SCA for setup (like `4000002500003155` listed [here](https://stripe.com/docs/testing#regulatory-cards)), verify that the SCA prompt shows up, and when it succeeds then verify in the Stripe Dashboard (e.g. in "Events") that the SetupIntent has succeeded.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

(remove me)
- [ ] Did I add a title? A descriptive, yet concise, title.
- [ ] How can this code break?
- [ ] What are we doing to make sure this code doesn't break?
