### PR TITLE
[WC_Stripe_Subs_Compat] Use `get_parent` method to get the subscription’s parent order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,7 @@
 *** Changelog ***
+= 5.2.0 - 2021-xx-xx =
+* Fix - Use `get_parent` method to avoid accessing `order` subscription property directly.
+
 = 5.1.0 - 2021-04-07 =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.
 * Fix - Pass customer language/locale to Stripe upon creation or modification.

--- a/includes/compat/class-wc-stripe-sepa-subs-compat.php
+++ b/includes/compat/class-wc-stripe-sepa-subs-compat.php
@@ -467,7 +467,7 @@ class WC_Stripe_Sepa_Subs_Compat extends WC_Gateway_Stripe_Sepa {
 		}
 
 		// If we couldn't find a Stripe customer linked to the account, fallback to the order meta data.
-		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->order ) {
+		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->get_parent() ) {
 			$stripe_customer_id = get_post_meta( $subscription->get_parent_id(), '_stripe_customer_id', true );
 			$stripe_source_id   = get_post_meta( $subscription->get_parent_id(), '_stripe_source_id', true );
 

--- a/includes/compat/class-wc-stripe-subs-compat.php
+++ b/includes/compat/class-wc-stripe-subs-compat.php
@@ -579,7 +579,7 @@ class WC_Stripe_Subs_Compat extends WC_Gateway_Stripe {
 		}
 
 		// If we couldn't find a Stripe customer linked to the account, fallback to the order meta data.
-		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->order ) {
+		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->get_parent() ) {
 			$stripe_customer_id = get_post_meta( $subscription->get_parent_id(), '_stripe_customer_id', true );
 			$stripe_source_id   = get_post_meta( $subscription->get_parent_id(), '_stripe_source_id', true );
 

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,10 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 5.2.0 - 2021-xx-xx =
+
+* Fix - Use `get_parent` method to avoid accessing `order` subscription property directly.
+
 = 5.1.0 - 2021-04-07 =
 
 * Fix - Don't attempt to submit level 3 data for non-US merchants.


### PR DESCRIPTION
Fixes #1381

Here we avoid using `WC_Stripe_Subs_Compat->order` directly given that since WooCommerce 3.0 we do not allow direct access to subscription properties. To get the parent order  we use now `WC_Subscription->get_parent()`.

### Description

I didn't know how to exactly reproduce the case where `$subscription->order` will be used so I've updated the DB manually in order to get to get to the point it will be used in this case:

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/752db9c62e3511835baaff6e34ace58674678ea0/includes/compat/class-wc-stripe-subs-compat.php#L581-L587

To achieve this I did the following changes:

- Rename the `_stripe_customer_id` post meta for the subscription  
- Rename the `wp__stripe_customer_id` user meta for the user associated to the subscription

This way we will get the data we need to display the card from the parent order instead.

| Before | After |
| ------------- | ------------- |
| <img width="879" alt="Screen Shot 2021-04-13 at 11 08 02 PM" src="https://user-images.githubusercontent.com/1025173/114653412-a23b4280-9cad-11eb-811d-86924db0096e.png">  | <img width="819" alt="Screen Shot 2021-04-13 at 11 08 13 PM" src="https://user-images.githubusercontent.com/1025173/114653426-abc4aa80-9cad-11eb-80ef-035512272591.png"> |

### Testing instructions

As mentioned I don't know exactly when we will encounter this case in the app so I've modified the DB in order to get to the point where the ofendind line will be called.

- As an admin create a subscription.
- As an user subscribe to the subscription
- Go to "Subscriptions" page `/my-account/subscriptions/`
- Click on the "view" button to see the subscription details.
- Then using a MySQL Client
  - Rename the `_stripe_customer_id` post meta for the subscription
  - Rename the `wp__stripe_customer_id` user meta for the user associated to the subscription
- Refresh the subscription page
- You should not see the warning indicating you can't access subscription properties and the card should be listed without errors.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
