### PR TITLE
Add Jurassic Tube support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ deploy-to-wp-org.sh
 tests/e2e/config/local-*
 
 # Volumes mounted by Docker containers
+docker/bin/jt
 docker/data
 docker/wordpress
 docker/logs

--- a/bin/jurassic-tube-setup.sh
+++ b/bin/jurassic-tube-setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Exit if any command fails.
+set -e
+
+echo "Checking if ${PWD}/docker/bin/jt directory exists..."
+
+if [ -d "${PWD}/docker/bin/jt" ]; then
+    echo "${PWD}/docker/bin/jt already exists."
+else
+    echo "Creating ${PWD}/docker/bin/jt directory..."
+    mkdir -p "${PWD}/docker/bin/jt"
+fi
+
+echo "Downloading the latest version of the installer script..."
+echo
+
+# Download the installer (if it's not already present):
+if [ ! -f "${PWD}/docker/bin/jt/installer.sh" ]; then
+    # Download the installer script:
+    curl "https://jurassic.tube/get-installer.php?env=wcpay" -o ${PWD}/docker/bin/jt/installer.sh && chmod +x ${PWD}/docker/bin/jt/installer.sh
+fi
+
+echo "Running the installation script..."
+echo
+
+# Run the installer script
+source $PWD/docker/bin/jt/installer.sh
+
+echo
+read -p "Go to https://jurassic.tube/ in a browser, paste your public key which was printed above into the box, and click 'Add Public Key'. Press enter to continue"
+echo
+
+read -p "Go to https://jurassic.tube/ in a browser, add a subdomain using the desired name for your subdomain, and click 'Add Subdomain'. The subdomain name is what you will use to access WC Payments in a browser. When this is done, type the subdomain name here and press enter. Please just type in the subdomain, not the full URL: " subdomain
+echo
+
+# npm run wp option update home https://${subdomain}.jurassic.tube/
+# npm run wp option update siteurl https://${subdomain}.jurassic.tube/
+
+read -p "Please enter your Automattic/WordPress.com username: " username
+echo
+
+${PWD}/docker/bin/jt/config.sh username ${username}
+${PWD}/docker/bin/jt/config.sh subdomain ${subdomain}
+
+echo "Setup complete!"
+echo "Use the command: docker/bin/jt/tunnel.sh from the root directory of your WC Payments project to start running Jurassic Tube."
+echo
+
+

--- a/bin/jurassic-tube-setup.sh
+++ b/bin/jurassic-tube-setup.sh
@@ -18,7 +18,7 @@ echo
 # Download the installer (if it's not already present):
 if [ ! -f "${PWD}/docker/bin/jt/installer.sh" ]; then
     # Download the installer script:
-    curl "https://jurassic.tube/get-installer.php?env=wcpay" -o ${PWD}/docker/bin/jt/installer.sh && chmod +x ${PWD}/docker/bin/jt/installer.sh
+    curl "https://jurassic.tube/get-installer.php?env=wc-stripe" -o ${PWD}/docker/bin/jt/installer.sh && chmod +x ${PWD}/docker/bin/jt/installer.sh
 fi
 
 echo "Running the installation script..."

--- a/bin/jurassic-tube-setup.sh
+++ b/bin/jurassic-tube-setup.sh
@@ -31,11 +31,8 @@ echo
 read -p "Go to https://jurassic.tube/ in a browser, paste your public key which was printed above into the box, and click 'Add Public Key'. Press enter to continue"
 echo
 
-read -p "Go to https://jurassic.tube/ in a browser, add a subdomain using the desired name for your subdomain, and click 'Add Subdomain'. The subdomain name is what you will use to access WC Payments in a browser. When this is done, type the subdomain name here and press enter. Please just type in the subdomain, not the full URL: " subdomain
+read -p "Go to https://jurassic.tube/ in a browser, add a subdomain using the desired name for your subdomain, and click 'Add Subdomain'. The subdomain name is what you will use to access WooCommerce Stripe Payment Gateway in a browser. When this is done, type the subdomain name here and press enter. Please just type in the subdomain, not the full URL: " subdomain
 echo
-
-# npm run wp option update home https://${subdomain}.jurassic.tube/
-# npm run wp option update siteurl https://${subdomain}.jurassic.tube/
 
 read -p "Please enter your Automattic/WordPress.com username: " username
 echo
@@ -44,7 +41,5 @@ ${PWD}/docker/bin/jt/config.sh username ${username}
 ${PWD}/docker/bin/jt/config.sh subdomain ${subdomain}
 
 echo "Setup complete!"
-echo "Use the command: docker/bin/jt/tunnel.sh from the root directory of your WC Payments project to start running Jurassic Tube."
+echo "Use the command: 'npm run jt:start' from the root directory of your WooCommerce Stripe Payment Gateway project to start running Jurassic Tube."
 echo
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ./docker/logs/apache2/:/var/log/apache2
       - .:/var/www/html/wp-content/plugins/woocommerce-gateway-stripe
       - ./docker/dev-php.ini:/usr/local/etc/php/conf.d/dev-php.ini
+      - ./docker/bin:/var/scripts
   db:
     container_name: woocommerce_stripe_mysql
     image: mysql:5.7

--- a/package.json
+++ b/package.json
@@ -64,7 +64,10 @@
     "test:single": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha --require babel-register",
     "test:php": "./bin/run-tests.sh",
     "lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist -n $(git ls-files | grep .php$)",
-    "lint:php-fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)"
+    "lint:php-fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
+    "jt:setup": "./bin/jurassic-tube-setup.sh",
+    "jt:start": "./docker/bin/jt/tunnel.sh",
+    "jt:stop": "./docker/bin/jt/tunnel.sh break"
   },
   "engines": {
     "node": ">=8.9.3",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:php": "./bin/run-tests.sh",
     "lint:php": "./vendor/bin/phpcs --standard=phpcs.xml.dist -n $(git ls-files | grep .php$)",
     "lint:php-fix": "./vendor/bin/phpcbf --standard=phpcs.xml.dist $(git ls-files | grep .php$)",
-    "jt:setup": "./bin/jurassic-tube-setup.sh",
+    "jt:setup": "npm run up && ./bin/jurassic-tube-setup.sh",
     "jt:start": "./docker/bin/jt/tunnel.sh",
     "jt:stop": "./docker/bin/jt/tunnel.sh break"
   },


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Adds shell script to handle Jurassic Tube setup
Add `npm` commands for Jurassic Tube `setup`, `start` and `stop` to package.json

## Testing instructions
1. Checkout the branch:
`git checkout tweak/add-jurassic-tube-to-npm-scripts`
2. Run the setup command:
`npm run jt:setup`
3. Follow the configuration steps in the script... 
4. Verify that it correctly starts Jurassic Tube:
`nom run jt:start`
5. Verify that it correctly stops up Jurassic Tube:
`npm run jt:stop`

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).