### PR TITLE
Fix PRB product page location option

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -960,7 +960,7 @@ class WC_Stripe_Payment_Request {
 		// Note the negation because if the filter returns `true` that means we should hide the PRB.
 		return ! apply_filters_deprecated(
 			'wc_stripe_hide_payment_request_on_product_page',
-			[ $should_show_on_product_page ],
+			[ ! $should_show_on_product_page ],
 			'5.5.0',
 			'', // There is no replacement.
 			$deprecation_message


### PR DESCRIPTION
The boolean return was not negated when it should have been which caused
the PRB to show up on the product page when it should've been disabled and
vice versa.

# Changes proposed in this Pull Request:

- Fixed the negation when applying the `should_hide_prb_on_product_page` filter.


# Testing instructions

- Open **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**.
- Add the **Product** value to the **Payment Request Button Locations** setting.
- Open any product page that's supported by PRBs.
- Make sure the PRB loads.
- Open **WooCommerce > Settings > Payments > Stripe – Credit Card (Stripe)**.
- Remove the **Product** value to the **Payment Request Button Locations** setting.
- Open any product page that's supported by PRBs.
- Make sure the PRB is not loaded.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

