### PR TITLE
Use shared configuration for shortcode- and block-based checkout flows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Changelog ***
 
+= 5.2.1 - 2021-xx-xx =
+* Fix - Remove calls to `has_block()` since it breaks compatibility with older versions of WordPress.
+* Tweak - Use the same JavaScript configurations for the Block-based and Shortcode-based checkout flows.
+
 = 5.2.0 - 2021-05-19 =
 * Fix - Use `get_parent` method to avoid accessing `order` subscription property directly.
 * Fix - Orders won't transition to 'Refunded' state if refund can't be created.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -14,8 +14,8 @@ import {
 
 const getAjaxUrl = ( endpoint ) => {
 	return getStripeServerData()
-		?.ajax_url.toString()
-		.replace( '%%endpoint%%', 'wc_stripe_' + endpoint );
+		?.ajax_url?.toString()
+		?.replace( '%%endpoint%%', 'wc_stripe_' + endpoint );
 };
 
 export const getCartDetails = () => {

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -1,5 +1,3 @@
-/* global wc_stripe_payment_request_params */
-
 /**
  * External dependencies
  */
@@ -8,17 +6,21 @@ import $ from 'jquery';
 /**
  * Internal dependencies
  */
-import { normalizeOrderData, normalizeAddress } from '../blocks/stripe-utils';
+import {
+	normalizeOrderData,
+	normalizeAddress,
+	getStripeServerData,
+} from '../blocks/stripe-utils';
 
 const getAjaxUrl = ( endpoint ) => {
-	return wc_stripe_payment_request_params.ajax_url
-		.toString()
+	return getStripeServerData()
+		?.ajax_url.toString()
 		.replace( '%%endpoint%%', 'wc_stripe_' + endpoint );
 };
 
 export const getCartDetails = () => {
 	const data = {
-		security: wc_stripe_payment_request_params.nonce.payment,
+		security: getStripeServerData()?.nonce?.payment,
 	};
 
 	return $.ajax( {
@@ -36,9 +38,9 @@ export const getCartDetails = () => {
  */
 export const updateShippingOptions = ( address, paymentRequestType ) => {
 	const data = {
-		security: wc_stripe_payment_request_params.nonce.shipping,
+		security: getStripeServerData()?.nonce?.shipping,
 		payment_request_type: paymentRequestType,
-		is_product_page: wc_stripe_payment_request_params.is_product_page,
+		is_product_page: getStripeServerData()?.is_product_page,
 		...normalizeAddress( address ),
 	};
 
@@ -51,9 +53,9 @@ export const updateShippingOptions = ( address, paymentRequestType ) => {
 
 export const updateShippingDetails = ( shippingOption ) => {
 	const data = {
-		security: wc_stripe_payment_request_params.nonce.update_shipping,
+		security: getStripeServerData()?.nonce?.update_shipping,
 		shipping_method: [ shippingOption.id ],
-		is_product_page: wc_stripe_payment_request_params.is_product_page,
+		is_product_page: getStripeServerData()?.is_product_page,
 	};
 
 	return $.ajax( {

--- a/client/blocks/credit-card/index.js
+++ b/client/blocks/credit-card/index.js
@@ -37,9 +37,9 @@ const StripeComponent = ( { RenderedComponent, ...props } ) => {
 const StripeLabel = ( props ) => {
 	const { PaymentMethodLabel } = props.components;
 
-	const labelText = getStripeServerData().title
-		? getStripeServerData().title
-		: __( 'Credit / Debit Card', 'woocommerce-gateway-stripe' );
+	const labelText =
+		getStripeServerData()?.title ??
+		__( 'Credit / Debit Card', 'woocommerce-gateway-stripe' );
 
 	return <PaymentMethodLabel text={ labelText } />;
 };
@@ -61,8 +61,8 @@ const stripeCcPaymentMethod = {
 	),
 	supports: {
 		// Use `false` as fallback values in case server provided configuration is missing.
-		showSavedCards: getStripeServerData().showSavedCards ?? false,
-		showSaveOption: getStripeServerData().showSaveOption ?? false,
+		showSavedCards: getStripeServerData()?.showSavedCards ?? false,
+		showSaveOption: getStripeServerData()?.showSaveOption ?? false,
 		features: getStripeServerData()?.supports ?? [],
 	},
 };

--- a/client/blocks/credit-card/payment-method.js
+++ b/client/blocks/credit-card/payment-method.js
@@ -18,7 +18,7 @@ import { InlineCard, CardElements } from './elements';
  */
 
 export const getStripeCreditCardIcons = () => {
-	return Object.entries( getStripeServerData().icons ).map(
+	return Object.entries( getStripeServerData()?.icons ).map(
 		( [ id, { src, alt } ] ) => {
 			return {
 				id,

--- a/client/blocks/credit-card/payment-method.js
+++ b/client/blocks/credit-card/payment-method.js
@@ -18,7 +18,7 @@ import { InlineCard, CardElements } from './elements';
  */
 
 export const getStripeCreditCardIcons = () => {
-	return Object.entries( getStripeServerData().icons ).map(
+	return Object.entries( getStripeServerData()?.icons ).map(
 		( [ id, { src, alt } ] ) => {
 			return {
 				id,
@@ -60,7 +60,7 @@ const CreditCardComponent = ( {
 	const cardIcons = getStripeCreditCardIcons();
 
 	const renderedCardElement =
-		getStripeServerData().inline_cc_form === 'yes' ? (
+		getStripeServerData()?.inline_cc_form === 'yes' ? (
 			<InlineCard
 				onChange={ onChange }
 				inputErrorComponent={ ValidationInputError }

--- a/client/blocks/credit-card/payment-method.js
+++ b/client/blocks/credit-card/payment-method.js
@@ -59,17 +59,18 @@ const CreditCardComponent = ( {
 	};
 	const cardIcons = getStripeCreditCardIcons();
 
-	const renderedCardElement = getStripeServerData().inline_cc_form ? (
-		<InlineCard
-			onChange={ onChange }
-			inputErrorComponent={ ValidationInputError }
-		/>
-	) : (
-		<CardElements
-			onChange={ onChange }
-			inputErrorComponent={ ValidationInputError }
-		/>
-	);
+	const renderedCardElement =
+		getStripeServerData().inline_cc_form === 'yes' ? (
+			<InlineCard
+				onChange={ onChange }
+				inputErrorComponent={ ValidationInputError }
+			/>
+		) : (
+			<CardElements
+				onChange={ onChange }
+				inputErrorComponent={ ValidationInputError }
+			/>
+		);
 	return (
 		<>
 			{ renderedCardElement }

--- a/client/blocks/credit-card/payment-method.js
+++ b/client/blocks/credit-card/payment-method.js
@@ -18,7 +18,7 @@ import { InlineCard, CardElements } from './elements';
  */
 
 export const getStripeCreditCardIcons = () => {
-	return Object.entries( getStripeServerData()?.icons ).map(
+	return Object.entries( getStripeServerData()?.icons ?? {} ).map(
 		( [ id, { src, alt } ] ) => {
 			return {
 				id,

--- a/client/blocks/credit-card/payment-method.js
+++ b/client/blocks/credit-card/payment-method.js
@@ -18,7 +18,7 @@ import { InlineCard, CardElements } from './elements';
  */
 
 export const getStripeCreditCardIcons = () => {
-	return Object.entries( getStripeServerData()?.icons ).map(
+	return Object.entries( getStripeServerData().icons ).map(
 		( [ id, { src, alt } ] ) => {
 			return {
 				id,

--- a/client/blocks/credit-card/use-payment-processing.js
+++ b/client/blocks/credit-card/use-payment-processing.js
@@ -59,9 +59,10 @@ export const usePaymentProcessing = (
 	// hook into and register callbacks for events
 	useEffect( () => {
 		const createSource = async ( ownerInfo ) => {
-			const elementToGet = getStripeServerData().inline_cc_form
-				? CardElement
-				: CardNumberElement;
+			const elementToGet =
+				getStripeServerData().inline_cc_form === 'yes'
+					? CardElement
+					: CardNumberElement;
 			return await stripe.createSource(
 				// @ts-ignore
 				elements?.getElement( elementToGet ),

--- a/client/blocks/credit-card/use-payment-processing.js
+++ b/client/blocks/credit-card/use-payment-processing.js
@@ -60,7 +60,7 @@ export const usePaymentProcessing = (
 	useEffect( () => {
 		const createSource = async ( ownerInfo ) => {
 			const elementToGet =
-				getStripeServerData().inline_cc_form === 'yes'
+				getStripeServerData()?.inline_cc_form === 'yes'
 					? CardElement
 					: CardNumberElement;
 			return await stripe.createSource(

--- a/client/blocks/payment-request/branded-buttons.js
+++ b/client/blocks/payment-request/branded-buttons.js
@@ -49,9 +49,7 @@ export const GooglePayButton = ( { onButtonClicked } ) => {
 	} = getStripeServerData()?.button;
 
 	const allowedTypes = [ 'short', 'long' ];
-	// Use pre-blocks settings until we merge the two distinct settings objects.
-	/* global wc_stripe_payment_request_params */
-	const { branded_type } = wc_stripe_payment_request_params.button; // eslint-disable-line camelcase
+	const { branded_type } = getStripeServerData()?.button; // eslint-disable-line camelcase
 	const type = allowedTypes.includes( branded_type ) ? branded_type : 'long'; // eslint-disable-line camelcase
 
 	// Allowed themes for Google Pay button image are 'dark' and 'light'.

--- a/client/blocks/payment-request/custom-button.js
+++ b/client/blocks/payment-request/custom-button.js
@@ -13,7 +13,7 @@ export const CustomButton = ( { onButtonClicked } ) => {
 		theme = 'dark',
 		height = '44',
 		customLabel = __( 'Buy now', 'woocommerce-gateway-stripe' ),
-	} = getStripeServerData().button;
+	} = getStripeServerData()?.button;
 	return (
 		<button
 			type={ 'button' }

--- a/client/blocks/payment-request/event-handlers.js
+++ b/client/blocks/payment-request/event-handlers.js
@@ -11,7 +11,6 @@ import {
 	updateShippingDetails,
 	createOrder,
 } from '../../api';
-import { getStripeServerData } from '../stripe-utils';
 
 const shippingAddressChangeHandler = ( paymentRequestType ) => ( evt ) => {
 	const { shippingAddress } = evt;
@@ -196,7 +195,7 @@ const paymentProcessingHandler = (
 	setExpressPaymentError
 ) => ( evt ) => {
 	const allowPrepaidCards =
-		getStripeServerData()?.allow_prepaid_card === 'yes';
+		wc_stripe_payment_request_params?.stripe?.allow_prepaid_card === 'yes';
 
 	// Check if we allow prepaid cards.
 	if ( ! allowPrepaidCards && evt?.source?.card?.funding === 'prepaid' ) {

--- a/client/blocks/payment-request/event-handlers.js
+++ b/client/blocks/payment-request/event-handlers.js
@@ -13,6 +13,7 @@ import {
 	updateShippingDetails,
 	createOrder,
 } from '../../api';
+import { getStripeServerData } from '../stripe-utils';
 
 const shippingAddressChangeHandler = ( paymentRequestType ) => ( evt ) => {
 	const { shippingAddress } = evt;
@@ -197,7 +198,7 @@ const paymentProcessingHandler = (
 	setExpressPaymentError
 ) => ( evt ) => {
 	const allowPrepaidCards =
-		wc_stripe_payment_request_params?.stripe?.allow_prepaid_card === 'yes';
+		getStripeServerData()?.allow_prepaid_card === 'yes';
 
 	// Check if we allow prepaid cards.
 	if ( ! allowPrepaidCards && evt?.source?.card?.funding === 'prepaid' ) {

--- a/client/blocks/payment-request/event-handlers.js
+++ b/client/blocks/payment-request/event-handlers.js
@@ -11,6 +11,7 @@ import {
 	updateShippingDetails,
 	createOrder,
 } from '../../api';
+import { getStripeServerData } from '../stripe-utils';
 
 const shippingAddressChangeHandler = ( paymentRequestType ) => ( evt ) => {
 	const { shippingAddress } = evt;
@@ -195,7 +196,7 @@ const paymentProcessingHandler = (
 	setExpressPaymentError
 ) => ( evt ) => {
 	const allowPrepaidCards =
-		wc_stripe_payment_request_params?.stripe?.allow_prepaid_card === 'yes';
+		getStripeServerData()?.stripe?.allow_prepaid_card === 'yes';
 
 	// Check if we allow prepaid cards.
 	if ( ! allowPrepaidCards && evt?.source?.card?.funding === 'prepaid' ) {

--- a/client/blocks/payment-request/event-handlers.js
+++ b/client/blocks/payment-request/event-handlers.js
@@ -1,5 +1,3 @@
-/* global wc_stripe_payment_request_params */
-
 /**
  * External dependencies
  */
@@ -202,9 +200,7 @@ const paymentProcessingHandler = (
 
 	// Check if we allow prepaid cards.
 	if ( ! allowPrepaidCards && evt?.source?.card?.funding === 'prepaid' ) {
-		setExpressPaymentError(
-			wc_stripe_payment_request_params?.i18n?.no_prepaid_card
-		);
+		setExpressPaymentError( getStripeServerData()?.i18n?.no_prepaid_card );
 	} else {
 		// Create the order and attempt to pay.
 		createOrder( evt, paymentRequestType ).then(

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -30,8 +30,6 @@ const paymentRequestPaymentMethod = {
 			return true;
 		}
 
-		// If the JS Payment Request Button configuration object loaded from PHP is not available
-		// we don't support payment requests.
 		if ( ! getStripeServerData()?.button ) {
 			return false;
 		}

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -35,7 +35,7 @@ const paymentRequestPaymentMethod = {
 		// If the `wc_stripe_payment_request_params` object is not available we don't support
 		// payment requests.
 		// eslint-disable-next-line camelcase
-		if ( typeof wc_stripe_payment_request_params === 'undefined' ) {
+		if ( getStripeServerData() === undefined ) {
 			return false;
 		}
 

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -1,5 +1,3 @@
-/* global wc_stripe_payment_request_params */
-
 /**
  * External dependencies
  */
@@ -32,10 +30,9 @@ const paymentRequestPaymentMethod = {
 			return true;
 		}
 
-		// If the `wc_stripe_payment_request_params` object is not available we don't support
-		// payment requests.
-		// eslint-disable-next-line camelcase
-		if ( getStripeServerData() === undefined ) {
+		// If the JS Payment Request Button configuration object loaded from PHP is not available
+		// we don't support payment requests.
+		if ( ! getStripeServerData()?.button ) {
 			return false;
 		}
 

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -30,12 +30,6 @@ const paymentRequestPaymentMethod = {
 			return true;
 		}
 
-		// If the JS Payment Request Button configuration object loaded from PHP is not available
-		// we don't support payment requests.
-		if ( ! getStripeServerData()?.button ) {
-			return false;
-		}
-
 		return loadStripe().then( ( stripe ) => {
 			// Create a payment request and check if we can make a payment to determine whether to
 			// show the Payment Request Button or not. This is necessary because a browser might be

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -30,6 +30,8 @@ const paymentRequestPaymentMethod = {
 			return true;
 		}
 
+		// If the JS Payment Request Button configuration object loaded from PHP is not available
+		// we don't support payment requests.
 		if ( ! getStripeServerData()?.button ) {
 			return false;
 		}

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -79,7 +79,7 @@ const PaymentRequestExpressComponent = ( {
 		type = 'default',
 		theme = 'dark',
 		height = '48',
-	} = getStripeServerData().button;
+	} = getStripeServerData()?.button;
 
 	const paymentRequestButtonStyle = {
 		paymentRequestButton: {

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -89,11 +89,9 @@ const PaymentRequestExpressComponent = ( {
 		},
 	};
 
-	// Use pre-blocks settings until we merge the two distinct settings objects.
-	/* global wc_stripe_payment_request_params */
-	const isBranded = wc_stripe_payment_request_params.button.is_branded;
-	const brandedType = wc_stripe_payment_request_params.button.branded_type;
-	const isCustom = wc_stripe_payment_request_params.button.is_custom;
+	const isBranded = getStripeServerData()?.button?.is_branded;
+	const brandedType = getStripeServerData()?.button?.branded_type;
+	const isCustom = getStripeServerData()?.button?.is_custom;
 
 	if ( ! paymentRequest ) {
 		return null;

--- a/client/blocks/stripe-utils/load-stripe.js
+++ b/client/blocks/stripe-utils/load-stripe.js
@@ -13,7 +13,7 @@ const stripePromise = () =>
 		try {
 			// Default to the 'auto' locale so Stripe chooses the browser's locale
 			// if the store's locale is not available.
-			const locale = getStripeServerData()?.stripeLocale ?? 'auto';
+			const locale = getStripeServerData()?.stripe_locale ?? 'auto';
 			resolve( loadStripe( getApiKey(), { locale } ) );
 		} catch ( error ) {
 			// In order to avoid showing console error publicly to users,

--- a/client/blocks/stripe-utils/load-stripe.js
+++ b/client/blocks/stripe-utils/load-stripe.js
@@ -13,7 +13,7 @@ const stripePromise = () =>
 		try {
 			// Default to the 'auto' locale so Stripe chooses the browser's locale
 			// if the store's locale is not available.
-			const locale = getStripeServerData()?.stripe_locale ?? 'auto';
+			const locale = getStripeServerData()?.stripeLocale ?? 'auto';
 			resolve( loadStripe( getApiKey(), { locale } ) );
 		} catch ( error ) {
 			// In order to avoid showing console error publicly to users,

--- a/client/blocks/stripe-utils/normalize.js
+++ b/client/blocks/stripe-utils/normalize.js
@@ -12,7 +12,7 @@
 /**
  * Internal dependencies
  */
-import { getStripeServerData } from '../stripe-utils';
+import { getStripeServerData } from './utils';
 
 /**
  * Normalizes order data received upon creating an order using the store's AJAX API.

--- a/client/blocks/stripe-utils/normalize.js
+++ b/client/blocks/stripe-utils/normalize.js
@@ -1,5 +1,3 @@
-/* global wc_stripe_payment_request_params */
-
 /**
  * @typedef {import('./type-defs').StripePaymentItem} StripePaymentItem
  * @typedef {import('./type-defs').StripeShippingOption} StripeShippingOption
@@ -10,6 +8,11 @@
  * @typedef {import('@woocommerce/type-defs/shipping').ShippingAddress} CartShippingAddress
  * @typedef {import('@woocommerce/type-defs/billing').BillingData} CartBillingAddress
  */
+
+/**
+ * Internal dependencies
+ */
+import { getStripeServerData } from '../stripe-utils';
 
 /**
  * Normalizes order data received upon creating an order using the store's AJAX API.
@@ -26,7 +29,7 @@ const normalizeOrderData = ( sourceEvent, paymentRequestType ) => {
 	const shipping = sourceEvent?.shippingAddress;
 
 	const data = {
-		_wpnonce: wc_stripe_payment_request_params.nonce.checkout,
+		_wpnonce: getStripeServerData()?.nonce?.checkout,
 		billing_first_name:
 			name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
 		billing_last_name: name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',

--- a/client/blocks/stripe-utils/type-defs.js
+++ b/client/blocks/stripe-utils/type-defs.js
@@ -280,11 +280,9 @@
 /**
  * @typedef {Object} StripeServerData
  *
- * @property {string}                      stripeTotalLabel     The string used for payment
- *                                                              descriptor.
- * @property {string}                      publicKey            The public api key for stripe
+ * @property {string}                      key                  The public api key for stripe
  *                                                              requests.
- * @property {boolean}                     allowPrepaidCard     True means that prepaid cards
+ * @property {boolean}                     allow_prepaid_card   True means that prepaid cards
  *                                                              can be used for payment.
  * @property {Object}                      button               Contains button styles
  * @property {string}                      button.type          The type of button.

--- a/client/blocks/stripe-utils/type-defs.js
+++ b/client/blocks/stripe-utils/type-defs.js
@@ -291,9 +291,9 @@
  *                                                              the button.
  * @property {string}                      button.locale        The locale to use for stripe
  *                                                              elements.
- * @property {boolean}                     inline_cc_form       Whether stripe cc should use
- *                                                              inline cc
- *                                                              form or separate inputs.
+ * @property {string}                      inline_cc_form       Whether stripe cc should use
+ *                                                              inline cc form or separate inputs.
+ *                                                              Either 'yes' or 'no'.
  * @property {{[k:string]:CreditCardIcon}} icons                Contains supported cc icons.
  * @property {boolean}                     showSavedCards       Used to indicate whether saved cards
  *                                                              can be used.

--- a/client/blocks/stripe-utils/type-defs.js
+++ b/client/blocks/stripe-utils/type-defs.js
@@ -282,8 +282,9 @@
  *
  * @property {string}                      key                  The public api key for stripe
  *                                                              requests.
- * @property {boolean}                     allow_prepaid_card   True means that prepaid cards
- *                                                              can be used for payment.
+ * @property {string}                      allow_prepaid_card   'yes' if prepaid cards
+ *                                                              can be used for payment,
+ *                                                              'no' otherwise.
  * @property {Object}                      button               Contains button styles
  * @property {string}                      button.type          The type of button.
  * @property {string}                      button.theme         The theme for the button.

--- a/client/blocks/stripe-utils/type-defs.js
+++ b/client/blocks/stripe-utils/type-defs.js
@@ -280,9 +280,11 @@
 /**
  * @typedef {Object} StripeServerData
  *
- * @property {string}                      key                  The public api key for stripe
+ * @property {string}                      stripeTotalLabel     The string used for payment
+ *                                                              descriptor.
+ * @property {string}                      publicKey            The public api key for stripe
  *                                                              requests.
- * @property {boolean}                     allow_prepaid_card   True means that prepaid cards
+ * @property {boolean}                     allowPrepaidCard     True means that prepaid cards
  *                                                              can be used for payment.
  * @property {Object}                      button               Contains button styles
  * @property {string}                      button.type          The type of button.

--- a/client/blocks/stripe-utils/utils.js
+++ b/client/blocks/stripe-utils/utils.js
@@ -36,7 +36,7 @@ const getStripeServerData = () => {
  * @return {string} The public api key for the stripe payment method.
  */
 const getApiKey = () => {
-	const apiKey = getStripeServerData().publicKey;
+	const apiKey = getStripeServerData()?.key;
 	if ( ! apiKey ) {
 		throw new Error(
 			'There is no api key available for stripe. Make sure it is available on the wc.stripe_data.stripe.key property.'

--- a/client/blocks/stripe-utils/utils.js
+++ b/client/blocks/stripe-utils/utils.js
@@ -38,7 +38,7 @@ const getStripeServerData = () => {
  * @return {string} The public api key for the stripe payment method.
  */
 const getApiKey = () => {
-	const apiKey = getStripeServerData().publicKey;
+	const apiKey = getStripeServerData()?.key;
 	if ( ! apiKey ) {
 		throw new Error(
 			'There is no api key available for stripe. Make sure it is available on the wc.stripe_data.stripe.key property.'

--- a/client/blocks/stripe-utils/utils.js
+++ b/client/blocks/stripe-utils/utils.js
@@ -1,5 +1,3 @@
-/* global wc_stripe_payment_request_params */
-
 /**
  * External dependencies
  */
@@ -62,8 +60,7 @@ export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 		country: cart.order_data.country_code,
 		requestPayerName: true,
 		requestPayerEmail: true,
-		requestPayerPhone:
-			wc_stripe_payment_request_params.checkout.needs_payer_phone,
+		requestPayerPhone: getStripeServerData()?.checkout?.needs_payer_phone,
 		requestShipping: cart.shipping_required ? true : false,
 		displayItems: cart.order_data.displayItems,
 	};

--- a/client/blocks/stripe-utils/utils.js
+++ b/client/blocks/stripe-utils/utils.js
@@ -36,7 +36,7 @@ const getStripeServerData = () => {
  * @return {string} The public api key for the stripe payment method.
  */
 const getApiKey = () => {
-	const apiKey = getStripeServerData()?.key;
+	const apiKey = getStripeServerData().publicKey;
 	if ( ! apiKey ) {
 		throw new Error(
 			'There is no api key available for stripe. Make sure it is available on the wc.stripe_data.stripe.key property.'

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -365,7 +365,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @return array  The configuration object to be loaded to JS.
 	 */
-	public function javascript_configuration() {
+	public function javascript_params() {
 		global $wp;
 
 		$stripe_params = [
@@ -478,7 +478,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		wp_localize_script(
 			'woocommerce_stripe',
 			'wc_stripe_params',
-			apply_filters( 'wc_stripe_params', $this->javascript_configuration() )
+			apply_filters( 'wc_stripe_params', $this->javascript_params() )
 		);
 
 		$this->tokenization_script();

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -458,6 +458,11 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		// If we're loading the cart or checkout block the scripts here should not be loaded.
+		if ( WC_Stripe_Helper::has_cart_or_checkout_block_on_current_page() ) {
+			return;
+		}
+
 		// If Stripe is not enabled bail.
 		if ( 'no' === $this->enabled ) {
 			return;

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -368,7 +368,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @return array  The configuration object to be loaded to JS.
 	 */
-	public static function javascript_configuration_object( $gateway_settings, $return_url = '' ) {
+	public static function javascript_configuration( $gateway_settings, $return_url = '' ) {
 		global $wp;
 		$testmode             = 'yes' === $gateway_settings['testmode'];
 		$publishable_key      = $testmode ? $gateway_settings['test_publishable_key'] : $gateway_settings['publishable_key'];
@@ -488,7 +488,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			'wc_stripe_params',
 			apply_filters(
 				'wc_stripe_params',
-				self::javascript_configuration_object( $this->settings, $this->get_stripe_return_url() )
+				self::javascript_configuration( $this->settings, $this->get_stripe_return_url() )
 			)
 		);
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -440,19 +440,13 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function payment_scripts() {
 		if (
 			! is_product()
-			&& ! is_cart()
-			&& ! is_checkout()
+			&& ! WC_Stripe_Helper::has_cart_or_checkout_shortcode_on_current_page()
 			&& ! isset( $_GET['pay_for_order'] ) // wpcs: csrf ok.
 			&& ! is_add_payment_method_page()
 			&& ! isset( $_GET['change_payment_method'] ) // wpcs: csrf ok.
 			&& ! ( ! empty( get_query_var( 'view-subscription' ) ) && is_callable( 'WCS_Early_Renewal_Manager::is_early_renewal_via_modal_enabled' ) && WCS_Early_Renewal_Manager::is_early_renewal_via_modal_enabled() )
 			|| ( is_order_received_page() )
 		) {
-			return;
-		}
-
-		// If we're loading the cart or checkout block the scripts here should not be loaded.
-		if ( WC_Stripe_Helper::has_cart_or_checkout_block_on_current_page() ) {
 			return;
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -363,20 +363,13 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Returns the JavaScript configuration object used on the product, cart, and checkout pages.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 * @param string $return_url The URL to return to on a successful checkout (thank you page).
-	 *
 	 * @return array  The configuration object to be loaded to JS.
 	 */
-	public static function javascript_configuration( $gateway_settings, $return_url = '' ) {
+	public function javascript_configuration() {
 		global $wp;
-		$testmode             = 'yes' === $gateway_settings['testmode'];
-		$publishable_key      = $testmode ? $gateway_settings['test_publishable_key'] : $gateway_settings['publishable_key'];
-		$inline_cc_form       = 'yes' === $gateway_settings['inline_cc_form'];
-		$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $gateway_settings['statement_descriptor'] );
 
 		$stripe_params = [
-			'key'                  => $publishable_key,
+			'key'                  => $this->publishable_key,
 			'i18n_terms'           => __( 'Please accept the terms and conditions first', 'woocommerce-gateway-stripe' ),
 			'i18n_required_fields' => __( 'Please fill in required checkout fields first', 'woocommerce-gateway-stripe' ),
 		];
@@ -414,12 +407,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$stripe_params['payment_intent_error']      = __( 'We couldn\'t initiate the payment. Please try again.', 'woocommerce-gateway-stripe' );
 		$stripe_params['sepa_mandate_notification'] = apply_filters( 'wc_stripe_sepa_mandate_notification', 'email' );
 		$stripe_params['allow_prepaid_card']        = apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no';
-		$stripe_params['inline_cc_form']            = $inline_cc_form ? 'yes' : 'no';
+		$stripe_params['inline_cc_form']            = $this->inline_cc_form ? 'yes' : 'no';
 		$stripe_params['is_checkout']               = ( is_checkout() && empty( $_GET['pay_for_order'] ) ) ? 'yes' : 'no'; // wpcs: csrf ok.
-		$stripe_params['return_url']                = $return_url;
+		$stripe_params['return_url']                = $this->get_stripe_return_url();
 		$stripe_params['ajaxurl']                   = WC_AJAX::get_endpoint( '%%endpoint%%' );
 		$stripe_params['stripe_nonce']              = wp_create_nonce( '_wc_stripe_nonce' );
-		$stripe_params['statement_descriptor']      = $statement_descriptor;
+		$stripe_params['statement_descriptor']      = $this->statement_descriptor;
 		$stripe_params['elements_options']          = apply_filters( 'wc_stripe_elements_options', [] );
 		$stripe_params['sepa_elements_options']     = $sepa_elements_options;
 		$stripe_params['invalid_owner_name']        = __( 'Billing First Name and Last Name are required.', 'woocommerce-gateway-stripe' );
@@ -491,10 +484,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		wp_localize_script(
 			'woocommerce_stripe',
 			'wc_stripe_params',
-			apply_filters(
-				'wc_stripe_params',
-				self::javascript_configuration( $this->settings, $this->get_stripe_return_url() )
-			)
+			apply_filters( 'wc_stripe_params', $this->javascript_configuration() )
 		);
 
 		$this->tokenization_script();

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -84,7 +84,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		$configuration = array_merge(
 			apply_filters(
 				'wc_stripe_params',
-				WC_Gateway_Stripe::javascript_configuration_object( $this->settings )
+				WC_Gateway_Stripe::javascript_configuration( $this->settings )
 			),
 			apply_filters(
 				'wc_stripe_payment_request_params',

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -84,11 +84,11 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		$configuration = array_merge(
 			apply_filters(
 				'wc_stripe_params',
-				WC_Gateway_Stripe::javascript_configuration( $this->settings )
+				[]
 			),
 			apply_filters(
 				'wc_stripe_payment_request_params',
-				WC_Stripe_Payment_Request::javascript_configuration( $this->settings )
+				[]
 			),
 			// Blocks-specific options
 			[

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -101,9 +101,9 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			]
 		);
 
-		// Blocks-specific that's nested in pre-existing Payment Request Button configuration, so
-		// we have to assign it like this to avoid overriding the rest of the 'button' configuration
-		// when merging the arrays.
+		// Blocks-specific option that's nested in pre-existing Payment Request Button
+		// configuration, so we have to assign it like this to avoid overriding the rest of the
+		// 'button' configuration when merging the arrays.
 		$configuration['button']['customLabel'] = $this->get_custom_payment_request_button_label();
 
 		return $configuration;

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -19,11 +19,20 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	protected $name = 'stripe';
 
 	/**
+	 * The Payment Request configuration class used for Shortcode PRBs. We use it here to retrieve
+	 * the same configurations.
+	 *
+	 * @var WC_Stripe_Payment_Request
+	 */
+	private $payment_request_configuration;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_payment_request_order_meta' ], 8, 2 );
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_stripe_intents' ], 9999, 2 );
+		$this->payment_request_configuration = new WC_Stripe_Payment_Request();
 	}
 
 	/**
@@ -95,7 +104,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				'showSaveOption' => $this->get_show_save_option(),
 				'isAdmin'        => is_admin(),
 				'button'         => [
-					'customLabel' => $this->get_custom_payment_request_button_label(),
+					'customLabel' => $this->payment_request_configuration->get_button_label(),
 				],
 			]
 		);
@@ -126,22 +135,10 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return array  the JS configuration for Stripe Payment Requests.
 	 */
 	private function get_payment_request_javascript_configuration() {
-		$pr = new WC_Stripe_Payment_Request();
 		return apply_filters(
 			'wc_stripe_payment_request_params',
-			$pr->javascript_configuration()
+			$this->payment_request_configuration->javascript_configuration()
 		);
-	}
-
-	/**
-	 * Get the custom label displayed on custom payment request buttons.
-	 *
-	 * @return string  The custom label.
-	 */
-	private function get_custom_payment_request_button_label() {
-		return isset( $this->settings['payment_request_button_label'] )
-			? $this->settings['payment_request_button_label']
-			: 'Buy now';
 	}
 
 	/**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -144,86 +144,12 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	}
 
 	/**
-	 * Returns the label to use accompanying the total in the stripe statement.
-	 *
-	 * @return string Statement descriptor.
-	 */
-	private function get_total_label() {
-		return ! empty( $this->settings['statement_descriptor'] ) ? WC_Stripe_Helper::clean_statement_descriptor( $this->settings['statement_descriptor'] ) : '';
-	}
-
-	/**
-	 * Returns the publishable api key for the Stripe service.
-	 *
-	 * @return string Public api key.
-	 */
-	private function get_publishable_key() {
-		$test_mode   = ( ! empty( $this->settings['testmode'] ) && 'yes' === $this->settings['testmode'] );
-		$setting_key = $test_mode ? 'test_publishable_key' : 'publishable_key';
-		return ! empty( $this->settings[ $setting_key ] ) ? $this->settings[ $setting_key ] : '';
-	}
-
-	/**
-	 * Returns whether to allow prepaid cards for payments.
-	 *
-	 * @return bool True means to allow prepaid card (default).
-	 */
-	private function get_allow_prepaid_card() {
-		return apply_filters( 'wc_stripe_allow_prepaid_card', true );
-	}
-
-	/**
 	 * Returns the title string to use in the UI (customisable via admin settings screen).
 	 *
 	 * @return string Title / label string
 	 */
 	private function get_title() {
 		return isset( $this->settings['title'] ) ? $this->settings['title'] : __( 'Credit / Debit Card', 'woocommerce-gateway-stripe' );
-	}
-
-	/**
-	 * Return the button type for the payment button.
-	 *
-	 * @return string Defaults to 'default'.
-	 */
-	private function get_button_type() {
-		return isset( $this->settings['payment_request_button_type'] ) ? $this->settings['payment_request_button_type'] : 'default';
-	}
-
-	/**
-	 * Return the theme to use for the payment button.
-	 *
-	 * @return string Defaults to 'dark'.
-	 */
-	private function get_button_theme() {
-		return isset( $this->settings['payment_request_button_theme'] ) ? $this->settings['payment_request_button_theme'] : 'dark';
-	}
-
-	/**
-	 * Return the height for the payment button.
-	 *
-	 * @return string A pixel value for the height (defaults to '64').
-	 */
-	private function get_button_height() {
-		return isset( $this->settings['payment_request_button_height'] ) ? str_replace( 'px', '', $this->settings['payment_request_button_height'] ) : '64';
-	}
-
-	/**
-	 * Return the inline cc option.
-	 *
-	 * @return boolean True if the inline CC form option is enabled.
-	 */
-	private function get_inline_cc_form() {
-		return isset( $this->settings['inline_cc_form'] ) && 'yes' === $this->settings['inline_cc_form'];
-	}
-
-	/**
-	 * Return the locale for the payment button.
-	 *
-	 * @return string Defaults to en_US.
-	 */
-	private function get_button_locale() {
-		return apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) );
 	}
 
 	/**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -298,7 +298,11 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return string[]
 	 */
 	public function get_supported_features() {
-		$gateway = new WC_Gateway_Stripe();
-		return array_filter( $gateway->supports, [ $gateway, 'supports' ] );
+		$gateways = WC()->payment_gateways->get_available_payment_gateways();
+		if ( isset( $gateways['stripe'] ) ) {
+			$gateway = $gateways['stripe'];
+			return array_filter( $gateway->supports, [ $gateway, 'supports' ] );
+		}
+		return [];
 	}
 }

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -28,11 +28,14 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 
 	/**
 	 * Constructor
+	 *
+	 * @param WC_Stripe_Payment_Request  The Stripe Payment Request configuration used for Payment
+	 *                                   Request buttons.
 	 */
-	public function __construct() {
+	public function __construct( $payment_request_configuration = null ) {
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_payment_request_order_meta' ], 8, 2 );
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_stripe_intents' ], 9999, 2 );
-		$this->payment_request_configuration = new WC_Stripe_Payment_Request();
+		$this->payment_request_configuration = null !== $payment_request_configuration ? $payment_request_configuration : new WC_Stripe_Payment_Request();
 	}
 
 	/**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -96,8 +96,8 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		// We need to call array_merge_recursive so the blocks 'button' setting doesn't overwrite
 		// what's provided from the gateway or payment request configuration.
 		return array_merge_recursive(
-			$this->get_gateway_javascript_configuration(),
-			$this->get_payment_request_javascript_configuration(),
+			$this->get_gateway_javascript_params(),
+			$this->get_payment_request_javascript_params(),
 			// Blocks-specific options
 			[
 				'title'          => $this->get_title(),
@@ -118,12 +118,12 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 *
 	 * @return array  the JS configuration from the Stripe Payment Gateway.
 	 */
-	private function get_gateway_javascript_configuration() {
+	private function get_gateway_javascript_params() {
 		$js_configuration = [];
 
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 		if ( isset( $gateways['stripe'] ) ) {
-			$js_configuration = $gateways['stripe']->javascript_configuration();
+			$js_configuration = $gateways['stripe']->javascript_params();
 		}
 
 		return apply_filters(
@@ -137,10 +137,10 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 *
 	 * @return array  the JS configuration for Stripe Payment Requests.
 	 */
-	private function get_payment_request_javascript_configuration() {
+	private function get_payment_request_javascript_params() {
 		return apply_filters(
 			'wc_stripe_payment_request_params',
-			$this->payment_request_configuration->javascript_configuration()
+			$this->payment_request_configuration->javascript_params()
 		);
 	}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -599,16 +599,6 @@ class WC_Stripe_Helper {
 	}
 
 	/**
-	 * Checks if this page contains a cart or checkout block.
-	 *
-	 * @since 5.3.0
-	 * @return boolean
-	 */
-	public static function has_cart_or_checkout_block_on_current_page() {
-		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
-	}
-
-	/**
 	 * Checks if this page contains a cart or checkout shortcode.
 	 *
 	 * @since 5.3.0

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -597,4 +597,14 @@ class WC_Stripe_Helper {
 		// Default to 'auto' so Stripe.js uses the browser locale.
 		return 'auto';
 	}
+
+	/**
+	 * Checks if this page contains a cart or checkout block.
+	 *
+	 * @since 5.2.1
+	 * @return boolean
+	 */
+	public static function has_cart_or_checkout_block_on_current_page() {
+		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
+	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -601,10 +601,21 @@ class WC_Stripe_Helper {
 	/**
 	 * Checks if this page contains a cart or checkout block.
 	 *
-	 * @since 5.2.1
+	 * @since 5.3.0
 	 * @return boolean
 	 */
 	public static function has_cart_or_checkout_block_on_current_page() {
 		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
+	}
+
+	/**
+	 * Checks if this page contains a cart or checkout shortcode.
+	 *
+	 * @since 5.3.0
+	 * @return boolean
+	 */
+	public static function has_cart_or_checkout_shortcode_on_current_page() {
+		return wc_post_content_has_shortcode( 'woocommerce_cart' )
+			|| wc_post_content_has_shortcode( 'woocommerce_checkout' );
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1560,5 +1560,3 @@ class WC_Stripe_Payment_Request {
 		];
 	}
 }
-
-new WC_Stripe_Payment_Request();

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -211,92 +211,78 @@ class WC_Stripe_Payment_Request {
 	/**
 	 * Gets the button type.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 *
 	 * @since   4.0.0
-	 * @version 5.2.1
+	 * @version 4.0.0
 	 * @return  string
 	 */
-	public static function get_button_type( $gateway_settings ) {
-		return isset( $gateway_settings['payment_request_button_type'] ) ? $gateway_settings['payment_request_button_type'] : 'default';
+	public function get_button_type() {
+		return isset( $this->stripe_settings['payment_request_button_type'] ) ? $this->stripe_settings['payment_request_button_type'] : 'default';
 	}
 
 	/**
 	 * Gets the button theme.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 *
 	 * @since   4.0.0
-	 * @version 5.2.1
+	 * @version 4.0.0
 	 * @return  string
 	 */
-	public static function get_button_theme( $gateway_settings ) {
-		return isset( $gateway_settings['payment_request_button_theme'] ) ? $gateway_settings['payment_request_button_theme'] : 'dark';
+	public function get_button_theme() {
+		return isset( $this->stripe_settings['payment_request_button_theme'] ) ? $this->stripe_settings['payment_request_button_theme'] : 'dark';
 	}
 
 	/**
 	 * Gets the button height.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 *
 	 * @since   4.0.0
-	 * @version 5.2.1
+	 * @version 4.0.0
 	 * @return  string
 	 */
-	public static function get_button_height( $gateway_settings ) {
-		return isset( $gateway_settings['payment_request_button_height'] ) ? str_replace( 'px', '', $gateway_settings['payment_request_button_height'] ) : '64';
+	public function get_button_height() {
+		return isset( $this->stripe_settings['payment_request_button_height'] ) ? str_replace( 'px', '', $this->stripe_settings['payment_request_button_height'] ) : '64';
 	}
 
 	/**
 	 * Checks if the button is branded.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 *
 	 * @since   4.4.0
-	 * @version 5.2.1
+	 * @version 4.4.0
 	 * @return  boolean
 	 */
-	public static function is_branded_button( $gateway_settings ) {
-		return 'branded' === self::get_button_type( $gateway_settings );
+	public function is_branded_button() {
+		return 'branded' === $this->get_button_type();
 	}
 
 	/**
 	 * Gets the branded button type.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 *
 	 * @since   4.4.0
-	 * @version 5.2.1
+	 * @version 4.4.0
 	 * @return  string
 	 */
-	public static function get_button_branded_type( $gateway_settings ) {
-		return isset( $gateway_settings['payment_request_button_branded_type'] ) ? $gateway_settings['payment_request_button_branded_type'] : 'default';
+	public function get_button_branded_type() {
+		return isset( $this->stripe_settings['payment_request_button_branded_type'] ) ? $this->stripe_settings['payment_request_button_branded_type'] : 'default';
 	}
 
 	/**
 	 * Checks if the button is custom.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 *
 	 * @since   4.4.0
-	 * @version 5.2.1
+	 * @version 4.4.0
 	 * @return  boolean
 	 */
-	public static function is_custom_button( $gateway_settings ) {
-		return 'custom' === self::get_button_type( $gateway_settings );
+	public function is_custom_button() {
+		return 'custom' === $this->get_button_type();
 	}
 
 	/**
 	 * Returns custom button css selector.
 	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 *
 	 * @since   4.4.0
 	 * @version 4.4.0
 	 * @return  string
 	 */
-	public static function custom_button_selector( $gateway_settings ) {
-		return self::is_custom_button( $gateway_settings ) ? '#wc-stripe-custom-button' : '';
+	public function custom_button_selector() {
+		return $this->is_custom_button() ? '#wc-stripe-custom-button' : '';
 	}
 
 	/**
@@ -592,66 +578,6 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Returns the JavaScript configuration object used for any pages with a payment request button.
-	 *
-	 * @param array $gateway_settings The Payment Gateway settings array.
-	 * @param bool $is_product_page Indicates whether the current page is a product's page.
-	 * @param WC_Product|bool $product A WC_Product if on a product page, false otherwise.
-	 *
-	 * @return array  The settings used for the payment request button in JavaScript.
-	 */
-	public static function javascript_configuration( $gateway_settings, $is_product_page = false, $product = false ) {
-		$testmode        = ( ! empty( $gateway_settings['testmode'] ) && 'yes' === $gateway_settings['testmode'] ) ? true : false;
-		$publishable_key = ! empty( $gateway_settings['publishable_key'] ) ? $gateway_settings['publishable_key'] : '';
-		if ( $testmode ) {
-			$publishable_key = ! empty( $gateway_settings['test_publishable_key'] ) ? $gateway_settings['test_publishable_key'] : '';
-		}
-
-		return [
-			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-			'stripe'          => [
-				'key'                => $publishable_key,
-				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
-			],
-			'nonce'           => [
-				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),
-				'shipping'                  => wp_create_nonce( 'wc-stripe-payment-request-shipping' ),
-				'update_shipping'           => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
-				'checkout'                  => wp_create_nonce( 'woocommerce-process_checkout' ),
-				'add_to_cart'               => wp_create_nonce( 'wc-stripe-add-to-cart' ),
-				'get_selected_product_data' => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
-				'log_errors'                => wp_create_nonce( 'wc-stripe-log-errors' ),
-				'clear_cart'                => wp_create_nonce( 'wc-stripe-clear-cart' ),
-			],
-			'i18n'            => [
-				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),
-				/* translators: Do not translate the [option] placeholder */
-				'unknown_shipping' => __( 'Unknown shipping option "[option]".', 'woocommerce-gateway-stripe' ),
-			],
-			'checkout'        => [
-				'url'               => wc_get_checkout_url(),
-				'currency_code'     => strtolower( get_woocommerce_currency() ),
-				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
-				'needs_shipping'    => WC()->cart->needs_shipping() ? 'yes' : 'no',
-				// Defaults to 'required' to match how core initializes this option.
-				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
-			],
-			'button'          => [
-				'type'         => self::get_button_type( $gateway_settings ),
-				'theme'        => self::get_button_theme( $gateway_settings ),
-				'height'       => self::get_button_height( $gateway_settings ),
-				'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ), // Default format is en_US.
-				'is_custom'    => self::is_custom_button( $gateway_settings ),
-				'is_branded'   => self::is_branded_button( $gateway_settings ),
-				'css_selector' => self::custom_button_selector( $gateway_settings ),
-				'branded_type' => self::get_button_branded_type( $gateway_settings ),
-			],
-			'is_product_page' => $is_product_page,
-			'product'         => $product,
-		];
-	}
-
-	/**
 	 * Load public scripts and styles.
 	 *
 	 * @since   3.1.0
@@ -685,19 +611,53 @@ class WC_Stripe_Payment_Request {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
+		$stripe_params = [
+			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'stripe'          => [
+				'key'                => $this->publishable_key,
+				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
+			],
+			'nonce'           => [
+				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),
+				'shipping'                  => wp_create_nonce( 'wc-stripe-payment-request-shipping' ),
+				'update_shipping'           => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
+				'checkout'                  => wp_create_nonce( 'woocommerce-process_checkout' ),
+				'add_to_cart'               => wp_create_nonce( 'wc-stripe-add-to-cart' ),
+				'get_selected_product_data' => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
+				'log_errors'                => wp_create_nonce( 'wc-stripe-log-errors' ),
+				'clear_cart'                => wp_create_nonce( 'wc-stripe-clear-cart' ),
+			],
+			'i18n'            => [
+				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),
+				/* translators: Do not translate the [option] placeholder */
+				'unknown_shipping' => __( 'Unknown shipping option "[option]".', 'woocommerce-gateway-stripe' ),
+			],
+			'checkout'        => [
+				'url'               => wc_get_checkout_url(),
+				'currency_code'     => strtolower( get_woocommerce_currency() ),
+				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
+				'needs_shipping'    => WC()->cart->needs_shipping() ? 'yes' : 'no',
+				// Defaults to 'required' to match how core initializes this option.
+				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
+			],
+			'button'          => [
+				'type'         => $this->get_button_type(),
+				'theme'        => $this->get_button_theme(),
+				'height'       => $this->get_button_height(),
+				'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ), // Default format is en_US.
+				'is_custom'    => $this->is_custom_button(),
+				'is_branded'   => $this->is_branded_button(),
+				'css_selector' => $this->custom_button_selector(),
+				'branded_type' => $this->get_button_branded_type(),
+			],
+			'is_product_page' => $this->is_product(),
+			'product'         => $this->get_product_data(),
+		];
+
 		wp_register_script( 'stripe', 'https://js.stripe.com/v3/', '', '3.0', true );
 		wp_register_script( 'wc_stripe_payment_request', plugins_url( 'assets/js/stripe-payment-request' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [ 'jquery', 'stripe' ], WC_STRIPE_VERSION, true );
 
-		$stripe_params = self::javascript_configuration(
-			$this->stripe_settings,
-			$this->is_product(),
-			$this->get_product_data()
-		);
-		wp_localize_script(
-			'wc_stripe_payment_request',
-			'wc_stripe_payment_request_params',
-			apply_filters( 'wc_stripe_payment_request_params', $stripe_params )
-		);
+		wp_localize_script( 'wc_stripe_payment_request', 'wc_stripe_payment_request_params', apply_filters( 'wc_stripe_payment_request_params', $stripe_params ) );
 
 		wp_enqueue_script( 'wc_stripe_payment_request' );
 
@@ -733,10 +693,10 @@ class WC_Stripe_Payment_Request {
 		<div id="wc-stripe-payment-request-wrapper" style="clear:both;padding-top:1.5em;display:none;">
 			<div id="wc-stripe-payment-request-button">
 				<?php
-				if ( self::is_custom_button( $this->stripe_settings ) ) {
+				if ( $this->is_custom_button() ) {
 					$label      = esc_html( $this->get_button_label() );
-					$class_name = esc_attr( 'button ' . self::get_button_theme( $this->stripe_settings ) );
-					$style      = esc_attr( 'height:' . self::get_button_height( $this->stripe_settings ) . 'px;' );
+					$class_name = esc_attr( 'button ' . $this->get_button_theme() );
+					$style      = esc_attr( 'height:' . $this->get_button_height() . 'px;' );
 					echo "<button id=\"wc-stripe-custom-button\" class=\"$class_name\" style=\"$style\"> $label </button>";
 				}
 				?>

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -557,16 +557,6 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Checks if this page contains a cart or checkout block.
-	 *
-	 * @since 5.2.0
-	 * @return boolean
-	 */
-	public function is_block() {
-		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
-	}
-
-	/**
 	 * Checks if this is a product page or content contains a product_page shortcode.
 	 *
 	 * @since 5.2.0
@@ -687,7 +677,9 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// If page is not supported, bail.
-		if ( ! $this->is_block() && ! $this->is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) ) {
+		if ( ! $this->is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) ) {
+			return;
+		} elseif ( WC_Stripe_Helper::has_cart_or_checkout_block_on_current_page() ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -607,12 +607,6 @@ class WC_Stripe_Payment_Request {
 			$publishable_key = ! empty( $gateway_settings['test_publishable_key'] ) ? $gateway_settings['test_publishable_key'] : '';
 		}
 
-		$needs_shipping = false;
-		$cart           = WC()->cart;
-		if ( $cart && method_exists( $cart, 'needs_shipping' ) ) {
-			$needs_shipping = $cart->needs_shipping();
-		}
-
 		return [
 			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'          => [
@@ -638,7 +632,7 @@ class WC_Stripe_Payment_Request {
 				'url'               => wc_get_checkout_url(),
 				'currency_code'     => strtolower( get_woocommerce_currency() ),
 				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
-				'needs_shipping'    => $needs_shipping ? 'yes' : 'no',
+				'needs_shipping'    => WC()->cart->needs_shipping() ? 'yes' : 'no',
 				// Defaults to 'required' to match how core initializes this option.
 				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
 			],

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -582,7 +582,7 @@ class WC_Stripe_Payment_Request {
 	 *
 	 * @return array  The settings used for the payment request button in JavaScript.
 	 */
-	public function javascript_configuration() {
+	public function javascript_params() {
 		return [
 			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'          => [
@@ -671,7 +671,7 @@ class WC_Stripe_Payment_Request {
 			'wc_stripe_payment_request_params',
 			apply_filters(
 				'wc_stripe_payment_request_params',
-				$this->javascript_configuration()
+				$this->javascript_params()
 			)
 		);
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -617,6 +617,12 @@ class WC_Stripe_Payment_Request {
 			$publishable_key = ! empty( $gateway_settings['test_publishable_key'] ) ? $gateway_settings['test_publishable_key'] : '';
 		}
 
+		$needs_shipping = false;
+		$cart           = WC()->cart;
+		if ( $cart && method_exists( $cart, 'needs_shipping' ) ) {
+			$needs_shipping = $cart->needs_shipping();
+		}
+
 		return [
 			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'          => [
@@ -642,7 +648,7 @@ class WC_Stripe_Payment_Request {
 				'url'               => wc_get_checkout_url(),
 				'currency_code'     => strtolower( get_woocommerce_currency() ),
 				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
-				'needs_shipping'    => WC()->cart->needs_shipping() ? 'yes' : 'no',
+				'needs_shipping'    => $needs_shipping ? 'yes' : 'no',
 				// Defaults to 'required' to match how core initializes this option.
 				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
 			],

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -211,78 +211,92 @@ class WC_Stripe_Payment_Request {
 	/**
 	 * Gets the button type.
 	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version 5.2.1
 	 * @return  string
 	 */
-	public function get_button_type() {
-		return isset( $this->stripe_settings['payment_request_button_type'] ) ? $this->stripe_settings['payment_request_button_type'] : 'default';
+	public static function get_button_type( $gateway_settings ) {
+		return isset( $gateway_settings['payment_request_button_type'] ) ? $gateway_settings['payment_request_button_type'] : 'default';
 	}
 
 	/**
 	 * Gets the button theme.
 	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version 5.2.1
 	 * @return  string
 	 */
-	public function get_button_theme() {
-		return isset( $this->stripe_settings['payment_request_button_theme'] ) ? $this->stripe_settings['payment_request_button_theme'] : 'dark';
+	public static function get_button_theme( $gateway_settings ) {
+		return isset( $gateway_settings['payment_request_button_theme'] ) ? $gateway_settings['payment_request_button_theme'] : 'dark';
 	}
 
 	/**
 	 * Gets the button height.
 	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version 5.2.1
 	 * @return  string
 	 */
-	public function get_button_height() {
-		return isset( $this->stripe_settings['payment_request_button_height'] ) ? str_replace( 'px', '', $this->stripe_settings['payment_request_button_height'] ) : '64';
+	public static function get_button_height( $gateway_settings ) {
+		return isset( $gateway_settings['payment_request_button_height'] ) ? str_replace( 'px', '', $gateway_settings['payment_request_button_height'] ) : '64';
 	}
 
 	/**
 	 * Checks if the button is branded.
 	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 *
 	 * @since   4.4.0
-	 * @version 4.4.0
+	 * @version 5.2.1
 	 * @return  boolean
 	 */
-	public function is_branded_button() {
-		return 'branded' === $this->get_button_type();
+	public static function is_branded_button( $gateway_settings ) {
+		return 'branded' === self::get_button_type( $gateway_settings );
 	}
 
 	/**
 	 * Gets the branded button type.
 	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 *
 	 * @since   4.4.0
-	 * @version 4.4.0
+	 * @version 5.2.1
 	 * @return  string
 	 */
-	public function get_button_branded_type() {
-		return isset( $this->stripe_settings['payment_request_button_branded_type'] ) ? $this->stripe_settings['payment_request_button_branded_type'] : 'default';
+	public static function get_button_branded_type( $gateway_settings ) {
+		return isset( $gateway_settings['payment_request_button_branded_type'] ) ? $gateway_settings['payment_request_button_branded_type'] : 'default';
 	}
 
 	/**
 	 * Checks if the button is custom.
 	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 *
 	 * @since   4.4.0
-	 * @version 4.4.0
+	 * @version 5.2.1
 	 * @return  boolean
 	 */
-	public function is_custom_button() {
-		return 'custom' === $this->get_button_type();
+	public static function is_custom_button( $gateway_settings ) {
+		return 'custom' === self::get_button_type( $gateway_settings );
 	}
 
 	/**
 	 * Returns custom button css selector.
 	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 *
 	 * @since   4.4.0
 	 * @version 4.4.0
 	 * @return  string
 	 */
-	public function custom_button_selector() {
-		return $this->is_custom_button() ? '#wc-stripe-custom-button' : '';
+	public static function custom_button_selector( $gateway_settings ) {
+		return self::is_custom_button( $gateway_settings ) ? '#wc-stripe-custom-button' : '';
 	}
 
 	/**
@@ -588,6 +602,66 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
+	 * Returns the JavaScript configuration object used for any pages with a payment request button.
+	 *
+	 * @param array $gateway_settings The Payment Gateway settings array.
+	 * @param bool $is_product_page Indicates whether the current page is a product's page.
+	 * @param WC_Product|bool $product A WC_Product if on a product page, false otherwise.
+	 *
+	 * @return array  The settings used for the payment request button in JavaScript.
+	 */
+	public static function javascript_configuration( $gateway_settings, $is_product_page = false, $product = false ) {
+		$testmode        = ( ! empty( $gateway_settings['testmode'] ) && 'yes' === $gateway_settings['testmode'] ) ? true : false;
+		$publishable_key = ! empty( $gateway_settings['publishable_key'] ) ? $gateway_settings['publishable_key'] : '';
+		if ( $testmode ) {
+			$publishable_key = ! empty( $gateway_settings['test_publishable_key'] ) ? $gateway_settings['test_publishable_key'] : '';
+		}
+
+		return [
+			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
+			'stripe'          => [
+				'key'                => $publishable_key,
+				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
+			],
+			'nonce'           => [
+				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),
+				'shipping'                  => wp_create_nonce( 'wc-stripe-payment-request-shipping' ),
+				'update_shipping'           => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
+				'checkout'                  => wp_create_nonce( 'woocommerce-process_checkout' ),
+				'add_to_cart'               => wp_create_nonce( 'wc-stripe-add-to-cart' ),
+				'get_selected_product_data' => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
+				'log_errors'                => wp_create_nonce( 'wc-stripe-log-errors' ),
+				'clear_cart'                => wp_create_nonce( 'wc-stripe-clear-cart' ),
+			],
+			'i18n'            => [
+				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),
+				/* translators: Do not translate the [option] placeholder */
+				'unknown_shipping' => __( 'Unknown shipping option "[option]".', 'woocommerce-gateway-stripe' ),
+			],
+			'checkout'        => [
+				'url'               => wc_get_checkout_url(),
+				'currency_code'     => strtolower( get_woocommerce_currency() ),
+				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
+				'needs_shipping'    => WC()->cart->needs_shipping() ? 'yes' : 'no',
+				// Defaults to 'required' to match how core initializes this option.
+				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
+			],
+			'button'          => [
+				'type'         => self::get_button_type( $gateway_settings ),
+				'theme'        => self::get_button_theme( $gateway_settings ),
+				'height'       => self::get_button_height( $gateway_settings ),
+				'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ), // Default format is en_US.
+				'is_custom'    => self::is_custom_button( $gateway_settings ),
+				'is_branded'   => self::is_branded_button( $gateway_settings ),
+				'css_selector' => self::custom_button_selector( $gateway_settings ),
+				'branded_type' => self::get_button_branded_type( $gateway_settings ),
+			],
+			'is_product_page' => $is_product_page,
+			'product'         => $product,
+		];
+	}
+
+	/**
 	 * Load public scripts and styles.
 	 *
 	 * @since   3.1.0
@@ -619,53 +693,19 @@ class WC_Stripe_Payment_Request {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		$stripe_params = [
-			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
-			'stripe'          => [
-				'key'                => $this->publishable_key,
-				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
-			],
-			'nonce'           => [
-				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),
-				'shipping'                  => wp_create_nonce( 'wc-stripe-payment-request-shipping' ),
-				'update_shipping'           => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
-				'checkout'                  => wp_create_nonce( 'woocommerce-process_checkout' ),
-				'add_to_cart'               => wp_create_nonce( 'wc-stripe-add-to-cart' ),
-				'get_selected_product_data' => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
-				'log_errors'                => wp_create_nonce( 'wc-stripe-log-errors' ),
-				'clear_cart'                => wp_create_nonce( 'wc-stripe-clear-cart' ),
-			],
-			'i18n'            => [
-				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),
-				/* translators: Do not translate the [option] placeholder */
-				'unknown_shipping' => __( 'Unknown shipping option "[option]".', 'woocommerce-gateway-stripe' ),
-			],
-			'checkout'        => [
-				'url'               => wc_get_checkout_url(),
-				'currency_code'     => strtolower( get_woocommerce_currency() ),
-				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
-				'needs_shipping'    => WC()->cart->needs_shipping() ? 'yes' : 'no',
-				// Defaults to 'required' to match how core initializes this option.
-				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
-			],
-			'button'          => [
-				'type'         => $this->get_button_type(),
-				'theme'        => $this->get_button_theme(),
-				'height'       => $this->get_button_height(),
-				'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ), // Default format is en_US.
-				'is_custom'    => $this->is_custom_button(),
-				'is_branded'   => $this->is_branded_button(),
-				'css_selector' => $this->custom_button_selector(),
-				'branded_type' => $this->get_button_branded_type(),
-			],
-			'is_product_page' => $this->is_product(),
-			'product'         => $this->get_product_data(),
-		];
-
 		wp_register_script( 'stripe', 'https://js.stripe.com/v3/', '', '3.0', true );
 		wp_register_script( 'wc_stripe_payment_request', plugins_url( 'assets/js/stripe-payment-request' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [ 'jquery', 'stripe' ], WC_STRIPE_VERSION, true );
 
-		wp_localize_script( 'wc_stripe_payment_request', 'wc_stripe_payment_request_params', apply_filters( 'wc_stripe_payment_request_params', $stripe_params ) );
+		$stripe_params = self::javascript_configuration(
+			$this->stripe_settings,
+			$this->is_product(),
+			$this->get_product_data()
+		);
+		wp_localize_script(
+			'wc_stripe_payment_request',
+			'wc_stripe_payment_request_params',
+			apply_filters( 'wc_stripe_payment_request_params', $stripe_params )
+		);
 
 		wp_enqueue_script( 'wc_stripe_payment_request' );
 
@@ -701,10 +741,10 @@ class WC_Stripe_Payment_Request {
 		<div id="wc-stripe-payment-request-wrapper" style="clear:both;padding-top:1.5em;display:none;">
 			<div id="wc-stripe-payment-request-button">
 				<?php
-				if ( $this->is_custom_button() ) {
+				if ( self::is_custom_button( $this->stripe_settings ) ) {
 					$label      = esc_html( $this->get_button_label() );
-					$class_name = esc_attr( 'button ' . $this->get_button_theme() );
-					$style      = esc_attr( 'height:' . $this->get_button_height() . 'px;' );
+					$class_name = esc_attr( 'button ' . self::get_button_theme( $this->stripe_settings ) );
+					$style      = esc_attr( 'height:' . self::get_button_height( $this->stripe_settings ) . 'px;' );
 					echo "<button id=\"wc-stripe-custom-button\" class=\"$class_name\" style=\"$style\"> $label </button>";
 				}
 				?>

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -647,9 +647,11 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// If page is not supported, bail.
-		if ( ! $this->is_product() && ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) ) {
-			return;
-		} elseif ( WC_Stripe_Helper::has_cart_or_checkout_block_on_current_page() ) {
+		if (
+			! $this->is_product()
+			&& ! WC_Stripe_Helper::has_cart_or_checkout_shortcode_on_current_page()
+			&& ! isset( $_GET['pay_for_order'] )
+		) {
 			return;
 		}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -93,6 +93,13 @@ function woocommerce_gateway_stripe() {
 			public $connect;
 
 			/**
+			 * Stripe Payment Request configurations.
+			 *
+			 * @var WC_Stripe_Payment_Request
+			 */
+			public $payment_request_configuration;
+
+			/**
 			 * Private clone method to prevent cloning of the instance of the
 			 * *Singleton* instance.
 			 *
@@ -117,8 +124,9 @@ function woocommerce_gateway_stripe() {
 
 				$this->init();
 
-				$this->api     = new WC_Stripe_Connect_API();
-				$this->connect = new WC_Stripe_Connect( $this->api );
+				$this->api                           = new WC_Stripe_Connect_API();
+				$this->connect                       = new WC_Stripe_Connect( $this->api );
+				$this->payment_request_configuration = new WC_Stripe_Payment_Request();
 
 				add_action( 'rest_api_init', [ $this, 'register_connect_routes' ] );
 			}
@@ -427,7 +435,11 @@ function woocommerce_gateway_stripe_woocommerce_block_support() {
 				$container->register(
 					WC_Stripe_Blocks_Support::class,
 					function() {
-						return new WC_Stripe_Blocks_Support();
+						if ( class_exists( 'WC_Stripe' ) ) {
+							return new WC_Stripe_Blocks_Support( WC_Stripe::get_instance()->payment_request_configuration );
+						} else {
+							return new WC_Stripe_Blocks_Support();
+						}
 					}
 				);
 				$payment_method_registry->register(


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: Link to the GitHub issue this PR addresses (if appropriate).
Fixes #1516 

1. Refactors the JS configuration preparation into static functions.
    - I'm a little unsure of this approach; is there a better way to make these configurations available to the Blocks Support class?
2. Calls the static JS configuration functions and uses the result for the blocks configuration.
3. Make sure only the Blocks JS is loaded on blocks pages.


# Testing instructions

Rather convoluted; test all the general payment flows, e.g.

- Payment with new card, saved card (Blocks + Shortcode)
- Payment with Payment Request Buttons (PRBs) (Blocks + Shortcode)
- 3DS with both PRBs, new card, saved cards (Blocks + Shortcode)
- Subscription payments (Blocks + Shortcode + Subscriptions >= 3.1.0)
    - Including renewals.
- Pre-Orders (Shortcode only, Blocks are not supported)
- Rendering of default, branded, and custom PRBs.
- Failed payments (Blocks + Shortcode)

Things to watch out for:

- Any sort of JS errors.
- Configurations that don't make it to the front-end (probably associated with JS errors).
- Discrepancies between the Shortcode- and Blocks-based cart/checkout pages.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

