### PR TITLE
POC: Add link to tooltip

### DIFF
--- a/client/components/payment-method-fees-pill/index.js
+++ b/client/components/payment-method-fees-pill/index.js
@@ -26,20 +26,32 @@ const FeeTerm = styled.dt`
 	margin-right: auto;
 `;
 
+const PStyled = styled.p`
+	text-align: left;
+	color: #ccc;
+	font-size: 11px;
+`;
+
 const FeesTooltipContent = () => {
 	return (
-		<FeesList>
-			<FeeTerm>Base fee</FeeTerm>
-			<dt>1.4% + $0.30</dt>
-			<FeeTerm>International payment method fee</FeeTerm>
-			<dt>1.5%</dt>
-			<FeeTerm>Foreign exchange fee</FeeTerm>
-			<dt>1.0%</dt>
-			<FeeTerm>Total per transaction</FeeTerm>
-			<dt>
-				<strong>3.9% + $0.30</strong>
-			</dt>
-		</FeesList>
+		<>
+			<FeesList>
+				<FeeTerm>Base fee</FeeTerm>
+				<dt>1.4% + $0.30</dt>
+				<FeeTerm>International payment method fee</FeeTerm>
+				<dt>1.5%</dt>
+				<FeeTerm>Foreign exchange fee</FeeTerm>
+				<dt>1.0%</dt>
+				<FeeTerm>Total per transaction</FeeTerm>
+				<dt>
+					<strong>3.9% + $0.30</strong>
+				</dt>
+			</FeesList>
+			<PStyled>
+				Dispute and failed transactions have separate fees.{ ' ' }
+				<a href="TODO?">Learn more</a>
+			</PStyled>
+		</>
 	);
 };
 


### PR DESCRIPTION
POC for paJDYF-2rk-p2#comment-7964

# Description
Attempt to add a link in tooltip. Adding onto the POC here https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1843

![image](https://user-images.githubusercontent.com/572862/133347230-3f790d5e-74c2-4c98-beb1-117546c3cc44.png)


