### PR TITLE
Fix subscription sign-up fees not showing up for Payment Request

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Use `get_parent` method to avoid accessing `order` subscription property directly.
 * Fix - Orders won't transition to 'Refunded' state if refund can't be created.
 * Fix - Normalize United Kingdom and Canada postal codes for Apple Pay.
+* Fix - Subscription sign-up fees not included in total for Payment Request Button.
 
 = 5.1.0 - 2021-04-07 =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -305,7 +305,7 @@ class WC_Stripe_Payment_Request {
 	 */
 	public function get_product_price( $product ) {
 		$product_price = $product->get_price();
-		// Add sign-up fees to product price in case of subscriptions.
+		// Add subscription sign-up fees to product price.
 		if ( 'subscription' === $product->get_type() && class_exists( 'WC_Subscriptions_Product' ) ) {
 			$product_price = $product->get_price() + WC_Subscriptions_Product::get_sign_up_fee( $product );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Use `get_parent` method to avoid accessing `order` subscription property directly.
 * Fix - Orders won't transition to 'Refunded' state if refund can't be created.
 * Fix - Normalize United Kingdom and Canada postal codes for Apple Pay.
+* Fix - Subscription sign-up fees not included in total for Payment Request Button.
 
 = 5.1.0 - 2021-04-07 =
 


### PR DESCRIPTION
Fixes #1459

# Changes proposed in this Pull Request:

- Add `get_product_price` method to calculate product totals, considering sign-up fees, on the product page.

# Testing instructions

- Ensure Payment Request Button is enabled under **WooCommerce > Settings > Payments > Stripe**.
- Install WooCommerce Subscriptions.
- Create a subscription product similar to the one from [this screenshot](https://camo.githubusercontent.com/9f5809e1c37c126d15c3a006d43adf061a3ebf2e17b92674f8594f01209ab827/68747470733a2f2f642e70722f692f484439557a632b).
- Go to that subscription product page.
- Notice the total price is correct.
