### PR TITLE
Payment Request: Fix non-default block checkout page and add support for product_page shortcode

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -476,10 +476,20 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
+	 * Checks if this page contains a cart or checkout block.
+	 *
+	 * @since 5.2.0
+	 * @return boolean
+	 */
+	public function is_block() {
+		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
+	}
+
+	/**
 	 * Load public scripts and styles.
 	 *
 	 * @since   3.1.0
-	 * @version 4.0.0
+	 * @version 5.2.0
 	 */
 	public function scripts() {
 		// If keys are not set bail.
@@ -494,11 +504,14 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		if ( ! is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) ) {
+		// If page is not supported, bail.
+		if ( ! $this->is_block() && ! is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) ) {
 			return;
 		}
 
 		if ( is_product() && ! $this->should_show_payment_button_on_product_page() ) {
+			return;
+		} elseif ( ! $this->should_show_payment_button_on_cart() ) {
 			return;
 		}
 
@@ -564,7 +577,7 @@ class WC_Stripe_Payment_Request {
 	 * Display the payment request button.
 	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version 5.2.0
 	 */
 	public function display_payment_request_button_html() {
 		global $post;
@@ -580,12 +593,6 @@ class WC_Stripe_Payment_Request {
 		}
 
 		if ( is_checkout() && ! apply_filters( 'wc_stripe_show_payment_request_on_checkout', false, $post ) ) {
-			return;
-		}
-
-		if ( is_product() && ! $this->should_show_payment_button_on_product_page() ) {
-			return;
-		} elseif ( ! $this->should_show_payment_button_on_cart() ) {
 			return;
 		}
 		?>
@@ -609,7 +616,7 @@ class WC_Stripe_Payment_Request {
 	 * Display payment request button separator.
 	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version 5.2.0
 	 */
 	public function display_payment_request_button_separator_html() {
 		global $post;
@@ -625,12 +632,6 @@ class WC_Stripe_Payment_Request {
 		}
 
 		if ( is_checkout() && ! apply_filters( 'wc_stripe_show_payment_request_on_checkout', false, $post ) ) {
-			return;
-		}
-
-		if ( is_product() && ! $this->should_show_payment_button_on_product_page() ) {
-			return;
-		} elseif ( ! $this->should_show_payment_button_on_cart() ) {
 			return;
 		}
 		?>

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -131,10 +131,11 @@ class WC_Stripe_Payment_Request {
 	 * This is needed so nonces can be verified by AJAX Request.
 	 *
 	 * @since  4.0.0
+	 * @version 5.2.0
 	 * @return void
 	 */
 	public function set_session() {
-		if ( ! is_product() || ( isset( WC()->session ) && WC()->session->has_session() ) ) {
+		if ( ! $this->is_product() || ( isset( WC()->session ) && WC()->session->has_session() ) ) {
 			return;
 		}
 
@@ -267,17 +268,15 @@ class WC_Stripe_Payment_Request {
 	 * Gets the product data for the currently viewed page
 	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version 5.2.0
 	 * @return  mixed Returns false if not on a product page, the product information otherwise.
 	 */
 	public function get_product_data() {
-		if ( ! is_product() ) {
+		if ( ! $this->is_product() ) {
 			return false;
 		}
 
-		global $post;
-
-		$product = wc_get_product( $post->ID );
+		$product = $this->get_product();
 
 		if ( 'variable' === $product->get_type() ) {
 			$attributes = wc_clean( wp_unslash( $_GET ) );
@@ -486,6 +485,41 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
+	 * Checks if this is a product page or content contains a product_page shortcode.
+	 *
+	 * @since 5.2.0
+	 * @return boolean
+	 */
+	public function is_product() {
+		return is_product() || wc_post_content_has_shortcode( 'product_page' );
+	}
+
+	/**
+	 * Get product from product page or product_page shortcode.
+	 *
+	 * @since 5.2.0
+	 * @return WC_Product Product object.
+	 */
+	public function get_product() {
+		global $post;
+
+		if ( is_product() ) {
+			return wc_get_product( $post->ID );
+		} elseif ( wc_post_content_has_shortcode( 'product_page' ) ) {
+			// Get id from product_page shortcode.
+			preg_match( '/\[product_page id="(?<id>\d+)"\]/', $post->post_content, $shortcode_match );
+
+			if ( ! isset( $shortcode_match['id'] ) ) {
+				return false;
+			}
+
+			return wc_get_product( $shortcode_match['id'] );
+		}
+
+		return false;
+	}
+
+	/**
 	 * Load public scripts and styles.
 	 *
 	 * @since   3.1.0
@@ -505,11 +539,11 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// If page is not supported, bail.
-		if ( ! $this->is_block() && ! is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) ) {
+		if ( ! $this->is_block() && ! $this->is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) ) {
 			return;
 		}
 
-		if ( is_product() && ! $this->should_show_payment_button_on_product_page() ) {
+		if ( $this->is_product() && ! $this->should_show_payment_button_on_product_page() ) {
 			return;
 		} elseif ( ! $this->should_show_payment_button_on_cart() ) {
 			return;
@@ -556,7 +590,7 @@ class WC_Stripe_Payment_Request {
 				'css_selector' => $this->custom_button_selector(),
 				'branded_type' => $this->get_button_branded_type(),
 			],
-			'is_product_page' => is_product(),
+			'is_product_page' => $this->is_product(),
 			'product'         => $this->get_product_data(),
 		];
 
@@ -588,7 +622,7 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		if ( ! is_cart() && ! is_checkout() && ! is_product() && ! isset( $_GET['pay_for_order'] ) ) {
+		if ( ! is_cart() && ! is_checkout() && ! $this->is_product() && ! isset( $_GET['pay_for_order'] ) ) {
 			return;
 		}
 
@@ -627,7 +661,7 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		if ( ! is_cart() && ! is_checkout() && ! is_product() && ! isset( $_GET['pay_for_order'] ) ) {
+		if ( ! is_cart() && ! is_checkout() && ! $this->is_product() && ! isset( $_GET['pay_for_order'] ) ) {
 			return;
 		}
 
@@ -660,16 +694,17 @@ class WC_Stripe_Payment_Request {
 	 * Whether payment button html should be rendered
 	 *
 	 * @since  4.3.2
+	 * @version 5.2.0
 	 * @return boolean
 	 */
 	private function should_show_payment_button_on_product_page() {
 		global $post;
 
-		$product = wc_get_product( $post->ID );
-
 		if ( apply_filters( 'wc_stripe_hide_payment_request_on_product_page', false, $post ) ) {
 			return false;
 		}
+
+		$product = $this->get_product();
 
 		if ( ! is_object( $product ) || ! in_array( $product->get_type(), $this->supported_product_types() ) ) {
 			return false;


### PR DESCRIPTION
Fixes #1525 

**Note:** This is a child of #1467.

# Changes proposed in this Pull Request:

- Allow PRB scripts to be enqueued if cart or checkout blocks are present.
- Allow PRB scripts to be enqueued if a product_page shortcode is present.
- Refactor the way the class gets the current product to also get the product from the product_page shortcode.

# Testing instructions

- Make sure you have Payment Request buttons enabled, and the website is served over HTTPS.

**Testing non-default block cart/checkout support:**

1. Make sure you have Gutenberg and WooCommerce Blocks installed.
2. Create a page and add a cart block. Do not make this page the default cart page under WooCommerce > Settings > Advanced.
3. Add items to the cart and visit the page you just created.
4. Notice the Payment Request button is displayed and works as expected.
5. Do the same for the checkout block and notice the PRB works as expected.

**Testing product_page shortcode support:**

1. Create a page and add a shortcode `[product_page id="*"]`, make sure you replace `*` with a simple product id.
2. Visit that page and notice the PRB works as expected.

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.