### PR TITLE
Add psuedo random option for remote inbox note A/B tests

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -214,6 +214,7 @@ function woocommerce_gateway_stripe() {
 						define( 'WC_STRIPE_INSTALLING', true );
 					}
 
+					add_wcpay_incetives_variant();
 					$this->update_plugin_version();
 				}
 			}
@@ -390,3 +391,18 @@ function woocommerce_gateway_stripe_init() {
 
 	woocommerce_gateway_stripe();
 }
+
+/**
+ * Add wcpay_incentives_variant option for WC Pay's store acquisition experiment v2
+ * P2 post can be found at https://wp.me/paJDYF-1uJ.
+ *
+ * This method can be removed when the experiement is finished.
+ */
+function add_wcpay_incetives_variant() {
+	$config_name = 'wcpay_incentives_variant';
+	if ( false === get_option( $config_name, false ) ) {
+		update_option( $config_name, mt_rand( 1, 5 ), false );
+	}
+}
+
+register_activation_hook( __FILE__, 'add_wcpay_incetives_variant' );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -399,9 +399,9 @@ function woocommerce_gateway_stripe_init() {
  */
 if ( ! function_exists( 'add_woocommerce_inbox_variant' ) ) {
 	function add_woocommerce_inbox_variant() {
-		$config_name = 'woocommerce_inbox_variant_binary';
+		$config_name = 'woocommerce_inbox_variant_assignment';
 		if ( false === get_option( $config_name, false ) ) {
-			update_option( $config_name, wp_rand( 1, 2 ) );
+			update_option( $config_name, wp_rand( 1, 12 ) );
 		}
 	}
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -401,7 +401,7 @@ if ( ! function_exists( 'add_woocommerce_inbox_variant' ) ) {
 	function add_woocommerce_inbox_variant() {
 		$config_name = 'woocommerce_inbox_variant';
 		if ( false === get_option( $config_name, false ) ) {
-			update_option( $config_name, wp_rand( 1, 5 ), false );
+			update_option( $config_name, wp_rand( 1, 5 ) );
 		}
 	}
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -214,7 +214,7 @@ function woocommerce_gateway_stripe() {
 						define( 'WC_STRIPE_INSTALLING', true );
 					}
 
-					add_wcpay_incetives_variant();
+					add_woocommerce_inbox_variant();
 					$this->update_plugin_version();
 				}
 			}
@@ -393,16 +393,16 @@ function woocommerce_gateway_stripe_init() {
 }
 
 /**
- * Add wcpay_incentives_variant option for WC Pay's store acquisition experiment v2
- * P2 post can be found at https://wp.me/paJDYF-1uJ.
+ * Add woocommerce_inbox_variant for the Remote Inbox Notification.
  *
- * This method can be removed when the experiement is finished.
+ * P2 post can be found at https://wp.me/paJDYF-1uJ.
  */
-function add_wcpay_incetives_variant() {
-	$config_name = 'wcpay_incentives_variant';
-	if ( false === get_option( $config_name, false ) ) {
-		update_option( $config_name, mt_rand( 1, 5 ), false );
+if ( ! function_exists( 'add_woocommerce_inbox_variant' ) ) {
+	function add_woocommerce_inbox_variant() {
+		$config_name = 'woocommerce_inbox_variant';
+		if ( false === get_option( $config_name, false ) ) {
+			update_option( $config_name, wp_rand( 1, 5 ), false );
+		}
 	}
 }
-
-register_activation_hook( __FILE__, 'add_wcpay_incetives_variant' );
+register_activation_hook( __FILE__, 'add_woocommerce_inbox_variant' );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -399,9 +399,9 @@ function woocommerce_gateway_stripe_init() {
  */
 if ( ! function_exists( 'add_woocommerce_inbox_variant' ) ) {
 	function add_woocommerce_inbox_variant() {
-		$config_name = 'woocommerce_inbox_variant';
+		$config_name = 'woocommerce_inbox_variant_binary';
 		if ( false === get_option( $config_name, false ) ) {
-			update_option( $config_name, wp_rand( 1, 5 ) );
+			update_option( $config_name, wp_rand( 1, 2 ) );
 		}
 	}
 }


### PR DESCRIPTION
Add WooCommerce inbox variant option.

#Changes proposed in this Pull Request:

P2: paJDYF-1uJ
Fixes https://github.com/Automattic/woocommerce.com/issues/10117

Description: This PR adds a new option `woocommerce_inbox_variant_assignment ` for the Remote Inbox Notification on plugin activation or upgrade.

* This PR does not clean up `woocommerce_inbox_variant_assignment ` option on uninstallation so that we don't create a different value in case user decides to install the plugin again.  


# Testing instructions

**Testing Activation**
1. Ensure `woocommerce_inbox_variant_assignment ` option does not exist. If it does, delete it before testing.
2. Deactivate stripe plugin then activate it again
3. `woocommerce_inbox_variant_assignment` option should be created.
4. Repeat step 2 and ensure that the value of `woocommerce_inbox_variant_assignment` does not change.

**Testing Upgrade**
1. Ensure `woocommerce_inbox_variant_assignment ` option does not exist. If it does, delete it before testing.
2. Change the value of `wc_stripe_version` option to something lower than the current value.
3. Navigate to Plugins -> Installed plugins
4. `woocommerce_inbox_variant_assignment ` option should be created.