### PR TITLE
Show correct card error when saving card for future use

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -640,6 +640,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				if ( ! empty( $response->error ) ) {
 					throw new WC_Stripe_Exception( print_r( $response, true ), $this->get_localized_error_message_from_response( $response ) );
 				}
+				if ( is_wp_error( $response ) ) {
+					throw new WC_Stripe_Exception( $response->get_error_message(), $response->get_error_message() );
+				}
 			}
 		} elseif ( $this->is_using_saved_payment_method() ) {
 			// Use an existing token, and then process the payment.
@@ -666,6 +669,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 				if ( ! empty( $response->error ) ) {
 					throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+				}
+				if ( is_wp_error( $response ) ) {
+					throw new WC_Stripe_Exception( $response->get_error_message(), $response->get_error_message() );
 				}
 				$source_id = $response;
 			} else {

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -266,7 +266,8 @@ class WC_Stripe_Customer {
 	 */
 	public function add_source( $source_id ) {
 		$response = $this->attach_source( $source_id );
-		if ( is_wp_error( $response ) ) {
+
+		if ( ! empty( $response->error ) || is_wp_error( $response ) ) {
 			return $response;
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -165,6 +165,10 @@ class WC_Stripe_Intent_Controller {
 
 			// 3. Attach the source to the customer (Setup Intents require that).
 			$source_object = $customer->attach_source( $source_id );
+
+			if ( ! empty( $source_object->error ) ) {
+				throw new Exception( $source_object->error->message );
+			}
 			if ( is_wp_error( $source_object ) ) {
 				throw new Exception( $source_object->get_error_message() );
 			}


### PR DESCRIPTION
Fixes #1450

The problem was that a `$response` object was being received from `attach_source()` that could contain a Stripe error. However, we were not checking for a Stripe error, only a WP_Error:

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7a25f88e6108560174b3cb7b3759fcff726fc868/includes/class-wc-stripe-customer.php#L256-L260

The function [`attach_source()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7a25f88e6108560174b3cb7b3759fcff726fc868/includes/class-wc-stripe-customer.php#L316) can return any of these three things:
- Successful Stripe `$response`
- Stripe `$response` with errors
- WP_Error object

This PR checks for both WP_Error and `$response->error` in all places where `attach_source()` and `add_source` are used.

The approach is a bit suboptimal since it would be better to return only one type of object and not have to make a check for both WP_Error and Stripe errors in the `$response` in every place we use a source.

### Steps to repro original issue
1. Add item to cart, go to checkout
2. Use test credit card `4000000000009995`
3. Check the "Save payment information to my account for future purchases." checkbox
4. See the issue (or fix)

### Steps to repro code path for `create_setup_intent`:
1. Go to My Account > Payment Methods > Add payment method at `my-account/add-payment-method/`
2. Add the test card `4000008400001280`
3. With the fix, see the correct error message when adding the card (without fix, see generic error message).