### PR TITLE
Add support for manually capturing charges in UPE

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -79,8 +79,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * Constructor
 	 */
 	public function __construct() {
-		$this->id             = self::ID;
-		$this->method_title   = __( 'Stripe', 'woocommerce-gateway-stripe' );
+		$this->id           = self::ID;
+		$this->method_title = __( 'Stripe', 'woocommerce-gateway-stripe' );
 		/* translators: 1) link to Stripe register page 2) link to Stripe api keys page */
 		$this->method_description = __( 'Stripe works by adding payment fields on the checkout and then sending the details to Stripe for verification.', 'woocommerce-gateway-stripe' );
 		$this->has_fields         = true;

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -308,7 +308,7 @@ class WC_Stripe_Intent_Controller {
 		$enabled_payment_methods = $gateway->get_upe_enabled_at_checkout_payment_method_ids();
 
 		$currency       = get_woocommerce_currency();
-		$capture        = ! empty( $gateway->get_option( 'capture' ) ) && $gateway->get_option( 'capture' ) === 'yes';
+		$capture        = empty( $gateway->get_option( 'capture' ) ) || $gateway->get_option( 'capture' ) === 'yes';
 		$payment_intent = WC_Stripe_API::request(
 			[
 				'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -295,10 +295,8 @@ class WC_Stripe_Intent_Controller {
 	 * @return array
 	 */
 	public function create_payment_intent( $order_id = null ) {
-		$settings = get_option( 'woocommerce_stripe_settings', [] );
-		$capture  = ! empty( $settings['capture'] ) && 'yes' === $settings['capture'];
-		$amount   = WC()->cart->get_total( false );
-		$order    = wc_get_order( $order_id );
+		$amount = WC()->cart->get_total( false );
+		$order  = wc_get_order( $order_id );
 		if ( is_a( $order, 'WC_Order' ) ) {
 			$amount = $order->get_total();
 		}
@@ -310,6 +308,7 @@ class WC_Stripe_Intent_Controller {
 		$enabled_payment_methods = $gateway->get_upe_enabled_at_checkout_payment_method_ids();
 
 		$currency       = get_woocommerce_currency();
+		$capture        = ! empty( $gateway->get_option( 'capture' ) ) && $gateway->get_option( 'capture' ) === 'yes';
 		$payment_intent = WC_Stripe_API::request(
 			[
 				'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -295,8 +295,10 @@ class WC_Stripe_Intent_Controller {
 	 * @return array
 	 */
 	public function create_payment_intent( $order_id = null ) {
-		$amount = WC()->cart->get_total( false );
-		$order  = wc_get_order( $order_id );
+		$settings = get_option( 'woocommerce_stripe_settings', [] );
+		$capture  = ! empty( $settings['capture'] ) && 'yes' === $settings['capture'];
+		$amount   = WC()->cart->get_total( false );
+		$order    = wc_get_order( $order_id );
 		if ( is_a( $order, 'WC_Order' ) ) {
 			$amount = $order->get_total();
 		}
@@ -313,6 +315,7 @@ class WC_Stripe_Intent_Controller {
 				'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
 				'currency'             => strtolower( $currency ),
 				'payment_method_types' => $enabled_payment_methods,
+				'capture_method'       => $capture ? 'automatic' : 'manual',
 			],
 			'payment_intents'
 		);

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -67,8 +67,8 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 	 * Constructor
 	 */
 	public function __construct() {
-		$this->id             = 'stripe_sepa';
-		$this->method_title   = __( 'Stripe SEPA Direct Debit', 'woocommerce-gateway-stripe' );
+		$this->id           = 'stripe_sepa';
+		$this->method_title = __( 'Stripe SEPA Direct Debit', 'woocommerce-gateway-stripe' );
 		/* translators: link */
 		$this->method_description = sprintf( __( 'All other general Stripe settings can be adjusted <a href="%s">here</a>.', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' ) );
 		$this->has_fields         = true;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -284,12 +284,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return string[]
 	 */
 	public function get_upe_enabled_payment_method_ids() {
-		return $this->get_option(
-			'upe_checkout_experience_accepted_payments',
-			[
-				'card',
-			]
-		);
+		$capture = ! empty( $this->get_option( 'capture' ) ) && $this->get_option( 'capture' ) === 'yes';
+		if ( ! $capture ) {
+			return ['card'];
+		}
+		return $this->get_option( 'upe_checkout_experience_accepted_payments', [ 'card' ] );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -286,7 +286,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	public function get_upe_enabled_payment_method_ids() {
 		$capture = ! empty( $this->get_option( 'capture' ) ) && $this->get_option( 'capture' ) === 'yes';
 		if ( ! $capture ) {
-			return ['card'];
+			return [ 'card' ];
 		}
 		return $this->get_option( 'upe_checkout_experience_accepted_payments', [ 'card' ] );
 	}

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -11,7 +11,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @var WC_Stripe_Intent_Controller
 	 */
-	private $mockController;
+	private $mock_controller;
 
 	/**
 	 * Gateway
@@ -38,11 +38,11 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->setMethods( [ 'maybe_process_upe_redirect' ] )
 			->getMock();
-		$this->mockController = $this->getMockBuilder( 'WC_Stripe_Intent_Controller' )
+		$this->mock_controller = $this->getMockBuilder( 'WC_Stripe_Intent_Controller' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'get_gateway' ] )
 			->getMock();
-		$this->mockController->expects( $this->any() )
+		$this->mock_controller->expects( $this->any() )
 			->method( 'get_gateway' )
 			->willReturn( $this->gateway );
 	}
@@ -66,7 +66,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-		$this->mockController->create_payment_intent( $this->order->get_id() );
+		$this->mock_controller->create_payment_intent( $this->order->get_id() );
 	}
 
 	public function test_manual_capture_from_the_settings() {
@@ -89,7 +89,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-		$this->mockController->create_payment_intent( $this->order->get_id() );
+		$this->mock_controller->create_payment_intent( $this->order->get_id() );
 	}
 
 	public function test_automatic_capture_from_the_settings() {
@@ -112,6 +112,6 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-		$this->mockController->create_payment_intent( $this->order->get_id() );
+		$this->mock_controller->create_payment_intent( $this->order->get_id() );
 	}
 }

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * These tests make assertions against class WC_Stripe_Intent_Controller
+ *
+ */
+
+
+class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
+	/**
+	 * Mocked controller under test.
+	 *
+	 * @var WC_Stripe_Intent_Controller
+	 */
+	private $mockController;
+
+	/**
+	 * Gateway
+	 *
+	 * @var WC_Stripe_UPE_Payment_Gateway
+	 */
+	private $gateway;
+
+	/**
+	 * Order
+	 *
+	 * @var WC_Order
+	 */
+	private $order;
+
+	/**
+	 * Sets up things all tests need.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->order          = WC_Helper_Order::create_order();
+		$this->gateway        = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'maybe_process_upe_redirect' ] )
+			->getMock();
+		$this->mockController = $this->getMockBuilder( 'WC_Stripe_Intent_Controller' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_gateway' ] )
+			->getMock();
+		$this->mockController->expects( $this->any() )
+			->method( 'get_gateway' )
+			->willReturn( $this->gateway );
+	}
+
+	public function test_wether_default_capture_method_is_set_in_the_intent() {
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			$this->assertArrayHasKey( 'capture_method', $parsed_args['body'] );
+			$this->assertEquals( 'automatic', $parsed_args['body']['capture_method'] );
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id'            => 1,
+						'client_secret' => '123',
+					]
+				),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mockController->create_payment_intent( $this->order->get_id() );
+	}
+
+	public function test_manual_capture_from_the_settings() {
+		$this->gateway->update_option( 'capture', 'no' );
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			$this->assertArrayHasKey( 'capture_method', $parsed_args['body'] );
+			$this->assertEquals( 'manual', $parsed_args['body']['capture_method'] );
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id'            => 1,
+						'client_secret' => '123',
+					]
+				),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mockController->create_payment_intent( $this->order->get_id() );
+	}
+
+	public function test_automatic_capture_from_the_settings() {
+		$this->gateway->update_option( 'capture', 'yes' );
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			$this->assertArrayHasKey( 'capture_method', $parsed_args['body'] );
+			$this->assertEquals( 'automatic', $parsed_args['body']['capture_method'] );
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id'            => 1,
+						'client_secret' => '123',
+					]
+				),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mockController->create_payment_intent( $this->order->get_id() );
+	}
+}

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -33,8 +33,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->order          = WC_Helper_Order::create_order();
-		$this->gateway        = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
+		$this->order           = WC_Helper_Order::create_order();
+		$this->gateway         = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
 			->disableOriginalConstructor()
 			->setMethods( [ 'maybe_process_upe_redirect' ] )
 			->getMock();
@@ -70,8 +70,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_manual_capture_from_the_settings() {
-		$this->gateway->update_option( 'capture', 'no' );
-		$test_request = function ( $preempt, $parsed_args, $url ) {
+		$this->gateway->settings['capture'] = 'no';
+		$test_request                       = function ( $preempt, $parsed_args, $url ) {
 			$this->assertArrayHasKey( 'capture_method', $parsed_args['body'] );
 			$this->assertEquals( 'manual', $parsed_args['body']['capture_method'] );
 
@@ -93,8 +93,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function test_automatic_capture_from_the_settings() {
-		$this->gateway->update_option( 'capture', 'yes' );
-		$test_request = function ( $preempt, $parsed_args, $url ) {
+		$this->gateway->settings['capture'] = 'yes';
+		$test_request                       = function ( $preempt, $parsed_args, $url ) {
 			$this->assertArrayHasKey( 'capture_method', $parsed_args['body'] );
 			$this->assertEquals( 'automatic', $parsed_args['body']['capture_method'] );
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:
Resolves #1786 

This PR adds support for manually capturing charges in UPE checkout. The capture flag was being ignored (always set to `yes`) and not respecting the configuration that is saved in the settings about whether it should be automatic or manual.

# Testing instructions

Assuming you have the store up and running in test mode:

1. Ensure you have `_wcstripe_feature_upe` set to `yes` in `wp_options` table.
2. Visit the store and log in as admin.
3. In the [Stripe settings page](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe), uncheck `Capture charge immediately` option and save.
4. Go to the store > `Shop` and add a product to the cart.
5. Go to checkout and pay using a test card (e.g. `4242 4242 4242 4242`).
6. Back to the WP Admin, go to `WooCommerce` > `Orders` > the order you just created.
7. The order should have status `On hold` and a similar note:

<img src="https://user-images.githubusercontent.com/10233985/132069853-af033dc1-8c98-4f3c-8d38-387ca7d81beb.png" alt="screenshot" width="300" />

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
