### PR TITLE
Use the plugin settings to choose PRB locations instead of filters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Fix - Possible use of an undefined variable `prepared_source`.
 * Add - 'wc_stripe_allowed_payment_processing_statuses' filter to customize order statuses that allow payment processing in the context of 3DS payments.
 * Add - Settings to control Payment Request Button locations in the Stripe plugin settings. Persists changes made through pre-existing filters, or defaults to the Cart and Product pages if no filters are in use.
-* Tweak - Removed the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.
+* Tweak - Deprecated the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.
 
 = 5.3.0 - 2021-07-21 =
 * Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,8 @@
 * Fix - Save payment method during 3D Secure flow for Block-based checkout.
 * Fix - Possible use of an undefined variable `prepared_source`.
 * Add - 'wc_stripe_allowed_payment_processing_statuses' filter to customize order statuses that allow payment processing in the context of 3DS payments.
+* Add - Settings to control Payment Request Button locations in the Stripe plugin settings. Persists changes made through pre-existing filters, or defaults to the Cart and Product pages if no filters are in use.
+* Tweak - Removed the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.
 
 = 5.3.0 - 2021-07-21 =
 * Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -181,16 +181,20 @@ return apply_filters(
 			],
 		],
 		'payment_request_locations'           => [
-			'title'       => __( 'Payment Request Button Locations', 'woocommerce-gateway-stripe' ),
-			'type'        => 'multiselect',
-			'description' => __( 'Select where you would like Payment Request Buttons to be displayed', 'woocommerce-gateway-stripe' ),
-			'desc_tip'    => true,
-			'options'     => [
-				'product'  => __( 'Product pages', 'woocommerce-gateway-stripe' ),
-				'cart'     => __( 'Cart page', 'woocommerce-gateway-stripe' ),
-				'checkout' => __( 'Checkout page', 'woocommerce-gateway-stripe' ),
+			'title'             => __( 'Payment Request Button Locations', 'woocommerce-gateway-stripe' ),
+			'type'              => 'multiselect',
+			'description'       => __( 'Select where you would like Payment Request Buttons to be displayed', 'woocommerce-gateway-stripe' ),
+			'desc_tip'          => true,
+			'class'             => 'wc-enhanced-select',
+			'options'           => [
+				'product'  => __( 'Product', 'woocommerce-gateway-stripe' ),
+				'cart'     => __( 'Cart', 'woocommerce-gateway-stripe' ),
+				'checkout' => __( 'Checkout', 'woocommerce-gateway-stripe' ),
 			],
-			'default'     => [ 'product', 'cart' ],
+			'default'           => [ 'product', 'cart' ],
+			'custom_attributes' => [
+				'data-placeholder' => __( 'Select pages', 'woocommerce-gateway-stripe' ),
+			],
 		],
 		'saved_cards'                         => [
 			'title'       => __( 'Saved Cards', 'woocommerce-gateway-stripe' ),

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -180,7 +180,7 @@ return apply_filters(
 				'long'  => __( 'Text and logo', 'woocommerce-gateway-stripe' ),
 			],
 		],
-		'payment_request_locations'           => [
+		'payment_request_button_locations'           => [
 			'title'             => __( 'Payment Request Button Locations', 'woocommerce-gateway-stripe' ),
 			'type'              => 'multiselect',
 			'description'       => __( 'Select where you would like Payment Request Buttons to be displayed', 'woocommerce-gateway-stripe' ),

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -180,6 +180,18 @@ return apply_filters(
 				'long'  => __( 'Text and logo', 'woocommerce-gateway-stripe' ),
 			],
 		],
+		'payment_request_locations'           => [
+			'title'       => __( 'Payment Request Button Locations', 'woocommerce-gateway-stripe' ),
+			'type'        => 'multiselect',
+			'description' => __( 'Select where you would like Payment Request Buttons to be displayed', 'woocommerce-gateway-stripe' ),
+			'desc_tip'    => true,
+			'options'     => [
+				'product'  => __( 'Product pages', 'woocommerce-gateway-stripe' ),
+				'cart'     => __( 'Cart page', 'woocommerce-gateway-stripe' ),
+				'checkout' => __( 'Checkout page', 'woocommerce-gateway-stripe' ),
+			],
+			'default'     => [ 'product', 'cart' ],
+		],
 		'saved_cards'                         => [
 			'title'       => __( 'Saved Cards', 'woocommerce-gateway-stripe' ),
 			'label'       => __( 'Enable Payment via Saved Cards', 'woocommerce-gateway-stripe' ),

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -129,8 +129,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		// TODO: Remove the `function_exists()` check once the minimum WP version has been bumped
 		//       to version 5.0.
 		if ( function_exists( 'has_block' ) ) {
-			$prb_locations = empty( $this->settings['payment_request_locations'] )
-				? [] : $this->settings['payment_request_locations'];
+			$prb_locations = $this->payment_request_configuration->get_button_locations();
 
 			// Don't show if PRBs are supposed to be hidden on the cart page.
 			// Note: The cart block has the PRB enabled by default.

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -129,13 +129,14 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		// TODO: Remove the `function_exists()` check once the minimum WP version has been bumped
 		//       to version 5.0.
 		if ( function_exists( 'has_block' ) ) {
-			global $post;
+			$prb_locations = empty( $this->settings['payment_request_locations'] )
+				? [] : $this->settings['payment_request_locations'];
 
 			// Don't show if PRBs are supposed to be hidden on the cart page.
 			// Note: The cart block has the PRB enabled by default.
 			if (
 				has_block( 'woocommerce/cart' )
-				&& ! apply_filters( 'wc_stripe_show_payment_request_on_cart', true )
+				&& ! in_array( 'cart', $prb_locations, true )
 			) {
 				return false;
 			}
@@ -145,7 +146,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			//       checkout where the PRB is disabled by default.
 			if (
 				has_block( 'woocommerce/checkout' )
-				&& ! apply_filters( 'wc_stripe_show_payment_request_on_checkout', true, $post )
+				&& ! in_array( 'checkout', $prb_locations, true )
 			) {
 				return false;
 			}

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -129,23 +129,18 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		// TODO: Remove the `function_exists()` check once the minimum WP version has been bumped
 		//       to version 5.0.
 		if ( function_exists( 'has_block' ) ) {
-			$prb_locations = $this->payment_request_configuration->get_button_locations();
-
 			// Don't show if PRBs are supposed to be hidden on the cart page.
-			// Note: The cart block has the PRB enabled by default.
 			if (
 				has_block( 'woocommerce/cart' )
-				&& ! in_array( 'cart', $prb_locations, true )
+				&& ! $this->payment_request_configuration->should_show_prb_on_cart_page()
 			) {
 				return false;
 			}
 
 			// Don't show if PRBs are supposed to be hidden on the checkout page.
-			// Note: The checkout block has the PRB enabled by default. This differs from the shortcode
-			//       checkout where the PRB is disabled by default.
 			if (
 				has_block( 'woocommerce/checkout' )
-				&& ! in_array( 'checkout', $prb_locations, true )
+				&& ! $this->payment_request_configuration->should_show_prb_on_checkout_page()
 			) {
 				return false;
 			}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -867,20 +867,17 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Don't show on cart if disabled.
-		if ( is_cart() && ! in_array( 'cart', $this->get_button_locations(), true ) ) {
+		if ( is_cart() && ! $this->should_show_prb_on_cart_page() ) {
 			return false;
 		}
 
 		// Don't show on checkout if disabled.
-		if ( is_checkout() && ! in_array( 'checkout', $this->get_button_locations(), true ) ) {
+		if ( is_checkout() && ! $this->should_show_prb_on_checkout_page() ) {
 			return false;
 		}
 
 		// Don't show if product page PRB is disabled.
-		if (
-			$this->is_product()
-			&& ! in_array( 'product', $this->get_button_locations(), true )
-		) {
+		if ( $this->is_product() && ! $this->should_show_prb_on_product_pages() ) {
 			return false;
 		}
 
@@ -890,6 +887,84 @@ class WC_Stripe_Payment_Request {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Returns true if Payment Request Buttons are enabled on the cart page, false
+	 * otherwise.
+	 *
+	 * @since   x.x.x
+	 * @version x.x.x
+	 * @return  boolean  True if PRBs are enabled on the cart page, false otherwise
+	 */
+	public function should_show_prb_on_cart_page() {
+		// Message we show for the deprecated PRB location filters. Intended for support so we
+		// don't provide translations.
+		$deprecation_message      =
+			'Please configure Payment Request Button locations through the Stripe plugin settings.';
+		$should_show_on_cart_page = in_array( 'cart', $this->get_button_locations(), true );
+
+		// Respect the deprecated filters, but add a deprecation notice.
+		return apply_filters_deprecated(
+			'wc_stripe_show_payment_request_on_cart',
+			[ $should_show_on_cart_page ],
+			'5.5.0',
+			'', // There is no replacement.
+			$deprecation_message
+		);
+	}
+
+	/**
+	 * Returns true if Payment Request Buttons are enabled on the checkout page, false
+	 * otherwise.
+	 *
+	 * @since   x.x.x
+	 * @version x.x.x
+	 * @return  boolean  True if PRBs are enabled on the checkout page, false otherwise
+	 */
+	public function should_show_prb_on_checkout_page() {
+		global $post;
+
+		// Message we show for the deprecated PRB location filters. Intended for support so we
+		// don't provide translations.
+		$deprecation_message          =
+			'Please configure Payment Request Button locations through the Stripe plugin settings.';
+		$should_show_on_checkout_page = in_array( 'checkout', $this->get_button_locations(), true );
+
+		// Respect the deprecated filters, but add a deprecation notice.
+		return apply_filters_deprecated(
+			'wc_stripe_show_payment_request_on_checkout',
+			[ $should_show_on_checkout_page, $post ],
+			'5.5.0',
+			'', // There is no replacement.
+			$deprecation_message
+		);
+	}
+
+	/**
+	 * Returns true if Payment Request Buttons are enabled on product pages, false
+	 * otherwise.
+	 *
+	 * @since   x.x.x
+	 * @version x.x.x
+	 * @return  boolean  True if PRBs are enabled on product pages, false otherwise
+	 */
+	public function should_show_prb_on_product_pages() {
+		// Message we show for the deprecated PRB location filters. Intended for support so we
+		// don't provide translations.
+		$deprecation_message         =
+			'Please configure Payment Request Button locations through the Stripe plugin settings.';
+		$should_show_on_product_page = in_array( 'product', $this->get_button_locations(), true );
+
+		// Respect the deprecated filters, but add a deprecation notice.
+		// Note the negation because if the filter returns `true` that means we should hide the PRB.
+		return ! apply_filters_deprecated(
+			'wc_stripe_hide_payment_request_on_product_page',
+			[ $should_show_on_product_page ],
+			'5.5.0',
+			'', // There is no replacement.
+			$deprecation_message
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1779,17 +1779,17 @@ class WC_Stripe_Payment_Request {
 
 	public function get_button_locations() {
 		// If the locations have not been set return the default setting.
-		if ( ! isset( $this->stripe_settings['payment_request_locations'] ) ) {
+		if ( ! isset( $this->stripe_settings['payment_request_button_locations'] ) ) {
 			return [ 'product', 'cart' ];
 		}
 
 		// If all locations are removed through the settings UI the location config will be set to
 		// an empty string "". If that's the case (and if the settings are not an array for any
 		// other reason) we should return an empty array.
-		if ( ! is_array( $this->stripe_settings['payment_request_locations'] ) ) {
+		if ( ! is_array( $this->stripe_settings['payment_request_button_locations'] ) ) {
 			return [];
 		}
 
-		return $this->stripe_settings['payment_request_locations'];
+		return $this->stripe_settings['payment_request_button_locations'];
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -828,10 +828,7 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		$prb_locations = empty( $this->stripe_settings['payment_request_locations'] )
-			? [] : $this->stripe_settings['payment_request_locations'];
-
-		if ( is_checkout() && ! in_array( 'checkout', $prb_locations, true ) ) {
+		if ( is_checkout() && ! in_array( 'checkout', $this->get_button_locations(), true ) ) {
 			return;
 		}
 		?>
@@ -869,23 +866,20 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
-		$prb_locations = empty( $this->stripe_settings['payment_request_locations'] )
-			? [] : $this->stripe_settings['payment_request_locations'];
-
 		// Don't show on cart if disabled.
-		if ( is_cart() && ! in_array( 'cart', $prb_locations, true ) ) {
+		if ( is_cart() && ! in_array( 'cart', $this->get_button_locations(), true ) ) {
 			return false;
 		}
 
 		// Don't show on checkout if disabled.
-		if ( is_checkout() && ! in_array( 'checkout', $prb_locations, true ) ) {
+		if ( is_checkout() && ! in_array( 'checkout', $this->get_button_locations(), true ) ) {
 			return false;
 		}
 
 		// Don't show if product page PRB is disabled.
 		if (
 			$this->is_product()
-			&& ! in_array( 'product', $prb_locations, true )
+			&& ! in_array( 'product', $this->get_button_locations(), true )
 		) {
 			return false;
 		}
@@ -1706,5 +1700,12 @@ class WC_Stripe_Payment_Request {
 			'message'      => $message,
 			'redirect_url' => $redirect_url,
 		];
+	}
+
+	public function get_button_locations() {
+		if ( ! isset( $this->stripe_settings['payment_request_locations'] ) ) {
+			return [ 'product', 'cart' ];
+		}
+		return $this->stripe_settings['payment_request_locations'];
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -818,8 +818,6 @@ class WC_Stripe_Payment_Request {
 	 * @version 5.2.0
 	 */
 	public function display_payment_request_button_separator_html() {
-		global $post;
-
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! isset( $gateways['stripe'] ) ) {
@@ -830,7 +828,10 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		if ( is_checkout() && ! apply_filters( 'wc_stripe_show_payment_request_on_checkout', false, $post ) ) {
+		$prb_locations = empty( $this->stripe_settings['payment_request_locations'] )
+			? [] : $this->stripe_settings['payment_request_locations'];
+
+		if ( is_checkout() && ! in_array( 'checkout', $prb_locations, true ) ) {
 			return;
 		}
 		?>
@@ -847,8 +848,6 @@ class WC_Stripe_Payment_Request {
 	 * @return  boolean  True if PRBs are supported on current page, false otherwise
 	 */
 	public function should_show_payment_request_button() {
-		global $post;
-
 		// If keys are not set bail.
 		if ( ! $this->are_keys_set() ) {
 			WC_Stripe_Logger::log( 'Keys are not set correctly.' );
@@ -870,20 +869,23 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
+		$prb_locations = empty( $this->stripe_settings['payment_request_locations'] )
+			? [] : $this->stripe_settings['payment_request_locations'];
+
 		// Don't show on cart if disabled.
-		if ( is_cart() && ! apply_filters( 'wc_stripe_show_payment_request_on_cart', true ) ) {
+		if ( is_cart() && ! in_array( 'cart', $prb_locations, true ) ) {
 			return false;
 		}
 
 		// Don't show on checkout if disabled.
-		if ( is_checkout() && ! apply_filters( 'wc_stripe_show_payment_request_on_checkout', false, $post ) ) {
+		if ( is_checkout() && ! in_array( 'checkout', $prb_locations, true ) ) {
 			return false;
 		}
 
 		// Don't show if product page PRB is disabled.
 		if (
 			$this->is_product()
-			&& apply_filters( 'wc_stripe_hide_payment_request_on_product_page', false, $post )
+			&& ! in_array( 'product', $prb_locations, true )
 		) {
 			return false;
 		}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1703,9 +1703,18 @@ class WC_Stripe_Payment_Request {
 	}
 
 	public function get_button_locations() {
+		// If the locations have not been set return the default setting.
 		if ( ! isset( $this->stripe_settings['payment_request_locations'] ) ) {
 			return [ 'product', 'cart' ];
 		}
+
+		// If all locations are removed through the settings UI the location config will be set to
+		// an empty string "". If that's the case (and if the settings are not an array for any
+		// other reason) we should return an empty array.
+		if ( ! is_array( $this->stripe_settings['payment_request_locations'] ) ) {
+			return [];
+		}
+
 		return $this->stripe_settings['payment_request_locations'];
 	}
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -245,8 +245,8 @@ function woocommerce_gateway_stripe() {
 			 */
 			public function update_prb_location_settings() {
 				$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
-				$prb_locations   = isset( $stripe_settings['payment_request_locations'] )
-					? $stripe_settings['payment_request_locations']
+				$prb_locations   = isset( $stripe_settings['payment_request_button_locations'] )
+					? $stripe_settings['payment_request_button_locations']
 					: [];
 				if ( ! empty( $stripe_settings ) && empty( $prb_locations ) ) {
 					global $post;
@@ -269,7 +269,7 @@ function woocommerce_gateway_stripe() {
 						$new_prb_locations[] = 'checkout';
 					}
 
-					$stripe_settings['payment_request_locations'] = $new_prb_locations;
+					$stripe_settings['payment_request_button_locations'] = $new_prb_locations;
 					update_option( 'woocommerce_stripe_settings', $stripe_settings );
 				}
 			}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes #1640

Instead of relying on filters to configure where to display Payment Request Buttons we now use a `multiselect` element in the Stripe settings to choose the locations we want to show PRBs in.

- Removed the `wc_stripe_hide_payment_request_on_product_page` filter.
- Removed the `wc_stripe_show_payment_request_on_checkout` filter.
- Removed the `wc_stripe_show_payment_request_on_cart` filter.
- Added the `payment_request_button_locations` setting.
- Move the results of the removed filters into the plugin settings.

## Testing instructions

> **Note:** You'll need database access to properly test this feature. The testing instructions will assume you're using phpMyAdmin.

> **Note:** You may see deprecation warnings if you have `WP_DEBUG` set to `true` while the code snippets (added later) are enabled.

### Test default values

1. `git checkout fix/1640-add-prb-location-settings`.
2. Clear any use of the removed filters (mentioned above).
3. Change the `WC_STRIPE_VERSION` constant [in `woocommerce-gateway-stripe.php:24`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/38744bb1c4add59869f5067734c0960f726b1228/woocommerce-gateway-stripe.php#L24) from whatever it's current value is to any other version, e.g. change `5.3.0` to `5.4.0`.
4. Open **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**
5. Make sure the **Payment Request Button Locations** setting is set to **Cart** and **Product**.
6. Make sure the PRBs are loaded on the **Product** pages.
7. Make sure the PRBs are loaded on the **Cart** page (both Blocks and Shortcode versions).
8. Make sure the PRBs are not loaded on the **Checkout** page (both Blocks and Shortcode versions).
9. Open phpMyAdmin, navigate to the **wp_options** table, toggle **Show all** on, search for **woocommerce_stripe_settings**, and click **Edit**.

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/13835680/129649524-a174d450-e508-460a-9ab7-6b7514a0b0a0.png">

10. Make sure the configuration array has a section that says: `s:25:"payment_request_button_locations";a:2:{i:0;s:7:"product";i:1;s:4:"cart";}`.

### Test filter configuration persistence

1. Install and activate the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
2. Go to **Snippets > Add new**.
3. Copy the following snippet into the **Code** text area. Save this snippet as **Show PRBs on the Checkout Page**.

```php
// Snippet name: Show PRBs on the Checkout Page.
function show_prb_on_checkout_page($should_show) {
	return true;
}
add_filter( 'wc_stripe_show_payment_request_on_checkout', 'show_prb_on_checkout_page' );
```

4. Make sure **Run snippet everywhere** is toggled on.
5. Click **Save changes and activate**.
6. Repeat the snippet creation and activation for the following 2 snippets; make sure both are in separate snippets with distinct names:

```php
// Snippet name: Hide PRBs on Product Pages.
function hide_prb_on_product_page( $hide_prb ) {
	return true;
}
add_filter( 'wc_stripe_hide_payment_request_on_product_page', 'hide_prb_on_product_page' );
```

```php
// Snippet name: Hide PRBs on the Cart Page.
function hide_prb_on_cart_page( $should_show_prb ) {
	return false;
}
add_filter( 'wc_stripe_show_payment_request_on_cart', 'hide_prb_on_cart_page' );
```

7. You should now have 3 snippets active:

<img width="672" alt="image" src="https://user-images.githubusercontent.com/13835680/129649163-c827fbcf-d9f0-465a-820c-2cdc5e0b1db4.png">

8. Open phpMyAdmin, navigate to the **wp_options** table, toggle **Show all** on, search for **woocommerce_stripe_settings**, and click **Edit**.

<img width="1085" alt="image" src="https://user-images.githubusercontent.com/13835680/129649524-a174d450-e508-460a-9ab7-6b7514a0b0a0.png">

9. Make the following changes to the **option_value**, and click **Go**:
	* Decrement the initial `a:XX` value by one. For example if the first letters are `a:24` change that to `a:23`.
	* Remove the whole `s:25:"payment_request_button_locations";a:2:{ ... }` part of the settings array. This will most likely be the last configuration in the settings array.

<details><summary>Example of changes applied to **option_value**</summary>
Change

```
a:24:{s:7:"enabled";s:3:"yes";s:5:"title";s:20:"Credit Card (Stripe)";s:11:"description";s:37:"Pay with your credit card via Stripe.";s:15:"api_credentials";s:0:"";s:8:"testmode";s:3:"yes";s:20:"test_publishable_key";s:42:"pk_test_xxxx";s:15:"test_secret_key";s:42:"sk_test_xxxx";s:15:"publishable_key";s:0:"";s:10:"secret_key";s:0:"";s:7:"webhook";s:0:"";s:19:"test_webhook_secret";s:38:"whsec_xxxx";s:14:"webhook_secret";s:0:"";s:14:"inline_cc_form";s:3:"yes";s:20:"statement_descriptor";s:7:"ATMTTC";s:7:"capture";s:3:"yes";s:15:"payment_request";s:3:"yes";s:27:"payment_request_button_type";s:3:"buy";s:28:"payment_request_button_theme";s:4:"dark";s:29:"payment_request_button_height";s:2:"44";s:28:"payment_request_button_label";s:7:"Buy now";s:35:"payment_request_button_branded_type";s:4:"long";s:11:"saved_cards";s:3:"yes";s:7:"logging";s:3:"yes";s:25:"payment_request_button_locations";a:2:{i:0;s:4:"cart";i:1;s:8:"checkout";}}
```

to

```
a:23:{s:7:"enabled";s:3:"yes";s:5:"title";s:20:"Credit Card (Stripe)";s:11:"description";s:37:"Pay with your credit card via Stripe.";s:15:"api_credentials";s:0:"";s:8:"testmode";s:3:"yes";s:20:"test_publishable_key";s:42:"pk_test_xxxx";s:15:"test_secret_key";s:42:"sk_test_xxxx";s:15:"publishable_key";s:0:"";s:10:"secret_key";s:0:"";s:7:"webhook";s:0:"";s:19:"test_webhook_secret";s:38:"whsec_xxxx";s:14:"webhook_secret";s:0:"";s:14:"inline_cc_form";s:3:"yes";s:20:"statement_descriptor";s:7:"ATMTTC";s:7:"capture";s:3:"yes";s:15:"payment_request";s:3:"yes";s:27:"payment_request_button_type";s:3:"buy";s:28:"payment_request_button_theme";s:4:"dark";s:29:"payment_request_button_height";s:2:"44";s:28:"payment_request_button_label";s:7:"Buy now";s:35:"payment_request_button_branded_type";s:4:"long";s:11:"saved_cards";s:3:"yes";s:7:"logging";s:3:"yes";}
```
</details>

10. Change the `WC_STRIPE_VERSION` constant [in `woocommerce-gateway-stripe.php:24`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/38744bb1c4add59869f5067734c0960f726b1228/woocommerce-gateway-stripe.php#L24) from whatever it's current value is to any other version, e.g. change `5.3.0` to `5.4.0`.
11. Open **Snippets** and disable any active snippets.
12. Open **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**
13. Make sure the **Payment Request Button Locations** option is set to **Checkout**.
14. Make sure the PRBs are loaded on the store's **Checkout** page (both Blocks and Shortcode versions).
15. Make sure the PRBs are not loaded on the store's **Cart** page (both Blocks and Shortcode versions).
16. Make sure the PRBs are not loaded on any of the store's **Product** pages.
17. Open phpMyAdmin, navigate to the **wp_options** table, toggle **Show all** on, search for **woocommerce_stripe_settings**, and click **Edit**.
18. Make sure the configuration array has a section that says: `s:25:"payment_request_button_locations";a:1:{i:0;s:8:"checkout";}`.

Now repeat steps 8 to 18 with all possible combinations of the snippets enabled/disabled:

| Show PRBs on the Checkout Page | Hide PRBs on Product Pages | Hide PRBs on the Cart Page | Configuration array value | PRB locations displayed |
|:---:|:---:|:---:|:---:|:---:|
| ✅ | ✅ | ✅ | `s:25:"payment_request_button_locations";a:1:{i:0;s:8:"checkout";}` | **Checkout** |
| ✅ | ✅ | ❌ | `s:25:"payment_request_button_locations";a:2:{i:0;s:4:"cart";i:1;s:8:"checkout";}` | **Cart**, **Checkout** |
| ✅ | ❌ | ✅ | `s:25:"payment_request_button_locations";a:2:{i:0;s:7:"product";i:1;s:8:"checkout";}` | **Product**, **Checkout** |
| ❌ | ✅ | ✅ | `s:25:"payment_request_button_locations";a:0:{}` | - |
| ✅ | ❌ | ❌ | `s:25:"payment_request_button_locations";a:3:{i:0;s:7:"product";i:1;s:4:"cart";i:2;s:8:"checkout";}` | **Product**, **Cart**, **Checkout** |
| ❌ | ✅ | ❌ | `s:25:"payment_request_button_locations";a:1:{i:0;s:4:"cart";}` | **Cart** |
| ❌ | ❌ | ✅ | `s:25:"payment_request_button_locations";a:1:{i:0;s:7:"product";}` | **Product** |
| ❌ | ❌ | ❌ | `s:25:"payment_request_button_locations";a:2:{i:0;s:7:"product";i:1;s:4:"cart";}` | **Product**, **Cart** |

### Test changing the settings

1. Open **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**
2. Choose any combination of **Product**, **Cart**, and **Checkout** as the value for **Payment Request Button Locations**.
3. Click **Save changes**
4. Make sure the Payment Request Buttons are only loaded on the pages you chose.

<img width="672" alt="image" src="https://user-images.githubusercontent.com/13835680/129644892-9627c448-6f0f-4b35-9b94-a6f1006e4271.png">

Repeat the testing instructions with all possible combinations of the PRB locations:

1. No locations selected.
1. **Product**.
2. **Cart**.
3. **Checkout**.
4. **Product**, **Cart**.
5. **Product**, **Checkout**.
6. **Cart**, **Checkout**.
7. **Product**, **Cart**, **Checkout**.

### Test filters taking precedence over plugin settings

1. Open **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**
2. Enable **Product** and **Cart** in the **Payment Request Button Locations** option.
3. Open **Snippets** and enable all the Code Snippets you added during one of the previous tests.
4. Make sure the PRBs are loaded on the store's **Checkout** page (both Blocks and Shortcode versions).
5. Make sure the PRBs are not loaded on the store's **Cart** page (both Blocks and Shortcode versions).
6. Make sure the PRBs are not loaded on any of the store's **Product** pages.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
