### PR TITLE
Fixed Stripe disables webhook if multiple applications are connected to an account.

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -71,7 +71,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			exit;
 		} else {
 			WC_Stripe_Logger::log( 'Incoming webhook failed validation: ' . print_r( $request_body, true ) );
-			status_header( 400 );
+			// A webhook endpoint must return a 2xx HTTP status code.
+			// @see https://stripe.com/docs/webhooks/build#return-a-2xx-status-code-quickly
+			status_header( 204 );
 			exit;
 		}
 	}


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: https://wordpress.org/support/topic/stripe-webhooks-failing/
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1136

Problem
* When multiple applications or site instances are connected a to Stripe account, then the signature of incoming events can be invalid on a particular site, because the event belongs to another site.

Details
* Stripe documents to only ever return a 2xx HTTP status code in a webhook endpoint: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1136
* Stripe states that they do not evaluate the status code, as long as it is a 2xx code, although they do seem to make a differentiation between 4xx and 5xx codes - whereas 4xx means an error on the client-side (Stripe) and that the event can/should be tried again.  Therefore the currently returned 4xx response code also causes many events to be retried, even though they will fail in the same way again.

Proposed solution
1. Change the HTTP status code from 400 to 204 in case of an error in the webhook handler.

Notes
* 204 means "No Content".  Of all available 2xx codes it matches the situation most closely.  Stripe does not document which status code to use in case of a validation error.


# Testing instructions

1. Create Stripe account.
2. Set up live Stripe API credentials in live site.
3. Set up testing Stripe API credentials in testing site.
4. Add webhook endpoint of live site in Stripe account.
5. Add webhook endpoint of testing site in Stripe account.

Both webhooks will work correctly and notifications for payments are received on both sites as expected.  But after some days, Stripe starts to send email notifications that the configured webhook endpoints are failing and that Stripe will automatically remove them, unless the problem is fixed.
