### PR TITLE
Check for any cart or checkout shortcode before enqueuing payment scripts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 5.2.3 - 2021-xx-xx =
+* Fix - Credit card icons and credit card input on custom shortcode checkout pages.
+
 = 5.2.2 - 2021-06-10 =
 * Fix - The absence of a cart causing fatal errors when rendering the Cart or Checkout block.
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -440,7 +440,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function payment_scripts() {
 		if (
 			! is_product()
-			&& ! WC_Stripe_Helper::has_cart_or_checkout_shortcode_on_current_page()
+			&& ! WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
 			&& ! isset( $_GET['pay_for_order'] ) // wpcs: csrf ok.
 			&& ! is_add_payment_method_page()
 			&& ! isset( $_GET['change_payment_method'] ) // wpcs: csrf ok.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -601,11 +601,10 @@ class WC_Stripe_Helper {
 	/**
 	 * Checks if this page contains a cart or checkout shortcode.
 	 *
-	 * @since 5.2.1
+	 * @since 5.2.3
 	 * @return boolean
 	 */
 	public static function has_cart_or_checkout_shortcode_on_current_page() {
-		return wc_post_content_has_shortcode( 'woocommerce_cart' )
-			|| wc_post_content_has_shortcode( 'woocommerce_checkout' );
+		return is_cart() || is_checkout();
 	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -599,12 +599,12 @@ class WC_Stripe_Helper {
 	}
 
 	/**
-	 * Checks if this page contains a cart or checkout shortcode.
+	 * Checks if this page is a cart or checkout page.
 	 *
 	 * @since 5.2.3
 	 * @return boolean
 	 */
-	public static function has_cart_or_checkout_shortcode_on_current_page() {
+	public static function has_cart_or_checkout_on_current_page() {
 		return is_cart() || is_checkout();
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -654,7 +654,7 @@ class WC_Stripe_Payment_Request {
 		// If page is not supported, bail.
 		if (
 			! $this->is_product()
-			&& ! WC_Stripe_Helper::has_cart_or_checkout_shortcode_on_current_page()
+			&& ! WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
 			&& ! isset( $_GET['pay_for_order'] )
 		) {
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -129,3 +129,5 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 5.2.3 - 2021-xx-xx =
 
 * Fix - Credit card icons and credit card input on custom shortcode checkout pages.
+
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -126,7 +126,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.2.2 - 2021-06-10 =
+= 5.2.3 - 2021-xx-xx =
 
-* Fix - The absence of a cart causing fatal errors when rendering the Cart or Checkout block.
-
+* Fix - Credit card icons and credit card input on custom shortcode checkout pages.


### PR DESCRIPTION
# Changes proposed in this Pull Request:

This fixes an issue with "non official" cart and checkout shortcode pages by reverting [two checks](https://github.com/woocommerce/woocommerce-gateway-stripe/commit/1273eac1aedb2de4b0e95b4f70275f0f73271b86#r52056868) from #1585 .


# Testing instructions

- In `trunk`, install [CartFlows](https://wordpress.org/plugins/cartflows/).
- Go to the CartFlows Flows page and create a new flow (wp-admin/admin.php?page=cartflows&path=flows).
- Select the first "Evergreen Product - 01" template.
- Click "Import flow"
- Click "Edit" on the checkout page and then click the Products tab. Add a product to it. e.g "Album".
- Click to view the newly created checkout page.
- Notice the credit card icons are awkward and the credit card input doesn't show up.
- Checkout this branch and notice the problem goes away.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
