### PR TITLE
Enable SEPA IBAN field for UPE checkout

### DIFF
--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -102,6 +102,9 @@ jQuery( function ( $ ) {
 	const elements = api.getStripe().elements( {
 		fonts: getFontRulesFromPage(),
 	} );
+	const sepaElementsOptions =
+		getStripeServerData()?.sepaElementsOptions ?? {};
+	const iban = elements.create( 'iban', sepaElementsOptions );
 
 	let upeElement = null;
 	let paymentIntentId = null;
@@ -324,6 +327,13 @@ jQuery( function ( $ ) {
 		) {
 			mountUPEElement();
 		}
+
+		if (
+			$( '#stripe-iban-element' ).length &&
+			! $( '#stripe-iban-element' ).children().length
+		) {
+			iban.mount( '#stripe-iban-element' );
+		}
 	} );
 
 	if (
@@ -351,6 +361,13 @@ jQuery( function ( $ ) {
 				$( 'form#order_review' ).submit();
 			}
 			mountUPEElement( useSetUpIntent );
+		}
+
+		if (
+			$( '#stripe-iban-element' ).length &&
+			! $( '#stripe-iban-element' ).children().length
+		) {
+			iban.mount( '#stripe-iban-element' );
 		}
 	}
 

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -148,6 +148,18 @@ jQuery( function ( $ ) {
 		$form.removeClass( 'processing' ).unblock();
 	};
 
+	/**
+	 * Checks whether SEPA IBAN element is present in the DOM and needs to be mounted
+	 *
+	 * @return {boolean} Whether IBAN needs to be mounted
+	 */
+	const doesIbanNeedToBeMounted = () => {
+		return (
+			$( '#stripe-iban-element' ).length &&
+			! $( '#stripe-iban-element' ).children().length
+		);
+	};
+
 	// Show error notice at top of checkout form.
 	const showError = ( errorMessage ) => {
 		let messageWrapper = '';
@@ -328,10 +340,7 @@ jQuery( function ( $ ) {
 			mountUPEElement();
 		}
 
-		if (
-			$( '#stripe-iban-element' ).length &&
-			! $( '#stripe-iban-element' ).children().length
-		) {
+		if ( doesIbanNeedToBeMounted() ) {
 			iban.mount( '#stripe-iban-element' );
 		}
 	} );
@@ -363,10 +372,7 @@ jQuery( function ( $ ) {
 			mountUPEElement( useSetUpIntent );
 		}
 
-		if (
-			$( '#stripe-iban-element' ).length &&
-			! $( '#stripe-iban-element' ).children().length
-		) {
+		if ( doesIbanNeedToBeMounted() ) {
 			iban.mount( '#stripe-iban-element' );
 		}
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -202,6 +202,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$stripe_params['orderId'] = $order_id;
 		}
 
+		$sepa_elements_options = apply_filters(
+			'wc_stripe_sepa_elements_options',
+			[
+				'supportedCountries' => [ 'SEPA' ],
+				'placeholderCountry' => WC()->countries->get_base_country(),
+				'style'              => [ 'base' => [ 'fontSize' => '15px' ] ],
+			]
+		);
+
 		$stripe_params['isCheckout']               = is_checkout() && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
 		$stripe_params['isOrderPay']               = is_wc_endpoint_url( 'order-pay' );
 		$stripe_params['return_url']               = $this->get_stripe_return_url();
@@ -211,6 +220,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['saveUPEAppearanceNonce']   = wp_create_nonce( '_wc_stripe_save_upe_appearance_nonce' );
 		$stripe_params['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
 		$stripe_params['accountDescriptor']        = 'accountDescriptor'; // TODO: this should be added to the Stripe settings page or remove it from here.
+		$stripe_params['sepaElementsOptions']      = $sepa_elements_options;
 
 		return $stripe_params;
 	}


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1751 

This PR adds a logic to mount the SEPA IBAN field in the new checkout experience for both checkout and adding a payment method flows.

# Testing instructions
1. Ensure you have the UPE feature flag set to `yes` in the database and SEPA enabled in the store.
2. Visit http://localhost:8082/ and log in.
3. Go to `My account` > `Payment methods` > `Add payment method`.
4. You should see an IBAN field when adding a SEPA payment method.
5. Go to `Shop` and add an item to the cart.
6. Go to Checkout and select `SEPA Direct Debit`.
7. You should see an IBAN field to type in.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
