### PR TITLE
Added filters to swap out credentials/webhook details based on cart/order data

### DIFF
--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -112,7 +112,7 @@ class WC_Stripe_API {
 	public static function request( $request, $api = 'charges', $method = 'POST', $with_headers = false ) {
 		WC_Stripe_Logger::log( "{$api} request: " . print_r( $request, true ) );
 
-		$headers         = self::get_headers();
+		$headers         = apply_filters('wc_stripe_api_request_get_headers', self::get_headers(), $request, $api, $method );
 		$idempotency_key = '';
 
 		if ( 'charges' === $api && 'POST' === $method ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -111,6 +111,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return WC_Stripe_Webhook_State::VALIDATION_FAILED_EMPTY_BODY;
 		}
 
+		$this->secret = apply_filters('wc_stripe_wehbook_validate_secret', $this->secret, $request_body );
 		if ( empty( $this->secret ) ) {
 			return $this->validate_request_user_agent( $request_headers );
 		}


### PR DESCRIPTION

# Changes proposed in this Pull Request:
Looking to swap out credentials/webhook details based on cart/order data. 
Add filter to swap webhook secret to validate incoming webhooks from multiple accounts.
Added filter to swap headers for API requests, passing all request data to determine which account.

Issue: Link to the GitHub issue this PR addresses (if appropriate).
Fixes #

Description: 
Looking to swap out credentials/webhook details based on cart/order data. 
Add filter to swap webhook secret to validate incoming webhooks from multiple accounts.
Added filter to swap headers for API requests, passing all request data to determine which account.


Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.


# Testing instructions
None. Added core filters for improved integration.
