### PR TITLE
Add UPE opt-in banner in stripe settings page

### DIFF
--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import GeneralSettingsSection from '..';
+
+describe( 'GeneralSettingsSection', () => {
+	it( 'should render the card information', () => {
+		render( <GeneralSettingsSection /> );
+
+		expect(
+			screen.queryByText( 'Credit card / debit card' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				'Let your customers pay with major credit and debit cards without leaving your store.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the opt-in banner with action elements', () => {
+		render( <GeneralSettingsSection /> );
+
+		expect( screen.queryByTestId( 'opt-in-banner' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Enable in your store' )
+		).toBeInTheDocument();
+		expect( screen.queryByText( 'Learn more' ) ).toBeInTheDocument();
+	} );
+} );

--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -8,11 +8,15 @@ import { screen, render } from '@testing-library/react';
  * Internal dependencies
  */
 import GeneralSettingsSection from '..';
+import UpeToggleContext from '../../upe-toggle/context';
 
 describe( 'GeneralSettingsSection', () => {
 	it( 'should render the card information', () => {
-		render( <GeneralSettingsSection /> );
-
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
 		expect(
 			screen.queryByText( 'Credit card / debit card' )
 		).toBeInTheDocument();
@@ -23,13 +27,32 @@ describe( 'GeneralSettingsSection', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should render the opt-in banner with action elements', () => {
-		render( <GeneralSettingsSection /> );
-
+	it( 'should render the opt-in banner with action elements if UPE is disabled', () => {
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
 		expect( screen.queryByTestId( 'opt-in-banner' ) ).toBeInTheDocument();
 		expect(
-			screen.queryByText( 'Enable in your store' )
+			screen.queryByRole( 'link', { name: 'Enable in your store' } )
 		).toBeInTheDocument();
 		expect( screen.queryByText( 'Learn more' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not render the opt-in banner if UPE is enabled', () => {
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByTestId( 'opt-in-banner' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: 'Enable in your store' } )
+		).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/settings/general-settings-section/index.js
+++ b/client/settings/general-settings-section/index.js
@@ -2,52 +2,85 @@
  * External dependencies
  */
 import React from 'react';
+import styled from '@emotion/styled';
 import { Card } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import CardBody from '../card-body';
-import SofortIcon from '../../payment-method-icons/sofort';
-import SepaIcon from '../../payment-method-icons/sepa';
 import CardsIcon from '../../payment-method-icons/cards';
-import GiropayIcon from '../../payment-method-icons/giropay';
-import ApplePayIcon from '../../payment-method-icons/apple-pay';
-import GooglePayIcon from '../../payment-method-icons/google-pay';
+import UPEOptInBanner from '../upe-opt-in-banner';
+
+const GeneralSettingsSectionWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+`;
+
+const CardBodyWrapper = styled( CardBody )`
+	display: flex;
+
+	> * {
+		margin-bottom: 0px;
+	}
+`;
+
+const PaymentMethodText = styled.div`
+	flex: 0 0 100%;
+
+	@media ( min-width: 660px ) {
+		flex: 1 1 auto;
+		margin-left: 12px;
+	}
+`;
+
+const PaymentMethodLabel = styled.div`
+	color: $gray-900;
+	display: inline-block;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 20px;
+	margin-bottom: 4px;
+`;
+
+const PaymentMethodDescription = styled.div`
+	color: ##646970;
+	font-size: 13px;
+	line-height: 16px;
+	margin-bottom: 14px;
+
+	@media ( min-width: 660px ) {
+		margin-bottom: 0px;
+	}
+`;
+
+const OptInBannerWrapper = styled.div`
+	div:first-of-type {
+		max-width: 100%;
+	}
+`;
 
 const GeneralSettingsSection = () => {
 	return (
-		<Card>
-			<CardBody>
-				The general settings sections goes here.
-				<ul>
-					<li>
-						<GooglePayIcon />
-						<GooglePayIcon size="medium" />
-					</li>
-					<li>
-						<ApplePayIcon />
-						<ApplePayIcon size="medium" />
-					</li>
-					<li>
-						<SofortIcon />
-						<SofortIcon size="medium" />
-					</li>
-					<li>
-						<GiropayIcon />
-						<GiropayIcon size="medium" />
-					</li>
-					<li>
-						<SepaIcon />
-						<SepaIcon size="medium" />
-					</li>
-					<li>
-						<CardsIcon />
-						<CardsIcon size="medium" />
-					</li>
-				</ul>
-			</CardBody>
-		</Card>
+		<GeneralSettingsSectionWrapper>
+			<Card>
+				<CardBodyWrapper>
+					<CardsIcon size="medium" />
+					<PaymentMethodText>
+						<PaymentMethodLabel>
+							Credit card / debit card
+						</PaymentMethodLabel>
+						<PaymentMethodDescription>
+							Let your customers pay with major credit and debit
+							cards without leaving your store.
+						</PaymentMethodDescription>
+					</PaymentMethodText>
+				</CardBodyWrapper>
+			</Card>
+			<OptInBannerWrapper data-testid="opt-in-banner">
+				<UPEOptInBanner />
+			</OptInBannerWrapper>
+		</GeneralSettingsSectionWrapper>
 	);
 };
 

--- a/client/settings/general-settings-section/index.js
+++ b/client/settings/general-settings-section/index.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import styled from '@emotion/styled';
+import { __ } from '@wordpress/i18n';
 import { Card } from '@wordpress/components';
 
 /**
@@ -11,6 +12,7 @@ import { Card } from '@wordpress/components';
 import CardBody from '../card-body';
 import CardsIcon from '../../payment-method-icons/cards';
 import UPEOptInBanner from '../upe-opt-in-banner';
+import UpeToggleContext from '../upe-toggle/context';
 
 const GeneralSettingsSectionWrapper = styled.div`
 	display: flex;
@@ -54,13 +56,15 @@ const PaymentMethodDescription = styled.div`
 	}
 `;
 
-const OptInBannerWrapper = styled.div`
+const UPEOptInBannerWrapper = styled.div`
 	div:first-of-type {
 		max-width: 100%;
 	}
 `;
 
 const GeneralSettingsSection = () => {
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
 	return (
 		<GeneralSettingsSectionWrapper>
 			<Card>
@@ -68,18 +72,25 @@ const GeneralSettingsSection = () => {
 					<CardsIcon size="medium" />
 					<PaymentMethodText>
 						<PaymentMethodLabel>
-							Credit card / debit card
+							{ __(
+								'Credit card / debit card',
+								'woocommerce-gateway-stripe'
+							) }
 						</PaymentMethodLabel>
 						<PaymentMethodDescription>
-							Let your customers pay with major credit and debit
-							cards without leaving your store.
+							{ __(
+								'Let your customers pay with major credit and debit cards without leaving your store.',
+								'woocommerce-gateway-stripe'
+							) }
 						</PaymentMethodDescription>
 					</PaymentMethodText>
 				</CardBodyWrapper>
 			</Card>
-			<OptInBannerWrapper data-testid="opt-in-banner">
-				<UPEOptInBanner />
-			</OptInBannerWrapper>
+			{ ! isUpeEnabled && (
+				<UPEOptInBannerWrapper data-testid="opt-in-banner">
+					<UPEOptInBanner />
+				</UPEOptInBannerWrapper>
+			) }
 		</GeneralSettingsSectionWrapper>
 	);
 };

--- a/client/settings/upe-opt-in-banner/index.js
+++ b/client/settings/upe-opt-in-banner/index.js
@@ -67,7 +67,11 @@ const UPEOptInBanner = () => (
 			</p>
 			<Actions>
 				<span>
-					<Button isPrimary href="?TODO" target="_blank">
+					<Button
+						isPrimary
+						href="?page=wc_stripe-onboarding_wizard"
+						target="_blank"
+					>
 						{ __(
 							'Enable in your store',
 							'woocommerce-gateway-stripe'


### PR DESCRIPTION
Fixes #1715

### Description
Showing the UPE opt-in banner in the main Stripe settings page. The payment method section is not implemented yet. A placeholder with card information has been added there. The main implementation of the payment methods will be done in #1716

### Changes in this PR
- Reused the `UPEOptInBanner` component 
- Added a placeholder over the banner with card information. 
- Added tests

![banner in stripe settings](https://user-images.githubusercontent.com/33387139/131354937-7cff38f1-038c-4f15-87e6-2f913a4e2e0b.png)

### Testing instructions
- Set `_wcstripe_feature_upe_settings` flag to `1` and go to the `Stripe` settings page. The banner should appear beside the payment accepted on the checkout section.

### QA steps

- [ ] The old Stripe settings page does not have the banner
- [ ] Set `_wcstripe_feature_upe_settings` flag to `1`. (Returning `true` from [this function](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/24277919aa7b9029c39ecd997dd133990e7f65c7/includes/class-wc-stripe-feature-flags.php#L34) should do the work). The new Stripe settings page has the banner
- [ ] All the tests are passing