### PR TITLE
Add missing billing information to the stripe customer object during checkout with the Checkout Block

### DIFF
--- a/client/blocks/credit-card/use-payment-processing.js
+++ b/client/blocks/credit-card/use-payment-processing.js
@@ -133,6 +133,11 @@ export const usePaymentProcessing = (
 					meta: {
 						paymentMethodData: {
 							stripe_source: response.source.id,
+							// The billing information here is relevant to properly create the
+							// Stripe Customer object.
+							billing_email: ownerInfo.email,
+							billing_first_name: billingData?.first_name ?? '',
+							billing_last_name: billingData?.last_name ?? '',
 							paymentMethod: PAYMENT_METHOD_NAME,
 							paymentRequestType: 'cc',
 						},


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1547

This PR adds the necessary payment information to the checkout request to ensure the Stripe Customer object is filled with the information available instead of empty strings.

_Before:_

![image](https://user-images.githubusercontent.com/13835680/118528432-d92fc880-b731-11eb-9ecc-16c714b107a0.png)


_After:_

![image](https://user-images.githubusercontent.com/13835680/118528289-af76a180-b731-11eb-9f96-0509ef812d41.png)


# Testing instructions

**Make sure you're not logged into an account on your site during testing.**

1. Install the `WooCommerce Blocks` plugin
2. Change your `Checkout` page so that it uses the `Checkout` block.
1. `git checkout trunk && npm run build:webpack`
2. Make a payment with a new credit card
3. Observe that in your [Stripe dashboard](https://dashboard.stripe.com/test/payments) the payment description will say `Name: , Guest`.
4. `git checkout fix/1547-missing-email-and-name-variables-in-stripe && npm run build:webpack`
5. Make a payment with a new credit card (can be the same as before, the key is entering the new card information)
6. Observe that in your [Stripe dashboard](https://dashboard.stripe.com/test/payments) the payment description will now show the customer's email address, e.g. `example@example.com`. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

