### PR TITLE
Update the GH workflows Ubuntu to 18.04 (from 16.04)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   woocommerce-compatibility:
     name:    Release
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast:    false
       max-parallel: 10
@@ -44,7 +44,7 @@ jobs:
   # a dedicated job, as allowed to fail
   compatibility-woocommerce-beta:
     name:    Beta
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   lint:
     name:    PHP linting
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   test:
     name:    PHP testing
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast:    false
       max-parallel: 10


### PR DESCRIPTION
This is in response to the warning that's been given for a while:

> Warning: setup-php will stop working on Ubuntu 16.04 from August 1, 2021. Please upgrade to Ubuntu 18.04 or Ubuntu 20.04 - https://setup-php.com/i/452

Which is now a hard error causing builds to fail:

> Error: setup-php is not supported on Ubuntu 16.04. Please upgrade to Ubuntu 18.04 or Ubuntu 20.04 - https://setup-php.com/i/452

Examples: [warning](https://github.com/woocommerce/woocommerce-gateway-stripe/runs/3184929579#step:4:9) & [error/failure](https://github.com/woocommerce/woocommerce-gateway-stripe/runs/3224369080#step:4:9)