### PR TITLE
Add custom CSS classname to Payment Request button based on its state

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -610,14 +610,18 @@ jQuery( function( $ ) {
 				}
 			});
 			
-			$( document.body ).on( 'wc_stripe_unblock_payment_request_button', function () {
+			$( document.body ).on( 'wc_stripe_unblock_payment_request_button wc_stripe_enable_payment_request_button', function () {
 				wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
 			} );
 			
 			$( document.body ).on( 'wc_stripe_block_payment_request_button', function () {
-				wc_stripe_payment_request.blockPaymentRequestButton( prButton );
+				wc_stripe_payment_request.blockPaymentRequestButton( prButton, 'wc_request_button_is_blocked' );
 			} );
-			
+
+			$( document.body ).on( 'wc_stripe_disable_payment_request_button', function () {
+				wc_stripe_payment_request.blockPaymentRequestButton( prButton, 'wc_request_button_is_disabled' );
+			} );
+
 			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
@@ -686,24 +690,22 @@ jQuery( function( $ ) {
 			}
 		},
 
-		blockPaymentRequestButton: function( prButton ) {
+		blockPaymentRequestButton: function( prButton, cssClassname ) {
 			// check if element isn't already blocked before calling block() to avoid blinking overlay issues
 			// blockUI.isBlocked is either undefined or 0 when element is not blocked
 			if ( $( '#wc-stripe-payment-request-button' ).data( 'blockUI.isBlocked' ) ) {
 				return;
 			}
 
-			$( '#wc-stripe-payment-request-button' ).block( { message: null } );
-			if ( wc_stripe_payment_request.isCustomPaymentRequestButton( prButton ) ) {
-				prButton.addClass( 'is-blocked' );
-			}
+			$( '#wc-stripe-payment-request-button' )
+				.addClass( cssClassname )
+				.block( { message: null } );
 		},
 
 		unblockPaymentRequestButton: function( prButton ) {
-			$( '#wc-stripe-payment-request-button' ).unblock();
-			if ( wc_stripe_payment_request.isCustomPaymentRequestButton( prButton ) ) {
-				prButton.removeClass( 'is-blocked' );
-			}
+			$( '#wc-stripe-payment-request-button' )
+				.removeClass( ['wc_request_button_is_blocked', 'wc_request_button_is_disabled'] )
+				.unblock();
 		},
 
 		/**

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -609,9 +609,17 @@ jQuery( function( $ ) {
 					paymentRequest.show();
 				}
 			});
-
-			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
+			
+			$( document.body ).on( 'wc_stripe_unblock_payment_request_button', function () {
+				wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+			} );
+			
+			$( document.body ).on( 'wc_stripe_block_payment_request_button', function () {
 				wc_stripe_payment_request.blockPaymentRequestButton( prButton );
+			} );
+			
+			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
+				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
 					$.when(
@@ -620,7 +628,7 @@ jQuery( function( $ ) {
 							displayItems: response.displayItems,
 						} )
 					).then( function () {
-						wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					} );
 				});
 			} );
@@ -628,17 +636,17 @@ jQuery( function( $ ) {
 			// Block the payment request button as soon as an "input" event is fired, to avoid sync issues
 			// when the customer clicks on the button before the debounced event is processed.
 			$( '.quantity' ).on( 'input', '.qty', function() {
-				wc_stripe_payment_request.blockPaymentRequestButton( prButton );
+				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 			} );
 
 			$( '.quantity' ).on( 'input', '.qty', wc_stripe_payment_request.debounce( 250, function() {
-				wc_stripe_payment_request.blockPaymentRequestButton( prButton );
+				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 				paymentRequestError = [];
 
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
 					if ( response.error ) {
 						paymentRequestError = [ response.error ];
-						wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					} else {
 						$.when(
 							paymentRequest.update( {
@@ -646,7 +654,7 @@ jQuery( function( $ ) {
 								displayItems: response.displayItems,
 							} )
 						).then( function () {
-							wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+							$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 						});
 					}
 				} );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -611,15 +611,15 @@ jQuery( function( $ ) {
 			});
 			
 			$( document.body ).on( 'wc_stripe_unblock_payment_request_button wc_stripe_enable_payment_request_button', function () {
-				wc_stripe_payment_request.unblockPaymentRequestButton( prButton );
+				wc_stripe_payment_request.unblockPaymentRequestButton();
 			} );
 			
 			$( document.body ).on( 'wc_stripe_block_payment_request_button', function () {
-				wc_stripe_payment_request.blockPaymentRequestButton( prButton, 'wc_request_button_is_blocked' );
+				wc_stripe_payment_request.blockPaymentRequestButton( 'wc_request_button_is_blocked' );
 			} );
 
 			$( document.body ).on( 'wc_stripe_disable_payment_request_button', function () {
-				wc_stripe_payment_request.blockPaymentRequestButton( prButton, 'wc_request_button_is_disabled' );
+				wc_stripe_payment_request.blockPaymentRequestButton( 'wc_request_button_is_disabled' );
 			} );
 
 			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
@@ -690,7 +690,7 @@ jQuery( function( $ ) {
 			}
 		},
 
-		blockPaymentRequestButton: function( prButton, cssClassname ) {
+		blockPaymentRequestButton: function( cssClassname ) {
 			// check if element isn't already blocked before calling block() to avoid blinking overlay issues
 			// blockUI.isBlocked is either undefined or 0 when element is not blocked
 			if ( $( '#wc-stripe-payment-request-button' ).data( 'blockUI.isBlocked' ) ) {
@@ -702,7 +702,7 @@ jQuery( function( $ ) {
 				.block( { message: null } );
 		},
 
-		unblockPaymentRequestButton: function( prButton ) {
+		unblockPaymentRequestButton: function() {
 			$( '#wc-stripe-payment-request-button' )
 				.removeClass( ['wc_request_button_is_blocked', 'wc_request_button_is_disabled'] )
 				.unblock();


### PR DESCRIPTION
# Changes proposed in this Pull Request:
Fixes #1539

This PR is built on top of https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1509 review my commits instead.

Adds a custom classname for each state of the Payment Request button. This is needed for https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1509 to work properly.

The appearance of the button is handled on the active theme. Here we are only adding classnames depending of the state of the button so the theme can be able to differentiate both states and stylize properly. A PR to the `storefront` theme was created to support this new state https://github.com/woocommerce/storefront/pull/1672

# Testing instructions

Within the `woocommerce-stripe-gateway` instance, with Google Payment button enabled, and with the "storefront" theme active.

- Go to a product page
- To trigger a state change on the Payment Request button. Change the amount introducing a new amount or using the caret buttons.
  - (You can also block the button using `jQuery(document.body).trigger('wc_stripe_block_payment_request_button')`)
- Notice the `wc_request_button_is_blocked` is added to `#wc-stripe-payment-request-button` element and removed after the AJAX request is finished
  - If you are able to test with https://github.com/woocommerce/storefront/pull/1672 you will see Payment Request button will be blocked and spinner will be displayed.
- Using the browser's console run the following `jQuery(document.body).trigger('wc_stripe_disable_payment_request_button')`
- Notice the `wc_request_button_is_disabled` is added to `#wc-stripe-payment-request-button` element.
  - If you are able to test with https://github.com/woocommerce/storefront/pull/1672 you will see Payment Request button will be disabled without spinner.
- Using the browser's console run the following `jQuery(document.body).trigger('wc_stripe_enable_payment_request_button')`. Payment Request button will be enabled and `wc_request_button_is_disabled` class will be removed from `#wc-stripe-payment-request-button`.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.