### PR TITLE
Prepare header and changelog for 5.5.0 release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -127,8 +127,11 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 5.x.x - 2021-xx-xx =
+* Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.
 * Fix - Save payment method during 3D Secure flow for Block-based checkout.
+* Fix - Show subtotal on Payment Request dialog.
 * Add - Settings to control Payment Request Button locations in the Stripe plugin settings. Persists changes made through pre-existing filters, or defaults to the Cart and Product pages if no filters are in use.
 * Tweak - Deprecated the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.
+* Add - Notice for WP & WC version compatibility check.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
 Requires at least: 4.6
-Tested up to: 5.7
+Tested up to: 5.8
 Requires PHP: 5.6
 Stable tag: 5.4.1
 License: GPLv3

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -7,9 +7,9 @@
  * Author URI: https://woocommerce.com/
  * Version: 5.4.1
  * Requires at least: 4.6
- * Tested up to: 5.7
+ * Tested up to: 5.8
  * WC requires at least: 3.3
- * WC tested up to: 5.4
+ * WC tested up to: 5.6
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */


### PR DESCRIPTION
# Changes proposed in this Pull Request:

- Updated "tested up to" versions in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/1734c787d126ec623b7fa86d8b874da478e7d75c (based on the current versions of each, as of the latest testing session)
- Sync'd changelog to readme.txt in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/2f8c3c5b5fc3449245c346ae4979e03872e0551a

# Testing instructions

n/a

-------------------
- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.