### PR TITLE
Fix SCA verification on free trial using Checkout block

### DIFF
--- a/client/blocks/three-d-secure/use-payment-intents.js
+++ b/client/blocks/three-d-secure/use-payment-intents.js
@@ -28,15 +28,15 @@ const openIntentModal = ( {
 } ) => {
 	const checkoutResponse = { type: successType };
 	if (
-		! paymentDetails.setup_intent &&
+		! paymentDetails.setup_intent_secret &&
 		! paymentDetails.payment_intent_secret
 	) {
 		return true;
 	}
-	const isSetupIntent = !! paymentDetails.setupIntent;
+	const isSetupIntent = !! paymentDetails.setup_intent_secret;
 	const verificationUrl = paymentDetails.verification_endpoint;
 	const intentSecret = isSetupIntent
-		? paymentDetails.setup_intent
+		? paymentDetails.setup_intent_secret
 		: paymentDetails.payment_intent_secret;
 	return stripe[ isSetupIntent ? 'confirmCardSetup' : 'confirmCardPayment' ](
 		intentSecret


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1615

Adjusts property accessed from returned payment details to proper `setup_intent_secret` name, in the case when a free trial checkout requires additional action via the handling in the Checkout block integration.

## Testing instructions

(Adapted from issue)
1. Put (only) subscription products with free trials in the cart
1. Check out using Checkout block, with 4000002500003155 test card which requires SCA on setup but not on recurring payments thereafter
1. <s>Verify that **renewal succeeds**. Can go to WooCommerce » Subscriptions, click through to subscription, and set free trial to end early – then select "Process manual renewal" action</s> OR go to the Stripe Dashboard » Developers » Events, and verify the presence of a "SetupIntent has succeeded" event. A slightly different way would be to go to Logs, click on the /v1/setup_intents request, click the `seti_` ID, and verify "Succeeded" status at top (instead of "Incomplete").

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.