### PR TITLE
Feature: Add customization options notice

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
 			'@wordpress/i18n',
 			'@wordpress/is-shallow-equal',
 			'@wordpress/element',
+			'@wordpress/data',
 		],
 	},
 };

--- a/client/components/inline-notice/index.js
+++ b/client/components/inline-notice/index.js
@@ -12,7 +12,7 @@ import './style.scss';
 
 const InlineNotice = ( { className, ...restProps } ) => (
 	<Notice
-		className={ classNames( 'wcpay-inline-notice', className ) }
+		className={ classNames( 'wcstripe-inline-notice', className ) }
 		{ ...restProps }
 	/>
 );

--- a/client/components/inline-notice/style.scss
+++ b/client/components/inline-notice/style.scss
@@ -1,6 +1,6 @@
 @import "../../styles/abstracts/styles.scss";
 
-.wcpay-inline-notice {
+.wcstripe-inline-notice {
 	// increasing the specificity of the styles to override the Gutenberg ones
 	&#{&} {
 		margin: 0;
@@ -9,5 +9,9 @@
 
 	&.is-info {
 		background: #def1f7;
+	}
+
+	&.components-notice.is-dismissible {
+		padding-right: 12px;
 	}
 }

--- a/client/settings/customization-option-notice/__tests__/customization-options-notice.test.js
+++ b/client/settings/customization-option-notice/__tests__/customization-options-notice.test.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import CustomizationOptionNotice from '..';
+import UpeToggleContext from '../../upe-toggle/context';
+
+jest.mock( '@wordpress/data' );
+
+jest.mock( '@wordpress/a11y', () => ( {
+	...jest.requireActual( '@wordpress/a11y' ),
+	speak: jest.fn(),
+} ) );
+
+describe( 'CustomizationOptionNotice', () => {
+	beforeEach( () => {
+		useDispatch.mockImplementation( () => ( {
+			updateOptions: jest.fn(),
+		} ) );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should render the notice when UPE and `wc_show_upe_customization_options_notice` is enabled', () => {
+		const selectMock = jest.fn( () => {
+			return {
+				getOption: () => {
+					return 'yes';
+				},
+				hasFinishedResolution: () => {
+					return true;
+				},
+			};
+		} );
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( selectMock );
+		} );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<CustomizationOptionNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByText( 'Where are customization options?' )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(
+				'In the new checkout experience, payment method details are automatically displayed in your customers’ languages so you don’t have to worry about writing them manually.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render the notice when UPE is disabled but `wc_show_upe_customization_options_notice` is enabled', () => {
+		const selectMock = jest.fn( () => {
+			return {
+				getOption: () => {
+					return 'yes';
+				},
+				hasFinishedResolution: () => {
+					return true;
+				},
+			};
+		} );
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( selectMock );
+		} );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<CustomizationOptionNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByText( 'Where are customization options?' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render the notice when UPE is enabled but `wc_show_upe_customization_options_notice` is disabled', () => {
+		const selectMock = jest.fn( () => {
+			return {
+				getOption: () => {
+					return 'no';
+				},
+				hasFinishedResolution: () => {
+					return true;
+				},
+			};
+		} );
+		useSelect.mockImplementation( ( callback ) => {
+			return callback( selectMock );
+		} );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<CustomizationOptionNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByText( 'Where are customization options?' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/client/settings/customization-option-notice/__tests__/customization-options-notice.test.js
+++ b/client/settings/customization-option-notice/__tests__/customization-options-notice.test.js
@@ -51,7 +51,7 @@ describe( 'CustomizationOptionNotice', () => {
 		);
 
 		expect(
-			screen.queryByText( 'Where are customization options?' )
+			screen.queryByText( 'Where are the customization options?' )
 		).toBeInTheDocument();
 		expect(
 			screen.queryByText(
@@ -82,7 +82,7 @@ describe( 'CustomizationOptionNotice', () => {
 		);
 
 		expect(
-			screen.queryByText( 'Where are customization options?' )
+			screen.queryByText( 'Where are the customization options?' )
 		).not.toBeInTheDocument();
 	} );
 
@@ -108,7 +108,7 @@ describe( 'CustomizationOptionNotice', () => {
 		);
 
 		expect(
-			screen.queryByText( 'Where are customization options?' )
+			screen.queryByText( 'Where are the customization options?' )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/client/settings/customization-option-notice/index.js
+++ b/client/settings/customization-option-notice/index.js
@@ -4,7 +4,6 @@
 import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import { __ } from '@wordpress/i18n';
-import { Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import interpolateComponents from 'interpolate-components';
@@ -12,16 +11,15 @@ import interpolateComponents from 'interpolate-components';
 /**
  * Internal dependencies
  */
+import InlineNotice from '../../components/inline-notice';
 import UpeToggleContext from '../upe-toggle/context';
 
-const NoticeWrapper = styled( Notice )`
-	background: #def1f7;
-	border-left: 4px solid #00aadc;
-	margin: 16px 0px;
-	padding-right: 12px;
+const NoticeWrapper = styled( InlineNotice )`
+	padding: 16px 24px;
 
-	&.is-dismissible {
-		padding-right: 12px;
+	&.wcstripe-inline-notice {
+		border-left: 4px solid #00aadc;
+		margin-bottom: 0;
 	}
 `;
 
@@ -62,7 +60,7 @@ const CustomizationOptionNotice = () => {
 		<NoticeWrapper isDismissible={ true } onRemove={ handleDismissNotice }>
 			{ interpolateComponents( {
 				mixedString: __(
-					'{{strong}}Where are customization options?{{/strong}} In the new checkout experience, payment method details are automatically displayed in your customers’ languages so you don’t have to worry about writing them manually.',
+					'{{strong}}Where are the customization options?{{/strong}} In the new checkout experience, payment method details are automatically displayed in your customers’ languages so you don’t have to worry about writing them manually.',
 					'woocommerce-gateway-stripe'
 				),
 				components: {

--- a/client/settings/customization-option-notice/index.js
+++ b/client/settings/customization-option-notice/index.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React, { useContext } from 'react';
+import styled from '@emotion/styled';
+import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * Internal dependencies
+ */
+import UpeToggleContext from '../upe-toggle/context';
+
+const NoticeWrapper = styled( Notice )`
+	background: #def1f7;
+	border-left: 4px solid #00aadc;
+	margin: 16px 0px;
+	padding-right: 12px;
+
+	&.is-dismissible {
+		padding-right: 12px;
+	}
+`;
+
+const CUSTOMIZATION_OPTIONS_NOTICE_OPTION =
+	'wc_show_upe_customization_options_notice';
+
+const CustomizationOptionNotice = () => {
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
+	const isCustomizationOptionsNoticeVisible = useSelect( ( select ) => {
+		const { getOption, hasFinishedResolution } = select(
+			'wc/admin/options'
+		);
+
+		const hasFinishedResolving = hasFinishedResolution( 'getOption', [
+			CUSTOMIZATION_OPTIONS_NOTICE_OPTION,
+		] );
+
+		const isOptionDismissed =
+			getOption( CUSTOMIZATION_OPTIONS_NOTICE_OPTION ) === 'no';
+
+		return hasFinishedResolving && ! isOptionDismissed;
+	} );
+
+	const { updateOptions } = useDispatch( 'wc/admin/options' );
+
+	const handleDismissNotice = useCallback( () => {
+		updateOptions( {
+			[ CUSTOMIZATION_OPTIONS_NOTICE_OPTION ]: 'no',
+		} );
+	}, [ updateOptions ] );
+
+	if ( ! isUpeEnabled || ! isCustomizationOptionsNoticeVisible ) {
+		return null;
+	}
+
+	return (
+		<NoticeWrapper isDismissible={ true } onRemove={ handleDismissNotice }>
+			{ interpolateComponents( {
+				mixedString: __(
+					'{{strong}}Where are customization options?{{/strong}} In the new checkout experience, payment method details are automatically displayed in your customers’ languages so you don’t have to worry about writing them manually.',
+					'woocommerce-gateway-stripe'
+				),
+				components: {
+					strong: <b />,
+				},
+			} ) }
+		</NoticeWrapper>
+	);
+};
+
+export default CustomizationOptionNotice;

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -15,6 +15,7 @@ import GeneralSettingsSection from '../general-settings-section';
 import ApplePayIcon from '../../payment-method-icons/apple-pay';
 import GooglePayIcon from '../../payment-method-icons/google-pay';
 import UpeToggleContext from '../upe-toggle/context';
+import CustomizationOptionNotice from '../customization-option-notice';
 
 const IconsWrapper = styled.ul`
 	li {
@@ -77,6 +78,7 @@ const PaymentMethodsPanel = () => {
 		<>
 			<SettingsSection Description={ PaymentMethodsDescription }>
 				<GeneralSettingsSection />
+				<CustomizationOptionNotice />
 			</SettingsSection>
 			<SettingsSection Description={ PaymentRequestDescription }>
 				<PaymentRequestSection />

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -12,6 +12,7 @@ import SettingsSection from '../settings-section';
 import CardBody from '../card-body';
 import PaymentsAndTransactionsSection from '../payments-and-transactions-section';
 import AdvancedSettingsSection from '../advanced-settings-section';
+import CustomizationOptionNotice from '../customization-option-notice';
 
 const GeneralSettingsDescription = () => (
 	<>
@@ -81,6 +82,7 @@ const PaymentSettingsPanel = () => {
 		<>
 			<SettingsSection Description={ GeneralSettingsDescription }>
 				<GeneralSettingsSection />
+				<CustomizationOptionNotice />
 			</SettingsSection>
 			<SettingsSection Description={ AccountDetailsDescription }>
 				<AccountDetailsSection />

--- a/client/settings/settings-manager/__tests__/index.test.js
+++ b/client/settings/settings-manager/__tests__/index.test.js
@@ -13,6 +13,14 @@ jest.mock( '@woocommerce/navigation', () => ( {
 	getQuery: jest.fn().mockReturnValue( {} ),
 } ) );
 
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn().mockReturnValue( {} ),
+	useDispatch: jest.fn().mockReturnValue( {} ),
+	combineReducers: jest.fn().mockReturnValue( {} ),
+	createReduxStore: jest.fn().mockReturnValue( {} ),
+	register: jest.fn().mockReturnValue( {} ),
+} ) );
+
 describe( 'SettingsManager', () => {
 	afterEach( () => {
 		jest.clearAllMocks();


### PR DESCRIPTION
Fixes #1719

### Description
Added a notice component for showing the customization options. Notice is dismissable and appears only when UPE is enabled in the main Stripe settings page.

Desktop view in `Payment Methods` tab inside the main Stripe settings page
![payment tab](https://user-images.githubusercontent.com/33387139/132300029-141519b3-c56e-4990-8277-2bb53f532a9e.png)

Desktop view in `Settings` tab inside the main Stripe settings page
![settings tab](https://user-images.githubusercontent.com/33387139/132300049-e7eb5648-a6ba-4573-b53b-4d1059123480.png)

Mobile view inside the main Stripe settings page
![mobile view customization options](https://user-images.githubusercontent.com/33387139/132300088-f31bdc09-fe1b-4321-8845-093d206b0a9f.png)

### Testing instructions

- Enable UPE checkout ([this](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/24277919aa7b9029c39ecd997dd133990e7f65c7/includes/class-wc-stripe-feature-flags.php#L24) function should return `true`) to make the notice visible
- Toggle the value of `wc_show_upe_customization_options_notice` in `wp_options` to manage the visibility of the notice from DB level.

### QA steps

- [ ] Notice is present when UPE checkout is enabled
- [ ] Notice is absent when UPE checkout is disabled
- [ ] Clicking the `close`/`cross` icon removes the notice
- [ ] Notice does not reappear on refresh once it has been dismissed