### PR TITLE
Save and clear UPE appearance

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -194,8 +194,24 @@ export default class WCStripeAPI {
 	 * @return {Promise} The final promise for the request to the server.
 	 */
 	saveUPEAppearance( appearance ) {
-		console.error( 'TODO: Not implemented yet: saveUPEAppearance' );
-		return null;
+		return this.request( getAjaxUrl( 'save_upe_appearance' ), {
+			appearance,
+			_ajax_nonce: getStripeServerData()?.saveUPEAppearanceNonce,
+		} )
+			.then( ( response ) => {
+				if ( response.result === 'failure' ) {
+					throw new Error( response.messages );
+				}
+				return response;
+			} )
+			.catch( ( error ) => {
+				if ( error.message ) {
+					throw error;
+				} else {
+					// Covers the case of error on the Ajax request.
+					throw new Error( error.statusText );
+				}
+			} );
 	}
 
 	/**

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -9,9 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles in-checkout AJAX calls, related to Payment Intents.
  */
 class WC_Stripe_Intent_Controller {
-
-	const UPE_APPEARANCE_TRANSIENT = 'wc_stripe_upe_appearance';
-
 	/**
 	 * Holds an instance of the gateway class.
 	 *
@@ -340,7 +337,7 @@ class WC_Stripe_Intent_Controller {
 
 			$appearance = isset( $_POST['appearance'] ) ? wc_clean( wp_unslash( $_POST['appearance'] ) ) : null;
 			if ( null !== $appearance ) {
-				set_transient( self::UPE_APPEARANCE_TRANSIENT, $appearance, DAY_IN_SECONDS );
+				set_transient( WC_Stripe_UPE_Payment_Gateway::UPE_APPEARANCE_TRANSIENT, $appearance, DAY_IN_SECONDS );
 			}
 			wp_send_json_success( $appearance, 200 );
 		} catch ( Exception $e ) {
@@ -359,7 +356,7 @@ class WC_Stripe_Intent_Controller {
 	 * Clear the saved UPE appearance transient value.
 	 */
 	public function clear_upe_appearance_transient() {
-		delete_transient( self::UPE_APPEARANCE_TRANSIENT );
+		delete_transient( WC_Stripe_UPE_Payment_Gateway::UPE_APPEARANCE_TRANSIENT );
 	}
 
 }

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -9,6 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles in-checkout AJAX calls, related to Payment Intents.
  */
 class WC_Stripe_Intent_Controller {
+
+	const UPE_APPEARANCE_TRANSIENT = 'wc_stripe_upe_appearance';
+
 	/**
 	 * Holds an instance of the gateway class.
 	 *
@@ -27,6 +30,10 @@ class WC_Stripe_Intent_Controller {
 		add_action( 'wc_ajax_wc_stripe_create_setup_intent', [ $this, 'create_setup_intent' ] );
 
 		add_action( 'wc_ajax_wc_stripe_create_payment_intent', [ $this, 'create_payment_intent_ajax' ] );
+
+		add_action( 'wc_ajax_wc_stripe_save_upe_appearance', [ $this, 'save_upe_appearance_ajax' ] );
+		add_action( 'wc_ajax_nopriv_wc_stripe_save_upe_appearance', [ $this, 'save_upe_appearance_ajax' ] );
+		add_action( 'switch_theme', [ $this, 'clear_upe_appearance_transient' ] );
 	}
 
 	/**
@@ -315,6 +322,44 @@ class WC_Stripe_Intent_Controller {
 			'id'            => $payment_intent->id,
 			'client_secret' => $payment_intent->client_secret,
 		];
+	}
+
+	/**
+	 * Handle AJAX request for saving UPE appearance value to transient.
+	 *
+	 * @throws Exception - If nonce or setup intent is invalid.
+	 */
+	public function save_upe_appearance_ajax() {
+		try {
+			$is_nonce_valid = check_ajax_referer( '_wc_stripe_save_upe_appearance_nonce', false, false );
+			if ( ! $is_nonce_valid ) {
+				throw new Exception(
+					__( 'Unable to update UPE appearance values at this time.', 'woocommerce-gateway-stripe' )
+				);
+			}
+
+			$appearance = isset( $_POST['appearance'] ) ? wc_clean( wp_unslash( $_POST['appearance'] ) ) : null;
+			if ( null !== $appearance ) {
+				set_transient( self::UPE_APPEARANCE_TRANSIENT, $appearance, DAY_IN_SECONDS );
+			}
+			wp_send_json_success( $appearance, 200 );
+		} catch ( Exception $e ) {
+			// Send back error so it can be displayed to the customer.
+			wp_send_json_error(
+				[
+					'error' => [
+						'message' => $e->getMessage(),
+					],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Clear the saved UPE appearance transient value.
+	 */
+	public function clear_upe_appearance_transient() {
+		delete_transient( self::UPE_APPEARANCE_TRANSIENT );
 	}
 
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -208,6 +208,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['ajax_url']                 = WC_AJAX::get_endpoint( '%%endpoint%%' );
 		$stripe_params['createPaymentIntentNonce'] = wp_create_nonce( '_wc_stripe_nonce' );
 		$stripe_params['upeAppeareance']           = get_transient( self::UPE_APPEARANCE_TRANSIENT );
+		$stripe_params['saveUPEAppearanceNonce']   = wp_create_nonce( '_wc_stripe_save_upe_appearance_nonce' );
 		$stripe_params['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
 		$stripe_params['accountDescriptor']        = 'accountDescriptor'; // TODO: this should be added to the Stripe settings page or remove it from here.
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:
Fixes #1709 

This PR implements a solution to store the UPE appearance values in a transient so they don't have to be calculated every time and can be used on pages where it is unable to be calculated (order pay page for example). The UPE appearance should be properly calculated, stored in a transient that expires in 24 hours or clears on theme change, and then applies the saved UPE appearance from the transient during checkout.

PS: not basing this PR from `develop` because it's broken and missing some UPE code, which do not allow me to test and rely my changes on it. So I tested on @diegocurbelo 's branch, where it should be working nicely.

# Testing instructions
Transient SQL check:
```sql
SELECT * FROM wp_options WHERE option_name = '_transient_wc_stripe_upe_appearance';
```
1. Access the database.
2. Run the transient query check and you should see no records.
3. Go to the shop page and add an item to the cart.
4. Go to the checkout page.
5. Run the transient query again and you should see one record.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
