### PR TITLE
Redirect to bank page during 3DS flow

### DIFF
--- a/client/blocks/three-d-secure/use-payment-intents.js
+++ b/client/blocks/three-d-secure/use-payment-intents.js
@@ -27,12 +27,20 @@ const openIntentModal = ( {
 	successType,
 } ) => {
 	const checkoutResponse = { type: successType };
+
+	if ( paymentDetails.manual_redirect ) {
+		// Need to redirect to bank instead of confirming via modal.
+		checkoutResponse.redirectUrl = paymentDetails.manual_redirect;
+		return checkoutResponse;
+	}
+
 	if (
 		! paymentDetails.setup_intent_secret &&
 		! paymentDetails.payment_intent_secret
 	) {
 		return true;
 	}
+
 	const isSetupIntent = !! paymentDetails.setup_intent_secret;
 	const verificationUrl = paymentDetails.verification_endpoint;
 	const intentSecret = isSetupIntent

--- a/client/blocks/three-d-secure/use-payment-intents.js
+++ b/client/blocks/three-d-secure/use-payment-intents.js
@@ -28,9 +28,9 @@ const openIntentModal = ( {
 } ) => {
 	const checkoutResponse = { type: successType };
 
-	if ( paymentDetails.manual_redirect ) {
+	if ( paymentDetails.redirect ) {
 		// Need to redirect to bank instead of confirming via modal.
-		checkoutResponse.redirectUrl = paymentDetails.manual_redirect;
+		checkoutResponse.redirectUrl = paymentDetails.redirect;
 		return checkoutResponse;
 	}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1396,7 +1396,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		// Try to confirm the intent & capture the charge (if 3DS is not required).
 		$confirm_request = [
 			'source'     => $prepared_source->source,
-			'return_url' => $this->get_return_url( $order ),
+			'return_url' => add_query_arg(
+				[
+					'order_id' => $order->get_id(),
+				],
+				$this->get_return_url( $order )
+			),
 		];
 
 		$level3_data      = $this->get_level3_data_from_order( $order );
@@ -1551,7 +1556,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				'payment_method' => $prepared_source->source,
 				'customer'       => $prepared_source->customer,
 				'confirm'        => 'true',
-				'return_url'     => $this->get_return_url( $order ),
+				'return_url'     => add_query_arg(
+					[
+						'order_id' => $order->get_id(),
+					],
+					$this->get_return_url( $order )
+				),
 			],
 			'setup_intents'
 		);
@@ -1589,7 +1599,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'off_session'          => 'true',
 			'confirm'              => 'true',
 			'confirmation_method'  => 'automatic',
-			'return_url'           => $this->get_return_url( $order ),
+			'return_url'           => add_query_arg(
+				[
+					'order_id' => $order->get_id(),
+				],
+				$this->get_return_url( $order )
+			),
 		];
 
 		if ( isset( $full_request['statement_descriptor'] ) ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1396,7 +1396,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		// Try to confirm the intent & capture the charge (if 3DS is not required).
 		$confirm_request = [
 			'source'     => $prepared_source->source,
-			'return_url' => $order->get_checkout_payment_url( true ),
+			'return_url' => $this->get_return_url( $order ),
 		];
 
 		$level3_data      = $this->get_level3_data_from_order( $order );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1395,7 +1395,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		// Try to confirm the intent & capture the charge (if 3DS is not required).
 		$confirm_request = [
-			'source' => $prepared_source->source,
+			'source'     => $prepared_source->source,
+			'return_url' => $order->get_checkout_payment_url( true ),
 		];
 
 		$level3_data      = $this->get_level3_data_from_order( $order );
@@ -1550,6 +1551,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				'payment_method' => $prepared_source->source,
 				'customer'       => $prepared_source->customer,
 				'confirm'        => 'true',
+				'return_url'     => $this->get_return_url( $order ),
 			],
 			'setup_intents'
 		);
@@ -1587,6 +1589,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'off_session'          => 'true',
 			'confirm'              => 'true',
 			'confirmation_method'  => 'automatic',
+			'return_url'           => $this->get_return_url( $order ),
 		];
 
 		if ( isset( $full_request['statement_descriptor'] ) ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -627,10 +627,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 					// Redirect to bank page when appropriate.
 					if ( property_exists( $intent, 'next_action' ) && 'redirect_to_url' === $intent->next_action->type ) {
-						$manual_redirect = $intent->next_action->redirect_to_url->url;
 						return [
-							'result'          => 'success',
-							'manual_redirect' => $manual_redirect,
+							'result'   => 'success',
+							'redirect' => $intent->next_action->redirect_to_url->url,
 						];
 					}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -621,6 +621,41 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				// Use the last charge within the intent to proceed.
 				$response = end( $intent->charges->data );
 
+				// If the intent requires a 3DS flow, redirect to it.
+				if ( 'requires_action' === $intent->status ) {
+					$this->unlock_order_payment( $order );
+
+					// Redirect to bank page when appropriate.
+					if ( property_exists( $intent, 'next_action' ) && 'redirect_to_url' === $intent->next_action->type ) {
+						$manual_redirect = $intent->next_action->redirect_to_url->url;
+						return [
+							'result'          => 'success',
+							'manual_redirect' => $manual_redirect,
+						];
+					}
+
+					if ( is_wc_endpoint_url( 'order-pay' ) ) {
+						$redirect_url = add_query_arg( 'wc-stripe-confirmation', 1, $order->get_checkout_payment_url( false ) );
+
+						return [
+							'result'   => 'success',
+							'redirect' => $redirect_url,
+						];
+					} else {
+						/**
+						 * This URL contains only a hash, which will be sent to `checkout.js` where it will be set like this:
+						 * `window.location = result.redirect`
+						 * Once this redirect is sent to JS, the `onHashChange` function will execute `handleCardPayment`.
+						 */
+
+						return [
+							'result'                => 'success',
+							'redirect'              => $this->get_return_url( $order ),
+							'payment_intent_secret' => $intent->client_secret,
+							'save_payment_method'   => $this->save_payment_method_requested(),
+						];
+					}
+				}
 			}
 
 			// Process valid response.


### PR DESCRIPTION
Successful payments work, but failing the 3DS check is not reported
correctly.

# Changes proposed in this Pull Request:

There are some [upcoming regulatory changes in India related to recurring (subscription) payments](https://support.stripe.com/questions/important-updates-to-rbi-regulations-on-recurring-card-payments-in-india) that require changes in how customers go through the 3DS flow. Stripe has indicated that the easiest way to accomplish this -- at least for the moment -- is to switch to the [bank redirect 3DS flow](https://stripe.com/docs/payments/3d-secure#manual-redirect).

For now, the easiest approach seems to be to apply this change to all 3DS payments -- we can be more selective with how we do this further down the line when we're sure we're compliant.

More context in pc4etw-ky-p2.

# Testing instructions

Go through the following critical flows **with a 3DS card such as `4000000000003220`**:

* [Save card at checkout](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#save-card-at-checkout)
* [Checkout with saved card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#checkout-with-saved-card)
* [Checkout with SCA card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#checkout-with-sca-card)
* [Checkout failures (with various cards)](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#checkout-failures-with-various-cards) (SCA failures only)
* [Checkout with Payment Request](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#checkout-with-payment-request) (with SCA card)
* [Add new payment method](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#add-new-payment-method)
* [Purchase subscription product](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#purchase-subscription-product)
* [Purchaser free trial subscription](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#purchase-free-trial-subscription)
* [Purchase multiple subscriptions (same schedule)](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#purchase-multiple-subscriptions-same-schedule)
* [Purchase multiple subscriptions (differing schedules)](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#purchase-multiple-subscriptions-differing-schedules)
* [Renew subscription](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#renew-subscription)
* [Change payment method to new card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#change-payment-method-to-new-card)
* [Renew subscription manually](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#renew-subscription-manually)
* [Renew subscription automatically](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#renew-subscription-automatically)
* [Blocks: Checkout with SCA card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-checkout-with-sca-card)
* [Blocks: Checkout failures (with various cards)](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-checkout-failures-with-various-cards) (SCA failures only)
* [Blocks: Checkout with Payment Request](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-checkout-with-payment-request-button)
* [Blocks: Save card at checkout](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-save-card-at-checkout)
* [Blocks: Checkout with saved card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-checkout-with-saved-card)
* [Blocks: Purchase subscription product](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-purchase-subscription-product)
* [Blocks: Purchase free trial subscription](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-purchase-free-trial-subscription)
* [Blocks: Purchase multiple subscriptions](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#blocks-purchase-multiple-subscriptions)


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
