### PR TITLE
feat: currency needed messaging

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -993,7 +993,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$subtext_messages     = $method->get_subtext_messages();
 			$data['description'] .= '<tr data-upe_method_id="' . $method_id . '">
 					<td class="name" width="">
-						<a href="#" class="wc-payment-gateway-method-title">' . $this->payment_methods[ $method_id ]->get_label() . '</a>
+						<a href="#" class="wc-payment-gateway-method-title">' . $method->get_label() . '</a>
 						' . ( empty( $subtext_messages ) ? '' : '<span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;' . $subtext_messages . '</span>' ) . '
 					</td>
 					<td class="status" width="1%"><a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#"><span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="The &quot;' . $method_id . '&quot; payment method is currently ' . $method_enabled . '">' . ( 'enabled' === $method_enabled ? 'Yes' : 'No' ) . '</span></a></td>

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -990,10 +990,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 		foreach ( $this->payment_methods as $method_id => $method ) {
 			$method_enabled       = in_array( $method_id, $this->get_upe_enabled_payment_method_ids(), true ) ? 'enabled' : 'disabled';
+			$subtext_messages     = $method->get_subtext_messages();
 			$data['description'] .= '<tr data-upe_method_id="' . $method_id . '">
-					<td class="name" width=""><a href="#" class="wc-payment-gateway-method-title">' . $this->payment_methods[ $method_id ]->get_label() . '</a><span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;Subtext goes here.</span></td>
+					<td class="name" width="">
+						<a href="#" class="wc-payment-gateway-method-title">' . $this->payment_methods[ $method_id ]->get_label() . '</a>
+						' . ( empty( $subtext_messages ) ? '' : '<span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;' . $subtext_messages . '</span>' ) . '
+					</td>
 					<td class="status" width="1%"><a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#"><span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="The &quot;' . $method_id . '&quot; payment method is currently ' . $method_enabled . '">' . ( 'enabled' === $method_enabled ? 'Yes' : 'No' ) . '</span></a></td>
-					<td class="description" width="">' . $this->payment_methods[ $method_id ]->get_description() . '</td>
+					<td class="description" width="">' . $method->get_description() . '</td>
 				</tr>';
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -268,4 +268,25 @@ abstract class WC_Stripe_UPE_Payment_Method {
 			$this->supported_currencies
 		);
 	}
+
+	/**
+	 * Returns the HTML for the subtext messaging in the old settings UI.
+	 *
+	 * @return string
+	 */
+	public function get_subtext_messages() {
+		// can be either a `currency` or `activation` messaging, to be displayed in the old settings UI.
+		$messages = [];
+
+		$currencies = $this->get_supported_currencies();
+		if ( ! empty( $currencies ) && ! in_array( get_woocommerce_currency(), $currencies, true ) ) {
+			/* translators: %s: List of comma-separated currencies. */
+			$tooltip_content = sprintf( esc_attr__( 'In order to be used at checkout, the payment method requires the store currency to be set to one of: %s', 'woocommerce-gateway-stripe' ), implode( ', ', $currencies ) );
+			$text            = __( 'Requires currency', 'woocommerce-gateway-stripe' );
+
+			$messages[] = $text . '<span class="tips" data-tip="' . $tooltip_content . '"><span class="woocommerce-help-tip" style="margin-top: 0;"></span></span>';
+		}
+
+		return count( $messages ) > 0 ? join( '&nbsp;–&nbsp;', $messages ) : '';
+	}
 }


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1895

Currency subtext for the old settings UI.
![2021-09-20 15 55 44](https://user-images.githubusercontent.com/273592/134074786-b49d29f6-249f-4481-92b7-c9afdb8091ac.gif)



# Testing instructions

- Enable the `_wcstripe_feature_upe` feature flag
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- UI is updated with new subtext