### PR TITLE
Add UPE feature flag controller

### DIFF
--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -11,8 +11,6 @@ defined( 'ABSPATH' ) || exit;
  * REST controller for UPE feature flag.
  */
 class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
-	const UPE_FLAG_NAME = '_wcpay_feature_upe';
-
 	/**
 	 * Endpoint namespace.
 	 *
@@ -70,10 +68,12 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public function get_flag(): WP_REST_Response {
+	public function get_flag() {
+		$settings = get_option( 'woocommerce_stripe_settings' );
+
 		return new WP_REST_Response(
 			[
-				'is_upe_enabled' =>  '1' === get_option( self::UPE_FLAG_NAME, '0' )
+				'is_upe_enabled' => empty( $settings['upe_checkout_experience_enabled'] ) ? 'no' : $settings['upe_checkout_experience_enabled'],
 			]
 		);
 	}
@@ -88,13 +88,16 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 			return new WP_REST_Response( [ 'result' => 'bad_request' ], 400 );
 		}
 
+		$settings       = get_option( 'woocommerce_stripe_settings' );
 		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
 
 		if ( $is_upe_enabled ) {
-			update_option( self::UPE_FLAG_NAME, '1' );
+			$settings['upe_checkout_experience_enabled'] = 'yes';
 		} else {
-			update_option( self::UPE_FLAG_NAME, '0' );
+			$settings['upe_checkout_experience_enabled'] = 'no';
 		}
+
+		update_option( 'woocommerce_stripe_settings', $settings );
 
 		return new WP_REST_Response( [ 'result' => 'success' ], 200 );
 	}

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Class WC_REST_UPE_Flag_Toggle_Controller
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for UPE feature flag.
+ */
+class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
+	const UPE_FLAG_NAME = '_wcpay_feature_upe';
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc_stripe/upe_flag_toggle';
+
+	/**
+	 * Verify access to request.
+	 */
+	public function check_permission() {
+		return current_user_can( 'manage_woocommerce' );
+	}
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_flag' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'set_flag' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [
+					'is_upe_enabled' => [
+						'description'       => __( 'Determines if the UPE feature flag is enabled.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'boolean',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Retrieve flag status.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_flag(): WP_REST_Response {
+		return new WP_REST_Response(
+			[
+				'is_upe_enabled' =>  '1' === get_option( self::UPE_FLAG_NAME, '0' )
+			]
+		);
+	}
+
+	/**
+	 * Update the data.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function set_flag( WP_REST_Request $request ) {
+		if ( ! $request->has_param( 'is_upe_enabled' ) ) {
+			return new WP_REST_Response( [ 'result' => 'bad_request' ], 400 );
+		}
+
+		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
+
+		if ( $is_upe_enabled ) {
+			update_option( self::UPE_FLAG_NAME, '1' );
+		} else {
+			update_option( self::UPE_FLAG_NAME, '0' );
+		}
+
+		return new WP_REST_Response( [ 'result' => 'success' ], 200 );
+	}
+}

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Class WC_REST_UPE_Flag_Toggle_Controller
- *
- * @package WooCommerce\Payments\Admin
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -11,6 +9,8 @@ defined( 'ABSPATH' ) || exit;
  * REST controller for UPE feature flag.
  */
 class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
+	const UPE_CHECKOUT_EXPERIENCE_FLAG = 'upe_checkout_experience_enabled';
+
 	/**
 	 * Endpoint namespace.
 	 *
@@ -73,7 +73,7 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 
 		return new WP_REST_Response(
 			[
-				'is_upe_enabled' => empty( $settings['upe_checkout_experience_enabled'] ) ? 'no' : $settings['upe_checkout_experience_enabled'],
+				'is_upe_enabled' => empty( $settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ] ) ? 'no' : $settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ],
 			]
 		);
 	}
@@ -93,9 +93,9 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 		$settings = get_option( 'woocommerce_stripe_settings' );
 
 		if ( $is_upe_enabled ) {
-			$settings['upe_checkout_experience_enabled'] = 'yes';
+			$settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ] = 'yes';
 		} else {
-			$settings['upe_checkout_experience_enabled'] = 'no';
+			$settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ] = 'no';
 		}
 
 		update_option( 'woocommerce_stripe_settings', $settings );

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -84,12 +84,13 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function set_flag( WP_REST_Request $request ) {
-		if ( ! $request->has_param( 'is_upe_enabled' ) ) {
+		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
+
+		if ( $is_upe_enabled === null ) {
 			return new WP_REST_Response( [ 'result' => 'bad_request' ], 400 );
 		}
 
 		$settings       = get_option( 'woocommerce_stripe_settings' );
-		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
 
 		if ( $is_upe_enabled ) {
 			$settings['upe_checkout_experience_enabled'] = 'yes';

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -86,11 +86,11 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 	public function set_flag( WP_REST_Request $request ) {
 		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
 
-		if ( $is_upe_enabled === null ) {
+		if ( null === $is_upe_enabled ) {
 			return new WP_REST_Response( [ 'result' => 'bad_request' ], 400 );
 		}
 
-		$settings       = get_option( 'woocommerce_stripe_settings' );
+		$settings = get_option( 'woocommerce_stripe_settings' );
 
 		if ( $is_upe_enabled ) {
 			$settings['upe_checkout_experience_enabled'] = 'yes';

--- a/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-rest-upe-flag-toggle-controller.php
@@ -55,7 +55,8 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 				'args'                => [
 					'is_upe_enabled' => [
 						'description'       => __( 'Determines if the UPE feature flag is enabled.', 'woocommerce-gateway-stripe' ),
-						'type'              => 'boolean',
+						'type'              => 'string',
+						'enum'              => [ 'yes', 'no' ],
 						'validate_callback' => 'rest_validate_request_arg',
 					],
 				],
@@ -69,11 +70,16 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_flag() {
-		$settings = get_option( 'woocommerce_stripe_settings' );
+		$settings       = get_option( 'woocommerce_stripe_settings' );
+		$is_upe_enabled = 'no';
+
+		if ( ! empty( $settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ] ) ) {
+			$is_upe_enabled = $settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ];
+		}
 
 		return new WP_REST_Response(
 			[
-				'is_upe_enabled' => empty( $settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ] ) ? 'no' : $settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ],
+				'is_upe_enabled' => $is_upe_enabled,
 			]
 		);
 	}
@@ -92,7 +98,7 @@ class WC_REST_UPE_Flag_Toggle_Controller extends WP_REST_Controller {
 
 		$settings = get_option( 'woocommerce_stripe_settings' );
 
-		if ( $is_upe_enabled ) {
+		if ( 'yes' === $is_upe_enabled ) {
 			$settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ] = 'yes';
 		} else {
 			$settings[ self::UPE_CHECKOUT_EXPERIENCE_FLAG ] = 'no';

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -46,7 +46,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 
 	public function test_set_flag_enabled_request_returns_status_code_200() {
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
-		$request->set_param( 'is_upe_enabled', true );
+		$request->set_param( 'is_upe_enabled', 'yes' );
 
 		$response = $this->controller->set_flag( $request );
 		$expected = [
@@ -63,7 +63,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 
 	public function test_set_flag_disabled_request_returns_status_code_200() {
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
-		$request->set_param( 'is_upe_enabled', false );
+		$request->set_param( 'is_upe_enabled', 'no' );
 
 		$response = $this->controller->set_flag( $request );
 		$expected = [

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -77,4 +77,16 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'no', $settings['upe_checkout_experience_enabled'] );
 	}
+
+	public function test_set_flag_missing_request_returns_status_code_400() {
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+
+		$response = $this->controller->set_flag( $request );
+		$expected = [
+			'result' => 'bad_request',
+		];
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( $expected, $response->get_data() );
+	}
 }

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * These teste make assertions against class WC_REST_UPE_Flag_Toggle_Controller.
+ *
+ * @package WooCommerce_Stripe/Tests/WC_REST_UPE_Flag_Toggle_Controller
+ */
+
+/**
+ * WC_REST_UPE_Flag_Toggle_Controller unit tests.
+ */
+class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
+	/**
+	 * Tested REST route.
+	 */
+	const ROUTE = '/wc/v3/payments/upe_flag_toggle';
+
+	/**
+	 * The system under test.
+	 *
+	 * @var WC_REST_UPE_Flag_Toggle_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
+
+		// Set the user so that we can pass the authentication.
+		wp_set_current_user( 1 );
+
+		$this->controller = new WC_REST_UPE_Flag_Toggle_Controller();
+	}
+
+	public function test_get_flag_request_returns_status_code_200() {
+		$response = $this->controller->get_flag();
+		$expected = [
+			'is_upe_enabled' => 'no',
+		];
+		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_set_flag_enabled_request_returns_status_code_200() {
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'is_upe_enabled', true );
+
+		$response = $this->controller->set_flag( $request );
+		$expected = [
+			'result' => 'success',
+		];
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $expected, $response->get_data() );
+
+		$settings = get_option( 'woocommerce_stripe_settings' );
+
+		$this->assertEquals( 'yes', $settings['upe_checkout_experience_enabled'] );
+	}
+
+	public function test_set_flag_disabled_request_returns_status_code_200() {
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+		$request->set_param( 'is_upe_enabled', false );
+
+		$response = $this->controller->set_flag( $request );
+		$expected = [
+			'result' => 'success',
+		];
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $expected, $response->get_data() );
+
+		$settings = get_option( 'woocommerce_stripe_settings' );
+
+		$this->assertEquals( 'no', $settings['upe_checkout_experience_enabled'] );
+	}
+}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -553,21 +553,17 @@ function woocommerce_gateway_stripe() {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/abstracts/abstract-wc-stripe-connect-rest-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-init-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-connect-controller.php';
-				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
 
-				$controllers = [
-					'WC_Stripe_Connect_REST_Oauth_Init_Controller' => [ $this->connect, $this->api ],
-					'WC_Stripe_Connect_REST_Oauth_Connect_Controller' => [ $this->connect, $this->api ],
-					'WC_REST_UPE_Flag_Toggle_Controller' => null,
-				];
+				$oauth_init    = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
+				$oauth_connect = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
 
-				foreach ( $controllers as $controller_name => $controller_params ) {
-					if ( empty( $controller_params ) ) {
-						$controller_instance = new $controller_name();
-					} else {
-						$controller_instance = new $controller_name( ...$controller_params );
-					}
-					$controller_instance->register_routes();
+				$oauth_init->register_routes();
+				$oauth_connect->register_routes();
+
+				if ( WC_Stripe_Feature_Flags::is_upe_enabled() ) {
+					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
+					$upe_flag_toggle_controller = new WC_REST_UPE_Flag_Toggle_Controller();
+					$upe_flag_toggle_controller->register_routes();
 				}
 			}
 		}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -128,7 +128,7 @@ function woocommerce_gateway_stripe() {
 				$this->connect                       = new WC_Stripe_Connect( $this->api );
 				$this->payment_request_configuration = new WC_Stripe_Payment_Request();
 
-				add_action( 'rest_api_init', [ $this, 'register_connect_routes' ] );
+				add_action( 'rest_api_init', [ $this, 'register_routes' ] );
 			}
 
 			/**
@@ -544,19 +544,31 @@ function woocommerce_gateway_stripe() {
 			}
 
 			/**
-			 * Register Stripe connect rest routes.
+			 * Register REST API routes.
+			 *
+			 * New endpoints/controllers can be added here.
 			 */
-			public function register_connect_routes() {
-
+			public function register_routes() {
+				/** API includes */
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/abstracts/abstract-wc-stripe-connect-rest-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-init-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-connect-controller.php';
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
 
-				$oauth_init    = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
-				$oauth_connect = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
+				$controllers = [
+					'WC_Stripe_Connect_REST_Oauth_Init_Controller' => [ $this->connect, $this->api ],
+					'WC_Stripe_Connect_REST_Oauth_Connect_Controller' => [ $this->connect, $this->api ],
+					'WC_REST_UPE_Flag_Toggle_Controller' => null,
+				];
 
-				$oauth_init->register_routes();
-				$oauth_connect->register_routes();
+				foreach ( $controllers as $controller_name => $controller_params ) {
+					if ( empty( $controller_params ) ) {
+						$controller_instance = new $controller_name();
+					} else {
+						$controller_instance = new $controller_name( ...$controller_params );
+					}
+					$controller_instance->register_routes();
+				}
 			}
 		}
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: 
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1684

Description: 
Adding a new end point `wp-json/wc/v3/wc_stripe/upe_flag_toggle` to toggle UPE feature. This will be used in UI so that users can click a button to enable UPE.

This end point is only available when `_wcstripe_feature_upe` is enabled.


# Testing instructions
1. You can test the API end point by using Postman and the API key generated from your localhost per instructions here (https://docs.woocommerce.com/document/woocommerce-rest-api/) 
2. Make sure you have `_wcstripe_feature_upe` flag enabled.
3. Use postman to go do a `GET` request to `https://localhost/wp-json/wc/v3/wc_stripe/upe_flag_toggle`. **Note: https**
4. You should see a JSON response `{"is_upe_enabled": "no"}`
5. If you want, you can double check your database `select * from wp_options where option_name ='woocommerce_stripe_settings'`. You should be able to see the serialized string and you can find the `is_upe_enabled` value there.
6. Make a `POST` request to `https://localhost/wp-json/wc/v3/wc_stripe/upe_flag_toggle` with body 
```
{
    "is_upe_enabled": "yes"
}
```
7. You should see a `200` response `{"result":"success"}`. 
8. Use postman to go do a `GET` request again to `https://localhost/wp-json/wc/v3/wc_stripe/upe_flag_toggle`.
9. You should see a JSON response `{"is_upe_enabled": "yes"}`. The flag has been updated.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

