### PR TITLE
Use createPaymentRequestUsingCart to check whether to show PRBs or not with Block-based checkout

### DIFF
--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -11,7 +11,11 @@ import { getSetting } from '@woocommerce/settings';
 import { PAYMENT_METHOD_NAME } from './constants';
 import { PaymentRequestExpress } from './payment-request-express';
 import { applePayImage } from './apple-pay-preview';
-import { getStripeServerData, loadStripe } from '../stripe-utils';
+import {
+	getStripeServerData,
+	loadStripe,
+	createPaymentRequestUsingCart,
+} from '../stripe-utils';
 
 const ApplePayPreview = () => <img src={ applePayImage } alt="" />;
 
@@ -39,18 +43,26 @@ const paymentRequestPaymentMethod = {
 			// Create a payment request and check if we can make a payment to determine whether to
 			// show the Payment Request Button or not. This is necessary because a browser might be
 			// able to load the Stripe JS object, but not support Payment Requests.
-			const paymentRequest = stripe.paymentRequest( {
-				total: {
-					label: 'Total',
-					amount: parseInt(
-						cartData?.cartTotals?.total_price ?? 0,
-						10
-					),
-					pending: true,
+			const fakeCart = {
+				order_data: {
+					total: {
+						label: 'Total',
+						amount: parseInt(
+							cartData?.cartTotals?.total_price ?? 0,
+							10
+						),
+						pending: true,
+					},
+					currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
+					country_code: getSetting( 'baseLocation', {} )?.country,
+					displayItems: [],
 				},
-				country: getSetting( 'baseLocation', {} )?.country,
-				currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
-			} );
+				shipping_required: false,
+			};
+			const paymentRequest = createPaymentRequestUsingCart(
+				stripe,
+				fakeCart
+			);
 
 			return paymentRequest.canMakePayment();
 		} );


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1574

We have some country-specific checks that we need to run when creating payment requests. More specifically we map Puerto Rico `PR` to the United States `US` since Stripe considers Puerto Rico a part of the US.

To make sure we're consistent, we need to make sure we construct the "test payment request" the same way we construct the "real payment request".

## Screenshots

| Checkout Before | Checkout After |
| :---: | :---: |
| <img width="861" alt="image" src="https://user-images.githubusercontent.com/13835680/119424917-edf1fa80-bcf5-11eb-8b69-30c558fd48a3.png"> | <img width="861" alt="image" src="https://user-images.githubusercontent.com/13835680/119424948-fea27080-bcf5-11eb-919d-c6267c428914.png"> |

# Testing instructions

1. Set your store's country to `Puerto Rico`.
2. `git checkout trunk && npm run build:webpack`
2. Add an item to your cart.
3. Open the Block-based Cart page.
4. Note that there is no PRB rendered there.'
5. Open the Block-based Checkout page.
6. Note that there is an error there re: displaying the PRB.
5. `git checkout fix/1547-show-prb-check && npm run build:webpack`
6. Open the Block-based Cart page again.
7. Note that there is now a payment request button present.
8. Open the Block-based Checkout page again.
9. Note that there is no error, and the payment request button is present.




-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

