### PR TITLE
fix: customization options notice destructure

### DIFF
--- a/client/components/inline-notice/style.scss
+++ b/client/components/inline-notice/style.scss
@@ -5,13 +5,13 @@
 	&#{&} {
 		margin: 0;
 		margin-bottom: $grid-unit-30;
+
+		&.is-dismissible {
+			padding-right: 12px;
+		}
 	}
 
 	&.is-info {
 		background: #def1f7;
-	}
-
-	&.components-notice.is-dismissible {
-		padding-right: 12px;
 	}
 }

--- a/client/settings/customization-options-notice/__tests__/customization-options-notice.test.js
+++ b/client/settings/customization-options-notice/__tests__/customization-options-notice.test.js
@@ -3,12 +3,12 @@
  */
 import React from 'react';
 import { screen, render } from '@testing-library/react';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import CustomizationOptionNotice from '..';
+import CustomizationOptionsNotice from '..';
 import UpeToggleContext from '../../upe-toggle/context';
 
 jest.mock( '@wordpress/data' );
@@ -18,9 +18,9 @@ jest.mock( '@wordpress/a11y', () => ( {
 	speak: jest.fn(),
 } ) );
 
-describe( 'CustomizationOptionNotice', () => {
+describe( 'CustomizationOptionsNotice', () => {
 	beforeEach( () => {
-		useDispatch.mockImplementation( () => ( {
+		dispatch.mockImplementation( () => ( {
 			updateOptions: jest.fn(),
 		} ) );
 	} );
@@ -46,7 +46,7 @@ describe( 'CustomizationOptionNotice', () => {
 
 		render(
 			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<CustomizationOptionNotice />
+				<CustomizationOptionsNotice />
 			</UpeToggleContext.Provider>
 		);
 
@@ -77,7 +77,7 @@ describe( 'CustomizationOptionNotice', () => {
 
 		render(
 			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
-				<CustomizationOptionNotice />
+				<CustomizationOptionsNotice />
 			</UpeToggleContext.Provider>
 		);
 
@@ -103,7 +103,7 @@ describe( 'CustomizationOptionNotice', () => {
 
 		render(
 			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<CustomizationOptionNotice />
+				<CustomizationOptionsNotice />
 			</UpeToggleContext.Provider>
 		);
 

--- a/client/settings/customization-options-notice/__tests__/customization-options-notice.test.js
+++ b/client/settings/customization-options-notice/__tests__/customization-options-notice.test.js
@@ -12,6 +12,9 @@ import CustomizationOptionsNotice from '..';
 import UpeToggleContext from '../../upe-toggle/context';
 
 jest.mock( '@wordpress/data' );
+jest.mock( '@woocommerce/data', () => ( {
+	OPTIONS_STORE_NAME: 'wc/admin/options',
+} ) );
 
 jest.mock( '@wordpress/a11y', () => ( {
 	...jest.requireActual( '@wordpress/a11y' ),
@@ -106,18 +109,5 @@ describe( 'CustomizationOptionsNotice', () => {
 		);
 
 		expect( container.firstChild ).toBeNull();
-	} );
-
-	it( 'should render (but not click) even though `useDispatch` returns `null`', () => {
-		useSelect.mockReturnValue( true );
-		useDispatch.mockReturnValue( null );
-
-		const { container } = render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<CustomizationOptionsNotice />
-			</UpeToggleContext.Provider>
-		);
-
-		expect( container.firstChild ).not.toBeNull();
 	} );
 } );

--- a/client/settings/customization-options-notice/__tests__/customization-options-notice.test.js
+++ b/client/settings/customization-options-notice/__tests__/customization-options-notice.test.js
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { screen, render } from '@testing-library/react';
-import { useSelect, dispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,7 +20,7 @@ jest.mock( '@wordpress/a11y', () => ( {
 
 describe( 'CustomizationOptionsNotice', () => {
 	beforeEach( () => {
-		dispatch.mockImplementation( () => ( {
+		useDispatch.mockImplementation( () => ( {
 			updateOptions: jest.fn(),
 		} ) );
 	} );
@@ -75,15 +75,13 @@ describe( 'CustomizationOptionsNotice', () => {
 			return callback( selectMock );
 		} );
 
-		render(
+		const { container } = render(
 			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
 				<CustomizationOptionsNotice />
 			</UpeToggleContext.Provider>
 		);
 
-		expect(
-			screen.queryByText( 'Where are the customization options?' )
-		).not.toBeInTheDocument();
+		expect( container.firstChild ).toBeNull();
 	} );
 
 	it( 'should not render the notice when UPE is enabled but `wc_show_upe_customization_options_notice` is disabled', () => {
@@ -101,14 +99,25 @@ describe( 'CustomizationOptionsNotice', () => {
 			return callback( selectMock );
 		} );
 
-		render(
+		const { container } = render(
 			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
 				<CustomizationOptionsNotice />
 			</UpeToggleContext.Provider>
 		);
 
-		expect(
-			screen.queryByText( 'Where are the customization options?' )
-		).not.toBeInTheDocument();
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should render (but not click) even though `useDispatch` returns `null`', () => {
+		useSelect.mockReturnValue( true );
+		useDispatch.mockReturnValue( null );
+
+		const { container } = render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<CustomizationOptionsNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		expect( container.firstChild ).not.toBeNull();
 	} );
 } );

--- a/client/settings/customization-options-notice/index.js
+++ b/client/settings/customization-options-notice/index.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import interpolateComponents from 'interpolate-components';
+import { OPTIONS_STORE_NAME } from '@woocommerce/data';
 
 /**
  * Internal dependencies
@@ -15,10 +16,8 @@ import InlineNotice from '../../components/inline-notice';
 import UpeToggleContext from '../upe-toggle/context';
 
 const NoticeWrapper = styled( InlineNotice )`
-	padding: 16px 24px;
-
-	&.wcstripe-inline-notice {
-		border-left: 4px solid #00aadc;
+	// increasing the specificity to override the margin value.
+	&& {
 		margin-bottom: 0;
 	}
 `;
@@ -31,7 +30,7 @@ const CustomizationOptionsNotice = () => {
 
 	const isCustomizationOptionsNoticeVisible = useSelect( ( select ) => {
 		const { getOption, hasFinishedResolution } = select(
-			'wc/admin/options'
+			OPTIONS_STORE_NAME
 		);
 
 		const hasFinishedResolving = hasFinishedResolution( 'getOption', [
@@ -44,13 +43,13 @@ const CustomizationOptionsNotice = () => {
 		return hasFinishedResolving && ! isOptionDismissed;
 	} );
 
-	const optionsDispatch = useDispatch( 'wc/admin/options' );
+	const { updateOptions } = useDispatch( OPTIONS_STORE_NAME );
 
 	const handleDismissNotice = useCallback( () => {
-		optionsDispatch.updateOptions( {
+		updateOptions( {
 			[ CUSTOMIZATION_OPTIONS_NOTICE_OPTION ]: 'no',
 		} );
-	}, [ optionsDispatch ] );
+	}, [ updateOptions ] );
 
 	if ( ! isUpeEnabled || ! isCustomizationOptionsNoticeVisible ) {
 		return null;

--- a/client/settings/customization-options-notice/index.js
+++ b/client/settings/customization-options-notice/index.js
@@ -4,7 +4,7 @@
 import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import { __ } from '@wordpress/i18n';
-import { useSelect, dispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import interpolateComponents from 'interpolate-components';
 
@@ -44,11 +44,13 @@ const CustomizationOptionsNotice = () => {
 		return hasFinishedResolving && ! isOptionDismissed;
 	} );
 
+	const optionsDispatch = useDispatch( 'wc/admin/options' );
+
 	const handleDismissNotice = useCallback( () => {
-		dispatch( 'wc/admin/options' ).updateOptions( {
+		optionsDispatch.updateOptions( {
 			[ CUSTOMIZATION_OPTIONS_NOTICE_OPTION ]: 'no',
 		} );
-	}, [] );
+	}, [ optionsDispatch ] );
 
 	if ( ! isUpeEnabled || ! isCustomizationOptionsNoticeVisible ) {
 		return null;

--- a/client/settings/customization-options-notice/index.js
+++ b/client/settings/customization-options-notice/index.js
@@ -4,7 +4,7 @@
 import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, dispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import interpolateComponents from 'interpolate-components';
 
@@ -26,7 +26,7 @@ const NoticeWrapper = styled( InlineNotice )`
 const CUSTOMIZATION_OPTIONS_NOTICE_OPTION =
 	'wc_show_upe_customization_options_notice';
 
-const CustomizationOptionNotice = () => {
+const CustomizationOptionsNotice = () => {
 	const { isUpeEnabled } = useContext( UpeToggleContext );
 
 	const isCustomizationOptionsNoticeVisible = useSelect( ( select ) => {
@@ -44,13 +44,11 @@ const CustomizationOptionNotice = () => {
 		return hasFinishedResolving && ! isOptionDismissed;
 	} );
 
-	const { updateOptions } = useDispatch( 'wc/admin/options' );
-
 	const handleDismissNotice = useCallback( () => {
-		updateOptions( {
+		dispatch( 'wc/admin/options' ).updateOptions( {
 			[ CUSTOMIZATION_OPTIONS_NOTICE_OPTION ]: 'no',
 		} );
-	}, [ updateOptions ] );
+	}, [] );
 
 	if ( ! isUpeEnabled || ! isCustomizationOptionsNoticeVisible ) {
 		return null;
@@ -71,4 +69,4 @@ const CustomizationOptionNotice = () => {
 	);
 };
 
-export default CustomizationOptionNotice;
+export default CustomizationOptionsNotice;

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -15,7 +15,7 @@ import GeneralSettingsSection from '../general-settings-section';
 import ApplePayIcon from '../../payment-method-icons/apple-pay';
 import GooglePayIcon from '../../payment-method-icons/google-pay';
 import UpeToggleContext from '../upe-toggle/context';
-import CustomizationOptionNotice from '../customization-option-notice';
+import CustomizationOptionsNotice from '../customization-options-notice';
 
 const IconsWrapper = styled.ul`
 	li {
@@ -78,7 +78,7 @@ const PaymentMethodsPanel = () => {
 		<>
 			<SettingsSection Description={ PaymentMethodsDescription }>
 				<GeneralSettingsSection />
-				<CustomizationOptionNotice />
+				<CustomizationOptionsNotice />
 			</SettingsSection>
 			<SettingsSection Description={ PaymentRequestDescription }>
 				<PaymentRequestSection />

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -12,7 +12,7 @@ import SettingsSection from '../settings-section';
 import CardBody from '../card-body';
 import PaymentsAndTransactionsSection from '../payments-and-transactions-section';
 import AdvancedSettingsSection from '../advanced-settings-section';
-import CustomizationOptionNotice from '../customization-option-notice';
+import CustomizationOptionsNotice from '../customization-options-notice';
 
 const GeneralSettingsDescription = () => (
 	<>
@@ -82,7 +82,7 @@ const PaymentSettingsPanel = () => {
 		<>
 			<SettingsSection Description={ GeneralSettingsDescription }>
 				<GeneralSettingsSection />
-				<CustomizationOptionNotice />
+				<CustomizationOptionsNotice />
 			</SettingsSection>
 			<SettingsSection Description={ AccountDetailsDescription }>
 				<AccountDetailsSection />

--- a/client/settings/settings-manager/__tests__/index.test.js
+++ b/client/settings/settings-manager/__tests__/index.test.js
@@ -13,13 +13,7 @@ jest.mock( '@woocommerce/navigation', () => ( {
 	getQuery: jest.fn().mockReturnValue( {} ),
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: jest.fn().mockReturnValue( {} ),
-	useDispatch: jest.fn().mockReturnValue( {} ),
-	combineReducers: jest.fn().mockReturnValue( {} ),
-	createReduxStore: jest.fn().mockReturnValue( {} ),
-	register: jest.fn().mockReturnValue( {} ),
-} ) );
+jest.mock( 'wcstripe/settings/customization-options-notice', () => () => null );
 
 describe( 'SettingsManager', () => {
 	afterEach( () => {

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -22,8 +22,6 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_checkout_enabled() {
-		delete_option('wc_show_upe_customization_options_notice');
-		return true;
 		$stripe_settings = get_option( 'woocommerce_stripe_settings', null );
 		return ! empty( $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] ) && 'yes' === $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ];
 	}

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -22,6 +22,8 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_checkout_enabled() {
+		delete_option('wc_show_upe_customization_options_notice');
+		return true;
 		$stripe_settings = get_option( 'woocommerce_stripe_settings', null );
 		return ! empty( $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] ) && 'yes' === $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ];
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3738,6 +3738,448 @@
         "prop-types": "^15.7.0"
       }
     },
+    "@woocommerce/data": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/data/-/data-1.4.0.tgz",
+      "integrity": "sha512-Koqgi+DyLJAVLSiE9CYFwe3OgRQnCgHiJL0VNjPnZA7wXeI2oqP7NSkpdPu/rLppIkQMRsRpkLHE8ScxjwnBRA==",
+      "dev": true,
+      "requires": {
+        "@woocommerce/date": "^3.1.0",
+        "@woocommerce/navigation": "^6.1.0",
+        "@wordpress/api-fetch": "2.2.8",
+        "@wordpress/compose": "3.23.1",
+        "@wordpress/core-data": "3.0.0",
+        "@wordpress/data": "5.0.0",
+        "@wordpress/data-controls": "2.0.0",
+        "@wordpress/element": "2.19.0",
+        "@wordpress/hooks": "2.11.0",
+        "@wordpress/i18n": "3.17.0",
+        "@wordpress/url": "2.21.0",
+        "md5": "^2.3.0",
+        "rememo": "^3.0.0"
+      },
+      "dependencies": {
+        "@wordpress/api-fetch": {
+          "version": "2.2.8",
+          "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-2.2.8.tgz",
+          "integrity": "sha512-mbdP9GvDe8Ojv8cobk30mfg2btEZDQEe7IgO+rGSlvVlHC88U8cc2VgOLNX6c9/6/sCvkoGd4Tsy85VbdTlTXw==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@wordpress/hooks": "^2.0.5",
+            "@wordpress/i18n": "^3.1.1",
+            "@wordpress/url": "^2.3.3"
+          }
+        },
+        "@wordpress/compose": {
+          "version": "3.23.1",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.23.1.tgz",
+          "integrity": "sha512-42xMoQZghhdErpBAvxcjlNKK21Lewq86KemDtAmbq9R+CYj93LGDYwceWdaqW7TwYuD9AgdI4ggr+dPhYFOCAA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@wordpress/deprecated": "^2.11.0",
+            "@wordpress/dom": "^2.16.0",
+            "@wordpress/element": "^2.19.0",
+            "@wordpress/is-shallow-equal": "^3.0.0",
+            "@wordpress/keycodes": "^2.18.0",
+            "@wordpress/priority-queue": "^1.10.0",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
+            "mousetrap": "^1.6.5",
+            "react-merge-refs": "^1.0.0",
+            "react-resize-aware": "^3.0.1",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-5.0.0.tgz",
+          "integrity": "sha512-Vcv0a6WXf0UKYkRQrXfITbd+MrjAAXl3YCuixmkC05LUiFjsMKbAFZ3AMPLAjTlWETQCcNvupi3lqmoIjeEBbg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^4.0.0",
+            "@wordpress/deprecated": "^3.0.0",
+            "@wordpress/element": "^3.0.0",
+            "@wordpress/is-shallow-equal": "^4.0.0",
+            "@wordpress/priority-queue": "^2.0.0",
+            "@wordpress/redux-routine": "^4.0.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "redux": "^4.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          },
+          "dependencies": {
+            "@wordpress/compose": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
+              "integrity": "sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@types/lodash": "4.14.149",
+                "@types/mousetrap": "^1.6.8",
+                "@wordpress/deprecated": "^3.2.0",
+                "@wordpress/dom": "^3.2.0",
+                "@wordpress/element": "^3.2.0",
+                "@wordpress/is-shallow-equal": "^4.2.0",
+                "@wordpress/keycodes": "^3.2.0",
+                "@wordpress/priority-queue": "^2.2.0",
+                "clipboard": "^2.0.1",
+                "lodash": "^4.17.21",
+                "mousetrap": "^1.6.5",
+                "react-resize-aware": "^3.1.0",
+                "use-memo-one": "^1.1.1"
+              }
+            },
+            "@wordpress/deprecated": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-3.2.1.tgz",
+              "integrity": "sha512-+mSpxeu0za9cNw30x9n0kZY/IUhmd9vhEzjZzLfT92lY3dDPXCEaE4IOSdPevcLpWTcKd7RhRMj2zXmaU5MA2g==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/hooks": "^3.2.0"
+              }
+            },
+            "@wordpress/dom": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-3.2.3.tgz",
+              "integrity": "sha512-0n1zGTKYt8lCxS5Q3fsFBUzDx+VjysrPX0Q/trE5b68NxJk4tIrQ9BeFa2wSZAmd1GPer0l/ZTbIGppgdtNUIg==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "lodash": "^4.17.21"
+              }
+            },
+            "@wordpress/element": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+              "integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@types/react": "^16.9.0",
+                "@types/react-dom": "^16.9.0",
+                "@wordpress/escape-html": "^2.2.0",
+                "lodash": "^4.17.21",
+                "react": "^17.0.1",
+                "react-dom": "^17.0.1"
+              }
+            },
+            "@wordpress/escape-html": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-2.2.1.tgz",
+              "integrity": "sha512-+5hMa+1BLYgHdOxPK7TF+hfAaKJY1UE6osZL8s4boYeaq/O23PFv4aCPQF+z9/4cIKyvOJPGk26Z1Op6DwJLGA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@wordpress/hooks": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.0.tgz",
+              "integrity": "sha512-nVR6V9kPxl8+aYQzQJdoDt+aKBKHHD0zplcYZbu2MHxjmHMvppAeL9mjzVhQZj/3n10NR2Ftk94mHQzHWfhCCg==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@wordpress/i18n": {
+              "version": "4.2.2",
+              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.2.2.tgz",
+              "integrity": "sha512-6PrfTDpeW5dfWyuqUx4Z5ApKFbh45CAbCs/G3PuZLlKJlXs/8p2Oq6Zxs0gLZk1QfHkw0t5qMx61lDlxWQhuPw==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/hooks": "^3.2.0",
+                "gettext-parser": "^1.3.1",
+                "lodash": "^4.17.21",
+                "memize": "^1.1.0",
+                "sprintf-js": "^1.1.1",
+                "tannin": "^1.2.0"
+              }
+            },
+            "@wordpress/is-shallow-equal": {
+              "version": "4.2.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-4.2.0.tgz",
+              "integrity": "sha512-9Oy7f3HFLMNfry4LLwYmfx4tROmusPAOfanv9F/MgzSBfMH7eyxU2JZd4KrP7IbPb59UfoUa8GhaLsnqKm66og==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@wordpress/keycodes": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.2.2.tgz",
+              "integrity": "sha512-z4B4vby+iGciJ9gvUBIozsseDkdQXDNuWm5szMnG5g1Nn7UGDWmfCNc9IHNs3alXySmAFev6d0T/o/zgm9BBvQ==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/i18n": "^4.2.2",
+                "lodash": "^4.17.21"
+              }
+            },
+            "@wordpress/priority-queue": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-2.2.1.tgz",
+              "integrity": "sha512-ou3dbfnWvIsTH6fZJhveobOxO0VH09XpIoKalDPVB9TD65LP5Zuy5KTn0ASV5V/+5KEdMNRxQ1U/9uPJc6wIXw==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "react": {
+              "version": "17.0.2",
+              "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+              "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1"
+              }
+            },
+            "react-dom": {
+              "version": "17.0.2",
+              "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+              "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+              "dev": true,
+              "requires": {
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "scheduler": "^0.20.2"
+              }
+            }
+          }
+        },
+        "@wordpress/deprecated": {
+          "version": "2.12.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.12.3.tgz",
+          "integrity": "sha512-qr+yDfTQfI3M4h6oY6IeHWwoHr4jxbILjSlV+Ht6Jjto9Owap6OuzSqR13Ev4xqIoG4C7b5B3gZXVfwVDae1zg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/hooks": "^2.12.3"
+          },
+          "dependencies": {
+            "@wordpress/hooks": {
+              "version": "2.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            }
+          }
+        },
+        "@wordpress/dom": {
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.18.0.tgz",
+          "integrity": "sha512-tM2WeQuSObl3nzWjUTF0/dyLnA7sdl/MXaSe32D64OF89bjSyJvjUipI7gjKzI3kJ7ddGhwcTggGvSB06MOoCQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "lodash": "^4.17.19"
+          }
+        },
+        "@wordpress/element": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.0.tgz",
+          "integrity": "sha512-t6GnllujeJU2N7RagWvPSSki+VnIxUQktg+cDAFDWC4XHCVoZKgs/0B48yeZSvd9T/t4ry0aILh+zeEJ+5DuHg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "@types/react": "^16.9.0",
+            "@types/react-dom": "^16.9.0",
+            "@wordpress/escape-html": "^1.11.0",
+            "lodash": "^4.17.19",
+            "react": "^16.13.1",
+            "react-dom": "^16.13.1"
+          }
+        },
+        "@wordpress/escape-html": {
+          "version": "1.12.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.12.2.tgz",
+          "integrity": "sha512-FabgSwznhdaUwe6hr1CsGpgxQbzqEoGevv73WIL1B9GvlZ6csRWodgHfWh4P6fYqpzxFL4WYB8wPJ1PdO32XFA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@wordpress/hooks": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.11.0.tgz",
+          "integrity": "sha512-TbvCrHcMiSZoyiflegEqVS3DDytDTpkms+yLUaGN4sMvNdR/Mv5s0WnNKyM0T49lbmZYPWlbWhwJ1F6hr/FQDg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+          "integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          }
+        },
+        "@wordpress/is-shallow-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-3.1.3.tgz",
+          "integrity": "sha512-eDLhfC4aaSgklzqwc6F/F4zmJVpTVTAvhqX+q0SP/8LPcP2HuKErPHVrEc75PMWqIutja2wJg98YSNPdewrj1w==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@wordpress/keycodes": {
+          "version": "2.19.3",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.19.3.tgz",
+          "integrity": "sha512-8rNdmP5M1ifTgLIL0dt/N1uTGsq/Rx1ydCXy+gg24WdxBRhyu5sudNVCtascVXo26aIfOH9OJRdqRZZTEORhog==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/i18n": "^3.20.0",
+            "lodash": "^4.17.19"
+          },
+          "dependencies": {
+            "@wordpress/hooks": {
+              "version": "2.12.3",
+              "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.12.3.tgz",
+              "integrity": "sha512-LmKiwKldZt6UYqOxV/a6+eUFXdvALFnB/pQx3RmrMvO64sgFhfR6dhrlv+uVbuuezSuv8dce1jx8lUWAT0krMA==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10"
+              }
+            },
+            "@wordpress/i18n": {
+              "version": "3.20.0",
+              "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.20.0.tgz",
+              "integrity": "sha512-SIoOJFB4UrrYAScS4H91CYCLW9dX3Ghv8pBKc/yHGculb1AdGr6gRMlmJxZV62Cn3CZ4Ga86c+FfR+GiBu0JPg==",
+              "dev": true,
+              "requires": {
+                "@babel/runtime": "^7.13.10",
+                "@wordpress/hooks": "^2.12.3",
+                "gettext-parser": "^1.3.1",
+                "lodash": "^4.17.19",
+                "memize": "^1.1.0",
+                "sprintf-js": "^1.1.1",
+                "tannin": "^1.2.0"
+              }
+            }
+          }
+        },
+        "@wordpress/priority-queue": {
+          "version": "1.11.2",
+          "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.11.2.tgz",
+          "integrity": "sha512-ulwmUOklY3orn1xXpcPnTyGWV5B/oycxI+cHZ6EevBVgM5sq+BW3xo0PKLR/MMm6UNBtFTu/71QAJrNZcD6V1g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10"
+          }
+        },
+        "@wordpress/url": {
+          "version": "2.21.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.21.0.tgz",
+          "integrity": "sha512-asTEPDkKirHyoGeoSv3tKHtqNStVUa0E/7ecd667rU7rnXQRB4AJU76fPdmi7aC9rpAz+en4FPtKrcloA2Sjgg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "lodash": "^4.17.19",
+            "react-native-url-polyfill": "^1.1.2"
+          }
+        },
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
+        }
+      }
+    },
+    "@woocommerce/date": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/date/-/date-3.1.0.tgz",
+      "integrity": "sha512-ZZx0/3+Ua2j65CKLCCgqi5cDzpmN6SSKmLtx5NHn5YeFLcgufz66oX5OVLlHOng9bOtqretXw2/Gh9E0c3CgLg==",
+      "dev": true,
+      "requires": {
+        "@wordpress/date": "3.13.0",
+        "@wordpress/i18n": "3.17.0",
+        "moment": "2.29.1",
+        "qs": "6.9.6"
+      },
+      "dependencies": {
+        "@wordpress/date": {
+          "version": "3.13.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.13.0.tgz",
+          "integrity": "sha512-mNN+0NVn1EQtpSk/3fyhuo9cDSrPBsTBdCtmiS3kN8ybkBhqXNTY+HInj0No3ZZ/xii1Hr8xYKm0YijtNtUs9g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "moment": "^2.22.1",
+            "moment-timezone": "^0.5.31"
+          }
+        },
+        "@wordpress/i18n": {
+          "version": "3.17.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.17.0.tgz",
+          "integrity": "sha512-CTZ0oezI6BT5GlmiE4X0fzRY6i7bNsX6hxiROkGlpREY6q4s1pnwhM8ggLIaP18Bvkb/HDkUEENDrv3iwM/LIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.19",
+            "memize": "^1.1.0",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.2.0"
+          }
+        },
+        "gettext-parser": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-1.4.0.tgz",
+          "integrity": "sha512-sedZYLHlHeBop/gZ1jdg59hlUEcpcZJofLq2JFwJT1zTqAU3l2wFv6IsuwFHGqbiT9DWzMUW4/em2+hspnmMMA==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.12",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "qs": {
+          "version": "6.9.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+          "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==",
+          "dev": true
+        },
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
+        }
+      }
+    },
     "@woocommerce/dependency-extraction-webpack-plugin": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.4.0.tgz",
@@ -4296,6 +4738,15 @@
         "@wordpress/url": "^3.2.1"
       }
     },
+    "@wordpress/autop": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.2.1.tgz",
+      "integrity": "sha512-dp5jm72v53ygEHiPp6CTyE8AzLEZ/YpW7kRKJGQwYz4U7wwkkfpsoattc/9uaQsv06AP6rEzT/ioGFOVZRuv9g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
     "@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
@@ -4349,6 +4800,157 @@
       "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-3.6.0.tgz",
       "integrity": "sha512-6/vXAmc9FSX7Y17UjKgUJoVU++Pv1U1G8uMx7iClRUaLetc7/jj2DD9PTyX/cdJjHr32e3yXuLVT9wfEbo6SEg==",
       "dev": true
+    },
+    "@wordpress/blob": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.2.1.tgz",
+      "integrity": "sha512-qD8wZ6n+hjoshV2dp9eGH3VismOM0kvrJn5cSe4PaoYDREqUhioJIDXktZxaohnvgWOq6xfJH6rS4Or8W0r9ew==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@wordpress/block-serialization-default-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.2.1.tgz",
+      "integrity": "sha512-TKLGqFiysDKtLnc0pjPD1AOU5fg0LX12XfrK9Ke6QmCP2q7e57+9ZM9SRzXQ2U8GRgsIiwhjzi31R2HQGXqYng==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@wordpress/blocks": {
+      "version": "9.1.8",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-9.1.8.tgz",
+      "integrity": "sha512-RYemYN+q5/M0k5mESBkQbsB101p9hWSOTSlGLzEPBj7yXJp/OnyQVdc2hAr6CQgX16CxOyRRXx1CYQdiOtXGYg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/autop": "^3.1.2",
+        "@wordpress/blob": "^3.1.2",
+        "@wordpress/block-serialization-default-parser": "^4.1.2",
+        "@wordpress/compose": "^4.1.6",
+        "@wordpress/data": "^5.1.6",
+        "@wordpress/deprecated": "^3.1.2",
+        "@wordpress/dom": "^3.1.5",
+        "@wordpress/element": "^3.1.2",
+        "@wordpress/hooks": "^3.1.1",
+        "@wordpress/html-entities": "^3.1.2",
+        "@wordpress/i18n": "^4.1.2",
+        "@wordpress/icons": "^4.0.3",
+        "@wordpress/is-shallow-equal": "^4.1.1",
+        "@wordpress/shortcode": "^3.1.2",
+        "hpq": "^1.3.0",
+        "lodash": "^4.17.21",
+        "rememo": "^3.0.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "tinycolor2": "^1.4.2",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
+          "integrity": "sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "^3.2.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/priority-queue": "^2.2.0",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-5.2.0.tgz",
+          "integrity": "sha512-NlPIC8PdKnPly9CnynQS1di59Af3eiCZrQgZm1VssfA620NDoJA5p3dlDYj/Ts4Ryzp78HCi7wjhkmbsHpnd6g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/element": "^3.2.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.0",
+            "@wordpress/redux-routine": "^4.2.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/element": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+          "integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/react": "^16.9.0",
+            "@types/react-dom": "^16.9.0",
+            "@wordpress/escape-html": "^2.2.0",
+            "lodash": "^4.17.21",
+            "react": "^17.0.1",
+            "react-dom": "^17.0.1"
+          }
+        },
+        "@wordpress/icons": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-4.1.0.tgz",
+          "integrity": "sha512-1FpEjT9kJbr0cWbgdgIwd2DoeerWijcVx3qCZ/WMFKNElBH9lfZLuWPI1hpX102HGWFcEi3VlbVpdBGeCeYQWg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^3.2.0",
+            "@wordpress/primitives": "^2.2.0"
+          }
+        },
+        "@wordpress/primitives": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-2.2.0.tgz",
+          "integrity": "sha512-WupgR+tt6fKGZE1UKy2gz3wDdpRL9MWQbVuetXv/7TPAz2ofOS2fZIsXNrl4D0HkA82gYh8w8s2TXK0XNyAAow==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/element": "^3.2.0",
+            "classnames": "^2.3.1"
+          }
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-dom": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "scheduler": "^0.20.2"
+          }
+        }
+      }
     },
     "@wordpress/browserslist-config": {
       "version": "4.1.0",
@@ -4423,6 +5025,109 @@
         "use-memo-one": "^1.1.1"
       }
     },
+    "@wordpress/core-data": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-3.0.0.tgz",
+      "integrity": "sha512-+snfZQ0duvd8ln1Z6vBNusOLyuYqWeF8N6W2zEbAlFIEMYkyAJw2+R6dxMgOp57e+sBlXi9cgxPrJtST7NH6Qw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/api-fetch": "^5.0.0",
+        "@wordpress/blocks": "^9.0.0",
+        "@wordpress/data": "^5.0.0",
+        "@wordpress/data-controls": "^2.0.0",
+        "@wordpress/element": "^3.0.0",
+        "@wordpress/html-entities": "^3.0.0",
+        "@wordpress/i18n": "^4.0.0",
+        "@wordpress/is-shallow-equal": "^4.0.0",
+        "@wordpress/url": "^3.0.0",
+        "equivalent-key-map": "^0.2.2",
+        "lodash": "^4.17.21",
+        "rememo": "^3.0.0",
+        "uuid": "^8.3.0"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
+          "integrity": "sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "^3.2.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/priority-queue": "^2.2.0",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-5.2.0.tgz",
+          "integrity": "sha512-NlPIC8PdKnPly9CnynQS1di59Af3eiCZrQgZm1VssfA620NDoJA5p3dlDYj/Ts4Ryzp78HCi7wjhkmbsHpnd6g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/element": "^3.2.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.0",
+            "@wordpress/redux-routine": "^4.2.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/element": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+          "integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/react": "^16.9.0",
+            "@types/react-dom": "^16.9.0",
+            "@wordpress/escape-html": "^2.2.0",
+            "lodash": "^4.17.21",
+            "react": "^17.0.1",
+            "react-dom": "^17.0.1"
+          }
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-dom": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "scheduler": "^0.20.2"
+          }
+        }
+      }
+    },
     "@wordpress/data": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-6.0.1.tgz",
@@ -4474,6 +5179,99 @@
           "requires": {
             "@babel/runtime": "^7.13.10",
             "lodash": "^4.17.21"
+          }
+        }
+      }
+    },
+    "@wordpress/data-controls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-2.0.0.tgz",
+      "integrity": "sha512-MoyObpMueHzmI4MOWAYF0ibzmPyNnWKT3RHRrVimO7WEmvCYrRnhi54umEpgkM086MB4pyVPbuvH2bJbRFpj6A==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@wordpress/api-fetch": "^5.0.0",
+        "@wordpress/data": "^5.0.0",
+        "@wordpress/deprecated": "^3.0.0"
+      },
+      "dependencies": {
+        "@wordpress/compose": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-4.2.0.tgz",
+          "integrity": "sha512-8CJ4wzTXT9ZP+uIvN1d2cPBv06ZmhUh+UKzSf7v1o7T28SaYRcoZbsvDD2dnXbS2ZwWPIYAD9waNLWjCBq/izA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/lodash": "4.14.149",
+            "@types/mousetrap": "^1.6.8",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/dom": "^3.2.0",
+            "@wordpress/element": "^3.2.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/keycodes": "^3.2.0",
+            "@wordpress/priority-queue": "^2.2.0",
+            "clipboard": "^2.0.1",
+            "lodash": "^4.17.21",
+            "mousetrap": "^1.6.5",
+            "react-resize-aware": "^3.1.0",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/data": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-5.2.0.tgz",
+          "integrity": "sha512-NlPIC8PdKnPly9CnynQS1di59Af3eiCZrQgZm1VssfA620NDoJA5p3dlDYj/Ts4Ryzp78HCi7wjhkmbsHpnd6g==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@wordpress/compose": "^4.2.0",
+            "@wordpress/deprecated": "^3.2.0",
+            "@wordpress/element": "^3.2.0",
+            "@wordpress/is-shallow-equal": "^4.2.0",
+            "@wordpress/priority-queue": "^2.2.0",
+            "@wordpress/redux-routine": "^4.2.0",
+            "equivalent-key-map": "^0.2.2",
+            "is-promise": "^4.0.0",
+            "lodash": "^4.17.21",
+            "memize": "^1.1.0",
+            "turbo-combine-reducers": "^1.0.2",
+            "use-memo-one": "^1.1.1"
+          }
+        },
+        "@wordpress/element": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-3.2.0.tgz",
+          "integrity": "sha512-YXJhtBF8FnFYwA9X6Dvs4k6yJf5wy1lhU04VNJVzoUDwCt/pK747RGePIPDdUWVd3X/TlyNH2yLRtcCyOC/SzQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.13.10",
+            "@types/react": "^16.9.0",
+            "@types/react-dom": "^16.9.0",
+            "@wordpress/escape-html": "^2.2.0",
+            "lodash": "^4.17.21",
+            "react": "^17.0.1",
+            "react-dom": "^17.0.1"
+          }
+        },
+        "react": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
+          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "react-dom": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
+          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "scheduler": "^0.20.2"
           }
         }
       }
@@ -4619,6 +5417,15 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.2.0.tgz",
       "integrity": "sha512-nVR6V9kPxl8+aYQzQJdoDt+aKBKHHD0zplcYZbu2MHxjmHMvppAeL9mjzVhQZj/3n10NR2Ftk94mHQzHWfhCCg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10"
+      }
+    },
+    "@wordpress/html-entities": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-3.2.1.tgz",
+      "integrity": "sha512-DHuIQ7MMyAcmkMM/VY8RibIcLiIcstk6Og09f4EWQegOgage6yMgnG7eI0nf2LBe65mttnda1EL51slc7XjaXg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.13.10"
@@ -5704,6 +6511,17 @@
           "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
           "dev": true
         }
+      }
+    },
+    "@wordpress/shortcode": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.2.1.tgz",
+      "integrity": "sha512-nVELegRjoy/ShrKx2julCSCHiXlp8NTPfxYQCqNomUJzosdqVg7hj/LGt1STu7vZIqPayS8iVG3V7d0s2kGAkg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "lodash": "^4.17.21",
+        "memize": "^1.1.0"
       }
     },
     "@wordpress/stylelint-config": {
@@ -8913,6 +9731,12 @@
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
@@ -9778,6 +10602,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -13186,6 +14016,12 @@
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
+    "hpq": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/hpq/-/hpq-1.3.0.tgz",
+      "integrity": "sha512-fvYTvdCFOWQupGxqkahrkA+ERBuMdzkxwtUdKrxR6rmMd4Pfl+iZ1QiQYoaZ0B/v0y59MOMnz3XFUWbT50/NWA==",
+      "dev": true
+    },
     "html-element-map": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
@@ -16351,6 +17187,17 @@
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
       "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
       "dev": true
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
     },
     "md5.js": {
       "version": "1.3.5",
@@ -20755,6 +21602,155 @@
       "dev": true,
       "optional": true
     },
+    "showdown": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-1.9.1.tgz",
+      "integrity": "sha512-9cGuS382HcvExtf5AHk7Cb4pAeQQ+h0eTr33V1mu+crYWV4KvWAw6el92bDrqGEk5d46Ai/fhbEUwqJ/mTCNEA==",
+      "dev": true,
+      "requires": {
+        "yargs": "^14.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
+        },
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "14.2.3",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^15.0.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "15.0.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.3.tgz",
+          "integrity": "sha512-/MVEVjTXy/cGAjdtQf8dW3V9b97bPN7rNn8ETj6BmAQL7ibC7O1Q9SPJbGjgh3SlwoBNXMzj/ZGIj8mBgl12YA==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -20770,6 +21766,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "dev": true
+    },
+    "simple-html-tokenizer": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
+      "integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
       "dev": true
     },
     "sirv": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@testing-library/user-event": "^13.2.1",
     "@types/react": "16.9.56",
     "@types/react-dom": "16.9.9",
+    "@woocommerce/data": "^1.4.0",
     "@woocommerce/dependency-extraction-webpack-plugin": "^1.4.0",
     "@woocommerce/eslint-plugin": "^1.1.0",
     "@woocommerce/navigation": "^6.1.0",


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Trying to fix this intermittent error:
```
TypeError: Cannot destructure property 'updateOptions' of 'Object(...)(...)' as it is null.
    at CustomizationOptionNotice (index.js:47) 
```

It seems to happen only sometimes 🤷 

The `useDispatch(‘wc/admin/options’)` is sometimes `null`, so that's why the error happens - we can't destructure it.
By using `dispatch` instead, hopefully things become better (since the descruturing now happens when the callback is triggered - it's delayed).

# Testing instructions

- Ensure you have the `_wcstripe_feature_upe_settings` flag enabled
- Ensure you have the `woocommerce_stripe_settings.upe_checkout_experience_enabled` flag enabled
- Go to the settings page: http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- The page should no longer break because of the above error 🤞 