### PR TITLE
Use triggers block/unblock the payment request button 

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -609,9 +609,17 @@ jQuery( function( $ ) {
 					paymentRequest.show();
 				}
 			});
-
-			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
+			
+			$( document.body ).on( 'wc_stripe_unblock_payment_request_button', function () {
+				wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+			} );
+			
+			$( document.body ).on( 'wc_stripe_block_payment_request_button', function () {
 				wc_stripe_payment_request.blockPaymentRequestButton( prButton );
+			} );
+			
+			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
+				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
 					$.when(
@@ -620,7 +628,7 @@ jQuery( function( $ ) {
 							displayItems: response.displayItems,
 						} )
 					).then( function () {
-						wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					} );
 				});
 			} );
@@ -628,17 +636,17 @@ jQuery( function( $ ) {
 			// Block the payment request button as soon as an "input" event is fired, to avoid sync issues
 			// when the customer clicks on the button before the debounced event is processed.
 			$( '.quantity' ).on( 'input', '.qty', function() {
-				wc_stripe_payment_request.blockPaymentRequestButton( prButton );
+				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 			} );
 
 			$( '.quantity' ).on( 'input', '.qty', wc_stripe_payment_request.debounce( 250, function() {
-				wc_stripe_payment_request.blockPaymentRequestButton( prButton );
+				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 				paymentRequestError = [];
 
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
 					if ( response.error ) {
 						paymentRequestError = [ response.error ];
-						wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					} else {
 						$.when(
 							paymentRequest.update( {
@@ -646,7 +654,7 @@ jQuery( function( $ ) {
 								displayItems: response.displayItems,
 							} )
 						).then( function () {
-							wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+							$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 						});
 					}
 				} );


### PR DESCRIPTION
Added by @v18:

**Please do not merge.** This PR is blocked until #1539 is solved. Then it can be merged to `trunk`. [See this comment for more details](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1509#issuecomment-825350215).

---


...On a single product page

Changes proposed in this Pull Request:

Use jQuery custom event triggers to block and unblock the payment request buttons

Issue: Link to the GitHub issue this PR addresses (if appropriate).
Fixes #1228 

Description: 
This is a first step for compatibility with complex product types. For example with Name Your Price, the payment request button should not be clickable until the minimum price is satisfied. With Mix and Match, the payment request button should not be clickable until all the selections are made to fill the container.

Probably still need a way to change the popup error notice to suit the need. Currently, you can get:
>Please select some product options before adding this product to your cart.

if the variation isn't selected, but would need a way to supply different notices.

Probably also need a way to pass ALL the form data (and in some cases a custom price). Currently, you are manually adding the data from Addons, but Name Your Price and Mix and Match would have different form data.

# Testing instructions

Can test this in the browser's console.

`jQuery( document.body ).trigger( 'wc_stripe_block_payment_request_button' );`

and

`jQuery( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );`

You should see the button go disabled and then be re-enabled. You can also see it happen when a variation is changed or when a product's quantity is changed. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
