### PR TITLE
Save regular and 3DS cards only after payment intent is confirmed

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -188,11 +188,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		return parent::is_available();
 	}
 
-	public function maybe_save_payment_method() {
-		$payment_method    = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
-		$force_save_source = apply_filters( 'wc_stripe_force_save_source', false, $prepared_source->customer );
+	public function save_payment_method_requested() {
+		$payment_method = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
 
-		return isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) || $force_save_source;
+		return isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
 	}
 
 	/**
@@ -647,7 +646,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				$is_token = true;
 			}
 		} elseif ( isset( $_POST['stripe_token'] ) && 'new' !== $_POST['stripe_token'] ) {
-			$source_id	= wc_clean( wp_unslash( $_POST['stripe_token'] ) );
+			$source_id = wc_clean( wp_unslash( $_POST['stripe_token'] ) );
 			$is_token  = true;
 		}
 
@@ -1058,8 +1057,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			],
 		];
 
-		if ( $this->maybe_save_payment_method() ) {
-			$request['setup_future_usage'] = 'off_session';
+		$force_save_source = apply_filters( 'wc_stripe_force_save_source', false, $prepared_source->source );
+
+		if ( $this->save_payment_method_requested() || $force_save_source ) {
+			$request['setup_future_usage']              = 'off_session';
+			$request['metadata']['save_payment_method'] = 'true';
 		}
 
 		if ( $prepared_source->customer ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -630,6 +630,18 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( ! empty( $_POST['stripe_source'] ) ) {
 			$source_object = self::get_source_object( wc_clean( wp_unslash( $_POST['stripe_source'] ) ) );
 			$source_id     = $source_object->id;
+
+			// This checks to see if customer opted to save the payment method to file.
+			$maybe_saved_card = isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
+
+			/**
+			 * This is true if the user wants to store the card to their account.
+			 * Criteria to save to file is they are logged in, they opted to save or product requirements and the source is
+			 * actually reusable. Either that or force_save_source is true.
+			 */
+			if ( ( $user_id && $this->saved_cards && $maybe_saved_card && 'reusable' === $source_object->usage ) || $force_save_source ) {
+				$customer->attach_source( $source_object->id );
+			}
 		} elseif ( $this->is_using_saved_payment_method() ) {
 			// Use an existing token, and then process the payment.
 			$wc_token_id = isset( $_POST[ 'wc-' . $payment_method . '-payment-token' ] ) ? wc_clean( wp_unslash( $_POST[ 'wc-' . $payment_method . '-payment-token' ] ) ) : '';

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -189,8 +189,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	public function maybe_save_payment_method() {
-		$payment_method = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
-		return isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
+		$payment_method    = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
+		$force_save_source = apply_filters( 'wc_stripe_force_save_source', false, $prepared_source->customer );
+
+		return isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) || $force_save_source;
 	}
 
 	/**
@@ -619,12 +621,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$customer->set_id( $existing_customer_id );
 		}
 
-		$force_save_source = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $customer );
-		$source_object     = '';
-		$source_id         = '';
-		$wc_token_id       = false;
-		$payment_method    = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
-		$is_token          = false;
+		$source_object  = '';
+		$source_id      = '';
+		$wc_token_id    = false;
+		$payment_method = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
+		$is_token       = false;
 
 		// New CC info was entered and we have a new source to process.
 		if ( ! empty( $_POST['stripe_source'] ) ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -647,24 +647,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				$is_token = true;
 			}
 		} elseif ( isset( $_POST['stripe_token'] ) && 'new' !== $_POST['stripe_token'] ) {
-			$stripe_token     = wc_clean( wp_unslash( $_POST['stripe_token'] ) );
-			$maybe_saved_card = isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
-
-			// This is true if the user wants to store the card to their account.
-			if ( ( $user_id && $this->saved_cards && $maybe_saved_card ) || $force_save_source ) {
-				$response = $customer->add_source( $stripe_token );
-
-				if ( ! empty( $response->error ) ) {
-					throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
-				}
-				if ( is_wp_error( $response ) ) {
-					throw new WC_Stripe_Exception( $response->get_error_message(), $response->get_error_message() );
-				}
-				$source_id = $response;
-			} else {
-				$source_id = $stripe_token;
-				$is_token  = true;
-			}
+			$source_id	= wc_clean( wp_unslash( $_POST['stripe_token'] ) );
+			$is_token  = true;
 		}
 
 		$customer_id = $customer->get_id();

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -625,25 +625,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( ! empty( $_POST['stripe_source'] ) ) {
 			$source_object = self::get_source_object( wc_clean( wp_unslash( $_POST['stripe_source'] ) ) );
 			$source_id     = $source_object->id;
-
-			// This checks to see if customer opted to save the payment method to file.
-			$maybe_saved_card = isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
-
-			/**
-			 * This is true if the user wants to store the card to their account.
-			 * Criteria to save to file is they are logged in, they opted to save or product requirements and the source is
-			 * actually reusable. Either that or force_save_source is true.
-			 */
-			if ( ( $user_id && $this->saved_cards && $maybe_saved_card && 'reusable' === $source_object->usage ) || $force_save_source ) {
-				$response = $customer->add_source( $source_object->id );
-
-				if ( ! empty( $response->error ) ) {
-					throw new WC_Stripe_Exception( print_r( $response, true ), $this->get_localized_error_message_from_response( $response ) );
-				}
-				if ( is_wp_error( $response ) ) {
-					throw new WC_Stripe_Exception( $response->get_error_message(), $response->get_error_message() );
-				}
-			}
 		} elseif ( $this->is_using_saved_payment_method() ) {
 			// Use an existing token, and then process the payment.
 			$wc_token_id = isset( $_POST[ 'wc-' . $payment_method . '-payment-token' ] ) ? wc_clean( wp_unslash( $_POST[ 'wc-' . $payment_method . '-payment-token' ] ) ) : '';
@@ -1085,6 +1066,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'payment_method_types' => [
 				'card',
 			],
+			'setup_future_usage'   => 'off_session',
 		];
 
 		if ( $prepared_source->customer ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -620,11 +620,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$customer->set_id( $existing_customer_id );
 		}
 
-		$source_object  = '';
-		$source_id      = '';
-		$wc_token_id    = false;
-		$payment_method = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
-		$is_token       = false;
+		$force_save_source = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $customer );
+		$source_object     = '';
+		$source_id         = '';
+		$wc_token_id       = false;
+		$payment_method    = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
+		$is_token          = false;
 
 		// New CC info was entered and we have a new source to process.
 		if ( ! empty( $_POST['stripe_source'] ) ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -188,6 +188,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		return parent::is_available();
 	}
 
+	public function maybe_save_payment_method() {
+		$payment_method = isset( $_POST['payment_method'] ) ? wc_clean( wp_unslash( $_POST['payment_method'] ) ) : 'stripe';
+		return isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
+	}
+
 	/**
 	 * Checks if we need to process pre orders when
 	 * pre orders is in the cart.
@@ -1066,8 +1071,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'payment_method_types' => [
 				'card',
 			],
-			'setup_future_usage'   => 'off_session',
 		];
+
+		if ( $this->maybe_save_payment_method() ) {
+			$request['setup_future_usage'] = 'off_session';
+		}
 
 		if ( $prepared_source->customer ) {
 			$request['customer'] = $prepared_source->customer;

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -627,9 +627,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				$intent = $this->confirm_intent( $intent, $order, $prepared_source );
 			}
 
-			$force_save_source = apply_filters( 'wc_stripe_force_save_source', false, $prepared_source->source );
+			$force_save_source_value = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $prepared_source->source );
 
-			if ( 'succeeded' === $intent->status && ( $this->save_payment_method_requested() || $force_save_source ) ) {
+			if ( 'succeeded' === $intent->status && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
 				$this->save_payment_method( $prepared_source->source_object );
 			}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -709,6 +709,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 	}
 
+	/**
+	 * Saves payment method
+	 *
+	 * @param object $source_object
+	 * @throws WC_Stripe_Exception
+	 */
 	public function save_payment_method( $source_object ) {
 		$user_id  = get_current_user_id();
 		$customer = new WC_Stripe_Customer( $user_id );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1047,7 +1047,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			'redirect_to' => rawurlencode( $result['redirect'] ),
 		];
 
-		if ( $this->save_payment_method_requested() ) {
+		$force_save_source_value = apply_filters( 'wc_stripe_force_save_source', false );
+
+		if ( $this->save_payment_method_requested() || $force_save_source_value ) {
 			$query_params['save_payment_method'] = true;
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -629,7 +629,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 			$force_save_source_value = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $prepared_source->source );
 
-			if ( 'succeeded' === $intent->status && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
+			if ( 'succeeded' === $intent->status && ! $this->is_using_saved_payment_method() && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
 				$this->save_payment_method( $prepared_source->source_object );
 			}
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -268,8 +268,6 @@ class WC_Stripe_Customer {
 	public function add_source( $source_id, $source_object ) {
 		$response = $source_object;
 
-		WC_Stripe_Logger::log( 'add_source - $response:' . print_r( $response, true ) );
-
 		if ( ! empty( $response->error ) || is_wp_error( $response ) ) {
 			return $response;
 		}

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -265,8 +265,8 @@ class WC_Stripe_Customer {
 	 * @param string $source_id
 	 * @return WP_Error|int
 	 */
-	public function add_source( $source_id, $source_object ) {
-		$response = $source_object;
+	public function add_source( $source_id ) {
+		$response = WC_Stripe_API::retrieve( 'sources/' . $source_id );
 
 		if ( ! empty( $response->error ) || is_wp_error( $response ) ) {
 			return $response;

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -265,8 +265,10 @@ class WC_Stripe_Customer {
 	 * @param string $source_id
 	 * @return WP_Error|int
 	 */
-	public function add_source( $source_id ) {
-		$response = $this->attach_source( $source_id );
+	public function add_source( $source_id, $source_object ) {
+		$response = $source_object;
+
+		WC_Stripe_Logger::log( 'add_source - $response:' . print_r( $response, true ) );
 
 		if ( ! empty( $response->error ) || is_wp_error( $response ) ) {
 			return $response;

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -105,7 +105,10 @@ class WC_Stripe_Intent_Controller {
 			if ( isset( $_GET['save_payment_method'] ) && ! empty( $_GET['save_payment_method'] ) ) {
 				$intent        = $gateway->get_intent_from_order( $order );
 				$source_object = WC_Stripe_API::retrieve( 'sources/' . $intent->source );
-				$gateway->save_payment_method( $source_object );
+
+				if ( 'true' === $intent->metadata->save_payment_method ) {
+					$gateway->save_payment_method( $source_object );
+				}
 			}
 
 			if ( ! isset( $_GET['is_ajax'] ) ) {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -101,6 +101,9 @@ class WC_Stripe_Intent_Controller {
 
 		try {
 			$gateway->verify_intent_after_checkout( $order );
+			$intent        = $gateway->get_intent_from_order( $order );
+			$source_object = WC_Stripe_API::retrieve( 'sources/' . $intent->source );
+			$gateway->save_payment_method( $source_object );
 
 			if ( ! isset( $_GET['is_ajax'] ) ) {
 				$redirect_url = isset( $_GET['redirect_to'] ) // wpcs: csrf ok.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -103,11 +103,19 @@ class WC_Stripe_Intent_Controller {
 			$gateway->verify_intent_after_checkout( $order );
 
 			if ( isset( $_GET['save_payment_method'] ) && ! empty( $_GET['save_payment_method'] ) ) {
-				$intent        = $gateway->get_intent_from_order( $order );
-				$source_object = WC_Stripe_API::retrieve( 'sources/' . $intent->source );
-
-				if ( 'true' === $intent->metadata->save_payment_method ) {
-					$gateway->save_payment_method( $source_object );
+				$intent = $gateway->get_intent_from_order( $order );
+				if ( isset( $intent->last_payment_error ) ) {
+					// Currently, Stripe saves the payment method even if the authentication fails for 3DS cards.
+					// Although, the card is not stored in DB we need to remove the source from the customer on Stripe
+					// in order to keep the sources in sync with the data in DB.
+					$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
+					$customer->delete_source( $intent->last_payment_error->source->id );
+				} else {
+					$metadata = $intent->metadata;
+					if ( isset( $metadata->save_payment_method ) && 'true' === $metadata->save_payment_method ) {
+						$source_object = WC_Stripe_API::retrieve( 'sources/' . $intent->source );
+						$gateway->save_payment_method( $source_object );
+					}
 				}
 			}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -101,9 +101,12 @@ class WC_Stripe_Intent_Controller {
 
 		try {
 			$gateway->verify_intent_after_checkout( $order );
-			$intent        = $gateway->get_intent_from_order( $order );
-			$source_object = WC_Stripe_API::retrieve( 'sources/' . $intent->source );
-			$gateway->save_payment_method( $source_object );
+
+			if ( isset( $_GET['save_payment_method'] ) && ! empty( $_GET['save_payment_method'] ) ) {
+				$intent        = $gateway->get_intent_from_order( $order );
+				$source_object = WC_Stripe_API::retrieve( 'sources/' . $intent->source );
+				$gateway->save_payment_method( $source_object );
+			}
 
 			if ( ! isset( $_GET['is_ajax'] ) ) {
 				$redirect_url = isset( $_GET['redirect_to'] ) // wpcs: csrf ok.


### PR DESCRIPTION
Fixes: #1362 and Fixes #1440

## Description

Changes how and when cards are saved. Before this PR cards were attached to the customer and saved in the DB  in the same place. We used the `WC_Stripe_Payment_Gateway->add_source` method which [attached and also stored](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/trunk/includes/class-wc-stripe-customer.php#L268) the card details in the DB. This usually worked fine except for 3DS cards because cards were saved no matter if the payment was successful or not.

Key changes we are making on this PR:

- We are using the `setup_future_usage` [payment intent's param](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-setup_future_usage) (per @diegocurbelo's [suggestion](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1362#issuecomment-811666153)) in order to keep the card on Stripe for later usage if the payment intent is confirmed.
- The card is saved in the DB **only** after the payment intent has been confirmed. This is done in two places.
  - For regular cards is done in `WC_Gateway_Stripe-> process_payment()` after the payment intent is confirmed.
  - For 3DS cards is done in `WC_Stripe_Intent_Controller -> verify_intent()` after the user submits the authentication step.
- For 3DS cards in order to know if the user wants to save the payment method (checkbox is marked) at the end of the second step we need to pass along the value of the checkbox via the intent's metadata.

## Observations

- Cards with the exact same information (number, expiry date, CVC) are saved multiple times if the user enters the same card multiple times as "New payment method" This is something that's currently happening in `trunk`. I just wanted to mention it in case this is an unwanted behavior. Stripe seems not to care about it so I'm keeping the behavior since fixing it is out of the scope of the PR.

## Testing

### User is logged in
- [x] User can purchase using a regular card.
  - Card used: `4242424242424242`
- [x] Using regular card, payment succeeds, checkbox is marked and payment method is saved.
  - Card used: `4242424242424242`
- [x] Using regular card, payment fails, checkbox is marked and payment method is not saved.
  - Card used: `4000000000000119` which declines with a `processing_error` code.
- [x] Using a 3DS card, auth is successful, payment succeeds, checkbox is marked and payment method is saved.
  - Card used: `4000002760003184`
- [x] Using a 3DS card, auth fails, payment fails, checkbox is marked and payment method is not saved.
  - Card used: `4000002760003184`
- [x] User can purchase using saved regular card
  - Saved Card used: `4242424242424242`
- [x] User can purchase using 3DS saved card
  - Saved Card used: `4000002760003184`
- [x] User can purchase using an already saved regular card as "New payment method"
  - Saved card used: `4242424242424242`
  - New card: `4242424242424242`
- [x] User can purchase using an already saved regular card as "New payment method" and checkbox is marked (card is saved again).
  - Saved card used: `4242424242424242`
  - New card: `4242424242424242`
- [x] User can purchase using an already saved 3DS card as "New payment method"
  - Saved card used: `4000002760003184`
- [x] User can purchase using an already saved 3DS card as "New payment method" and checkbox is marked (card is saved again)
  - Saved card used: `4000002760003184`
  - New card: `4000002760003184`
- [x] Test `wc_stripe_force_save_source` hook with regular cards
  - Card used: `4242424242424242`
- [x] Test `wc_stripe_force_save_source` hook with 3DS cards
  - Card used: `4000002760003184`

### User is not logged in

- [x] User can make a purchase using a regular card.
  - Card used: `4242424242424242`
- [x] User makes a purchase using a regular card and it fails gracefully.
  - Card used: `4242424242424242`
- [x] User can purchase using a 3DS card if auth is successful
- [x] User can not purchase using a 3DS card if auth fails

Any suggestion on testing a case not considered on this list would be great.