### PR TITLE
Fix payment request buttons for Chinese provinces in Chrome

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 = 5.0.0 - 2021-xx-xx =
 * Add - Display time of last Stripe webhook in settings.
+* Fix - Payment Request Buttons for Chinese provinces in Chrome.
 
 = 4.9.0 - 2021-02-24 =
 * Fix    - Add fees as line items sent to Stripe to prevent Level 3 errors.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1143,15 +1143,9 @@ class WC_Stripe_Payment_Request {
 		$city      = $address['city'];
 		$address_1 = $address['address'];
 		$address_2 = $address['address_2'];
-		$wc_states = WC()->countries->get_states( $country );
 
-		/**
-		 * In some versions of Chrome, state can be a full name. So we need
-		 * to convert that to abbreviation as WC is expecting that.
-		 */
-		if ( 2 < strlen( $state ) && ! empty( $wc_states ) && ! isset( $wc_states[ $state ] ) ) {
-			$state = array_search( ucwords( strtolower( $state ) ), $wc_states, true );
-		}
+		// Normalizes state to calculate shipping zones.
+		$state = $this->get_normalized_state();
 
 		WC()->shipping->reset_shipping();
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1088,6 +1088,7 @@ class WC_Stripe_Payment_Request {
 			$match_from_state_input = false;
 
 			// China - Adapt dropdown values from Chrome and accept manually typed values like 云南.
+			// WC states: https://github.com/woocommerce/woocommerce/blob/master/i18n/states.php
 			if ( 'CN' === $country ) {
 				$replace_map            = array(
 					// Rename regions with different spelling.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1089,7 +1089,7 @@ class WC_Stripe_Payment_Request {
 
 			// China - Adapt dropdown values from Chrome and accept manually typed values like 云南.
 			if ( 'CN' === $country ) {
-				$replace_map            = [
+				$replace_map            = array(
 					// Rename regions with different spelling.
 					'Macau'     => 'Macao',
 					'Neimenggu' => 'Inner Mongolia',
@@ -1101,7 +1101,7 @@ class WC_Stripe_Payment_Request {
 					'Huizuzizhiqu'    => '',
 					'Weiwuerzizhiqu'  => '',
 					'Zhuangzuzizhiqu' => '',
-				];
+				);
 				$state                  = trim( str_replace( array_keys( $replace_map ), array_values( $replace_map ), $state ) );
 				$match_from_state_input = true;
 			}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1048,10 +1048,10 @@ class WC_Stripe_Payment_Request {
 	 * @version 5.0.0
 	 */
 	public function normalize_state() {
-		$billing_country  = ! empty( $_POST['billing_country'] ) ? wc_clean( $_POST['billing_country'] ) : '';
-		$shipping_country = ! empty( $_POST['shipping_country'] ) ? wc_clean( $_POST['shipping_country'] ) : '';
-		$billing_state    = ! empty( $_POST['billing_state'] ) ? wc_clean( $_POST['billing_state'] ) : '';
-		$shipping_state   = ! empty( $_POST['shipping_state'] ) ? wc_clean( $_POST['shipping_state'] ) : '';
+		$billing_country  = ! empty( $_POST['billing_country'] ) ? wc_clean( wp_unslash( $_POST['billing_country'] ) ) : '';
+		$shipping_country = ! empty( $_POST['shipping_country'] ) ? wc_clean( wp_unslash( $_POST['shipping_country'] ) ) : '';
+		$billing_state    = ! empty( $_POST['billing_state'] ) ? wc_clean( wp_unslash( $_POST['billing_state'] ) ) : '';
+		$shipping_state   = ! empty( $_POST['shipping_state'] ) ? wc_clean( wp_unslash( $_POST['shipping_state'] ) ) : '';
 
 		if ( $billing_state && $billing_country ) {
 			$_POST['billing_state'] = $this->get_normalized_state( $billing_state, $billing_country );
@@ -1078,7 +1078,7 @@ class WC_Stripe_Payment_Request {
 	public function get_normalized_state( $state, $country ) {
 		$wc_valid_states = $country ? WC()->countries->get_states( $country ) : [];
 
-		if ( $state && $country && is_array( $wc_valid_states ) && sizeof( $wc_valid_states ) > 0 ) {
+		if ( $state && $country && is_array( $wc_valid_states ) && count( $wc_valid_states ) > 0 ) {
 
 			// If it's already normalized, skip.
 			if ( in_array( $state, array_keys( $wc_valid_states ) ) ) {
@@ -1090,11 +1090,11 @@ class WC_Stripe_Payment_Request {
 			// China - Adapt dropdown values from Chrome and accept manually typed values like 云南.
 			// WC states: https://github.com/woocommerce/woocommerce/blob/master/i18n/states.php
 			if ( 'CN' === $country ) {
-				$replace_map            = array(
+				$replace_map            = [
 					// Rename regions with different spelling.
-					'Macau'     => 'Macao',
-					'Neimenggu' => 'Inner Mongolia',
-					'Xizang'    => 'Tibet',
+					'Macau'           => 'Macao',
+					'Neimenggu'       => 'Inner Mongolia',
+					'Xizang'          => 'Tibet',
 					// Remove suffixes.
 					'Shi'             => '',
 					'Sheng'           => '',
@@ -1102,7 +1102,7 @@ class WC_Stripe_Payment_Request {
 					'Huizuzizhiqu'    => '',
 					'Weiwuerzizhiqu'  => '',
 					'Zhuangzuzizhiqu' => '',
-				);
+				];
 				$state                  = trim( str_replace( array_keys( $replace_map ), array_values( $replace_map ), $state ) );
 				$match_from_state_input = true;
 			}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1045,7 +1045,7 @@ class WC_Stripe_Payment_Request {
 	 * Normalizes billing and shipping state fields.
 	 *
 	 * @since 4.0.0
-	 * @version 4.9.0
+	 * @version 5.0.0
 	 */
 	public function normalize_state() {
 		$billing_country  = ! empty( $_POST['billing_country'] ) ? wc_clean( $_POST['billing_country'] ) : '';
@@ -1068,7 +1068,7 @@ class WC_Stripe_Payment_Request {
 	 * what WC is expecting and throws an error. An example
 	 * for Ireland the county dropdown in Chrome shows "Co. Clare" format.
 	 *
-	 * @since 4.9.0
+	 * @since 5.0.0
 	 *
 	 * @param string $state   Full state name or an already normalized abbreviation.
 	 * @param string $country Two-letter country code.
@@ -1150,7 +1150,7 @@ class WC_Stripe_Payment_Request {
 	 * @param array $address Shipping address.
 	 *
 	 * @since   3.1.0
-	 * @version 4.0.0
+	 * @version 5.0.0
 	 */
 	protected function calculate_shipping( $address = [] ) {
 		$country   = $address['country'];

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1119,7 +1119,9 @@ class WC_Stripe_Payment_Request {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
 		}
 
-		$this->normalize_state();
+		// Normalizes billing and shipping state values.
+		$_POST['billing_state']  = $this->get_normalized_state( 'billing' );
+		$_POST['shipping_state'] = $this->get_normalized_state( 'shipping' );
 
 		WC()->checkout()->process_checkout();
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1162,14 +1162,6 @@ class WC_Stripe_Payment_Request {
 		// Normalizes state to calculate shipping zones.
 		$state = $this->get_normalized_state( $state, $country );
 
-		/**
-		 * In some versions of Chrome, state can be a full name. So we need
-		 * to convert that to abbreviation as WC is expecting that.
-		 */
-		if ( 2 < strlen( $state ) && ! empty( $wc_states ) && ! isset( $wc_states[ $state ] ) ) {
-			$state = array_search( ucwords( strtolower( $state ) ), $wc_states, true );
-		}
-
 		WC()->shipping->reset_shipping();
 
 		if ( $postcode && WC_Validation::is_postcode( $postcode, $country ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 5.0.0 - 2021-xx-xx =
 
 * Add - Display time of last Stripe webhook in settings.
+* Fix - Payment Request Buttons for Chinese provinces in Chrome.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1065 

**Some context on this PR:**

Chrome and Opera (both Chromium based browsers), offer a dropdown list of states/provinces when you add shipping or billing addresses for the Payment Request Buttons. - This is a problem, because WooCommerce expects the state to be formatted as an abbreviated state code.

For some countries like the United States or Brazil, Chrome returns an abbreviated state code like `CA` (California). But for other countries like Argentina or China, it returns a full state/province name.

I also tested Safari, Edge and Brave, which support the Payment Request API, and they don't provide a dropdown list of states. - You have to type it manually. So in this case, matching the full length state with the WC abbreviated state is required.

Currently, there is a function `normalize_state`, which loops through WC states and finds the state that matches the dropdown values in Chrome.

**Changes proposed:**

- Implement a fix for China in the state normalization function.
- Refactor state normalization when calculating shipping.

# Testing instructions

- Create a shipping zone in `Anhui / 安徽, China` or any other Chinese state, and add a flat rate of $1.
- Make sure Payment Request Buttons is enabled and you have the `* 4242` test card added to Chrome.
- Go to the HTTPS URL of a product page that has shipping enabled and click the `Buy now` button.
- Choose China as your shipping country and the state you have configured in your shipping zone (e.g Anhui), fill the Zipcode with a 6 digit number and the other address details with fake data.
- Notice the Flat rate $1 shipping method is applied.
- Click "Pay" and notice the payment goes through without any errors.
- Check the orders page and see if the shipping info is correct, specially the state.
- Check also if billing/shipping details are correct when you choose Chinese provinces or states in other countries.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
