### PR TITLE
Allow developers to customize the User-Agent validation format for Webhook requests

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -90,7 +90,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return false;
 		}
 
-		if ( ! empty( $request_headers['USER-AGENT'] ) && ! preg_match( '/Stripe/', $request_headers['USER-AGENT'] ) ) {
+		// Make sure the User Agent, if present, matches the expected format.
+		$user_agent_format = apply_filters('wc_stripe_webhook_user_agent_format', '/Stripe/');
+		if ( ! empty( $request_headers['USER-AGENT'] ) && ! preg_match( $user_agent_format, $request_headers['USER-AGENT'] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1195 (partially)

Description: This PR introduces a filter to allow developers to customize the User-Agent validation format for Webhook requests.

As described in the aforementioned issue, when using this plugin while behind an Amazon CloudFront CDN, all webhook requests fail with status 400. This is because the Amazon CloudFront overwrites the User-Agent header for all requests with `Amazon CloudFront` ([as described in their specs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-user-agent-header)). Right now, though, a webhook request is considered valid only when its User-Agent header is empty or contains the word `Stripe` (see [WC_Stripe_Webhook_Handler::is_valid_request](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/0cf7865a6367e25073e5270f07f9e724363f851c/includes/class-wc-stripe-webhook-handler.php#L93-L95)).

I've introduced a filter to allow website owners to specify a different User-Agent validation format (the default remains `/Stripe/`). This should provide an opt-in workaround for users trying to use webhooks while behind an Amazon CloudFront CDN, without affecting users relying on existing functionalities.

# Testing instructions

1. In an existing installation
2. Add a filter (eg. via child theme) with name `wc_stripe_webhook_user_agent_format`, returning a custom regex
3. Send a *valid* webhook request with a custom User-Agent header matching the provided regex
4. The webhook request should succeed (previously, it only did if the User-Agent contained the word 'Stripe')

---

- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.