### PR TITLE
Payment Request: Fix shipping calculation for UK and CA postal codes with Apple Pay

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 5.2.0 - 2021-xx-xx =
 * Fix - Use `get_parent` method to avoid accessing `order` subscription property directly.
 * Fix - Orders won't transition to 'Refunded' state if refund can't be created.
+* Fix - Normalize United Kingdom and Canada postal codes for Apple Pay.
 
 = 5.1.0 - 2021-04-07 =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 * Fix - Use `get_parent` method to avoid accessing `order` subscription property directly.
 * Fix - Orders won't transition to 'Refunded' state if refund can't be created.
+* Fix - Normalize United Kingdom and Canada postal codes for Apple Pay.
 
 = 5.1.0 - 2021-04-07 =
 


### PR DESCRIPTION
Fixes #1198

Ported from 1528-gh-Automattic/woocommerce-payments

#### Changes proposed in this Pull Request:

For privacy reasons, Apple Pay redacts the postal code when calculating shipping options and displays only the first 3 characters for Canada and the first 4 characters for UK postal codes. The full postal code is submitted once the order is placed.

There was a bug with UK postal codes specifically, due to the [way WC validates UK postal codes](https://github.com/woocommerce/woocommerce/blob/ec77c3bcc985f26c97b962e53d8f9fb9d355c3cf/includes/class-wc-validation.php#L132), that was preventing it to display wildcard shipping zones when the postal code was redacted from Apple Pay.

#### Changes proposed in this Pull Request

- Fix the UK issue by filling the redacted postal code with `*`, so WC can calculate the shipping options based on up to 4 characters shipping zones.
- Remove the `woocommerce_validate_postcode` filter, which was used when calculating shipping options.

#### Testing instructions

- Ensure your site is served over HTTPS and is publicly accessible.
- Ensure you have a real card added to your Apple Wallet.
- Add a wildcard shipping zone with the following postal code in the UK: `LN10*`. Add a flat rate of $1 to it.
- Go to a product page with shipping in Safari and click the "Buy with Apple Pay" button.
- Add a new shipping address in the United Kingdom with a random city, state and street number, add `LN10 6SH` as the postal code.
- Notice the flat rate of $1 gets added.
- If you try with a postal code of `LN11 6SH`, it should not work.
- For shipping zones in Canada, the same behavior should apply, but you can add only up to 3 characters shipping zones, e.g: `T5T*`. - This is due to the Apple Pay privacy limitation.