### PR TITLE
Add order metadata to UPE Stripe transaction

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -345,9 +345,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		if ( $payment_intent_id ) {
 			if ( $payment_needed ) {
 				$request = [
-					'amount'   => $converted_amount,
-					'currency' => $currency,
+					'amount'      => $converted_amount,
+					'currency'    => $currency,
+					/* translators: 1) blog name 2) order number */
+					'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
 				];
+
+				// Get user/customer for order.
+				$customer_id = $this->get_stripe_customer_id( $order );
+				if ( ! empty( $customer_id ) ) {
+					$request['customer'] = $customer_id;
+				}
 
 				if ( '' !== $selected_upe_payment_type ) {
 					// Only update the payment_method_types if we have a reference to the payment type the customer selected.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -358,6 +358,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 					$request['setup_future_usage'] = 'off_session';
 				}
 
+				$request['metadata'] = $this->get_metadata_from_order( $order );
+
 				WC_Stripe_API::request_with_level3_data(
 					$request,
 					"payment_intents/$payment_intent_id",
@@ -627,5 +629,29 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		}
 
 		return [ $payment_method_type, $payment_method_details ];
+	}
+
+	/**
+	 * Prepares Stripe metadata for a given order.
+	 *
+	 * @param WC_Order $order Order being processed.
+	 *
+	 * @return array Array of keyed metadata values.
+	 */
+	private function get_metadata_from_order( $order ) {
+
+		// TODO: change this after adding the subscriptions trait: $this->is_payment_recurring( $order->get_id() ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
+		$payment_type = 'single';
+		$name         = sanitize_text_field( $order->get_billing_first_name() ) . ' ' . sanitize_text_field( $order->get_billing_last_name() );
+		$email        = sanitize_email( $order->get_billing_email() );
+
+		return [
+			'customer_name'  => $name,
+			'customer_email' => $email,
+			'site_url'       => esc_url( get_site_url() ),
+			'order_id'       => $order->get_id(),
+			'order_key'      => $order->get_order_key(),
+			'payment_type'   => $payment_type,
+		];
 	}
 }


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: #1729

UPE transactions sent to Stripe are missing `customer`, `description`, and `metadata` values.
The metadata fields that should be included are:
- customer_name
- customer_email
- site_url
- order_id
- order_key
- payment_type

# Testing instructions

- Add an item to your cart and complete a successful checkout.
- Note the order number
- Visit your site's Stripe dashboard
- Go to the `Payouts` section
- Check that a payment exists for the recently completed order:
<img width="862" alt="Screen Shot 2021-08-24 at 18 10 04" src="https://user-images.githubusercontent.com/407542/130690407-a170676e-ea5e-4ed8-a5cf-abfd51c5c68b.png">

- Click the payment to view the details
- Check that the customer was linked to the payment:
<img width="590" alt="Screen Shot 2021-08-24 at 18 11 38" src="https://user-images.githubusercontent.com/407542/130690568-1b4e9469-d999-4471-8fff-e2cc60959c2d.png">

- Scroll down, and check the metadata values are present:
<img width="500" alt="Screen Shot 2021-08-24 at 17 30 03" src="https://user-images.githubusercontent.com/407542/130685555-82ea7fa3-e304-46a2-a6be-ba64f5ab7aea.png">

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).