### PR TITLE
 Variable Products: Fix price when “Default form values” is set

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -314,6 +314,14 @@ class WC_Stripe_Payment_Request {
 		if ( 'variable' === $product->get_type() ) {
 			$attributes = wc_clean( wp_unslash( $_GET ) );
 
+			if ( empty( $attributes ) ) {
+				$get_default_attributes = $product->get_default_attributes();
+				$attributes             = [];
+				foreach ( $get_default_attributes as $key => $value ) {
+					$attributes[ 'attribute_' . $key ] = $value;
+				}
+			}
+
 			$data_store   = WC_Data_Store::load( 'product' );
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -316,7 +316,7 @@ class WC_Stripe_Payment_Request {
 			$attributes           = [];
 
 			foreach ( $variation_attributes as $attribute_name => $attribute_values ) {
-				$attribute_key                = 'attribute_' . $attribute_name;
+				$attribute_key                = 'attribute_' . sanitize_title( $attribute_name );
 				$attributes[ $attribute_key ] = isset( $_GET[ $attribute_key ] ) ? wc_clean( wp_unslash( $_GET[ $attribute_key ] ) ) : $product->get_variation_default_attribute( $attribute_name );
 			}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -312,14 +312,12 @@ class WC_Stripe_Payment_Request {
 		$product = wc_get_product( $post->ID );
 
 		if ( 'variable' === $product->get_type() ) {
-			$attributes = wc_clean( wp_unslash( $_GET ) );
+			$variation_attributes = $product->get_variation_attributes();
+			$attributes           = [];
 
-			if ( empty( $attributes ) ) {
-				$get_default_attributes = $product->get_default_attributes();
-				$attributes             = [];
-				foreach ( $get_default_attributes as $key => $value ) {
-					$attributes[ 'attribute_' . $key ] = $value;
-				}
+			foreach ( $variation_attributes as $attribute_name => $attribute_values ) {
+				$attribute_key                = 'attribute_' . $attribute_name;
+				$attributes[ $attribute_key ] = isset( $_GET[ $attribute_key ] ) ? wc_clean( wp_unslash( $_GET[ $attribute_key ] ) ) : $product->get_variation_default_attribute( $attribute_name );
 			}
 
 			$data_store   = WC_Data_Store::load( 'product' );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -316,8 +316,12 @@ class WC_Stripe_Payment_Request {
 			$attributes           = [];
 
 			foreach ( $variation_attributes as $attribute_name => $attribute_values ) {
-				$attribute_key                = 'attribute_' . sanitize_title( $attribute_name );
-				$attributes[ $attribute_key ] = isset( $_GET[ $attribute_key ] ) ? wc_clean( wp_unslash( $_GET[ $attribute_key ] ) ) : $product->get_variation_default_attribute( $attribute_name );
+				$attribute_key = 'attribute_' . sanitize_title( $attribute_name );
+
+				// Passed value via GET takes precedence. Otherwise get the default value for given attribute
+				$attributes[ $attribute_key ] = isset( $_GET[ $attribute_key ] )
+					? wc_clean( wp_unslash( $_GET[ $attribute_key ] ) )
+					: $product->get_variation_default_attribute( $attribute_name );
 			}
 
 			$data_store   = WC_Data_Store::load( 'product' );


### PR DESCRIPTION
Fixes #829 

Here we are fixing the default total amount for "Variable Products". This value is set when page loads and is taken from `wc_stripe_payment_request_params.product.total.amount`.

Previously, it failed because the default attributes were returned without the `attribute_` prefix. Because of this we weren't able to get the right `variation_id` using `$data_store->find_matching_product_variation( $product, $attributes )`. 

On this PR we are adding the prefix manually. I've asked on Slack (p1618615018086800-slack-C0E1AV8T0) if it's there a cleaner way to do it. No response. Although I see no downsides on doing it manually since it's only used for this case.

# Testing

I've tested this for "Variable Products". @ricardo suggested I should also test with "Composite" and "Mixed and Match" product types but both disable the button on the Product's page:

**Composite Products**

Plugin users after [v7.1.4](http://changelogs.s3.amazonaws.com/changelogs/woocommerce-composite-products/changelog.txt) (released last December) will not encounter this error: 

<details>
 <summary>
Plugin is hiding the button on the Product Page using `wc_stripe_hide_payment_request_on_product_page` filter.
</summary>

```php
public static function init() {
  add_filter( 'wc_stripe_hide_payment_request_on_product_page', array( __CLASS__, 'hide_stripe_quickpay' ), 10, 2 );
}

/**
 * Hide Stripe Quick-pay buttons for non-static Composites.
 *
 * @since 7.1.4
 *
 */
public static function hide_stripe_quickpay( $hide_button, $post ) {

  global $product;

  $the_product = $product && is_a( $product, 'WC_Product' ) ? $product : wc_get_product( $post->ID );

  if ( $the_product && $the_product->is_type( 'composite' ) ) {
    $hide_button = true;
  }

  return $hide_button;
}
```

</details>

**Mix and Match Products**

<details>
 <summary>
Plugin is using `wc_stripe_payment_request_supported_types` filter to remove support for `mix-and-match` product type on Stripe.
</summary>

```php
public static function init() {

  // Hide Stripe's payment request buttons on MNNM products.
  add_filter( 'wc_stripe_payment_request_supported_types', array( __CLASS__, 'supported_request_product_types' ) );

}

/**
 * Hide Stripe's instant pay buttons
 *
 * @param   array $types - The product types that can support payment request buttons.
 * @return  array
 */
public static function supported_request_product_types( $types ) {
  $key = array_search( 'mix-and-match', $types );

  if ( $key ) { 
    unset( $types[$key] );
  }
  
  return $types;
}
```

</details>

@v18 what do you suggest here? Should I try to make sure this fix works with Composite and Mix and Match product types even though the plugins itself are not supporting the "Buy now" button on the product page? I've already tested with Composite products and it seems to be working fine but I had to hardcode their plugin to enable the button.

### Testing instructions

First of all, use Chrome create the following attributes and its terms as follows:

| Attribute | Terms |
| ------------- | ------------- |
| color | red, green, blue  |
| size | medium, large, extra large |


1. Create new variable product
2. Click "Attributes" tab 
3. Add "color" attribute. Add "red", "green", and "blue" as values. Click "use for variations"
4. Add "size" attribute. Add "extra large", "large", "medium" as values. . Click "use for variations"
5. Click "Save attributes" button
6. Click "Variations" tab and Click "Go" button
7. Click "Any Color" and pick "red". Click "Any size" and pick "medium". Set Regular price to "10"
8. Click "Go button"
9. Click "Any Color" and pick "green". Click "Any size" and pick "large". Set Regular price to "15"
10. Click "Go button"
11. Click "Any Color" and pick "blue". Click "Any size" and pick "extra large". Set Regular price to "20"
12. Set "Default Form Values:" to "red", "medium"
12. Click "Save changes" then Click "Publish" to publish the product.
13. Go to the product's page.
14. You should see `$10.00` as price.
15. Click on "Buy now" button and you should see `$10.00` as total in the Google Payment dialog.

### Testing list

```
Product Attributes
------------------

size        color  Price
------------------------
medium        red     10
large       green     15
extra large  blue     20
extra large   any     25
extra large   red     30
```

DFV = Default Form Values;

- [x] DFV is "medium" and "red" then price is $10.00
- [x] DFV is "large" and "green" then price is $15.00
- [x] DFV is "extra large" and "blue" then price is $20.00
- [x] DFV is "extra large" and "No default color" then price is not set. Clicking "But now" button will result in an error asking the user to pick a "color".
- [x] **DFV is "extra large" and "red" then price is $25.00** (*)
- [x] DFV is "large" and "green" and URL has `?attribute_pa_size=extra-large`. Selected attributes are "extra large" and "green". Then price is $25.
- [x] **DFV is "extra-large" and "blue" and URL has `?attribute_pa_color=red`. Selected attributes are "extra large" and "red". Then price is $25** (**)
- [x] DFV is "large" and "blue". Since there's no variation for it. No variation will be selected. No price is set. User will be asked to pick a variation.
- [x] DFV is "large" and "blue" and URL has `?attribute_pa_size=extra-large`. Selected attributes are "extra-large" and "blue". Then price is $20.

---

*, ** This case actually should be `$30`. But the issue is not in our end. It seems for [WooCommerce](https://github.com/woocommerce/woocommerce/blob/840849ad838cb49b514878d210d0e0d6495cc14f/includes/data-stores/class-wc-product-data-store-cpt.php#L1093-L1174) the position of the attribute pair is more relevant over the exact match of the DFV. I've [created an issue](https://github.com/woocommerce/woocommerce/issues/29726) reporting this on the `woocommerce` repo


