### PR TITLE
feat: add upcoming UPE compatibility info

### DIFF
--- a/includes/admin/class-wc-stripe-upe-compatibility-controller.php
+++ b/includes/admin/class-wc-stripe-upe-compatibility-controller.php
@@ -1,0 +1,97 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Controls the UPE compatibility before we release UPE - adds some notices for the merchant if necessary.
+ *
+ * @since 5.5.0
+ */
+class WC_Stripe_UPE_Compatibility_Controller {
+	public function __construct() {
+		add_action( 'admin_notices', [ $this, 'add_upcoming_compatibility_notice' ] );
+		add_action( 'admin_init', [ $this, 'add_admin_note' ] );
+	}
+
+	/**
+	 * I created this as a separate method so it can be mocked in unit tests.
+	 *
+	 * @retun string
+	 */
+	public function get_wc_version() {
+		return WC_VERSION;
+	}
+
+	public function add_upcoming_compatibility_notice() {
+		$unsatisfied_requirements = array_filter(
+			[
+				[
+					'name'        => 'WordPress',
+					'version'     => get_bloginfo( 'version' ),
+					'requirement' => WC_STRIPE_UPE_MIN_WP_VER,
+					'message'     => sprintf( __( 'Wordpress %s or greater' ), WC_STRIPE_UPE_MIN_WP_VER ),
+				],
+				[
+					'name'        => 'WooCommerce',
+					'version'     => $this->get_wc_version(),
+					'requirement' => WC_STRIPE_UPE_MIN_WC_VER,
+					'message'     => sprintf( __( 'WooCommerce %s or greater to be installed and active' ), WC_STRIPE_UPE_MIN_WC_VER ),
+				],
+			],
+			function ( $requirement ) {
+				return version_compare( $requirement['version'], $requirement['requirement'], '<' );
+			}
+		);
+
+		if ( count( $unsatisfied_requirements ) === 0 ) {
+			return;
+		}
+
+		$unsatisfied_requirements_message = join(
+			__( ' and ', 'woocommerce-gateway-stripe' ),
+			array_map(
+				function ( $requirement ) {
+					return $requirement['message'];
+				},
+				$unsatisfied_requirements
+			)
+		);
+
+		$unsatisfied_requirements_versions = join(
+			__( ' and ', 'woocommerce-gateway-stripe' ),
+			array_map(
+				function ( $requirement ) {
+					return $requirement['name'] . ' ' . $requirement['requirement'];
+				},
+				$unsatisfied_requirements
+			)
+		);
+
+		echo '<div class="error"><p><strong>';
+		echo wp_kses_post(
+			sprintf(
+				/* translators: $1. Minimum WooCommerce and/or WordPress versions. $2. Current WooCommerce and/or versions. $3 Learn more link. */
+				_n(
+					'Starting with version 5.6.0, Stripe will require %1$s. Your version of %2$s will no longer be supported. <a href="%3$s" target="_blank">Learn more here</a>.',
+					'Starting with version 5.6.0, Stripe will require %1$s. Your versions of %2$s will no longer be supported. <a href="%3$s" target="_blank">Learn more here</a>.',
+					count( $unsatisfied_requirements ),
+					'woocommerce-gateway-stripe'
+				),
+				$unsatisfied_requirements_message,
+				$unsatisfied_requirements_versions,
+				'?TODO'
+			)
+		);
+		echo '</strong></p></div>';
+	}
+
+	public function add_admin_note() {
+		// admin notes are not supported on older versions of WooCommerce.
+		if ( version_compare( $this->get_wc_version(), '4.4.0', '>=' ) ) {
+			require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-upe-compatibility-note.php';
+			WC_Stripe_UPE_Compatibility_Note::init();
+		}
+	}
+}

--- a/includes/admin/class-wc-stripe-upe-compatibility-controller.php
+++ b/includes/admin/class-wc-stripe-upe-compatibility-controller.php
@@ -16,7 +16,7 @@ class WC_Stripe_UPE_Compatibility_Controller {
 	}
 
 	/**
-	 * I created this as a separate method so it can be mocked in unit tests.
+	 * I created this as a separate method, so it can be mocked in unit tests.
 	 *
 	 * @retun string
 	 */
@@ -25,6 +25,13 @@ class WC_Stripe_UPE_Compatibility_Controller {
 	}
 
 	public function add_upcoming_compatibility_notice() {
+		/*
+		 * The following might be hard to read, but here's what I'm trying to do:
+		 * - If WP and WC are both supported -> nothing to do
+		 * - If WC is not supported -> construct message saying "Stripe will require WooCommerce 5.4 or greater to be installed and active. Your version of WooCommerce [X.X] will no longer be supported"
+		 * - If WP is not supported -> construct message saying "Stripe will require WordPress 5.6 or greater. Your version of WordPress [X.X] will no longer be supported"
+		 * - If WC & WP are both not supported -> construct message saying "Stripe will require WordPress 5.6 or greater and WooCommerce 5.4 or greater to be installed and active. Your versions of WordPress [X.X] and WooCommerce [X.X] will no longer be supported"
+		 */
 		$unsatisfied_requirements = array_filter(
 			[
 				[

--- a/includes/admin/class-wc-stripe-upe-compatibility-controller.php
+++ b/includes/admin/class-wc-stripe-upe-compatibility-controller.php
@@ -31,13 +31,16 @@ class WC_Stripe_UPE_Compatibility_Controller {
 					'name'        => 'WordPress',
 					'version'     => get_bloginfo( 'version' ),
 					'requirement' => WC_STRIPE_UPE_MIN_WP_VER,
-					'message'     => sprintf( __( 'Wordpress %s or greater' ), WC_STRIPE_UPE_MIN_WP_VER ),
+					/* translators: %s. WordPress version installed. */
+					'message'     => sprintf( __( 'WordPress %s or greater', 					'woocommerce-gateway-stripe' ), WC_STRIPE_UPE_MIN_WP_VER ),
 				],
 				[
 					'name'        => 'WooCommerce',
 					'version'     => $this->get_wc_version(),
 					'requirement' => WC_STRIPE_UPE_MIN_WC_VER,
-					'message'     => sprintf( __( 'WooCommerce %s or greater to be installed and active' ), WC_STRIPE_UPE_MIN_WC_VER ),
+					/* translators: %s. WooCommerce version installed. */
+					'message'     => sprintf( __( 'WooCommerce %s or greater to be installed and active',					'woocommerce-gateway-stripe'
+					), WC_STRIPE_UPE_MIN_WC_VER ),
 				],
 			],
 			function ( $requirement ) {

--- a/includes/admin/class-wc-stripe-upe-compatibility-controller.php
+++ b/includes/admin/class-wc-stripe-upe-compatibility-controller.php
@@ -30,17 +30,22 @@ class WC_Stripe_UPE_Compatibility_Controller {
 				[
 					'name'        => 'WordPress',
 					'version'     => get_bloginfo( 'version' ),
-					'requirement' => WC_STRIPE_UPE_MIN_WP_VER,
+					'requirement' => WC_Stripe_UPE_Compatibility::MIN_WP_VERSION,
 					/* translators: %s. WordPress version installed. */
-					'message'     => sprintf( __( 'WordPress %s or greater', 					'woocommerce-gateway-stripe' ), WC_STRIPE_UPE_MIN_WP_VER ),
+					'message'     => sprintf( __( 'WordPress %s or greater', 'woocommerce-gateway-stripe' ), WC_Stripe_UPE_Compatibility::MIN_WP_VERSION ),
 				],
 				[
 					'name'        => 'WooCommerce',
 					'version'     => $this->get_wc_version(),
-					'requirement' => WC_STRIPE_UPE_MIN_WC_VER,
+					'requirement' => WC_Stripe_UPE_Compatibility::MIN_WC_VERSION,
 					/* translators: %s. WooCommerce version installed. */
-					'message'     => sprintf( __( 'WooCommerce %s or greater to be installed and active',					'woocommerce-gateway-stripe'
-					), WC_STRIPE_UPE_MIN_WC_VER ),
+					'message'     => sprintf(
+						__(
+							'WooCommerce %s or greater to be installed and active',
+							'woocommerce-gateway-stripe'
+						),
+						WC_Stripe_UPE_Compatibility::MIN_WC_VERSION
+					),
 				],
 			],
 			function ( $requirement ) {
@@ -84,7 +89,7 @@ class WC_Stripe_UPE_Compatibility_Controller {
 				),
 				$unsatisfied_requirements_message,
 				$unsatisfied_requirements_versions,
-				'?TODO'
+				WC_Stripe_UPE_Compatibility::LEARN_MORE_LINK
 			)
 		);
 		echo '</strong></p></div>';

--- a/includes/admin/class-wc-stripe-upe-compatibility-controller.php
+++ b/includes/admin/class-wc-stripe-upe-compatibility-controller.php
@@ -45,8 +45,8 @@ class WC_Stripe_UPE_Compatibility_Controller {
 					'name'        => 'WooCommerce',
 					'version'     => $this->get_wc_version(),
 					'requirement' => WC_Stripe_UPE_Compatibility::MIN_WC_VERSION,
-					/* translators: %s. WooCommerce version installed. */
 					'message'     => sprintf(
+						/* translators: %s. WooCommerce version installed. */
 						__(
 							'WooCommerce %s or greater to be installed and active',
 							'woocommerce-gateway-stripe'

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -19,7 +19,6 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_settings_redesign_enabled() {
-//		return true;
 		return '1' === get_option( '_wcstripe_feature_upe_settings', '0' );
 	}
 }

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -19,6 +19,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_settings_redesign_enabled() {
+//		return true;
 		return '1' === get_option( '_wcstripe_feature_upe_settings', '0' );
 	}
 }

--- a/includes/class-wc-stripe-upe-compatibility.php
+++ b/includes/class-wc-stripe-upe-compatibility.php
@@ -1,0 +1,18 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class WC_Stripe_UPE_Compatibility {
+	const MIN_WP_VERSION  = '5.7';
+	const MIN_WC_VERSION  = '5.4';
+	const LEARN_MORE_LINK = '?TODO';
+
+	public static function is_wp_supported() {
+		return version_compare( get_bloginfo( 'version' ), self::MIN_WP_VERSION, '<' ) === false;
+	}
+
+	public static function is_wc_supported() {
+		return version_compare( WC_VERSION, self::MIN_WC_VERSION, '<' ) === false;
+	}
+}

--- a/includes/class-wc-stripe-upe-compatibility.php
+++ b/includes/class-wc-stripe-upe-compatibility.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class WC_Stripe_UPE_Compatibility {
-	const MIN_WP_VERSION  = '5.7';
+	const MIN_WP_VERSION  = '5.6';
 	const MIN_WC_VERSION  = '5.4';
 	const LEARN_MORE_LINK = '?TODO';
 

--- a/includes/notes/class-wc-stripe-upe-compatibility-note.php
+++ b/includes/notes/class-wc-stripe-upe-compatibility-note.php
@@ -30,6 +30,7 @@ class WC_Stripe_UPE_Compatibility_Note {
 		$note       = new $note_class();
 
 		$note->set_title( __( 'Important compatibility information about WooCommerce Stripe', 'woocommerce-gateway-stripe' ) );
+		/* translators: $1 WordPress version installed. $2 WooCommerce version installed. */
 		$note->set_content( sprintf( __( 'Starting with version 5.6.0, WooCommerce Stripe will require WordPress %1$s or greater and WooCommerce %2$s or greater to be installed and active.', 'woocommerce-gateway-stripe' ), WC_STRIPE_UPE_MIN_WP_VER, WC_STRIPE_UPE_MIN_WC_VER ) );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_WARNING );
 		$note->set_name( self::NOTE_NAME );

--- a/includes/notes/class-wc-stripe-upe-compatibility-note.php
+++ b/includes/notes/class-wc-stripe-upe-compatibility-note.php
@@ -31,14 +31,14 @@ class WC_Stripe_UPE_Compatibility_Note {
 
 		$note->set_title( __( 'Important compatibility information about WooCommerce Stripe', 'woocommerce-gateway-stripe' ) );
 		/* translators: $1 WordPress version installed. $2 WooCommerce version installed. */
-		$note->set_content( sprintf( __( 'Starting with version 5.6.0, WooCommerce Stripe will require WordPress %1$s or greater and WooCommerce %2$s or greater to be installed and active.', 'woocommerce-gateway-stripe' ), WC_STRIPE_UPE_MIN_WP_VER, WC_STRIPE_UPE_MIN_WC_VER ) );
+		$note->set_content( sprintf( __( 'Starting with version 5.6.0, WooCommerce Stripe will require WordPress %1$s or greater and WooCommerce %2$s or greater to be installed and active.', 'woocommerce-gateway-stripe' ), WC_Stripe_UPE_Compatibility::MIN_WP_VERSION, WC_Stripe_UPE_Compatibility::MIN_WC_VERSION ) );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_WARNING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Learn more', 'woocommerce-gateway-stripe' ),
-			'?TODO',
+			WC_Stripe_UPE_Compatibility::LEARN_MORE_LINK,
 			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
@@ -62,7 +62,7 @@ class WC_Stripe_UPE_Compatibility_Note {
 	public static function init() {
 		// if the note hasn't been added, add it
 		// if it has been added and the merchant has upgraded WC & WP, delete it
-		if ( version_compare( WC_VERSION, WC_STRIPE_UPE_MIN_WC_VER, '<' ) || version_compare( get_bloginfo( 'version' ), WC_STRIPE_UPE_MIN_WP_VER, '<' ) ) {
+		if ( ! WC_Stripe_UPE_Compatibility::is_wc_supported() || ! WC_Stripe_UPE_Compatibility::is_wp_supported() ) {
 			self::possibly_add_note();
 		} else {
 			self::possibly_delete_note();

--- a/includes/notes/class-wc-stripe-upe-compatibility-note.php
+++ b/includes/notes/class-wc-stripe-upe-compatibility-note.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Display a notice to merchants to inform them that WC Stripe will no longer support older versions of WooCommerce.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Stripe_UPE_Compatibility_Note
+ */
+class WC_Stripe_UPE_Compatibility_Note {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-stripe-upe-wc-compatibility-note';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note_class = self::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Important compatibility information about WooCommerce Stripe', 'woocommerce-gateway-stripe' ) );
+		$note->set_content( sprintf( __( 'Starting with version 5.6.0, WooCommerce Stripe will require WordPress %1$s or greater and WooCommerce %2$s or greater to be installed and active.', 'woocommerce-gateway-stripe' ), WC_STRIPE_UPE_MIN_WP_VER, WC_STRIPE_UPE_MIN_WC_VER ) );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_WARNING );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-gateway-stripe' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Learn more', 'woocommerce-gateway-stripe' ),
+			'?TODO',
+			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
+			true
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Get the class type to be used for the note.
+	 *
+	 * @return string
+	 */
+	private static function get_note_class() {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+			return Note::class;
+		} else {
+			return WC_Admin_Note::class;
+		}
+	}
+
+	public static function init() {
+		// if the note hasn't been added, add it
+		// if it has been added and the merchant has upgraded WC & WP, delete it
+		if ( version_compare( WC_VERSION, WC_STRIPE_UPE_MIN_WC_VER, '<' ) || version_compare( get_bloginfo( 'version' ), WC_STRIPE_UPE_MIN_WP_VER, '<' ) ) {
+			self::possibly_add_note();
+		} else {
+			self::possibly_delete_note();
+		}
+	}
+}

--- a/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
+++ b/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
@@ -32,9 +32,9 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
 
 		$this->controller = $this->getMockBuilder( WC_Stripe_UPE_Compatibility_Controller::class )
-		                         ->disableOriginalConstructor()
-		                         ->setMethods( [ 'get_wc_version' ] )
-		                         ->getMock();
+								 ->disableOriginalConstructor()
+								 ->setMethods( [ 'get_wc_version' ] )
+								 ->getMock();
 	}
 
 	public function tearDown() {
@@ -55,37 +55,37 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_should_not_add_a_notice_when_the_wp_and_wc_versions_are_satisfied() {
-		$this->overwrite_wc_version('5.7.0');
-		$this->overwrite_wp_version('5.7.0');
+		$this->overwrite_wc_version( '5.7.0' );
+		$this->overwrite_wp_version( '5.7.0' );
 
-		$this->expectOutputString('');
+		$this->expectOutputString( '' );
 
 		$this->controller->add_upcoming_compatibility_notice();
 	}
 
 	public function test_should_add_a_notice_when_the_wc_version_is_not_satisfied() {
-		$this->overwrite_wp_version('5.7.0');
-		$this->overwrite_wc_version('5.2.0');
+		$this->overwrite_wp_version( '5.7.0' );
+		$this->overwrite_wc_version( '5.2.0' );
 
-		$this->expectOutputRegex('/Stripe will require WooCommerce 5\.4 or greater to be installed and active\. Your version of WooCommerce 5\.4 will no longer be supported/');
+		$this->expectOutputRegex( '/Stripe will require WooCommerce 5\.4 or greater to be installed and active\. Your version of WooCommerce 5\.4 will no longer be supported/' );
 
 		$this->controller->add_upcoming_compatibility_notice();
 	}
 
 	public function test_should_add_a_notice_when_the_wp_version_is_not_satisfied() {
-		$this->overwrite_wp_version('5.5.0');
-		$this->overwrite_wc_version('5.7.0');
+		$this->overwrite_wp_version( '5.5.0' );
+		$this->overwrite_wc_version( '5.7.0' );
 
-		$this->expectOutputRegex('/Stripe will require Wordpress 5\.6 or greater\. Your version of WordPress 5\.6 will no longer be supported/');
+		$this->expectOutputRegex( '/Stripe will require WordPress 5\.6 or greater\. Your version of WordPress 5\.6 will no longer be supported/' );
 
 		$this->controller->add_upcoming_compatibility_notice();
 	}
 
 	public function test_should_add_a_notice_when_the_wp_and_wc_versions_are_not_satisfied() {
-		$this->overwrite_wp_version('5.5.0');
-		$this->overwrite_wc_version('5.2.0');
+		$this->overwrite_wp_version( '5.5.0' );
+		$this->overwrite_wc_version( '5.2.0' );
 
-		$this->expectOutputRegex('/Stripe will require Wordpress 5\.6 or greater and WooCommerce 5\.4 or greater to be installed and active\. Your versions of WordPress 5\.6 and WooCommerce 5\.4 will no longer be supported/');
+		$this->expectOutputRegex( '/Stripe will require WordPress 5\.6 or greater and WooCommerce 5\.4 or greater to be installed and active\. Your versions of WordPress 5\.6 and WooCommerce 5\.4 will no longer be supported/' );
 
 		$this->controller->add_upcoming_compatibility_notice();
 	}

--- a/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
+++ b/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
@@ -67,7 +67,7 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 		$this->overwrite_wp_version( '5.7.0' );
 		$this->overwrite_wc_version( '5.2.0' );
 
-		$this->expectOutputRegex( '/Stripe will require WooCommerce 5\.4 or greater to be installed and active\. Your version of WooCommerce 5\.4 will no longer be supported/' );
+		$this->expectOutputRegex( '/Stripe will require WooCommerce 5.4 or greater to be installed and active. Your version of WooCommerce 5.4 will no longer be supported/' );
 
 		$this->controller->add_upcoming_compatibility_notice();
 	}
@@ -76,7 +76,7 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 		$this->overwrite_wp_version( '5.5.0' );
 		$this->overwrite_wc_version( '5.7.0' );
 
-		$this->expectOutputRegex( '/Stripe will require WordPress 5\.6 or greater\. Your version of WordPress 5\.6 will no longer be supported/' );
+		$this->expectOutputRegex( '/Stripe will require WordPress 5.6 or greater. Your version of WordPress 5.6 will no longer be supported/' );
 
 		$this->controller->add_upcoming_compatibility_notice();
 	}
@@ -85,7 +85,7 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 		$this->overwrite_wp_version( '5.5.0' );
 		$this->overwrite_wc_version( '5.2.0' );
 
-		$this->expectOutputRegex( '/Stripe will require WordPress 5\.6 or greater and WooCommerce 5\.4 or greater to be installed and active\. Your versions of WordPress 5\.6 and WooCommerce 5\.4 will no longer be supported/' );
+		$this->expectOutputRegex( '/Stripe will require WordPress 5.6 or greater and WooCommerce 5.4 or greater to be installed and active. Your versions of WordPress 5.6 and WooCommerce 5.4 will no longer be supported/' );
 
 		$this->controller->add_upcoming_compatibility_notice();
 	}

--- a/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
+++ b/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * This test makes assertions against the class WC_Stripe_UPE_Compatibility_Controller.
+ *
+ * @package WooCommerce_Stripe/Tests/WC_Stripe_UPE_Compatibility_Controller
+ */
+
+/**
+ * WC_Stripe_UPE_Compatibility_Controller unit tests.
+ */
+class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
+	/**
+	 * @var WC_Stripe_UPE_Compatibility_Controller
+	 */
+	private $controller;
+
+	/**
+	 * @var string
+	 */
+	private $initial_wp_version;
+
+	/**
+	 * Pre-test setup
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// saving these values to that they can be restored after the test runs
+		global $wp_version;
+		$this->initial_wp_version = $wp_version;
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
+
+		$this->controller = $this->getMockBuilder( WC_Stripe_UPE_Compatibility_Controller::class )
+		                         ->disableOriginalConstructor()
+		                         ->setMethods( [ 'get_wc_version' ] )
+		                         ->getMock();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		// restore the overwritten values
+		global $wp_version;
+		$wp_version = $this->initial_wp_version;
+	}
+
+	protected function overwrite_wp_version( $version ) {
+		global $wp_version;
+		$wp_version = $version;
+	}
+
+	protected function overwrite_wc_version( $version ) {
+		$this->controller->method( 'get_wc_version' )->willReturn( $version );
+	}
+
+	public function test_should_not_add_a_notice_when_the_wp_and_wc_versions_are_satisfied() {
+		$this->overwrite_wc_version('5.7.0');
+		$this->overwrite_wp_version('5.7.0');
+
+		$this->expectOutputString('');
+
+		$this->controller->add_upcoming_compatibility_notice();
+	}
+
+	public function test_should_add_a_notice_when_the_wc_version_is_not_satisfied() {
+		$this->overwrite_wp_version('5.7.0');
+		$this->overwrite_wc_version('5.2.0');
+
+		$this->expectOutputRegex('/Stripe will require WooCommerce 5\.4 or greater to be installed and active\. Your version of WooCommerce 5\.4 will no longer be supported/');
+
+		$this->controller->add_upcoming_compatibility_notice();
+	}
+
+	public function test_should_add_a_notice_when_the_wp_version_is_not_satisfied() {
+		$this->overwrite_wp_version('5.5.0');
+		$this->overwrite_wc_version('5.7.0');
+
+		$this->expectOutputRegex('/Stripe will require Wordpress 5\.6 or greater\. Your version of WordPress 5\.6 will no longer be supported/');
+
+		$this->controller->add_upcoming_compatibility_notice();
+	}
+
+	public function test_should_add_a_notice_when_the_wp_and_wc_versions_are_not_satisfied() {
+		$this->overwrite_wp_version('5.5.0');
+		$this->overwrite_wc_version('5.2.0');
+
+		$this->expectOutputRegex('/Stripe will require Wordpress 5\.6 or greater and WooCommerce 5\.4 or greater to be installed and active\. Your versions of WordPress 5\.6 and WooCommerce 5\.4 will no longer be supported/');
+
+		$this->controller->add_upcoming_compatibility_notice();
+	}
+}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -668,6 +668,11 @@ function woocommerce_gateway_stripe_woocommerce_block_support() {
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
 			function( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
+				// I noticed some incompatibility with WP 5.x and WC 5.3
+				if ( ! class_exists( 'WC_Stripe_Payment_Request' ) ) {
+					return;
+				}
+
 				$container = Automattic\WooCommerce\Blocks\Package::container();
 				// registers as shared instance.
 				$container->register(

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -25,8 +25,6 @@ define( 'WC_STRIPE_VERSION', '5.4.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 define( 'WC_STRIPE_MIN_WC_VER', '3.0' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.3' );
-define( 'WC_STRIPE_UPE_MIN_WP_VER', '5.6' );
-define( 'WC_STRIPE_UPE_MIN_WC_VER', '5.4' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'WC_STRIPE_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
@@ -50,7 +48,7 @@ function woocommerce_stripe_missing_wc_notice() {
  */
 function woocommerce_stripe_wc_not_supported() {
 	/* translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version. */
-	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ? WC_STRIPE_UPE_MIN_WC_VER : WC_STRIPE_MIN_WC_VER, WC_VERSION ) . '</strong></p></div>';
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ? WC_Stripe_UPE_Compatibility::MIN_WC_VERSION : WC_STRIPE_MIN_WC_VER, WC_VERSION ) . '</strong></p></div>';
 }
 
 /**
@@ -60,7 +58,7 @@ function woocommerce_stripe_wc_not_supported() {
  */
 function woocommerce_stripe_wp_not_supported() {
 	/* translators: $1. Minimum WordPress version. $2. Current WordPress version. */
-	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WordPress %1$s or greater to be installed and active. WordPress %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_STRIPE_UPE_MIN_WP_VER, get_bloginfo( 'version' ) ) . '</strong></p></div>';
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WordPress %1$s or greater to be installed and active. WordPress %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_Stripe_UPE_Compatibility::MIN_WP_VERSION, get_bloginfo( 'version' ) ) . '</strong></p></div>';
 }
 
 function woocommerce_gateway_stripe() {
@@ -605,6 +603,7 @@ add_action( 'plugins_loaded', 'woocommerce_gateway_stripe_init' );
 function woocommerce_gateway_stripe_init() {
 	// including this here so that all the classes have the ability to leverage `WC_Stripe_Feature_Flags`
 	require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-feature-flags.php';
+	require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-upe-compatibility.php';
 	load_plugin_textdomain( 'woocommerce-gateway-stripe', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 
 	if ( ! class_exists( 'WooCommerce' ) ) {
@@ -617,13 +616,13 @@ function woocommerce_gateway_stripe_init() {
 		return;
 	}
 
-	if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() && version_compare( WC_VERSION, WC_STRIPE_UPE_MIN_WC_VER, '<' ) ) {
+	if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() && ! WC_Stripe_UPE_Compatibility::is_wc_supported() ) {
 		add_action( 'admin_notices', 'woocommerce_stripe_wc_not_supported' );
 		return;
 	}
 
 	// technically speaking, WooCommerce also wouldn't support the same version of WP as we are, but I guess this doesn't hurt.
-	if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() && version_compare( get_bloginfo( 'version' ), WC_STRIPE_UPE_MIN_WP_VER, '<' ) ) {
+	if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() && ! WC_Stripe_UPE_Compatibility::is_wp_supported() ) {
 		add_action( 'admin_notices', 'woocommerce_stripe_wp_not_supported' );
 		return;
 	}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -668,10 +668,6 @@ function woocommerce_gateway_stripe_woocommerce_block_support() {
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
 			function( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
-				if ( ! class_exists( 'WC_Stripe_Payment_Request' ) ) {
-					return;
-				}
-
 				$container = Automattic\WooCommerce\Blocks\Package::container();
 				// registers as shared instance.
 				$container->register(

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -25,6 +25,8 @@ define( 'WC_STRIPE_VERSION', '5.4.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '5.6.0' );
 define( 'WC_STRIPE_MIN_WC_VER', '3.0' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '3.3' );
+define( 'WC_STRIPE_UPE_MIN_WP_VER', '5.6' );
+define( 'WC_STRIPE_UPE_MIN_WC_VER', '5.4' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );
 define( 'WC_STRIPE_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
@@ -48,7 +50,17 @@ function woocommerce_stripe_missing_wc_notice() {
  */
 function woocommerce_stripe_wc_not_supported() {
 	/* translators: $1. Minimum WooCommerce version. $2. Current WooCommerce version. */
-	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_STRIPE_MIN_WC_VER, WC_VERSION ) . '</strong></p></div>';
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce %1$s or greater to be installed and active. WooCommerce %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ? WC_STRIPE_UPE_MIN_WC_VER : WC_STRIPE_MIN_WC_VER, WC_VERSION ) . '</strong></p></div>';
+}
+
+/**
+ * WooCommerce not supported fallback notice.
+ *
+ * @since 5.5.0
+ */
+function woocommerce_stripe_wp_not_supported() {
+	/* translators: $1. Minimum WordPress version. $2. Current WordPress version. */
+	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WordPress %1$s or greater to be installed and active. WordPress %2$s is no longer supported.', 'woocommerce-gateway-stripe' ), WC_STRIPE_UPE_MIN_WP_VER, get_bloginfo( 'version' ) ) . '</strong></p></div>';
 }
 
 function woocommerce_gateway_stripe() {
@@ -153,7 +165,6 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-apple-pay-registration.php';
 				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-pre-orders-compat.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-stripe.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-feature-flags.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php';
@@ -192,6 +203,11 @@ function woocommerce_gateway_stripe() {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-onboarding-controller.php';
 						new WC_Stripe_Onboarding_Controller();
 					}
+				}
+
+				if ( ! WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
+					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
+					new WC_Stripe_UPE_Compatibility_Controller();
 				}
 
 				// REMOVE IN THE FUTURE.
@@ -587,6 +603,8 @@ function woocommerce_gateway_stripe() {
 add_action( 'plugins_loaded', 'woocommerce_gateway_stripe_init' );
 
 function woocommerce_gateway_stripe_init() {
+	// including this here so that all the classes have the ability to leverage `WC_Stripe_Feature_Flags`
+	require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-feature-flags.php';
 	load_plugin_textdomain( 'woocommerce-gateway-stripe', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
 
 	if ( ! class_exists( 'WooCommerce' ) ) {
@@ -596,6 +614,17 @@ function woocommerce_gateway_stripe_init() {
 
 	if ( version_compare( WC_VERSION, WC_STRIPE_MIN_WC_VER, '<' ) ) {
 		add_action( 'admin_notices', 'woocommerce_stripe_wc_not_supported' );
+		return;
+	}
+
+	if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() && version_compare( WC_VERSION, WC_STRIPE_UPE_MIN_WC_VER, '<' ) ) {
+		add_action( 'admin_notices', 'woocommerce_stripe_wc_not_supported' );
+		return;
+	}
+
+	// technically speaking, WooCommerce also wouldn't support the same version of WP as we are, but I guess this doesn't hurt.
+	if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() && version_compare( get_bloginfo( 'version' ), WC_STRIPE_UPE_MIN_WP_VER, '<' ) ) {
+		add_action( 'admin_notices', 'woocommerce_stripe_wp_not_supported' );
 		return;
 	}
 
@@ -617,6 +646,15 @@ if ( ! function_exists( 'add_woocommerce_inbox_variant' ) ) {
 }
 register_activation_hook( __FILE__, 'add_woocommerce_inbox_variant' );
 
+function wcstripe_deactivated() {
+	// admin notes are not supported on older versions of WooCommerce.
+	if ( version_compare( WC_VERSION, '4.4.0', '>=' ) ) {
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-upe-compatibility-note.php';
+		WC_Stripe_UPE_Compatibility_Note::possibly_delete_note();
+	}
+}
+register_deactivation_hook( __FILE__, 'wcstripe_deactivated' );
+
 // Hook in Blocks integration. This action is called in a callback on plugins loaded, so current Stripe plugin class
 // implementation is too late.
 add_action( 'woocommerce_blocks_loaded', 'woocommerce_gateway_stripe_woocommerce_block_support' );
@@ -631,6 +669,10 @@ function woocommerce_gateway_stripe_woocommerce_block_support() {
 		add_action(
 			'woocommerce_blocks_payment_method_type_registration',
 			function( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
+				if ( ! class_exists( 'WC_Stripe_Payment_Request' ) ) {
+					return;
+				}
+
 				$container = Automattic\WooCommerce\Blocks\Package::container();
 				// registers as shared instance.
 				$container->register(

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -601,7 +601,7 @@ function woocommerce_gateway_stripe() {
 add_action( 'plugins_loaded', 'woocommerce_gateway_stripe_init' );
 
 function woocommerce_gateway_stripe_init() {
-	// including this here so that all the classes have the ability to leverage `WC_Stripe_Feature_Flags`
+	// including this here so that all the classes have the ability to leverage `WC_Stripe_Feature_Flags` and `WC_Stripe_UPE_Compatibility`
 	require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-feature-flags.php';
 	require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-upe-compatibility.php';
 	load_plugin_textdomain( 'woocommerce-gateway-stripe', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1712

Adding some compatibility notes
- With `_wcstripe_feature_upe_settings` disabled (i.e.: for the next version of WCStripe):
  - Show inbox note
  - Show wp-admin notice
  - Allow execution flow
- With `_wcstripe_feature_upe_settings` enabled (i.e.: for the version of WCStripe released at the end of September):
  - Show wp-admin notice
  - Interrupt execution flow

## Testing instructions

- With `_wcstripe_feature_upe_settings` disabled and incompatible WP version (execution of Stripe is allowed):
![Screen Shot 2021-08-25 at 2 40 30 PM](https://user-images.githubusercontent.com/273592/130854261-e6f3c129-aea8-43ec-8cac-da64b78633d2.png)
- With `_wcstripe_feature_upe_settings` disabled and incompatible WC version (execution of Stripe is allowed):
![Screen Shot 2021-08-25 at 2 44 20 PM](https://user-images.githubusercontent.com/273592/130854734-f9a295e9-0db4-45cf-9006-053077a11eb2.png)
- With `_wcstripe_feature_upe_settings` disabled and incompatible WP & WC version (execution of Stripe is allowed):
![Screen Shot 2021-08-25 at 2 45 23 PM](https://user-images.githubusercontent.com/273592/130854862-521b38ee-f481-4dbb-bddd-eab6299478fd.png)
- With `_wcstripe_feature_upe_settings` disabled and incompatible WP or WC version:
![Screen Shot 2021-08-25 at 2 46 02 PM](https://user-images.githubusercontent.com/273592/130854938-73e75172-9383-4751-939a-bc97da41b011.png)

----

- With `_wcstripe_feature_upe_settings` enabled and incompatible WC version (execution of Stripe is interrupted):
![Screen Shot 2021-08-25 at 2 53 01 PM](https://user-images.githubusercontent.com/273592/130855852-8316830d-7dd6-4067-836a-d9d1488b4020.png)
- With `_wcstripe_feature_upe_settings` enabled and incompatible WP version (execution of Stripe is interrupted):
![Screen Shot 2021-08-25 at 2 39 00 PM](https://user-images.githubusercontent.com/273592/130854054-d676461d-0294-432a-b43c-f033061ed58f.png)
