### PR TITLE
Use sub's update_payment_method function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 4.x.x - xxxx-xx-xx =
+* Fix - updating subscription payment methods from My Account page adds a note to the subscription
+
 = 4.6.0 - 2020-12-15 =
 * Tweak - Update packages for Composer 2 compatibility.
 * Tweak - Use full jQuery function calls instead of soon-to-be-deprecated shorthands.

--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -109,10 +109,16 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 			if ( ! empty( $all_subs ) ) {
 				foreach ( $all_subs as $sub ) {
 					if ( $sub->has_status( $subs_statuses ) ) {
-						update_post_meta( $sub->get_id(), '_stripe_source_id', $source_id );
-						update_post_meta( $sub->get_id(), '_stripe_customer_id', $stripe_customer->get_id() );
-						update_post_meta( $sub->get_id(), '_payment_method', $this->id );
-						update_post_meta( $sub->get_id(), '_payment_method_title', $this->method_title );
+						WC_Subscriptions_Change_Payment_Gateway::update_payment_method(
+							$sub,
+							$this->id,
+							array(
+								'post_meta' => array(
+									'_stripe_source_id' => array( 'value' => $source_id ),
+									'_stripe_customer_id' => array( 'value' => $stripe_customer->get_id() ),
+								),
+							)
+						);
 					}
 				}
 			}

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -118,10 +118,16 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 			if ( ! empty( $all_subs ) ) {
 				foreach ( $all_subs as $sub ) {
 					if ( $sub->has_status( $subs_statuses ) ) {
-						update_post_meta( $sub->get_id(), '_stripe_source_id', $source_id );
-						update_post_meta( $sub->get_id(), '_stripe_customer_id', $stripe_customer->get_id() );
-						update_post_meta( $sub->get_id(), '_payment_method', $this->id );
-						update_post_meta( $sub->get_id(), '_payment_method_title', $this->method_title );
+						WC_Subscriptions_Change_Payment_Gateway::update_payment_method(
+							$sub,
+							$this->id,
+							array(
+								'post_meta' => array(
+									'_stripe_source_id' => array( 'value' => $source_id ),
+									'_stripe_customer_id' => array( 'value' => $stripe_customer->get_id() ),
+								),
+							)
+						);
 					}
 				}
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 4.x.x - xxxx-xx-xx =
+* Fix - updating subscription payment methods from My Account page adds a note to the subscription
+
 = 4.6.0 - 2020-12-15 =
 * Tweak - Update packages for Composer 2 compatibility.
 * Tweak - Use full jQuery function calls instead of soon-to-be-deprecated shorthands.


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1419 

Description: Replaces the manual setting of post meta when updating subscriptions methods with a call to `WC_Subscriptions_Change_Payment_Gateway::update_payment_method`. This should allow the Subscriptions extension to handle the payment method update, including adding notes to the order.


# Testing instructions

- Purchase a subscription
- Verify the subscription appears in the admin panel and check the notes added to it
- Go to My Account and add a new Stripe payment method. **Make sure `Update the Payment Method used for all of my active subscriptions.` is checked**
- After adding a new method, refresh the subscription in the admin panel
- A note should be present:
<img width="288" alt="Screenshot 2020-12-16 at 13 59 18" src="https://user-images.githubusercontent.com/800604/102358018-e9872000-3fa6-11eb-8a0a-97d19e7f8bc0.png">
