### PR TITLE
refactor: add settings UI flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 5.x.x - 2021-xx-xx =
+* Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.
 * Fix - Save payment method during 3D Secure flow for Block-based checkout.
 * Add - Settings to control Payment Request Button locations in the Stripe plugin settings. Persists changes made through pre-existing filters, or defaults to the Cart and Product pages if no filters are in use.
 * Tweak - Deprecated the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -1,0 +1,74 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Controls whether we're on the settings page and enqueues the JS code.
+ *
+ * @since 5.4.1
+ */
+class WC_Stripe_Settings_Controller {
+	public function __construct() {
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
+		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
+	}
+
+	/**
+	 * Prints the admin options for the gateway.
+	 * Remove this action once we're fully migrated to UPE and move the wrapper in the `admin_options` method of the UPE gateway.
+	 *
+	 * @param WC_Stripe_Payment_Gateway $gateway the Stripe gateway.
+	 */
+	public function admin_options( WC_Stripe_Payment_Gateway $gateway ) {
+		global $hide_save_button;
+		$hide_save_button = true;
+		echo '<h2>' . esc_html( $gateway->get_method_title() );
+		wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout' ) );
+		echo '</h2>';
+		echo '<div id="wc-stripe-account-settings-container"></div>';
+	}
+
+	/**
+	 * Load admin scripts.
+	 */
+	public function admin_scripts() {
+		if ( 'woocommerce_page_wc-settings' !== get_current_screen()->id ) {
+			return;
+		}
+
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
+			// Webpack generates an assets file containing a dependencies array for our built JS file.
+			$script_path       = 'build/upe_settings.js';
+			$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe_settings.asset.php';
+			$script_url        = plugins_url( $script_path, WC_STRIPE_MAIN_FILE );
+			$script_asset      = file_exists( $script_asset_path )
+				? require( $script_asset_path )
+				: [ 'dependencies' => [], 'version' => WC_STRIPE_VERSION ];
+
+			wp_register_script(
+				'woocommerce_stripe_admin',
+				$script_url,
+				$script_asset['dependencies'],
+				$script_asset['version'],
+				true
+			);
+		} else {
+			wp_register_script( 'woocommerce_stripe_admin', plugins_url( 'assets/js/stripe-admin' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION, true );
+		}
+
+		$params = [
+			'time'             => time(),
+			'i18n_out_of_sync' => wp_kses(
+				__( '<strong>Warning:</strong> your site\'s time does not match the time on your browser and may be incorrect. Some payment methods depend on webhook verification and verifying webhooks with a signing secret depends on your site\'s time being correct, so please check your site\'s time before setting a webhook secret. You may need to contact your site\'s hosting provider to correct the site\'s time.', 'woocommerce-gateway-stripe' ),
+				[ 'strong' => [] ]
+			),
+		];
+		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
+
+		wp_enqueue_script( 'woocommerce_stripe_admin' );
+	}
+}

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -46,8 +46,11 @@ class WC_Stripe_Settings_Controller {
 			$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe_settings.asset.php';
 			$script_url        = plugins_url( $script_path, WC_STRIPE_MAIN_FILE );
 			$script_asset      = file_exists( $script_asset_path )
-				? require( $script_asset_path )
-				: [ 'dependencies' => [], 'version' => WC_STRIPE_VERSION ];
+				? require $script_asset_path
+				: [
+					'dependencies' => [],
+					'version'      => WC_STRIPE_VERSION,
+				];
 
 			wp_register_script(
 				'woocommerce_stripe_admin',

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -83,17 +83,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public $pre_orders;
 
 	/**
-	 * Set of parameters to build the URL to the gateway's settings page.
-	 *
-	 * @var string[]
-	 */
-	private static $settings_url_params = [
-		'page'    => 'wc-settings',
-		'tab'     => 'checkout',
-		'section' => self::ID,
-	];
-
-	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -144,7 +133,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		// Hooks.
 		add_action( 'wp_enqueue_scripts', [ $this, 'payment_scripts' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_fee' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_payout' ], 20 );
@@ -348,71 +336,16 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Output the React Settings page wrapper
-	 */
-	private function output_settings_page_wrapper() {
-		global $hide_save_button;
-		$hide_save_button = true;
-		echo '<h2>' . esc_html( $this->get_method_title() );
-		wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout' ) );
-		echo '</h2>';
-		echo '<div id="wc-stripe-account-settings-container"></div>';
-	}
-
-	/**
 	 * Maybe override the parent admin_options method.
 	 */
 	public function admin_options() {
-		if ( ! WC_Stripe_Feature_Flags::is_upe_enabled() ) {
+		if ( ! WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
 			parent::admin_options();
-			return;
-		}
-		$this->output_settings_page_wrapper();
-	}
 
-	/**
-	 * Load admin scripts.
-	 *
-	 * @since   3.1.0
-	 * @version 3.1.0
-	 */
-	public function admin_scripts() {
-		if ( 'woocommerce_page_wc-settings' !== get_current_screen()->id ) {
 			return;
 		}
 
-		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-
-		if ( WC_Stripe_Feature_Flags::is_upe_enabled() ) {
-			// Webpack generates an assets file containing a dependencies array for our built JS file.
-			$script_path       = 'build/upe_settings.js';
-			$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe_settings.asset.php';
-			$script_url        = plugins_url( $script_path, WC_STRIPE_MAIN_FILE );
-			$script_asset      = file_exists( $script_asset_path )
-			? require( $script_asset_path )
-			: [ 'dependencies' => [] ];
-
-			wp_register_script( // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-				'woocommerce_stripe_admin',
-				$script_url,
-				$script_asset['dependencies'],
-				null,
-				true
-			);
-		} else {
-			wp_register_script( 'woocommerce_stripe_admin', plugins_url( 'assets/js/stripe-admin' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION, true );
-		}
-
-		$params = [
-			'time'             => time(),
-			'i18n_out_of_sync' => wp_kses(
-				__( '<strong>Warning:</strong> your site\'s time does not match the time on your browser and may be incorrect. Some payment methods depend on webhook verification and verifying webhooks with a signing secret depends on your site\'s time being correct, so please check your site\'s time before setting a webhook secret. You may need to contact your site\'s hosting provider to correct the site\'s time.', 'woocommerce-gateway-stripe' ),
-				[ 'strong' => [] ]
-			),
-		];
-		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
-
-		wp_enqueue_script( 'woocommerce_stripe_admin' );
+		do_action('wc_stripe_gateway_admin_options_wrapper', $this);
 	}
 
 	/**

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -345,7 +345,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		do_action('wc_stripe_gateway_admin_options_wrapper', $this);
+		do_action( 'wc_stripe_gateway_admin_options_wrapper', $this );
 	}
 
 	/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -10,6 +10,15 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_enabled() {
-		return '1' === get_option( '_wcstripe_feature_upe', '0' );
+		return '1' === get_option( '_wcstripe_feature_upe', '0' ) || self::is_upe_settings_redesign_enabled();
+	}
+
+	/**
+	 * Checks whether the feature flag used for the new settings + UPE is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_upe_settings_redesign_enabled() {
+		return '1' === get_option( '_wcstripe_feature_upe_settings', '0' );
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -107,7 +107,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'payment_scripts' ] );
 	}
 
@@ -120,30 +119,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Load admin scripts.
-	 *
-	 * @since x.x.x
-	 * @version x.x.x
+	 * Maybe override the parent admin_options method.
 	 */
-	public function admin_scripts() {
-		if ( 'woocommerce_page_wc-settings' !== get_current_screen()->id ) {
+	public function admin_options() {
+		if ( ! WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
+			parent::admin_options();
+
 			return;
 		}
 
-		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-
-		wp_register_script( 'woocommerce_stripe_admin', plugins_url( 'assets/js/stripe-admin' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION, true );
-
-		$params = [
-			'time'             => time(),
-			'i18n_out_of_sync' => wp_kses(
-				__( '<strong>Warning:</strong> your site\'s time does not match the time on your browser and may be incorrect. Some payment methods depend on webhook verification and verifying webhooks with a signing secret depends on your site\'s time being correct, so please check your site\'s time before setting a webhook secret. You may need to contact your site\'s hosting provider to correct the site\'s time.', 'woocommerce-gateway-stripe' ),
-				[ 'strong' => [] ]
-			),
-		];
-		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
-
-		wp_enqueue_script( 'woocommerce_stripe_admin' );
+		do_action('wc_stripe_gateway_admin_options_wrapper', $this);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -128,7 +128,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		do_action('wc_stripe_gateway_admin_options_wrapper', $this);
+		do_action( 'wc_stripe_gateway_admin_options_wrapper', $this );
 	}
 
 	/**

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -184,6 +184,9 @@ function woocommerce_gateway_stripe() {
 
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';
+					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-settings-controller.php';
+
+					new WC_Stripe_Settings_Controller();
 				}
 
 				// REMOVE IN THE FUTURE.
@@ -200,6 +203,7 @@ function woocommerce_gateway_stripe() {
 				if ( version_compare( WC_VERSION, '3.4', '<' ) ) {
 					add_filter( 'woocommerce_get_sections_checkout', [ $this, 'filter_gateway_order_admin' ] );
 				}
+
 			}
 
 			/**


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Based on this discussion: p1629406184041400/1629383980.012900-slack-C02BHNRN6R1

Separating the feature flag for the updated settings UI and the UPE feature flag.

# Testing instructions

- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe

- With no feature flags set (no changes):
![Screen Shot 2021-08-19 at 4 27 38 PM](https://user-images.githubusercontent.com/273592/130146929-9c3bd661-d50a-421c-8050-61c8ceccfbc6.png)

- With the `_wcstripe_feature_upe` flag enabled (UPE fields are displayed in old settings):
![Screen Shot 2021-08-19 at 4 27 55 PM](https://user-images.githubusercontent.com/273592/130147004-80fd391d-b038-48c9-b20e-06982f4610dd.png)

- With the `_wcstripe_feature_upe_settings` flag enabled (WIP of settings redesign - just ensure that the `upe_settings` script is enqueued: https://d.pr/i/o8kYKb )
![Screen Shot 2021-08-19 at 4 28 17 PM](https://user-images.githubusercontent.com/273592/130147081-9761f93a-a82d-448d-a796-ee1128966cd6.png)
