### PR TITLE
Update to the logic to return the appropriate icons depending on store location

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
 * Fix - Apple Pay domain verification with live secret key.
+* Fix - Display the correct accepted card branding depending on store currency and location.
 
 = 4.8.0 - 2021-01-28 =
 * Fix   - Filter more disallowed characters from statement descriptors.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -185,7 +185,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * Get_icon function.
 	 *
 	 * @since 1.0.0
-	 * @version 4.0.0
+	 * @version 4.9.0
 	 * @return string
 	 */
 	public function get_icon() {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -190,17 +190,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function get_icon() {
 		$icons = $this->payment_icons();
+		$supported_card_brands = WC_Stripe_Helper::get_supported_card_brands();
 
 		$icons_str = '';
 
-		$icons_str .= isset( $icons['visa'] ) ? $icons['visa'] : '';
-		$icons_str .= isset( $icons['amex'] ) ? $icons['amex'] : '';
-		$icons_str .= isset( $icons['mastercard'] ) ? $icons['mastercard'] : '';
-
-		if ( 'USD' === get_woocommerce_currency() ) {
-			$icons_str .= isset( $icons['discover'] ) ? $icons['discover'] : '';
-			$icons_str .= isset( $icons['jcb'] ) ? $icons['jcb'] : '';
-			$icons_str .= isset( $icons['diners'] ) ? $icons['diners'] : '';
+		foreach ( $supported_card_brands as $brand ) {
+			$icons_str .= isset( $icons[ $brand ] ) ? $icons[ $brand ] : ''; 
 		}
 
 		return apply_filters( 'woocommerce_gateway_icon', $icons_str, $this->id );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -316,6 +316,39 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Gets the supported card brands, taking the store's base country and currency into account.
+	 * For more information, please see: https://stripe.com/docs/payments/cards/supported-card-brands.
+	 *
+	 * @return array
+	 */
+	public static function get_supported_card_brands() {
+		$base_country = wc_get_base_location()['country'];
+		$base_currency = get_woocommerce_currency();
+
+		$supported_card_brands = [ 'visa', 'mastercard' ];
+
+		// American Express is not supported in Brazil and Malaysia.
+		if ( ! in_array( $base_country, [ 'BR', 'MY' ] ) ) {
+			array_push( $supported_card_brands, 'amex' );
+		}
+
+		// Discover and Diners Club are only supported in the US and Canada. 
+		if ( in_array( $base_country, [ 'US', 'CA' ] ) && $base_currency === 'USD' ) {
+			array_push( $supported_card_brands, 'discover', 'diners' );
+		}
+
+		// See: https://support.stripe.com/questions/accepting-japan-credit-bureau-(jcb)-payments.
+		if ( 'US' === $base_country && 'USD' === $base_currency ||
+			 'JP' === $base_country && 'JPY' === $base_currency ||
+			 in_array( ['CA', 'AU', 'NZ' ], $base_country ) 
+		) {
+			array_push( $supported_card_brands, 'jcb' );
+		}
+
+		return $supported_card_brands;
+	}
+
+	/**
 	 * Gets all the saved setting options from a specific method.
 	 * If specific setting is passed, only return that.
 	 *

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -319,28 +319,30 @@ class WC_Stripe_Helper {
 	 * Gets the supported card brands, taking the store's base country and currency into account.
 	 * For more information, please see: https://stripe.com/docs/payments/cards/supported-card-brands.
 	 *
+	 * @since 4.9.0
+	 * @version 4.9.0
 	 * @return array
 	 */
 	public static function get_supported_card_brands() {
 		$base_country = wc_get_base_location()['country'];
 		$base_currency = get_woocommerce_currency();
 
-		$supported_card_brands = [ 'visa', 'mastercard' ];
+		$supported_card_brands = array( 'visa', 'mastercard' );
 
 		// American Express is not supported in Brazil and Malaysia.
-		if ( ! in_array( $base_country, [ 'BR', 'MY' ] ) ) {
+		if ( ! in_array( $base_country, array( 'BR', 'MY' ) ) ) {
 			array_push( $supported_card_brands, 'amex' );
 		}
 
 		// Discover and Diners Club are only supported in the US and Canada. 
-		if ( in_array( $base_country, [ 'US', 'CA' ] ) && $base_currency === 'USD' ) {
+		if ( in_array( $base_country, array( 'US', 'CA' ) ) && $base_currency === 'USD' ) {
 			array_push( $supported_card_brands, 'discover', 'diners' );
 		}
 
 		// See: https://support.stripe.com/questions/accepting-japan-credit-bureau-(jcb)-payments.
 		if ( 'US' === $base_country && 'USD' === $base_currency ||
 			 'JP' === $base_country && 'JPY' === $base_currency ||
-			 in_array( ['CA', 'AU', 'NZ' ], $base_country ) 
+			 in_array( $base_country, array( 'CA', 'AU', 'NZ' ) ) 
 		) {
 			array_push( $supported_card_brands, 'jcb' );
 		}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -329,13 +329,13 @@ class WC_Stripe_Helper {
 
 		$supported_card_brands = array( 'visa', 'mastercard' );
 
-		// American Express is not supported in Brazil and Malaysia.
+		// American Express is not supported in Brazil and Malaysia (https://stripe.com/docs/payments/cards/supported-card-brands).
 		if ( ! in_array( $base_country, array( 'BR', 'MY' ) ) ) {
 			array_push( $supported_card_brands, 'amex' );
 		}
 
-		// Discover and Diners Club are only supported in the US and Canada. 
-		if ( in_array( $base_country, array( 'US', 'CA' ) ) && $base_currency === 'USD' ) {
+		// Discover and Diners Club are only supported in the US and Canada. If the store is in the US, USD must be used. (https://stripe.com/docs/currencies#presentment-currencies). 
+		if ( 'US' === $base_country && 'USD' === $base_currency || 'CA' === $base_country ) {
 			array_push( $supported_card_brands, 'discover', 'diners' );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Add fees as line items sent to Stripe to prevent Level 3 errors.
 * Fix - Adding a SEPA payment method doesn't work.
 * Fix - Apple Pay domain verification with live secret key.
+* Fix - Display the correct accepted card branding depending on store currency and location.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -107,20 +107,20 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 
 	public function test_get_icon_with_us_store() {
 		$location_callback = function() {
-			return [
-				'country' => 'US',
-				'state'   => 'CA'
-			];
+			return 'US:CA';
 		};
 
 		$currency_callback = function() {
 			return 'USD';
 		};
 
-		add_filter( 'wc_get_base_location', $location_callback );
-		add_filter( 'get_woocommerce_currency', $currency_callback );
-
+		add_filter( 'woocommerce_get_base_location', $location_callback );
+		add_filter( 'woocommerce_currency', $currency_callback );
+		
 		$payment_icons = $this->gateway->get_icon();
+
+		remove_filter( 'woocommerce_get_base_location', $location_callback );
+		remove_filter( 'woocommerce_currency', $currency_callback );
 
 		$this->assertContains( 'visa.svg', $payment_icons );
 		$this->assertContains( 'amex.svg', $payment_icons );
@@ -132,46 +132,46 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 
 	public function test_get_icon_with_br_store() {
 		$location_callback = function() {
-			return [
-				'country' => 'BR',
-				'state'   => ''
-			];
+			return 'BR';
 		};
 
 		$currency_callback = function() {
 			return 'USD';
 		};
 
-		add_filter( 'wc_get_base_location', $location_callback );
-		add_filter( 'get_woocommerce_currency', $currency_callback );
+		add_filter( 'woocommerce_get_base_location', $location_callback );
+		add_filter( 'woocommerce_currency', $currency_callback );
 
 		$payment_icons = $this->gateway->get_icon();
 
+		remove_filter( 'woocommerce_get_base_location', $location_callback );
+		remove_filter( 'woocommerce_currency', $currency_callback );
+
 		$this->assertContains( 'visa.svg', $payment_icons );
 		$this->assertContains( 'mastercard.svg', $payment_icons );
-		$this->assertContains( 'diners.svg', $payment_icons );
-		$this->assertContains( 'discover.svg', $payment_icons );
-		$this->assertContains( 'jcb.svg', $payment_icons );
+		$this->assertNotContains( 'diners.svg', $payment_icons );
+		$this->assertNotContains( 'discover.svg', $payment_icons );
+		$this->assertNotContains( 'jcb.svg', $payment_icons );
 		$this->assertNotContains( 'amex.svg', $payment_icons );
 	}
 	
 	
 	public function test_get_icon_with_non_dollar_currency() {
 		$location_callback = function() {
-			return [
-				'country' => 'US',
-				'state'   => 'CA'
-			];
+			return 'US:CA';
 		};
 
 		$currency_callback = function() {
 			return 'GBP';
 		};
 
-		add_filter( 'wc_get_base_location', $location_callback );
-		add_filter( 'get_woocommerce_currency', $currency_callback );
+		add_filter( 'woocommerce_get_base_location', $location_callback );
+		add_filter( 'woocommerce_currency', $currency_callback );
 
 		$payment_icons = $this->gateway->get_icon();
+
+		remove_filter( 'woocommerce_get_base_location', $location_callback );
+		remove_filter( 'woocommerce_currency', $currency_callback );
 
 		$this->assertContains( 'visa.svg', $payment_icons );
 		$this->assertContains( 'mastercard.svg', $payment_icons );
@@ -183,20 +183,20 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 
 	public function test_get_icon_with_ca_store() {
 		$location_callback = function() {
-			return [
-				'country' => 'CA',
-				'state'   => ''
-			];
+			return 'CA';
 		};
 
 		$currency_callback = function() {
 			return 'USD';
 		};
 
-		add_filter( 'wc_get_base_location', $location_callback );
-		add_filter( 'get_woocommerce_currency', $currency_callback );
+		add_filter( 'woocommerce_get_base_location', $location_callback );
+		add_filter( 'woocommerce_currency', $currency_callback );
 
 		$payment_icons = $this->gateway->get_icon();
+
+		remove_filter( 'woocommerce_get_base_location', $location_callback );
+		remove_filter( 'woocommerce_currency', $currency_callback );
 
 		$this->assertContains( 'visa.svg', $payment_icons );
 		$this->assertContains( 'amex.svg', $payment_icons );
@@ -206,22 +206,22 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertContains( 'jcb.svg', $payment_icons );
 	}
 
-	public function test_get_icon_with_jp_non_jpy_store() {
+	public function test_get_icon_with_jp_store() {
 		$location_callback = function() {
-			return [
-				'country' => 'JP',
-				'state'   => ''
-			];
+			return 'JP';
 		};
 
 		$currency_callback = function() {
 			return 'JPY';
 		};
 
-		add_filter( 'wc_get_base_location', $location_callback );
-		add_filter( 'get_woocommerce_currency', $currency_callback );
+		add_filter( 'woocommerce_get_base_location', $location_callback );
+		add_filter( 'woocommerce_currency', $currency_callback );
 
 		$payment_icons = $this->gateway->get_icon();
+
+		remove_filter( 'woocommerce_get_base_location', $location_callback );
+		remove_filter( 'woocommerce_currency', $currency_callback );
 
 		// JCP only accepts JPY in Japanese stores:
 		$this->assertContains( 'visa.svg', $payment_icons );
@@ -234,20 +234,20 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 
 	public function test_get_icon_with_jp_non_jpy_store() {
 		$location_callback = function() {
-			return [
-				'country' => 'JP',
-				'state'   => ''
-			];
+			return 'JP';
 		};
 
 		$currency_callback = function() {
 			return 'USD';
 		};
 
-		add_filter( 'wc_get_base_location', $location_callback );
-		add_filter( 'get_woocommerce_currency', $currency_callback );
+		add_filter( 'woocommerce_get_base_location', $location_callback );
+		add_filter( 'woocommerce_currency', $currency_callback );
 
 		$payment_icons = $this->gateway->get_icon();
+
+		remove_filter( 'woocommerce_get_base_location', $location_callback );
+		remove_filter( 'woocommerce_currency', $currency_callback );
 
 		// JCP only accepts JPY in Japanese stores:
 		$this->assertContains( 'visa.svg', $payment_icons );

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -104,4 +104,157 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		remove_filter( 'pre_http_request', $callback );
 	}
+
+	public function test_get_icon_with_us_store() {
+		$location_callback = function() {
+			return [
+				'country' => 'US',
+				'state'   => 'CA'
+			];
+		};
+
+		$currency_callback = function() {
+			return 'USD';
+		};
+
+		add_filter( 'wc_get_base_location', $location_callback );
+		add_filter( 'get_woocommerce_currency', $currency_callback );
+
+		$payment_icons = $this->gateway->get_icon();
+
+		$this->assertContains( 'visa.svg', $payment_icons );
+		$this->assertContains( 'amex.svg', $payment_icons );
+		$this->assertContains( 'mastercard.svg', $payment_icons );
+		$this->assertContains( 'diners.svg', $payment_icons );
+		$this->assertContains( 'discover.svg', $payment_icons );
+		$this->assertContains( 'jcb.svg', $payment_icons );
+	}
+
+	public function test_get_icon_with_br_store() {
+		$location_callback = function() {
+			return [
+				'country' => 'BR',
+				'state'   => ''
+			];
+		};
+
+		$currency_callback = function() {
+			return 'USD';
+		};
+
+		add_filter( 'wc_get_base_location', $location_callback );
+		add_filter( 'get_woocommerce_currency', $currency_callback );
+
+		$payment_icons = $this->gateway->get_icon();
+
+		$this->assertContains( 'visa.svg', $payment_icons );
+		$this->assertContains( 'mastercard.svg', $payment_icons );
+		$this->assertContains( 'diners.svg', $payment_icons );
+		$this->assertContains( 'discover.svg', $payment_icons );
+		$this->assertContains( 'jcb.svg', $payment_icons );
+		$this->assertNotContains( 'amex.svg', $payment_icons );
+	}
+	
+	
+	public function test_get_icon_with_non_dollar_currency() {
+		$location_callback = function() {
+			return [
+				'country' => 'US',
+				'state'   => 'CA'
+			];
+		};
+
+		$currency_callback = function() {
+			return 'GBP';
+		};
+
+		add_filter( 'wc_get_base_location', $location_callback );
+		add_filter( 'get_woocommerce_currency', $currency_callback );
+
+		$payment_icons = $this->gateway->get_icon();
+
+		$this->assertContains( 'visa.svg', $payment_icons );
+		$this->assertContains( 'mastercard.svg', $payment_icons );
+		$this->assertContains( 'amex.svg', $payment_icons );
+		$this->assertNotContains( 'diners.svg', $payment_icons );
+		$this->assertNotContains( 'discover.svg', $payment_icons );
+		$this->assertNotContains( 'jcb.svg', $payment_icons );
+	}
+
+	public function test_get_icon_with_ca_store() {
+		$location_callback = function() {
+			return [
+				'country' => 'CA',
+				'state'   => ''
+			];
+		};
+
+		$currency_callback = function() {
+			return 'USD';
+		};
+
+		add_filter( 'wc_get_base_location', $location_callback );
+		add_filter( 'get_woocommerce_currency', $currency_callback );
+
+		$payment_icons = $this->gateway->get_icon();
+
+		$this->assertContains( 'visa.svg', $payment_icons );
+		$this->assertContains( 'amex.svg', $payment_icons );
+		$this->assertContains( 'mastercard.svg', $payment_icons );
+		$this->assertContains( 'diners.svg', $payment_icons );
+		$this->assertContains( 'discover.svg', $payment_icons );
+		$this->assertContains( 'jcb.svg', $payment_icons );
+	}
+
+	public function test_get_icon_with_jp_non_jpy_store() {
+		$location_callback = function() {
+			return [
+				'country' => 'JP',
+				'state'   => ''
+			];
+		};
+
+		$currency_callback = function() {
+			return 'JPY';
+		};
+
+		add_filter( 'wc_get_base_location', $location_callback );
+		add_filter( 'get_woocommerce_currency', $currency_callback );
+
+		$payment_icons = $this->gateway->get_icon();
+
+		// JCP only accepts JPY in Japanese stores:
+		$this->assertContains( 'visa.svg', $payment_icons );
+		$this->assertContains( 'amex.svg', $payment_icons );
+		$this->assertContains( 'mastercard.svg', $payment_icons );
+		$this->assertNotContains( 'diners.svg', $payment_icons );
+		$this->assertNotContains( 'discover.svg', $payment_icons );
+		$this->assertContains( 'jcb.svg', $payment_icons );
+	}
+
+	public function test_get_icon_with_jp_non_jpy_store() {
+		$location_callback = function() {
+			return [
+				'country' => 'JP',
+				'state'   => ''
+			];
+		};
+
+		$currency_callback = function() {
+			return 'USD';
+		};
+
+		add_filter( 'wc_get_base_location', $location_callback );
+		add_filter( 'get_woocommerce_currency', $currency_callback );
+
+		$payment_icons = $this->gateway->get_icon();
+
+		// JCP only accepts JPY in Japanese stores:
+		$this->assertContains( 'visa.svg', $payment_icons );
+		$this->assertContains( 'amex.svg', $payment_icons );
+		$this->assertContains( 'mastercard.svg', $payment_icons );
+		$this->assertNotContains( 'diners.svg', $payment_icons );
+		$this->assertNotContains( 'discover.svg', $payment_icons );
+		$this->assertNotContains( 'jcb.svg', $payment_icons );
+	}
 }


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1115 

Description: This PR addresses some out of date logic for deciding which branding to display on the checkout page. Certain branding (e.g. Diners Club and Discover) should only display if the store is located in either USA or Canada, and the store currency is USD, for example.

The logic is even more complex for JCB, where the branding should display if one of the following conditions is met:
- Store is in US and accepts USD
- Store is in Japan and accepts JPY
- Store is in Canada, Australia, or New Zealand.

For more information, please see Stripe documentation on [Supported Card Brands](https://stripe.com/docs/payments/cards/supported-card-brands) and [Accepting JCB](https://support.stripe.com/questions/accepting-japan-credit-bureau-(jcb)-payments).

It would be good to get a second pair of eyes on whether this logic looks sensible/in line with what is mentioned on Stripe's documentation. The overall intent of this PR is to ensure we are only displaying payment methods that are valid/in line with the store currency and location. Note that it would be better to use the store country data from the Stripe account, but the WooCommerce store location seems an acceptable proxy for this.

# Testing instructions

- Check out this branch. 
- Confirm unit tests pass.
- Go to the checkout on a US store with US currency, verify that Visa, Mastercard, Amex, Diner's Club, Discover, and JCB are displayed.
- Change the store currency to something else.
- Verify that JCB is no longer displayed on the checkout.
- Change the store location to Japan and the currency to JPY.
- Verify that Visa, Mastercard, Amex and JCB are displayed on the checkout. 
-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.