### PR TITLE
`npm run up`: Provide default.env file to docker run command

### DIFF
--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -18,7 +18,7 @@ redirect_output() {
 # https://hub.docker.com/_/wordpress#running-as-an-arbitrary-user
 cli()
 {
-	redirect_output docker run -it --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
+	redirect_output docker run -it --env-file default.env --rm --user xfs --volumes-from $WP_CONTAINER --network container:$WP_CONTAINER wordpress:cli "$@"
 }
 
 set +e


### PR DESCRIPTION
Commands that run with `docker run` does not have all the env vars we need to complete the installation. We need to provide them manually.

### Before fix

Installation is stuck in `Waiting until the service is ready...`


```
~/www/woocommerce-gateway-stripe ‹trunk› » npm run up

> woocommerce-gateway-stripe@5.0.0 up
> docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh

Building wordpress
[+] Building 1.3s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 709B                                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/wordpress:php7.3                                                                                                                                                                                                    1.2s
 => [1/5] FROM docker.io/library/wordpress:php7.3@sha256:f6945551c4a83ad02ab596828c3f7315f3613808304dd4ce86903277a65ea8a9                                                                                                                                              0.0s
 => CACHED [2/5] RUN pecl install xdebug-2.9.8  && echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini  && echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini  && echo 'xdebug.remote_host=host.docker.internal' >> /usr/local/etc/php/php.ini  &&   0.0s
 => CACHED [3/5] RUN apt-get update  && apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq                                                                                                                          0.0s
 => CACHED [4/5] RUN apt-get install -y openssh-client                                                                                                                                                                                                                 0.0s
 => CACHED [5/5] RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  && chmod +x wp-cli.phar  && mv wp-cli.phar /usr/local/bin/wp                                                                                                   0.0s
 => exporting to image                                                                                                                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                                                                                                                0.0s
 => => writing image sha256:1185ee014c2f985d5b76fa9ff72af71f45affcc530033340ee14642e1408f1f7                                                                                                                                                                           0.0s
 => => naming to docker.io/library/wordpress-xdebug                                                                                                                                                                                                                    0.0s
Successfully built 1185ee014c2f985d5b76fa9ff72af71f45affcc530033340ee14642e1408f1f7
Recreating woocommerce_stripe_phpmyadmin ... done
Recreating woocommerce_stripe_mysql      ... done
Recreating woocommerce_stripe_wordpress  ... done
Waiting until the service is ready...
Waiting until the service is ready...
Waiting until the service is ready...
Waiting until the service is ready...
Waiting until the service is ready...
Waiting until the service is ready...
```

Logs in the `woocommerce_stripe_mysql` container suggests the script is trying to connect with invalid credentials.

```
2021-03-23T19:53:59.664118Z 241 [Note] Access denied for user 'example username'@'172.19.0.4' (using password: YES)
```

on the other hand in `wp-config.php` we have

```php
define( 'DB_USER', getenv_docker('WORDPRESS_DB_USER', 'example username') );
```

I tested by dumping `var_dump(getenv_docker('WORDPRESS_DB_USER', 'example username'));` to see if the WP installation is getting the right values from the .env file:

```
/var/www/html/wp-config.php:39:
string(9) "wordpress"
```

And apparently it is getting the right values. So I tried testing what `printenv` returns using the `cli` function in `docker-setup.sh`

```
~/www/woocommerce-gateway-stripe ‹trunk› » npm run up
...
Recreating woocommerce_stripe_wordpress  ... done
HOSTNAME=bca8beedbe1c
PHP_INI_DIR=/usr/local/etc/php
SHLVL=1
HOME=/etc/X11/fs
PHP_LDFLAGS=-Wl,-O1 -pie
PHP_CFLAGS=-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
PHP_VERSION=7.4.16
GPG_KEYS=426...
PHP_CPPFLAGS=-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
PHP_ASC_URL=https://www.php.net/distributions/php-7.4.16.tar.xz.asc
PHP_URL=https://www.php.net/distributions/php-7.4.16.tar.xz
TERM=xterm
WORDPRESS_CLI_GPG_KEY=63A...
WORDPRESS_CLI_VERSION=2.4.0
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
PHPIZE_DEPS=autoconf 		dpkg-dev dpkg 		file 		g++ 		gcc 		libc-dev 		make 		pkgconf 		re2c
PWD=/var/www/html
PHP_SHA256=1c1...
WORDPRESS_CLI_SHA512=404...
Waiting until the service is ready...
```

We can notice it doesn't have the env vars we need to complete the installation correctly like `WORDPRESS_DB_USER`, `WORDPRESS_DB_PASSWORD`, `WORDPRESS_DB_NAME`, etc.  


### After fix

Output of `cli printenv` with the fix. We can see it has the env vars from the `default.env` file

```
HOSTNAME=02897937baf2
PHP_INI_DIR=/usr/local/etc/php
SHLVL=1
HOME=/etc/X11/fs
MYSQL_ROOT_PASSWORD=wordpress
PHP_LDFLAGS=-Wl,-O1 -pie
PHP_CFLAGS=-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
WC_STRIPE_DIR=/var/www/html/wp-content/plugins/woocommerce-gateway-stripe
PHP_VERSION=7.4.16
WORDPRESS_DB_PASSWORD=wordpress
GPG_KEYS=426...
PHP_CPPFLAGS=-fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
PHP_ASC_URL=https://www.php.net/distributions/php-7.4.16.tar.xz.asc
WORDPRESS_DB_HOST=db:3306
PHP_URL=https://www.php.net/distributions/php-7.4.16.tar.xz
TERM=xterm
WORDPRESS_DB_USER=wordpress
WORDPRESS_CLI_GPG_KEY=63A...
WORDPRESS_CLI_VERSION=2.4.0
MYSQL_PASSWORD=wordpress
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
WORDPRESS_DEBUG=1
MYSQL_USER=wordpress
WORDPRESS_DB_NAME=wordpress
PHPIZE_DEPS=autoconf    dpkg-dev dpkg     file    g++     gcc     libc-dev    make    pkgconf     re2c
PWD=/var/www/html
ABSPATH=/usr/src/wordpress/
PHP_SHA256=1c1...
MYSQL_DATABASE=wordpress
WORDPRESS_CLI_SHA512=404...
```

Running  `npm run up`  finishes successfully

```
~/www/woocommerce-gateway-stripe ‹fix-docker-setup› » npm run up                                                                                                                                                                                                      130 ↵

> woocommerce-gateway-stripe@5.0.0 up
> docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh

Building wordpress
[+] Building 1.2s (9/9) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 709B                                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/wordpress:php7.3                                                                                                                                                                                                    1.1s
 => [1/5] FROM docker.io/library/wordpress:php7.3@sha256:f6945551c4a83ad02ab596828c3f7315f3613808304dd4ce86903277a65ea8a9                                                                                                                                              0.0s
 => CACHED [2/5] RUN pecl install xdebug-2.9.8  && echo 'xdebug.remote_enable=1' >> /usr/local/etc/php/php.ini  && echo 'xdebug.remote_port=9000' >> /usr/local/etc/php/php.ini  && echo 'xdebug.remote_host=host.docker.internal' >> /usr/local/etc/php/php.ini  &&   0.0s
 => CACHED [3/5] RUN apt-get update  && apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq                                                                                                                          0.0s
 => CACHED [4/5] RUN apt-get install -y openssh-client                                                                                                                                                                                                                 0.0s
 => CACHED [5/5] RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar  && chmod +x wp-cli.phar  && mv wp-cli.phar /usr/local/bin/wp                                                                                                   0.0s
 => exporting to image                                                                                                                                                                                                                                                 0.0s
 => => exporting layers                                                                                                                                                                                                                                                0.0s
 => => writing image sha256:1185ee014c2f985d5b76fa9ff72af71f45affcc530033340ee14642e1408f1f7                                                                                                                                                                           0.0s
 => => naming to docker.io/library/wordpress-xdebug                                                                                                                                                                                                                    0.0s
Successfully built 1185ee014c2f985d5b76fa9ff72af71f45affcc530033340ee14642e1408f1f7
Creating woocommerce_stripe_phpmyadmin ... done
Creating woocommerce_stripe_mysql      ... done
Creating woocommerce_stripe_wordpress  ... done
Waiting until the service is ready...
Waiting until the service is ready...
Waiting until the service is ready...

Setting up environment...

Pulling the WordPress CLI docker image...
Setting up WordPress...
Updating WordPress to the latest version...
Updating the WordPress database...
Configuring WordPress to work with ngrok (in order to allow creating a Jetpack-WPCOM connection)
Enabling WordPress debug flags
Enabling WordPress development environment (enforces Stripe testing mode)
Updating permalink structure
Installing and activating WooCommerce...
Installing and activating Storefront theme...
Adding basic WooCommerce settings...
Importing WooCommerce shop pages...
Installing and activating the WordPress Importer plugin...
Importing some sample data...
Activating the WooCommerce Stripe Payment Gateway plugin...

SUCCESS! You should now be able to access http://localhost:8082/wp-admin/
You can login by using the username and password both as 'admin'
```