### PR TITLE
fix: prevent scripts queue when not necessary

### DIFF
--- a/includes/admin/class-wc-stripe-onboarding-controller.php
+++ b/includes/admin/class-wc-stripe-onboarding-controller.php
@@ -1,7 +1,5 @@
 <?php
 
-use Automattic\WooCommerce\Admin\PageController;
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -12,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 5.4.1
  */
 class WC_Stripe_Onboarding_Controller {
+	const SCREEN_ID = 'admin_page_wc_stripe-onboarding_wizard';
+
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_onboarding_wizard' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
@@ -22,6 +22,15 @@ class WC_Stripe_Onboarding_Controller {
 	 * Load admin scripts.
 	 */
 	public function admin_scripts() {
+		$current_screen = get_current_screen();
+		if ( ! $current_screen ) {
+			return;
+		}
+
+		if ( empty( $current_screen->id ) || self::SCREEN_ID !== $current_screen->id ) {
+			return;
+		}
+
 		// Webpack generates an assets file containing a dependencies array for our built JS file.
 		$script_path       = 'build/upe_onboarding_wizard.js';
 		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe_onboarding_wizard.asset.php';
@@ -77,7 +86,7 @@ class WC_Stripe_Onboarding_Controller {
 		wc_admin_connect_page(
 			[
 				'id'        => 'wc-stripe-onboarding-wizard',
-				'screen_id' => 'admin_page_wc_stripe-onboarding_wizard',
+				'screen_id' => self::SCREEN_ID,
 				'title'     => __( 'Onboarding Wizard', 'woocommerce-gateway-stripe' ),
 			]
 		);


### PR DESCRIPTION
# Changes proposed in this Pull Request:

We're queuing the `upe_onboarding_wizard.js` script even when not needed.
In the settings pages, (http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe / http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&area=payment_requests) we're queuing the `upe_onboarding_wizard.js` scripts, although it has no reason for being there.

This means that both `upe_onboarding_wizard.js` and `upe_settings.js` are registering the `wc/stripe` store. Which means that they each cancel each other's store changes.

By adding some checks on the onboarding wizard controller, we can ensure that we don't queue `upe_onboarding_wizard.js` unnecessarily.

I first noticed this because we're calling the settings endpoint multiple times, when we shouldn't.
![Screen Shot 2021-09-15 at 5 48 34 PM](https://user-images.githubusercontent.com/273592/133519902-2b5ae04a-74e7-4091-ba74-0bb10155f718.png)

Now we're calling it only once.
![Screen Shot 2021-09-15 at 5 49 36 PM](https://user-images.githubusercontent.com/273592/133519998-567e22d4-8bb6-4185-bbca-b220b81482a7.png)


# Testing instructions
- Ensure you have the `_wcstripe_feature_upe_settings` flag enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- Settings endpoint (`wp-json/wc/v3/wc_stripe/settings`) is called only once