### PR TITLE
Payment Request Button: Guide users to authentication when it is required

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -376,7 +376,14 @@ jQuery( function( $ ) {
 					if ( ! result ) {
 						return;
 					}
-					paymentRequestType = result.applePay ? 'apple_pay' : 'payment_request_api';
+					if ( result.applePay ) {
+						paymentRequestType = 'apple_pay';
+					} else if ( result.googlePay ) {
+						paymentRequestType = 'google_pay';
+					} else {
+						paymentRequestType = 'payment_request_api';
+					}
+
 					wc_stripe_payment_request.attachPaymentRequestButtonEventListeners( prButton, paymentRequest );
 					wc_stripe_payment_request.showPaymentRequestButton( prButton );
 				} );
@@ -588,6 +595,13 @@ jQuery( function( $ ) {
 			var addToCartButton = $( '.single_add_to_cart_button' );
 
 			prButton.on( 'click', function ( evt ) {
+				// If login is required for checkout, display redirect confirmation dialog.
+				if ( wc_stripe_payment_request_params.login_confirmation ) {
+					evt.preventDefault();
+					displayLoginConfirmation( paymentRequestType );
+					return;
+				}
+
 				// First check if product can be added to cart.
 				if ( addToCartButton.is( '.disabled' ) ) {
 					evt.preventDefault(); // Prevent showing payment request modal.
@@ -669,14 +683,25 @@ jQuery( function( $ ) {
 		},
 
 		attachCartPageEventListeners: function ( prButton, paymentRequest ) {
-			if ( ( ! wc_stripe_payment_request_params.button.is_custom || ! wc_stripe_payment_request.isCustomPaymentRequestButton( prButton ) ) &&
-				( ! wc_stripe_payment_request_params.button.is_branded || ! wc_stripe_payment_request.isBrandedPaymentRequestButton( prButton ) ) ) {
-				return;
-			}
-
 			prButton.on( 'click', function ( evt ) {
-				evt.preventDefault();
-				paymentRequest.show();
+				// If login is required for checkout, display redirect confirmation dialog.
+				if ( wc_stripe_payment_request_params.login_confirmation ) {
+					evt.preventDefault();
+					displayLoginConfirmation( paymentRequestType );
+					return;
+				}
+
+				if (
+					wc_stripe_payment_request.isCustomPaymentRequestButton(
+						prButton
+					) ||
+					wc_stripe_payment_request.isBrandedPaymentRequestButton(
+						prButton
+					)
+				) {
+					evt.preventDefault();
+					paymentRequest.show();
+				}
 			} );
 		},
 
@@ -747,5 +772,31 @@ jQuery( function( $ ) {
 			element.css( 'background-image', 'url(' + fallback + ')' );
 		}
 		testImg.src = background;
+	}
+
+	// TODO: Replace this by `client/blocks/payment-request/login-confirmation.js`
+	// when we start using webpack to build this file.
+	function displayLoginConfirmation( paymentRequestType ) {
+		if ( ! wc_stripe_payment_request_params.login_confirmation ) {
+			return;
+		}
+
+		let message = wc_stripe_payment_request_params.login_confirmation?.message;
+
+		// Replace dialog text with specific payment request type "Apple Pay" or "Google Pay".
+		if ( 'payment_request_api' !== paymentRequestType ) {
+			message = message.replace(
+				/\*\*.*?\*\*/,
+				'apple_pay' === paymentRequestType ? 'Apple Pay' : 'Google Pay'
+			);
+		}
+
+		// Remove asterisks from string.
+		message = message.replace( /\*\*/g, '' );
+
+		if ( confirm( message ) ) {
+			// Redirect to my account page.
+			window.location.href = wc_stripe_payment_request_params.login_confirmation?.redirect_url;
+		}
 	}
 } );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -781,7 +781,7 @@ jQuery( function( $ ) {
 			return;
 		}
 
-		let message = wc_stripe_payment_request_params.login_confirmation?.message;
+		var message = wc_stripe_payment_request_params.login_confirmation.message;
 
 		// Replace dialog text with specific payment request type "Apple Pay" or "Google Pay".
 		if ( 'payment_request_api' !== paymentRequestType ) {
@@ -796,7 +796,7 @@ jQuery( function( $ ) {
 
 		if ( confirm( message ) ) {
 			// Redirect to my account page.
-			window.location.href = wc_stripe_payment_request_params.login_confirmation?.redirect_url;
+			window.location.href = wc_stripe_payment_request_params.login_confirmation.redirect_url;
 		}
 	}
 } );

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 5.x.x - 2021-xx-xx =
 * Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
+* Tweak - Payment request button should guide users to login when necessary.
 
 = 5.2.3 - 2021-06-11 =
 * Fix - Credit card icons and credit card input on custom shortcode checkout pages.

--- a/client/blocks/payment-request/login-confirmation.js
+++ b/client/blocks/payment-request/login-confirmation.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import { getStripeServerData } from '../stripe-utils';
+
+/**
+ * Displays a `confirm` dialog which leads to a redirect.
+ *
+ * @param {string} paymentRequestType Can be either apple_pay, google_pay or payment_request_api.
+ */
+export const displayLoginConfirmation = ( paymentRequestType ) => {
+	if ( ! getStripeServerData()?.login_confirmation ) {
+		return;
+	}
+
+	let message = getStripeServerData()?.login_confirmation?.message;
+
+	// Replace dialog text with specific payment request type "Apple Pay" or "Google Pay".
+	if ( paymentRequestType !== 'payment_request_api' ) {
+		message = message.replace(
+			/\*\*.*?\*\*/,
+			paymentRequestType === 'apple_pay' ? 'Apple Pay' : 'Google Pay'
+		);
+	}
+
+	// Remove asterisks from string.
+	message = message.replace( /\*\*/g, '' );
+
+	// eslint-disable-next-line no-alert, no-undef
+	if ( confirm( message ) ) {
+		// Redirect to my account page.
+		window.location.href = getStripeServerData()?.login_confirmation?.redirect_url;
+	}
+};

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -68,6 +68,7 @@ const PaymentRequestExpressComponent = ( {
 		setExpressPaymentError
 	);
 	const onPaymentRequestButtonClick = useOnClickHandler(
+		paymentRequestType,
 		setExpressPaymentError,
 		onClick
 	);
@@ -97,21 +98,23 @@ const PaymentRequestExpressComponent = ( {
 		return null;
 	}
 
-	// Prepare the onClick handler for our custom made Payment Request buttons.
-	const customAndBrandedClickHandler = () => {
-		onPaymentRequestButtonClick();
-		paymentRequest.show();
-	};
-
 	if ( isCustom ) {
 		return (
-			<CustomButton onButtonClicked={ customAndBrandedClickHandler } />
+			<CustomButton
+				onButtonClicked={ ( evt ) => {
+					onPaymentRequestButtonClick( evt, paymentRequest );
+				} }
+			/>
 		);
 	}
 
 	if ( isBranded && shouldUseGooglePayBrand() ) {
 		return (
-			<GooglePayButton onButtonClicked={ customAndBrandedClickHandler } />
+			<GooglePayButton
+				onButtonClicked={ ( evt ) => {
+					onPaymentRequestButtonClick( evt, paymentRequest );
+				} }
+			/>
 		);
 	}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -596,7 +596,7 @@ class WC_Stripe_Payment_Request {
 			if ( WC_Subscriptions_Product::is_subscription( $product ) ) {
 				return true;
 			}
-		} elseif ( $this->is_checkout() || $this->is_cart() ) {
+		} elseif ( WC_Stripe_Helper::has_cart_or_checkout_on_current_page() ) {
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 				if ( WC_Subscriptions_Product::is_subscription( $_product ) ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -106,11 +106,11 @@ class WC_Stripe_Payment_Request {
 	 * @return bool
 	 */
 	public function is_authentication_required() {
-		// If guest checkout is disabled and account creation is not possible, authentication is required.
+		// If guest checkout is disabled and account creation upon checkout is not possible, authentication is required.
 		if ( 'no' === get_option( 'woocommerce_enable_guest_checkout', 'yes' ) && ! $this->is_account_creation_possible() ) {
 			return true;
 		}
-		// If cart contains subscription and account creation is not posible, authentication is required.
+		// If cart contains subscription and account creation upon checkout is not posible, authentication is required.
 		if ( $this->has_subscription_product() && ! $this->is_account_creation_possible() ) {
 			return true;
 		}
@@ -119,7 +119,7 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Checks whether account creation is possible during checkout.
+	 * Checks whether account creation is possible upon checkout.
 	 *
 	 * @since 5.1.0
 	 *

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -196,6 +196,7 @@ class WC_Stripe_Payment_Request {
 			wc_setcookie( 'wc_stripe_payment_request_redirect_url', $url, time() + MINUTE_IN_SECONDS * 10 );
 			// Redirects to "my-account" page.
 			wp_safe_redirect( get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ) );
+			exit;
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,5 +128,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 5.x.x - 2021-xx-xx =
 * Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
+* Tweak - Payment request button should guide users to login when necessary.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #1537

Ported from [WCPay#1811](https://github.com/Automattic/woocommerce-payments/pull/1811)

#### Changes proposed in this Pull Request

- Display the button instead of hiding it when authentication is required.
- Add a dialog which tells users to login before checking out.
- Redirect users back to the checkout flow after authentication.

#### Testing instructions

First, run `npm run build:webpack` to build the assets from this branch.

1. Go to **WooCommerce > Settings > Accounts & Privacy** and disable the following settings:
  - Allow customers to place orders without an account.
  - Allow customers to create an account during checkout.
2. Make sure you have **Payment request buttons** enabled under **Payments > Settings**.
3. Make sure you're not logged in.
3. Go to a product page in Chrome and click the payment request button.
4. Notice there's a dialog and the "Confirm" button redirects you to my-account.
5. Sign in or create an account.
6. After authentication, you should be redirected back to the same page.
7. When trying do use PRB while logged in, you should not see the confirmation dialog.

Please also test steps 3-8 with
- Block cart (and checkout when you're logged in).
- A simple subscription product.

![gif](https://user-images.githubusercontent.com/5509901/122165183-3a8ca980-ce4e-11eb-9d18-b328edc74935.gif)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.