### PR TITLE
Fix broken link to changelog in readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -135,5 +135,5 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix   - Guard against fatal errors caused by WC_Admin_Note.
 * Fix   - Display error message when payment made with payment request buttons fails.
 
-See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/master/changelog.txt).
 


### PR DESCRIPTION
# Description

I just noticed that I accidentally broke the link to the full changelog in the 4.5.5 release. This PR updates the readme to fix the link.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
