### PR TITLE
Catch possible WC_Admin_Note exceptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Tweak - Use JSON.parse() instead of jQuery.parseJSON().
 * Tweak - Remove holiday messaging from Apple Pay note after Dec 22.
 * Fix   - Compatibility with the Stripe for WooCommerce plugin.
+* Fix   - Guard against fatal errors caused by WC_Admin_Note.
 
 = 4.5.5 - 2020-11-17 =
 * Fix - Guard against fatal errors that may occur on inbox data store load.

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -124,36 +124,40 @@ class WC_Stripe_Inbox_Notes {
 			return;
 		}
 
-		$note = new WC_Admin_Note();
-		$note->set_title( self::get_success_title() );
-		$note->set_content( __( 'Now that you accept Apple Pay® with Stripe, you can increase conversion rates by letting your customers know that Apple Pay is available. Here’s a marketing guide to help you get started.', 'woocommerce-gateway-stripe' ) );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
-		$note->set_name( self::SUCCESS_NOTE_NAME );
-		$note->set_source( 'woocommerce-gateway-stripe' );
-		$note->add_action(
-			'marketing-guide',
-			__( 'See marketing guide', 'woocommerce-gateway-stripe' ),
-			'https://developer.apple.com/apple-pay/marketing/'
-		);
-		$note->save();
+		try {
+			$note = new WC_Admin_Note();
+			$note->set_title( self::get_success_title() );
+			$note->set_content( __( 'Now that you accept Apple Pay® with Stripe, you can increase conversion rates by letting your customers know that Apple Pay is available. Here’s a marketing guide to help you get started.', 'woocommerce-gateway-stripe' ) );
+			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+			$note->set_name( self::SUCCESS_NOTE_NAME );
+			$note->set_source( 'woocommerce-gateway-stripe' );
+			$note->add_action(
+				'marketing-guide',
+				__( 'See marketing guide', 'woocommerce-gateway-stripe' ),
+				'https://developer.apple.com/apple-pay/marketing/'
+			);
+			$note->save();
+		} catch ( Exception $e ) {} // @codingStandardsIgnoreLine.
 	}
 
 	/**
 	 * Show note indicating domain verification failure.
 	 */
 	public static function create_failure_note() {
-		$note = new WC_Admin_Note();
-		$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-gateway-stripe' ) );
-		$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This must be resolved before Apple Pay can be offered to your customers.', 'woocommerce-gateway-stripe' ) );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
-		$note->set_name( self::FAILURE_NOTE_NAME );
-		$note->set_source( 'woocommerce-gateway-stripe' );
-		$note->add_action(
-			'learn-more',
-			__( 'Learn more', 'woocommerce-gateway-stripe' ),
-			'https://docs.woocommerce.com/document/stripe/#apple-pay'
-		);
-		$note->save();
+		try {
+			$note = new WC_Admin_Note();
+			$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-gateway-stripe' ) );
+			$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This must be resolved before Apple Pay can be offered to your customers.', 'woocommerce-gateway-stripe' ) );
+			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_name( self::FAILURE_NOTE_NAME );
+			$note->set_source( 'woocommerce-gateway-stripe' );
+			$note->add_action(
+				'learn-more',
+				__( 'Learn more', 'woocommerce-gateway-stripe' ),
+				'https://docs.woocommerce.com/document/stripe/#apple-pay'
+			);
+			$note->save();
+		} catch ( Exception $e ) {} // @codingStandardsIgnoreLine.
 	}
 
 	/**
@@ -185,12 +189,14 @@ class WC_Stripe_Inbox_Notes {
 		$deleted_an_unactioned_note = false;
 
 		foreach ( (array) $note_ids as $note_id ) {
-			$note = new WC_Admin_Note( $note_id );
-			if ( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED == $note->get_status() ) {
-				$note->delete();
-				$deleted_an_unactioned_note = true;
-			}
-			unset( $note );
+			try {
+				$note = new WC_Admin_Note( $note_id );
+				if ( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED == $note->get_status() ) {
+					$note->delete();
+					$deleted_an_unactioned_note = true;
+				}
+				unset( $note );
+			} catch ( Exception $e ) {} // @codingStandardsIgnoreLine.
 		}
 
 		if ( $deleted_an_unactioned_note ) {

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Use JSON.parse() instead of jQuery.parseJSON().
 * Tweak - Remove holiday messaging from Apple Pay note after Dec 22.
 * Fix   - Compatibility with the Stripe for WooCommerce plugin.
+* Fix   - Guard against fatal errors caused by WC_Admin_Note.
 
 See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
Fixes #1414

The problematic line from that issue is here:

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/4.5.5/includes/admin/class-wc-stripe-inbox-notes.php#L121

Using `new WC_Admin_Note()` makes a call to `\WC_Data_Store::load( 'admin-note' )` which can result in an Exception raised when 'admin-note' in an invalid type. You can make it an invalid type by [using a filter](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1372#issuecomment-728814679).

For this PR I checked for all uses of:
- WC_Admin_Note
- WC_Admin*
- WC_Data*

If I'm missing any other problematic areas related to WC Admin, let me know so they can be fixed.