### PR TITLE
Fix fatal with PHP 8 when enabling UPE

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -64,7 +64,13 @@ abstract class WC_Stripe_UPE_Payment_Method {
 	 */
 	public function __construct( $token_service ) {
 		$main_settings       = get_option( 'woocommerce_stripe_settings' );
-		$enabled_upe_methods = $main_settings['upe_checkout_experience_accepted_payments'];
+
+		if ( isset( $main_settings['upe_checkout_experience_accepted_payments'] ) ) {
+			$enabled_upe_methods = $main_settings['upe_checkout_experience_accepted_payments'];
+		} else {
+			$enabled_upe_methods = [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID ];
+		}
+
 		$this->enabled       = in_array( static::STRIPE_ID, $enabled_upe_methods, true );
 		// $this->token_service = $token_service;
 	}


### PR DESCRIPTION
When enabling the UPE checkout on the setting page it will throw a fatal in PHP 8.
```
 Fatal error: Uncaught Error: in_array(): Argument #2 ($haystack) must be of type array, null given
in /home/dave/extendables/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 68

Call stack:

in_array()
/home/dave/extendables/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php:68
WC_Stripe_UPE_Payment_Method::__construct()
/home/dave/extendables/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php:25
WC_Stripe_UPE_Payment_Method_CC::__construct()
/home/dave/extendables/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php:86
WC_Stripe_UPE_Payment_Gateway::__construct()
/home/dave/extendables/woocommerce-gateway-stripe/woocommerce-gateway-stripe.php:500
WC_Stripe::disable_upe()
```
This is because the setting key 'upe_checkout_experience_accepted_payments' is null and it is not initialized because we are accessing the option directly here.
 
# Testing instructions

Delete the option `woocommerce_stripe_settings` so it starts with nothing. Turn on the UPE feature flag. Try to enable UPE in settings. It should work with no warnings. 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
