### PR TITLE
Update Payment Request button for Variable Products

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -552,6 +552,7 @@ jQuery( function( $ ) {
 					} else if ( addToCartButton.is( '.wc-variation-selection-needed' ) ) {
 						window.alert( wc_add_to_cart_variation_params.i18n_make_a_selection_text );
 					}
+					$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					return;
 				}
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -274,7 +274,7 @@ jQuery( function( $ ) {
 			var data = {
 				security: wc_stripe_payment_request_params.nonce.add_to_cart,
 				product_id: product_id,
-				qty: $( '.quantity .qty' ).val(),
+				quantity: $( '.quantity .qty' ).val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
 				has_shipping_address: hasShippingAddress,
 			};

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -403,32 +403,6 @@ jQuery( function( $ ) {
 			}
 		},
 
-		getSelectedProductData: function() {
-			var product_id = $( '.single_add_to_cart_button' ).val();
-
-			// Check if product is a variable product.
-			if ( $( '.single_variation_wrap' ).length ) {
-				product_id = $( '.single_variation_wrap' ).find( 'input[name="product_id"]' ).val();
-			}
-
-			var addons = $( '#product-addons-total' ).data('price_data') || [];
-			var addon_value = addons.reduce( function ( sum, addon ) { return sum + addon.cost; }, 0 );
-
-			var data = {
-				security: wc_stripe_payment_request_params.nonce.get_selected_product_data,
-				product_id: product_id,
-				qty: $( '.quantity .qty' ).val(),
-				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
-				addon_value: addon_value,
-			};
-
-			return $.ajax( {
-				type: 'POST',
-				data: data,
-				url:  wc_stripe_payment_request.getAjaxURL( 'get_selected_product_data' )
-			} );
-		},
-
 		/**
 		 * Creates stripe paymentRequest element or connects to custom button
 		 *
@@ -582,21 +556,6 @@ jQuery( function( $ ) {
 
 			$( document.body ).on( 'wc_stripe_disable_payment_request_button', function () {
 				wc_stripe_payment_request.blockPaymentRequestButton( 'wc_request_button_is_disabled' );
-			} );
-
-			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
-				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
-
-				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
-					$.when(
-						paymentRequest.update( {
-							total: response.total,
-							displayItems: response.displayItems,
-						} )
-					).then( function () {
-						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
-					} );
-				});
 			} );
 		},
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -999,18 +999,19 @@ class WC_Stripe_Payment_Request {
 				define( 'WOOCOMMERCE_CART', true );
 			}
 
-			$product_id       = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-			$product          = wc_get_product( $product_id );
-			$quantity         = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
-			$has_enough_stock = $product->has_enough_stock( $quantity );
-			$product_type     = $product->get_type();
-			$variation_id     = 0;
-			$attributes       = [];
+			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$product    = wc_get_product( $product_id );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: %d is the product Id */
 				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
+
+			$quantity         = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
+			$has_enough_stock = $product->has_enough_stock( $quantity );
+			$product_type     = $product->get_type();
+			$variation_id     = 0;
+			$attributes       = [];
 
 			WC()->shipping->reset_shipping();
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1001,8 +1001,8 @@ class WC_Stripe_Payment_Request {
 
 			$product_id       = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
 			$product          = wc_get_product( $product_id );
-			$qty              = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
-			$has_enough_stock = $product->has_enough_stock( $qty );
+			$quantity         = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
+			$has_enough_stock = $product->has_enough_stock( $quantity );
 			$product_type     = $product->get_type();
 			$variation_id     = 0;
 			$attributes       = [];
@@ -1027,7 +1027,7 @@ class WC_Stripe_Payment_Request {
 
 				if ( ! empty( $variation_id ) ) {
 					$variation        = wc_get_product( $variation_id );
-					$has_enough_stock = $variation->has_enough_stock( $qty );
+					$has_enough_stock = $variation->has_enough_stock( $quantity );
 				}
 			}
 
@@ -1036,7 +1036,7 @@ class WC_Stripe_Payment_Request {
 				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
 			}
 
-			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
+			WC()->cart->add_to_cart( $product->get_id(), $quantity, $variation_id, $attributes );
 
 			// This method is called from the product page only. Always display itemized items.
 			$itemized_display_items = true;


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Part of #1563. #1577 follow-up.

- Removes completely traces of `getSelectedProductData`/`get_selected_product_data `. Removal started in #1577. Now it's completely removed after confirming is not needed for variable products.
- Fixes an issue where Shipping amount was not correct after changing/updating Shipping Method.
- Fixes a validation issue that happened when a variation didn't have enough stock. Error is displayed correctly now.

# Testing instructions

This PR focuses on variable products only. Fortunately #1577 already covers many of the cases already so I focused here on cases that might broke for variable products only.

1. Create a "color" attribute.
2. Add terms "red", "green", "blue".
3. Create a variation from all attributes.
4. Apply different scenarios to it. You can use the same cases I've tested on the Test list below.
5. Check correct amount and item list is correct in Google Pay/Apple Pay.

#### Test list - Variable Product

- [x] Regular Price
- [x] Regular Price with default variation
- [x] With quantity
- [x] With Sale Price
- [x] Variation Without enough stock - Works better now with add-ons.
- [x] With Shipping
- [x] With Shipping, when changing Shipping Method
- [x] With Taxes
- [x] With Virtual products
- [x] Car Page With Coupon
- [x] With add-ons - This one actually works even better now
- [x] Cart Block
- [x] Checkout Block

