### PR TITLE
Wrap the react container with another wrapper div with class "wrap"

### DIFF
--- a/includes/admin/class-wc-stripe-onboarding-controller.php
+++ b/includes/admin/class-wc-stripe-onboarding-controller.php
@@ -71,6 +71,6 @@ class WC_Stripe_Onboarding_Controller {
 	 * Output a container for react app to mount on.
 	 */
 	public function render_onboarding_wizard() {
-		echo '<div id="wc-stripe-onboarding-wizard-container"></div>';
+		echo '<div class="wrap"><div id="wc-stripe-onboarding-wizard-container"></div></div>';
 	}
 }


### PR DESCRIPTION
This lets wc-admin to be able to locate the "wrap" element so that it can append the notice below it.

# Changes proposed in this Pull Request:
Add `<div class="wrap"></div>` around react container.

Issue: Link to the GitHub issue this PR addresses (if appropriate).
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1744

# Testing instructions
1. Make sure `_wcstripe_feature_upe_settings` is set to 1; or have this function return true.
2. Go to `wp-admin/admin.php?page=wc_stripe-onboarding_wizard` and you should see a placeholder onboarding wizard page. 
3. Confirm onboarding react app is now below the notice:  
![image](https://user-images.githubusercontent.com/572862/130860659-d8bf55f9-771d-4f99-87da-abca9c18dc8e.png)
