### PR TITLE
Update Payment Request button for Bundles

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1471,6 +1471,11 @@ class WC_Stripe_Payment_Request {
 		// Default show only subtotal instead of itemization.
 		if ( ! apply_filters( 'wc_stripe_payment_request_hide_itemization', true ) || $itemized_display_items ) {
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+				// Exclude bundled items to avoid making the list too big
+				if ( function_exists( 'wc_pb_is_bundled_cart_item' ) && wc_pb_is_bundled_cart_item( $cart_item ) ) {
+					continue;
+				}
+
 				$amount         = $cart_item['line_subtotal'];
 				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
 


### PR DESCRIPTION
Part of #1563. #1597 follow-up.

## Changes proposed in this Pull Request

Improves integration of the Payment Request button on the product page with bundles created with [Product Bundles](https://woocommerce.com/products/product-bundles/).

Currently, the PR button is displayed on the product page for bundles but it's not working properly. Shipping address section on the payment dialog is now showing up when it's required.

Apparently, the PR button has been working correctly on the Cart page. So I've tried to make it work exactly like it on the product page.

I've build a small list of the possible cases and observed when the "Shipping" is displayed to the user or not.

```
Bundle with simple products - unassembled
  - ✅ cart totals
  - ✅ payment dialog
Bundle withsimple products - assembled
  - ✅ cart totals
  - ✅ payment dialog
Bundle with virtual products - unassembled
  - ❌ cart totals
  - ❌ payment dialog: 
Bundle with virtual products - assembled
  - ✅ cart totals: 
  - ✅ payment dialog

✅ = Shows shipping section
❌ = Hidden shipping section
```

## Testing instructions

First of all you need to Install the [Product Bundles plugin](https://woocommerce.com/products/product-bundles/) in order to be able to create product bundles.

In order to make the PR button on the product page to work correctly with bundles we need to make a small modification to the plugin. In the File `woocommerce-product-bundles/templates/single-product/add-to-cart/bundle-button.php` update the following line:

```php
?><button type="submit" class="single_add_to_cart_button bundle_add_to_cart_button button alt"><?php echo $product->single_add_to_cart_text(); ?></button>
```
with:

```php
?><button value="<?php echo esc_attr( $product->get_id() ); ?>" type="submit" class="single_add_to_cart_button bundle_add_to_cart_button button alt"><?php echo $product->single_add_to_cart_text(); ?></button>

```

I'll ping the team responsible of the plugin to update their code later.

**Bundle with products that require shipping.**

1. Create a simple product, set a price. Save product.
2. Create a bundle product, set a price.
3. Add simple product created in step 1 to the bundle created in step 2.
4. Save bundle.
4. Go to product page (bundle)
5. Check PR button is displaying correctly and it gives the option to add a Shipping address
6. Confirm taxes, and everything are calculated correctly.

**Bundle with product that doesn't require shipping.**

1. Create a virtual product, check "virtual" checkbox, set a price. Save product.
2. Create a bundle product, set a price.
3. Add virtual product created in step 1 to the bundle created in step 2.
4. Save bundle.
4. Go to product page (bundle)
5. Check PR button is displaying correctly and it doesn't offer the option to add a Shipping address
6. Confirm taxes, and everything are calculated correctly.

- Note: Try mixing up product types and/or adding more products to the bundle. Also try different options. Like Bundle types (Product Data -> Shipping): Assembled, Unassembled.
- Also, all the tests I did were compared to how the bundle is handled in the cart page. So I'd recommend checking it there when doing any test on the product page.

TODO:
- [x] Check with cart and checkout blocks 