### PR TITLE
Check for the existence of the WC Cart before using it to generate JS configuration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 5.2.2 - 2021-xx-xx =
+* Fix - The absence of a cart causing fatal errors when rendering the Cart or Checkout block.
+
 = 5.2.1 - 2021-06-10 =
 * Fix - Remove calls to `has_block()` since it breaks compatibility with older versions of WordPress.
 * Tweak - Use the same JavaScript configurations for the Block-based and Shortcode-based checkout flows.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -583,6 +583,11 @@ class WC_Stripe_Payment_Request {
 	 * @return array  The settings used for the payment request button in JavaScript.
 	 */
 	public function javascript_params() {
+		$needs_shipping = 'no';
+		if ( ! is_null( WC()->cart ) && WC()->cart->needs_shipping() ) {
+			$needs_shipping = 'yes';
+		}
+
 		return [
 			'ajax_url'        => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'          => [
@@ -608,7 +613,7 @@ class WC_Stripe_Payment_Request {
 				'url'               => wc_get_checkout_url(),
 				'currency_code'     => strtolower( get_woocommerce_currency() ),
 				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
-				'needs_shipping'    => WC()->cart->needs_shipping() ? 'yes' : 'no',
+				'needs_shipping'    => $needs_shipping,
 				// Defaults to 'required' to match how core initializes this option.
 				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
 			],

--- a/readme.txt
+++ b/readme.txt
@@ -126,8 +126,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.2.1 - 2021-06-10 =
+= 5.2.2 - 2021-xx-xx =
 
-* Fix - Remove calls to `has_block()` since it breaks compatibility with older versions of WordPress.
-* Tweak - Use the same JavaScript configurations for the Block-based and Shortcode-based checkout flows.
+* Fix - The absence of a cart causing fatal errors when rendering the Cart or Checkout block.
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

- Check for the existence of `WC()->cart` before trying to call `WC()->cart->needs_shipping()`

The lack of this check causes a fatal error when modifying a page in Gutenberg with the Cart or Checkout block on it.

# Testing instructions

- `git checkout trunk`
- `git pull`
- `npm run build:webpack`
- Open **Pages > [Page with cart or checkout block on it]**
- Notice the fatal error occurring
- `git checkout fix-fatal-error-when-no-wc-cart-available`
- Open **Pages > [Page with cart or checkout block on it]**
- Notice the fatal error no longer occurs.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

