### PR TITLE
Show payment method description

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -993,7 +993,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$data['description'] .= '<tr data-upe_method_id="' . $method_id . '">
 					<td class="name" width=""><a href="#" class="wc-payment-gateway-method-title">' . $method_id . '</a><span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;Subtext goes here.</span></td>
 					<td class="status" width="1%"><a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#"><span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="The &quot;' . $method_id . '&quot; payment method is currently ' . $method_enabled . '">' . ( 'enabled' === $method_enabled ? 'Yes' : 'No' ) . '</span></a></td>
-					<td class="description" width="">Long description text goes here.</td>
+					<td class="description" width="">' . $this->get_payment_method_description( $method_id ) . '</td>
 				</tr>';
 		}
 
@@ -1002,6 +1002,40 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			<span id="wc_stripe_upe_change_notice" class="hidden">' . __( 'You must save your changes.', 'woocommerce-gateway-stripe' ) . '</span>';
 
 		return $this->generate_title_html( $key, $data );
+	}
+
+	private function get_payment_method_description( $method ) {
+		$description_mapper = [
+			'card' => __(
+				'Let your customers pay with major credit and debit cards without leaving your store.',
+				'woocommerce-gateway-stripe'
+			),
+			'giropay' => __(
+				'Expand your business with giropay — Germany’s second most popular payment system.',
+				'woocommerce-gateway-stripe'
+			),
+			'sepa_debit' => __(
+				'Reach 500 million customers and over 20 million businesses across the European Union.',
+				'woocommerce-gateway-stripe'
+			),
+			'sofort' => __(
+				'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
+				'woocommerce-gateway-stripe'
+			),
+			'eps' => __(
+				'EPS is an Austria-based payment method that allows customers to complete transactions online using their bank credentials.',
+				'woocommerce-gateway-stripe'
+			),
+			'bancontact' => __(
+				'Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.',
+				'woocommerce-gateway-stripe'
+			),
+			'ideal' => __(
+				'iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.',
+				'woocommerce-gateway-stripe'
+			),
+		];
+		return isset( $description_mapper[ $method ] ) ? $description_mapper[ $method ] : 'Long description text goes here.';
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -991,9 +991,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		foreach ( $this->payment_methods as $method_id => $method ) {
 			$method_enabled       = in_array( $method_id, $this->get_upe_enabled_payment_method_ids(), true ) ? 'enabled' : 'disabled';
 			$data['description'] .= '<tr data-upe_method_id="' . $method_id . '">
-					<td class="name" width=""><a href="#" class="wc-payment-gateway-method-title">' . $method_id . '</a><span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;Subtext goes here.</span></td>
+					<td class="name" width=""><a href="#" class="wc-payment-gateway-method-title">' . $this->payment_methods[ $method_id ]->get_label() . '</a><span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;Subtext goes here.</span></td>
 					<td class="status" width="1%"><a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#"><span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="The &quot;' . $method_id . '&quot; payment method is currently ' . $method_enabled . '">' . ( 'enabled' === $method_enabled ? 'Yes' : 'No' ) . '</span></a></td>
-					<td class="description" width="">' . $this->get_payment_method_description( $method_id ) . '</td>
+					<td class="description" width="">' . $this->payment_methods[ $method_id ]->get_description() . '</td>
 				</tr>';
 		}
 
@@ -1002,40 +1002,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			<span id="wc_stripe_upe_change_notice" class="hidden">' . __( 'You must save your changes.', 'woocommerce-gateway-stripe' ) . '</span>';
 
 		return $this->generate_title_html( $key, $data );
-	}
-
-	private function get_payment_method_description( $method ) {
-		$description_mapper = [
-			'card' => __(
-				'Let your customers pay with major credit and debit cards without leaving your store.',
-				'woocommerce-gateway-stripe'
-			),
-			'giropay' => __(
-				'Expand your business with giropay — Germany’s second most popular payment system.',
-				'woocommerce-gateway-stripe'
-			),
-			'sepa_debit' => __(
-				'Reach 500 million customers and over 20 million businesses across the European Union.',
-				'woocommerce-gateway-stripe'
-			),
-			'sofort' => __(
-				'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
-				'woocommerce-gateway-stripe'
-			),
-			'eps' => __(
-				'EPS is an Austria-based payment method that allows customers to complete transactions online using their bank credentials.',
-				'woocommerce-gateway-stripe'
-			),
-			'bancontact' => __(
-				'Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.',
-				'woocommerce-gateway-stripe'
-			),
-			'ideal' => __(
-				'iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.',
-				'woocommerce-gateway-stripe'
-			),
-		];
-		return isset( $description_mapper[ $method ] ) ? $description_mapper[ $method ] : 'Long description text goes here.';
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
@@ -21,5 +21,10 @@ class WC_Stripe_UPE_Payment_Method_Bancontact extends WC_Stripe_UPE_Payment_Meth
 		$this->title                = 'Pay with Bancontact';
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
+		$this->label                = __( 'Bancontact', 'woocommerce-gateway-stripe' );
+		$this->description          = __(
+			'Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.',
+			'woocommerce-gateway-stripe'
+		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -24,6 +24,11 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 		$this->stripe_id   = self::STRIPE_ID;
 		$this->title       = 'Credit card / debit card';
 		$this->is_reusable = true;
+		$this->label       = __( 'Credit card / debit card', 'woocommerce-gateway-stripe' );
+		$this->description = __(
+			'Let your customers pay with major credit and debit cards without leaving your store.',
+			'woocommerce-gateway-stripe'
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-eps.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-eps.php
@@ -21,5 +21,10 @@ class WC_Stripe_UPE_Payment_Method_Eps extends WC_Stripe_UPE_Payment_Method {
 		$this->title                = 'Pay with EPS';
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'EUR' ];
+		$this->label                = __( 'EPS', 'woocommerce-gateway-stripe' );
+		$this->description          = __(
+			'EPS is an Austria-based payment method that allows customers to complete transactions online using their bank credentials.',
+			'woocommerce-gateway-stripe'
+		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php
@@ -21,5 +21,10 @@ class WC_Stripe_UPE_Payment_Method_Giropay extends WC_Stripe_UPE_Payment_Method 
 		$this->title                = 'Pay with giropay';
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'EUR' ];
+		$this->label                = __( 'giropay', 'woocommerce-gateway-stripe' );
+		$this->description          = __(
+			'Expand your business with giropay — Germany’s second most popular payment system.',
+			'woocommerce-gateway-stripe'
+		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
@@ -21,5 +21,10 @@ class WC_Stripe_UPE_Payment_Method_Ideal extends WC_Stripe_UPE_Payment_Method {
 		$this->title                = 'Pay with iDEAL';
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
+		$this->label                = __( 'iDEAL', 'woocommerce-gateway-stripe' );
+		$this->description          = __(
+			'iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.',
+			'woocommerce-gateway-stripe'
+		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -23,6 +23,11 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 		$this->title                = 'Pay with SEPA Direct Debit';
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
+		$this->label                = __( 'Sepa Direct Debit', 'woocommerce-gateway-stripe' );
+		$this->description          = __(
+			'Reach 500 million customers and over 20 million businesses across the European Union.',
+			'woocommerce-gateway-stripe'
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -30,6 +30,20 @@ abstract class WC_Stripe_UPE_Payment_Method {
 	protected $title;
 
 	/**
+	 * Method label
+	 *
+	 * @var string
+	 */
+	protected $label;
+
+	/**
+	 * Method description
+	 *
+	 * @var string
+	 */
+	protected $description;
+
+	/**
 	 * Can payment method be saved or reused?
 	 *
 	 * @var bool
@@ -92,6 +106,24 @@ abstract class WC_Stripe_UPE_Payment_Method {
 	 */
 	public function get_title( $payment_details = false ) {
 		return $this->title;
+	}
+
+	/**
+	 * Returns payment method label
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return $this->label;
+	}
+
+	/**
+	 * Returns payment method description
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return $this->description;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1892

### Description
Currently, the payment method description shows a placeholder text `Long description text goes here` for all methods. The changes in this PR renders the actual description beside each method. Used data from [this file](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/client/payment-methods-map.js)

![desc](https://user-images.githubusercontent.com/33387139/133982757-f2179b49-a111-4a2b-8f35-f5fb89b477e8.png)

### Testing instructions
- Enable UPE preview