### PR TITLE
Fix payments with custom order status made via payment or setup intents

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Do not ask for a Shipping Address if no Shipping Zone is defined.
 * Fix - Return HTTP 204 when webhook validation fails so Stripe won't stop sending certain webhook events after too many failed validations.
 * Fix - Possible use of an undefined variable `prepared_source`.
+* Add - 'wc_stripe_allowed_payment_processing_statuses' filter to customize order statuses that allow payment processing in the context of 3DS payments.
 
 = 5.3.0 - 2021-07-21 =
 * Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1110,7 +1110,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		clean_post_cache( $order->get_id() );
 		$order = wc_get_order( $order->get_id() );
 
-		if ( ! $order->has_status( [ 'pending', 'failed' ] ) ) {
+		if ( ! $order->has_status(
+			apply_filters(
+				'wc_stripe_allowed_payment_processing_statuses',
+				[ 'pending', 'failed' ]
+			)
+		) ) {
 			// If payment has already been completed, this function is redundant.
 			return;
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -742,7 +742,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( ! $order->has_status( [ 'pending', 'failed' ] ) ) {
+		if ( ! $order->has_status(
+			apply_filters(
+				'wc_stripe_allowed_payment_processing_statuses',
+				[ 'pending', 'failed' ]
+			)
+		) ) {
 			return;
 		}
 
@@ -789,7 +794,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( ! $order->has_status( [ 'pending', 'failed' ] ) ) {
+		if ( ! $order->has_status(
+			apply_filters(
+				'wc_gateway_stripe_allowed_payment_processing_statuses',
+				[ 'pending', 'failed' ]
+			)
+		) ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -281,7 +281,10 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			$statuses = [ 'pending', 'failed' ];
+			$statuses = apply_filters(
+				'wc_stripe_allowed_payment_processing_statuses',
+				[ 'pending', 'failed' ]
+			);
 
 			if ( $order->has_status( $statuses ) ) {
 				$this->send_failed_order_email( $order_id );

--- a/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
@@ -270,7 +270,12 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-eps.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-eps.php
@@ -269,7 +269,12 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-giropay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-giropay.php
@@ -269,7 +269,12 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-ideal.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-ideal.php
@@ -269,7 +269,12 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -376,7 +376,12 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-p24.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-p24.php
@@ -266,7 +266,12 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -405,7 +405,12 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-sofort.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sofort.php
@@ -282,7 +282,12 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			if ( $order->has_status( [ 'pending', 'failed' ] ) ) {
+			if ( $order->has_status(
+				apply_filters(
+					'wc_stripe_allowed_payment_processing_statuses',
+					[ 'pending', 'failed' ]
+				)
+			) ) {
 				$this->send_failed_order_email( $order_id );
 			}
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Supercedes #1499 

This filter is used to control which order statuses allow a payment to be processed in the context of 3DS payments and the associated webhooks. By default the only statuses treated as such are `pending` and `failed`.

This is mostly useful when merchants assign a custom status to an order before payment processing begins. Before this commit a custom order status would capture the payment, but the order status wasn't updated.

# Testing instructions

> **Note:** Webhooks must be configured correctly for the testing to work correctly.

> **Note:** You must install the [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/) plugin for the **Draft** order status to be available.

1. Make sure payments are captured immediately by going to **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**, make sure **Capture** is toggled on, and click **Save changes**.
2. Install and activate the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
3. Go to **Snippets > Add new**
4. Copy the following snippet into the **Code** text area. You can choose any name you want.

```php
function add_draft_to_allowed_payment_processing_statuses( $statuses ) {
	if ( ! in_array( 'checkout-draft', $statuses ) ) {
		$statuses[] = 'checkout-draft';
	}
	return $statuses;
}
add_filter( 'wc_stripe_allowed_payment_processing_statuses', 'add_draft_to_allowed_payment_processing_statuses' );
```

<img width="967" alt="image" src="https://user-images.githubusercontent.com/13835680/128262187-2b0bc3fd-d263-4051-b3f5-86686cbdb2a6.png">

5. Make sure **Run snippet everywhere** is toggled
6. Click **Save changes and activate**
7. Go to **WooCommerce > Orders** and click **Add Order**
8. Set the order status to **Draft**
9. Select the customer for your current account — or any account you have access to on your site. The customer details should be filled in automatically.

<img width="893" alt="image" src="https://user-images.githubusercontent.com/13835680/128262549-3eafe408-c729-4b69-84bf-b52a9a792e0b.png">

10. Click **Add item(s)** followed by **Add product(s)** and add any product to the order.

<img width="893" alt="image" src="https://user-images.githubusercontent.com/13835680/128262620-ec5ed835-071a-464f-8cb6-2bd010a0cc18.png">

<img width="893" alt="image" src="https://user-images.githubusercontent.com/13835680/128262716-d0c82e8a-8e87-462c-a1d3-a63534dd9a99.png">

11. Click **Create**
12. Click **Customer payment page**
13. Pay for the order with a 3DS card: `4000000000003220`
14. Go back to the order details page
15. Make sure the order status has changed to **Processing** (or **completed** for digital orders).
16. Turn off immediate payment capture by going to **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**, make sure **Capture** is toggled off, and click **Save changes**. 
17. Repeat steps 2-14 (create a draft order, pay through the **Customer payment page** page)
18. Make sure the order status has changed to **On hold**.
19. Make sure there is a note that starts with `Stripe charge authorized (Charge ID: ch_xyz).`
20. Change the payment status to **Processing**
21. Make sure a note has appeared that says `Stripe charge complete (Charge ID: ch_3JKqQ7KFePZ3MR450VtiEw3i)`

Repeat these testing instructions with the following conditions:

1. Use a non-3DS card and make sure everything behaves the same.
2. Add a product to the draft order that has stock and make sure the stock management behaves in the following ways:
    - Stock is not reduced when the order is created (after step 11)
    - (For immediate capture) stock is reduced after payment (after step 13)
    - (For manual capture) stock is reduced after authorization (after step 20)
    - **Tip:** To add stock to a product go to **Products**, select any product, go to **Inventory**, toggle **Manage stock?** on, change **Stock quantity** to a positive number, and click **Update**.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

