### PR TITLE
Update Payment Request button after adding product to the cart

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -5,20 +5,13 @@ jQuery( function( $ ) {
 	var stripe = Stripe( wc_stripe_payment_request_params.stripe.key, {
 		locale: typeof wc_stripe_params !== 'undefined' ? wc_stripe_params.stripe_locale : 'auto',
 	} ),
-		paymentRequestType;
+		paymentRequestType,
+		hasShippingAddress = false;
 
 	/**
 	 * Object to handle Stripe payment forms.
 	 */
 	var wc_stripe_payment_request = {
-		/**
-		 * Indicates if the user has picked or entered a shipping address on the payment dialog.
-		 *
-		 * @since 5.3.0
-		 * @type {boolean}
-		 */
-		hasShippingAddress: false,
-
 		/**
 		 * Get WC AJAX endpoint URL.
 		 *
@@ -283,7 +276,7 @@ jQuery( function( $ ) {
 				product_id: product_id,
 				qty: $( '.quantity .qty' ).val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
-				has_shipping_address: wc_stripe_payment_request.hasShippingAddress,
+				has_shipping_address: hasShippingAddress,
 			};
 
 			// add addons data to the POST body
@@ -376,7 +369,7 @@ jQuery( function( $ ) {
 
 				// Possible statuses success, fail, invalid_payer_name, invalid_payer_email, invalid_payer_phone, invalid_shipping_address.
 				paymentRequest.on( 'shippingaddresschange', function( evt ) {
-					wc_stripe_payment_request.hasShippingAddress = true;
+					hasShippingAddress = true;
 
 					$.when( wc_stripe_payment_request.updateShippingOptions( evt.shippingAddress ) ).then( function( response ) {
 						evt.updateWith( { status: response.result, shippingOptions: response.shipping_options, total: response.total, displayItems: response.displayItems } );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -576,7 +576,7 @@ jQuery( function( $ ) {
 
 		attachPaymentRequestButtonEventListeners: function( prButton, paymentRequest ) {
 			// First, mark the body so we know a payment request button was used.
-			// This way error handling can any display errors in the most appropriate place.
+			// This way error handling can display any error in the most appropriate place.
 			prButton.on( 'click', function ( evt ) {
 				$( 'body' ).addClass( 'woocommerce-stripe-prb-clicked' );
 			});

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -12,14 +12,6 @@ jQuery( function( $ ) {
 	 */
 	var wc_stripe_payment_request = {
 		/**
-		 * Indicates if the user has picked or entered a shipping address on the payment dialog.
-		 *
-		 * @since 5.3.0
-		 * @type {boolean}
-		 */
-		hasShippingAddress: false,
-
-		/**
 		 * Get WC AJAX endpoint URL.
 		 *
 		 * @param  {String} endpoint Endpoint.
@@ -285,7 +277,6 @@ jQuery( function( $ ) {
 				product_id: product_id,
 				qty: $( '.quantity .qty' ).val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
-				has_shipping_address: wc_stripe_payment_request.hasShippingAddress,
 			};
 
 			// add addons data to the POST body
@@ -378,8 +369,6 @@ jQuery( function( $ ) {
 
 				// Possible statuses success, fail, invalid_payer_name, invalid_payer_email, invalid_payer_phone, invalid_shipping_address.
 				paymentRequest.on( 'shippingaddresschange', function( evt ) {
-					wc_stripe_payment_request.hasShippingAddress = true;
-
 					$.when( wc_stripe_payment_request.updateShippingOptions( evt.shippingAddress ) ).then( function( response ) {
 						evt.updateWith( { status: response.result, shippingOptions: response.shipping_options, total: response.total, displayItems: response.displayItems } );
 					} );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -386,9 +386,9 @@ jQuery( function( $ ) {
 
 				// Possible statuses success, fail, invalid_payer_name, invalid_payer_email, invalid_payer_phone, invalid_shipping_address.
 				paymentRequest.on( 'shippingaddresschange', function( evt ) {
+					// TODO: Check if this is needed
 					wc_stripe_payment_request.shippingPending = false;
 
-					// This probably will no longer necessary since we will make the call to `wc_stripe_add_to_cart` anyways
 					$.when( wc_stripe_payment_request.updateShippingOptions( paymentDetails, evt.shippingAddress ) ).then( function( response ) {
 						evt.updateWith( { status: response.result, shippingOptions: response.shipping_options, total: response.total, displayItems: response.displayItems } );
 					} );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -11,7 +11,14 @@ jQuery( function( $ ) {
 	 * Object to handle Stripe payment forms.
 	 */
 	var wc_stripe_payment_request = {
+		/**
+		 * Indicates wether the user needs to pick or enter a shipping address on the payment dialog.
+		 *
+		 * @since 5.3.0
+		 * @type {boolean}
+		 */
 		shippingPending: true,
+
 		/**
 		 * Get WC AJAX endpoint URL.
 		 *

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -216,7 +216,6 @@ jQuery( function( $ ) {
 		/**
 		 * Update shipping options.
 		 *
-		 * @param {Object}         details Payment details.
 		 * @param {PaymentAddress} address Shipping address.
 		 */
 		updateShippingOptions: function( address ) {
@@ -242,10 +241,9 @@ jQuery( function( $ ) {
 		/**
 		 * Updates the shipping price and the total based on the shipping option.
 		 *
-		 * @param {Object}   details        The line items and shipping options.
 		 * @param {String}   shippingOption User's preferred shipping option to use for shipping price calculations.
 		 */
-		updateShippingDetails: function( details, shippingOption ) {
+		updateShippingDetails: function( shippingOption ) {
 			var data = {
 				security: wc_stripe_payment_request_params.nonce.update_shipping,
 				shipping_method: [ shippingOption.id ],

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -34,7 +34,8 @@ jQuery( function( $ ) {
 		getCartDetails: function() {
 			var data = {
 				security: wc_stripe_payment_request_params.nonce.payment,
-				shipping_pending: wc_stripe_payment_request.shippingPending,
+				// In the cart page a shipping amount is always returned. This keeps previous behavior.
+				shipping_pending: false,
 			};
 
 			$.ajax( {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -278,7 +278,8 @@ jQuery( function( $ ) {
 				security: wc_stripe_payment_request_params.nonce.add_to_cart,
 				product_id: product_id,
 				qty: $( '.quantity .qty' ).val(),
-				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : []
+				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
+				shipping_pending: wc_stripe_payment_request.shippingPending,
 			};
 
 			// add addons data to the POST body

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -359,7 +359,7 @@ jQuery( function( $ ) {
 					country: cart.order_data.country_code,
 					requestPayerName: true,
 					requestPayerEmail: true,
-					requestPayerPhone: wc_stripe_payment_request_params.checkout.needs_payer_phone, // TODO: This can be moved to the ajax request
+					requestPayerPhone: cart.needs_payer_phone,
 					requestShipping: cart.shipping_required ? true : false, // TODO: This can also be move to the ajax request
 					displayItems: cart.order_data.displayItems
 				};

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -26,7 +26,8 @@ jQuery( function( $ ) {
 
 		getCartDetails: function() {
 			var data = {
-				security: wc_stripe_payment_request_params.nonce.payment
+				security: wc_stripe_payment_request_params.nonce.payment,
+				shipping_pending: wc_stripe_payment_request.shippingPending,
 			};
 
 			$.ajax( {
@@ -353,8 +354,8 @@ jQuery( function( $ ) {
 					country: cart.order_data.country_code,
 					requestPayerName: true,
 					requestPayerEmail: true,
-					requestPayerPhone: wc_stripe_payment_request_params.checkout.needs_payer_phone,
-					requestShipping: cart.shipping_required ? true : false,
+					requestPayerPhone: wc_stripe_payment_request_params.checkout.needs_payer_phone, // TODO: This can be moved to the ajax request
+					requestShipping: cart.shipping_required ? true : false, // TODO: This can also be move to the ajax request
 					displayItems: cart.order_data.displayItems
 				};
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -579,7 +579,6 @@ jQuery( function( $ ) {
 				// First check if product can be added to cart.
 				var addToCartButton = $( '.single_add_to_cart_button' );
 				if ( addToCartButton.is( '.disabled' ) ) {
-					evt.preventDefault(); // Prevent showing payment request modal.
 					if ( addToCartButton.is( '.wc-variation-is-unavailable' ) ) {
 						window.alert( wc_add_to_cart_variation_params.i18n_unavailable_text );
 					} else if ( addToCartButton.is( '.wc-variation-selection-needed' ) ) {
@@ -589,7 +588,6 @@ jQuery( function( $ ) {
 				}
 
 				if ( 0 < paymentRequestError.length ) {
-					evt.preventDefault();
 					window.alert( paymentRequestError );
 					$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					return;

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -275,6 +275,7 @@ jQuery( function( $ ) {
 				product_id: product_id,
 				qty: $( '.quantity .qty' ).val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
+				has_shipping_address: wc_stripe_payment_request.hasShippingAddress,
 			};
 
 			// add addons data to the POST body

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -663,6 +663,8 @@ jQuery( function( $ ) {
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 				paymentRequestError = [];
 
+				// TODO: This request seems unnecesary since we will add the product(s) to the cart when the user clicks the PRB.
+				// Let's remove it after confirm removing it is accepted behavior.
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
 					if ( response.error ) {
 						paymentRequestError = [ response.error ];

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -569,8 +569,6 @@ jQuery( function( $ ) {
 		},
 
 		attachProductPageEventListeners: function( prButton, paymentRequest ) {
-			var paymentRequestError = [];
-
 			prButton.on( 'click', function ( evt ) {
 				evt.preventDefault(); // Prevent showing payment request modal.
 
@@ -584,12 +582,6 @@ jQuery( function( $ ) {
 					} else if ( addToCartButton.is( '.wc-variation-selection-needed' ) ) {
 						window.alert( wc_add_to_cart_variation_params.i18n_make_a_selection_text );
 					}
-					return;
-				}
-
-				if ( 0 < paymentRequestError.length ) {
-					window.alert( paymentRequestError );
-					$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					return;
 				}
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -25,7 +25,7 @@ jQuery( function( $ ) {
 
 		getCartDetails: function() {
 			var data = {
-				security: wc_stripe_payment_request_params.nonce.payment,
+				security: wc_stripe_payment_request_params.nonce.payment
 			};
 
 			$.ajax( {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -585,20 +585,20 @@ jQuery( function( $ ) {
 					return;
 				}
 
-				wc_stripe_payment_request.addToCart().then(function (response) {
+				wc_stripe_payment_request.addToCart().then( function( response ) {
 					if ( response.error ) {
 						window.alert( response.error );
 						return;
 					}
 
-					paymentRequest.update({
+					paymentRequest.update( {
 						total: response.total,
 						displayItems: response.displayItems,
-					});
+					} );
 					paymentRequest.show();
-				}).always(function() {
+				} ).always( function() {
 					$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
-				});
+				} );
 			});
 
 			$( document.body ).on( 'wc_stripe_unblock_payment_request_button wc_stripe_enable_payment_request_button', function () {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -373,7 +373,7 @@ jQuery( function( $ ) {
 				} );
 
 				paymentRequest.on( 'shippingoptionchange', function( evt ) {
-					$.when( wc_stripe_payment_request.updateShippingDetails( paymentDetails, evt.shippingOption ) ).then( function( response ) {
+					$.when( wc_stripe_payment_request.updateShippingDetails( evt.shippingOption ) ).then( function( response ) {
 						if ( 'success' === response.result ) {
 							evt.updateWith( { status: 'success', total: response.total, displayItems: response.displayItems } );
 						}

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -322,13 +322,10 @@ jQuery( function( $ ) {
 		 * @version 4.8.0
 		 */
 		startPaymentRequest: function( cart ) {
-			var paymentDetails,
-				options;
+			var options;
 
 			if ( wc_stripe_payment_request_params.is_product_page ) {
 				options = wc_stripe_payment_request.getRequestOptionsFromLocal();
-
-				paymentDetails = options;
 			} else {
 				options = {
 					total: cart.total,
@@ -340,8 +337,6 @@ jQuery( function( $ ) {
 					requestShipping: cart.requestShipping,
 					displayItems: cart.displayItems
 				};
-
-				paymentDetails = cart.order_data;
 			}
 
 			// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -597,6 +597,7 @@ jQuery( function( $ ) {
 
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
+				// TODO: Check if this block still relevant.
 				// First check if product can be added to cart.
 				var addToCartButton = $( '.single_add_to_cart_button' );
 				if ( addToCartButton.is( '.disabled' ) ) {
@@ -612,10 +613,17 @@ jQuery( function( $ ) {
 				if ( 0 < paymentRequestError.length ) {
 					evt.preventDefault();
 					window.alert( paymentRequestError );
+					$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					return;
 				}
 
 				wc_stripe_payment_request.addToCart().then(function (response) {
+					if ( response.error ) {
+						window.alert( response.error );
+						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+						return;
+					}
+
 					paymentRequest.update({
 						total: response.total,
 						displayItems: response.displayItems,

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -12,6 +12,14 @@ jQuery( function( $ ) {
 	 */
 	var wc_stripe_payment_request = {
 		/**
+		 * Indicates if the user has picked or entered a shipping address on the payment dialog.
+		 *
+		 * @since 5.3.0
+		 * @type {boolean}
+		 */
+		hasShippingAddress: false,
+
+		/**
 		 * Get WC AJAX endpoint URL.
 		 *
 		 * @param  {String} endpoint Endpoint.
@@ -368,6 +376,8 @@ jQuery( function( $ ) {
 
 				// Possible statuses success, fail, invalid_payer_name, invalid_payer_email, invalid_payer_phone, invalid_shipping_address.
 				paymentRequest.on( 'shippingaddresschange', function( evt ) {
+					wc_stripe_payment_request.hasShippingAddress = true;
+
 					$.when( wc_stripe_payment_request.updateShippingOptions( evt.shippingAddress ) ).then( function( response ) {
 						evt.updateWith( { status: response.result, shippingOptions: response.shipping_options, total: response.total, displayItems: response.displayItems } );
 					} );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -328,8 +328,6 @@ jQuery( function( $ ) {
 				requestPayerName: true,
 				requestPayerEmail: true,
 				requestPayerPhone: wc_stripe_payment_request_params.checkout.needs_payer_phone,
-				requestShipping: wc_stripe_payment_request_params.product.requestShipping,
-				displayItems: wc_stripe_payment_request_params.product.displayItems
 			};
 		},
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -669,7 +669,6 @@ jQuery( function( $ ) {
 			} );
 
 			$( '.quantity' ).on( 'input', '.qty', wc_stripe_payment_request.debounce( 250, function() {
-				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 				paymentRequestError = [];
 
 				// TODO: This request seems unnecesary since we will add the product(s) to the cart when the user clicks the PRB.

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -11,6 +11,7 @@ jQuery( function( $ ) {
 	 * Object to handle Stripe payment forms.
 	 */
 	var wc_stripe_payment_request = {
+		shippingPending: true,
 		/**
 		 * Get WC AJAX endpoint URL.
 		 *
@@ -230,6 +231,7 @@ jQuery( function( $ ) {
 				address_2: typeof address.addressLine[1] === 'undefined' ? '' : address.addressLine[1],
 				payment_request_type: paymentRequestType,
 				is_product_page: wc_stripe_payment_request_params.is_product_page,
+				shipping_pending: wc_stripe_payment_request.shippingPending,
 			};
 
 			return $.ajax( {
@@ -383,6 +385,9 @@ jQuery( function( $ ) {
 
 				// Possible statuses success, fail, invalid_payer_name, invalid_payer_email, invalid_payer_phone, invalid_shipping_address.
 				paymentRequest.on( 'shippingaddresschange', function( evt ) {
+					wc_stripe_payment_request.shippingPending = false;
+
+					// This probably will no longer necessary since we will make the call to `wc_stripe_add_to_cart` anyways
 					$.when( wc_stripe_payment_request.updateShippingOptions( paymentDetails, evt.shippingAddress ) ).then( function( response ) {
 						evt.updateWith( { status: response.result, shippingOptions: response.shipping_options, total: response.total, displayItems: response.displayItems } );
 					} );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -453,7 +453,6 @@ jQuery( function( $ ) {
 			} );
 		},
 
-
 		/**
 		 * Creates a wrapper around a function that ensures a function can not
 		 * called in rappid succesion. The function can only be executed once and then agin after
@@ -742,7 +741,7 @@ jQuery( function( $ ) {
 		 */
 		init: function() {
 			if ( wc_stripe_payment_request_params.is_product_page ) {
-				wc_stripe_payment_request.startPaymentRequest( '' );
+				wc_stripe_payment_request.startPaymentRequest();
 			} else {
 				wc_stripe_payment_request.getCartDetails();
 			}

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -315,19 +315,6 @@ jQuery( function( $ ) {
 			} );
 		},
 
-		clearCart: function() {
-			var data = {
-					'security': wc_stripe_payment_request_params.nonce.clear_cart
-				};
-
-			return $.ajax( {
-				type:    'POST',
-				data:    data,
-				url:     wc_stripe_payment_request.getAjaxURL( 'clear_cart' ),
-				success: function( response ) {}
-			} );
-		},
-
 		getRequestOptionsFromLocal: function() {
 			return {
 				total: wc_stripe_payment_request_params.product.total,

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -588,7 +588,6 @@ jQuery( function( $ ) {
 				wc_stripe_payment_request.addToCart().then(function (response) {
 					if ( response.error ) {
 						window.alert( response.error );
-						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 						return;
 					}
 

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -44,19 +44,17 @@ const paymentRequestPaymentMethod = {
 			// show the Payment Request Button or not. This is necessary because a browser might be
 			// able to load the Stripe JS object, but not support Payment Requests.
 			const fakeCart = {
-				order_data: {
-					total: {
-						label: 'Total',
-						amount: parseInt(
-							cartData?.cartTotals?.total_price ?? 0,
-							10
-						),
-						pending: true,
-					},
-					currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
-					country_code: getSetting( 'baseLocation', {} )?.country,
-					displayItems: [],
+				total: {
+					label: 'Total',
+					amount: parseInt(
+						cartData?.cartTotals?.total_price ?? 0,
+						10
+					),
+					pending: true,
 				},
+				currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
+				country_code: getSetting( 'baseLocation', {} )?.country,
+				displayItems: [],
 				shipping_required: false,
 			};
 			const paymentRequest = createPaymentRequestUsingCart(

--- a/client/blocks/stripe-utils/utils.js
+++ b/client/blocks/stripe-utils/utils.js
@@ -57,14 +57,14 @@ const getApiKey = () => {
  */
 export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 	const options = {
-		total: cart.order_data.total,
-		currency: cart.order_data.currency,
-		country: cart.order_data.country_code,
+		total: cart.total,
+		currency: cart.currency,
+		country: cart.country_code,
 		requestPayerName: true,
 		requestPayerEmail: true,
 		requestPayerPhone: cart.needs_payer_phone,
-		requestShipping: cart.order_data.requestShipping,
-		displayItems: cart.order_data.displayItems,
+		requestShipping: cart.requestShipping,
+		displayItems: cart.displayItems,
 	};
 
 	// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.

--- a/client/blocks/stripe-utils/utils.js
+++ b/client/blocks/stripe-utils/utils.js
@@ -62,9 +62,8 @@ export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 		country: cart.order_data.country_code,
 		requestPayerName: true,
 		requestPayerEmail: true,
-		requestPayerPhone:
-			wc_stripe_payment_request_params.checkout.needs_payer_phone,
-		requestShipping: cart.shipping_required ? true : false,
+		requestPayerPhone: cart.needs_payer_phone,
+		requestShipping: cart.order_data.requestShipping,
 		displayItems: cart.order_data.displayItems,
 	};
 

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -28,8 +28,8 @@ return apply_filters(
 			'desc_tip'    => true,
 		],
 		'api_credentials'                     => [
-			'title'       => __( 'Stripe Account Keys', 'woocommerce-gateway-stripe' ),
-			'type'        => 'stripe_account_keys',
+			'title' => __( 'Stripe Account Keys', 'woocommerce-gateway-stripe' ),
+			'type'  => 'stripe_account_keys',
 		],
 		'testmode'                            => [
 			'title'       => __( 'Test mode', 'woocommerce-gateway-stripe' ),

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -82,24 +82,24 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 */
 	public function get_payment_method_data() {
 		return [
-			'stripeTotalLabel'    => $this->get_total_label(),
-			'publicKey'           => $this->get_publishable_key(),
-			'allowPrepaidCard'    => $this->get_allow_prepaid_card(),
-			'title'               => $this->get_title(),
-			'button'              => [
+			'stripeTotalLabel' => $this->get_total_label(),
+			'publicKey'        => $this->get_publishable_key(),
+			'allowPrepaidCard' => $this->get_allow_prepaid_card(),
+			'title'            => $this->get_title(),
+			'button'           => [
 				'type'        => $this->get_button_type(),
 				'theme'       => $this->get_button_theme(),
 				'height'      => $this->get_button_height(),
 				'locale'      => $this->get_button_locale(),
 				'customLabel' => isset( $this->settings['payment_request_button_label'] ) ? $this->settings['payment_request_button_label'] : 'Buy now',
 			],
-			'inline_cc_form'      => $this->get_inline_cc_form(),
-			'icons'               => $this->get_icons(),
-			'showSavedCards'      => $this->get_show_saved_cards(),
-			'showSaveOption'      => $this->get_show_save_option(),
-			'supports'            => $this->get_supported_features(),
-			'stripeLocale'        => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
-			'isAdmin'             => is_admin(),
+			'inline_cc_form'   => $this->get_inline_cc_form(),
+			'icons'            => $this->get_icons(),
+			'showSavedCards'   => $this->get_show_saved_cards(),
+			'showSaveOption'   => $this->get_show_save_option(),
+			'supports'         => $this->get_supported_features(),
+			'stripeLocale'     => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+			'isAdmin'          => is_admin(),
 		];
 	}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1480,7 +1480,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Mandatory payment details.
-		$data['needs_payer_phone'] = 'required' == get_option( 'woocommerce_checkout_phone_field', 'required' );
+		$data['needs_payer_phone'] = 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' );
 		$data['currency']          = strtolower( get_woocommerce_currency() );
 		$data['country_code']      = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -816,10 +816,7 @@ class WC_Stripe_Payment_Request {
 
 		WC()->cart->calculate_totals();
 
-		// In the cart page a shipping amount is always returned. This keeps current behavior.
-		$has_shipping_address = true;
-
-		$data = $this->build_response( false, $has_shipping_address );
+		$data = $this->build_response( false, true );
 		wp_send_json( $data );
 	}
 
@@ -953,7 +950,7 @@ class WC_Stripe_Payment_Request {
 
 		$itemized_display_items = filter_input( INPUT_POST, 'is_product_page', FILTER_VALIDATE_BOOLEAN );
 
-		$data           = $this->build_response( $itemized_display_items, true ); // `ajax_update_shipping_method` is called only when the user has added a shipping address
+		$data           = $this->build_response( $itemized_display_items, true );
 		$data['result'] = 'success';
 
 		wp_send_json( $data );
@@ -1372,12 +1369,12 @@ class WC_Stripe_Payment_Request {
 
 
 	/**
-	 * Builds response to pass to the Payment Request
+	 * Builds response to pass to the Payment Request.
 	 *
 	 * @since   x.x.x
 	 *
 	 * @param bool $itemized_display_items Wether to return an array of items with its details or not.
-	 * @param bool $has_shipping_address True is the user has picked or entered a shipping address on the payment dialog.
+	 * @param bool $has_shipping_address Indicates if user has selected a shipping address on the payment dialog.
 	 */
 	protected function build_response( $itemized_display_items = false, $has_shipping_address = false ) {
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -201,7 +201,6 @@ class WC_Stripe_Payment_Request {
 		add_action( 'wc_ajax_wc_stripe_create_order', [ $this, 'ajax_create_order' ] );
 		add_action( 'wc_ajax_wc_stripe_add_to_cart', [ $this, 'ajax_add_to_cart' ] );
 		add_action( 'wc_ajax_wc_stripe_get_selected_product_data', [ $this, 'ajax_get_selected_product_data' ] );
-		add_action( 'wc_ajax_wc_stripe_clear_cart', [ $this, 'ajax_clear_cart' ] );
 		add_action( 'wc_ajax_wc_stripe_log_errors', [ $this, 'ajax_log_errors' ] );
 
 		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
@@ -632,7 +631,6 @@ class WC_Stripe_Payment_Request {
 				'add_to_cart'               => wp_create_nonce( 'wc-stripe-add-to-cart' ),
 				'get_selected_product_data' => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
 				'log_errors'                => wp_create_nonce( 'wc-stripe-log-errors' ),
-				'clear_cart'                => wp_create_nonce( 'wc-stripe-clear-cart' ),
 			],
 			'i18n'            => [
 				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),
@@ -834,19 +832,6 @@ class WC_Stripe_Payment_Request {
 
 		WC_Stripe_Logger::log( $errors );
 
-		exit;
-	}
-
-	/**
-	 * Clears cart.
-	 *
-	 * @since   3.1.4
-	 * @version 4.0.0
-	 */
-	public function ajax_clear_cart() {
-		check_ajax_referer( 'wc-stripe-clear-cart', 'security' );
-
-		WC()->cart->empty_cart();
 		exit;
 	}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1513,7 +1513,7 @@ class WC_Stripe_Payment_Request {
 			'pending' => true, // TODO: Check when this should be false
 		];
 
-		$data['displayItems'] = $this->build_display_items( $itemized_display_items, $shipping_pending, $shipping, $page );
+		$data['displayItems'] = $this->build_display_items( $itemized_display_items, $shipping_pending, $shipping, $discounts );
 
 		return $data;
 	}
@@ -1528,7 +1528,7 @@ class WC_Stripe_Payment_Request {
 	 * @param  bool $shipping_pending       True is the user hasn't defined yet a shipping address. @since 5.3.0
 	 * @param  bool $shipping               Total shipping cost. @since 5.3.0
 	 */
-	protected function build_display_items( $itemized_display_items = false, $shipping_pending = true, $shipping = 0 ) {
+	protected function build_display_items( $itemized_display_items = false, $shipping_pending = true, $shipping = 0, $discounts = 0 ) {
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );
 		}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1464,13 +1464,13 @@ class WC_Stripe_Payment_Request {
 
 		// Shipping
 		$shipping           = wc_format_decimal( WC()->cart->get_shipping_total(), WC()->cart->dp );
-		$shipping_to_remove = 0;
+		$shipping_to_substract = 0;
 
 		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
 			$data['requestShipping'] = ( wc_shipping_enabled() && WC()->cart->needs_shipping() );
 
 			if ( $shipping_pending ) {
-				$shipping_to_remove = $shipping;
+				$shipping_to_substract = $shipping;
 				$shipping           = 0;
 
 				$data['shippingOptions'] = [
@@ -1504,7 +1504,7 @@ class WC_Stripe_Payment_Request {
 		} else {
 			// Getting the total amount from the cart automatically adds a shipping cost to it
 			// We need to remove it if the user hasn't picked a shipping addres yet
-			$order_total = WC()->cart->get_total( false ) - $tax_to_substract - $shipping_to_remove;
+			$order_total = WC()->cart->get_total( false ) - $tax_to_substract - $shipping_to_substract;
 		}
 
 		$data['total'] = [

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1415,7 +1415,6 @@ class WC_Stripe_Payment_Request {
 			$qty = ! isset( $_POST['qty'] ) ? 1 : apply_filters( 'woocommerce_add_to_cart_quantity', absint( $_POST['qty'] ), $product_id );
 			$addon_value = isset( $_POST['addon_value'] ) ? max( floatval( $_POST['addon_value'] ), 0 ) : 0;
 
-			$total = $qty * $this->get_product_price( $product ) + $addon_value;
 			$quantity_label = 1 < $qty ? ' (x' . $qty . ')' : '';
 
 			if ( wc_shipping_enabled() && $product->needs_shipping() ) {
@@ -1428,16 +1427,13 @@ class WC_Stripe_Payment_Request {
 				];
 			}
 
-			WC()->cart->calculate_totals();
+			$totals = WC()->cart->get_totals();
 
 			$data['total']        = [
 				'label'   => $this->total_label,
-				'amount'  => WC_Stripe_Helper::get_stripe_amount( $total ),
+				'amount'  => WC_Stripe_Helper::get_stripe_amount( $totals['total'] ),
 				'pending' => true,
 			];
-
-			$cart = WC()->cart->get_cart();
-			WC_Stripe_Logger::log('$cart ' . print_r($cart, true));
 
 			$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 			$data['currency']        = strtolower( get_woocommerce_currency() );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1048,13 +1048,12 @@ class WC_Stripe_Payment_Request {
 
 			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
 			$product    = wc_get_product( $product_id );
+			$qty        = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: %d is the product Id */
 				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
-
-			$qty = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
 
 			if ( ! $product->has_enough_stock( $qty ) ) {
 				/* translators: 1: product name 2: quantity in stock */

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -349,28 +349,8 @@ class WC_Stripe_Payment_Request {
 		}
 
 		$data  = [];
-		$items = [];
-
-		$items[] = [
-			'label'  => $product->get_name(),
-			'amount' => WC_Stripe_Helper::get_stripe_amount( $this->get_product_price( $product ) ),
-		];
-
-		if ( wc_tax_enabled() ) {
-			$items[] = [
-				'label'   => __( 'Tax', 'woocommerce-gateway-stripe' ),
-				'amount'  => 0,
-				'pending' => true,
-			];
-		}
 
 		if ( wc_shipping_enabled() && $product->needs_shipping() ) {
-			$items[] = [
-				'label'   => __( 'Shipping', 'woocommerce-gateway-stripe' ),
-				'amount'  => 0,
-				'pending' => true,
-			];
-
 			$data['shippingOptions'] = [
 				'id'     => 'pending',
 				'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
@@ -386,8 +366,6 @@ class WC_Stripe_Payment_Request {
 		];
 
 		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
-		$data['currency']        = strtolower( get_woocommerce_currency() );
-		$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 
 		return apply_filters( 'wc_stripe_payment_request_product_data', $data, $product );
 	}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -388,7 +388,7 @@ class WC_Stripe_Payment_Request {
 			'pending' => true,
 		];
 
-		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
+		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() ); // TODO: This seems no longer needed
 		$data['currency']        = strtolower( get_woocommerce_currency() );
 		$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 
@@ -1520,17 +1520,20 @@ class WC_Stripe_Payment_Request {
 			];
 		}
 
-		if ( $shipping_pending ) {
-			$items[] = [
-				'label'   => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
-				'amount'  => 0,
-				'pending' => true,
-			];
-		} elseif ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $shipping ),
-			];
+		// Shipping
+		if ( WC()->cart->needs_shipping() ) {
+			if ( $shipping_pending ) {
+				$items[] = [
+					'label'   => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
+					'amount'  => 0,
+					'pending' => true,
+				];
+			} elseif ( wc_shipping_enabled() ) {
+				$items[] = [
+					'label'  => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
+					'amount' => WC_Stripe_Helper::get_stripe_amount( $shipping ),
+				];
+			}
 		}
 
 		if ( WC()->cart->has_discount() ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1035,8 +1035,8 @@ class WC_Stripe_Payment_Request {
 		check_ajax_referer( 'wc-stripe-get-selected-product-data', 'security' );
 
 		try {
-			$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-			$product      = wc_get_product( $product_id );
+			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$product    = wc_get_product( $product_id );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: %d is the product Id */
@@ -1065,8 +1065,8 @@ class WC_Stripe_Payment_Request {
 				define( 'WOOCOMMERCE_CART', true );
 			}
 
-			$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-			$product      = wc_get_product( $product_id );
+			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$product    = wc_get_product( $product_id );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: %d is the product Id */
@@ -1098,7 +1098,7 @@ class WC_Stripe_Payment_Request {
 			$data = $this->build_response();
 			wp_send_json( $data );
 
-		} catch (Exception $e) {
+		} catch ( Exception $e ) {
 			wp_send_json( [ 'error' => wp_strip_all_tags( $e->getMessage() ) ] );
 		}
 
@@ -1404,32 +1404,32 @@ class WC_Stripe_Payment_Request {
 	 * Builds the response object to pass to Payment Request
 	 *
 	 * @since 5.3.0
-	 * 
+	 *
 	 * @return array Data object used to update Payment Request button on the client
 	 */
 	protected function build_response() {
-			$data = [];
-			$items = [];
-			$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-			$product      = wc_get_product( $product_id );
-			$qty = ! isset( $_POST['qty'] ) ? 1 : apply_filters( 'woocommerce_add_to_cart_quantity', absint( $_POST['qty'] ), $product_id );
+			$data        = [];
+			$items       = [];
+			$product_id  = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$product     = wc_get_product( $product_id );
+			$qty         = ! isset( $_POST['qty'] ) ? 1 : apply_filters( 'woocommerce_add_to_cart_quantity', absint( $_POST['qty'] ), $product_id );
 			$addon_value = isset( $_POST['addon_value'] ) ? max( floatval( $_POST['addon_value'] ), 0 ) : 0;
 
 			$quantity_label = 1 < $qty ? ' (x' . $qty . ')' : '';
 
-			if ( wc_shipping_enabled() && $product->needs_shipping() ) {
-				// Check if this is needed
-				$data['shippingOptions'] = [
-					'id'     => 'pending',
-					'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
-					'detail' => '',
-					'amount' => 0,
-				];
-			}
+		if ( wc_shipping_enabled() && $product->needs_shipping() ) {
+			// Check if this is needed
+			$data['shippingOptions'] = [
+				'id'     => 'pending',
+				'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
+				'detail' => '',
+				'amount' => 0,
+			];
+		}
 
 			$totals = WC()->cart->get_totals();
 
-			$data['total']        = [
+			$data['total'] = [
 				'label'   => $this->total_label,
 				'amount'  => WC_Stripe_Helper::get_stripe_amount( $totals['total'] ),
 				'pending' => true,
@@ -1438,7 +1438,7 @@ class WC_Stripe_Payment_Request {
 			$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 			$data['currency']        = strtolower( get_woocommerce_currency() );
 			$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
-			$data['result'] = 'success';
+			$data['result']          = 'success';
 
 			$data += $this->build_display_items( true );
 
@@ -1497,8 +1497,8 @@ class WC_Stripe_Payment_Request {
 
 		if ( wc_tax_enabled() ) {
 			$items[] = [
-				'label'  => esc_html( __( 'Tax', 'woocommerce-gateway-stripe' ) ),
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $tax ),
+				'label'   => esc_html( __( 'Tax', 'woocommerce-gateway-stripe' ) ),
+				'amount'  => WC_Stripe_Helper::get_stripe_amount( $tax ),
 				'pending' => true,
 			];
 		}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1390,13 +1390,11 @@ class WC_Stripe_Payment_Request {
 		$data['currency']     = strtolower( get_woocommerce_currency() );
 		$data['country_code'] = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 		$items                = [];
-		$subtotal             = 0;
 
 		// Default show only subtotal instead of itemization.
 		if ( ! apply_filters( 'wc_stripe_payment_request_hide_itemization', true ) || $itemized_display_items ) {
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				$amount         = $cart_item['line_subtotal'];
-				$subtotal      += $cart_item['line_subtotal'];
 				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
 
 				$item = [

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1414,11 +1414,8 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Tax
-		$tax              = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
-		$tax_to_substract = 0;
-
 		if ( wc_tax_enabled() ) {
-			$tax_to_substract = $tax;
+			$tax = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
 
 			$items[] = [
 				'label'   => esc_html( __( 'Tax', 'woocommerce-gateway-stripe' ) ),
@@ -1428,13 +1425,16 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Shipping
-		$shipping              = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
 		$shipping_to_substract = 0;
 
 		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
 			$data['requestShipping'] = true;
+			$shipping                = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
 
 			if ( ! $has_shipping_address ) {
+				// If the frontend says we don't have a shipping address but
+				// there's an amount for shipping it means a shipping address is on the session
+				// and we should remove that amount from the cart's total.
 				$shipping_to_substract = $shipping;
 				$shipping              = 0;
 			}
@@ -1490,7 +1490,7 @@ class WC_Stripe_Payment_Request {
 		} else {
 			// Getting the total amount from the cart automatically adds a shipping cost to it
 			// We need to remove it if the user hasn't picked a shipping address yet
-			$order_total = WC()->cart->get_total( false ) - $tax_to_substract - $shipping_to_substract;
+			$order_total = WC()->cart->get_total( false ) - $shipping_to_substract;
 		}
 
 		// Mandatory payment details.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1013,11 +1013,21 @@ class WC_Stripe_Payment_Request {
 
 		WC()->cart->calculate_totals();
 
-		$product_view_options      = filter_input_array( INPUT_POST, [ 'is_product_page' => FILTER_SANITIZE_STRING ] );
-		$should_show_itemized_view = ! isset( $product_view_options['is_product_page'] ) ? true : filter_var( $product_view_options['is_product_page'], FILTER_VALIDATE_BOOLEAN );
+		$product_view_options = filter_input_array(
+			INPUT_POST,
+			[
+				'is_product_page'  => FILTER_SANITIZE_STRING,
+				'shipping_pending' => FILTER_VALIDATE_BOOLEAN,
+			]
+		);
 
-		$data           = [];
-		$data          += $this->build_display_items( $should_show_itemized_view );
+		if ( $product_view_options['is_product_page'] ) {
+			$page = 'product_page';
+		} else {
+			$page = 'cart_page';
+		}
+
+		$data           = $this->build_response( false, $page ); // address is always present to make this request
 		$data['result'] = 'success';
 
 		wp_send_json( $data );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -348,23 +348,12 @@ class WC_Stripe_Payment_Request {
 			}
 		}
 
-		$data = [];
-
-		if ( wc_shipping_enabled() && $product->needs_shipping() ) {
-			$data['shippingOptions'] = [
-				'id'     => 'pending',
-				'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
-				'detail' => '',
-				'amount' => 0,
-			];
-		}
-
-		$data['total'] = [
+		$data                    = [];
+		$data['total']           = [
 			'label'   => apply_filters( 'wc_stripe_payment_request_total_label', $this->total_label ),
 			'amount'  => WC_Stripe_Helper::get_stripe_amount( $this->get_product_price( $product ) ),
 			'pending' => true,
 		];
-
 		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 
 		return apply_filters( 'wc_stripe_payment_request_product_data', $data, $product );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1036,6 +1036,7 @@ class WC_Stripe_Payment_Request {
 
 		try {
 			$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$product      = wc_get_product( $product_id );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: %d is the product Id */

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -869,6 +869,7 @@ class WC_Stripe_Payment_Request {
 		// Set mandatory payment details.
 		$data = [
 			'shipping_required' => WC()->cart->needs_shipping(),
+			'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
 			'order_data'        => [
 				'currency'     => strtolower( $currency ),
 				'country_code' => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -317,7 +317,7 @@ class WC_Stripe_Payment_Request {
 	 * Gets the product data for the currently viewed page
 	 *
 	 * @since   4.0.0
-	 * @version 5.2.0
+	 * @version x.x.x
 	 * @return  mixed Returns false if not on a product page, the product information otherwise.
 	 */
 	public function get_product_data() {
@@ -348,7 +348,7 @@ class WC_Stripe_Payment_Request {
 			}
 		}
 
-		$data  = [];
+		$data = [];
 
 		if ( wc_shipping_enabled() && $product->needs_shipping() ) {
 			$data['shippingOptions'] = [
@@ -567,7 +567,7 @@ class WC_Stripe_Payment_Request {
 	 * Load public scripts and styles.
 	 *
 	 * @since   3.1.0
-	 * @version 5.2.0
+	 * @version x.x.x
 	 */
 	public function scripts() {
 		// If keys are not set bail.
@@ -815,6 +815,8 @@ class WC_Stripe_Payment_Request {
 
 	/**
 	 * Get cart details.
+	 *
+	 * @version x.x.x
 	 */
 	public function ajax_get_cart_details() {
 		check_ajax_referer( 'wc-stripe-payment-request', 'security' );
@@ -834,6 +836,8 @@ class WC_Stripe_Payment_Request {
 
 	/**
 	 * Get shipping options.
+	 *
+	 * @version x.x.x
 	 *
 	 * @see WC_Cart::get_shipping_packages().
 	 * @see WC_Shipping::calculate_shipping().
@@ -863,6 +867,8 @@ class WC_Stripe_Payment_Request {
 
 	/**
 	 * Gets shipping options available for specified shipping address
+	 *
+	 * @version x.x.x
 	 *
 	 * @param array  $shipping_address Shipping address.
 	 * @param boolean $itemized_display_items Indicates whether to show subtotals or itemized views.
@@ -941,6 +947,8 @@ class WC_Stripe_Payment_Request {
 
 	/**
 	 * Update shipping method.
+	 *
+	 * @version x.x.x
 	 */
 	public function ajax_update_shipping_method() {
 		check_ajax_referer( 'wc-stripe-update-shipping-method', 'security' );
@@ -983,7 +991,7 @@ class WC_Stripe_Payment_Request {
 	 * Gets the selected product data.
 	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version x.x.x
 	 * @return  array $data
 	 */
 	public function ajax_get_selected_product_data() {
@@ -1016,7 +1024,7 @@ class WC_Stripe_Payment_Request {
 	 * Adds the current product to the cart. Used on product detail page.
 	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version x.x.x
 	 * @return  array $data
 	 */
 	public function ajax_add_to_cart() {
@@ -1368,8 +1376,7 @@ class WC_Stripe_Payment_Request {
 	/**
 	 * Builds response to pass to the Payment Request
 	 *
-	 * @since   3.1.0
-	 * @version 4.0.0
+	 * @since   x.x.x
 	 *
 	 * @param bool $itemized_display_items Wether to return an array of items with its details or not.
 	 * @param bool $has_shipping_address True is the user has picked or entered a shipping address on the payment dialog.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1476,7 +1476,7 @@ class WC_Stripe_Payment_Request {
 		$shipping_to_substract = 0;
 
 		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
-			$data['requestShipping'] = ( wc_shipping_enabled() && WC()->cart->needs_shipping() );
+			$data['requestShipping'] = true;
 
 			if ( $shipping_pending ) {
 				$shipping_to_substract = $shipping;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -381,14 +381,12 @@ class WC_Stripe_Payment_Request {
 			];
 		}
 
-		$data['displayItems'] = $items;
 		$data['total']        = [
 			'label'   => apply_filters( 'wc_stripe_payment_request_total_label', $this->total_label ),
 			'amount'  => WC_Stripe_Helper::get_stripe_amount( $this->get_product_price( $product ) ),
 			'pending' => true,
 		];
 
-		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() ); // TODO: This seems no longer needed
 		$data['currency']        = strtolower( get_woocommerce_currency() );
 		$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 
@@ -1470,16 +1468,20 @@ class WC_Stripe_Payment_Request {
 		$shipping           = wc_format_decimal( WC()->cart->get_shipping_total(), WC()->cart->dp );
 		$shipping_to_remove = 0;
 
-		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() && $shipping_pending ) {
-			$shipping_to_remove = $shipping;
-			$shipping           = 0;
+		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
+			$data['requestShipping'] = ( wc_shipping_enabled() && WC()->cart->needs_shipping() );
 
-			$data['shippingOptions'] = [
-				'id'     => 'pending',
-				'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
-				'detail' => '',
-				'amount' => 0,
-			];
+			if ( $shipping_pending ) {
+				$shipping_to_remove = $shipping;
+				$shipping           = 0;
+
+				$data['shippingOptions'] = [
+					'id'     => 'pending',
+					'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
+					'detail' => '',
+					'amount' => 0,
+				];
+			}
 		}
 
 		// Discounts

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -893,6 +893,9 @@ class WC_Stripe_Payment_Request {
 	 * phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag
 	 */
 	public function get_shipping_options( $shipping_address, $itemized_display_items = false ) {
+		// This method is only called when the user has selected a Shipping address
+		$has_shipping_address = true;
+
 		try {
 			// Set the shipping options.
 			$data = [];
@@ -948,10 +951,10 @@ class WC_Stripe_Payment_Request {
 
 			WC()->cart->calculate_totals();
 
-			$data          += $this->build_response( $itemized_display_items, true );
+			$data          += $this->build_response( $itemized_display_items, $has_shipping_address );
 			$data['result'] = 'success';
 		} catch ( Exception $e ) {
-			$data          += $this->build_response( $itemized_display_items, true );
+			$data          += $this->build_response( $itemized_display_items, $has_shipping_address );
 			$data['result'] = 'invalid_shipping_address';
 		}
 
@@ -1080,17 +1083,7 @@ class WC_Stripe_Payment_Request {
 				WC()->cart->add_to_cart( $product->get_id(), $qty );
 			}
 
-			$post_input = filter_input_array(
-				INPUT_POST,
-				[
-					'has_shipping_address' => FILTER_VALIDATE_BOOLEAN,
-				]
-			);
-
-			$has_shipping_address   = $post_input['has_shipping_address'];
-			$itemized_display_items = true; // This method is called from the product page only. Always display itemized items.
-
-			$data = $this->build_response( $itemized_display_items, $has_shipping_address );
+			$data = $this->build_response( $itemized_display_items, true ); // This method is called from the product page only. Always display itemized items.
 			wp_send_json( $data );
 		} catch ( Exception $e ) {
 			wp_send_json( [ 'error' => wp_strip_all_tags( $e->getMessage() ) ] );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1069,7 +1069,9 @@ class WC_Stripe_Payment_Request {
 				WC()->cart->add_to_cart( $product->get_id(), $qty );
 			}
 
-			$data = $this->build_response( $itemized_display_items, true ); // This method is called from the product page only. Always display itemized items.
+			$itemized_display_items = true; // This method is called from the product page only. Always display itemized items.
+
+			$data = $this->build_response( $itemized_display_items, true );
 			wp_send_json( $data );
 		} catch ( Exception $e ) {
 			wp_send_json( [ 'error' => wp_strip_all_tags( $e->getMessage() ) ] );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1452,18 +1452,18 @@ class WC_Stripe_Payment_Request {
 		$data['country_code'] = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 
 		// Taxes
-		$taxes            = WC()->cart->tax_total + WC()->cart->shipping_tax_total;
+		$tax              = WC()->cart->tax_total + WC()->cart->shipping_tax_total;
 		$tax_to_substract = 0;
 
 		if ( wc_tax_enabled() ) {
 			if ( $shipping_pending ) {
-				$tax_to_substract = $taxes;
+				$tax_to_substract = $tax;
 				$tax              = 0;
 			}
 		}
 
 		// Shipping
-		$shipping           = wc_format_decimal( WC()->cart->get_shipping_total(), WC()->cart->dp );
+		$shipping              = wc_format_decimal( WC()->cart->get_shipping_total(), WC()->cart->dp );
 		$shipping_to_substract = 0;
 
 		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
@@ -1471,7 +1471,7 @@ class WC_Stripe_Payment_Request {
 
 			if ( $shipping_pending ) {
 				$shipping_to_substract = $shipping;
-				$shipping           = 0;
+				$shipping              = 0;
 
 				$data['shippingOptions'] = [
 					'id'     => 'pending',

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1407,7 +1407,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Tax
-		$tax              = WC()->cart->tax_total + WC()->cart->shipping_tax_total;
+		$tax              = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
 		$tax_to_substract = 0;
 
 		if ( wc_tax_enabled() ) {
@@ -1424,7 +1424,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Shipping
-		$shipping              = WC()->cart->get_shipping_total();
+		$shipping              = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
 		$shipping_to_substract = 0;
 
 		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
@@ -1446,13 +1446,15 @@ class WC_Stripe_Payment_Request {
 		$discounts = 0;
 
 		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
-			$discounts = WC()->cart->get_cart_discount_total();
+			$discounts = wc_format_decimal( WC()->cart->get_cart_discount_total(), WC()->cart->dp );
 		} else {
 			$applied_coupons = array_values( WC()->cart->get_coupon_discount_totals() );
 
 			foreach ( $applied_coupons as $amount ) {
 				$discounts += (float) $amount;
 			}
+
+			$discounts = wc_format_decimal( $discounts, WC()->cart->dp );
 		}
 
 		if ( WC()->cart->has_discount() ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1397,12 +1397,10 @@ class WC_Stripe_Payment_Request {
 				$amount         = $cart_item['line_subtotal'];
 				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
 
-				$item = [
+				$items[] = [
 					'label'  => $cart_item['data']->get_name() . $quantity_label,
 					'amount' => WC_Stripe_Helper::get_stripe_amount( $amount ),
 				];
-
-				$items[] = $item;
 			}
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1481,8 +1481,8 @@ class WC_Stripe_Payment_Request {
 
 		// Order total
 		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
-			$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp ) + $discounts;
-			$order_total = wc_format_decimal( $items_total + $tax + $shipping - $discounts, WC()->cart->dp );
+			$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp );
+			$order_total = wc_format_decimal( $items_total + $tax + $shipping, WC()->cart->dp );
 		} else {
 			// Getting the total amount from the cart automatically adds a shipping cost to it
 			// We need to remove it if the user hasn't picked a shipping address yet

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1116,7 +1116,6 @@ class WC_Stripe_Payment_Request {
 				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
 			}
 
-			// Do we need to do this before emptying the cart?
 			WC()->shipping->reset_shipping();
 
 			// First empty the cart to prevent wrong calculation.

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -133,7 +133,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 
 
 	public function test_get_shipping_options_returns_shipping_options() {
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, false );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, true );
 
 		$expected_shipping_options = array_map(
 			'self::get_shipping_option',
@@ -145,7 +145,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_shipping_options_returns_chosen_option() {
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, false );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, true );
 
 		$flat_rate              = $this->get_shipping_option( $this->flat_rate_id );
 		$expected_display_items = [
@@ -156,6 +156,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 			[
 				'label'  => 'Shipping',
 				'amount' => $flat_rate['amount'],
+				'pending' => true,
 			],
 		];
 
@@ -167,7 +168,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 		$method_id = self::get_shipping_option_rate_id( $this->local_pickup_id );
 		$this->pr->update_shipping_method( [ $method_id ] );
 
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, false );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, true );
 
 		$expected_shipping_options = array_map(
 			'self::get_shipping_option',

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -150,7 +150,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 		$flat_rate              = $this->get_shipping_option( $this->flat_rate_id );
 		$expected_display_items = [
 			[
-				'label' => 'Dummy Product',
+				'label'  => 'Dummy Product',
 				'amount' => 1000,
 			],
 			[

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -133,7 +133,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 
 
 	public function test_get_shipping_options_returns_shipping_options() {
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, false );
 
 		$expected_shipping_options = array_map(
 			'self::get_shipping_option',
@@ -145,10 +145,14 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_shipping_options_returns_chosen_option() {
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, false );
 
 		$flat_rate              = $this->get_shipping_option( $this->flat_rate_id );
 		$expected_display_items = [
+			[
+				'label' => 'Dummy Product',
+				'amount' => 1000,
+			],
 			[
 				'label'  => 'Shipping',
 				'amount' => $flat_rate['amount'],
@@ -163,7 +167,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 		$method_id = self::get_shipping_option_rate_id( $this->local_pickup_id );
 		$this->pr->update_shipping_method( [ $method_id ] );
 
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, false );
 
 		$expected_shipping_options = array_map(
 			'self::get_shipping_option',

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -154,8 +154,8 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 				'amount' => 1000,
 			],
 			[
-				'label'  => 'Shipping',
-				'amount' => $flat_rate['amount'],
+				'label'   => 'Shipping',
+				'amount'  => $flat_rate['amount'],
 				'pending' => true,
 			],
 		];


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Part of #1563

- Changes the approach on how to respond to AJAX request for the Payment Request button. Now the information needed to display on the payment dialog (amount, shipping, taxes, display items, etc) will come from the backend asynchronously instead of relying of `wc_stripe_payment_request_params`. Unlike previous approach we will get that information from the cart now instead of calculating everything on the fly on the client or based on the product's price.
- `build_response()` will be in charge of building the data object used to respond to AJAX requests according to the state of the Payment Request button or what page the user is making the request.
- The behavior where product information was updated when changing the quantity input on the product page was removed. There's no reason to do that anymore because the real and latest payment information comes from the backend at the moment the user clicks the Payment Request button.

# Testing instructions

This PR focuses on simple products only. I've tried to test as many cases as I could but I might be missing something. Please make it break.

1. Create a simple product
2. Apply different scenarios to it. You can use the same cases I've tested on the Test list below.
3. Check correct amount and item list is correct in Google Pay/Apple Pay.

#### Test list - Simple Product

- [x] Regular Price
  - Note: When testing with no shipping zones (and without shipping methods) the "Shipping" display item is not displayed. It was displayed before but after picking an address the "Shipping" item was removed. I think the new behavior is better. No need to show the "Shipping" item if no shipping options are defined. Error is returned correctly when this happens
- [x] Errors correctly when no shipping zones are defined
- [x] Regular Price with quantity
- [x] With Sale price
- [x] With Sale price + Quantity
- [x] With shipping address
- [x] Virtual Product
- [x] Downloadable
  - Note: When updating the quantity the "Shipping" item is displayed correctly. Unlike the previous behavior the "Shipping" item was reset to `0` which was incorrect.
- [x] Needs shipping - Just check if "Shipping Address" section is not displayed to the user if product doesn't require Shipping like virtual products.
- [x] Virtual with Sale price
- [x] Sold individually
- [x] Virtual sold individually
- [x] Without enough stock
- [x] With invalid shipping address
- [x] Regular Price with tax
- [x] Regular Price with tax and quantity
- [x] With coupon (fixed rate and percentage)
- [x] PRB: Default, Branded, etc
- [x] Descriptor
- [x] Cart page
- [x] With Product Add-Ons
  - Note: It didn't work before. it only worked when changing the quantity. No need to do that anymore it works just by picking an add-on now.
- [x] Checkout block/Express checkout

#### Keep in mind

- [x] https://github.com/woocommerce/woocommerce-gateway-stripe/pull/727
- [x] https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1100

#### Observations

- `wc_stripe_get_selected_product_data` is not returning the same response as `wc_stripe_add_to_cart`

--- 
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.