### PR TITLE
UPE - Support free trial subscriptions

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -125,7 +125,7 @@ export default class WCStripeAPI {
 	/**
 	 * Updates a payment intent with data from order: customer, level3 data and and maybe sets the payment for future use.
 	 *
-	 * @param {string} paymentIntentId The id of the payment intent.
+	 * @param {string} intentId The id of the payment intent.
 	 * @param {number} orderId The id of the order.
 	 * @param {string} savePaymentMethod 'yes' if saving.
 	 * @param {string} selectedUPEPaymentType The name of the selected UPE payment type or empty string.
@@ -133,14 +133,19 @@ export default class WCStripeAPI {
 	 * @return {Promise} The final promise for the request to the server.
 	 */
 	updateIntent(
-		paymentIntentId,
+		intentId,
 		orderId,
 		savePaymentMethod,
 		selectedUPEPaymentType
 	) {
+		// Don't update setup intents.
+		if ( intentId.includes( 'seti_' ) ) {
+			return;
+		}
+
 		return this.request( this.getAjaxUrl( 'update_payment_intent' ), {
 			stripe_order_id: orderId,
-			wc_payment_intent_id: paymentIntentId,
+			wc_payment_intent_id: intentId,
 			save_payment_method: savePaymentMethod,
 			selected_upe_payment_type: selectedUPEPaymentType,
 			_ajax_nonce: this.options?.updatePaymentIntentNonce,

--- a/client/blocks/upe/fields.js
+++ b/client/blocks/upe/fields.js
@@ -40,9 +40,13 @@ const UPEField = ( {
 
 		async function createIntent() {
 			try {
-				const response = await api.createIntent(
-					getBlocksConfiguration()?.orderId
-				);
+				const paymentRequired = getBlocksConfiguration()
+					?.isPaymentRequired;
+				const response = paymentRequired
+					? await api.createIntent(
+							getBlocksConfiguration()?.orderId
+					  )
+					: await api.initSetupIntent();
 				setPaymentIntentId( response.id );
 				setClientSecret( response.client_secret );
 			} catch ( error ) {

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -351,7 +351,10 @@ jQuery( function ( $ ) {
 			! $( '#wc-stripe-upe-element' ).children().length &&
 			isUPEEnabled
 		) {
-			mountUPEElement();
+			const isSetupIntent = ! (
+				getStripeServerData()?.isPaymentRequired ?? true
+			);
+			mountUPEElement( isSetupIntent );
 		}
 
 		if ( doesIbanNeedToBeMounted() ) {
@@ -372,7 +375,7 @@ jQuery( function ( $ ) {
 			const isChangingPayment = getStripeServerData()?.isChangingPayment;
 
 			// We use a setup intent if we are on the screens to add a new payment method or to change a subscription payment.
-			const useSetUpIntent =
+			const isSetupIntent =
 				$( 'form#add_payment_method' ).length || isChangingPayment;
 
 			if ( isChangingPayment && getStripeServerData()?.newTokenFormId ) {
@@ -383,7 +386,7 @@ jQuery( function ( $ ) {
 				$( token ).prop( 'selected', true ).trigger( 'click' );
 				$( 'form#order_review' ).submit();
 			}
-			mountUPEElement( useSetUpIntent );
+			mountUPEElement( isSetupIntent );
 		}
 
 		if ( doesIbanNeedToBeMounted() ) {
@@ -514,7 +517,7 @@ jQuery( function ( $ ) {
 		}
 
 		blockUI( $form );
-		// Create object where keys are form field names and keys are form field values
+		// Create object where keys are form field names and values are form field values
 		const formFields = $form.serializeArray().reduce( ( obj, field ) => {
 			obj[ field.name ] = field.value;
 			return obj;

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -555,7 +555,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Store extra meta data for an order from a Stripe Response.
 	 */
 	public function process_response( $response, $order ) {
-		// TODO: This does not support setup intents.
 		WC_Stripe_Logger::log( 'Processing response: ' . print_r( $response, true ) );
 
 		$order_id = $order->get_id();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -296,6 +296,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 		}
 
+		$amount = WC()->cart->get_total( false );
+		$order  = isset( $order_id ) ? wc_get_order( $order_id ) : null;
+		if ( is_a( $order, 'WC_Order' ) ) {
+			$amount = $order->get_total();
+		}
+
+		$converted_amount = WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( get_woocommerce_currency() ) );
+		// Pre-orders and free trial subscriptions don't require payments.
+		$stripe_params['isPaymentRequired'] = 0 < $converted_amount;
+
 		return $stripe_params;
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -621,13 +621,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			list( $payment_method_type, $payment_method_details ) = $this->get_payment_method_data_from_intent( $intent );
 
-			// Use the last charge within the intent to proceed.
-			if ( isset( $intent->charges ) ) {
-				$charge = end( $intent->charges->data );
-				$this->process_response( $charge, $order );
+			if ( $payment_needed ) {
+				// Use the last charge within the intent to proceed.
+				$this->process_response( end( $intent->charges->data ), $order );
 			} else {
-				// TODO: Add implementation for setup intents.
-				$this->process_response( $intent, $order );
+				$order->payment_complete();
 			}
 			$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
 
@@ -759,10 +757,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		} else {
 			$intent = $this->stripe_request( 'setup_intents/' . $intent_id . '?expand[]=payment_method' );
 		}
-		$error = $intent->last_payment_error;
 
-		if ( ! empty( $error ) ) {
-			WC_Stripe_Logger::log( 'Error when processing payment: ' . $error->message );
+		if ( ! empty( $intent->last_payment_error ) ) {
+			WC_Stripe_Logger::log( 'Error when processing payment: ' . $intent->last_payment_error->message );
 			throw new WC_Stripe_Exception( __( "We're not able to process this payment. Please try again later.", 'woocommerce-gateway-stripe' ) );
 		}
 
@@ -782,13 +779,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$this->save_payment_method_to_order( $order, $prepared_payment_method );
 		}
 
-		// Use the last charge within the intent to proceed.
-		if ( isset( $intent->charges ) ) {
-			$charge = end( $intent->charges->data );
-			$this->process_response( $charge, $order );
+		if ( $payment_needed ) {
+			// Use the last charge within the intent to proceed.
+			$this->process_response( end( $intent->charges->data ), $order );
 		} else {
-			// TODO: Add implementation for setup intents.
-			$this->process_response( $intent, $order );
+			$order->payment_complete();
 		}
 		$this->save_intent_to_order( $order, $intent );
 		$this->set_payment_method_title_for_order( $order, $payment_method_type, $payment_method_details );
@@ -1095,7 +1090,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$payment_method_type    = ! empty( $payment_method_details ) ? $payment_method_details['type'] : '';
 			}
 		} elseif ( 'setup_intent' === $intent->object ) {
-			$payment_method_options = array_keys( $intent->payment_method_options );
+			$payment_method_options = array_keys( (array) $intent->payment_method_options );
 			$payment_method_type    = ! empty( $payment_method_options ) ? $payment_method_options[0] : '';
 			// Setup intents don't have details, keep the false value.
 		}


### PR DESCRIPTION
Fixes #1867

# Changes proposed in this Pull Request:

- If order is being processed with a setup intent and doesn't require payment, complete the order right away, like `process_payment` for credit card payments.
- Use a setup intent for displaying the UPE payment fields in case the product doesn't require payment.

# Testing instructions

- Ensure you have the UPE feature flag enabled.
- Install [WooCommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/), in case you haven't already.
- Navigate to **Products -> Add new**
- Under "Product data", select simple subscription, and add a subscription price and a free trial period.
- As a shopper, add the newly created free trial subscription product to the cart and try to complete the checkout.
- Ensure the checkout works and the order is moved to "processing" or "completed".
- Ensure the subscription is made active.
- As a merchant, navigate to "WooCommerce -> Subscriptions" and open the newly created subscription.
- Ensure you can process a renewal under "Subscription actions".
- Ensure a new order is attached to the subscription under "Related Orders", and the status of that order is "processing" or "completed".
