### PR TITLE
Pass missing $post object to filter callbacks

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -950,6 +950,8 @@ class WC_Stripe_Payment_Request {
 	 * @return  boolean  True if PRBs are enabled on product pages, false otherwise
 	 */
 	public function should_show_prb_on_product_pages() {
+		global $post;
+
 		// Message we show for the deprecated PRB location filters. Intended for support so we
 		// don't provide translations.
 		$deprecation_message         =
@@ -960,7 +962,7 @@ class WC_Stripe_Payment_Request {
 		// Note the negation because if the filter returns `true` that means we should hide the PRB.
 		return ! apply_filters_deprecated(
 			'wc_stripe_hide_payment_request_on_product_page',
-			[ ! $should_show_on_product_page ],
+			[ ! $should_show_on_product_page, $post ],
 			'5.5.0',
 			'', // There is no replacement.
 			$deprecation_message

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -271,7 +271,7 @@ function woocommerce_gateway_stripe() {
 				if ( ! empty( $stripe_settings ) && empty( $prb_locations ) ) {
 					global $post;
 
-					$should_show_on_product_page  = ! apply_filters( 'wc_stripe_hide_payment_request_on_product_page', false );
+					$should_show_on_product_page  = ! apply_filters( 'wc_stripe_hide_payment_request_on_product_page', false, $post );
 					$should_show_on_cart_page     = apply_filters( 'wc_stripe_show_payment_request_on_cart', true );
 					$should_show_on_checkout_page = apply_filters( 'wc_stripe_show_payment_request_on_checkout', false, $post );
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1640 This is just a small addition to @reykjalin's [PR](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1672).

While testing https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1732 I noticed some third party plugins still use the filter along with the `$post` parameter. Given that we forgot to pass `$post` to the `wc_stripe_hide_payment_request_on_product_page` filter, in those cases when the code uses `$post` it throws an error and break the site.`

```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function hide_stripe_quickpay(), 1 passed in /var/www/html/wp-includes/class-wp-hook.php on line 303 and exactly 2 expected in /var/www/html/wp-content/plugins/code-snippets/php/snippet-ops.php(469) : eval()'d code on line 7
  |  
  | ArgumentCountError: Too few arguments to function hide_stripe_quickpay(), 1 passed in /var/www/html/wp-includes/class-wp-hook.php on line 303 and exactly 2 expected in /var/www/html/wp-content/plugins/code-snippets/php/snippet-ops.php(469) : eval()'d code on line 7
  |  
```


# Testing instructions

- `git checkout fix-missing-param-filter`
- Install and activate the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
- Copy the following snippet into the Code text area. Save this snippet as "add filter".

```php
add_action('wp_loaded', 'add_my_filter');

function add_my_filter() {
	add_filter( 'wc_stripe_hide_payment_request_on_product_page', 'hide_stripe_quickpay', 10, 2 );
}

function hide_stripe_quickpay($default_value, $post) {
	var_dump($post);
}
```
- Make sure "Run snippet everywhere" is toggled on.
- Click "Save changes" then activate the snippet.
- Visit any product page
- You should see the deprecation warning along with the contents of the `$post` variable. The site should still work normally.
- Switch to `develop`branch
- Refresh product page
- You should see the deprecation warning then an error message:

```
Fatal error: Uncaught ArgumentCountError: Too few arguments to function hide_stripe_quickpay(), 1 passed in /var/www/html/wp-includes/class-wp-hook.php on line 303 and exactly 2 expected in /var/www/html/wp-content/plugins/code-snippets/php/snippet-ops.php(469) : eval()'d code on line 7
  |  
  | ArgumentCountError: Too few arguments to function hide_stripe_quickpay(), 1 passed in /var/www/html/wp-includes/class-wp-hook.php on line 303 and exactly 2 expected in /var/www/html/wp-content/plugins/code-snippets/php/snippet-ops.php(469) : eval()'d code on line 7
  |  
```

- the site should not work.

Not adding a CHANGELOG entry because this should've been included in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1672


-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
