### PR TITLE
Fix early renew modal stuck loading and error

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -253,7 +253,11 @@ jQuery( function( $ ) {
 			);
 
 			// Subscription early renewals modal.
-			$( '#early_renewal_modal_submit' ).on( 'click', this.onEarlyRenewalSubmit );
+			if ($('#early_renewal_modal_submit[data-payment-method]').length) {
+				$('#early_renewal_modal_submit[data-payment-method=stripe]').on('click', this.onEarlyRenewalSubmit);
+			} else {
+				$('#early_renewal_modal_submit').on('click', this.onEarlyRenewalSubmit);
+			}
 
 			wc_stripe_form.createElements();
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1246

Check for payment method attribute before hook Into early renew modal submit button. 
Using the new attribute from WC Subscriptions (4123-gh-woocommerce/woocommerce-subscriptions) we can check the payment method and then hook into it only it uses Stripe gateway.
Added a condition to check for the existence of the attribute to support older versions of WC Subscription too. This way it will work as always for older versions, and prevent the issue on newer ones.

Just to confirm, I should add changelog entries for this, right?

# Testing instructions
You need to use 4123-gh-woocommerce/woocommerce-subscriptions, until it got merged.

Doing an early renew on **My account > Subscriptions**, clicking on **Renew now** button. For a subscription with Stripe gateway or any other, should proceed without issues. Before this, you'll get stuck on a loading state, for a subscription without Stripe as gateway.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.