### PR TITLE
Fix missing space in return statement

### DIFF
--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -42,7 +42,7 @@ class WC_Stripe_Inbox_Notes {
 			return __( 'Boost sales this holiday season with Apple Pay!', 'woocommerce-gateway-stripe' );
 		}
 
-		return__( 'Boost sales with Apple Pay!', 'woocommerce-gateway-stripe' );
+		return __( 'Boost sales with Apple Pay!', 'woocommerce-gateway-stripe' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1429

I searched using the regex `return[^\s]*;` for any other return statements missing a space (none found).