### PR TITLE
[Payment Request Button] Do not ask for Shipping Address if no Shipping Zone is defined

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 5.x.x - 2021-xx-xx =
 * Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.
+* Fix - Do not ask for a Shipping Address if no Shipping Zone is defined.
 * Tweak - Payment request button should guide users to login when necessary.
 
 = 5.2.3 - 2021-06-11 =

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -417,7 +417,7 @@ class WC_Stripe_Payment_Request {
 			'pending' => true,
 		];
 
-		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
+		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() && 0 !== wc_get_shipping_method_count( true ) );
 		$data['currency']        = strtolower( get_woocommerce_currency() );
 		$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
 


### PR DESCRIPTION
Fixes #1635

Additionally checks if at least one Shipping Zone is created in order to ask for a Shipping Address in the payment modal.

# Testing instructions

On a WP site with Stripe, Payment Request buttons enabled and **no Shipping Zones** created:

- Create simple product
- Go to product page
- Click PRB
- "Shipping Address" option **must not be present** in payment dialog
- Go to WooCommerce -> Settings -> Shipping. Then create a Shipping Zone. Add at least one Shipping option.
- Go to product page
- Click PRB
- "Shipping Address" option must be present.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
