### PR TITLE
Allow sending Stripe email receipt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 = 5.0.0 - 2021-xx-xx =
 * Add - Display time of last Stripe webhook in settings.
 * Fix - Payment Request Buttons for Chinese provinces in Chrome.
+* Fix - Enable wc_stripe_send_stripe_receipt filter to send Stripe emails.
 
 = 4.9.0 - 2021-02-24 =
 * Fix    - Add fees as line items sent to Stripe to prevent Level 3 errors.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1092,6 +1092,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$request['shipping'] = $full_request['shipping'];
 		}
 
+		if ( isset( $full_request['receipt_email'] ) ) {
+			$request['receipt_email'] = $full_request['receipt_email'];
+		}
+
 		/**
 		 * Filter the return value of the WC_Payment_Gateway_CC::generate_create_intent_request.
 		 *

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 * Add - Display time of last Stripe webhook in settings.
 * Fix - Payment Request Buttons for Chinese provinces in Chrome.
+* Fix - Enable wc_stripe_send_stripe_receipt filter to send Stripe emails.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #1030

Send receipt_email parameter for payment requests if it's available.

This change checks for the `receipt_email` param when getting the payment request object from `generate_payment_request()`.

If `receipt_email` is sent with a request, Stripe will send an email for that payment ([doc](https://stripe.com/docs/receipts#automatically-send-receipts-when-payments-are-successful)). This will only work in live mode, so it's a bit hard to test. 

To test:
1.  Add the snippet `add_filter( 'wc_stripe_send_stripe_receipt', '__return_true' );` to your store
2. Check out with a product
3. See Stripe receipt is sent to the customer email