### PR TITLE
Don't attempt to submit level 3 data for non-US merchants

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** Changelog ***
+= 5.1.0 - 2021-xx-xx =
+* Fix - Don't attempt to submit level 3 data for non-US merchants.
+
 = 5.0.0 - 2021-03-17 =
 * Add - Display time of last Stripe webhook in settings.
 * Add - wc_stripe_webhook_validate_user_agent filter to customize webhook user-agent validation.

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -187,7 +187,7 @@ class WC_Stripe_API {
 	 * the payment to go through.
 	 *
 	 * @since 4.3.2
-	 * @version 5.0.0
+	 * @version 5.1.0
 	 *
 	 * @param array    $request     Array with request parameters.
 	 * @param string   $api         The API path for the request.

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -187,7 +187,7 @@ class WC_Stripe_API {
 	 * the payment to go through.
 	 *
 	 * @since 4.3.2
-	 * @version 4.3.2
+	 * @version 5.0.0
 	 *
 	 * @param array    $request     Array with request parameters.
 	 * @param string   $api         The API path for the request.
@@ -197,17 +197,17 @@ class WC_Stripe_API {
 	 * @return stdClass|array The response
 	 */
 	public static function request_with_level3_data( $request, $api, $level3_data, $order ) {
-		// Do not add level3 data it's the array is empty.
-		if ( empty( $level3_data ) ) {
-			return self::request(
-				$request,
-				$api
-			);
-		}
-
-		// If there's a transient indicating that level3 data was not accepted by
-		// Stripe in the past for this account, do not try to add level3 data.
-		if ( get_transient( 'wc_stripe_level3_not_allowed' ) ) {
+		// 1. Do not add level3 data if the array is empty.
+		// 2. Do not add level3 data if there's a transient indicating that level3 was
+		// not accepted by Stripe in the past for this account.
+		// 3. Do not try to add level3 data if merchant is not based in the US.
+		// https://stripe.com/docs/level3#level-iii-usage-requirements
+		// (Needs to be authenticated with a level3 gated account to see above docs).
+		if (
+			empty( $level3_data ) ||
+			get_transient( 'wc_stripe_level3_not_allowed' ) ||
+			'US' !== WC()->countries->get_base_country()
+		) {
 			return self::request(
 				$request,
 				$api

--- a/readme.txt
+++ b/readme.txt
@@ -126,12 +126,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.0.0 - 2021-03-17 =
+= 5.1.0 - 2021-xx-xx =
 
-* Add - Display time of last Stripe webhook in settings.
-* Add - wc_stripe_webhook_validate_user_agent filter to customize webhook user-agent validation.
-* Fix - Payment Request Buttons for Chinese provinces in Chrome.
-* Fix - Enable wc_stripe_send_stripe_receipt filter to send Stripe emails.
-* Fix - Check for more errors when attaching sources to customers.
+* Fix - Don't attempt to submit level 3 data for non-US merchants.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #1366

# Changes proposed in this Pull Request:

We attempt to submit the level3 parameter in the request if the `wc_stripe_level3_not_allowed` transient isn't set.
If the request fails, the transient is created, but a 400 ERR is logged in the merchant's Stripe dashboard.

Even though the error happens only once every 3 months (this transient is set to expire after 3 months), people often contact us, concerned about the log in their dashboard.

To help in reducing tickets around this issue, we're adding another check to see if the account is based in the US. Since [level3 is currently only enabled for US merchants](https://stripe.com/docs/level3#level-iii-usage-requirements).

Ideally, we should probably check the country from the Stripe account instead of WC, but that would require another API request.

Since enabling an account for level3 requires a manual action from Stripe, the majority of US merchants don't have that enabled, so I think we're fine with a simpler approach.

# Testing instructions

- Delete the `wc_stripe_level3_not_allowed` transient from wp_options.
- Change your WC country to anything other than "US".
- Try to make a test purchase, notice no errors in the Stripe dashboard logs. Notice no `wc_stripe_level3_not_allowed` transient is created.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
