### PR TITLE
chore: add survey emoji

### DIFF
--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -79,7 +79,7 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 				await setIsUpeEnabled( false );
 				createSuccessNotice(
 					__(
-						'What made you disable the new payments experience?',
+						'🤔 What made you disable the new payments experience?',
 						'woocommerce-gateway-stripe'
 					),
 					{


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Just a little copy update.

I needed to confirm with UX whether it was ok that the emojis would appear like the OS would interpret them (rather than all have the same theme).

Tested in:

Chrome
![Screen Shot 2021-09-10 at 3 00 27 PM](https://user-images.githubusercontent.com/273592/132911422-9968fa09-f701-4f21-ac33-ec049684d528.png)

Safari
![Screen Shot 2021-09-10 at 3 03 39 PM](https://user-images.githubusercontent.com/273592/132911433-b5f5dfee-9876-452e-adcc-81cb8989382d.png)

Firefox
![Screen Shot 2021-09-10 at 3 04 32 PM](https://user-images.githubusercontent.com/273592/132911448-33c3adbd-f14e-4200-878c-53c2e2392865.png)


# Testing instructions
- Ensure you have the `_wcstripe_feature_upe_settings` feature enabled
- Ensure you have the `woocommerce_stripe_settings.upe_checkout_experience_enabled` feature enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- Disable UPE through the hamburger menu on the payment methods section
- Confirm the choice in the modal
- The snackbar should appear with an emoji