### PR TITLE
Trim the refund reason to a max of 500 characters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 4.8.0 - 2021-xx-xx =
 * Fix - Filter more disallowed characters from statement descriptors.
+* Fix - Trim the refund reason to a max of 500 characters.
 
 = 4.7.0 - 2020-12-22 =
 * Fix - Updating subscription payment methods from the "My Account" page now adds a note to the subscription.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -851,7 +851,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $reason ) {
-			// Trim the refund reason to a max of 500 characters.
+			// Trim the refund reason to a max of 500 characters due to Stripe limits: https://stripe.com/docs/api/metadata.
 			if ( strlen( $reason ) > 500 ) {
 				$reason = function_exists( 'mb_substr' ) ? mb_substr( $reason, 0, 450 ) : substr( $reason, 0, 450 );
 				// Add some explainer text indicating where to find the full refund reason.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -852,7 +852,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		if ( $reason ) {
 			// Trim the refund reason to a max of 499 characters.
-			if ( 499 < strlen( $reason ) ) {
+			if ( strlen( $reason ) >= 500 ) {
 				$reason = substr( $reason, 0, 450 );
 				// Add some explainer text indicating where to find the full refund reason.
 				$reason = $reason . '... [See WooCommerce order page for full text.]';

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -853,7 +853,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( $reason ) {
 			// Trim the refund reason to a max of 499 characters.
 			if ( strlen( $reason ) >= 500 ) {
-				$reason = substr( $reason, 0, 450 );
+				$reason = function_exists( 'mb_substr' ) ? mb_substr( $reason, 0, 450 ) : substr( $reason, 0, 450 );
 				// Add some explainer text indicating where to find the full refund reason.
 				$reason = $reason . '... [See WooCommerce order page for full text.]';
 			}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -851,8 +851,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $reason ) {
-			// Trim the refund reason to a max of 499 characters.
-			if ( strlen( $reason ) >= 500 ) {
+			// Trim the refund reason to a max of 500 characters.
+			if ( strlen( $reason ) > 500 ) {
 				$reason = function_exists( 'mb_substr' ) ? mb_substr( $reason, 0, 450 ) : substr( $reason, 0, 450 );
 				// Add some explainer text indicating where to find the full refund reason.
 				$reason = $reason . '... [See WooCommerce order page for full text.]';

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -851,8 +851,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $reason ) {
-			// Trim the refund reason to a max of 450 characters.
-			if ( 450 < strlen( $reason ) ) {
+			// Trim the refund reason to a max of 499 characters.
+			if ( 499 < strlen( $reason ) ) {
 				$reason = substr( $reason, 0, 450 );
 				// Add some explainer text indicating where to find the full refund reason.
 				$reason = $reason . '... [See WooCommerce order page for full text.]';

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -819,7 +819,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Refund a charge.
 	 *
 	 * @since 3.1.0
-	 * @version 4.0.0
+	 * @version 4.8.0
 	 * @param  int $order_id
 	 * @param  float $amount
 	 * @return bool

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -851,6 +851,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $reason ) {
+			// Trim the refund reason to a max of 499 characters.
+			if ( 499 < strlen( $reason ) ) {
+				$reason = substr( $reason, 0, 499 );
+			}
+			
 			$request['metadata'] = array(
 				'reason' => $reason,
 			);

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -851,9 +851,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		if ( $reason ) {
-			// Trim the refund reason to a max of 499 characters.
-			if ( 499 < strlen( $reason ) ) {
-				$reason = substr( $reason, 0, 499 );
+			// Trim the refund reason to a max of 450 characters.
+			if ( 450 < strlen( $reason ) ) {
+				$reason = substr( $reason, 0, 450 );
+				// Add some explainer text indicating where to find the full refund reason.
+				$reason = $reason . '... [See WooCommerce order page for full text.]';
 			}
 			
 			$request['metadata'] = array(


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issuing a refund where the refund reason is >500 characters will return an error in Stripe, but WC mostly behaves like the refund worked. This change trims the refund reason down to fit within Stripe's limit.

Fixes #1446

# Testing instructions

1. Start with a test WC site + Stripe in test mode.
2. Place an order for a product.
3. Refund the full amount of the order. In the Reason box, insert some dummy text greater than 500 chars in length.
4. Issue the refund.
5. Notice the order status changes to Refunded.
6. Click the txn ID at the top to go directly to the Stripe page for the transaction.
7. Scroll down to the "Events and logs" section.
8. There will be an error indicating that the refund reason "must be a string under 500 characters."
9. Apply the change in this pull request.
10. Repeat this same test with a different transaction.
11. Stripe should issue the refund, with the trimmed refund reason visible in the logs.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.