### PR TITLE
Fix UPE running on PHP 8.0

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -295,7 +295,7 @@ class WC_Stripe_Intent_Controller {
 	public function create_payment_intent( $order_id = null ) {
 		$amount = WC()->cart->get_total( false );
 		$order  = wc_get_order( $order_id );
-		if ( method_exists( $order, 'get_total' ) ) {
+		if ( is_a( $order, 'WC_Order' ) ) {
 			$amount = $order->get_total();
 		}
 


### PR DESCRIPTION
method_exists will throw fatal error when running php 8 and $order is false

# Testing instructions

Testing instructions: Enable UPE and try to checkout with PHP 8. Ajax request to payment intent will 500 without this change. With this change you can checkout.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
