### PR TITLE
Retrieve real account status

### DIFF
--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -1,4 +1,4 @@
-/* global wc_stripe_admin_settings */
+/* global wc_stripe_settings_params */
 /**
  * External dependencies
  */
@@ -13,6 +13,7 @@ import {
 import { moreVertical } from '@wordpress/icons';
 import SettingsSection from '../settings-section';
 import CardBody from '../card-body';
+import Pill from '../../components/pill';
 import AccountStatus from '../account-details';
 import PaymentsAndTransactionsSection from '../payments-and-transactions-section';
 import AdvancedSettingsSection from '../advanced-settings-section';
@@ -101,14 +102,17 @@ const AccountSettingsDropdownMenu = () => {
 };
 
 const AccountDetailsSection = () => {
-	const accountStatus = wc_stripe_admin_settings.accountStatus;
+	const accountStatus = wc_stripe_settings_params.accountStatus;
 
 	return (
 		<Card className="account-details">
 			<CardHeader className="account-details__header">
-				<h4 className="account-details__header">
-					{ accountStatus.email }
-				</h4>
+				{ accountStatus.email && (
+					<h4 className="account-details__header">
+						{ accountStatus.email }
+					</h4>
+				) }
+				{ accountStatus.mode === 'test' && <Pill>Test Mode</Pill> }
 				<AccountSettingsDropdownMenu />
 			</CardHeader>
 			<CardBody>

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -1,7 +1,4 @@
 /* global wc_stripe_settings_params */
-/**
- * External dependencies
- */
 import { __ } from '@wordpress/i18n';
 import { React } from 'react';
 import {

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -1,3 +1,7 @@
+/* global wc_stripe_admin_settings */
+/**
+ * External dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { React } from 'react';
 import {
@@ -96,24 +100,19 @@ const AccountSettingsDropdownMenu = () => {
 	);
 };
 
-const accountStatusMock = {
-	paymentsEnabled: true,
-	depositsEnabled: true,
-	email: 'hello@johndoe.com',
-	accountLink: 'https://stripe.com/support',
-};
-
 const AccountDetailsSection = () => {
+	const accountStatus = wc_stripe_admin_settings.accountStatus;
+
 	return (
 		<Card className="account-details">
 			<CardHeader className="account-details__header">
 				<h4 className="account-details__header">
-					{ accountStatusMock.email }
+					{ accountStatus.email }
 				</h4>
 				<AccountSettingsDropdownMenu />
 			</CardHeader>
 			<CardBody>
-				<AccountStatus accountStatus={ accountStatusMock } />
+				<AccountStatus accountStatus={ accountStatus } />
 			</CardBody>
 		</Card>
 	);

--- a/client/settings/settings-manager/__tests__/index.test.js
+++ b/client/settings/settings-manager/__tests__/index.test.js
@@ -9,6 +9,18 @@ jest.mock( '@woocommerce/navigation', () => ( {
 jest.mock( 'wcstripe/settings/customization-options-notice', () => () => null );
 
 describe( 'SettingsManager', () => {
+	beforeEach( () => {
+		global.wc_stripe_settings_params = {
+			accountStatus: {
+				email: 'test@example.com',
+				mode: 'test',
+				paymentsEnabled: true,
+				depositsEnabled: true,
+				accountLink: 'https://stripe.com/support',
+			},
+		};
+	} );
+
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -87,6 +87,11 @@ class WC_Stripe_Settings_Controller {
 		];
 		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
 
+		$settings = [
+			'accountStatus' => WC_Stripe_Account::get_account_status(),
+		];
+		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_admin_settings', $settings );
+
 		wp_enqueue_script( 'woocommerce_stripe_admin' );
 	}
 }

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -11,14 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Settings_Controller {
 	/**
-	 * Stripe Account
+	 * Constructor
 	 *
-	 * @var WC_Stripe_Account
+	 * @param WC_Stripe_Account $account Stripe account
 	 */
-	private $account;
-
-	public function __construct() {
-		$this->account = new WC_Stripe_Account();
+	public function __construct( WC_Stripe_Account $account ) {
+		$this->account = $account;
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
 	}

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -10,7 +10,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 5.4.1
  */
 class WC_Stripe_Settings_Controller {
+	/**
+	 * Stripe Account
+	 *
+	 * @var WC_Stripe_Account
+	 */
+	private $account;
+
 	public function __construct() {
+		$this->account = new WC_Stripe_Account();
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'wc_stripe_gateway_admin_options_wrapper', [ $this, 'admin_options' ] );
 	}
@@ -84,13 +92,9 @@ class WC_Stripe_Settings_Controller {
 			),
 			'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			'stripe_oauth_url'        => $oauth_url,
+			'accountStatus'           => $this->account->get_account_status(),
 		];
 		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
-
-		$settings = [
-			'accountStatus' => WC_Stripe_Account::get_account_status(),
-		];
-		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_admin_settings', $settings );
 
 		wp_enqueue_script( 'woocommerce_stripe_admin' );
 	}

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -11,6 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Settings_Controller {
 	/**
+	 * The Stripe account instance.
+	 *
+	 * @var WC_Stripe_Account
+	 */
+	private $account;
+
+	/**
 	 * Constructor
 	 *
 	 * @param WC_Stripe_Account $account Stripe account

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -62,7 +62,8 @@ class WC_Stripe_Account {
 		$expiration = 2 * HOUR_IN_SECONDS;
 
 		try {
-			$account = ( $this->stripe_api )::retrieve( 'account' );
+			// need call_user_func() as (  $this->stripe_api )::retrieve this syntax is not supported in php < 5.2
+			$account = call_user_func( [ $this->stripe_api, 'retrieve' ], 'account' );
 		} catch ( WC_Stripe_Exception $e ) {
 			return [];
 		}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -14,12 +14,21 @@ class WC_Stripe_Account {
 	const ACCOUNT_API    = 'account';
 
 	/**
+	 * Constructor
+	 *
+	 * @param WC_Stripe_Connect $connect Stripe connect
+	 */
+	public function __construct( WC_Stripe_Connect $connect ) {
+		$this->connect = $connect;
+	}
+
+	/**
 	 * Gets and caches the data for the account connected to this site.
 	 *
 	 * @return array Account data or empty if failed to retrieve account data.
 	 */
 	public function get_cached_account_data() {
-		if ( ! woocommerce_gateway_stripe()->connect->is_connected() ) {
+		if ( ! $this->connect->is_connected() ) {
 			return [];
 		}
 
@@ -29,8 +38,7 @@ class WC_Stripe_Account {
 			return $account;
 		}
 
-		$account = $this->cache_account();
-		return $account;
+		return $this->cache_account();
 	}
 
 	/**

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -12,7 +12,20 @@ class WC_Stripe_Account {
 
 	const LIVE_ACCOUNT_OPTION = 'wcstripe_account_data_live';
 	const TEST_ACCOUNT_OPTION = 'wcstripe_account_data_test';
-	const ACCOUNT_API         = 'account';
+
+	/**
+	 * The Stripe connect instance.
+	 *
+	 * @var WC_Stripe_Connect
+	 */
+	private $connect;
+
+	/**
+	 * The Stripe API class to access the static method.
+	 *
+	 * @var WC_Stripe_API
+	 */
+	private $stripe_api;
 
 	/**
 	 * Constructor
@@ -74,7 +87,7 @@ class WC_Stripe_Account {
 		// Create or update the account option cache.
 		set_transient( $this->get_transient_key(), $account_cache, $expiration );
 
-		return $account;
+		return json_decode( json_encode( $account ), true );
 	}
 
 	/**

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -1,0 +1,160 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Stripe_Account class.
+ *
+ * Communicates with Stripe API.
+ */
+class WC_Stripe_Account {
+
+	const ACCOUNT_OPTION = 'wcstripe_account_data';
+	const ACCOUNT_API    = 'account';
+
+	public function __construct() {
+		self::cache_account();
+	}
+
+	/**
+	 * Gets and caches the data for the account connected to this site.
+	 *
+	 * @return array Account data or empty if failed to retrieve account data.
+	 */
+	public static function get_cached_account_data() {
+		if ( ! woocommerce_gateway_stripe()->connect->is_connected() ) {
+			return [];
+		}
+
+		$account = self::read_account_from_cache();
+
+		if ( ! empty( $account ) ) {
+			return $account;
+		}
+
+		$account = self::cache_account();
+		return $account;
+	}
+
+	/**
+	 * Read the account from the WP option we cache it in.
+	 *
+	 * @return array
+	 */
+	private static function read_account_from_cache() {
+		$account_cache = get_option( self::ACCOUNT_OPTION );
+
+		if ( false === $account_cache || ! isset( $account_cache['account'] ) || ! isset( $account_cache['expires'] ) ) {
+			// No option found or the data isn't in the shape we expect.
+			return [];
+		}
+
+		// Set $account to empty if the cache has expired, triggering another fetch.
+		if ( $account_cache['expires'] < time() ) {
+			return [];
+		}
+
+		// We have fresh account data in the cache, so return it.
+		return $account_cache['account'];
+	}
+
+	/**
+	 * Caches account data for a period of time.
+	 */
+	private static function cache_account() {
+		$expiration = 2 * HOUR_IN_SECONDS;
+
+		try {
+			$account = WC_Stripe_API::request(
+				[],
+				self::ACCOUNT_API,
+				'GET'
+			);
+		} catch ( WC_Stripe_Exception $e ) {
+			return [];
+		}
+
+		// Add the account data and expiry time to the array we're caching.
+		$account_cache            = [];
+		$account_cache['account'] = $account;
+		$account_cache['expires'] = time() + $expiration;
+
+		// Create or update the account option cache.
+		if ( false === get_option( self::ACCOUNT_OPTION ) ) {
+			add_option( self::ACCOUNT_OPTION, $account_cache, '', 'no' );
+		} else {
+			update_option( self::ACCOUNT_OPTION, $account_cache, 'no' );
+		}
+
+		return $account;
+	}
+
+	/**
+	 * Refetches account data and returns the fresh data.
+	 *
+	 * @return array Either the new account data or empty if unavailable.
+	 */
+	public static function refresh_account_data() {
+		self::clear_cache();
+		return self::get_cached_account_data();
+	}
+
+	/**
+	 * Wipes the account data option.
+	 */
+	public static function clear_cache() {
+		delete_option( self::ACCOUNT_OPTION );
+	}
+
+	/**
+	 * Indicates whether card payments are enabled for this (Stripe) account.
+	 *
+	 * @return bool True if account can accept card payments, false otherwise.
+	 */
+	private static function are_payments_enabled( $account ) {
+		$capabilities = $account['capabilities'] ? $account['capabilities'] : [];
+
+		if ( empty( $capabilities ) ) {
+			return false;
+		}
+
+		return isset( $capabilities['card_payments'] ) && 'active' === $capabilities['card_payments'];
+	}
+
+	/**
+	 * Indicates if payouts are enabled for the (Stripe) account and if there is deposits schedule set.
+	 *
+	 * @return bool Returns 'false' if payouts aren't enabled for the (Stripe) account or of there is no
+	 * deposits schedule set.
+	 */
+	private static function are_deposits_enabled( $account ) {
+		$are_payouts_enabled = $account['payouts_enabled'] || false;
+		$payout_settings     = $account['settings']['payouts'] ? $account['settings']['payouts'] : [];
+
+		if ( ! $are_payouts_enabled || ! isset( $payout_settings['schedule']['interval'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets the acoount's status from the acount data that is connected to this site.
+	 *
+	 * @return array Account status data or empty if failed to retrieve account data.
+	 */
+	public static function get_account_status() {
+		$account = json_decode( json_encode( self::get_cached_account_data() ), true );
+
+		if ( empty( $account ) ) {
+			return [];
+		}
+		return [
+			'email'           => isset( $account['email'] ) ? $account['email'] : '',
+			'paymentsEnabled' => self::are_payments_enabled( $account ),
+			'depositsEnabled' => self::are_deposits_enabled( $account ),
+			'accountLink'     => 'https://stripe.com/support',
+		];
+	}
+}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -18,9 +18,11 @@ class WC_Stripe_Account {
 	 * Constructor
 	 *
 	 * @param WC_Stripe_Connect $connect Stripe connect
+	 * @param $stripe_api Stripe API class
 	 */
-	public function __construct( WC_Stripe_Connect $connect ) {
-		$this->connect = $connect;
+	public function __construct( WC_Stripe_Connect $connect, $stripe_api ) {
+		$this->connect    = $connect;
+		$this->stripe_api = $stripe_api;
 	}
 
 	/**
@@ -60,11 +62,7 @@ class WC_Stripe_Account {
 		$expiration = 2 * HOUR_IN_SECONDS;
 
 		try {
-			$account = WC_Stripe_API::request(
-				[],
-				self::ACCOUNT_API,
-				'GET'
-			);
+			$account = ( $this->stripe_api )::retrieve( 'account' );
 		} catch ( WC_Stripe_Exception $e ) {
 			return [];
 		}

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -22,8 +22,17 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->mock_account = $this->getMockBuilder( 'WC_Stripe_Account' )
+									->disableOriginalConstructor()
+									->setMethods(
+										[
+											'get_account_status',
+										]
+									)
+									->getMock();
+
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-settings-controller.php';
-		$this->controller = new WC_Stripe_Settings_Controller();
+		$this->controller = new WC_Stripe_Settings_Controller( $this->mock_account );
 		$this->gateway    = new WC_Gateway_Stripe();
 
 	}

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -52,3 +52,4 @@ require_once __DIR__ . '/helpers/class-wc-helper-product.php';
 require_once __DIR__ . '/helpers/class-wc-helper-shipping.php';
 require_once __DIR__ . '/helpers/class-wc-helper-order.php';
 require_once __DIR__ . '/helpers/class-wc-helper-token.php';
+require_once __DIR__ . '/helpers/class-wc-helper-stripe-api.php';

--- a/tests/phpunit/helpers/class-wc-helper-stripe-api.php
+++ b/tests/phpunit/helpers/class-wc-helper-stripe-api.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Stripe API helpers.
+ *
+ * @package WooCommerce\Tests
+ */
+
+/**
+ * Class WC_Helper_Stripe_Api.
+ *
+ * This helper class should ONLY be used for unit tests!.
+ * This helper class is used to mock static functions of WC_Stripe_API
+ */
+class WC_Helper_Stripe_Api {
+
+	/**
+	 * retrieve data. This is the equivalent mock for WC_Stripe_API::retrieve
+	 *
+	 * @param string data type
+	 *
+	 * @return array retrieved data mock
+	 */
+	public static function retrieve( $key = 'account' ) {
+		return [
+			'id'    => '1234',
+			'email' => 'test@example.com',
+		];
+	}
+}

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Class WC_Stripe_Account_Test
+ *
+ * @package WooCommerce_Stripe/Tests/WC_Stripe_Account
+ */
+
+/**
+ * Class WC_Stripe_Account tests.
+ */
+class WC_Stripe_Account_Test extends WP_UnitTestCase {
+	public function setUp() {
+		parent::setUp();
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-account.php';
+		$this->account = new WC_Stripe_Account();
+
+		$stripe_settings                         = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['enabled']              = 'yes';
+		$stripe_settings['testmode']             = 'yes';
+		$stripe_settings['test_publishable_key'] = 'pk_test_key';
+		$stripe_settings['test_secret_key']      = 'sk_test_key';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
+		$this->mock_api_client = $this->getMockBuilder( 'WC_Stripe_API' )
+									->disableOriginalConstructor()
+									->setMethods(
+										[
+											'request',
+										]
+									)
+									->getMock();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		delete_transient( 'wcstripe_account_data' );
+		delete_option( 'woocommerce_stripe_settings' );
+	}
+
+	public function test_get_cached_account_data_returns_empty_when_stripe_is_not_connected() {
+		delete_option( 'woocommerce_stripe_settings' );
+		$cached_data = $this->account->get_cached_account_data();
+
+		$this->assertEmpty( $cached_data );
+	}
+
+	public function test_get_cached_account_data_returns_data_when_cache_is_valid() {
+		$account = [
+			'id'   => '1234',
+			'mode' => 'test',
+		];
+		set_transient( 'wcstripe_account_data', $account );
+
+		$cached_data = $this->account->get_cached_account_data();
+
+		$this->assertSame( $cached_data, $account );
+	}
+
+	public function test_get_cached_account_data_fetch_data_when_cache_is_invalid() {
+		$response_data        = [
+			'id' => '1234',
+		];
+		$expected_cached_data = [
+			'id'   => '1234',
+			'mode' => 'test',
+		];
+		$this->mock_api_client->expects( $this->once() )->method( 'request' )->will(
+			$this->returnValue( $response_data )
+		);
+
+		$cached_data = $this->account->get_cached_account_data();
+
+		$this->assertEmpty( $cached_data );
+	}
+
+	public function test_clear_cache() {
+		$account = [
+			'id'   => '1234',
+			'mode' => 'test',
+		];
+		set_transient( 'wcstripe_account_data', $account );
+
+		$this->account->clear_cache();
+		$this->assertFalse( get_transient( 'wcstripe_account_data' ) );
+	}
+
+	public function test_get_account_status() {
+		$account = [
+			'id'              => '1234',
+			'email'           => 'test@example.com',
+			'capabilities'    => [],
+			'payouts_enabled' => false,
+			'settings'        => [
+				'payouts' => [],
+			],
+			'mode'            => 'test',
+		];
+		set_transient( 'wcstripe_account_data', $account );
+
+		$expected_response = [
+			'email'           => 'test@example.com',
+			'paymentsEnabled' => false,
+			'depositsEnabled' => false,
+			'accountLink'     => 'https://stripe.com/support',
+			'mode'            => 'test',
+		];
+
+		$account_status = $this->account->get_account_status();
+
+		$this->assertSame( $account_status, $expected_response );
+	}
+
+	public function test_get_account_status_with_error_when_account_is_empty() {
+		delete_option( 'woocommerce_stripe_settings' );
+
+		$expected_response = [
+			'error' => true,
+		];
+
+		$account_status = $this->account->get_account_status();
+		$this->assertSame( $account_status, $expected_response );
+	}
+}

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -9,6 +9,13 @@
  * Class WC_Stripe_Account tests.
  */
 class WC_Stripe_Account_Test extends WP_UnitTestCase {
+	/**
+	 * The Stripe account instance.
+	 *
+	 * @var WC_Stripe_Account
+	 */
+	private $account;
+
 	public function setUp() {
 		parent::setUp();
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -205,7 +205,8 @@ function woocommerce_gateway_stripe() {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();
 					} else {
-						new WC_Stripe_Settings_Controller();
+						$this->account = new WC_Stripe_Account();
+						new WC_Stripe_Settings_Controller( $this->account );
 					}
 
 					if ( WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -193,6 +193,7 @@ function woocommerce_gateway_stripe() {
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-settings-controller.php';
+					require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-account.php';
 
 					if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-old-settings-upe-toggle-controller.php';

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -188,6 +188,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-upe-compatibility.php';
 				require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
 				require_once dirname( __FILE__ ) . '/includes/migrations/class-allowed-payment-request-button-types-update.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-account.php';
 				new Allowed_Payment_Request_Button_Types_Update();
 
 				if ( is_admin() ) {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -205,7 +205,7 @@ function woocommerce_gateway_stripe() {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();
 					} else {
-						$this->account = new WC_Stripe_Account( $this->connect );
+						$this->account = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
 						new WC_Stripe_Settings_Controller( $this->account );
 					}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -125,10 +125,6 @@ function woocommerce_gateway_stripe() {
 
 				$this->init();
 
-				$this->api                           = new WC_Stripe_Connect_API();
-				$this->connect                       = new WC_Stripe_Connect( $this->api );
-				$this->payment_request_configuration = new WC_Stripe_Payment_Request();
-
 				add_action( 'rest_api_init', [ $this, 'register_routes' ] );
 			}
 
@@ -191,6 +187,10 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-account.php';
 				new Allowed_Payment_Request_Button_Types_Update();
 
+				$this->api                           = new WC_Stripe_Connect_API();
+				$this->connect                       = new WC_Stripe_Connect( $this->api );
+				$this->payment_request_configuration = new WC_Stripe_Payment_Request();
+
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-settings-controller.php';
@@ -205,7 +205,7 @@ function woocommerce_gateway_stripe() {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();
 					} else {
-						$this->account = new WC_Stripe_Account();
+						$this->account = new WC_Stripe_Account( $this->connect );
 						new WC_Stripe_Settings_Controller( $this->account );
 					}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -101,6 +101,13 @@ function woocommerce_gateway_stripe() {
 			public $payment_request_configuration;
 
 			/**
+			 * Stripe Account.
+			 *
+			 * @var WC_Stripe_Account
+			 */
+			private $account;
+
+			/**
 			 * Private clone method to prevent cloning of the instance of the
 			 * *Singleton* instance.
 			 *


### PR DESCRIPTION
Fixes #1822

### Description
Retrieving the real account data from Stripe API and showing them in the UI.

![email exists](https://user-images.githubusercontent.com/33387139/133590914-27b5578c-df37-422c-8dda-851bd224353f.png)

### Changes proposed
- Created a 'WC_Stripe_Account' class to manage account data
- Ported some functions from `WCPay` here
- Using WP Option for caching account data. Similar caching is also implemented in WCPay and useful for handling Stripe rate limit. Initially implemented without the caching and after a few requests started getting `cURL error 28: Resolving timed out after 10000 milliseconds`.  
- Added a global variable `wc_stripe_admin_settings` intended to include all account settings related data.

### Testing instructions
With test keys
- Add test key from the old UI
- Enable the `_wcstripe_feature_upe_settings` feature flag to check the account status in the new UI

With live keys
- Add live key from the old UI
- Enable the `_wcstripe_feature_upe_settings` feature flag to check the account status in the new UI

### QA steps
To be added.....

### Pending
- What to show when Email is empty. (The email property is not present in response when requested using test key)
- What to show when error occurs and failed to retrieve account data