### PR TITLE
Try SCA prompt on payment form without page reload

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -528,9 +528,10 @@ jQuery( function( $ ) {
 				$( wc_stripe_form.form ).off( 'submit', wc_stripe_form.form.onSubmit );
 			}
 
-			if ( $( 'form#order_review' ).length ) {
+			if ( $( 'form#add_payment_method' ).length || $( 'form#order_review' ).length ) {
+				var delimiter = window.location.toString().indexOf( '?' ) === -1 ? '?' : '&';
 				return $.ajax( {
-					url: window.location + '&is_ajax',
+					url: window.location + delimiter + 'is_ajax',
 					method: 'post',
 					data: wc_stripe_form.form.serialize(),
 					success: function( response ) {

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -528,6 +528,19 @@ jQuery( function( $ ) {
 				$( wc_stripe_form.form ).off( 'submit', wc_stripe_form.form.onSubmit );
 			}
 
+			if ( $( 'form#order_review' ).length ) {
+				return $.ajax( {
+					url: window.location + '&is_ajax',
+					method: 'post',
+					data: wc_stripe_form.form.serialize(),
+					success: function( response ) {
+						if ( response.result === 'success' ) {
+							window.location = response.redirect;
+						}
+					},
+				} );
+			}
+
 			wc_stripe_form.form.trigger( 'submit' );
 		},
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -962,10 +962,29 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		do_action( 'wc_stripe_add_payment_method_' . $_POST['payment_method'] . '_success', $source_id, $source_object );
 
-		return array(
+		$result = array(
 			'result'   => 'success',
 			'redirect' => wc_get_endpoint_url( 'payment-methods' ),
 		);
+
+		$setup_intent = WC_Stripe_API::request( array(
+			'payment_method' => $source_id,
+			'customer'       => $stripe_customer->get_id(),
+			'confirm'        => 'true',
+		), 'setup_intents' );
+
+		if ( is_wp_error( $setup_intent ) ) {
+			WC_Stripe_Logger::log( "Unable to create SetupIntent when adding payment method: " . print_r( $setup_intent, true ) );
+		} elseif ( 'requires_action' === $setup_intent->status ) {
+			$result['redirect'] = sprintf( '#confirm-si-%s:%s', $setup_intent->client_secret, rawurlencode( $result['redirect'] ) );
+		}
+
+		if ( isset( $_GET['is_ajax'] ) ) {
+			wp_send_json( $result );
+			exit;
+		}
+
+		return $result;
 	}
 
 	/**


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Allows SCA prompt to appear directly via the hashchange method (i.e. **without page reload**) even in cases where the form submission currently triggers a full page load. This is an experimental branch, intended for consideration / discussion but not ready for code review / merge.

**Pay for order:** https://github.com/woocommerce/woocommerce-gateway-stripe/commit/d418c5d3881713ce8b731022a80ecedcb2d6fe31 effectively _submits the "Pay for order" form via an AJAX request_ just so that the (hash) "redirect" to SCA prompt can work without an actual page reload. (It does this by `exit`ing from a filter, which IMO is mildly hacky 🤔.) Note that the "Checkout" flow returns JSON for AJAX requests [[source](https://github.com/woocommerce/woocommerce/blob/1add2556d636d5ff0f4d538c41874d6b823b27a7/includes/class-wc-checkout.php#L963-L970)], but the "Pay for order" flow doesn't [[source](https://github.com/woocommerce/woocommerce/blob/1add2556d636d5ff0f4d538c41874d6b823b27a7/includes/class-wc-form-handler.php#L443-L446)] – this change works around that.

<table><tr><td>
<img width="420" alt="hash-redirect-pay-for-order-without-reload-before" src="https://user-images.githubusercontent.com/1867547/101879353-3316db80-3b5f-11eb-8968-6dda4ab6adf0.png">
</td><td>
<img width="420" alt="hash-redirect-pay-for-order-without-reload-after" src="https://user-images.githubusercontent.com/1867547/101879356-34480880-3b5f-11eb-91b4-25d54d064a78.png">
</td></tr></table>

**Change payment method:** https://github.com/woocommerce/woocommerce-gateway-stripe/commit/370dab16ffef799fa4110033ce2b70d8d1271513 would fix https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1046 by making the "Change payment method" screen work the same way (except even more hacky since it has to filter and exit from `wp_redirect` 🌶 – _edit:_ oh wait, I forgot I didn't end up filtering that, but would still need to for some things to work which happen [after the payment result filter](1405-gh-woocommerce/woocommerce-subscriptions/blob/e8ecd1ae0a49c1ab0eddf994e291cb58e7b69c6f/includes/class-wc-subscriptions-change-payment-gateway.php#L367-L384)). It is very similar to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1405/commits/892d9960af5ea8fcc2825d5c44ef479a11da46b4 but simpler because the hash redirect can reuse the existing handling function (including the JSON response tweak). Note: I thought that this alternative approach would avoid the success message issue I encountered in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1405 if we wanted to save only after the Intent succeeds – and I suppose it does, but I'm not seeing the "Payment method updated." message at all now with this change, so we'd probably need to debug that or add a new notice of our own. 

<table><tr><td>
<img width="420" alt="hash-redirect-without-reload-before" src="https://user-images.githubusercontent.com/1867547/101878050-e9c58c80-3b5c-11eb-88ed-5839e96b22c2.png">
</td><td>
<img width="420" alt="hash-redirect-without-reload-after" src="https://user-images.githubusercontent.com/1867547/101878052-eaf6b980-3b5c-11eb-84b1-f76e47ee0160.png">
</td></tr></table>

**Add payment method:** https://github.com/woocommerce/woocommerce-gateway-stripe/commit/0153804d2d3f64706679407c4a63c7fd4699349f would fix https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1391 by having the "Add payment method" screen work this way as well, but being otherwise similar to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1408. (Not especially hacky 😇.) In this version, nothing gets updated after the modal authentication step, but if we need to, we can introduce another bit of indirection.

<table><tr><td>
<img width="420" alt="hash-redirect-add-payment-method-without-reload-before" src="https://user-images.githubusercontent.com/1867547/101881449-74f55100-3b62-11eb-9544-fed338b77d9a.png">
</td><td>
<img width="420" alt="hash-redirect-add-payment-method-without-reload-after" src="https://user-images.githubusercontent.com/1867547/101881457-758de780-3b62-11eb-966b-d3fefcf3536c.png">
</td></tr></table>

All **error cases** need attention before this PR can be considered for merge, as JSON responses are currently not being sent for any of them. (A couple are indicated with TODOs here, but not all.)

## Testing instructions

Observe that the SCA prompt shows up (if required) without a page load on "Pay for order" screen (using test card `4000000000003063`), and on "Change payment method" (for subscription) and "Add payment method" screens (using test card `4000002500003155`).

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

(remove me)
- [ ] Did I add a title? A descriptive, yet concise, title.
- [ ] How can this code break?
- [ ] What are we doing to make sure this code doesn't break?