### PR TITLE
Save payment method in the token service

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use WC_Stripe_Subscriptions_Utilities;
+
 // phpcs:disable WordPress.Files.FileName
 
 /**
@@ -13,6 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0.0
  */
 abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
+
+	use WC_Stripe_Subscriptions_Utilities;
+
 	/**
 	 * Displays the admin settings webhook description.
 	 *

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -3,8 +3,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use WC_Stripe_Subscriptions_Utilities;
-
 // phpcs:disable WordPress.Files.FileName
 
 /**

--- a/includes/compat/subscriptions/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-stripe-subscriptions-utilities.php
@@ -1,7 +1,6 @@
 <?php
 /**
  * Trait WC_Stripe_Subscriptions_Utilities
- *
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/compat/subscriptions/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/subscriptions/trait-wc-stripe-subscriptions-utilities.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Trait WC_Stripe_Subscriptions_Utilities
+ *
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Utility functions related to WC Subscriptions.
+ */
+trait WC_Stripe_Subscriptions_Utilities {
+
+	/**
+	 * Checks if subscriptions are enabled on the site.
+	 *
+	 * @return bool Whether subscriptions is enabled or not.
+	 */
+	public function is_subscriptions_enabled() {
+		return class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' );
+	}
+}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -515,7 +515,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @param WC_Payment_Token $token The token to save.
 	 */
 	public function maybe_add_token_to_subscription_order( $order, $token ) {
-		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ) ) {
+		if ( $this->is_subscriptions_enabled() ) {
 			$subscriptions = wcs_get_subscriptions_for_order( $order->get_id() );
 			foreach ( $subscriptions as $subscription ) {
 				$payment_token = $this->get_payment_token( $subscription );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -37,19 +37,19 @@ abstract class WC_Stripe_UPE_Payment_Method {
 	protected $is_reusable;
 
 	/**
-	 * Instance of WC Payments Token Service to save payment method
+	 * Instance of WC Stripe Payments Token Service to save payment method
 	 *
-	 * @var WC_Payments_Token_Service
+	 * @var WC_Stripe_Payment_Tokens
 	 */
 	protected $token_service;
 
 	/**
 	 * Create instance of payment method
 	 *
-	 * @param WC_Payments_Token_Service $token_service Instance of WC_Payments_Token_Service.
+	 * @param WC_Stripe_Payment_Tokens $token_service Instance of WC_Stripe_Payment_Tokens.
 	 */
 	public function __construct( $token_service ) {
-		//      $this->token_service = $token_service;
+		$this->token_service = $token_service;
 	}
 
 	/**
@@ -98,13 +98,13 @@ abstract class WC_Stripe_UPE_Payment_Method {
 	/**
 	 * Add payment method to user and return WC payment token
 	 *
-	 * @param WP_User $user User to get payment token from.
-	 * @param string  $payment_method_id Stripe payment method ID string.
+	 * @param WC_Stripe_Customer $user User to get payment token from.
+	 * @param stdClass  $payment_method Stripe payment method ID string.
 	 *
 	 * @return WC_Payment_Token_CC|WC_Payment_Token_WCPay_SEPA WC object for payment token.
 	 */
-	public function get_payment_token_for_user( $user, $payment_method_id ) {
-		//      return $this->token_service->add_payment_method_to_user( $payment_method_id, $user );
+	public function get_payment_token_for_user( $user, $payment_method ) {
+		return $this->token_service->add_payment_method_to_user( $payment_method, $user );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use WC_Stripe_Subscriptions_Utilities;
+
 /**
  * Abstract UPE Payment Method class
  *
@@ -14,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Extendable abstract class for payment methods.
  */
 abstract class WC_Stripe_UPE_Payment_Method {
+
+	use WC_Stripe_Subscriptions_Utilities;
 
 	/**
 	 * Stripe key name
@@ -114,7 +118,7 @@ abstract class WC_Stripe_UPE_Payment_Method {
 	 * @return bool
 	 */
 	public function is_subscription_item_in_cart() {
-		if ( class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ) ) {
+		if ( $this->is_subscriptions_enabled() ) {
 			return WC_Subscriptions_Cart::cart_contains_subscription() || 0 < count( wcs_get_order_type_cart_items( 'renewal' ) );
 		}
 		return false;

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -142,6 +142,7 @@ function woocommerce_gateway_stripe() {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-privacy.php';
 				}
 
+				require_once dirname( __FILE__ ) . '/includes/compat/subscriptions/trait-wc-stripe-subscriptions-utilities.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-exception.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-logger.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-helper.php';


### PR DESCRIPTION
# Changes proposed in this Pull Request:
Issue #1686

This PR ports the WCPay token service implementation to the UPE. That allows the user to save a payment method using the new UPE checkout.

# Testing instructions

1. Ensure you have the UPE feature flag enabled.
2. Visit http://localhost:8082 and log in.
3. Go to `Shop` and add a product to the cart.
4. Go to `Checkout`.
5. Pay using a test credit card (e.g. `4242 4242 4242 4242`) and make sure you tick to save the payment method.
6. Visit http://localhost:8082/my-account/payment-methods The credit card you just used should be listed there.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
