### PR TITLE
Return a WP_Error to indicate refund initiation problems

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** Changelog ***
+= 5.x.x - 2021-xx-xx =
+* Fix - Orders won't transition to 'Refunded' state if refund can't be created.
+
 = 5.1.0 - 2021-04-07 =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.
 * Fix - Pass customer language/locale to Stripe upon creation or modification.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -912,7 +912,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( ! empty( $response->error ) ) {
 			WC_Stripe_Logger::log( 'Error: ' . $response->error->message );
 
-			return $response;
+			return new WP_Error(
+				'stripe_error',
+				sprintf(
+					/* translators: %1$s is a stripe error message */
+					__( 'There was a problem initiating a refund: %1$s', 'woocommerce-gateway-stripe' ),
+					$response->error->message
+				)
+			);
 
 		} elseif ( ! empty( $response->id ) ) {
 			$formatted_amount = wc_price( $response->amount / 100 );

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 5.x.x - 2021-xx-xx =
+* Fix - Orders won't transition to 'Refunded' state if refund can't be created.
+
 = 5.1.0 - 2021-04-07 =
 
 * Fix - Don't attempt to submit level 3 data for non-US merchants.


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: Link to the GitHub issue this PR addresses (if appropriate).
Fixes #1523 

For a long time Stripe refunds were mostly based on asynchronous process and the errors were captured by webhooks. With introduction of iDeal/Sofort and probably some other payment methods some checks for refunds are performed during the synchronous POST call to `/v1/refunds`. Those errors were not captured anywhere and WooCommerce completed order status transition expecting the payment to be fully refunded.

There is already some error handling during the synchronous phase to store failures in the logs. Alongside logging a `WP_Error` object will be returned to the caller to indicate an issue with refund initiation. As a result, shop manager will see a message like below and the order _will not be transitioned_ to the 'Refunded' state.

<img width="358" alt="image" src="https://user-images.githubusercontent.com/683297/114559785-603ddc80-9c6c-11eb-8f48-895b60a683a9.png">

# Testing instructions

This change doesn't rely on any specific shop set-up.

 * Create a test order, complete checkout and ensure it is in a **Processing** state.
 * Make Stripe API return error or hack to the Stripe response like I did. E.g. you can use the following snippet:
 ```diff
 diff --git a/includes/abstracts/abstract-wc-stripe-payment-gateway.php b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
index 0920407..27ca29c 100644
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -909,6 +909,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
                        $response = WC_Stripe_API::request( $request, 'refunds' );
                }
 
+               $response->error = (object) [
+                       'message' => 'test error',
+                       'type'    => 'invalid_request_error',
+               ];
+
                if ( ! empty( $response->error ) ) {
                        WC_Stripe_Logger::log( 'Error: ' . $response->error->message );
```
 * Go to the Order management page, open the order and start a refund with Stripe.
 * You should see an error message as above.
 * Remove the code for Stripe error simulation.
 * Initiate refund again. It should complete succesfully unless Stripe returns some other error in your set-up.                        
-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
