### PR TITLE
Address deprecations introduced in WC Admin v1.7.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Subscription sign-up fees not included in total for Payment Request Button.
 * Add - Support for Credit Card payments (incl. 3DS payments) via WooCommerce Blocks; limited to WooCommerce Core product types.
 * Add - Support for payments (incl. 3DS payments) paid via Payment Request Buttons in WooCommerce Blocks; limited to WooCommerce Core product types.
+* Fix - Choose the appropriate version of the WooCommerce Admin Notes API based on which API is available.
 
 = 5.1.0 - 2021-04-07 =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -1,10 +1,8 @@
 <?php
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
 
 /**
  * Class that adds Inbox notifications.
@@ -49,11 +47,8 @@ class WC_Stripe_Inbox_Notes {
 	 * Manage notes to show after Apple Pay domain verification.
 	 */
 	public static function notify_on_apple_pay_domain_verification( $verification_complete ) {
-		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
-			return;
-		}
-
-		if ( ! class_exists( 'WC_Data_Store' ) ) {
+		$admin_notes_class = WC_Stripe_Woo_Compat_Utils::get_notes_class();
+		if ( ! class_exists( $admin_notes_class ) || ! class_exists( 'WC_Data_Store' ) ) {
 			return;
 		}
 
@@ -63,7 +58,7 @@ class WC_Stripe_Inbox_Notes {
 			// Delete all previously created, soft deleted and unactioned failure notes (Legacy).
 			while ( ! empty( $failure_note_ids ) ) {
 				$note_id = array_pop( $failure_note_ids );
-				$note    = WC_Admin_Notes::get_note( $note_id );
+				$note    = $admin_notes_class::get_note( $note_id );
 				$note->delete();
 			}
 		} catch ( Exception $e ) {} // @codingStandardsIgnoreLine
@@ -121,10 +116,11 @@ class WC_Stripe_Inbox_Notes {
 		}
 
 		try {
-			$note = new WC_Admin_Note();
+			$admin_note_class = WC_Stripe_Woo_Compat_Utils::get_note_class();
+			$note             = new $admin_note_class();
 			$note->set_title( self::get_success_title() );
 			$note->set_content( __( 'Now that you accept Apple Pay® with Stripe, you can increase conversion rates by letting your customers know that Apple Pay is available. Here’s a marketing guide to help you get started.', 'woocommerce-gateway-stripe' ) );
-			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_MARKETING );
+			$note->set_type( $admin_note_class::E_WC_ADMIN_NOTE_MARKETING );
 			$note->set_name( self::SUCCESS_NOTE_NAME );
 			$note->set_source( 'woocommerce-gateway-stripe' );
 			$note->add_action(
@@ -141,10 +137,11 @@ class WC_Stripe_Inbox_Notes {
 	 */
 	public static function create_failure_note() {
 		try {
-			$note = new WC_Admin_Note();
+			$admin_note_class = WC_Stripe_Woo_Compat_Utils::get_note_class();
+			$note             = new $admin_note_class();
 			$note->set_title( __( 'Apple Pay domain verification needed', 'woocommerce-gateway-stripe' ) );
 			$note->set_content( __( 'The WooCommerce Stripe Gateway extension attempted to perform domain verification on behalf of your store, but was unable to do so. This must be resolved before Apple Pay can be offered to your customers.', 'woocommerce-gateway-stripe' ) );
-			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_type( $admin_note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 			$note->set_name( self::FAILURE_NOTE_NAME );
 			$note->set_source( 'woocommerce-gateway-stripe' );
 			$note->add_action(
@@ -162,11 +159,8 @@ class WC_Stripe_Inbox_Notes {
 	 * on/about 2020 Dec 22.
 	 */
 	public static function cleanup_campaign_2020() {
-		if ( ! class_exists( 'Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes' ) ) {
-			return;
-		}
-
-		if ( ! class_exists( 'WC_Data_Store' ) ) {
+		$admin_notes_class = WC_Stripe_Woo_Compat_Utils::get_notes_class();
+		if ( ! class_exists( $admin_notes_class ) || ! class_exists( 'WC_Data_Store' ) ) {
 			return;
 		}
 
@@ -184,10 +178,11 @@ class WC_Stripe_Inbox_Notes {
 
 		$deleted_an_unactioned_note = false;
 
+		$admin_note_class = WC_Stripe_Woo_Compat_Utils::get_note_class();
 		foreach ( (array) $note_ids as $note_id ) {
 			try {
-				$note = new WC_Admin_Note( $note_id );
-				if ( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED == $note->get_status() ) {
+				$note = new $admin_note_class( $note_id );
+				if ( $admin_note_class::E_WC_ADMIN_NOTE_UNACTIONED == $note->get_status() ) {
 					$note->delete();
 					$deleted_an_unactioned_note = true;
 				}

--- a/includes/compat/class-wc-stripe-woo-compat-utils.php
+++ b/includes/compat/class-wc-stripe-woo-compat-utils.php
@@ -1,0 +1,41 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\Notes;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Notes;
+
+/**
+ * Util class for handling compatibilities with different versions of WooCommerce core.
+ */
+class WC_Stripe_Woo_Compat_Utils {
+	/**
+	 * Return non-deprecated class for instantiating WC-Admin notes.
+	 *
+	 * @return string
+	 */
+	public static function get_note_class() {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+			return Note::class;
+		}
+
+		return WC_Admin_Note::class;
+	}
+
+	/**
+	 * Return non-deprecated class for instantiating WC-Admin notes.
+	 *
+	 * @return string
+	 */
+	public static function get_notes_class() {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Notes' ) ) {
+			return Notes::class;
+		}
+
+		return WC_Admin_Notes::class;
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Subscription sign-up fees not included in total for Payment Request Button.
 * Add - Support for Credit Card payments (incl. 3DS payments) via WooCommerce Blocks; limited to WooCommerce Core product types.
 * Add - Support for payments (incl. 3DS payments) paid via Payment Request Buttons in WooCommerce Blocks; limited to WooCommerce Core product types.
+* Fix - Choose the appropriate version of the WooCommerce Admin Notes API based on which API is available.
 
 = 5.1.0 - 2021-04-07 =
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -156,6 +156,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-multibanco.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-payment-request.php';
 				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-subs-compat.php';
+				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-woo-compat-utils.php';
 				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-sepa-subs-compat.php';
 				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect.php';
 				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect-api.php';


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1489
Fixes #1489 

Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.

Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.


# Testing instructions


- Navigate to the Gateway configuration page
- Configure the gateway to use live Stripe publishable + secret keys.
- Disable the Payment Request buttons setting and then re-enable it to trigger an Apple Pay verification error inbox note.
- Ensure docker/logs/apache2/error.log has no new entries mentioning 'is deprecated since version 1.7.0'.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
