### PR TITLE
feat: add UPE flag context provider

### DIFF
--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -8,6 +8,7 @@ import ReactDOM from 'react-dom';
  * Internal dependencies
  */
 import SettingsManager from './settings-manager';
+import UpeToggleContextProvider from './upe-toggle/provider';
 import './styles.scss';
 
 const settingsContainer = document.getElementById(
@@ -15,5 +16,14 @@ const settingsContainer = document.getElementById(
 );
 
 if ( settingsContainer ) {
-	ReactDOM.render( <SettingsManager />, settingsContainer );
+	ReactDOM.render(
+		<UpeToggleContextProvider
+			defaultIsUpeEnabled={
+				woocommerce_stripe_admin.upe_setting_value === 'yes'
+			}
+		>
+			<SettingsManager />
+		</UpeToggleContextProvider>,
+		settingsContainer
+	);
 }

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 /**
  * External dependencies
  */
@@ -19,7 +20,7 @@ if ( settingsContainer ) {
 	ReactDOM.render(
 		<UpeToggleContextProvider
 			defaultIsUpeEnabled={
-				woocommerce_stripe_admin.upe_setting_value === 'yes'
+				wc_stripe_settings_params.upe_setting_value === 'yes'
 			}
 		>
 			<SettingsManager />

--- a/client/settings/upe-toggle/__tests__/provider.test.js
+++ b/client/settings/upe-toggle/__tests__/provider.test.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import React, { useEffect, useContext } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+
+import UpeToggleContextProvider from '../provider';
+import UpeToggleContext from '../context';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'UpeToggleContextProvider', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+
+		apiFetch.mockResolvedValue( true );
+	} );
+
+	afterAll( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'should render the initial state', () => {
+		const childrenMock = jest.fn().mockReturnValue( null );
+		render(
+			<UpeToggleContextProvider>
+				<UpeToggleContext.Consumer>
+					{ childrenMock }
+				</UpeToggleContext.Consumer>
+			</UpeToggleContextProvider>
+		);
+
+		expect( childrenMock ).toHaveBeenCalledWith( {
+			isUpeEnabled: false,
+			setIsUpeEnabled: expect.any( Function ),
+			status: 'resolved',
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should render the initial state given a default value for isUpeEnabled', () => {
+		const childrenMock = jest.fn().mockReturnValue( null );
+		render(
+			<UpeToggleContextProvider defaultIsUpeEnabled={ true }>
+				<UpeToggleContext.Consumer>
+					{ childrenMock }
+				</UpeToggleContext.Consumer>
+			</UpeToggleContextProvider>
+		);
+
+		expect( childrenMock ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				isUpeEnabled: true,
+			} )
+		);
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should call the API and resolve when setIsUpeEnabled has been called', async () => {
+		const childrenMock = jest.fn().mockReturnValue( null );
+
+		const UpdateUpeDisabledFlagMock = () => {
+			const { setIsUpeEnabled } = useContext( UpeToggleContext );
+			useEffect( () => {
+				setIsUpeEnabled( false );
+			}, [ setIsUpeEnabled ] );
+
+			return null;
+		};
+
+		render(
+			<UpeToggleContextProvider defaultIsUpeEnabled>
+				<UpdateUpeDisabledFlagMock />
+				<UpeToggleContext.Consumer>
+					{ childrenMock }
+				</UpeToggleContext.Consumer>
+			</UpeToggleContextProvider>
+		);
+
+		expect( childrenMock ).toHaveBeenCalledWith( {
+			isUpeEnabled: true,
+			setIsUpeEnabled: expect.any( Function ),
+			status: 'resolved',
+		} );
+
+		expect( childrenMock ).toHaveBeenCalledWith( {
+			isUpeEnabled: true,
+			setIsUpeEnabled: expect.any( Function ),
+			status: 'pending',
+		} );
+
+		await waitFor( () =>
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/wc/v3/wc_stripe/upe_flag_toggle',
+				method: 'POST',
+				// eslint-disable-next-line camelcase
+				data: { is_upe_enabled: 'no' },
+			} )
+		);
+
+		await waitFor( () => expect( apiFetch ).toHaveReturned() );
+
+		expect( childrenMock ).toHaveBeenCalledWith( {
+			isUpeEnabled: false,
+			setIsUpeEnabled: expect.any( Function ),
+			status: 'resolved',
+		} );
+	} );
+} );

--- a/client/settings/upe-toggle/context.js
+++ b/client/settings/upe-toggle/context.js
@@ -1,0 +1,12 @@
+/**
+ * External dependencies
+ */
+import { createContext } from 'react';
+
+const UpeToggleContext = createContext( {
+	isUpeEnabled: false,
+	setIsUpeEnabled: () => null,
+	status: 'resolved',
+} );
+
+export default UpeToggleContext;

--- a/client/settings/upe-toggle/provider.js
+++ b/client/settings/upe-toggle/provider.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useMemo, useState } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import UpeToggleContext from './context';
+
+const UpeToggleContextProvider = ( { children, defaultIsUpeEnabled } ) => {
+	const [ isUpeEnabled, setIsUpeEnabled ] = useState(
+		Boolean( defaultIsUpeEnabled )
+	);
+	const [ status, setStatus ] = useState( 'resolved' );
+
+	const updateFlag = useCallback(
+		( value ) => {
+			setStatus( 'pending' );
+
+			return apiFetch( {
+				path: `/wc/v3/wc_stripe/upe_flag_toggle`,
+				method: 'POST',
+				data: { is_upe_enabled: Boolean( value ) ? 'yes' : 'no' },
+			} )
+				.then( () => {
+					setIsUpeEnabled( Boolean( value ) );
+					setStatus( 'resolved' );
+				} )
+				.catch( () => {
+					setStatus( 'error' );
+				} );
+		},
+		[ setStatus, setIsUpeEnabled ]
+	);
+
+	const contextValue = useMemo(
+		() => ( { isUpeEnabled, setIsUpeEnabled: updateFlag, status } ),
+		[ isUpeEnabled, updateFlag, status ]
+	);
+
+	return (
+		<UpeToggleContext.Provider value={ contextValue }>
+			{ children }
+		</UpeToggleContext.Provider>
+	);
+};
+
+export default UpeToggleContextProvider;

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -61,14 +61,14 @@ class WC_Stripe_Settings_Controller {
 			wp_register_script( 'woocommerce_stripe_admin', plugins_url( 'assets/js/stripe-admin' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION, true );
 		}
 
-		$gateway_settings = get_option('woocommerce_stripe_settings', []);
-		$params = [
+		$gateway_settings = get_option( 'woocommerce_stripe_settings', [] );
+		$params           = [
 			'time'              => time(),
 			'i18n_out_of_sync'  => wp_kses(
 				__( '<strong>Warning:</strong> your site\'s time does not match the time on your browser and may be incorrect. Some payment methods depend on webhook verification and verifying webhooks with a signing secret depends on your site\'s time being correct, so please check your site\'s time before setting a webhook secret. You may need to contact your site\'s hosting provider to correct the site\'s time.', 'woocommerce-gateway-stripe' ),
 				[ 'strong' => [] ]
 			),
-			'upe_setting_value' => isset( $gateway_settings['upe_checkout_experience_enabled'] ) ? 'no' : $gateway_settings['upe_checkout_experience_enabled'],
+			'upe_setting_value' => isset( $gateway_settings['upe_checkout_experience_enabled'] ) ? $gateway_settings['upe_checkout_experience_enabled'] : 'no',
 		];
 		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -62,11 +62,12 @@ class WC_Stripe_Settings_Controller {
 		}
 
 		$params = [
-			'time'             => time(),
-			'i18n_out_of_sync' => wp_kses(
+			'time'              => time(),
+			'i18n_out_of_sync'  => wp_kses(
 				__( '<strong>Warning:</strong> your site\'s time does not match the time on your browser and may be incorrect. Some payment methods depend on webhook verification and verifying webhooks with a signing secret depends on your site\'s time being correct, so please check your site\'s time before setting a webhook secret. You may need to contact your site\'s hosting provider to correct the site\'s time.', 'woocommerce-gateway-stripe' ),
 				[ 'strong' => [] ]
 			),
+			'upe_setting_value' => isset( $gateway_settings['upe_checkout_experience_enabled'] ) ? 'no' : $gateway_settings['upe_checkout_experience_enabled'],
 		];
 		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -61,6 +61,7 @@ class WC_Stripe_Settings_Controller {
 			wp_register_script( 'woocommerce_stripe_admin', plugins_url( 'assets/js/stripe-admin' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION, true );
 		}
 
+		$gateway_settings = get_option('woocommerce_stripe_settings', []);
 		$params = [
 			'time'              => time(),
 			'i18n_out_of_sync'  => wp_kses(

--- a/package-lock.json
+++ b/package-lock.json
@@ -3617,6 +3617,17 @@
         "@wordpress/i18n": "^4.2.1"
       }
     },
+    "@wordpress/api-fetch": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-5.2.1.tgz",
+      "integrity": "sha512-hmZnll1Z4u9A1vS3hHf9epzTvK+oIWkASLPO+Yq1BK1SwDiNGcZxwWMr+kDSEWd0ProccTsgo4EAbIS9vnhoUQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/i18n": "^4.2.1",
+        "@wordpress/url": "^3.2.1"
+      }
+    },
     "@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
@@ -4806,6 +4817,17 @@
         "stylelint-config-recommended": "^3.0.0",
         "stylelint-config-recommended-scss": "^4.2.0",
         "stylelint-scss": "^3.17.2"
+      }
+    },
+    "@wordpress/url": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.2.1.tgz",
+      "integrity": "sha512-+AJt74qWz+iXkT05sBUBjx5EF3niFkvr1CqaIbWCew9/j47de6r0AHjaFhaiCCsq5fg1eqRe74sZKHrMmIWKQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "lodash": "^4.17.21",
+        "react-native-url-polyfill": "^1.1.2"
       }
     },
     "@wordpress/warning": {
@@ -18228,6 +18250,15 @@
         "moment": ">=1.6.0"
       }
     },
+    "react-native-url-polyfill": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
+      "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
+      "dev": true,
+      "requires": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      }
+    },
     "react-outside-click-handler": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.3.0.tgz",
@@ -23218,6 +23249,25 @@
         "lodash": "^4.7.0",
         "tr46": "^2.0.2",
         "webidl-conversions": "^6.1.0"
+      }
+    },
+    "whatwg-url-without-unicode": {
+      "version": "8.0.0-3",
+      "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
+      "integrity": "sha512-HoKuzZrUlgpz35YO27XgD28uh/WJH4B0+3ttFqRo//lmq+9T/mIOJ6kqmINI9HpUpz1imRC/nR/lxKpJiv0uig==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.4.3",
+        "punycode": "^2.1.1",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/react-dom": "16.9.9",
     "@woocommerce/dependency-extraction-webpack-plugin": "^1.4.0",
     "@woocommerce/eslint-plugin": "^1.1.0",
+    "@wordpress/api-fetch": "^5.2.1",
     "@wordpress/babel-plugin-makepot": "^4.2.0",
     "@wordpress/babel-preset-default": "^6.3.1",
     "@wordpress/components": "^15.0.0",


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Adding a context provider to toggle the UPE flag, similar to WCPay: https://github.com/Automattic/woocommerce-payments/tree/develop/client/settings/wcpay-upe-toggle

This will be used in the onboarding wizard and on the main settings, to determine whether the merchant has enabled the UPE feature.

## Testing instructions
There's not much to test yet, because we're still building the settings.
But the unit tests I added should provide sufficient proof for the functionality to be working.