### PR TITLE
Payment Request button: Add support for Mix and Match product types on the product page

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -264,16 +264,9 @@ jQuery( function( $ ) {
 		 *
 		 */
 		addToCart: function() {
-			var product_id = $( '.single_add_to_cart_button' ).val();
-
-			// Check if product is a variable product.
-			if ( $( '.single_variation_wrap' ).length ) {
-				product_id = $( '.single_variation_wrap' ).find( 'input[name="product_id"]' ).val();
-			}
-
 			var data = {
 				security: wc_stripe_payment_request_params.nonce.add_to_cart,
-				product_id: product_id,
+				product_id: $( '[name="add-to-cart"], .single_add_to_cart_button' ).val(),
 				quantity: $( '.quantity .qty' ).last().val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
 				has_shipping_address: hasShippingAddress,

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -274,7 +274,7 @@ jQuery( function( $ ) {
 			var data = {
 				security: wc_stripe_payment_request_params.nonce.add_to_cart,
 				product_id: product_id,
-				qty: $( '.quantity .qty' ).val(),
+				quantity: $( '.quantity .qty' ).val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
 				has_shipping_address: hasShippingAddress,
 			};
@@ -410,32 +410,6 @@ jQuery( function( $ ) {
 			}
 		},
 
-		getSelectedProductData: function() {
-			var product_id = $( '.single_add_to_cart_button' ).val();
-
-			// Check if product is a variable product.
-			if ( $( '.single_variation_wrap' ).length ) {
-				product_id = $( '.single_variation_wrap' ).find( 'input[name="product_id"]' ).val();
-			}
-
-			var addons = $( '#product-addons-total' ).data('price_data') || [];
-			var addon_value = addons.reduce( function ( sum, addon ) { return sum + addon.cost; }, 0 );
-
-			var data = {
-				security: wc_stripe_payment_request_params.nonce.get_selected_product_data,
-				product_id: product_id,
-				qty: $( '.quantity .qty' ).val(),
-				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
-				addon_value: addon_value,
-			};
-
-			return $.ajax( {
-				type: 'POST',
-				data: data,
-				url:  wc_stripe_payment_request.getAjaxURL( 'get_selected_product_data' )
-			} );
-		},
-
 		/**
 		 * Creates stripe paymentRequest element or connects to custom button
 		 *
@@ -565,6 +539,7 @@ jQuery( function( $ ) {
 					} else if ( addToCartButton.is( '.wc-variation-selection-needed' ) ) {
 						window.alert( wc_add_to_cart_variation_params.i18n_make_a_selection_text );
 					}
+					$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 					return;
 				}
 
@@ -594,21 +569,6 @@ jQuery( function( $ ) {
 
 			$( document.body ).on( 'wc_stripe_disable_payment_request_button', function () {
 				wc_stripe_payment_request.blockPaymentRequestButton( 'wc_request_button_is_disabled' );
-			} );
-
-			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
-				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
-
-				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
-					$.when(
-						paymentRequest.update( {
-							total: response.total,
-							displayItems: response.displayItems,
-						} )
-					).then( function () {
-						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
-					} );
-				});
 			} );
 		},
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -274,13 +274,15 @@ jQuery( function( $ ) {
 			var data = {
 				security: wc_stripe_payment_request_params.nonce.add_to_cart,
 				product_id: product_id,
-				quantity: $( '.quantity .qty' ).val(),
+				quantity: $( '.quantity .qty' ).last().val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
 				has_shipping_address: hasShippingAddress,
 			};
 
+			var $form = $( 'form.cart' );
+			var formData = $form.serializeArray();
+
 			// add addons data to the POST body
-			var formData = $( 'form.cart' ).serializeArray();
 			$.each( formData, function( i, field ) {
 				if ( /^addon-/.test( field.name ) ) {
 					if ( /\[\]$/.test( field.name ) ) {
@@ -295,6 +297,13 @@ jQuery( function( $ ) {
 					}
 				}
 			} );
+
+			// Add Mix and Match data to payload
+			if ( $form.is( '.mnm_form' ) ) {
+				$('.mnm_child_products .mnm-quantity').each(function( i, el ) {
+					data[ el.name ] = el.value;
+				})
+			}
 
 			return $.ajax( {
 				type: 'POST',

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -39,19 +39,17 @@ const paymentRequestPaymentMethod = {
 			// show the Payment Request Button or not. This is necessary because a browser might be
 			// able to load the Stripe JS object, but not support Payment Requests.
 			const fakeCart = {
-				order_data: {
-					total: {
-						label: 'Total',
-						amount: parseInt(
-							cartData?.cartTotals?.total_price ?? 0,
-							10
-						),
-						pending: true,
-					},
-					currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
-					country_code: getSetting( 'baseLocation', {} )?.country,
-					displayItems: [],
+				total: {
+					label: 'Total',
+					amount: parseInt(
+						cartData?.cartTotals?.total_price ?? 0,
+						10
+					),
+					pending: true,
 				},
+				currency: cartData?.cartTotals?.currency_code?.toLowerCase(),
+				country_code: getSetting( 'baseLocation', {} )?.country,
+				displayItems: [],
 				shipping_required: false,
 			};
 			const paymentRequest = createPaymentRequestUsingCart(

--- a/client/blocks/stripe-utils/utils.js
+++ b/client/blocks/stripe-utils/utils.js
@@ -55,14 +55,14 @@ const getApiKey = () => {
  */
 export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 	const options = {
-		total: cart.order_data.total,
-		currency: cart.order_data.currency,
-		country: cart.order_data.country_code,
+		total: cart.total,
+		currency: cart.currency,
+		country: cart.country_code,
 		requestPayerName: true,
 		requestPayerEmail: true,
 		requestPayerPhone: getStripeServerData()?.checkout?.needs_payer_phone,
-		requestShipping: cart.shipping_required ? true : false,
-		displayItems: cart.order_data.displayItems,
+		requestShipping: cart.requestShipping,
+		displayItems: cart.displayItems,
 	};
 
 	// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -28,8 +28,8 @@ return apply_filters(
 			'desc_tip'    => true,
 		],
 		'api_credentials'                     => [
-			'title'       => __( 'Stripe Account Keys', 'woocommerce-gateway-stripe' ),
-			'type'        => 'stripe_account_keys',
+			'title' => __( 'Stripe Account Keys', 'woocommerce-gateway-stripe' ),
+			'type'  => 'stripe_account_keys',
 		],
 		'testmode'                            => [
 			'title'       => __( 'Test mode', 'woocommerce-gateway-stripe' ),

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -498,6 +498,7 @@ class WC_Stripe_Payment_Request {
 				'booking',
 				'bundle',
 				'composite',
+				'mix-and-match',
 			]
 		);
 	}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -228,7 +228,6 @@ class WC_Stripe_Payment_Request {
 		add_action( 'wc_ajax_wc_stripe_update_shipping_method', [ $this, 'ajax_update_shipping_method' ] );
 		add_action( 'wc_ajax_wc_stripe_create_order', [ $this, 'ajax_create_order' ] );
 		add_action( 'wc_ajax_wc_stripe_add_to_cart', [ $this, 'ajax_add_to_cart' ] );
-		add_action( 'wc_ajax_wc_stripe_get_selected_product_data', [ $this, 'ajax_get_selected_product_data' ] );
 		add_action( 'wc_ajax_wc_stripe_log_errors', [ $this, 'ajax_log_errors' ] );
 
 		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
@@ -646,13 +645,12 @@ class WC_Stripe_Payment_Request {
 				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
 			],
 			'nonce'              => [
-				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),
-				'shipping'                  => wp_create_nonce( 'wc-stripe-payment-request-shipping' ),
-				'update_shipping'           => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
-				'checkout'                  => wp_create_nonce( 'woocommerce-process_checkout' ),
-				'add_to_cart'               => wp_create_nonce( 'wc-stripe-add-to-cart' ),
-				'get_selected_product_data' => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
-				'log_errors'                => wp_create_nonce( 'wc-stripe-log-errors' ),
+				'payment'         => wp_create_nonce( 'wc-stripe-payment-request' ),
+				'shipping'        => wp_create_nonce( 'wc-stripe-payment-request-shipping' ),
+				'update_shipping' => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
+				'checkout'        => wp_create_nonce( 'woocommerce-process_checkout' ),
+				'add_to_cart'     => wp_create_nonce( 'wc-stripe-add-to-cart' ),
+				'log_errors'      => wp_create_nonce( 'wc-stripe-log-errors' ),
 			],
 			'i18n'               => [
 				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),
@@ -1097,39 +1095,6 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Gets the selected product data.
-	 *
-	 * @since   4.0.0
-	 * @version x.x.x
-	 * @return  array $data
-	 */
-	public function ajax_get_selected_product_data() {
-		check_ajax_referer( 'wc-stripe-get-selected-product-data', 'security' );
-
-		try {
-			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-			$product    = wc_get_product( $product_id );
-			$qty        = ! isset( $_POST['qty'] ) ? 1 : apply_filters( 'woocommerce_add_to_cart_quantity', absint( $_POST['qty'] ), $product_id );
-
-			if ( ! is_a( $product, 'WC_Product' ) ) {
-				/* translators: %d is the product Id */
-				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
-			}
-
-			// TODO: Added the same check in `ajax_add_to_cart` just in case we remove this (`ajax_get_selected_product_data`) method. Do not remove before checking with Variable products
-			if ( ! $product->has_enough_stock( $qty ) ) {
-				/* translators: 1: product name 2: quantity in stock */
-				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
-			}
-
-			$data = $this->build_response();
-			wp_send_json( $data );
-		} catch ( Exception $e ) {
-			wp_send_json( [ 'error' => wp_strip_all_tags( $e->getMessage() ) ] );
-		}
-	}
-
-	/**
 	 * Adds the current product to the cart. Used on product detail page.
 	 *
 	 * @since   4.0.0
@@ -1146,17 +1111,17 @@ class WC_Stripe_Payment_Request {
 
 			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
 			$product    = wc_get_product( $product_id );
-			$qty        = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: %d is the product Id */
 				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
 
-			if ( ! $product->has_enough_stock( $qty ) ) {
-				/* translators: 1: product name 2: quantity in stock */
-				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
-			}
+			$quantity         = ! isset( $_POST['quantity'] ) ? 1 : absint( $_POST['quantity'] );
+			$has_enough_stock = $product->has_enough_stock( $quantity );
+			$product_type     = $product->get_type();
+			$variation_id     = 0;
+			$attributes       = [];
 
 			WC()->shipping->reset_shipping();
 
@@ -1171,12 +1136,18 @@ class WC_Stripe_Payment_Request {
 				$data_store   = WC_Data_Store::load( 'product' );
 				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
-				WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
+				if ( ! empty( $variation_id ) ) {
+					$variation        = wc_get_product( $variation_id );
+					$has_enough_stock = $variation->has_enough_stock( $quantity );
+				}
 			}
 
-			if ( 'simple' === $product_type || 'subscription' === $product_type ) {
-				WC()->cart->add_to_cart( $product->get_id(), $qty );
+			if ( ! $has_enough_stock ) {
+				/* translators: 1: product name 2: quantity in stock */
+				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
 			}
+
+			WC()->cart->add_to_cart( $product->get_id(), $quantity, $variation_id, $attributes );
 
 			// This method is called from the product page only. Always display itemized items.
 			$itemized_display_items = true;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -229,7 +229,6 @@ class WC_Stripe_Payment_Request {
 		add_action( 'wc_ajax_wc_stripe_create_order', [ $this, 'ajax_create_order' ] );
 		add_action( 'wc_ajax_wc_stripe_add_to_cart', [ $this, 'ajax_add_to_cart' ] );
 		add_action( 'wc_ajax_wc_stripe_get_selected_product_data', [ $this, 'ajax_get_selected_product_data' ] );
-		add_action( 'wc_ajax_wc_stripe_clear_cart', [ $this, 'ajax_clear_cart' ] );
 		add_action( 'wc_ajax_wc_stripe_log_errors', [ $this, 'ajax_log_errors' ] );
 
 		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
@@ -348,7 +347,7 @@ class WC_Stripe_Payment_Request {
 	 * Gets the product data for the currently viewed page
 	 *
 	 * @since   4.0.0
-	 * @version 5.2.0
+	 * @version x.x.x
 	 * @return  mixed Returns false if not on a product page, the product information otherwise.
 	 */
 	public function get_product_data() {
@@ -379,47 +378,13 @@ class WC_Stripe_Payment_Request {
 			}
 		}
 
-		$data  = [];
-		$items = [];
-
-		$items[] = [
-			'label'  => $product->get_name(),
-			'amount' => WC_Stripe_Helper::get_stripe_amount( $this->get_product_price( $product ) ),
-		];
-
-		if ( wc_tax_enabled() ) {
-			$items[] = [
-				'label'   => __( 'Tax', 'woocommerce-gateway-stripe' ),
-				'amount'  => 0,
-				'pending' => true,
-			];
-		}
-
-		if ( wc_shipping_enabled() && $product->needs_shipping() ) {
-			$items[] = [
-				'label'   => __( 'Shipping', 'woocommerce-gateway-stripe' ),
-				'amount'  => 0,
-				'pending' => true,
-			];
-
-			$data['shippingOptions'] = [
-				'id'     => 'pending',
-				'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
-				'detail' => '',
-				'amount' => 0,
-			];
-		}
-
-		$data['displayItems'] = $items;
-		$data['total']        = [
+		$data                    = [];
+		$data['total']           = [
 			'label'   => apply_filters( 'wc_stripe_payment_request_total_label', $this->total_label ),
 			'amount'  => WC_Stripe_Helper::get_stripe_amount( $this->get_product_price( $product ) ),
 			'pending' => true,
 		];
-
 		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
-		$data['currency']        = strtolower( get_woocommerce_currency() );
-		$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 
 		return apply_filters( 'wc_stripe_payment_request_product_data', $data, $product );
 	}
@@ -688,7 +653,6 @@ class WC_Stripe_Payment_Request {
 				'add_to_cart'               => wp_create_nonce( 'wc-stripe-add-to-cart' ),
 				'get_selected_product_data' => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
 				'log_errors'                => wp_create_nonce( 'wc-stripe-log-errors' ),
-				'clear_cart'                => wp_create_nonce( 'wc-stripe-clear-cart' ),
 			],
 			'i18n'               => [
 				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),
@@ -723,7 +687,7 @@ class WC_Stripe_Payment_Request {
 	 * Load public scripts and styles.
 	 *
 	 * @since   3.1.0
-	 * @version 5.2.0
+	 * @version x.x.x
 	 */
 	public function scripts() {
 		// If page is not supported, bail.
@@ -955,20 +919,9 @@ class WC_Stripe_Payment_Request {
 	}
 
 	/**
-	 * Clears cart.
-	 *
-	 * @since   3.1.4
-	 * @version 4.0.0
-	 */
-	public function ajax_clear_cart() {
-		check_ajax_referer( 'wc-stripe-clear-cart', 'security' );
-
-		WC()->cart->empty_cart();
-		exit;
-	}
-
-	/**
 	 * Get cart details.
+	 *
+	 * @version x.x.x
 	 */
 	public function ajax_get_cart_details() {
 		check_ajax_referer( 'wc-stripe-payment-request', 'security' );
@@ -979,24 +932,14 @@ class WC_Stripe_Payment_Request {
 
 		WC()->cart->calculate_totals();
 
-		$currency = get_woocommerce_currency();
-
-		// Set mandatory payment details.
-		$data = [
-			'shipping_required' => WC()->cart->needs_shipping(),
-			'order_data'        => [
-				'currency'     => strtolower( $currency ),
-				'country_code' => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
-			],
-		];
-
-		$data['order_data'] += $this->build_display_items();
-
+		$data = $this->build_response( false, true );
 		wp_send_json( $data );
 	}
 
 	/**
 	 * Get shipping options.
+	 *
+	 * @version x.x.x
 	 *
 	 * @see WC_Cart::get_shipping_packages().
 	 * @see WC_Shipping::calculate_shipping().
@@ -1005,7 +948,7 @@ class WC_Stripe_Payment_Request {
 	public function ajax_get_shipping_options() {
 		check_ajax_referer( 'wc-stripe-payment-request-shipping', 'security' );
 
-		$shipping_address          = filter_input_array(
+		$shipping_address = filter_input_array(
 			INPUT_POST,
 			[
 				'country'   => FILTER_SANITIZE_STRING,
@@ -1016,23 +959,29 @@ class WC_Stripe_Payment_Request {
 				'address_2' => FILTER_SANITIZE_STRING,
 			]
 		);
-		$product_view_options      = filter_input_array( INPUT_POST, [ 'is_product_page' => FILTER_SANITIZE_STRING ] );
-		$should_show_itemized_view = ! isset( $product_view_options['is_product_page'] ) ? true : filter_var( $product_view_options['is_product_page'], FILTER_VALIDATE_BOOLEAN );
 
-		$data = $this->get_shipping_options( $shipping_address, $should_show_itemized_view );
+		$itemized_display_items = filter_input( INPUT_POST, 'is_product_page', FILTER_VALIDATE_BOOLEAN );
+
+		$data = $this->get_shipping_options( $shipping_address, $itemized_display_items );
+
 		wp_send_json( $data );
 	}
 
 	/**
 	 * Gets shipping options available for specified shipping address
 	 *
-	 * @param array   $shipping_address       Shipping address.
+	 * @version x.x.x
+	 *
+	 * @param array  $shipping_address Shipping address.
 	 * @param boolean $itemized_display_items Indicates whether to show subtotals or itemized views.
 	 *
 	 * @return array Shipping options data.
 	 * phpcs:ignore Squiz.Commenting.FunctionCommentThrowTag
 	 */
 	public function get_shipping_options( $shipping_address, $itemized_display_items = false ) {
+		// This method is only called when the user has selected a Shipping address
+		$has_shipping_address = true;
+
 		try {
 			// Set the shipping options.
 			$data = [];
@@ -1095,10 +1044,10 @@ class WC_Stripe_Payment_Request {
 
 			WC()->cart->calculate_totals();
 
-			$data          += $this->build_display_items( $itemized_display_items );
+			$data          += $this->build_response( $itemized_display_items, $has_shipping_address );
 			$data['result'] = 'success';
 		} catch ( Exception $e ) {
-			$data          += $this->build_display_items( $itemized_display_items );
+			$data          += $this->build_response( $itemized_display_items, $has_shipping_address );
 			$data['result'] = 'invalid_shipping_address';
 		}
 
@@ -1107,6 +1056,8 @@ class WC_Stripe_Payment_Request {
 
 	/**
 	 * Update shipping method.
+	 *
+	 * @version x.x.x
 	 */
 	public function ajax_update_shipping_method() {
 		check_ajax_referer( 'wc-stripe-update-shipping-method', 'security' );
@@ -1120,11 +1071,9 @@ class WC_Stripe_Payment_Request {
 
 		WC()->cart->calculate_totals();
 
-		$product_view_options      = filter_input_array( INPUT_POST, [ 'is_product_page' => FILTER_SANITIZE_STRING ] );
-		$should_show_itemized_view = ! isset( $product_view_options['is_product_page'] ) ? true : filter_var( $product_view_options['is_product_page'], FILTER_VALIDATE_BOOLEAN );
+		$itemized_display_items = filter_input( INPUT_POST, 'is_product_page', FILTER_VALIDATE_BOOLEAN );
 
-		$data           = [];
-		$data          += $this->build_display_items( $should_show_itemized_view );
+		$data           = $this->build_response( $itemized_display_items, true );
 		$data['result'] = 'success';
 
 		wp_send_json( $data );
@@ -1151,91 +1100,29 @@ class WC_Stripe_Payment_Request {
 	 * Gets the selected product data.
 	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version x.x.x
 	 * @return  array $data
 	 */
 	public function ajax_get_selected_product_data() {
 		check_ajax_referer( 'wc-stripe-get-selected-product-data', 'security' );
 
 		try {
-			$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-			$qty          = ! isset( $_POST['qty'] ) ? 1 : apply_filters( 'woocommerce_add_to_cart_quantity', absint( $_POST['qty'] ), $product_id );
-			$addon_value  = isset( $_POST['addon_value'] ) ? max( floatval( $_POST['addon_value'] ), 0 ) : 0;
-			$product      = wc_get_product( $product_id );
-			$variation_id = null;
+			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$product    = wc_get_product( $product_id );
+			$qty        = ! isset( $_POST['qty'] ) ? 1 : apply_filters( 'woocommerce_add_to_cart_quantity', absint( $_POST['qty'] ), $product_id );
 
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: %d is the product Id */
 				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
 
-			if ( 'variable' === $product->get_type() && isset( $_POST['attributes'] ) ) {
-				$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
-
-				$data_store   = WC_Data_Store::load( 'product' );
-				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
-
-				if ( ! empty( $variation_id ) ) {
-					$product = wc_get_product( $variation_id );
-				}
-			}
-
-			// Force quantity to 1 if sold individually and check for existing item in cart.
-			if ( $product->is_sold_individually() ) {
-				$qty = apply_filters( 'wc_stripe_payment_request_add_to_cart_sold_individually_quantity', 1, $qty, $product_id, $variation_id );
-			}
-
+			// TODO: Added the same check in `ajax_add_to_cart` just in case we remove this (`ajax_get_selected_product_data`) method. Do not remove before checking with Variable products
 			if ( ! $product->has_enough_stock( $qty ) ) {
 				/* translators: 1: product name 2: quantity in stock */
 				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
 			}
 
-			$total = $qty * $this->get_product_price( $product ) + $addon_value;
-
-			$quantity_label = 1 < $qty ? ' (x' . $qty . ')' : '';
-
-			$data  = [];
-			$items = [];
-
-			$items[] = [
-				'label'  => $product->get_name() . $quantity_label,
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $total ),
-			];
-
-			if ( wc_tax_enabled() ) {
-				$items[] = [
-					'label'   => __( 'Tax', 'woocommerce-gateway-stripe' ),
-					'amount'  => 0,
-					'pending' => true,
-				];
-			}
-
-			if ( wc_shipping_enabled() && $product->needs_shipping() ) {
-				$items[] = [
-					'label'   => __( 'Shipping', 'woocommerce-gateway-stripe' ),
-					'amount'  => 0,
-					'pending' => true,
-				];
-
-				$data['shippingOptions'] = [
-					'id'     => 'pending',
-					'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
-					'detail' => '',
-					'amount' => 0,
-				];
-			}
-
-			$data['displayItems'] = $items;
-			$data['total']        = [
-				'label'   => $this->total_label,
-				'amount'  => WC_Stripe_Helper::get_stripe_amount( $total ),
-				'pending' => true,
-			];
-
-			$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
-			$data['currency']        = strtolower( get_woocommerce_currency() );
-			$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
-
+			$data = $this->build_response();
 			wp_send_json( $data );
 		} catch ( Exception $e ) {
 			wp_send_json( [ 'error' => wp_strip_all_tags( $e->getMessage() ) ] );
@@ -1246,46 +1133,66 @@ class WC_Stripe_Payment_Request {
 	 * Adds the current product to the cart. Used on product detail page.
 	 *
 	 * @since   4.0.0
-	 * @version 4.0.0
+	 * @version x.x.x
 	 * @return  array $data
 	 */
 	public function ajax_add_to_cart() {
 		check_ajax_referer( 'wc-stripe-add-to-cart', 'security' );
 
-		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
-			define( 'WOOCOMMERCE_CART', true );
+		try {
+			if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
+				define( 'WOOCOMMERCE_CART', true );
+			}
+
+			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$product    = wc_get_product( $product_id );
+			$qty        = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
+
+			if ( ! is_a( $product, 'WC_Product' ) ) {
+				/* translators: %d is the product Id */
+				throw new Exception( sprintf( __( 'Product with the ID (%d) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
+			}
+
+			if ( ! $product->has_enough_stock( $qty ) ) {
+				/* translators: 1: product name 2: quantity in stock */
+				throw new Exception( sprintf( __( 'You cannot add that amount of "%1$s"; to the cart because there is not enough stock (%2$s remaining).', 'woocommerce-gateway-stripe' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity(), $product ) ) );
+			}
+
+			WC()->shipping->reset_shipping();
+
+			// First empty the cart to prevent wrong calculation.
+			WC()->cart->empty_cart();
+
+			$product_type = $product->get_type();
+
+			if ( ( 'variable' === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
+				$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
+
+				$data_store   = WC_Data_Store::load( 'product' );
+				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+
+				WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
+			}
+
+			if ( 'simple' === $product_type || 'subscription' === $product_type ) {
+				WC()->cart->add_to_cart( $product->get_id(), $qty );
+			}
+
+			// This method is called from the product page only. Always display itemized items.
+			$itemized_display_items = true;
+
+			// We need to pass `has_shipping_address` from the frontend to fix an unwanted behavior with Google Pay
+			// when canceling the payment the shipping amount was reset to `0`.
+			// It happened because the browser remembers the shipping address and shipping method allowing the user
+			// to submit the payment without paying for shipping.
+			$has_shipping_address = filter_input( INPUT_POST, 'has_shipping_address', FILTER_VALIDATE_BOOLEAN );
+
+			$data = $this->build_response( $itemized_display_items, $has_shipping_address );
+			wp_send_json( $data );
+		} catch ( Exception $e ) {
+			wp_send_json( [ 'error' => wp_strip_all_tags( $e->getMessage() ) ] );
 		}
 
-		WC()->shipping->reset_shipping();
-
-		$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-		$qty          = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
-		$product      = wc_get_product( $product_id );
-		$product_type = $product->get_type();
-
-		// First empty the cart to prevent wrong calculation.
-		WC()->cart->empty_cart();
-
-		if ( ( 'variable' === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
-			$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
-
-			$data_store   = WC_Data_Store::load( 'product' );
-			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
-
-			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		}
-
-		if ( 'simple' === $product_type || 'subscription' === $product_type ) {
-			WC()->cart->add_to_cart( $product->get_id(), $qty );
-		}
-
-		WC()->cart->calculate_totals();
-
-		$data           = [];
-		$data          += $this->build_display_items();
-		$data['result'] = 'success';
-
-		wp_send_json( $data );
 	}
 
 	/**
@@ -1583,38 +1490,73 @@ class WC_Stripe_Payment_Request {
 		return $shipping;
 	}
 
+
 	/**
-	 * Builds the line items to pass to Payment Request
+	 * Builds response to pass to the Payment Request.
 	 *
-	 * @since   3.1.0
-	 * @version 4.0.0
+	 * @since   x.x.x
+	 *
+	 * @param bool $itemized_display_items Wether to return an array of items with its details or not.
+	 * @param bool $has_shipping_address Indicates if user has selected a shipping address on the payment dialog.
 	 */
-	protected function build_display_items( $itemized_display_items = false ) {
+	protected function build_response( $itemized_display_items = false, $has_shipping_address = false ) {
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );
 		}
 
-		$items     = [];
-		$subtotal  = 0;
-		$discounts = 0;
+		$data                 = [];
+		$data['currency']     = strtolower( get_woocommerce_currency() );
+		$data['country_code'] = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+		$items                = [];
 
 		// Default show only subtotal instead of itemization.
 		if ( ! apply_filters( 'wc_stripe_payment_request_hide_itemization', true ) || $itemized_display_items ) {
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 				$amount         = $cart_item['line_subtotal'];
-				$subtotal      += $cart_item['line_subtotal'];
 				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
 
-				$product_name = $cart_item['data']->get_name();
-
-				$item = [
-					'label'  => $product_name . $quantity_label,
+				$items[] = [
+					'label'  => $cart_item['data']->get_name() . $quantity_label,
 					'amount' => WC_Stripe_Helper::get_stripe_amount( $amount ),
 				];
-
-				$items[] = $item;
 			}
 		}
+
+		// Tax
+		if ( wc_tax_enabled() ) {
+			$tax = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
+
+			$items[] = [
+				'label'   => esc_html( __( 'Tax', 'woocommerce-gateway-stripe' ) ),
+				'amount'  => WC_Stripe_Helper::get_stripe_amount( $tax ),
+				'pending' => true,
+			];
+		}
+
+		// Shipping
+		$shipping_to_substract = 0;
+
+		if ( wc_shipping_enabled() && WC()->cart->needs_shipping() ) {
+			$data['requestShipping'] = true;
+			$shipping                = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
+
+			if ( ! $has_shipping_address ) {
+				// If the frontend says we don't have a shipping address but
+				// there's an amount for shipping it means a shipping address is on the session
+				// and we should remove that amount from the cart's total.
+				$shipping_to_substract = $shipping;
+				$shipping              = 0;
+			}
+
+			$items[] = [
+				'label'   => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
+				'amount'  => WC_Stripe_Helper::get_stripe_amount( $shipping ),
+				'pending' => true,
+			];
+		}
+
+		// Discounts
+		$discounts = 0;
 
 		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
 			$discounts = wc_format_decimal( WC()->cart->get_cart_discount_total(), WC()->cart->dp );
@@ -1624,26 +1566,8 @@ class WC_Stripe_Payment_Request {
 			foreach ( $applied_coupons as $amount ) {
 				$discounts += (float) $amount;
 			}
-		}
 
-		$discounts   = wc_format_decimal( $discounts, WC()->cart->dp );
-		$tax         = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
-		$shipping    = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
-		$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp ) + $discounts;
-		$order_total = version_compare( WC_VERSION, '3.2', '<' ) ? wc_format_decimal( $items_total + $tax + $shipping - $discounts, WC()->cart->dp ) : WC()->cart->get_total( false );
-
-		if ( wc_tax_enabled() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Tax', 'woocommerce-gateway-stripe' ) ),
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $tax ),
-			];
-		}
-
-		if ( WC()->cart->needs_shipping() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $shipping ),
-			];
+			$discounts = wc_format_decimal( $discounts, WC()->cart->dp );
 		}
 
 		if ( WC()->cart->has_discount() ) {
@@ -1653,6 +1577,7 @@ class WC_Stripe_Payment_Request {
 			];
 		}
 
+		// Fees
 		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
 			$cart_fees = WC()->cart->fees;
 		} else {
@@ -1667,14 +1592,30 @@ class WC_Stripe_Payment_Request {
 			];
 		}
 
-		return [
-			'displayItems' => $items,
-			'total'        => [
-				'label'   => $this->total_label,
-				'amount'  => max( 0, apply_filters( 'woocommerce_stripe_calculated_total', WC_Stripe_Helper::get_stripe_amount( $order_total ), $order_total, WC()->cart ) ),
-				'pending' => false,
-			],
+		// Order total
+		if ( version_compare( WC_VERSION, '3.2', '<' ) ) {
+			$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp );
+			$order_total = wc_format_decimal( $items_total + $tax + $shipping, WC()->cart->dp );
+		} else {
+			// Getting the total amount from the cart automatically adds a shipping cost to it
+			// We need to remove it if the user hasn't picked a shipping address yet
+			$order_total = WC()->cart->get_total( false ) - $shipping_to_substract;
+		}
+
+		// Mandatory payment details.
+		$data['needs_payer_phone'] = 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' );
+		$data['currency']          = strtolower( get_woocommerce_currency() );
+		$data['country_code']      = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+
+		$data['displayItems'] = $items;
+
+		$data['total'] = [
+			'label'   => $this->total_label,
+			'amount'  => max( 0, apply_filters( 'woocommerce_stripe_calculated_total', WC_Stripe_Helper::get_stripe_amount( $order_total ), $order_total, WC()->cart ) ),
+			'pending' => false,
 		];
+
+		return $data;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1484,6 +1484,14 @@ class WC_Stripe_Payment_Request {
 		// Default show only subtotal instead of itemization.
 		if ( ! apply_filters( 'wc_stripe_payment_request_hide_itemization', true ) || $itemized_display_items ) {
 			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+
+				// Exclude child items to avoid making the list too big
+				$is_mix_n_match_item = function_exists( 'wc_mnm_is_child_cart_item' ) && wc_mnm_is_child_cart_item( $cart_item );
+
+				if ( $is_mix_n_match_item ) {
+					continue;
+				}
+
 				$amount         = $cart_item['line_subtotal'];
 				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
 

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -133,7 +133,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 
 
 	public function test_get_shipping_options_returns_shipping_options() {
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, true );
 
 		$expected_shipping_options = array_map(
 			'self::get_shipping_option',
@@ -145,13 +145,18 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_shipping_options_returns_chosen_option() {
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, true );
 
 		$flat_rate              = $this->get_shipping_option( $this->flat_rate_id );
 		$expected_display_items = [
 			[
-				'label'  => 'Shipping',
-				'amount' => $flat_rate['amount'],
+				'label'  => 'Dummy Product',
+				'amount' => 1000,
+			],
+			[
+				'label'   => 'Shipping',
+				'amount'  => $flat_rate['amount'],
+				'pending' => true,
 			],
 		];
 
@@ -163,7 +168,7 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 		$method_id = self::get_shipping_option_rate_id( $this->local_pickup_id );
 		$this->pr->update_shipping_method( [ $method_id ] );
 
-		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS );
+		$data = $this->pr->get_shipping_options( self::SHIPPING_ADDRESS, true );
 
 		$expected_shipping_options = array_map(
 			'self::get_shipping_option',


### PR DESCRIPTION
Part of #1563. Adds Mix and Match support wanted for #1401

### Changes needed from plugin

Comment last line in `woocommerce-mix-and-match-products/includes/compatibility/modules/class-wc-mnm-stripe-compatibility.php`

```php
// WC_MNM_Stripe_Compatibility::init();
```
