### PR TITLE
Add fees as line items sent to Stripe to prevent Level 3 errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,6 @@
 *** Changelog ***
+= 4.9.0 - 2021-xx-xx
+* Fix   - Add fees as line items sent to Stripe to prevent Level 3 errors.
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the same license as the WooCommerce Stripe Gateway package.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce Stripe Gateway 4.7.0\n"
+"Project-Id-Version: WooCommerce Stripe Gateway 4.8.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-gateway-stripe\n"
-"POT-Creation-Date: 2021-01-28 01:47:05+00:00\n"
+"POT-Creation-Date: 2021-02-12 15:12:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -56,8 +56,8 @@ msgstr ""
 
 #: includes/abstracts/abstract-wc-stripe-payment-gateway.php:450
 #: includes/class-wc-stripe-order-handler.php:298
-#: includes/class-wc-stripe-webhook-handler.php:340
-#: includes/class-wc-stripe-webhook-handler.php:390
+#: includes/class-wc-stripe-webhook-handler.php:384
+#: includes/class-wc-stripe-webhook-handler.php:434
 #. translators: transaction id
 msgid "Stripe charge complete (Charge ID: %s)"
 msgstr ""
@@ -1006,8 +1006,8 @@ msgid ""
 msgstr ""
 
 #: includes/class-wc-gateway-stripe.php:1131
-#: includes/class-wc-stripe-webhook-handler.php:674
-#: includes/class-wc-stripe-webhook-handler.php:713
+#: includes/class-wc-stripe-webhook-handler.php:728
+#: includes/class-wc-stripe-webhook-handler.php:773
 #. translators: 1) The error message that was received from Stripe.
 msgid "Stripe SCA authentication failed. Reason: %s"
 msgstr ""
@@ -1219,7 +1219,7 @@ msgstr ""
 msgid "SEPA IBAN ending in %s"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:291
+#: includes/class-wc-stripe-webhook-handler.php:293
 #. translators: 1) The URL to the order.
 msgid ""
 "A dispute was created for this order. Response is needed. Please go to your "
@@ -1227,34 +1227,46 @@ msgid ""
 "Dashboard</a> to review this dispute."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:335
+#: includes/class-wc-stripe-webhook-handler.php:322
+msgid "The dispute was lost or accepted."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:324
+msgid "The dispute was resolved in your favor."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:326
+msgid "The inquiry or retrieval was closed."
+msgstr ""
+
+#: includes/class-wc-stripe-webhook-handler.php:379
 #. translators: partial captured amount
 msgid "This charge was partially captured via Stripe Dashboard in the amount of: %s"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:417
+#: includes/class-wc-stripe-webhook-handler.php:461
 msgid "This payment failed to clear."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:450
-msgid "This payment has cancelled."
+#: includes/class-wc-stripe-webhook-handler.php:498
+msgid "This payment was cancelled."
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:485
+#: includes/class-wc-stripe-webhook-handler.php:537
 msgid "Refunded via Stripe Dashboard"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:485
-#: includes/class-wc-stripe-webhook-handler.php:513
+#: includes/class-wc-stripe-webhook-handler.php:537
+#: includes/class-wc-stripe-webhook-handler.php:565
 msgid "Pre-Authorization Released via Stripe Dashboard"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:513
+#: includes/class-wc-stripe-webhook-handler.php:565
 #. translators: 1) dollar amount 2) transaction id 3) refund message
 msgid "Refunded %1$s - Refund ID: %2$s - %3$s"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:544
+#: includes/class-wc-stripe-webhook-handler.php:598
 #. translators: 1) The URL to the order. 2) The reason type.
 msgid ""
 "A review has been opened for this order. Action is needed. Please go to "
@@ -1262,7 +1274,7 @@ msgid ""
 "Dashboard</a> to review the issue. Reason: (%2$s)"
 msgstr ""
 
-#: includes/class-wc-stripe-webhook-handler.php:577
+#: includes/class-wc-stripe-webhook-handler.php:631
 #. translators: 1) The reason type.
 msgid "The opened review for this order is now closed. Reason: (%s)"
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -126,11 +126,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 4.8.0 - 2021-01-28 =
-* Fix   - Filter more disallowed characters from statement descriptors.
-* Fix   - Payment request button for Puerto Rico.
-* Fix   - Handle error if country is not supported for payment request button.
-* Fix   - Trim the refund reason to a max of 500 characters.
-* Tweak - Display warning on webhook secret when server time is off from device time.
+= 4.9.0 - 2021-xx-xx
+* Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -17,7 +17,7 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
 
-$wc_tests_framework_base_dir = dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/woocommerce/tests/framework/';
+$wc_tests_framework_base_dir = dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) . '/woocommerce/tests/legacy/framework/';
 require_once( $wc_tests_framework_base_dir . 'class-wc-mock-session-handler.php' );
 //require_once( $wc_tests_framework_base_dir . 'class-wc-unit-test-case.php' );
 require_once( $wc_tests_framework_base_dir . 'helpers/class-wc-helper-product.php' );

--- a/tests/phpunit/test-wc-stripe-level-3-data.php
+++ b/tests/phpunit/test-wc-stripe-level-3-data.php
@@ -255,7 +255,8 @@ class WC_Stripe_Level3_Data_Test extends WP_UnitTestCase {
 		update_option( 'woocommerce_store_postcode', '94110' );
 
 		$mock_order   = $this->mock_level_3_order( '98012', true );
-		$level_3_data = $this->wcpay_gateway->get_level3_data_from_order( $mock_order );
+		$gateway      = new WC_Gateway_Stripe();
+		$level_3_data = $gateway->get_level3_data_from_order( $mock_order );
 
 		$this->assertEquals( $expected_data, $level_3_data );
 	}


### PR DESCRIPTION
Fixes #1462

# Changes proposed in this Pull Request:

 * Add fees as line items sent to Stripe in Level 3 data to prevent errors.

Description: Fees were not included into the Level3 and that could cause Stripe errors on level3 data due to amount mismatch.

# Testing instructions

 * Create order in admin.
 * Choose **Add item(s)**, and then only add a fee.
 * **Save/Create** as *Pending Payment*
 * Use **Customer payment page** link in order to go to checkout.
 * Check out. (previously you could not)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
