### PR TITLE
Add partner ID to API request header and exclude from filter

### DIFF
--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -81,15 +81,19 @@ class WC_Stripe_API {
 		$user_agent = self::get_user_agent();
 		$app_info   = $user_agent['application'];
 
-		return apply_filters(
+		$headers = apply_filters(
 			'woocommerce_stripe_request_headers',
 			[
-				'Authorization'              => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
-				'Stripe-Version'             => self::STRIPE_API_VERSION,
-				'User-Agent'                 => $app_info['name'] . '/' . $app_info['version'] . ' (' . $app_info['url'] . ')',
-				'X-Stripe-Client-User-Agent' => wp_json_encode( $user_agent ),
+				'Authorization'  => 'Basic ' . base64_encode( self::get_secret_key() . ':' ),
+				'Stripe-Version' => self::STRIPE_API_VERSION,
 			]
 		);
+
+		// These headers should not be overridden for this gateway.
+		$headers['User-Agent']                 = $app_info['name'] . '/' . $app_info['version'] . ' (' . $app_info['url'] . ')';
+		$headers['X-Stripe-Client-User-Agent'] = wp_json_encode( $user_agent );
+
+		return $headers;
 	}
 
 	/**

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -57,9 +57,10 @@ class WC_Stripe_API {
 	 */
 	public static function get_user_agent() {
 		$app_info = [
-			'name'    => 'WooCommerce Stripe Gateway',
-			'version' => WC_STRIPE_VERSION,
-			'url'     => 'https://woocommerce.com/products/stripe/',
+			'name'       => 'WooCommerce Stripe Gateway',
+			'version'    => WC_STRIPE_VERSION,
+			'url'        => 'https://woocommerce.com/products/stripe/',
+			'partner_id' => 'pp_partner_EYuSt9peR0WTMg',
 		];
 
 		return [


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1536

# Changes proposed in this Pull Request:

Add user agent headers _after_ `woocommerce_stripe_request_headers` filter is applied, since it is used for referral attribution and should not be modifiable in this way (props @v18 for this commit). Also, include partner ID in the header's application info.

# Testing instructions

Add a filter on `woocommerce_stripe_request_headers` that sets (or unsets) the user agent headers – in `trunk`, the user agent headers will be modified but in this branch they should not be. This can be verified by logging the headers, and making a request to the API (e.g. by checking out with Stripe payment method). [See [testing example](https://github.com/woocommerce/woocommerce-gateway-stripe/compare/update/user-agent-header...update/user-agent-header-testing).]

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
