### PR TITLE
Save payment method on 3DS flow, when requested, in Block-based checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 5.x.x - 2021-xx-xx =
 * Fix - Do not ask for a Shipping Address if no Shipping Zone is defined.
 * Fix - Return HTTP 204 when webhook validation fails so Stripe won't stop sending certain webhook events after too many failed validations.
-* Fix - Save payment method on 3D Security flow for Block-based checkout.
+* Fix - Save payment method during 3D Secure flow for Block-based checkout.
 * Fix - Possible use of an undefined variable `prepared_source`.
 * Add - 'wc_stripe_allowed_payment_processing_statuses' filter to customize order statuses that allow payment processing in the context of 3DS payments.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 5.x.x - 2021-xx-xx =
 * Fix - Do not ask for a Shipping Address if no Shipping Zone is defined.
 * Fix - Return HTTP 204 when webhook validation fails so Stripe won't stop sending certain webhook events after too many failed validations.
+* Fix - Save payment method on 3D Security flow for Block-based checkout.
 
 = 5.3.0 - 2021-07-21 =
 * Fix - Disable Payment Request Buttons when order has to be split into multiple packages because Payment Requests do not support that use case.

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -28,8 +28,8 @@ return apply_filters(
 			'desc_tip'    => true,
 		],
 		'api_credentials'                     => [
-			'title'       => __( 'Stripe Account Keys', 'woocommerce-gateway-stripe' ),
-			'type'        => 'stripe_account_keys',
+			'title' => __( 'Stripe Account Keys', 'woocommerce-gateway-stripe' ),
+			'type'  => 'stripe_account_keys',
 		],
 		'testmode'                            => [
 			'title'       => __( 'Test mode', 'woocommerce-gateway-stripe' ),

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -683,6 +683,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 							'result'                => 'success',
 							'redirect'              => $this->get_return_url( $order ),
 							'payment_intent_secret' => $intent->client_secret,
+							'save_payment_method'   => $this->save_payment_method_requested(),
 						];
 					}
 				}

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -308,8 +308,8 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				|| ! empty( $result->payment_details['setup_intent_secret'] )
 			)
 		) {
-			$payment_details                          = $result->payment_details;
-			$payment_details['verification_endpoint'] = add_query_arg(
+			$payment_details       = $result->payment_details;
+			$verification_endpoint = add_query_arg(
 				[
 					'order'       => $context->order->get_id(),
 					'nonce'       => wp_create_nonce( 'wc_stripe_confirm_pi' ),
@@ -317,6 +317,15 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				],
 				home_url() . \WC_Ajax::get_endpoint( 'wc_stripe_verify_intent' )
 			);
+
+			if ( isset( $payment_details['save_payment_method'] ) && ! empty( $payment_details['save_payment_method'] ) ) {
+				$verification_endpoint = add_query_arg(
+					[ 'save_payment_method' => true ],
+					$verification_endpoint,
+				);
+			}
+
+			$payment_details['verification_endpoint'] = $verification_endpoint;
 			$result->set_payment_details( $payment_details );
 			$result->set_status( 'success' );
 		}

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -318,7 +318,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				home_url() . \WC_Ajax::get_endpoint( 'wc_stripe_verify_intent' )
 			);
 
-			if ( isset( $payment_details['save_payment_method'] ) && ! empty( $payment_details['save_payment_method'] ) ) {
+			if ( ! empty( $payment_details['save_payment_method'] ) ) {
 				$verification_endpoint = add_query_arg(
 					[ 'save_payment_method' => true ],
 					$verification_endpoint

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -321,7 +321,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			if ( isset( $payment_details['save_payment_method'] ) && ! empty( $payment_details['save_payment_method'] ) ) {
 				$verification_endpoint = add_query_arg(
 					[ 'save_payment_method' => true ],
-					$verification_endpoint,
+					$verification_endpoint
 				);
 			}
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1639 

It touches the PHP side of the Block-based checkout. It's adding the save payment method logic for a 3DS flow.

# Testing instructions

1. Create a page with the Checkout block.
2. Add an item to the cart, and go to the checkout page you just created that contains the checkout block.
3. Pay with a [3DS card](https://stripe.com/docs/testing#three-ds-cards), e.g. `4000000000003220`, and tick the "Save payment information to my account for future purchases." checkbox.
5. Authorize the transaction.
6. If you go to My account > Payment methods, you should see the card you just used listed.
7. If you go the Stripe dashboard, you should see the card attached to the customer you used to make the purchase.
<img width="465" alt="image" src="https://user-images.githubusercontent.com/13835680/126235369-7eca22ba-5afb-4bdc-8fe0-2fb943e5ceee.png">

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
