### PR TITLE
fix: blank settings page

### DIFF
--- a/includes/admin/class-wc-stripe-onboarding-controller.php
+++ b/includes/admin/class-wc-stripe-onboarding-controller.php
@@ -32,7 +32,7 @@ class WC_Stripe_Onboarding_Controller {
 				'dependencies' => [],
 				'version'      => WC_STRIPE_VERSION,
 			];
-		$style_path = 'build/style-upe_onboarding_wizard.css';
+		$style_path = 'build/upe_onboarding_wizard.css';
 		$style_url = plugins_url( $style_path, WC_STRIPE_MAIN_FILE );
 
 		wp_register_script(

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -40,7 +40,7 @@ class WC_Stripe_Payment_Requests_Controller {
 
 		wp_register_style(
 			'wc_stripe-payment-requests_customizer',
-			plugins_url( 'build/style-payment_requests_customizer.css', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/payment_requests_customizer.css', WC_STRIPE_MAIN_FILE ),
 			[],
 			$script_asset['version']
 		);

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -59,7 +59,7 @@ class WC_Stripe_Settings_Controller {
 			);
 			wp_register_style(
 				'woocommerce_stripe_admin',
-				plugins_url( 'build/style-upe_settings.css', WC_STRIPE_MAIN_FILE ),
+				plugins_url( 'build/upe_settings.css', WC_STRIPE_MAIN_FILE ),
 				[ 'wc-components' ],
 				$script_asset['version']
 			);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,10 @@ const DependencyExtractionWebpackPlugin = require( '@woocommerce/dependency-extr
 
 module.exports = {
 	...defaultConfig,
+	optimization: {
+		...defaultConfig.optimization,
+		splitChunks: undefined,
+	},
 	plugins: [
 		...defaultConfig.plugins.filter(
 			( plugin ) =>


### PR DESCRIPTION
# Changes proposed in this Pull Request:
The settings page is blank.

This is happening because Webpack is optimizing the code by generating some common chunks, which we are not loading via PHP.

This PR disables the chunks generation, so that all the code is included in one file.
This is a bit less efficient, but works for now, while we look for a different solution.

# Testing instructions
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&area=payment_requests
- Page loads
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- Page loads