### PR TITLE
Fix Apple Pay domain registration to use only the live secret key

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 = 4.9.0 - 2021-xx-xx =
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
+* Fix - Apple Pay domain verification with live secret key.
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -146,7 +146,7 @@ return apply_filters(
 			'title'       => __( 'Payment Request Buttons', 'woocommerce-gateway-stripe' ),
 			'label'       => sprintf(
 				/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe dashboard opening anchor tag 5) Stripe dashboard closing anchor tag */
-				__( 'Enable Payment Request Buttons. (Apple Pay/Google Pay) %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service. (Apple Pay domain verification is performed automatically; configuration can be found on the %4$sStripe dashboard%5$s.)', 'woocommerce-gateway-stripe' ),
+				__( 'Enable Payment Request Buttons. (Apple Pay/Google Pay) %1$sBy using Apple Pay, you agree to %2$s and %3$s\'s terms of service. (Apple Pay domain verification is performed automatically in live mode; configuration can be found on the %4$sStripe dashboard%5$s.)', 'woocommerce-gateway-stripe' ),
 				'<br />',
 				'<a href="https://stripe.com/apple-pay/legal" target="_blank">Stripe</a>',
 				'<a href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/" target="_blank">Apple</a>',

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -125,7 +125,7 @@ class WC_Stripe_Apple_Pay_Registration {
 		}
 
 		$path = WC_STRIPE_PLUGIN_PATH . '/apple-developer-merchantid-domain-association';
-		header( 'Content-Type: application/octet-stream' );
+		header( 'Content-Type: text/plain;charset=utf-8' );
 		echo esc_html( file_get_contents( $path ) );
 		exit;
 	}

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -83,11 +83,11 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * Gets the Stripe secret key for the current mode.
 	 *
 	 * @since 4.5.3
+	 * @version 4.9.0
 	 * @return string Secret key.
 	 */
 	private function get_secret_key() {
-		$testmode = 'yes' === $this->get_option( 'testmode', 'no' );
-		return $testmode ? $this->get_option( 'test_secret_key' ) : $this->get_option( 'secret_key' );
+		return $this->get_option( 'secret_key' );
 	}
 
 	/**
@@ -134,7 +134,7 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * Makes request to register the domain with Stripe/Apple Pay.
 	 *
 	 * @since 3.1.0
-	 * @version 4.5.4
+	 * @version 4.9.0
 	 * @param string $secret_key
 	 */
 	private function make_domain_registration_request( $secret_key ) {

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -158,6 +158,7 @@ class WC_Stripe_Apple_Pay_Registration {
 			array(
 				'headers' => $headers,
 				'body'    => http_build_query( $data ),
+				'timeout' => 30,
 			)
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -127,7 +127,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 4.9.0 - 2021-xx-xx =
+
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
+* Fix - Apple Pay domain verification with live secret key.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #1359

# Changes proposed in this Pull Request:

- Use live secret for Apple Pay domain verification.
- Change response headers when serving the association file (See [Stripe's file](https://stripe.com/.well-known/apple-developer-merchantid-domain-association)).
- Increase request timeout limit (default is 5):This is necessary in live mode, because Apple needs to request and validate the file. This often takes more than 5 seconds. This was probably overlooked in test mode, because it always responds with a successful response without actually verifying the file.

# Testing instructions

- Use [Ngrok](https://ngrok.com) and generate a new domain.
- Check "Log debug messages" in Settings to check domain verification.
- Try using only test mode keys and saving - It shouldn't make any requests to verify your domain (Check `WooCommerce > Status > Logs`).
- Try using live keys and saving - `WooCommerce > Status > Logs` should display `Your domain has been verified with Apple Pay!`
- Check if the Apple Pay button is visible in any product page or the cart page.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).