### PR TITLE
feat: payments accepted section

### DIFF
--- a/client/components/confirmation-modal/index.js
+++ b/client/components/confirmation-modal/index.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { Modal } from '@wordpress/components';
+import classNames from 'classnames';
+import { HorizontalRule } from '@wordpress/primitives';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const ConfirmationModal = ( { children, actions, className, ...props } ) => (
+	<Modal
+		className={ classNames( 'wcstripe-confirmation-modal', className ) }
+		{ ...props }
+	>
+		{ children }
+		<HorizontalRule className="wcstripe-confirmation-modal__separator" />
+		<div className="wcstripe-confirmation-modal__footer">{ actions }</div>
+	</Modal>
+);
+
+export default ConfirmationModal;

--- a/client/components/confirmation-modal/style.scss
+++ b/client/components/confirmation-modal/style.scss
@@ -1,0 +1,34 @@
+@import "../../styles/abstracts/styles.scss";
+
+.wcstripe-confirmation-modal {
+	// increasing the specificity of the styles, to ensure it is honored
+	&#{&} {
+		max-width: 600px;
+		min-width: 400px;
+	}
+
+	// to ensure that the separator extends all the way, even with different versions of Gutenberg
+	.components-modal__content {
+		padding: 0 $grid-unit-30 $grid-unit-30;
+	}
+
+	.components-modal__header {
+		margin: 0 -#{$grid-unit-30} $grid-unit-30;
+		padding: 0 $grid-unit-30;
+	}
+
+	&__separator {
+		margin: $grid-unit-30 -#{$grid-unit-30};
+	}
+
+	&__footer {
+		display: flex;
+		justify-content: flex-end;
+
+		> * {
+			&:not( :first-child ) {
+				margin-left: $grid-unit-20;
+			}
+		}
+	}
+}

--- a/client/components/payment-method-fees-pill/index.js
+++ b/client/components/payment-method-fees-pill/index.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Pill from '../pill';
+
+// eslint-disable-next-line no-unused-vars
+const PaymentMethodFeesPill = ( { id, ...restProps } ) => {
+	// get the fees based off on the payment method's id
+	// this is obviously hardcoded for testing purposes, since we don't have the fees yet
+	const fees = '3.9% + $0.30';
+
+	return (
+		<Pill
+			{ ...restProps }
+			aria-label={ sprintf(
+				/* translators: %s: Transaction fee text. */
+				__( 'Base transaction fees: %s', 'woocommerce-gateway-stripe' ),
+				fees
+			) }
+		>
+			<span>{ fees }</span>
+		</Pill>
+	);
+};
+
+export default PaymentMethodFeesPill;

--- a/client/components/pill/index.js
+++ b/client/components/pill/index.js
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import styled from '@emotion/styled';
 
-const PillWrapper = styled.span`
+const Pill = styled.span`
 	border: 1px solid #757575;
 	border-radius: 28px;
 	color: #757575;
@@ -15,7 +14,5 @@ const PillWrapper = styled.span`
 	padding: 2px 8px;
 	width: fit-content;
 `;
-
-const Pill = ( { ...restProps } ) => <PillWrapper { ...restProps } />;
 
 export default Pill;

--- a/client/settings/general-settings-section/__tests__/disable-upe-confirmation-modal.test.js
+++ b/client/settings/general-settings-section/__tests__/disable-upe-confirmation-modal.test.js
@@ -1,0 +1,107 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useDispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import DisableUpeConfirmationModal from '../disable-upe-confirmation-modal';
+import UpeToggleContext from '../../upe-toggle/context';
+import {
+	useEnabledPaymentMethods,
+	useGetAvailablePaymentMethods,
+} from '../data-mock';
+
+jest.mock( '../data-mock', () => ( {
+	useGetAvailablePaymentMethods: jest.fn(),
+	useEnabledPaymentMethods: jest.fn(),
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+	combineReducers: jest.fn(),
+} ) );
+
+describe( 'DisableUpeConfirmationModal', () => {
+	beforeEach( () => {
+		useGetAvailablePaymentMethods.mockReturnValue( [ 'card', 'giropay' ] );
+		useEnabledPaymentMethods.mockReturnValue( [ [ 'card' ], jest.fn() ] );
+		useDispatch.mockReturnValue( {} );
+	} );
+
+	it( 'should not render the list of payment methods when only card is enabled', () => {
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<DisableUpeConfirmationModal />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByText( /Payment methods that require/ )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should not render the list of payment methods when there are multiple payments enabled', () => {
+		useEnabledPaymentMethods.mockReturnValue( [
+			[ 'giropay' ],
+			jest.fn(),
+		] );
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<DisableUpeConfirmationModal />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByText( /Payment methods that require/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should call onClose when the action is cancelled', () => {
+		const handleCloseMock = jest.fn();
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<DisableUpeConfirmationModal onClose={ handleCloseMock } />
+			</UpeToggleContext.Provider>
+		);
+
+		expect( handleCloseMock ).not.toHaveBeenCalled();
+
+		userEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( handleCloseMock ).toHaveBeenCalled();
+	} );
+
+	it( 'should allow to disable UPE and close the modal', async () => {
+		const setIsUpeEnabledMock = jest.fn().mockResolvedValue( true );
+		useDispatch.mockReturnValue( {
+			createErrorNotice: () => null,
+			createSuccessNotice: () => null,
+		} );
+		const handleCloseMock = jest.fn();
+		render(
+			<UpeToggleContext.Provider
+				value={ {
+					isUpeEnabled: false,
+					setIsUpeEnabled: setIsUpeEnabledMock,
+				} }
+			>
+				<DisableUpeConfirmationModal onClose={ handleCloseMock } />
+			</UpeToggleContext.Provider>
+		);
+
+		expect( handleCloseMock ).not.toHaveBeenCalled();
+		expect( setIsUpeEnabledMock ).not.toHaveBeenCalled();
+
+		userEvent.click( screen.getByRole( 'button', { name: 'Disable' } ) );
+
+		await waitFor( () => expect( setIsUpeEnabledMock ).toHaveBeenCalled() );
+
+		expect( handleCloseMock ).toHaveBeenCalled();
+	} );
+} );

--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -3,20 +3,42 @@
  */
 import React from 'react';
 import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import GeneralSettingsSection from '..';
 import UpeToggleContext from '../../upe-toggle/context';
+import {
+	useEnabledPaymentMethods,
+	useGetAvailablePaymentMethods,
+} from '../data-mock';
+
+jest.mock( '../data-mock', () => ( {
+	useGetAvailablePaymentMethods: jest.fn(),
+	useEnabledPaymentMethods: jest.fn(),
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn().mockReturnValue( {} ),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
+	combineReducers: jest.fn(),
+} ) );
 
 describe( 'GeneralSettingsSection', () => {
-	it( 'should render the card information', () => {
+	beforeEach( () => {
+		useGetAvailablePaymentMethods.mockReturnValue( [ 'card' ] );
+		useEnabledPaymentMethods.mockReturnValue( [ [ 'card' ], jest.fn() ] );
+	} );
+
+	it( 'should render the card information and the opt-in banner with action elements if UPE is disabled', () => {
 		render(
 			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
 				<GeneralSettingsSection />
 			</UpeToggleContext.Provider>
 		);
+
 		expect(
 			screen.queryByText( 'Credit card / debit card' )
 		).toBeInTheDocument();
@@ -25,19 +47,7 @@ describe( 'GeneralSettingsSection', () => {
 				'Let your customers pay with major credit and debit cards without leaving your store.'
 			)
 		).toBeInTheDocument();
-	} );
-
-	it( 'should render the opt-in banner with action elements if UPE is disabled', () => {
-		render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
-				<GeneralSettingsSection />
-			</UpeToggleContext.Provider>
-		);
 		expect( screen.queryByTestId( 'opt-in-banner' ) ).toBeInTheDocument();
-		expect(
-			screen.queryByRole( 'link', { name: 'Enable in your store' } )
-		).toBeInTheDocument();
-		expect( screen.queryByText( 'Learn more' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should not render the opt-in banner if UPE is enabled', () => {
@@ -50,9 +60,97 @@ describe( 'GeneralSettingsSection', () => {
 		expect(
 			screen.queryByTestId( 'opt-in-banner' )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'should allow to enable a payment method when UPE is enabled', () => {
+		useGetAvailablePaymentMethods.mockReturnValue( [
+			'card',
+			'giropay',
+			'sofort',
+			'sepa_debit',
+		] );
+		const updateEnabledMethodsMock = jest.fn();
+		useEnabledPaymentMethods.mockReturnValue( [
+			[ 'card' ],
+			updateEnabledMethodsMock,
+		] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
+		const giropayCheckbox = screen.getByRole( 'checkbox', {
+			name: /giropay/,
+		} );
+
+		expect( updateEnabledMethodsMock ).not.toHaveBeenCalled();
+		expect( giropayCheckbox ).not.toBeChecked();
+
+		userEvent.click( giropayCheckbox );
+
+		expect( updateEnabledMethodsMock ).toHaveBeenCalledWith( [
+			'card',
+			'giropay',
+		] );
+	} );
+
+	it( 'should allow to disable a payment method when UPE is enabled', () => {
+		useGetAvailablePaymentMethods.mockReturnValue( [
+			'card',
+			'giropay',
+			'sofort',
+			'sepa_debit',
+		] );
+		const updateEnabledMethodsMock = jest.fn();
+		useEnabledPaymentMethods.mockReturnValue( [
+			[ 'card' ],
+			updateEnabledMethodsMock,
+		] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
+		const cardCheckbox = screen.getByRole( 'checkbox', {
+			name: /Credit card/,
+		} );
+
+		expect( updateEnabledMethodsMock ).not.toHaveBeenCalled();
+		expect( cardCheckbox ).toBeChecked();
+
+		userEvent.click( cardCheckbox );
+
+		expect( updateEnabledMethodsMock ).toHaveBeenCalledWith( [] );
+	} );
+
+	it( 'should display a modal to allow to disable UPE', () => {
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
 		expect(
-			screen.queryByRole( 'link', { name: 'Enable in your store' } )
+			screen.queryByText( /Without the new payments experience/ )
 		).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Learn more' ) ).not.toBeInTheDocument();
+
+		userEvent.click(
+			screen.getByRole( 'button', {
+				name: 'Disable the new Payment Experience',
+			} )
+		);
+		userEvent.click(
+			screen.getByRole( 'menuitem', {
+				name: 'Disable',
+			} )
+		);
+
+		expect(
+			screen.queryByText( /Without the new payments experience/ )
+		).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/general-settings-section/data-mock.js
+++ b/client/settings/general-settings-section/data-mock.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { useContext, useState } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import UpeToggleContext from '../upe-toggle/context';
+
+export const useGetAvailablePaymentMethods = () => {
+	// doing this check _only_ for testing purposes - this hook
+	// should probably rely on a global state, once the data layer has been implemented.
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+	if ( isUpeEnabled ) {
+		return [ 'card', 'giropay', 'sofort', 'sepa_debit' ];
+	}
+
+	return [ 'card' ];
+};
+
+// placing 2 elements _just_ for testing purposes
+export const useEnabledPaymentMethods = () => useState( [ 'card', 'giropay' ] );

--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -1,0 +1,189 @@
+/**
+ * External dependencies
+ */
+import React, { useContext } from 'react';
+import styled from '@emotion/styled';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { Button, ExternalLink } from '@wordpress/components';
+import interpolateComponents from 'interpolate-components';
+
+/**
+ * Internal dependencies
+ */
+import ConfirmationModal from 'wcstripe/components/confirmation-modal';
+import InlineNotice from 'wcstripe/components/inline-notice';
+import PaymentMethodsMap from '../../payment-methods-map';
+import UpeToggleContext from '../upe-toggle/context';
+import { useEnabledPaymentMethods } from './data-mock';
+
+const DeactivatingPaymentMethodsList = styled.ul`
+	min-height: 150px;
+
+	> * {
+		&:not( :last-child ) {
+			margin-bottom: $grid-unit-10;
+		}
+	}
+`;
+
+const PaymentMethodListItemContent = styled.div`
+	display: inline-flex;
+	align-items: center;
+	vertical-align: middle;
+	flex-wrap: nowrap;
+
+	> * {
+		margin-right: 4px;
+		line-height: 1em;
+
+		&:last-child {
+			margin-right: 0;
+		}
+	}
+`;
+
+const DisableUpeConfirmationModal = ( { onClose } ) => {
+	const { status, setIsUpeEnabled } = useContext( UpeToggleContext );
+
+	const { createErrorNotice, createSuccessNotice } = useDispatch(
+		'core/notices'
+	);
+
+	const handleConfirmation = () => {
+		const callback = async () => {
+			try {
+				await setIsUpeEnabled( false );
+				createSuccessNotice(
+					__(
+						'What made you disable the new payments experience?',
+						'woocommerce-gateway-stripe'
+					),
+					{
+						actions: [
+							{
+								label: __(
+									'Share feedback (1 min)',
+									'woocommerce-gateway-stripe'
+								),
+								url:
+									'https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey',
+							},
+						],
+					}
+				);
+				onClose();
+			} catch ( err ) {
+				createErrorNotice(
+					__(
+						'There was an error disabling the new payment methods.',
+						'woocommerce-gateway-stripe'
+					)
+				);
+			}
+		};
+
+		// creating a separate callback so that the UI isn't blocked by the async call.
+		callback();
+	};
+
+	const [ enabledPaymentMethodIds ] = useEnabledPaymentMethods();
+	const upePaymentMethods = enabledPaymentMethodIds.filter(
+		( method ) => method !== 'card'
+	);
+
+	return (
+		<>
+			<ConfirmationModal
+				title={ __(
+					'Disable the new payments experience',
+					'woocommerce-gateway-stripe'
+				) }
+				onRequestClose={ onClose }
+				actions={
+					<>
+						<Button
+							isSecondary
+							disabled={ status === 'pending' }
+							onClick={ onClose }
+						>
+							{ __( 'Cancel', 'woocommerce-gateway-stripe' ) }
+						</Button>
+						<Button
+							isPrimary
+							isDestructive
+							isBusy={ status === 'pending' }
+							disabled={ status === 'pending' }
+							onClick={ handleConfirmation }
+						>
+							{ __( 'Disable', 'woocommerce-gateway-stripe' ) }
+						</Button>
+					</>
+				}
+			>
+				<p>
+					{ __(
+						'Without the new payments experience, your customers will only be able to pay using credit card / debit card. You will not be able to add other sales-boosting payment methods anymore.',
+						'woocommerce-gateway-stripe'
+					) }
+				</p>
+
+				{ upePaymentMethods.length > 0 ? (
+					<>
+						<p>
+							{ __(
+								'Payment methods that require the new payments experience:',
+								'woocommerce-gateway-stripe'
+							) }
+						</p>
+						<DeactivatingPaymentMethodsList>
+							{ upePaymentMethods.map( ( method ) => {
+								const { Icon, label } = PaymentMethodsMap[
+									method
+								];
+
+								return (
+									<li key={ method }>
+										<PaymentMethodListItemContent>
+											<Icon size="small" />
+											<span>{ label }</span>
+										</PaymentMethodListItemContent>
+									</li>
+								);
+							} ) }
+						</DeactivatingPaymentMethodsList>
+					</>
+				) : null }
+
+				<InlineNotice status="info" isDismissible={ false }>
+					{ interpolateComponents( {
+						mixedString: __(
+							'Need help? Visit {{ docsLink /}} or {{supportLink /}}.',
+							'woocommerce-gateway-stripe'
+						),
+						components: {
+							docsLink: (
+								<ExternalLink href="?TODO">
+									{ __(
+										'Stripe docs',
+										'woocommerce-gateway-stripe'
+									) }
+								</ExternalLink>
+							),
+							supportLink: (
+								<ExternalLink href="https://woocommerce.com/contact-us/">
+									{ __(
+										'contact support',
+										'woocommerce-gateway-stripe'
+									) }
+								</ExternalLink>
+							),
+						},
+					} ) }
+				</InlineNotice>
+			</ConfirmationModal>
+		</>
+	);
+};
+
+export default DisableUpeConfirmationModal;

--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -7,6 +7,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { Button, ExternalLink } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
+import { Icon, info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -16,6 +17,16 @@ import InlineNotice from 'wcstripe/components/inline-notice';
 import PaymentMethodsMap from '../../payment-methods-map';
 import UpeToggleContext from '../upe-toggle/context';
 import { useEnabledPaymentMethods } from './data-mock';
+
+const AlertIcon = styled( Icon )`
+	fill: #d94f4f;
+	margin-right: 4px;
+`;
+
+const ModalTitleWrapper = styled.span`
+	display: inline-flex;
+	align-items: center;
+`;
 
 const DeactivatingPaymentMethodsList = styled.ul`
 	min-height: 150px;
@@ -42,6 +53,18 @@ const PaymentMethodListItemContent = styled.div`
 		}
 	}
 `;
+
+const ModalTitle = () => {
+	return (
+		<ModalTitleWrapper>
+			<AlertIcon icon={ info } />
+			{ __(
+				'Disable the new payments experience',
+				'woocommerce-gateway-stripe'
+			) }
+		</ModalTitleWrapper>
+	);
+};
 
 const DisableUpeConfirmationModal = ( { onClose } ) => {
 	const { status, setIsUpeEnabled } = useContext( UpeToggleContext );
@@ -95,10 +118,7 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 	return (
 		<>
 			<ConfirmationModal
-				title={ __(
-					'Disable the new payments experience',
-					'woocommerce-gateway-stripe'
-				) }
+				title={ <ModalTitle /> }
 				onRequestClose={ onClose }
 				actions={
 					<>
@@ -138,14 +158,15 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 						</p>
 						<DeactivatingPaymentMethodsList>
 							{ upePaymentMethods.map( ( method ) => {
-								const { Icon, label } = PaymentMethodsMap[
-									method
-								];
+								const {
+									Icon: MethodIcon,
+									label,
+								} = PaymentMethodsMap[ method ];
 
 								return (
 									<li key={ method }>
 										<PaymentMethodListItemContent>
-											<Icon size="small" />
+											<MethodIcon size="small" />
 											<span>{ label }</span>
 										</PaymentMethodListItemContent>
 									</li>

--- a/client/settings/general-settings-section/index.js
+++ b/client/settings/general-settings-section/index.js
@@ -3,95 +3,158 @@
  */
 import React, { useContext } from 'react';
 import styled from '@emotion/styled';
-import { __ } from '@wordpress/i18n';
-import { Card } from '@wordpress/components';
+import { Card, CheckboxControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import PaymentMethodFeesPill from 'wcstripe/components/payment-method-fees-pill';
 import CardBody from '../card-body';
-import CardsIcon from '../../payment-method-icons/cards';
-import UPEOptInBanner from '../upe-opt-in-banner';
+import UpeOptInBanner from '../upe-opt-in-banner';
 import UpeToggleContext from '../upe-toggle/context';
+import {
+	useEnabledPaymentMethods,
+	useGetAvailablePaymentMethods,
+} from './data-mock';
+import PaymentMethodDescription from './payment-method-description';
+import SectionHeading from './section-heading';
+import PaymentMethodsMap from '../../payment-methods-map';
+import PaymentMethodSetupHelp from './payment-method-setup-help';
 
-const GeneralSettingsSectionWrapper = styled.div`
+const StyledUpeOptInBanner = styled( UpeOptInBanner )`
+	max-width: 100%;
+	margin: 0;
+`;
+
+const StyledCard = styled( Card )`
+	margin-bottom: 12px;
+`;
+
+const PaymentMethodsList = styled.ul`
+	margin: 0;
+
+	> li {
+		margin: 0;
+		padding: 16px 24px 14px 24px;
+
+		@media ( min-width: 660px ) {
+			padding: 24px 24px 24px 24px;
+		}
+
+		&:not( :last-child ) {
+			box-shadow: inset 0 -1px 0 #e8eaeb;
+		}
+	}
+`;
+
+const PaymentMethodWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
-`;
-
-const CardBodyWrapper = styled( CardBody )`
-	display: flex;
-
-	> * {
-		margin-bottom: 0px;
-	}
-`;
-
-const PaymentMethodText = styled.div`
-	flex: 0 0 100%;
+	flex-wrap: nowrap;
 
 	@media ( min-width: 660px ) {
-		flex: 1 1 auto;
-		margin-left: 12px;
+		flex-direction: row;
+		align-items: center;
 	}
 `;
 
-const PaymentMethodLabel = styled.div`
-	color: $gray-900;
-	display: inline-block;
-	font-size: 14px;
-	font-weight: 600;
-	line-height: 20px;
-	margin-bottom: 4px;
-`;
-
-const PaymentMethodDescription = styled.div`
-	color: ##646970;
-	font-size: 13px;
-	line-height: 16px;
-	margin-bottom: 14px;
+const StyledFees = styled( PaymentMethodFeesPill )`
+	flex: 1 0 auto;
+	margin-top: 20px;
+	margin-left: 32px;
 
 	@media ( min-width: 660px ) {
-		margin-bottom: 0px;
+		margin-top: 0;
+		margin-left: 24px;
 	}
 `;
 
-const UPEOptInBannerWrapper = styled.div`
-	div:first-of-type {
-		max-width: 100%;
+const PaymentMethodCheckbox = styled( CheckboxControl )`
+	.components-base-control__field {
+		margin: 0;
+		display: flex;
+
+		@media ( min-width: 660px ) {
+			align-items: center;
+		}
 	}
 `;
 
 const GeneralSettingsSection = () => {
 	const { isUpeEnabled } = useContext( UpeToggleContext );
 
+	const [
+		enabledPaymentMethods,
+		setEnabledPaymentMethods,
+	] = useEnabledPaymentMethods();
+	const availablePaymentMethods = useGetAvailablePaymentMethods();
+
+	const makeCheckboxChangeHandler = ( method ) => ( hasBeenChecked ) => {
+		if ( hasBeenChecked ) {
+			setEnabledPaymentMethods( [ ...enabledPaymentMethods, method ] );
+		} else {
+			setEnabledPaymentMethods(
+				enabledPaymentMethods.filter( ( m ) => m !== method )
+			);
+		}
+	};
+
 	return (
-		<GeneralSettingsSectionWrapper>
-			<Card>
-				<CardBodyWrapper>
-					<CardsIcon size="medium" />
-					<PaymentMethodText>
-						<PaymentMethodLabel>
-							{ __(
-								'Credit card / debit card',
-								'woocommerce-gateway-stripe'
-							) }
-						</PaymentMethodLabel>
-						<PaymentMethodDescription>
-							{ __(
-								'Let your customers pay with major credit and debit cards without leaving your store.',
-								'woocommerce-gateway-stripe'
-							) }
-						</PaymentMethodDescription>
-					</PaymentMethodText>
-				</CardBodyWrapper>
-			</Card>
+		<>
+			<StyledCard>
+				<SectionHeading />
+				<CardBody size={ null }>
+					<PaymentMethodsList>
+						{ availablePaymentMethods.map( ( method ) => {
+							const {
+								Icon,
+								label,
+								description,
+							} = PaymentMethodsMap[ method ];
+
+							return (
+								<li key={ method }>
+									<PaymentMethodWrapper>
+										{ isUpeEnabled ? (
+											<>
+												<PaymentMethodCheckbox
+													label={
+														<PaymentMethodDescription
+															Icon={ Icon }
+															description={
+																description
+															}
+															label={ label }
+														/>
+													}
+													onChange={ makeCheckboxChangeHandler(
+														method
+													) }
+													checked={ enabledPaymentMethods.includes(
+														method
+													) }
+												/>
+												<StyledFees id={ method } />
+											</>
+										) : (
+											<PaymentMethodDescription
+												Icon={ Icon }
+												description={ description }
+												label={ label }
+											/>
+										) }
+									</PaymentMethodWrapper>
+									<PaymentMethodSetupHelp id={ method } />
+								</li>
+							);
+						} ) }
+					</PaymentMethodsList>
+				</CardBody>
+			</StyledCard>
 			{ ! isUpeEnabled && (
-				<UPEOptInBannerWrapper data-testid="opt-in-banner">
-					<UPEOptInBanner />
-				</UPEOptInBannerWrapper>
+				<StyledUpeOptInBanner data-testid="opt-in-banner" />
 			) }
-		</GeneralSettingsSectionWrapper>
+		</>
 	);
 };
 

--- a/client/settings/general-settings-section/payment-method-description.js
+++ b/client/settings/general-settings-section/payment-method-description.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div`
+	display: flex;
+	align-items: center;
+`;
+
+const IconWrapper = styled.div`
+	display: none;
+	margin-right: 14px;
+
+	@media ( min-width: 660px ) {
+		display: block;
+	}
+`;
+
+const Label = styled.div`
+	color: #1e1e1e;
+	display: inline-block;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 20px;
+	margin-bottom: 4px;
+`;
+
+const Description = styled.div`
+	color: #757575;
+	font-size: 13px;
+	line-height: 16px;
+`;
+
+const PaymentMethodDescription = ( {
+	Icon = () => null,
+	label,
+	description,
+	...restProps
+} ) => {
+	return (
+		<Wrapper { ...restProps }>
+			<IconWrapper>
+				<Icon size="medium" />
+			</IconWrapper>
+			<div>
+				<Label>{ label }</Label>
+				<Description>{ description }</Description>
+			</div>
+		</Wrapper>
+	);
+};
+
+export default PaymentMethodDescription;

--- a/client/settings/general-settings-section/payment-method-setup-help.js
+++ b/client/settings/general-settings-section/payment-method-setup-help.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import styled from '@emotion/styled';
+import { __ } from '@wordpress/i18n';
+import { Icon, info } from '@wordpress/icons';
+
+const Wrapper = styled.div`
+	display: flex;
+	flex-wrap: nowrap;
+	margin-top: 20px;
+	align-items: center;
+`;
+
+const StyledIcon = styled( Icon )`
+	fill: #949494;
+	margin-right: 12px;
+	flex: 0 0 24px;
+
+	@media ( min-width: 600px ) {
+		flex-basis: 20px;
+	}
+`;
+
+const Text = styled.div`
+	color: #757575;
+	font-size: 13px;
+	line-height: 16px;
+`;
+
+const PaymentMethodSetupHelp = ( { id } ) => {
+	if ( id !== 'sepa_debit' ) {
+		return null;
+	}
+
+	return (
+		<Wrapper>
+			<StyledIcon icon={ info } />
+			<Text>
+				{ __(
+					'You must provide more information to enable Direct debit payment (SEPA).',
+					'woocommerce-gateway-stripe'
+				) }
+			</Text>
+		</Wrapper>
+	);
+};
+
+export default PaymentMethodSetupHelp;

--- a/client/settings/general-settings-section/section-heading.js
+++ b/client/settings/general-settings-section/section-heading.js
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import React, { useContext, useState } from 'react';
+import styled from '@emotion/styled';
+import { __ } from '@wordpress/i18n';
+import { CardHeader, DropdownMenu } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import Pill from 'wcstripe/components/pill';
+import UpeToggleContext from '../upe-toggle/context';
+import DisableUpeConfirmationModal from './disable-upe-confirmation-modal';
+
+const StyledHeader = styled( CardHeader )`
+	justify-content: space-between;
+
+	.components-dropdown-menu__toggle.has-icon {
+		padding: 0;
+		min-width: unset;
+	}
+
+	button.components-dropdown-menu__menu-item:last-of-type {
+		color: rgb( 220, 30, 30 );
+	}
+`;
+
+const Title = styled.h4`
+	margin: 0;
+	font-size: 16px;
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	line-height: 2em;
+
+	> * {
+		&:not( :last-child ) {
+			margin-right: 4px;
+		}
+	}
+`;
+
+const SectionHeading = () => {
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
+	const [ isConfirmationModalOpen, setIsConfirmationModalOpen ] = useState(
+		false
+	);
+
+	if ( ! isUpeEnabled ) {
+		return null;
+	}
+
+	return (
+		<StyledHeader>
+			<Title>
+				<span>
+					{ __( 'Payment methods', 'woocommerce-gateway-stripe' ) }
+				</span>{ ' ' }
+				<Pill>
+					{ __( 'Early access', 'woocommerce-gateway-stripe' ) }
+				</Pill>
+			</Title>
+			{ isConfirmationModalOpen && (
+				<DisableUpeConfirmationModal
+					onClose={ () => setIsConfirmationModalOpen( false ) }
+				/>
+			) }
+			<DropdownMenu
+				icon={ moreVertical }
+				label={ __(
+					'Disable the new Payment Experience',
+					'woocommerce-gateway-stripe'
+				) }
+				controls={ [
+					{
+						title: __( 'Disable', 'woocommerce-gateway-stripe' ),
+						onClick: () => setIsConfirmationModalOpen( true ),
+					},
+				] }
+			/>
+		</StyledHeader>
+	);
+};
+
+export default SectionHeading;

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { __ } from '@wordpress/i18n';
 import { ExternalLink } from '@wordpress/components';
 import styled from '@emotion/styled';
@@ -14,6 +14,7 @@ import PaymentRequestSection from '../payment-request-section';
 import GeneralSettingsSection from '../general-settings-section';
 import ApplePayIcon from '../../payment-method-icons/apple-pay';
 import GooglePayIcon from '../../payment-method-icons/google-pay';
+import UpeToggleContext from '../upe-toggle/context';
 
 const IconsWrapper = styled.ul`
 	li {
@@ -22,24 +23,31 @@ const IconsWrapper = styled.ul`
 	}
 `;
 
-const PaymentMethodsDescription = () => (
-	<>
-		<h2>
-			{ __(
-				'Payments accepted on checkout',
-				'woocommerce-gateway-stripe'
+const PaymentMethodsDescription = () => {
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
+	return (
+		<>
+			<h2>
+				{ __(
+					'Payments accepted on checkout',
+					'woocommerce-gateway-stripe'
+				) }
+			</h2>
+
+			{ isUpeEnabled && (
+				<p>
+					{ __(
+						'Add and edit payments available to customers at checkout. ' +
+							'Based on their device type, location, your customers will ' +
+							'only see the most relevant payment methods.',
+						'woocommerce-gateway-stripe'
+					) }
+				</p>
 			) }
-		</h2>
-		<p>
-			{ __(
-				'Add and edit payments available to customers at checkout. ' +
-					'Based on their device type, location, your customers will ' +
-					'only see the most relevant payment methods.',
-				'woocommerce-gateway-stripe'
-			) }
-		</p>
-	</>
-);
+		</>
+	);
+};
 
 const PaymentRequestDescription = () => (
 	<>

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -38,9 +38,9 @@ const PaymentMethodsDescription = () => {
 			{ isUpeEnabled && (
 				<p>
 					{ __(
-						'Add and edit payments available to customers at checkout. ' +
-							'Based on their device type, location, your customers will ' +
-							'only see the most relevant payment methods.',
+						'Select payments available to customers at checkout. ' +
+							'Based on their device type, location, and purchase history, ' +
+							'your customers will only see the most relevant payment methods.',
 						'woocommerce-gateway-stripe'
 					) }
 				</p>

--- a/client/settings/upe-opt-in-banner/index.js
+++ b/client/settings/upe-opt-in-banner/index.js
@@ -48,8 +48,8 @@ const ImageWrapper = styled.div`
 	}
 `;
 
-const UPEOptInBanner = () => (
-	<BannerWrapper>
+const UpeOptInBanner = ( props ) => (
+	<BannerWrapper { ...props }>
 		<InformationWrapper>
 			<Pill>{ __( 'Early access', 'woocommerce-gateway-stripe' ) }</Pill>
 			<h3>
@@ -94,7 +94,7 @@ const bannerContainer = document.getElementById(
 );
 
 if ( bannerContainer ) {
-	ReactDOM.render( <UPEOptInBanner />, bannerContainer );
+	ReactDOM.render( <UpeOptInBanner />, bannerContainer );
 }
 
-export default UPEOptInBanner;
+export default UpeOptInBanner;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4424,13 +4424,13 @@
       }
     },
     "@wordpress/data": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.0.tgz",
-      "integrity": "sha512-fkub4wwdD2z7Ctn0syvNfDKodBeRlq/BCHObuklGAPu8hiyB7Fzel7VqHK11u77K+5fEO5UMYzqif1HDdICQOw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
+      "integrity": "sha512-0t6SAHJf8kFJ+LYBHpfW4Hy64yq8YkY1ptWQurMWiNOpJolxO5WeODGN5TH2Qxr/RvDTbqAZm4zeZHIYxJS1wg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10",
-        "@wordpress/compose": "^5.0.0",
+        "@wordpress/compose": "^5.0.1",
         "@wordpress/deprecated": "^3.2.1",
         "@wordpress/element": "^4.0.0",
         "@wordpress/is-shallow-equal": "^4.2.0",
@@ -4442,6 +4442,40 @@
         "memize": "^1.1.0",
         "turbo-combine-reducers": "^1.0.2",
         "use-memo-one": "^1.1.1"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-5.0.1.tgz",
+          "integrity": "sha512-DZVGrtnJW/1Ze1fCox7tosOnz+bf1ngnCUA1SkSn/FEHm7gZobbLkm0d5GOymXCqYO7MoZiDkTsAZN8to8rImQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.1",
+            "@wordpress/dom": "^3.2.2",
+            "@wordpress/element": "^4.0.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.1",
+            "@wordpress/priority-queue": "^2.2.1",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/dom": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.2.tgz",
+          "integrity": "sha512-FRhnTsRO5/+fDBDU+Hs8WvMLd5+2eFgnu1jKCoumywqBx7WPJv6b3g5xFsiKliaj7aP1Jk0t55nYHPNMgfwBwA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "lodash": "^4.17.21"
+          }
+        }
       }
     },
     "@wordpress/date": {
@@ -5409,6 +5443,53 @@
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
             "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+              "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+              "dev": true
+            }
+          }
+        },
+        "puppeteer": {
+          "version": "npm:puppeteer-core@5.5.0",
+          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
+          "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "devtools-protocol": "0.0.818844",
+            "extract-zip": "^2.0.0",
+            "https-proxy-agent": "^4.0.0",
+            "node-fetch": "^2.6.1",
+            "pkg-dir": "^4.2.0",
+            "progress": "^2.0.1",
+            "proxy-from-env": "^1.0.0",
+            "rimraf": "^3.0.2",
+            "tar-fs": "^2.0.0",
+            "unbzip2-stream": "^1.3.3",
+            "ws": "^7.2.3"
           }
         },
         "react": {
@@ -12851,6 +12932,14 @@
       "integrity": "sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw=",
       "dev": true
     },
+    "gridicons": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/gridicons/-/gridicons-3.4.0.tgz",
+      "integrity": "sha512-GikyCOcfhwHSN8tfsZvcWwWSaRLebVZCvDzfFg0X50E+dIAnG2phfFUTNa06dXA09kqRYCdnu8sPO8pSYO3UVA==",
+      "requires": {
+        "prop-types": "^15.5.7"
+      }
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -18989,86 +19078,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
-    },
-    "puppeteer": {
-      "version": "npm:puppeteer-core@5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-5.5.0.tgz",
-      "integrity": "sha512-tlA+1n+ziW/Db03hVV+bAecDKse8ihFRXYiEypBe9IlLRvOCzYFG6qrCMBYK34HO/Q/Ecjc+tvkHRAfLVH+NgQ==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
-        "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "pkg-dir": "^4.2.0",
-        "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
-        "rimraf": "^3.0.2",
-        "tar-fs": "^2.0.0",
-        "unbzip2-stream": "^1.3.3",
-        "ws": "^7.2.3"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-          "dev": true,
-          "requires": {
-            "find-up": "^4.0.0"
-          }
-        }
-      }
     },
     "q": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "@wordpress/babel-preset-default": "^6.3.1",
     "@wordpress/base-styles": "^3.6.0",
     "@wordpress/components": "^15.0.0",
+    "@wordpress/data": "^6.0.1",
     "@wordpress/i18n": "^4.2.1",
     "@wordpress/jest-preset-default": "^7.1.0",
+    "@wordpress/primitives": "^3.0.0",
     "@wordpress/scripts": "^13.0.2",
     "archiver": "^5.0.0",
     "babel": "^6.5.2",
@@ -68,6 +70,7 @@
     "@stripe/stripe-js": "1.11.0",
     "@wordpress/icons": "^5.0.1",
     "classnames": "^2.3.1",
+    "gridicons": "^3.4.0",
     "interpolate-components": "^1.1.1"
   },
   "assets": {


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1716

General settings section.

PLEASE NOTE:
- The requirements on the ticket are different because newer designs are being reviewed: p1631001920004300-slack-C01RTUVR81K - I tried to get as close as possible to the end result
- The list of enabled methods in the modal does not reflect the main list of enabled methods (because we would need a global store for that)
![2021-09-08 10 57 52](https://user-images.githubusercontent.com/273592/132555681-5c66cc35-ec1b-4dfd-8263-3b8fd5e85351.gif)
- The design is still being worked on, so the confirmation modal to disable a payment method is not implemented yet (we need confirmation from UX for that)
- The docs are still TODO
- Fees are hardcoded (but I included the pill from the designs, for now)

# Testing instructions
- Enable the `_wcstripe_feature_upe_settings` flag on your site
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- With the `woocommerce_stripe_settings.upe_checkout_experience_enabled` disabled:
![Screen Shot 2021-09-08 at 10 58 14 AM](https://user-images.githubusercontent.com/273592/132555729-b14aca93-9a5a-4109-989c-3eca7229174f.png)
![Screen Shot 2021-09-08 at 10 58 40 AM](https://user-images.githubusercontent.com/273592/132555741-d2a424c2-985a-431f-a7ea-bc9810ba887f.png)
- With the `woocommerce_stripe_settings.upe_checkout_experience_enabled` enabled:
![Screen Shot 2021-09-07 at 5 18 15 PM](https://user-images.githubusercontent.com/273592/132555828-a4eebcf8-548a-496c-bbb2-0d3644af764b.png)
![Screen Shot 2021-09-07 at 5 18 24 PM](https://user-images.githubusercontent.com/273592/132555844-6745964d-8541-4842-b451-c46d63c92f01.png)