### PR TITLE
Show count of enabled payment methods in main settings page

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -103,15 +103,20 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		// Load the settings.
 		$this->init_settings();
 
-		$main_settings                 = get_option( 'woocommerce_stripe_settings' );
-		$enabled_payment_methods_count = count( $this->get_upe_enabled_payment_method_ids() );
-		$this->title                   = $enabled_payment_methods_count . ( $enabled_payment_methods_count > 1 ? ' payment methods' : ' payment method' );
-		$this->description             = $this->get_option( 'description' );
-		$this->enabled                 = $this->get_option( 'enabled' );
-		$this->testmode                = ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'];
-		$this->publishable_key         = ! empty( $main_settings['publishable_key'] ) ? $main_settings['publishable_key'] : '';
-		$this->secret_key              = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
-		$this->statement_descriptor    = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
+		$main_settings              = get_option( 'woocommerce_stripe_settings' );
+		$this->title                = $this->get_option( 'title' );
+		$this->description          = $this->get_option( 'description' );
+		$this->enabled              = $this->get_option( 'enabled' );
+		$this->testmode             = ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'];
+		$this->publishable_key      = ! empty( $main_settings['publishable_key'] ) ? $main_settings['publishable_key'] : '';
+		$this->secret_key           = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
+		$this->statement_descriptor = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
+
+		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
+		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
+			$enabled_payment_methods_count = count( $this->get_upe_enabled_payment_method_ids() );
+			$this->title                   = $enabled_payment_methods_count . ( $enabled_payment_methods_count > 1 ? ' payment methods' : ' payment method' );
+		}
 
 		if ( $this->testmode ) {
 			$this->publishable_key = ! empty( $main_settings['test_publishable_key'] ) ? $main_settings['test_publishable_key'] : '';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -115,7 +115,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
 			$enabled_payment_methods_count = count( $this->get_upe_enabled_payment_method_ids() );
-			$this->title                   = $enabled_payment_methods_count . ( $enabled_payment_methods_count > 1 ? ' payment methods' : ' payment method' );
+			/* translators: $1. Count of enabled payment methods. */
+			$this->title = sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count );
 		}
 
 		if ( $this->testmode ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -103,14 +103,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		// Load the settings.
 		$this->init_settings();
 
-		$main_settings              = get_option( 'woocommerce_stripe_settings' );
-		$this->title                = $this->get_option( 'title' );
-		$this->description          = $this->get_option( 'description' );
-		$this->enabled              = $this->get_option( 'enabled' );
-		$this->testmode             = ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'];
-		$this->publishable_key      = ! empty( $main_settings['publishable_key'] ) ? $main_settings['publishable_key'] : '';
-		$this->secret_key           = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
-		$this->statement_descriptor = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
+		$main_settings                 = get_option( 'woocommerce_stripe_settings' );
+		$enabled_payment_methods_count = count( $this->get_upe_enabled_payment_method_ids() );
+		$this->title                   = $enabled_payment_methods_count . ( $enabled_payment_methods_count > 1 ? ' payment methods' : ' payment method' );
+		$this->description             = $this->get_option( 'description' );
+		$this->enabled                 = $this->get_option( 'enabled' );
+		$this->testmode                = ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'];
+		$this->publishable_key         = ! empty( $main_settings['publishable_key'] ) ? $main_settings['publishable_key'] : '';
+		$this->secret_key              = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
+		$this->statement_descriptor    = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
 
 		if ( $this->testmode ) {
 			$this->publishable_key = ! empty( $main_settings['test_publishable_key'] ) ? $main_settings['test_publishable_key'] : '';


### PR DESCRIPTION
Fixes #1726

### Description
When UPE preview and UPE checkout feature flags are enabled, currently the method name is `Stripe UPE`. Changes in this PR show the number of enabled payment methods beside the method name. This change is only applicable to the settings page only, not the checkout page.

**When `_wcstripe_feature_upe_settings` is enabled**
For 1 method enabled
![1 method](https://user-images.githubusercontent.com/33387139/133218861-4399f514-941b-452e-822d-c970404741e2.png)

For multiple methods enabled
![4 methods](https://user-images.githubusercontent.com/33387139/133218865-a73950a3-9c87-4a67-a3a6-7bbad19f715e.png)

**When `_wcstripe_feature_upe_settings` is disabled**
![without ff](https://user-images.githubusercontent.com/33387139/133218907-a17c8284-e1ee-4f75-8223-5e04fe92a514.png)

### Testing instructions
- Enable UPE preview and UPE checkout

### QA checklist
- [ ] Count of enabled payment method is visible beside the method name on the settings page
- [ ] Count of enabled payment method is not visible on the checkout page
- [ ] UI is unchanged when the feature flag is disabled
