### PR TITLE
Payment Request: Display "Subtotal" on payment dialogs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 5.x.x - 2021-xx-xx =
 * Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.
 * Fix - Save payment method during 3D Secure flow for Block-based checkout.
+* Fix - Show subtotal on Payment Request dialog.
 * Add - Settings to control Payment Request Button locations in the Stripe plugin settings. Persists changes made through pre-existing filters, or defaults to the Cart and Product pages if no filters are in use.
 * Tweak - Deprecated the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.
 * Add - Notice for WP & WC version compatibility check.

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -150,6 +150,10 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 		$flat_rate              = $this->get_shipping_option( $this->flat_rate_id );
 		$expected_display_items = [
 			[
+				'label'  => 'Subtotal',
+				'amount' => 1000,
+			],
+			[
 				'label'  => 'Shipping',
 				'amount' => $flat_rate['amount'],
 			],


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1605

Adds `Subtotal` to the "item" list on payment dialogs by PRB

<img width="516" alt="Screen Shot 2021-08-25 at 3 11 25 PM" src="https://user-images.githubusercontent.com/1025173/130858037-ce5ebd0e-1ada-4bd3-9cb5-a9c16c7e7080.png">


# Testing instructions

The "Subtotal" line is added to all places **except to the product page**. In the product page the product name is used by default.

- Make sure PRB is enabled
- Create two simple products "product 1" and "product 2". Only add a price. No need to add anything else.
- Visit "product 1's" page. Then click "Add to cart"
- Visit "product 2's" page. Then click "Add to cart"
- Go to Cart page
- Click on PRB
- Subtotal should be present in the order summary. The amount should equals the result of both product prices.

To test if the "itemized" list option is still preserved we need to add some code:

- Install and activate the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
- Go to Snippets > Add new.
- Copy the following snippet into the Code text area. Save this snippet as "show itemization".

```php
add_filter('wc_stripe_payment_request_hide_itemization', '__return_false');
```

- Visit "product 1's" page. Then click "Add to cart"
- Visit "product 2's" page. Then click "Add to cart"
- Go to **Cart** page
- Click on PRB
- "Subtotal" line should not be present. Instead every product should be listed.

The same applies for the "Checkout" page and Cart and Checkout blocks.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
