### PR TITLE
Use customer_id from order meta for subscription renewal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 5.4.1 - 2021-xx-xx =
+* Fix - Get Subscription CustomerID from Order instead of User.
+
 = 5.4.0 - 2021-08-18 =
 * Fix - Do not ask for a Shipping Address if no Shipping Zone is defined.
 * Fix - Return HTTP 204 when webhook validation fails so Stripe won't stop sending certain webhook events after too many failed validations.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -281,16 +281,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @version 4.0.0
 	 */
 	public function get_stripe_customer_id( $order ) {
-		$customer = get_user_option( '_stripe_customer_id', $order->get_customer_id() );
+		// Try to get it via the order first.
+		$customer = $order->get_meta( '_stripe_customer_id', true );
 
 		if ( empty( $customer ) ) {
-			// Try to get it via the order.
-			return $order->get_meta( '_stripe_customer_id', true );
-		} else {
-			return $customer;
+			$customer = get_user_option( '_stripe_customer_id', $order->get_customer_id() );
 		}
 
-		return false;
+		return $customer;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -126,10 +126,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.4.0 - 2021-08-18 =
-* Fix - Do not ask for a Shipping Address if no Shipping Zone is defined.
-* Fix - Return HTTP 204 when webhook validation fails so Stripe won't stop sending certain webhook events after too many failed validations.
-* Fix - Possible use of an undefined variable `prepared_source`.
-* Add - 'wc_stripe_allowed_payment_processing_statuses' filter to customize order statuses that allow payment processing in the context of 3DS payments.
+= 5.4.1 - 2021-xx-xx =
+* Fix - Get Subscription CustomerID from Order instead of User.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: #1775
Fixes #1775

Currently, when renewing a subscription (in `prepare_order_source`) we are using the `customer_id` from the user meta, this PR changes that code to use the `customer_id` from the order, and from the user meta as a backup if not present in the order.

This is due to a bug reported in version 5.4.0:
> The get_stripe_customer_id() function it now calls first checks if the user option is set, and if not uses the subscription order meta, but it should check the subscription order meta first if the subscription has the customer ID option. Otherwise, the Customer ID option/text box/meta on the subscription is useless. Today most of my subscriptions failed, as the Customer ID has been updated on the subscriptions since the initial orders (when the old customer ID’s were stored to the user options). Now I have to go through all my subscriptions and update the corresponding customer’s ‘_stripe_customer_id’ option to match the new customer ID in the subscriptions, or manually revert this line of file back to the previous code myself. But why have this option still be in the subscription if it does nothing? I’d really prefer to keep this option in the subscription and reference to it correctly in the code.

# Testing instructions

1. Check out branch `release/5.4.0`
2. Get a subscription order
3. Update `customer_id` in the subscription (by clicking the pen icon to edit billing information) to something invalid
4. Attempt to process a renewal of the order created in (2)
5. Check that the renewal process succeeds (and it shouldn't)
6. Check out this branch 
7. Attempt to process a renewal of the order created in (2)
8. Check that this time renewal fails (the customer_id used is the new invalid one)

- Also create a new subscription to test that the normal flow works.