### PR TITLE
Fix adding a SEPA payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 = 4.9.0 - 2021-xx-xx =
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
-* Fix - Adding a SEPA payment method doesn't work
+* Fix - Adding a SEPA payment method doesn't work.
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
-= 4.9.0 - 2021-xx-xx
-* Fix   - Add fees as line items sent to Stripe to prevent Level 3 errors.
+= 4.9.0 - 2021-xx-xx =
+* Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
+* Fix - Adding a SEPA payment method doesn't work
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -170,6 +170,16 @@ class WC_Stripe_Intent_Controller {
 				throw new Exception( $source_object->get_error_message() );
 			}
 
+			// SEPA Direct Debit payments do not require any customer action after the source has been created.
+			// Once the customer has provided their IBAN details and accepted the mandate, no further action is needed and the resulting source is directly chargeable.
+			if ( 'sepa_debit' === $source_object->type ) {
+				$response = [
+					'status' => 'success',
+				];
+				echo wp_json_encode( $response );
+				return;
+			}
+
 			// 4. Generate the setup intent
 			$setup_intent = WC_Stripe_API::request(
 				[

--- a/readme.txt
+++ b/readme.txt
@@ -126,7 +126,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.9.0 - 2021-xx-xx
+= 4.9.0 - 2021-xx-xx =
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
+* Fix - Adding a SEPA payment method doesn't work
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 4.9.0 - 2021-xx-xx =
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
-* Fix - Adding a SEPA payment method doesn't work
+* Fix - Adding a SEPA payment method doesn't work.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: #1451
Fixes #1451

Description:
SEPA Direct Debit payments do not require any customer action after the source has been created. Once the customer has provided their IBAN details and accepted the mandate, no further action is needed and the resulting source is directly chargeable.
The specific change is to not send a SetupIntent request if the payment method being added is of type `sepa_debit`.

# Testing instructions

1. Go to the My account page > Payment Methods
2. Click the `ADD PAYMENT METHOD` button
3. Select the option: `SEPA Direct Debit`
4. Enter the IBAN number
5. Click the `ADD PAYMENT METHOD` button to confirm
6. A confirmation message is shown, and the page reloads with the new payment method now listed.

This can also be verified in Stripe:
1. Login to your Stripe account (or use the `Stripe account settings` link in the Stripe Payments config in the store admin)
2. Select the `Customers` menu option
3. Select the currently logged in customer from the list
4. The newly added SEPA direct Debit should be listed in the _Payments Methods_ list shown in the right side

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
