### PR TITLE
feat: onboarding UPE enable

### DIFF
--- a/client/settings/upe-opt-in-banner/index.js
+++ b/client/settings/upe-opt-in-banner/index.js
@@ -67,11 +67,7 @@ const UpeOptInBanner = () => (
 			</p>
 			<Actions>
 				<span>
-					<Button
-						isPrimary
-						href="?page=wc_stripe-onboarding_wizard"
-						target="_blank"
-					>
+					<Button isPrimary href="?page=wc_stripe-onboarding_wizard">
 						{ __(
 							'Enable in your store',
 							'woocommerce-gateway-stripe'

--- a/client/upe-onboarding-wizard/index.js
+++ b/client/upe-onboarding-wizard/index.js
@@ -1,4 +1,4 @@
-/* global wc_stripe_settings_params */
+/* global wc_stripe_onboarding_params */
 /**
  * External dependencies
  */
@@ -19,7 +19,7 @@ if ( container ) {
 	ReactDOM.render(
 		<UpeToggleContextProvider
 			defaultIsUpeEnabled={
-				wc_stripe_settings_params.is_upe_checkout_enabled === '1'
+				wc_stripe_onboarding_params.is_upe_checkout_enabled === '1'
 			}
 		>
 			<OnboardingWizard />

--- a/client/upe-onboarding-wizard/index.js
+++ b/client/upe-onboarding-wizard/index.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 /**
  * External dependencies
  */
@@ -7,6 +8,7 @@ import ReactDOM from 'react-dom';
 /**
  * Internal dependencies
  */
+import UpeToggleContextProvider from 'wcstripe/settings/upe-toggle/provider';
 import OnboardingWizard from './onboarding-wizard';
 
 const container = document.getElementById(
@@ -14,5 +16,14 @@ const container = document.getElementById(
 );
 
 if ( container ) {
-	ReactDOM.render( <OnboardingWizard />, container );
+	ReactDOM.render(
+		<UpeToggleContextProvider
+			defaultIsUpeEnabled={
+				wc_stripe_settings_params.is_upe_checkout_enabled === '1'
+			}
+		>
+			<OnboardingWizard />
+		</UpeToggleContextProvider>,
+		container
+	);
 }

--- a/client/upe-onboarding-wizard/onboarding-wizard.js
+++ b/client/upe-onboarding-wizard/onboarding-wizard.js
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useContext } from 'react';
 import { Card, CardBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 import Wizard from './wizard/wrapper/provider';
 import WizardTask from './wizard/task';
 import WizardTaskList from './wizard/task-list';
@@ -16,10 +17,21 @@ import AddPaymentMethodsTask from './upe-preview-methods-selector/add-payment-me
 import './style.scss';
 
 const OnboardingWizard = () => {
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
 	return (
 		<Card className="upe-preview-methods-selector">
 			<CardBody>
-				<Wizard defaultActiveTask="enable-upe-preview">
+				<Wizard
+					defaultActiveTask={
+						isUpeEnabled
+							? 'add-payment-methods'
+							: 'enable-upe-preview'
+					}
+					defaultCompletedTasks={ {
+						'enable-upe-preview': isUpeEnabled,
+					} }
+				>
 					<WizardTaskList>
 						<WizardTask id="enable-upe-preview">
 							<EnableUpePreviewTask />

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/enable-upe-preview-task.test.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/enable-upe-preview-task.test.js
@@ -2,31 +2,45 @@
  * External dependencies
  */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 /**
  * Internal dependencies
  */
 import WizardTaskContext from '../../wizard/task/context';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
+
 import EnableUpePreviewTask from '../enable-upe-preview-task';
 
 describe( 'EnableUpePreviewTask', () => {
 	it( 'should enable the UPE flag when clicking the "Enable" button', async () => {
 		const setCompletedMock = jest.fn();
+		const setIsUpeEnabledMock = jest.fn().mockResolvedValue( true );
 
 		render(
-			<WizardTaskContext.Provider
-				value={ { setCompleted: setCompletedMock } }
+			<UpeToggleContext.Provider
+				value={ {
+					isUpeEnabled: false,
+					setIsUpeEnabled: setIsUpeEnabledMock,
+				} }
 			>
-				<EnableUpePreviewTask />
-			</WizardTaskContext.Provider>
+				<WizardTaskContext.Provider
+					value={ { setCompleted: setCompletedMock } }
+				>
+					<EnableUpePreviewTask />
+				</WizardTaskContext.Provider>
+			</UpeToggleContext.Provider>
 		);
 
 		expect( setCompletedMock ).not.toHaveBeenCalled();
+		expect( setIsUpeEnabledMock ).not.toHaveBeenCalled();
 
 		userEvent.click( screen.getByText( 'Enable' ) );
 
+		await waitFor( () =>
+			expect( setIsUpeEnabledMock ).toHaveBeenCalledWith( true )
+		);
 		expect( setCompletedMock ).toHaveBeenCalledWith(
 			true,
 			'add-payment-methods'

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/enable-upe-preview-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/enable-upe-preview-task.js
@@ -10,6 +10,7 @@ import { Icon, store, people } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 import WizardTaskContext from '../wizard/task/context';
 import CollapsibleBody from '../wizard/collapsible-body';
 import WizardTaskItem from '../wizard/task-item';
@@ -18,9 +19,12 @@ import './style.scss';
 
 const EnableUpePreviewTask = () => {
 	const { setCompleted } = useContext( WizardTaskContext );
+	const { setIsUpeEnabled, status } = useContext( UpeToggleContext );
 
 	const handleContinueClick = useCallback( () => {
-		setCompleted( true, 'add-payment-methods' );
+		setIsUpeEnabled( true ).then( () => {
+			setCompleted( true, 'add-payment-methods' );
+		} );
 	}, [ setCompleted ] );
 
 	return (
@@ -115,7 +119,12 @@ const EnableUpePreviewTask = () => {
 						</CardBody>
 					</Card>
 				</div>
-				<Button onClick={ handleContinueClick } isPrimary>
+				<Button
+					isBusy={ status === 'pending' }
+					disabled={ status === 'pending' }
+					onClick={ handleContinueClick }
+					isPrimary
+				>
 					{ __( 'Enable', 'woocommerce-gateway-stripe' ) }
 				</Button>
 			</CollapsibleBody>

--- a/includes/admin/class-wc-stripe-onboarding-controller.php
+++ b/includes/admin/class-wc-stripe-onboarding-controller.php
@@ -42,9 +42,13 @@ class WC_Stripe_Onboarding_Controller {
 			$script_asset['version'],
 			true
 		);
-		wp_localize_script( 'wc_stripe_onboarding_wizard', 'wc_stripe_settings_params', [
-			'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
-		] );
+		wp_localize_script(
+			'wc_stripe_onboarding_wizard',
+			'wc_stripe_settings_params',
+			[
+				'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+			]
+		);
 		wp_register_style(
 			'wc_stripe_onboarding_wizard',
 			$style_url,

--- a/includes/admin/class-wc-stripe-onboarding-controller.php
+++ b/includes/admin/class-wc-stripe-onboarding-controller.php
@@ -42,6 +42,9 @@ class WC_Stripe_Onboarding_Controller {
 			$script_asset['version'],
 			true
 		);
+		wp_localize_script( 'wc_stripe_onboarding_wizard', 'wc_stripe_settings_params', [
+			'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+		] );
 		wp_register_style(
 			'wc_stripe_onboarding_wizard',
 			$style_url,

--- a/includes/admin/class-wc-stripe-onboarding-controller.php
+++ b/includes/admin/class-wc-stripe-onboarding-controller.php
@@ -44,7 +44,7 @@ class WC_Stripe_Onboarding_Controller {
 		);
 		wp_localize_script(
 			'wc_stripe_onboarding_wizard',
-			'wc_stripe_settings_params',
+			'wc_stripe_onboarding_params',
 			[
 				'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			]


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Helps with https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1718

Allows enabling UPE via the onboarding wizard.

![2021-09-08 15 15 55](https://user-images.githubusercontent.com/273592/132579183-26aee2dc-9b64-446b-bf15-001c9cac4055.gif)


# Testing instructions

- Ensure you have the UPE preview enabled (`_wcstripe_feature_upe_settings`)
- Ensure you have the UPE flag disabled (`woocommerce_stripe_settings.upe_checkout_experience_enabled`)
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- Click "Enable in your store"
- You should be redirected to the onboarding wizard
- The onboarding wizard should show you the first step
- Click "Enable"
- The second step should display
- Refreshing the page should show again the second step (since UPE has already been enabled)
