### PR TITLE
Apple pay - Best way forward to verify domain

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
 * Fix - Apple Pay domain verification with live secret key.
+* Fix - Remove duplicate Apple Pay domain registration Inbox notes.
+* Add - Copy Apple Pay domain registration file and trigger domain registration on domain name change.
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -57,6 +57,9 @@ class WC_Stripe_Inbox_Notes {
 			return;
 		}
 
+		$data_store       = WC_Data_Store::load( 'admin-note' );
+		$failure_note_ids = $data_store->get_notes_with_name( self::FAILURE_NOTE_NAME );
+
 		if ( $verification_complete ) {
 			if ( self::should_show_marketing_note() && ! wp_next_scheduled( self::POST_SETUP_SUCCESS_ACTION ) ) {
 				wp_schedule_single_event( time() + DAY_IN_SECONDS, self::POST_SETUP_SUCCESS_ACTION );
@@ -64,8 +67,6 @@ class WC_Stripe_Inbox_Notes {
 
 			// If the domain verification completed after failure note was created, make sure it's marked as actioned.
 			try {
-				$data_store       = WC_Data_Store::load( 'admin-note' );
-				$failure_note_ids = $data_store->get_notes_with_name( self::FAILURE_NOTE_NAME );
 				if ( ! empty( $failure_note_ids ) ) {
 					$note_id = array_pop( $failure_note_ids );
 					$note    = WC_Admin_Notes::get_note( $note_id );

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -66,9 +66,7 @@ class WC_Stripe_Inbox_Notes {
 				$note    = WC_Admin_Notes::get_note( $note_id );
 				$note->delete();
 			}
-		} catch ( Exception $e ) {
-			return;
-		}
+		} catch ( Exception $e ) {} // @codingStandardsIgnoreLine
 
 		if ( $verification_complete ) {
 			if ( self::should_show_marketing_note() && ! wp_next_scheduled( self::POST_SETUP_SUCCESS_ACTION ) ) {

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -57,29 +57,26 @@ class WC_Stripe_Inbox_Notes {
 			return;
 		}
 
-		$data_store       = WC_Data_Store::load( 'admin-note' );
-		$failure_note_ids = $data_store->get_notes_with_name( self::FAILURE_NOTE_NAME );
+		try {
+			$data_store       = WC_Data_Store::load( 'admin-note' );
+			$failure_note_ids = $data_store->get_notes_with_name( self::FAILURE_NOTE_NAME );
+			// Delete all previously created, soft deleted and unactioned failure notes (Legacy).
+			while ( ! empty( $failure_note_ids ) ) {
+				$note_id = array_pop( $failure_note_ids );
+				$note    = WC_Admin_Notes::get_note( $note_id );
+				$note->delete();
+			}
+		} catch ( Exception $e ) {
+			return;
+		}
 
 		if ( $verification_complete ) {
 			if ( self::should_show_marketing_note() && ! wp_next_scheduled( self::POST_SETUP_SUCCESS_ACTION ) ) {
 				wp_schedule_single_event( time() + DAY_IN_SECONDS, self::POST_SETUP_SUCCESS_ACTION );
 			}
-
-			// If the domain verification completed after failure note was created, make sure it's marked as actioned.
-			try {
-				if ( ! empty( $failure_note_ids ) ) {
-					$note_id = array_pop( $failure_note_ids );
-					$note    = WC_Admin_Notes::get_note( $note_id );
-					if ( false !== $note && WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED !== $note->get_status() ) {
-						$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
-						$note->save();
-					}
-				}
-			} catch ( Exception $e ) {}  // @codingStandardsIgnoreLine.
 		} else {
-			if ( empty( $failure_note_ids ) ) {
-				self::create_failure_note();
-			}
+			// Create new note if verification failed.
+			self::create_failure_note();
 		}
 	}
 

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -150,9 +150,9 @@ class WC_Stripe_Apple_Pay_Registration {
 					sprintf( __( 'To enable Apple Pay, domain association file must be hosted at %s.', 'woocommerce-payments' ), $url )
 				);
 			}
+		} else {
+			WC_Stripe_Logger::log( __( 'Domain association file updated.', 'woocommerce-payments' ) );
 		}
-
-		WC_Stripe_Logger::log( __( 'Domain association file updated.', 'woocommerce-payments' ) );
 	}
 
 	/**

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -44,7 +44,7 @@ class WC_Stripe_Apple_Pay_Registration {
 
 	public function __construct() {
 		add_action( 'init', array( $this, 'add_domain_association_rewrite_rule' ) );
-		add_action( 'admin_init', [ $this, 'verify_domain_on_domain_name_change' ] );
+		add_action( 'admin_init', array( $this, 'verify_domain_on_domain_name_change' ) );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 		add_filter( 'query_vars', array( $this, 'whitelist_domain_association_query_param' ), 10, 1 );
 		add_action( 'parse_request', array( $this, 'parse_domain_association_request' ), 10, 1 );
@@ -54,7 +54,7 @@ class WC_Stripe_Apple_Pay_Registration {
 		add_action( 'update_option_woocommerce_stripe_settings', array( $this, 'verify_domain_on_updated_settings' ), 10, 2 );
 
 		$this->stripe_settings         = get_option( 'woocommerce_stripe_settings', array() );
-		$this->domain_name             = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : str_replace( [ 'https://', 'http://' ], '', get_site_url() ); // @codingStandardsIgnoreLine
+		$this->domain_name             = isset( $_SERVER['HTTP_HOST'] ) ? $_SERVER['HTTP_HOST'] : str_replace( array( 'https://', 'http://' ), '', get_site_url() ); // @codingStandardsIgnoreLine
 		$this->apple_pay_domain_set    = 'yes' === $this->get_option( 'apple_pay_domain_set', 'no' );
 		$this->apple_pay_verify_notice = '';
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
 * Fix - Apple Pay domain verification with live secret key.
+* Fix - Remove duplicate Apple Pay domain registration Inbox notes.
+* Add - Copy Apple Pay domain registration file and trigger domain registration on domain name change.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-apple-pay-registration.php
+++ b/tests/phpunit/test-wc-stripe-apple-pay-registration.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * These teste make assertions against class WC_Stripe_Apple_Pay_Registration.
+ *
+ * @package WooCommerce_Stripe/Tests/Apple_Pay_Registration
+ */
+
+/**
+ * WC_Stripe_Apple_Pay_Registration unit tests.
+ */
+class WC_Stripe_Apple_Pay_Registration_Test extends WP_UnitTestCase {
+
+	/**
+	 * System under test.
+	 *
+	 * @var WC_Stripe_Apple_Pay_Registration
+	 */
+	private $wc_apple_pay_registration;
+
+	/**
+	 * Domain association file name.
+	 *
+	 * @var string
+	 */
+	private $file_name;
+
+	/**
+	 * Domain association file contents.
+	 *
+	 * @var string
+	 */
+	private $file_contents;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->wc_apple_pay_registration = new WC_Stripe_Apple_Pay_Registration();
+
+		$this->file_name     = 'apple-developer-merchantid-domain-association';
+		$this->file_contents = file_get_contents( WC_STRIPE_PLUGIN_PATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$path     = untrailingslashit( ABSPATH );
+		$dir      = '.well-known';
+		$fullpath = $path . '/' . $dir . '/' . $this->file_name;
+		// Unlink domain association file before tests.
+		@unlink( $fullpath ); // @codingStandardsIgnoreLine
+	}
+
+	public function test_update_domain_association_file() {
+		$path     = untrailingslashit( ABSPATH );
+		$dir      = '.well-known';
+		$fullpath = $path . '/' . $dir . '/' . $this->file_name;
+
+		$this->wc_apple_pay_registration->update_domain_association_file();
+		$expected_file_contents = file_get_contents( $fullpath ); // @codingStandardsIgnoreLine
+
+		$this->assertEquals( $expected_file_contents, $this->file_contents );
+	}
+
+	public function test_add_domain_association_rewrite_rule() {
+		$this->set_permalink_structure( '/%postname%/' );
+		$this->wc_apple_pay_registration->add_domain_association_rewrite_rule();
+		flush_rewrite_rules();
+
+		global $wp_rewrite;
+		$rewrite_rule = 'index.php?' . $this->file_name . '=1';
+
+		$this->assertContains( $rewrite_rule, $wp_rewrite->rewrite_rules() );
+	}
+}

--- a/tests/phpunit/test-wc-stripe-apple-pay-registration.php
+++ b/tests/phpunit/test-wc-stripe-apple-pay-registration.php
@@ -39,8 +39,8 @@ class WC_Stripe_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 
 		$this->wc_apple_pay_registration = new WC_Stripe_Apple_Pay_Registration();
 
-		$this->file_name     = 'apple-developer-merchantid-domain-association';
-		$this->file_contents = file_get_contents( WC_STRIPE_PLUGIN_PATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine
+		$this->file_name             = 'apple-developer-merchantid-domain-association';
+		$this->initial_file_contents = file_get_contents( WC_STRIPE_PLUGIN_PATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine
 	}
 
 	public function tearDown() {
@@ -59,9 +59,9 @@ class WC_Stripe_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 		$fullpath = $path . '/' . $dir . '/' . $this->file_name;
 
 		$this->wc_apple_pay_registration->update_domain_association_file();
-		$expected_file_contents = file_get_contents( $fullpath ); // @codingStandardsIgnoreLine
+		$updated_file_contents = file_get_contents( $fullpath ); // @codingStandardsIgnoreLine
 
-		$this->assertEquals( $expected_file_contents, $this->file_contents );
+		$this->assertEquals( $updated_file_contents, $this->initial_file_contents );
 	}
 
 	public function test_add_domain_association_rewrite_rule() {


### PR DESCRIPTION
Fixes #1376
Fixes #1442
Fixes #1330

This PR is complementary to #1465 in improving domain registration reliability.

The default method (rewrite rule) doesn't work when permalinks are set to Plain, so we try to copy the domain association file to the domain root as a fallback. This fallback may not work for lack of permissions in modifying the .well-known folder.

# Changes proposed in this Pull Request:

- Restore file copy method and adapt it as a fallback.
- Add tests to both verification methods.
- Trigger domain verification upon domain name change.
- Fix duplicate registration failure inbox notices:
  By deleting previously generated notes and creating a new failure note if necessary. I first tried managing soft deleted notes or unactioned notes, but the code became complex and I thought it would be better to simply delete all notes and then recreate one if verification fails - It's also better because it pushes the newest error note to the top.

# Testing instructions

## Test domain registration with fallback method

- Make sure you have live publishable and secret keys in settings.
- Go to [http://localhost:8082/wp-admin/options-permalink.php](http://localhost:8082/wp-admin/options-permalink.php) and set your permalink setting to `Plain`. This will break the rewrite rule method.
- Make sure you have a new unverified domain. You can use [Ngrok](https://ngrok.com): `ngrok http 8082`.
- Open any wp-admin page of your unverified domain. - A new domain registration request shall be triggered.
- Check any HTTPS product URL using Safari (Mac or iOS), with an active payment method in Apple Wallet. You should be able to see the Apple Pay button.

## Testing duplicate inbox note

For the #1376 issue, you'll want to make the domain registration fail. You can easily test this by trying to verify `localhost:8082`.

- Open your [localhost Stripe](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe) settings.
- Disable Payment Request Buttons, save, then enable and save again.
- You should see the following Inbox Notice in your WooCommerce Home: "Apple Pay domain verification needed".
- Try repeating the process and check if there aren't duplicate notices.
- Try validating your domain with Ngrok and check if the note disappears.

Note: If you keep a wp-admin tab open with different URLs, it can trigger the domain registration (by domain name change) with timed Ajax calls - So make sure you don't have wp-admin with different URLs open at the same time.
