### PR TITLE
Add missing changelog entries for the 5.2.0 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,13 +6,17 @@
 * Fix - Normalize United Kingdom and Canada postal codes for Apple Pay.
 * Fix - Subscription sign-up fees not included in total for Payment Request Button.
 * Fix - Reduce requests sent to server from stripe settings page.
+* Fix - Choose the appropriate version of the WooCommerce Admin Notes API based on which API is available.
+* Fix - Customer information is now correctly displayed in the Stripe Payments Dashboard when a new customer checks out through the WooCommerce Checkout Block.
+* Fix - Pass customer language/locale to Stripe upon creation or modification.
+* Fix - Initial price for Variable Products is now correctly shown when a Payment Request is started.
 * Add - Support for Credit Card payments (incl. 3DS payments) via WooCommerce Blocks; limited to WooCommerce Core product types.
 * Add - Support for payments (incl. 3DS payments) paid via Payment Request Buttons in WooCommerce Blocks; limited to WooCommerce Core product types.
-* Fix - Choose the appropriate version of the WooCommerce Admin Notes API based on which API is available.
+* Add - Support for custom and branded Payment Request Buttons when using the Cart and Checkout blocks.
+* Tweak - Should customer opt to save their card, the card is now saved after a payment has been confirmed.
 
 = 5.1.0 - 2021-04-07 =
 * Fix - Don't attempt to submit level 3 data for non-US merchants.
-* Fix - Pass customer language/locale to Stripe upon creation or modification.
 * Fix - Hide Payment Request Buttons when guest checkout is disabled.
 * Fix - Match Payment Request states with WooCommerce states.
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,9 +132,15 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Orders won't transition to 'Refunded' state if refund can't be created.
 * Fix - Normalize United Kingdom and Canada postal codes for Apple Pay.
 * Fix - Subscription sign-up fees not included in total for Payment Request Button.
+* Fix - Reduce requests sent to server from stripe settings page.
+* Fix - Choose the appropriate version of the WooCommerce Admin Notes API based on which API is available.
+* Fix - Customer information is now correctly displayed in the Stripe Payments Dashboard when a new customer checks out through the WooCommerce Checkout Block.
+* Fix - Pass customer language/locale to Stripe upon creation or modification.
+* Fix - Initial price for Variable Products is now correctly shown when a Payment Request is started.
 * Add - Support for Credit Card payments (incl. 3DS payments) via WooCommerce Blocks; limited to WooCommerce Core product types.
 * Add - Support for payments (incl. 3DS payments) paid via Payment Request Buttons in WooCommerce Blocks; limited to WooCommerce Core product types.
-* Fix - Choose the appropriate version of the WooCommerce Admin Notes API based on which API is available.
+* Add - Support for custom and branded Payment Request Buttons when using the Cart and Checkout blocks.
+* Tweak - Should customer opt to save their card, the card is now saved after a payment has been confirmed.
 
 = 5.1.0 - 2021-04-07 =
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Added some missing changelog entries in preparation for releasing v5.2.0.


# Testing instructions

N/A

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
