### PR TITLE
Add !empty check to avoid PHP notice

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -180,7 +180,7 @@ class WC_Stripe_Intent_Controller {
 				'setup_intents'
 			);
 
-			if ( $setup_intent->error ) {
+			if ( ! empty( $setup_intent->error ) ) {
 				$error_response_message = print_r( $setup_intent, true );
 				WC_Stripe_Logger::log("Failed create Setup Intent while saving a card.");
 				WC_Stripe_Logger::log("Response: $error_response_message");


### PR DESCRIPTION
Fix for:

```php
PHP Notice:  Undefined property: stdClass::$error in [redacted]/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-intent-controller.php on line 183
```