### PR TITLE
Fix undefined variable error for prepared_source.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 = 5.1.0 - 2021-xx-xx =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.
+* Fix - Fix undefined variable error for prepared_source.
 
 = 5.0.0 - 2021-03-17 =
 * Add - Display time of last Stripe webhook in settings.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -238,9 +238,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$order->save();
 				}
 
-				if ( $this->is_no_such_token_error( $response->error ) && $prepared_source->token_id ) {
+				if ( $this->is_no_such_token_error( $response->error ) && $source_object->token_id ) {
 					// Source param wrong? The CARD may have been deleted on stripe's end. Remove token and show message.
-					$wc_token = WC_Payment_Tokens::get( $prepared_source->token_id );
+					$wc_token = WC_Payment_Tokens::get( $source_object->token_id );
 					$wc_token->delete();
 					$localized_message = __( 'This card is no longer available and has been removed.', 'woocommerce-gateway-stripe' );
 					$order->add_order_note( $localized_message );

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 5.1.0 - 2021-xx-xx =
 
 * Fix - Don't attempt to submit level 3 data for non-US merchants.
+* Fix - Fix undefined variable error for prepared_source.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #894

* Fixing the variable name, as it appears to have been a [copy/paste error in a previous edit](https://github.com/woocommerce/woocommerce-gateway-stripe/commit/ee76a856138473e9e22a2bf8c594d7268f56527a#diff-7ec8a10518a51c152ae0db4c831da193d4181028f68ee994b510b99205c37b9eL137-L141). 


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
