### PR TITLE
Spelling update CTA disconnected account

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1309,7 +1309,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			if ( ! is_wp_error( $oauth_url ) ) {
 				$api_credentials_text = sprintf(
 				/* translators: %1, %2 and %3 are all HTML markup tags */
-					__( '%1$sSetup or link an existing Stripe account.%2$s By clicking this button you agree to the %3$sTerms of Service%2$s. Or, manually enter Stripe account keys below.', 'woocommerce-gateway-stripe' ),
+					__( '%1$sSet up or link an existing Stripe account.%2$s By clicking this button you agree to the %3$sTerms of Service%2$s. Or, manually enter Stripe account keys below.', 'woocommerce-gateway-stripe' ),
 					'<a id="wc_stripe_connect_button" href="' . $oauth_url . '" class="button button-primary">',
 					'</a>',
 					'<a href="https://wordpress.com/tos">'


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Updated the instructions in the "Account keys" CTA: the button currently reads:

> Setup or link an existing Stripe account.

"Setup" is not the verb, but the noun. So updating to

> Set up or link an existing Stripe account.


Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.

![https://d.pr/i/fqcT9r](https://d.pr/i/fqcT9r+)

# Testing instructions

* Go to Admin > WooCommerce > Settings > Payments > Stripe
* Make sure the account is not connected, see the button to connect

Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
