### PR TITLE
fix: onboarding wizard spacing

### DIFF
--- a/client/additional-methods-setup/__tests__/onboarding-wizard-test.js
+++ b/client/additional-methods-setup/__tests__/onboarding-wizard-test.js
@@ -7,7 +7,6 @@ describe( 'OnboardingWizard', () => {
 	it( 'should render the onboarding wizard', () => {
 		render( <OnboardingWizard /> );
 
-		expect ( screen.getByText( 'Hello wizard page' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Hello wizard page' ) ).toBeInTheDocument();
 	} );
-
 } );

--- a/client/additional-methods-setup/index.js
+++ b/client/additional-methods-setup/index.js
@@ -1,18 +1,18 @@
 /**
  * External dependencies
  */
- import React from 'react';
- import ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 
- /**
-  * Internal dependencies
-  */
- import OnboardingWizard from './onboarding-wizard';
+/**
+ * Internal dependencies
+ */
+import OnboardingWizard from './onboarding-wizard';
 
- const container = document.getElementById(
-     'wc-stripe-onboarding-wizard-container'
- );
+const container = document.getElementById(
+	'wc-stripe-onboarding-wizard-container'
+);
 
- if ( container ) {
-     ReactDOM.render( <OnboardingWizard />, container );
- }
+if ( container ) {
+	ReactDOM.render( <OnboardingWizard />, container );
+}

--- a/client/additional-methods-setup/onboarding-wizard.js
+++ b/client/additional-methods-setup/onboarding-wizard.js
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
- import React from 'react';
+import React from 'react';
 
- const OnboardingWizard = () => {
-	return (<div>Hello wizard page</div>);
+const OnboardingWizard = () => {
+	return <div>Hello wizard page</div>;
 };
 
 export default OnboardingWizard;

--- a/client/settings/settings-tab-panel/style.scss
+++ b/client/settings/settings-tab-panel/style.scss
@@ -1,4 +1,4 @@
 .components-tab-panel__tabs {
-	border-bottom: 1px solid #C3C4C7;
+	border-bottom: 1px solid #c3c4c7;
 	margin-bottom: 32px;
 }


### PR DESCRIPTION
# Changes proposed in this Pull Request:

I noticed all these files have 2 leading spaces 🤔 


# Testing instructions
No more leading spaces?

You can get a similar result with `npx prettier --write client/`