### PR TITLE
Payment Request button:  Various Improvements

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -532,13 +532,8 @@ jQuery( function( $ ) {
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
 				// First check if product can be added to cart.
-				var addToCartButton = $( '.single_add_to_cart_button' );
-				if ( addToCartButton.is( '.disabled' ) ) {
-					if ( addToCartButton.is( '.wc-variation-is-unavailable' ) ) {
-						window.alert( wc_add_to_cart_variation_params.i18n_unavailable_text );
-					} else if ( addToCartButton.is( '.wc-variation-selection-needed' ) ) {
-						window.alert( wc_add_to_cart_variation_params.i18n_make_a_selection_text );
-					}
+				if ( $( '.single_add_to_cart_button' ).is( '.wc-variation-selection-needed' ) ) {
+					window.alert( wc_add_to_cart_variation_params.i18n_make_a_selection_text );
 					$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					return;
 				}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1122,6 +1122,7 @@ class WC_Stripe_Payment_Request {
 			$product_type     = $product->get_type();
 			$variation_id     = 0;
 			$attributes       = [];
+			$is_in_stock      = $product->is_in_stock();
 
 			WC()->shipping->reset_shipping();
 
@@ -1137,7 +1138,12 @@ class WC_Stripe_Payment_Request {
 				if ( ! empty( $variation_id ) ) {
 					$variation        = wc_get_product( $variation_id );
 					$has_enough_stock = $variation->has_enough_stock( $quantity );
+					$is_in_stock      = $variation->is_in_stock();
 				}
+			}
+
+			if ( ! $is_in_stock ) {
+				throw new Exception( sprintf( __( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce-gateway-stripe' ) ) );
 			}
 
 			if ( ! $has_enough_stock ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1127,7 +1127,7 @@ class WC_Stripe_Payment_Request {
 			}
 
 			if ( ! $is_in_stock ) {
-				throw new Exception( sprintf( __( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce-gateway-stripe' ) ) );
+				throw new Exception( __( 'Sorry, this product is unavailable. Please choose a different combination.', 'woocommerce-gateway-stripe' ) );
 			}
 
 			if ( ! $has_enough_stock ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -325,24 +325,6 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Gets the product total price.
-	 *
-	 * @since 5.2.0
-	 *
-	 * @param object $product WC_Product_* object.
-	 * @return integer Total price.
-	 */
-	public function get_product_price( $product ) {
-		$product_price = $product->get_price();
-		// Add subscription sign-up fees to product price.
-		if ( 'subscription' === $product->get_type() && class_exists( 'WC_Subscriptions_Product' ) ) {
-			$product_price = $product->get_price() + WC_Subscriptions_Product::get_sign_up_fee( $product );
-		}
-
-		return $product_price;
-	}
-
-	/**
 	 * Gets the product data for the currently viewed page
 	 *
 	 * @since   4.0.0
@@ -380,7 +362,7 @@ class WC_Stripe_Payment_Request {
 		$data                    = [];
 		$data['total']           = [
 			'label'   => apply_filters( 'wc_stripe_payment_request_total_label', $this->total_label ),
-			'amount'  => WC_Stripe_Helper::get_stripe_amount( $this->get_product_price( $product ) ),
+			'amount'  => WC_Stripe_Helper::get_stripe_amount( $product->get_price() ),
 			'pending' => true,
 		];
 		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1128,8 +1128,6 @@ class WC_Stripe_Payment_Request {
 			// First empty the cart to prevent wrong calculation.
 			WC()->cart->empty_cart();
 
-			$product_type = $product->get_type();
-
 			if ( ( 'variable' === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
 				$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1117,12 +1117,13 @@ class WC_Stripe_Payment_Request {
 				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
 
-			$quantity         = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
-			$has_enough_stock = $product->has_enough_stock( $quantity );
-			$product_type     = $product->get_type();
-			$variation_id     = 0;
-			$attributes       = [];
-			$is_in_stock      = $product->is_in_stock();
+			$quantity              = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
+			$has_enough_stock      = $product->has_enough_stock( $quantity );
+			$product_type          = $product->get_type();
+			$variation_id          = 0;
+			$attributes            = [];
+			$is_in_stock           = $product->is_in_stock();
+			$stock_qty_for_display = wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product );
 
 			WC()->shipping->reset_shipping();
 
@@ -1136,9 +1137,10 @@ class WC_Stripe_Payment_Request {
 				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 				if ( ! empty( $variation_id ) ) {
-					$variation        = wc_get_product( $variation_id );
-					$has_enough_stock = $variation->has_enough_stock( $quantity );
-					$is_in_stock      = $variation->is_in_stock();
+					$variation             = wc_get_product( $variation_id );
+					$has_enough_stock      = $variation->has_enough_stock( $quantity );
+					$is_in_stock           = $variation->is_in_stock();
+					$stock_qty_for_display = wc_format_stock_quantity_for_display( $variation->get_stock_quantity(), $variation );
 				}
 			}
 
@@ -1148,7 +1150,7 @@ class WC_Stripe_Payment_Request {
 
 			if ( ! $has_enough_stock ) {
 				/* translators: 1: product name 2: quantity in stock */
-				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
+				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), $stock_qty_for_display ) );
 			}
 
 			WC()->cart->add_to_cart( $product->get_id(), $quantity, $variation_id, $attributes );


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Part of #1563. #1587 follow-up. 

Minor improvements.

<!--
Enables the Payment Request button on the cart page for subscriptions created using the [WooCommerce Subscriptions plugin](https://woocommerce.com/products/woocommerce-subscriptions/), virtual subscriptions, downloadable and variable subscriptions. **It doesn't work for Trial Subscriptions that require Shipping** though. Will create a separate issue for it. 

# Testing instructions

First of all you need to Install the WooCommerce Subscriptions plugin in order to create subscriptions.

**For simple subscriptions**

1. Create a simple subscription 
2. Go to the subscription page
3. Click the Payment Request button
4. Displayed items should be correct
5. Payment dialog should include the Shipping Address section

You can use all the cases mentioned below

<details>
<summary>
Simple Subscriptions test list
</summary>

- [x] with Regular price
- [x] with Sale price
- [x] with Tax Status: none
- [x] with Tax Status: taxable, Tax class: Reduced rate 
- [x] with Sign-up fee
- [x] with Sign-up fee + Sale price
- [x] with quantity
- [x] Without stock (button is not displayed)
- [x] With not enough stock (alert with error message should be displayed)
- [x] sold individually

</details>


**For virtual subscriptions**

1. Create a simple subscription 
2. **Check "Virtual" option**
3. Go to the subscription page
4. Click the Payment Request button
5. Displayed items should be correct
6. Payment dialog should **not** include Shipping Address section

You can use all the cases mentioned below

<details>
<summary>
 Simple Subscriptions - Virtual
</summary>

- [x] with Regular price
- [x] with Sale price
- [x] with Tax Status: none
- [x] with Tax Status: taxable, Tax class: Reduced rate 
- [x] with Sign-up fee
- [x] with Sign-up fee + Sale price
- [x] with quantity
- [x] Without stock (button is not displayed)
- [x] With not enough stock (alert with error message should be displayed)
- [x] sold individually

</details>

**For variable subscriptions**

1. Create a variable subscription 
2. Add custom "color" attribute with terms: "red", "green", "blue", with prices, 100 200, 300 respectively. 
3. Create a variation for all attributes
3. Go to the subscription page
4. Select a variation
4. Click the Payment Request button
5. Displayed items should be correct
6. Payment dialog should include the Shipping Address section

You can use all the cases mentioned below

<details>
<summary>Variable Subscription</summary>

- [x] variation with Regular price
- [x] with "Default Form values"
- [x] variation with Sale price
- [x] variation with Tax class: Reduced rate 
- [x] variation with Sign-up fee
- [x] variation with Sign-up fee + Sale price
- [x] variation with quantity
- [x] variation without stock (button is not displayed)
- [x] variation with not enough stock (alert with error message should be displayed)
- [x] variation is virtual

</details>


#### Observations
- This PR does not work with Trial Subscriptions. PR button is hidden for this case.
- PR button shouldn't be displayed if product is added to cart and is set to "Out of stock". 
- PR button shouldn't be displayed if quantity is greater than stock
- Payment dialog asks for Shipping address when selecting a virtual variation
-->