### PR TITLE
Make webhook user agent validation optional

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -143,11 +143,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
 	 */
 	private function validate_request_user_agent( $request_headers ) {
-		if ( ! empty( $request_headers['USER-AGENT'] ) && ! preg_match( '/Stripe/', $request_headers['USER-AGENT'] ) ) {
-			return WC_Stripe_Webhook_State::VALIDATION_FAILED_USER_AGENT_INVALID;
-		}
+		$ua_is_valid = empty( $request_headers['USER-AGENT'] ) || preg_match( '/Stripe/', $request_headers['USER-AGENT'] );
+		$ua_is_valid = apply_filters( 'wc_stripe_webhook_validate_user_agent', $ua_is_valid, $request_headers );
 
-		return WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED;
+		return $ua_is_valid ? WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED : WC_Stripe_Webhook_State::VALIDATION_FAILED_USER_AGENT_INVALID;
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -94,8 +94,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 5.0.0
-	 * @param string $request_headers The request headers from Stripe.
-	 * @param string $request_body The request body from Stripe.
+	 * @param array $request_headers The request headers from Stripe.
+	 * @param array $request_body    The request body from Stripe.
 	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
 	 */
 	public function validate_request( $request_headers, $request_body ) {
@@ -139,7 +139,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 5.0.0
 	 * @version 5.0.0
-	 * @param string $request_headers The request headers from Stripe.
+	 * @param array $request_headers The request headers from Stripe.
 	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
 	 */
 	private function validate_request_user_agent( $request_headers ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -106,31 +106,45 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return WC_Stripe_Webhook_State::VALIDATION_FAILED_EMPTY_BODY;
 		}
 
-		if ( ! empty( $request_headers['USER-AGENT'] ) && ! preg_match( '/Stripe/', $request_headers['USER-AGENT'] ) ) {
-			return WC_Stripe_Webhook_State::VALIDATION_FAILED_USER_AGENT_INVALID;
+		if ( empty( $this->secret ) ) {
+			return $this->validate_request_user_agent( $request_headers );
 		}
 
-		if ( ! empty( $this->secret ) ) {
-			// Check for a valid signature.
-			$signature_format = '/^t=(?P<timestamp>\d+)(?P<signatures>(,v\d+=[a-z0-9]+){1,2})$/';
-			if ( empty( $request_headers['STRIPE-SIGNATURE'] ) || ! preg_match( $signature_format, $request_headers['STRIPE-SIGNATURE'], $matches ) ) {
-				return WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_INVALID;
-			}
+		// Check for a valid signature.
+		$signature_format = '/^t=(?P<timestamp>\d+)(?P<signatures>(,v\d+=[a-z0-9]+){1,2})$/';
+		if ( empty( $request_headers['STRIPE-SIGNATURE'] ) || ! preg_match( $signature_format, $request_headers['STRIPE-SIGNATURE'], $matches ) ) {
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_INVALID;
+		}
 
-			// Verify the timestamp.
-			$timestamp = intval( $matches['timestamp'] );
-			if ( abs( $timestamp - time() ) > 5 * MINUTE_IN_SECONDS ) {
-				return WC_Stripe_Webhook_State::VALIDATION_FAILED_TIMESTAMP_MISMATCH;
-			}
+		// Verify the timestamp.
+		$timestamp = intval( $matches['timestamp'] );
+		if ( abs( $timestamp - time() ) > 5 * MINUTE_IN_SECONDS ) {
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_TIMESTAMP_MISMATCH;
+		}
 
 		// Generate the expected signature.
 		$signed_payload     = $timestamp . '.' . $request_body;
 		$expected_signature = hash_hmac( 'sha256', $signed_payload, $this->secret );
 
-			// Check if the expected signature is present.
-			if ( ! preg_match( '/,v\d+=' . preg_quote( $expected_signature, '/' ) . '/', $matches['signatures'] ) ) {
-				return WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH;
-			}
+		// Check if the expected signature is present.
+		if ( ! preg_match( '/,v\d+=' . preg_quote( $expected_signature, '/' ) . '/', $matches['signatures'] ) ) {
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH;
+		}
+
+		return WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED;
+	}
+
+	/**
+	 * Verify User Agent of the incoming webhook notification. Used as fallback for the cases when webhook secret is missing.
+	 *
+	 * @since 5.0.0
+	 * @version 5.0.0
+	 * @param string $request_headers The request headers from Stripe.
+	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
+	 */
+	private function validate_request_user_agent( $request_headers ) {
+		if ( ! empty( $request_headers['USER-AGENT'] ) && ! preg_match( '/Stripe/', $request_headers['USER-AGENT'] ) ) {
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_USER_AGENT_INVALID;
 		}
 
 		return WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED;

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -123,9 +123,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				return WC_Stripe_Webhook_State::VALIDATION_FAILED_TIMESTAMP_MISMATCH;
 			}
 
-			// Generate the expected signature.
-			$signed_payload     = $timestamp . '.' . $request_body;
-			$expected_signature = hash_hmac( 'sha256', $signed_payload, $this->secret );
+		// Generate the expected signature.
+		$signed_payload     = $timestamp . '.' . $request_body;
+		$expected_signature = hash_hmac( 'sha256', $signed_payload, $this->secret );
 
 			// Check if the expected signature is present.
 			if ( ! preg_match( '/,v\d+=' . preg_quote( $expected_signature, '/' ) . '/', $matches['signatures'] ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -144,7 +144,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	private function validate_request_user_agent( $request_headers ) {
 		$ua_is_valid = empty( $request_headers['USER-AGENT'] ) || preg_match( '/Stripe/', $request_headers['USER-AGENT'] );
-		$ua_is_valid = apply_filters( 'wc_stripe_webhook_validate_user_agent', $ua_is_valid, $request_headers );
+		$ua_is_valid = apply_filters( 'wc_stripe_webhook_is_user_agent_valid', $ua_is_valid, $request_headers );
 
 		return $ua_is_valid ? WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED : WC_Stripe_Webhook_State::VALIDATION_FAILED_USER_AGENT_INVALID;
 	}

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -72,11 +72,10 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_ERROR );
 	}
 
-	private function cleanup_webhook_secret () {
+	private function cleanup_webhook_secret() {
 		$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
 		unset( $stripe_settings['webhook_secret'] );
 		unset( $stripe_settings['test_webhook_secret'] );
-		unset( $stripe_settings['testmode'] );
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 		$this->wc_stripe_webhook_handler = new WC_Stripe_Webhook_Handler;
 	}

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -73,11 +73,11 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	}
 
 	private function cleanup_webhook_secret() {
-		$stripe_settings = get_option( 'woocommerce_stripe_settings', array() );
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
 		unset( $stripe_settings['webhook_secret'] );
 		unset( $stripe_settings['test_webhook_secret'] );
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
-		$this->wc_stripe_webhook_handler = new WC_Stripe_Webhook_Handler;
+		$this->wc_stripe_webhook_handler = new WC_Stripe_Webhook_Handler();
 	}
 
 	private function set_valid_request_data( $overwrite_timestamp = null ) {
@@ -225,7 +225,12 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Test custom user agent validator
 	public function test_get_error_custom_user_agent_validator() {
 		$this->cleanup_webhook_secret();
-		add_filter( 'wc_stripe_webhook_is_user_agent_valid', function() { return false; } );
+		add_filter(
+			'wc_stripe_webhook_is_user_agent_valid',
+			function() {
+				return false;
+			}
+		);
 
 		$this->set_valid_request_data();
 		$this->process_webhook();
@@ -235,7 +240,12 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Test user agent validation ignored
 	public function test_skip_user_agent_validation() {
 		// Run test without cleaning up webhook secret.
-		add_filter( 'wc_stripe_webhook_is_user_agent_valid', function() { return false; } );
+		add_filter(
+			'wc_stripe_webhook_is_user_agent_valid',
+			function() {
+				return false;
+			}
+		);
 
 		$this->set_valid_request_data();
 		$this->process_webhook();

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -226,7 +226,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Test custom user agent validator
 	public function test_get_error_custom_user_agent_validator() {
 		$this->cleanup_webhook_secret();
-		add_filter( 'wc_stripe_webhook_validate_user_agent', function() { return false; } );
+		add_filter( 'wc_stripe_webhook_is_user_agent_valid', function() { return false; } );
 
 		$this->set_valid_request_data();
 		$this->process_webhook();
@@ -236,7 +236,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Test user agent validation ignored
 	public function test_skip_user_agent_validation() {
 		// Run test without cleaning up webhook secret.
-		add_filter( 'wc_stripe_webhook_validate_user_agent', function() { return false; } );
+		add_filter( 'wc_stripe_webhook_is_user_agent_valid', function() { return false; } );
 
 		$this->set_valid_request_data();
 		$this->process_webhook();


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Based on #1483 and superceeds it.
Fixes #1195 

Description: 

* Make user agent validation a fallback for the cases when webhooks secret is not configured in plugin settings.
* Add filter to user agent validation to allow custom validations for environments like AWS Cloudfront.

From #1483:

> As described in the aforementioned issue, when using this plugin while behind an Amazon CloudFront CDN, all webhook requests fail with status 400. This is because the Amazon CloudFront overwrites the User-Agent header for all requests with Amazon CloudFront ([as described in their specs](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/RequestAndResponseBehaviorCustomOrigin.html#request-custom-user-agent-header)). Right now, though, a webhook request is considered valid only when its User-Agent header is empty or contains the word Stripe (see [WC_Stripe_Webhook_Handler::is_valid_request](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/0cf7865a6367e25073e5270f07f9e724363f851c/includes/class-wc-stripe-webhook-handler.php#L93-L95)).

> I've introduced a filter to allow website owners to specify a different User-Agent validation format (the default remains /Stripe/). This should provide an opt-in workaround for users trying to use webhooks while behind an Amazon CloudFront CDN, without affecting users relying on existing functionalities.

# Testing instructions

UA validation check.
1. In an existing installation make sure webhook sercret is not set in the plugin settings.
2. Add a filter (eg. via child theme) with name wc_stripe_webhook_validate_user_agent, returning true;
3. Send a webhook request with a custom User-Agent header not matching default check.
4. The webhook request should succeed (previously, it only did if the User-Agent contained the word 'Stripe').

UA fallback check.
1. Update filter introduced above to always return false;
2. Send a webhook request. It should fail.
3. Configure webhook secret in the plugin and DO NOT change or remove filter.
4. Send signed webhook request from Stripe (Stripe cli might be helpful). Request should succeed.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
