### PR TITLE
Reset Payment Request button when Shipping option changes

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -320,7 +320,9 @@ jQuery( function( $ ) {
 		 * Starts the payment request
 		 *
 		 * @since 4.0.0
-		 * @version 4.8.0
+		 * @version x.x.x
+		 *
+		 * @return {Object} Payment Request object
 		 */
 		startPaymentRequest: function( paymentRequestOptions ) {
 			// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.
@@ -621,10 +623,25 @@ jQuery( function( $ ) {
 				.unblock();
 		},
 
+
+		/**
+		 * Checks if we should reset the current Payment Request button based on passed options.
+		 *
+		 * @since x.x.x
+		 *
+		 * @return {boolean}
+		 */
 		shouldResetPaymentRequest: function ( paymentRequestOptions ) {
 			return paymentRequestOptions.requestShipping !== currentPaymentRequestOptions.requestShipping;
 		},
 
+		/**
+		 * Destroys given Payment Request button and creates a new one based on passed options
+		 *
+		 * @since x.x.x
+		 *
+		 * @return {Object} Payment Request object
+		 */
 		resetPaymentRequest: function ( prButton, options ) {
 			prButton.destroy();
 			return wc_stripe_payment_request.startPaymentRequest( options );

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -532,8 +532,8 @@ jQuery( function( $ ) {
 						return;
 					}
 
-					if ( wc_stripe_payment_request.shouldTogglePaymentRequest( paymentRequestOptions ) ) {
-						const paymentRequest = wc_stripe_payment_request.togglePaymentRequest( prButton, paymentRequestOptions );
+					if ( wc_stripe_payment_request.shouldResetPaymentRequest( paymentRequestOptions ) ) {
+						const paymentRequest = wc_stripe_payment_request.resetPaymentRequest( prButton, paymentRequestOptions );
 
 						// We need to wait for next tick to be able to open the payment dialog.
 						setTimeout(function() {
@@ -621,12 +621,12 @@ jQuery( function( $ ) {
 				.unblock();
 		},
 
-		shouldTogglePaymentRequest: function ( paymentRequestOptions ) {
+		shouldResetPaymentRequest: function ( paymentRequestOptions ) {
 			return paymentRequestOptions.requestShipping !== currentPaymentRequestOptions.requestShipping;
 		},
 
-		togglePaymentRequest: function ( prButton, options ) {
-			prButton.destroy(); // TODO: should we use unmount maybe?
+		resetPaymentRequest: function ( prButton, options ) {
+			prButton.destroy();
 			return wc_stripe_payment_request.startPaymentRequest( options );
 		},
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -34,19 +34,8 @@ jQuery( function( $ ) {
 				type:    'POST',
 				data:    data,
 				url:     wc_stripe_payment_request.getAjaxURL( 'get_cart_details' ),
-				success: function( cart ) {
-					const options = {
-						total: cart.total,
-						currency: cart.currency,
-						country: cart.country_code,
-						requestPayerName: true,
-						requestPayerEmail: true,
-						requestPayerPhone: cart.needs_payer_phone,
-						requestShipping: cart.requestShipping,
-						displayItems: cart.displayItems
-					};
-
-					wc_stripe_payment_request.startPaymentRequest( options );
+				success: function( paymentRequestOptions ) {
+					wc_stripe_payment_request.startPaymentRequest( paymentRequestOptions );
 				}
 			} );
 		},

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -649,8 +649,9 @@ jQuery( function( $ ) {
 		 */
 		init: function() {
 			if ( wc_stripe_payment_request_params.is_product_page ) {
-				const options = wc_stripe_payment_request.getRequestOptionsFromLocal();
-				wc_stripe_payment_request.startPaymentRequest( options );
+				const paymentRequestOptions = wc_stripe_payment_request.getRequestOptionsFromLocal();
+				wc_stripe_payment_request.startPaymentRequest( paymentRequestOptions );
+				currentPaymentRequestOptions = paymentRequestOptions;
 			} else {
 				wc_stripe_payment_request.getCartDetails();
 			}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -366,7 +366,7 @@ class WC_Stripe_Payment_Request {
 			'pending' => true,
 		];
 
-		// This value won't be user anymore. Leaving it for just to be able to create the PR button on page load.
+		// This value won't be used anymore. Leaving it for just to be able to create the PR button on page load.
 		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 
 		return apply_filters( 'wc_stripe_payment_request_product_data', $data, $product );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1463,10 +1463,8 @@ class WC_Stripe_Payment_Request {
 			define( 'WOOCOMMERCE_CART', true );
 		}
 
-		$data                 = [];
-		$data['currency']     = strtolower( get_woocommerce_currency() );
-		$data['country_code'] = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
-		$items                = [];
+		$data  = [];
+		$items = [];
 
 		// Default show only subtotal instead of itemization.
 		if ( ! apply_filters( 'wc_stripe_payment_request_hide_itemization', true ) || $itemized_display_items ) {
@@ -1562,9 +1560,11 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Mandatory payment details.
-		$data['needs_payer_phone'] = 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' );
+		$data['requestPayerPhone'] = 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' );
 		$data['currency']          = strtolower( get_woocommerce_currency() );
-		$data['country_code']      = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+		$data['country']           = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+		$data['requestPayerEmail'] = true;
+		$data['requestPayerName']  = true;
 
 		$data['displayItems'] = $items;
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -365,7 +365,7 @@ class WC_Stripe_Payment_Request {
 			'amount'  => WC_Stripe_Helper::get_stripe_amount( $product->get_price() ),
 			'pending' => true,
 		];
-		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
+		$data['requestShipping'] = false; // ( wc_shipping_enabled() && $product->needs_shipping() );
 
 		return apply_filters( 'wc_stripe_payment_request_product_data', $data, $product );
 	}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -365,7 +365,9 @@ class WC_Stripe_Payment_Request {
 			'amount'  => WC_Stripe_Helper::get_stripe_amount( $product->get_price() ),
 			'pending' => true,
 		];
-		$data['requestShipping'] = false; // ( wc_shipping_enabled() && $product->needs_shipping() );
+
+		// This value won't be user anymore. Leaving it for just to be able to create the PR button on page load.
+		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 
 		return apply_filters( 'wc_stripe_payment_request_product_data', $data, $product );
 	}


### PR DESCRIPTION
Fixes #1624 

This PR introduces a new behavior to the Payment Request Button (PRB) on the Product page (Although the changes here could affect other places). The PRB will now be destroyed and re-created depending on the response of adding a product to the cart (`/?wc-ajax=wc_stripe_add_to_cart`) which happens when the user clicks the PRB.

The PRB will be destroyed **only** if the response object contains a different value for `requestShipping` than the current one.

This fixes the problem we currently have for some products and some advanced product types (e.g. Bundles, Composite Products): The PRB is created with `requestShipping: true` but then the user adds a product/bundle/composite product that doesn't need shipping making the "Shipping Address" section on the payment request dialog useless and it has to be removed.

### Testing instructions

To test this new behavior we need to create a variable product with two variants as follows:

- Create a new product
- Select "Variable Product" as product type.
- Click "Attributes", Then click "Add" while "Custom product attribute" is selected
- Create "size" attribute with "small|medium" as values
- Click "Variations" then while "Create variations from all attributes" is selected click "Go"
- Set Regular price to `100` for small variation
- Set Regular price to `200` and click "virtual" for medium variation.
- Go to product page
- Set "size" to "small" then click PRB. Shipping Address must be present on the payment dialog. Cancel dialog.
- Set "size" to "medium" then click PRB Shipping Address should not be present on the payment dialog.

There's no need to test with Bundles or Composite Products. They will be addressed in separate PRs.

### Testing List

- [x] Google Pay
- [ ] Apple Pay
- [ ] Default Payment Request button
- [ ] Custom Payment Request button
- [ ] Branded Payment Request button

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
