### PR TITLE
Add more detailed notes and status to refunded order with charge authorization

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,9 @@
 *** Changelog ***
 = 4.9.0 - 2021-xx-xx =
-* Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
-* Fix - Adding a SEPA payment method doesn't work.
-* Fix - Apple Pay domain verification with live secret key.
-* Add - Detailed notes and status to refunded order with charge authorization.
+* Fix    - Add fees as line items sent to Stripe to prevent Level 3 errors.
+* Fix    - Adding a SEPA payment method doesn't work.
+* Fix    - Apple Pay domain verification with live secret key.
+* Update - Notes and status when refunding order with charge authorization.
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
 * Fix - Apple Pay domain verification with live secret key.
+* Add - Detailed notes and status to refunded order with charge authorization.
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -464,7 +464,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			}
 
 			/* translators: transaction id */
-			$order->update_status( 'on-hold', sprintf( __( 'Stripe charge authorized (Charge ID: %s). Process order to take payment, or cancel to remove the pre-authorization.', 'woocommerce-gateway-stripe' ), $response->id ) );
+			$order->update_status( 'on-hold', sprintf( __( 'Stripe charge authorized (Charge ID: %s). Process order to take payment, or cancel to remove the pre-authorization. Attempting to refund the order in part or in full will release the authorization and cancel the payment.', 'woocommerce-gateway-stripe' ), $response->id ) );
 		}
 
 		if ( is_callable( array( $order, 'save' ) ) ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -891,7 +891,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			}
 		}
 
-		if ( ! $intent_cancelled ) {
+		if ( ! $intent_cancelled && 'yes' === $captured ) {
 			$response = WC_Stripe_API::request( $request, 'refunds' );
 		}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -819,10 +819,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Refund a charge.
 	 *
 	 * @since 3.1.0
-	 * @version 4.8.0
+	 * @version 4.9.0
 	 * @param  int $order_id
 	 * @param  float $amount
+	 *
 	 * @return bool
+	 * @throws Exception Throws exception when charge wasn't captured.
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
 		$order = wc_get_order( $order_id );
@@ -871,7 +873,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$intent = $this->get_intent_from_order( $order );
 		$intent_cancelled = false;
 		if ( $intent ) {
-			// If the order has a Payment Intent pending capture, then the Intent itself must be refunded (cancelled), not the Charge
+			// If the order has a Payment Intent pending capture, then the Intent itself must be refunded (cancelled), not the Charge.
 			if ( ! empty( $intent->error ) ) {
 				$response = $intent;
 				$intent_cancelled = true;
@@ -901,23 +903,35 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return $response;
 
 		} elseif ( ! empty( $response->id ) ) {
-			$order->update_meta_data( '_stripe_refund_id', $response->id );
-
-			$amount = wc_price( $response->amount / 100 );
-
+			$formatted_amount = wc_price( $response->amount / 100 );
 			if ( in_array( strtolower( $order->get_currency() ), WC_Stripe_Helper::no_decimal_currencies() ) ) {
-				$amount = wc_price( $response->amount );
+				$formatted_amount = wc_price( $response->amount );
 			}
+
+			// If charge wasn't captured, skip creating a refund and cancel order.
+			if ( 'yes' !== $captured ) {
+				/* translators: dollar amount */
+				$order->add_order_note( sprintf( __( 'Pre-Authorization for %s voided.', 'woocommerce-gateway-stripe' ), $formatted_amount ) );
+				$order->update_status( 'cancelled' );
+				// If amount is set, that means this function was called from the manual refund form.
+				if ( ! is_null( $amount ) ) {
+					// Throw an exception to provide a custom message on why the refund failed.
+					throw new Exception( __( 'The authorization was voided and the order cancelled. Click okay to continue, then refresh the page.', 'woocommerce-gateway-stripe' ) );
+				}
+				else {
+					// If refund was initiaded by changing order status, prevent refund without errors.
+					return false;
+				}
+			}
+
+			$order->update_meta_data( '_stripe_refund_id', $response->id );
 
 			if ( isset( $response->balance_transaction ) ) {
 				$this->update_fees( $order, $response->balance_transaction );
 			}
 
 			/* translators: 1) dollar amount 2) transaction id 3) refund message */
-			$refund_message = ( isset( $captured ) && 'yes' === $captured )
-				? sprintf( __( 'Refunded %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $amount, $response->id, $reason )
-				/* translators: transaction id */
-				: sprintf( __( 'The Stripe charge %s was not captured. The payment for this order has not been made.', 'woocommerce-gateway-stripe' ), $charge_id );
+			$refund_message = sprintf( __( 'Refunded %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $formatted_amount, $response->id, $reason );
 
 			$order->add_order_note( $refund_message );
 			WC_Stripe_Logger::log( 'Success: ' . html_entity_decode( wp_strip_all_tags( $refund_message ) ) );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -242,7 +242,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function validate_minimum_order_amount( $order ) {
 		if ( $order->get_total() * 100 < WC_Stripe_Helper::get_minimum_amount() ) {
-			/* translators: 1) dollar amount */
+			/* translators: 1) amount (including currency symbol) */
 			throw new WC_Stripe_Exception( 'Did not meet minimum amount', sprintf( __( 'Sorry, the minimum allowed order total is %1$s to use this payment method.', 'woocommerce-gateway-stripe' ), wc_price( WC_Stripe_Helper::get_minimum_amount() / 100 ) ) );
 		}
 	}
@@ -910,15 +910,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 			// If charge wasn't captured, skip creating a refund and cancel order.
 			if ( 'yes' !== $captured ) {
-				/* translators: dollar amount */
+				/* translators: amount (including currency symbol) */
 				$order->add_order_note( sprintf( __( 'Pre-Authorization for %s voided.', 'woocommerce-gateway-stripe' ), $formatted_amount ) );
 				$order->update_status( 'cancelled' );
 				// If amount is set, that means this function was called from the manual refund form.
 				if ( ! is_null( $amount ) ) {
 					// Throw an exception to provide a custom message on why the refund failed.
 					throw new Exception( __( 'The authorization was voided and the order cancelled. Click okay to continue, then refresh the page.', 'woocommerce-gateway-stripe' ) );
-				}
-				else {
+				} else {
 					// If refund was initiaded by changing order status, prevent refund without errors.
 					return false;
 				}
@@ -930,7 +929,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				$this->update_fees( $order, $response->balance_transaction );
 			}
 
-			/* translators: 1) dollar amount 2) transaction id 3) refund message */
+			/* translators: 1) amount (including currency symbol) 2) transaction id 3) refund message */
 			$refund_message = sprintf( __( 'Refunded %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $formatted_amount, $response->id, $reason );
 
 			$order->add_order_note( $refund_message );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -914,7 +914,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			}
 
 			/* translators: 1) dollar amount 2) transaction id 3) refund message */
-			$refund_message = ( isset( $captured ) && 'yes' === $captured ) ? sprintf( __( 'Refunded %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $amount, $response->id, $reason ) : __( 'Pre-Authorization Released', 'woocommerce-gateway-stripe' );
+			$refund_message = ( isset( $captured ) && 'yes' === $captured )
+				? sprintf( __( 'Refunded %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $amount, $response->id, $reason )
+				/* translators: transaction id */
+				: sprintf( __( 'The Stripe charge %s was not captured. The payment for this order has not been made.', 'woocommerce-gateway-stripe' ), $charge_id );
 
 			$order->add_order_note( $refund_message );
 			WC_Stripe_Logger::log( 'Success: ' . html_entity_decode( wp_strip_all_tags( $refund_message ) ) );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -738,7 +738,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			</td>
 			<td width="1%"></td>
 			<td class="total">
-				-&nbsp;<?php echo wc_price( $fee, array( 'currency' => $currency ) ); // wpcs: xss ok. ?>
+				-<?php echo wc_price( $fee, array( 'currency' => $currency ) ); // wpcs: xss ok. ?>
 			</td>
 		</tr>
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -562,7 +562,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				}
 
 				/* translators: 1) dollar amount 2) transaction id 3) refund message */
-				$refund_message = ( isset( $captured ) && 'yes' === $captured ) ? sprintf( __( 'Refunded %1$s - Refund ID: %2$s - %3$s', 'woocommerce-gateway-stripe' ), $amount, $notification->data->object->refunds->data[0]->id, $reason ) : __( 'Pre-Authorization Released via Stripe Dashboard', 'woocommerce-gateway-stripe' );
+				$refund_message = ( isset( $captured ) && 'yes' === $captured )
+					? sprintf( __( 'Refunded %1$s - Refund ID: %2$s - %3$s', 'woocommerce-gateway-stripe' ), $amount, $notification->data->object->refunds->data[0]->id, $reason )
+					: __( 'Pre-Authorization cancelled via Stripe Dashboard. The charge for this order was cancelled and no payment was received.', 'woocommerce-gateway-stripe' );
 
 				$order->add_order_note( $refund_message );
 			}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -537,7 +537,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				// If the process was initiated from wp-admin,
 				// the order was already cancelled, so we don't need a new note.
 				if ( 'cancelled' !== $order->get_status() ) {
-					/* translators: dollar amount */
+					/* translators: amount (including currency symbol) */
 					$order->add_order_note( sprintf( __( 'Pre-Authorization for %s voided from the Stripe Dashboard.', 'woocommerce-gateway-stripe' ), $amount ) );
 					$order->update_status( 'cancelled' );
 				}
@@ -572,7 +572,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$this->update_fees( $order, $notification->data->object->refunds->data[0]->balance_transaction );
 				}
 
-				/* translators: 1) dollar amount 2) transaction id 3) refund message */
+				/* translators: 1) amount (including currency symbol) 2) transaction id 3) refund message */
 				$order->add_order_note( sprintf( __( 'Refunded %1$s - Refund ID: %2$s - %3$s', 'woocommerce-gateway-stripe' ), $amount, $notification->data->object->refunds->data[0]->id, $reason ) );
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
 * Fix - Apple Pay domain verification with live secret key.
+* Add - Detailed notes and status to refunded order with charge authorization.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -128,9 +128,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 4.9.0 - 2021-xx-xx =
 
-* Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
-* Fix - Adding a SEPA payment method doesn't work.
-* Fix - Apple Pay domain verification with live secret key.
-* Add - Detailed notes and status to refunded order with charge authorization.
+* Fix    - Add fees as line items sent to Stripe to prevent Level 3 errors.
+* Fix    - Adding a SEPA payment method doesn't work.
+* Fix    - Apple Pay domain verification with live secret key.
+* Update - Notes and status when refunding order with charge authorization.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1480
Fixes #1470
Fixes #757

- Add more detailed notes to refunded orders with charge authorization.
- Automatically cancel order when attempting to refund an order with charge authorization.
- Prevent Woo from creating a refund for an order with charge authorization.

This part of the code was kinda messy to work with. I tried to improve readability by adding some comments. Please let me know if you have questions about the changes in the code.

# Testing instructions

- Disable "Capture charge immediately" from the plugin settings.
- Enable test mode, add test secret keys and set up a test webhook secret key.
- Make a test order with two items.
- As store owner, refund one of the items. Notice the following result:
  - The order must get cancelled.
  - A note is added: `Pre-Authorization for [value] voided.`.
  - The refund is not added in order details.
- Make a new order and cancel it from the Stripe dashboard. Notice the following result:
  - The order must get cancelled.
  - A different note is added: `Pre-Authorization for [value] voided from the Stripe Dashboard.`.
  - The refund is not added in order details.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
