### PR TITLE
Hide Payment Request Buttons when guest checkout is not possible

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 = 5.1.0 - 2021-xx-xx =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.
+* Fix - Hide Payment Request Buttons when guest checkout is disabled.
 
 = 5.0.0 - 2021-03-17 =
 * Add - Display time of last Stripe webhook in settings.

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -119,7 +119,7 @@ class WC_Stripe_Apple_Pay_Registration {
 	 * with the file from the plugin directory.
 	 *
 	 * @since 4.9.0
-	 * @return bool Wether file is up to date or not.
+	 * @return bool Whether file is up to date or not.
 	 */
 	private function verify_hosted_domain_association_file_is_up_to_date() {
 		// Contents of domain association file from plugin dir.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -99,6 +99,40 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
+	 * Checks whether authentication is required for checkout.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @return bool
+	 */
+	public function is_authentication_required() {
+		// If guest checkout is disabled, authentication might be required.
+		if ( 'no' === get_option( 'woocommerce_enable_guest_checkout', 'yes' ) ) {
+			// If account creation is not possible, authentication is required.
+			return ! $this->is_account_creation_possible();
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks whether account creation is possible during checkout.
+	 *
+	 * @since 5.1.0
+	 *
+	 * @return bool
+	 */
+	public function is_account_creation_possible() {
+		// If automatically generate username/password are disabled, the Payment Request API
+		// can't include any of those fields, so account creation is not possible.
+		return (
+			'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' ) &&
+			'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) &&
+			'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' )
+		);
+	}
+
+	/**
 	 * Checks if keys are set and valid.
 	 *
 	 * @since  4.0.6
@@ -447,13 +481,18 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Checks the cart to see if all items are allowed to used.
+	 * Checks the cart to see if all items are allowed to be used.
 	 *
 	 * @since   3.1.4
 	 * @version 4.0.0
 	 * @return  boolean
 	 */
 	public function allowed_items_in_cart() {
+		// Pre Orders compatibility where we don't support charge upon release.
+		if ( class_exists( 'WC_Pre_Orders_Cart' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() && class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() ) ) {
+			return false;
+		}
+
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 
@@ -461,13 +500,13 @@ class WC_Stripe_Payment_Request {
 				return false;
 			}
 
-			// Trial subscriptions with shipping are not supported
-			if ( class_exists( 'WC_Subscriptions_Order' ) && WC_Subscriptions_Cart::cart_contains_subscription() && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
+			// Not supported for subscription products when user is not authenticated and account creation is not possible.
+			if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $_product ) && ! is_user_logged_in() && ! $this->is_account_creation_possible() ) {
 				return false;
 			}
 
-			// Pre Orders compatbility where we don't support charge upon release.
-			if ( class_exists( 'WC_Pre_Orders_Order' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() && WC_Pre_Orders_Product::product_is_charged_upon_release( WC_Pre_Orders_Cart::get_pre_order_product() ) ) {
+			// Trial subscriptions with shipping are not supported.
+			if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $_product ) && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
 				return false;
 			}
 		}
@@ -645,9 +684,15 @@ class WC_Stripe_Payment_Request {
 	 * @return boolean
 	 */
 	private function should_show_payment_button_on_cart() {
+		// Not supported when user isn't authenticated and authentication is required.
+		if ( ! is_user_logged_in() && $this->is_authentication_required() ) {
+			return false;
+		}
+
 		if ( ! apply_filters( 'wc_stripe_show_payment_request_on_cart', true ) ) {
 			return false;
 		}
+
 		if ( ! $this->allowed_items_in_cart() ) {
 			WC_Stripe_Logger::log( 'Items in the cart has unsupported product type ( Payment Request button disabled )' );
 			return false;
@@ -674,14 +719,33 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
-		// Trial subscriptions with shipping are not supported
-		if ( class_exists( 'WC_Subscriptions_Order' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+		// Not supported when user isn't authenticated and authentication is required.
+		if ( ! is_user_logged_in() && $this->is_authentication_required() ) {
+			return false;
+		}
+
+		// Not supported for subscription products when user is not authenticated and account creation is not possible.
+		if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $product ) && ! is_user_logged_in() && ! $this->is_account_creation_possible() ) {
+			return false;
+		}
+
+		// Trial subscriptions with shipping are not supported.
+		if ( class_exists( 'WC_Subscriptions_Product' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
 			return false;
 		}
 
 		// Pre Orders charge upon release not supported.
-		if ( class_exists( 'WC_Pre_Orders_Order' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
-			WC_Stripe_Logger::log( 'Pre Order charge upon release is not supported. ( Payment Request button disabled )' );
+		if ( class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product ) ) {
+			return false;
+		}
+
+		// Composite products are not supported on the product page.
+		if ( class_exists( 'WC_Composite_Products' ) && function_exists( 'is_composite_product' ) && is_composite_product() ) {
+			return false;
+		}
+
+		// Mix and match products are not supported on the product page.
+		if ( class_exists( 'WC_Mix_and_Match' ) && $product->is_type( 'mix-and-match' ) ) {
 			return false;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -475,7 +475,6 @@ class WC_Stripe_Payment_Request {
 				'booking',
 				'bundle',
 				'composite',
-				'mix-and-match',
 			]
 		);
 	}
@@ -741,11 +740,6 @@ class WC_Stripe_Payment_Request {
 
 		// Composite products are not supported on the product page.
 		if ( class_exists( 'WC_Composite_Products' ) && function_exists( 'is_composite_product' ) && is_composite_product() ) {
-			return false;
-		}
-
-		// Mix and match products are not supported on the product page.
-		if ( class_exists( 'WC_Mix_and_Match' ) && $product->is_type( 'mix-and-match' ) ) {
 			return false;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 5.1.0 - 2021-xx-xx =
 
 * Fix - Don't attempt to submit level 3 data for non-US merchants.
+* Fix - Hide Payment Request Buttons when guest checkout is disabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #1352
Fixes #1194

This is a fix ported over from 1393-gh-Automattic/woocommerce-payments.

#### Changes proposed in this Pull Request

- Hide Payment Request button if authentication is required (if guest checkout and signup upon checkout are disabled).
- Hide Payment Request button for Subscription products when creating an account upon checkout isn't possible.
- Hide Payment Request button on the product page for "mix-and-match" and "composite" products, because of related issue in #829 - In the cart page it works as expected.

I added a changelog only for the guest checkout fix (which also applies for Subscriptions), because the other issue with Mix and Match and Composite products should be properly fixed in #829.

#### Testing instructions
**Scenario: A**
- Disable `Allow customers to create an account during checkout` in WooCommerce > Settings > Accounts & Privacy.
- Make sure you're not authenticated and visit a subscription product page.
- Notice there's no Payment Request button.
- Enable `Allow customers to create an account during checkout` and notice the button is displayed.

**Scenario: B**
- Disable `Allow customers to create an account during checkout` and `Allow customers to place orders without an account`.
- Make sure you're not authenticated and visit a simple product page.
- Notice there's no Payment Request button.
- Enable either `Allow customers to create an account during checkout` or `Allow customers to place orders without an account` (if automatically generate an account username and password are enabled as well). - notice the button is displayed.

**Scenario: C**
- Disable `Allow customers to create an account during checkout` and `Allow customers to place orders without an account`.
- Authenticate.
- Notice the button is displayed for any supported product.

**Scenario: D**
- Visit any [Composite](https://woocommerce.com/products/composite-products/) or [Mix and Match](http://www.woocommerce.com/products/woocommerce-mix-and-match-products/) product page.
- Notice the button is not displayed.
- Visit the cart and notice the button is displayed and works as expected.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.