### PR TITLE
Fix UPE on Pay for Order page

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -174,6 +174,45 @@ export default class WCStripeAPI {
 	}
 
 	/**
+	 * Updates a payment intent with data from order: customer, level3 data and and maybe sets the payment for future use.
+	 *
+	 * @param {string} paymentIntentId The id of the payment intent.
+	 * @param {number} orderId The id of the order.
+	 * @param {string} savePaymentMethod 'yes' if saving.
+	 * @param {string} selectedUPEPaymentType The name of the selected UPE payment type or empty string.
+	 *
+	 * @return {Promise} The final promise for the request to the server.
+	 */
+	updateIntent(
+		paymentIntentId,
+		orderId,
+		savePaymentMethod,
+		selectedUPEPaymentType
+	) {
+		return this.request( getAjaxUrl( 'update_payment_intent' ), {
+			wc_stripe_order_id: orderId,
+			wc_payment_intent_id: paymentIntentId,
+			save_payment_method: savePaymentMethod,
+			wc_stripe_selected_upe_payment_type: selectedUPEPaymentType,
+			_ajax_nonce: getStripeServerData()?.updatePaymentIntentNonce,
+		} )
+			.then( ( response ) => {
+				if ( response.result === 'failure' ) {
+					throw new Error( response.messages );
+				}
+				return response;
+			} )
+			.catch( ( error ) => {
+				if ( error.message ) {
+					throw error;
+				} else {
+					// Covers the case of error on the Ajaxrequest.
+					throw new Error( error.statusText );
+				}
+			} );
+	}
+
+	/**
 	 * Extracts the details about a payment intent from the redirect URL,
 	 * and displays the intent confirmation modal (if needed).
 	 *

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -190,10 +190,10 @@ export default class WCStripeAPI {
 		selectedUPEPaymentType
 	) {
 		return this.request( getAjaxUrl( 'update_payment_intent' ), {
-			wc_stripe_order_id: orderId,
+			stripe_order_id: orderId,
 			wc_payment_intent_id: paymentIntentId,
 			save_payment_method: savePaymentMethod,
-			wc_stripe_selected_upe_payment_type: selectedUPEPaymentType,
+			selected_upe_payment_type: selectedUPEPaymentType,
 			_ajax_nonce: getStripeServerData()?.updatePaymentIntentNonce,
 		} )
 			.then( ( response ) => {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -264,8 +264,6 @@ class WC_Stripe_Intent_Controller {
 
 	/**
 	 * Handle AJAX request for creating a payment intent for Stripe UPE.
-	 *
-	 * @throws Exception - If nonce or setup intent is invalid.
 	 */
 	public function create_payment_intent_ajax() {
 		try {
@@ -331,8 +329,6 @@ class WC_Stripe_Intent_Controller {
 	 * Handle AJAX request for updating a payment intent for Stripe UPE.
 	 *
 	 * @since x.x.x
-	 *
-	 * @throws Exception - If nonce or setup intent is invalid.
 	 */
 	public function update_payment_intent_ajax() {
 		try {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -269,7 +269,7 @@ class WC_Stripe_Intent_Controller {
 	 */
 	public function create_payment_intent_ajax() {
 		try {
-			$is_nonce_valid = check_ajax_referer( '_wc_stripe_nonce', false, false );
+			$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_payment_intent_nonce', false, false );
 			if ( ! $is_nonce_valid ) {
 				throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
 			}
@@ -425,7 +425,7 @@ class WC_Stripe_Intent_Controller {
 	 */
 	public function save_upe_appearance_ajax() {
 		try {
-			$is_nonce_valid = check_ajax_referer( '_wc_stripe_save_upe_appearance_nonce', false, false );
+			$is_nonce_valid = check_ajax_referer( 'wc_stripe_save_upe_appearance_nonce', false, false );
 			if ( ! $is_nonce_valid ) {
 				throw new Exception(
 					__( 'Unable to update UPE appearance values at this time.', 'woocommerce-gateway-stripe' )

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -341,10 +341,10 @@ class WC_Stripe_Intent_Controller {
 				throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
 			}
 
-			$order_id                  = isset( $_POST['wc_stripe_order_id'] ) ? absint( $_POST['wc_stripe_order_id'] ) : null;
+			$order_id                  = isset( $_POST['stripe_order_id'] ) ? absint( $_POST['stripe_order_id'] ) : null;
 			$payment_intent_id         = isset( $_POST['wc_payment_intent_id'] ) ? wc_clean( wp_unslash( $_POST['wc_payment_intent_id'] ) ) : '';
 			$save_payment_method       = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
-			$selected_upe_payment_type = ! empty( $_POST['wc_stripe_selected_upe_payment_type'] ) ? wc_clean( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ) ) : '';
+			$selected_upe_payment_type = ! empty( $_POST['selected_upe_payment_type'] ) ? wc_clean( wp_unslash( $_POST['selected_upe_payment_type'] ) ) : '';
 
 			wp_send_json_success( $this->update_payment_intent( $payment_intent_id, $order_id, $save_payment_method, $selected_upe_payment_type ), 200 );
 		} catch ( Exception $e ) {

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -395,7 +395,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$is_nonce_valid = check_admin_referer( 'wcpay_process_redirect_order_nonce' );
+		$is_nonce_valid = check_admin_referer( 'wc_stripe_process_redirect_order_nonce' );
 		if ( ! $is_nonce_valid || empty( $_GET['wc_payment_method'] ) ) {
 			return;
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -208,10 +208,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['isCheckout']               = is_checkout() && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
 		$stripe_params['return_url']               = $this->get_stripe_return_url();
 		$stripe_params['ajax_url']                 = WC_AJAX::get_endpoint( '%%endpoint%%' );
-		$stripe_params['createPaymentIntentNonce'] = wp_create_nonce( '_wc_stripe_nonce' );
+		$stripe_params['createPaymentIntentNonce'] = wp_create_nonce( 'wc_stripe_create_payment_intent_nonce' );
 		$stripe_params['updatePaymentIntentNonce'] = wp_create_nonce( 'wc_stripe_update_payment_intent_nonce' );
 		$stripe_params['upeAppeareance']           = get_transient( self::UPE_APPEARANCE_TRANSIENT );
-		$stripe_params['saveUPEAppearanceNonce']   = wp_create_nonce( '_wc_stripe_save_upe_appearance_nonce' );
+		$stripe_params['saveUPEAppearanceNonce']   = wp_create_nonce( 'wc_stripe_save_upe_appearance_nonce' );
 		$stripe_params['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
 		$stripe_params['accountDescriptor']        = 'accountDescriptor'; // TODO: this should be added to the Stripe settings page or remove it from here.
 		$stripe_params['sepaElementsOptions']      = $sepa_elements_options;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -554,6 +554,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 		$payment_method_title = $this->payment_methods[ $payment_method_type ]->get_title( $payment_method_details );
 
+		$order->set_payment_method( self::ID );
 		$order->set_payment_method_title( $payment_method_title );
 		$order->save();
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -671,7 +671,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @return array Array of keyed metadata values.
 	 */
-	private function get_metadata_from_order( $order ) {
+	public function get_metadata_from_order( $order ) {
 
 		// TODO: change this after adding the subscriptions trait: $this->is_payment_recurring( $order->get_id() ) ? Payment_Type::RECURRING() : Payment_Type::SINGLE();
 		$payment_type = 'single';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -196,12 +196,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			'locale'       => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
 		];
 
-		// If we're on the pay page we need to pass stripe.js the address of the order.
-		if ( isset( $_GET['pay_for_order'] ) && 'true' === $_GET['pay_for_order'] ) { // wpcs: csrf ok.
-			$order_id                 = wc_clean( $wp->query_vars['order-pay'] ); // wpcs: csrf ok, sanitization ok, xss ok.
-			$stripe_params['orderId'] = $order_id;
-		}
-
 		$sepa_elements_options = apply_filters(
 			'wc_stripe_sepa_elements_options',
 			[
@@ -212,15 +206,35 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		);
 
 		$stripe_params['isCheckout']               = is_checkout() && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
-		$stripe_params['isOrderPay']               = is_wc_endpoint_url( 'order-pay' );
 		$stripe_params['return_url']               = $this->get_stripe_return_url();
 		$stripe_params['ajax_url']                 = WC_AJAX::get_endpoint( '%%endpoint%%' );
 		$stripe_params['createPaymentIntentNonce'] = wp_create_nonce( '_wc_stripe_nonce' );
+		$stripe_params['updatePaymentIntentNonce'] = wp_create_nonce( 'wc_stripe_update_payment_intent_nonce' );
 		$stripe_params['upeAppeareance']           = get_transient( self::UPE_APPEARANCE_TRANSIENT );
 		$stripe_params['saveUPEAppearanceNonce']   = wp_create_nonce( '_wc_stripe_save_upe_appearance_nonce' );
 		$stripe_params['paymentMethodsConfig']     = $this->get_enabled_payment_method_config();
 		$stripe_params['accountDescriptor']        = 'accountDescriptor'; // TODO: this should be added to the Stripe settings page or remove it from here.
 		$stripe_params['sepaElementsOptions']      = $sepa_elements_options;
+
+		if ( is_wc_endpoint_url( 'order-pay' ) ) {
+			$order_id                    = absint( get_query_var( 'order-pay' ) );
+			$stripe_params['orderId']    = $order_id;
+			$stripe_params['isOrderPay'] = true;
+			$order                       = wc_get_order( $order_id );
+
+			if ( is_a( $order, 'WC_Order' ) ) {
+				$stripe_params['orderReturnURL'] = esc_url_raw(
+					add_query_arg(
+						[
+							'order_id'          => $order_id,
+							'wc_payment_method' => self::ID,
+							'_wpnonce'          => wp_create_nonce( 'wc_stripe_process_redirect_order_nonce' ),
+						],
+						$this->get_return_url( $order )
+					)
+				);
+			}
+		}
 
 		return $stripe_params;
 	}
@@ -397,7 +411,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 						[
 							'order_id'            => $order_id,
 							'wc_payment_method'   => self::ID,
-							'_wpnonce'            => wp_create_nonce( 'wcpay_process_redirect_order_nonce' ),
+							'_wpnonce'            => wp_create_nonce( 'wc_stripe_process_redirect_order_nonce' ),
 							'save_payment_method' => $save_payment_method ? 'yes' : 'no',
 						],
 						$this->get_return_url( $order )


### PR DESCRIPTION
Fixes #1669 

This PR is a port and adaptation of the changes from WCPay (2274-gh-Automattic/woocommerce-payments)

# Changes proposed in this Pull Request:

* Add an endpoint to update the intent before confirming, so we add metadata, customer and level3 data.
* Once the payment is confirmed and the order updated with `process_upe_redirect_payment`, the user is redirected to the order received page.

# Testing instructions

1. With UPE enabled, create an order from **WooCommerce > Orders > New Order**, or change an existing order to "Pending Payment". Click "Create/Update".
2. Click on "Customer payment page" and you should see the UPE form.
3. The credit card payment should work as expected with UPE enabled.

Saving a payment method still doesn't work. Support for it should be added via #1730 or a subsequent issue.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.