### PR TITLE
feat: add UPE tracking capability

### DIFF
--- a/client/settings/upe-toggle/__tests__/provider.test.js
+++ b/client/settings/upe-toggle/__tests__/provider.test.js
@@ -109,7 +109,7 @@ describe( 'UpeToggleContextProvider', () => {
 
 		await waitFor( () => expect( apiFetch ).toHaveReturned() );
 
-		expect( recordEvent ).toHaveBeenCalledWith( 'wstripe_upe_disabled' );
+		expect( recordEvent ).toHaveBeenCalledWith( 'wcstripe_upe_disabled' );
 		expect( childrenMock ).toHaveBeenCalledWith( {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),

--- a/client/settings/upe-toggle/__tests__/provider.test.js
+++ b/client/settings/upe-toggle/__tests__/provider.test.js
@@ -11,8 +11,10 @@ import apiFetch from '@wordpress/api-fetch';
 
 import UpeToggleContextProvider from '../provider';
 import UpeToggleContext from '../context';
+import { recordEvent } from 'wcstripe/tracking';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( 'wcstripe/tracking', () => ( { recordEvent: jest.fn() } ) );
 
 describe( 'UpeToggleContextProvider', () => {
 	afterEach( () => {
@@ -41,6 +43,7 @@ describe( 'UpeToggleContextProvider', () => {
 			status: 'resolved',
 		} );
 		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( recordEvent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should render the initial state given a default value for isUpeEnabled', () => {
@@ -59,6 +62,7 @@ describe( 'UpeToggleContextProvider', () => {
 			} )
 		);
 		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( recordEvent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should call the API and resolve when setIsUpeEnabled has been called', async () => {
@@ -105,6 +109,7 @@ describe( 'UpeToggleContextProvider', () => {
 
 		await waitFor( () => expect( apiFetch ).toHaveReturned() );
 
+		expect( recordEvent ).toHaveBeenCalledWith( 'wstripe_upe_disabled' );
 		expect( childrenMock ).toHaveBeenCalledWith( {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),

--- a/client/settings/upe-toggle/provider.js
+++ b/client/settings/upe-toggle/provider.js
@@ -11,7 +11,7 @@ import UpeToggleContext from './context';
 // eslint-disable-next-line @woocommerce/dependency-group,import/no-unresolved
 import { recordEvent } from 'wcstripe/tracking';
 
-function trackToggle( isEnabled ) {
+function trackUpeToggle( isEnabled ) {
 	const eventName = isEnabled
 		? 'wstripe_upe_enabled'
 		: 'wstripe_upe_disabled';
@@ -37,7 +37,7 @@ const UpeToggleContextProvider = ( { children, defaultIsUpeEnabled } ) => {
 				data: { is_upe_enabled: sanitizedValue },
 			} )
 				.then( () => {
-					trackToggle( sanitizedValue );
+					trackUpeToggle( sanitizedValue );
 					setIsUpeEnabled( sanitizedValue );
 					setStatus( 'resolved' );
 				} )

--- a/client/settings/upe-toggle/provider.js
+++ b/client/settings/upe-toggle/provider.js
@@ -8,6 +8,16 @@ import apiFetch from '@wordpress/api-fetch';
  * Internal dependencies
  */
 import UpeToggleContext from './context';
+// eslint-disable-next-line @woocommerce/dependency-group,import/no-unresolved
+import { recordEvent } from 'wcstripe/tracking';
+
+function trackToggle( isEnabled ) {
+	const eventName = isEnabled
+		? 'wstripe_upe_enabled'
+		: 'wstripe_upe_disabled';
+
+	recordEvent( eventName );
+}
 
 const UpeToggleContextProvider = ( { children, defaultIsUpeEnabled } ) => {
 	const [ isUpeEnabled, setIsUpeEnabled ] = useState(
@@ -27,6 +37,7 @@ const UpeToggleContextProvider = ( { children, defaultIsUpeEnabled } ) => {
 				data: { is_upe_enabled: sanitizedValue },
 			} )
 				.then( () => {
+					trackToggle( sanitizedValue );
 					setIsUpeEnabled( sanitizedValue );
 					setStatus( 'resolved' );
 				} )

--- a/client/settings/upe-toggle/provider.js
+++ b/client/settings/upe-toggle/provider.js
@@ -13,8 +13,8 @@ import { recordEvent } from 'wcstripe/tracking';
 
 function trackUpeToggle( isEnabled ) {
 	const eventName = isEnabled
-		? 'wstripe_upe_enabled'
-		: 'wstripe_upe_disabled';
+		? 'wcstripe_upe_enabled'
+		: 'wcstripe_upe_disabled';
 
 	recordEvent( eventName );
 }

--- a/client/tracking/__tests__/index.test.js
+++ b/client/tracking/__tests__/index.test.js
@@ -1,0 +1,35 @@
+import { recordEvent } from '..';
+
+jest.mock( '@wordpress/dom-ready', () => ( cb ) => cb() );
+
+describe( 'tracking', () => {
+	beforeEach( () => {
+		global.wcTracks = undefined;
+	} );
+
+	it( 'does not fail if the global library is not present in the DOM', () => {
+		expect( () =>
+			recordEvent( 'event_name', { value: '1' } )
+		).not.toThrow();
+	} );
+
+	it( 'does not track if tracking is not enabled', () => {
+		const recordEventMock = jest.fn();
+		global.wcTracks = { recordEvent: recordEventMock, isEnabled: false };
+
+		recordEvent( 'event_name', { value: '1' } );
+
+		expect( recordEventMock ).not.toHaveBeenCalled();
+	} );
+	it( 'does tracks the event with its payload', () => {
+		const recordEventMock = jest.fn();
+		global.wcTracks = { recordEvent: recordEventMock, isEnabled: true };
+
+		recordEvent( 'event_name', { value: '1' } );
+
+		expect( recordEventMock ).toHaveBeenCalledWith(
+			'event_name',
+			expect.objectContaining( { value: '1' } )
+		);
+	} );
+} );

--- a/client/tracking/index.js
+++ b/client/tracking/index.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+const LIBRARY_MOCK = {
+	isEnabled: false,
+	recordEvent: () => null,
+};
+
+/**
+ * Returns the tracking library from the global event.
+ *
+ * @return {Object} The tracking library.
+ */
+function getLibrary() {
+	if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
+		return window.wc.tracks;
+	}
+
+	if ( window.wcTracks && window.wcTracks.recordEvent ) {
+		return window.wcTracks;
+	}
+
+	return LIBRARY_MOCK;
+}
+
+/**
+ * Checks if site tracking is enabled.
+ *
+ * @return {boolean} True if site tracking is enabled.
+ */
+function isEnabled() {
+	return getLibrary().isEnabled;
+}
+
+/**
+ * Records site event.
+ *
+ * @param {string}  eventName       Name of the event.
+ * @param {Object?} eventProperties Event properties.
+ */
+export function recordEvent( eventName, eventProperties ) {
+	// Wc-admin track script could be enqueued after our plugin, wrap in domReady
+	// to make sure we're not too early.
+	domReady( () => {
+		if ( ! isEnabled() ) {
+			return;
+		}
+
+		getLibrary().recordEvent( eventName, eventProperties );
+	} );
+}

--- a/client/tracking/index.js
+++ b/client/tracking/index.js
@@ -48,7 +48,6 @@ export function recordEvent( eventName, eventProperties ) {
 	// Wc-admin track script could be enqueued after our plugin, wrap in domReady
 	// to make sure we're not too early.
 	domReady( () => {
-		console.log( '###', { isEnabled: isEnabled(), lib: getLibrary() } );
 		if ( ! isEnabled() ) {
 			return;
 		}

--- a/client/tracking/index.js
+++ b/client/tracking/index.js
@@ -4,7 +4,6 @@
 import domReady from '@wordpress/dom-ready';
 
 const LIBRARY_MOCK = {
-	isEnabled: false,
 	recordEvent: () => null,
 };
 
@@ -14,7 +13,12 @@ const LIBRARY_MOCK = {
  * @return {Object} The tracking library.
  */
 function getLibrary() {
-	if ( window.wc && window.wc.tracks && window.wc.tracks.recordEvent ) {
+	if (
+		window.wc &&
+		window.wc.tracks &&
+		window.wc.tracks.recordEvent &&
+		typeof window.wc.tracks.recordEvent === 'function'
+	) {
 		return window.wc.tracks;
 	}
 
@@ -31,7 +35,7 @@ function getLibrary() {
  * @return {boolean} True if site tracking is enabled.
  */
 function isEnabled() {
-	return getLibrary().isEnabled;
+	return window.wcTracks && window.wcTracks.isEnabled;
 }
 
 /**
@@ -44,6 +48,7 @@ export function recordEvent( eventName, eventProperties ) {
 	// Wc-admin track script could be enqueued after our plugin, wrap in domReady
 	// to make sure we're not too early.
 	domReady( () => {
+		console.log( '###', { isEnabled: isEnabled(), lib: getLibrary() } );
 		if ( ! isEnabled() ) {
 			return;
 		}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@wordpress/components": "^15.0.0",
     "@wordpress/data": "^6.0.1",
     "@wordpress/data-controls": "^2.2.3",
+    "@wordpress/dom-ready": "^3.2.1",
     "@wordpress/i18n": "^4.2.1",
     "@wordpress/icons": "^5.0.1",
     "@wordpress/jest-preset-default": "^7.1.0",


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Tracking events for enabling/disabling the UPE feature.

Background info: p1631646724053500-slack-C02BHNRN6R1

## Testing instructions
- Ensure you have "Enables WooCommerce Analytics" enabled at http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features (if available)
- Ensure you have "Allow usage of WooCommerce to be tracked" enabled at http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com
- Ensure you have the `_wcstripe_feature_upe_settings` feature enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc_stripe-onboarding_wizard to enable UPE
- Enable UPE
- You should see a network request for the tracked event on the `pixel.wp.com` domain
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe to disable UPE
- Disable UPE through the hamburger menu
- You should see a network request for the tracked event on the `pixel.wp.com` domain
![Screen Shot 2021-09-14 at 6 08 11 PM](https://user-images.githubusercontent.com/273592/133345449-7bcd0762-48b5-46a2-9b25-75c300bac7a2.png)