### PR TITLE
fixed 3d secure payment with custom order status

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -599,7 +599,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			if ( $use_order_source ) {
 				$prepared_source = $this->prepare_order_source( $order );
 			} else {
-				$prepared_source = $this->prepare_source( get_current_user_id(), $force_save_source, $stripe_customer_id );
+				$prepared_source = $this->prepare_source($order->get_customer_id() , $force_save_source, $stripe_customer_id );
 			}
 
 			$this->maybe_disallow_prepaid_card( $prepared_source );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -599,7 +599,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			if ( $use_order_source ) {
 				$prepared_source = $this->prepare_order_source( $order );
 			} else {
-				$prepared_source = $this->prepare_source($order->get_customer_id() , $force_save_source, $stripe_customer_id );
+				$prepared_source = $this->prepare_source(get_current_user_id(), $force_save_source, $stripe_customer_id );
 			}
 
 			$this->maybe_disallow_prepaid_card( $prepared_source );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -743,7 +743,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( ! $order->has_status( [ 'pending', 'failed' ] ) ) {
+		if ( ! $order->has_status(apply_filters('wc_stripe_process_intent_statuses',[ 'pending', 'failed' ]) ) ) {
 			return;
 		}
 
@@ -790,7 +790,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( ! $order->has_status( [ 'pending', 'failed' ] ) ) {
+		if ( ! $order->has_status(apply_filters('wc_stripe_process_intent_statuses',[ 'pending', 'failed' ]) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Added a filter that fixes a bug with 3d secure payments on the order-pay page if the order status is custom. The problem was that if the status was not pending or failed, then after successful payment the status of the order did not change to processing


# Testing instructions

to check, you need to create an order for the user and assign a custom status to the order. Then make a payment on the order-pay page

