### PR TITLE
Update woorelease config to include version replace paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,12 @@
     "node": ">=8.9.3",
     "npm": ">=5.5.1"
   },
-  "config": {
-    "wp_org_slug": "woocommerce-gateway-stripe"
+  "woorelease": {
+    "wp_org_slug": "woocommerce-gateway-stripe",
+    "version_replace_paths": [
+      "includes",
+      "templates",
+      "woocommerce-gateway-stripe.php"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "node": ">=8.9.3",
     "npm": ">=5.5.1"
   },
-  "woorelease": {
+  "config": {
     "wp_org_slug": "woocommerce-gateway-stripe",
     "version_replace_paths": [
       "includes",


### PR DESCRIPTION
# Changes proposed in this Pull Request:

This PR updates the release config for woorelease to replace `@since x.x.x` and `@version x.x.x` based on 310-gh-woocommerce/woorelease

# Testing instructions

- Create a test branch based on this one and change some PHP files under `includes` with `@since x.x.x` or `@version x.x.x`.
- Clone woorelease and run `npm run build`.
- Extract `woorelease.phar` from `woorelease.zip` and replace that with your current `wr` path.
- Run `wr simulate --product_version=5.2.0 https://github.com/woocommerce/woocommerce-gateway-stripe/tree/{YOUR_BRANCH_NAME}` (replace with your branch name and the desired new version).
- `cd` into the temporary folder logged at `Cloned to temporary folder: /var/folders/fb/.../woocommerce-gateway-stripe`.
- Run `git diff` and notice `x.x.x` was replaced with the new version.
