### PR TITLE
Catch Stripe API errors on create intent

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -278,6 +278,7 @@ class WC_Stripe_Intent_Controller {
 
 			wp_send_json_success( $this->create_payment_intent( $order_id ), 200 );
 		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log( 'Create payment intent error: ' . $e->getMessage() );
 			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(
 				[
@@ -293,7 +294,7 @@ class WC_Stripe_Intent_Controller {
 	 * Creates payment intent using current cart or order and store details.
 	 *
 	 * @param {int} $order_id The id of the order if intent created from Order.
-	 *
+	 * @throws Exception - If the create intent call returns with an error.
 	 * @return array
 	 */
 	public function create_payment_intent( $order_id = null ) {
@@ -314,6 +315,10 @@ class WC_Stripe_Intent_Controller {
 			],
 			'payment_intents'
 		);
+
+		if ( ! empty( $payment_intent->error ) ) {
+			throw new Exception( $payment_intent->error->message );
+		}
 
 		return [
 			'id'            => $payment_intent->id,


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1738 

This PR checks for errors when creating an intent from the Stripe API. Previously when an error was encountered it would only show itself with an error when trying to reference the id of the intent which was not set. This update checks for an error on the intent and throws an exception if there is one. There was one scenario I didn't account for here as it seemed like it might be overkill, but let me know if we want to throw another check in the case that an error is not set AND the id and client secret are not set as well. I'm not sure how that state could be reached, so felt it was overkill, but wanted to raise it in case others saw a way it could happen.


# Testing instructions

- Start with a store with this branch and UPE enabled (`_wcstripe_feature_upe` set to 'yes' in `wp_options` table) and the new checkout experience enabled from the WC Stripe settings page.
- Create a product that is under 50 cents USD.
- As customer, add this product to cart and go to checkout.
- Confirm that the error message: `Amount must be at least $0.50 usd` is displayed on the checkout page.

![UPE-50cent-error](https://user-images.githubusercontent.com/68524302/131559278-3c0abe40-5fca-44d5-9a7c-f8df8d4a6c98.png)

Another error can be checked by using store currency of USD and enabling giropay and visiting the checkout page.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
