### PR TITLE
Hide Payment Request Buttons when cart contains multiple packages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 5.x.x - 2021-xx-xx =
-* Fix - Disabled Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
+* Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
 
 = 5.2.3 - 2021-06-11 =
 * Fix - Credit card icons and credit card input on custom shortcode checkout pages.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 5.x.x - 2021-xx-xx =
+* Fix - Disabled Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
+
 = 5.2.3 - 2021-06-11 =
 * Fix - Credit card icons and credit card input on custom shortcode checkout pages.
 

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -30,6 +30,10 @@ const paymentRequestPaymentMethod = {
 			return true;
 		}
 
+		if ( ! getStripeServerData()?.shouldShowPaymentRequestButton ) {
+			return false;
+		}
+
 		return loadStripe().then( ( stripe ) => {
 			// Create a payment request and check if we can make a payment to determine whether to
 			// show the Payment Request Button or not. This is necessary because a browser might be

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -106,12 +106,47 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				'showSavedCards'                 => $this->get_show_saved_cards(),
 				'showSaveOption'                 => $this->get_show_save_option(),
 				'isAdmin'                        => is_admin(),
+				'shouldShowPaymentRequestButton' => $this->should_show_payment_request_button(),
 				'button'                         => [
 					'customLabel' => $this->payment_request_configuration->get_button_label(),
 				],
-				'shouldShowPaymentRequestButton' => $this->payment_request_configuration->should_show_payment_button_on_cart(),
 			]
 		);
+	}
+
+	/**
+	 * Returns true if the PRB should be shown on the current page, false otherwise.
+	 *
+	 * Note: We use `has_block()` in this function, which isn't supported until WP 5.0. However,
+	 * WooCommerce Blocks hasn't supported a WP version lower than 5.0 since 2019. Since this
+	 * function is only called when the WooCommerce Blocks extension is available, it should be
+	 * safe to call `has_block()` here.
+	 * That said, we only run those checks if the `has_block()` function exists, just in case.
+	 *
+	 * @return boolean  True if PRBs should be displayed, false otherwise
+	 */
+	private function should_show_payment_request_button() {
+		// TODO: Remove the `function_exists()` check once the minimum WP version has been bumpted
+		//       to version 5.0.
+		if ( function_exists( 'has_block' ) ) {
+			// Don't show if PRBs are supposed to be hidden on the cart page.
+			if (
+				has_block( 'woocommerce/cart' )
+				&& ! apply_filters( 'wc_stripe_show_payment_request_on_cart', true )
+			) {
+				return false;
+			}
+
+			// Don't show PRB if there are unsupported products in the cart.
+			if (
+				( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) )
+				&& ! $this->payment_request_configuration->allowed_items_in_cart()
+			) {
+				return false;
+			}
+		}
+
+		return $this->payment_request_configuration->should_show_payment_request_button();
 	}
 
 	/**

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -100,15 +100,16 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			$this->get_payment_request_javascript_params(),
 			// Blocks-specific options
 			[
-				'title'          => $this->get_title(),
-				'icons'          => $this->get_icons(),
-				'supports'       => $this->get_supported_features(),
-				'showSavedCards' => $this->get_show_saved_cards(),
-				'showSaveOption' => $this->get_show_save_option(),
-				'isAdmin'        => is_admin(),
-				'button'         => [
+				'title'                          => $this->get_title(),
+				'icons'                          => $this->get_icons(),
+				'supports'                       => $this->get_supported_features(),
+				'showSavedCards'                 => $this->get_show_saved_cards(),
+				'showSaveOption'                 => $this->get_show_save_option(),
+				'isAdmin'                        => is_admin(),
+				'button'                         => [
 					'customLabel' => $this->payment_request_configuration->get_button_label(),
 				],
+				'shouldShowPaymentRequestButton' => $this->payment_request_configuration->should_show_payment_button_on_cart(),
 			]
 		);
 	}

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -126,13 +126,26 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return boolean  True if PRBs should be displayed, false otherwise
 	 */
 	private function should_show_payment_request_button() {
-		// TODO: Remove the `function_exists()` check once the minimum WP version has been bumpted
+		// TODO: Remove the `function_exists()` check once the minimum WP version has been bumped
 		//       to version 5.0.
 		if ( function_exists( 'has_block' ) ) {
+			global $post;
+
 			// Don't show if PRBs are supposed to be hidden on the cart page.
+			// Note: The cart block has the PRB enabled by default.
 			if (
 				has_block( 'woocommerce/cart' )
 				&& ! apply_filters( 'wc_stripe_show_payment_request_on_cart', true )
+			) {
+				return false;
+			}
+
+			// Don't show if PRBs are supposed to be hidden on the checkout page.
+			// Note: The checkout block has the PRB enabled by default. This differs from the shortcode
+			//       checkout where the PRB is disabled by default.
+			if (
+				has_block( 'woocommerce/checkout' )
+				&& ! apply_filters( 'wc_stripe_show_payment_request_on_checkout', true, $post )
 			) {
 				return false;
 			}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -521,7 +521,7 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
-		// If the cart is not available we don't have any unsupported prodcuts in the cart, so we
+		// If the cart is not available we don't have any unsupported products in the cart, so we
 		// return true. This can happen e.g. when loading the cart or checkout blocks in Gutenberg.
 		if ( is_null( WC()->cart ) ) {
 			return true;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -689,8 +689,8 @@ class WC_Stripe_Payment_Request {
 	/**
 	 * Returns true if the current page supports Payment Request Buttons, false otherwise.
 	 *
-	 * @since   5.3.0
-	 * @version 5.3.0
+	 * @since   x.x.x
+	 * @version x.x.x
 	 * @return  boolean  True if the current page is supported, false otherwise.
 	 */
 	private function is_page_supported() {
@@ -770,8 +770,8 @@ class WC_Stripe_Payment_Request {
 	 * Returns true if Payment Request Buttons are supported on the current page, false
 	 * otherwise.
 	 *
-	 * @since   5.3.0
-	 * @version 5.3.0
+	 * @since   x.x.x
+	 * @version x.x.x
 	 * @return  boolean  True if PRBs are supported on current page, false otherwise
 	 */
 	public function should_show_payment_request_button() {
@@ -834,8 +834,8 @@ class WC_Stripe_Payment_Request {
 	 *
 	 * @param WC_Product $param  The product that's being checked for support.
 	 *
-	 * @since   5.3.0
-	 * @version 5.3.0
+	 * @since   x.x.x
+	 * @version x.x.x
 	 * @return boolean  True if the provided product is supported, false otherwise.
 	 */
 	private function is_product_supported( $product ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -988,7 +988,8 @@ class WC_Stripe_Payment_Request {
 
 					foreach ( $package['rates'] as $key => $rate ) {
 						if ( in_array( $rate->id, $shipping_rate_ids, true ) ) {
-							// Payment requests throw a fit if there are duplicate IDs.
+							// The Payment Requests will try to load indefinitely if there are duplicate shipping
+							// option IDs.
 							throw new Exception( __( 'Unable to provide shipping options for Payment Requests.', 'woocommerce-gateway-stripe' ) );
 						}
 						$shipping_rate_ids[]        = $rate->id;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -539,6 +539,13 @@ class WC_Stripe_Payment_Request {
 			}
 		}
 
+		// We don't support multiple packages with Payment Request Buttons because we can't offer
+		// a good UX.
+		$packages = WC()->cart->get_shipping_packages();
+		if ( 1 < count( $packages ) ) {
+			return false;
+		}
+
 		return true;
 	}
 
@@ -760,7 +767,7 @@ class WC_Stripe_Payment_Request {
 	 * @since  4.4.1
 	 * @return boolean
 	 */
-	private function should_show_payment_button_on_cart() {
+	public function should_show_payment_button_on_cart() {
 		// Not supported when user isn't authenticated and authentication is required.
 		if ( ! is_user_logged_in() && $this->is_authentication_required() ) {
 			return false;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -689,7 +689,9 @@ class WC_Stripe_Payment_Request {
 	/**
 	 * Returns true if the current page supports Payment Request Buttons, false otherwise.
 	 *
-	 * @return boolean  True if the current page is supported, false otherwise.
+	 * @since   5.3.0
+	 * @version 5.3.0
+	 * @return  boolean  True if the current page is supported, false otherwise.
 	 */
 	private function is_page_supported() {
 		return $this->is_product()

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -695,9 +695,7 @@ class WC_Stripe_Payment_Request {
 	 */
 	private function is_page_supported() {
 		return $this->is_product()
-			|| is_checkout()
-			|| is_cart()
-			|| WC_Stripe_Helper::has_cart_or_checkout_shortcode_on_current_page()
+			|| WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
 			|| isset( $_GET['pay_for_order'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
@@ -797,7 +795,7 @@ class WC_Stripe_Payment_Request {
 		// Don't show if on the cart or checkout page, or if page contains the cart or checkout
 		// shortcodes, with items in the cart that aren't supported.
 		if (
-			( is_cart() || is_checkout() || WC_Stripe_Helper::has_cart_or_checkout_shortcode_on_current_page() )
+			WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
 			&& ! $this->allowed_items_in_cart()
 		) {
 			return false;

--- a/readme.txt
+++ b/readme.txt
@@ -126,8 +126,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.2.3 - 2021-06-11 =
-
-* Fix - Credit card icons and credit card input on custom shortcode checkout pages.
+= 5.x.x - 2021-xx-xx =
+* Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1504 

When an order is split across multiple packages customers are allowed to choose individual shipping options for each package. This quickly grows in complexity according to `<number_of_packages>^<number_of_shipping_options>` — having just 2 packages with 3 shipping options each results in `2^3 = 8` combinations of shipping options.

We can think of no good way to present this in the Payment Request Dialog that isn't confusing so we decided to hide the buttons when this happens.

# Testing instructions

We need to test that you can pay with PRBs for the following types of orders:

- Contain any amount of products without a shipping package associated with them.
- Contains **only 1** product with a shipping package associated with it.

These types of orders should hide the PRBs:

- Contain **2 or more** products with a shipping package associated with them.

To test this:

1. Make sure you have 2-3 different shipping methods available.
1. Install the [Advanced Shipping Packages plugin](https://woocommerce.com/products/woocommerce-advanced-shipping-packages/).
1. Go to **WooCommerce > Settings > Shipping > Shipping Classes** and create 3 different shipping classes.
1. Go to **WooCommerce > Settings > Shipping > Packages** and create 3 packages, each corresponding to a shipping class.
1. Go to **Products > All Products**, choose 3 different products (e.g. Beanie, Belt, and Sunglasses) and assign each a different shipping class (you'll find this under Product Details > Shipping)
1. Add all 3 products to the cart
1. Go to the Cart page
1. Make sure that no PRBs are visible
    - In `trunk` you should see the PRB
1. Remove any 2 items from the cart.
2. Reload the cart page.
3. See that the PRB is now visible
4. Remove the last item from the cart
5. Add 1 or more items to the cart that don't have a shipping package associated with them.
6. Go the cart page.
7. See that the PRB is visible.

**Make sure to test both the shortcode and block-based carts and checkouts**

Finally, test the single product page; make sure that you can use the PRB no matter whether the product has a shipping package associated with it or not.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
