### PR TITLE
Add/1898 move upe payment methods checkboxes

### DIFF
--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -247,7 +247,7 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Helper::is
 	if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 		// This adds the payment method section
 		$upe_settings['upe_checkout_experience_accepted_payments'] = [
-			'title'       => __( 'Payments accepted on checkout (Early access)', 'woocommerce-gateway-stripe' ),
+			'title'   => __( 'Payments accepted on checkout (Early access)', 'woocommerce-gateway-stripe' ),
 			'type'    => 'upe_checkout_experience_accepted_payments',
 			'default' => [ 'card' ],
 		];

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -247,6 +247,7 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Helper::is
 	if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 		// This adds the payment method section
 		$upe_settings['upe_checkout_experience_accepted_payments'] = [
+			'title'       => __( 'Payments accepted on checkout (Early access)', 'woocommerce-gateway-stripe' ),
 			'type'    => 'upe_checkout_experience_accepted_payments',
 			'default' => [ 'card' ],
 		];

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -229,10 +229,6 @@ $stripe_settings = apply_filters(
 
 if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Helper::is_pre_orders_exists() ) {
 	$upe_settings = [
-		'upe_checkout_experience' => [
-			'title' => __( 'Checkout experience', 'woocommerce-gateway-stripe' ),
-			'type'  => 'title',
-		],
 		WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => [
 			'title'       => __( 'New checkout experience', 'woocommerce-gateway-stripe' ),
 			'label'       => sprintf(

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -234,15 +234,22 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Helper::is
 			'type'  => 'title',
 		],
 		WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => [
-			'title'       => __( 'Enable/Disable', 'woocommerce-gateway-stripe' ),
-			'label'       => __( 'Enable new checkout experience', 'woocommerce-gateway-stripe' ),
+			'title'       => __( 'New checkout experience', 'woocommerce-gateway-stripe' ),
+			'label'       => sprintf(
+				/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe dashboard opening anchor tag 5) Stripe dashboard closing anchor tag */
+				__( 'Try the new payment experience (Early access) %1$sGet early access to a new, smarter payment experience on checkout and let us know what you think by %2$s. We recommend this feature for experienced merchants as the functionality is currently limited. %3$s', 'woocommerce-gateway-stripe' ),
+				'<br />',
+				'<a href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" target="_blank">submitting your feedback</a>',
+				'<a href="?TODO" target="_blank">Learn more</a>'
+			),
 			'type'        => 'checkbox',
-			'description' => __( 'If enabled, users will... TBD', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),
 			'default'     => 'no',
 			'desc_tip'    => true,
 		],
 	];
 	if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+		// This adds the payment method section
 		$upe_settings['upe_checkout_experience_accepted_payments'] = [
 			'type'    => 'upe_checkout_experience_accepted_payments',
 			'default' => [ 'card' ],

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -251,8 +251,8 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Helper::is
 			'default' => [ 'card' ],
 		];
 	}
-	// Insert UPE options below the 'description' setting.
-	$stripe_settings = array_merge( array_splice( $stripe_settings, 0, array_search( 'description', array_keys( $stripe_settings ), true ) + 1 ), $upe_settings, $stripe_settings );
+	// Insert UPE options below the 'logging' setting.
+	$stripe_settings = array_merge( $stripe_settings, $upe_settings );
 
 	// in the new settings, "checkout" is going to be enabled by default (if it is a new WCStripe installation).
 	$stripe_settings['payment_request_button_locations']['default'][] = 'checkout';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -977,7 +977,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return string
 	 */
 	public function generate_upe_checkout_experience_accepted_payments_html( $key, $data ) {
-		$data['description'] = '<table class="wc_gateways widefat form-table" cellspacing="0" aria-describedby="wc_stripe_upe_method_selection">
+		$data['description'] = '<p>' . __( "Select payments available to customers at checkout. We'll only show your customers the most relevant payment methods based on their currency and location.", 'woocommerce-gateway-stripe' ) . '</p>
+		<table class="wc_gateways widefat form-table" cellspacing="0" aria-describedby="wc_stripe_upe_method_selection">
 			<thead>
 				<tr>
 					<th class="name">Method</th>

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -977,8 +977,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	 * @return string
 	 */
 	public function generate_upe_checkout_experience_accepted_payments_html( $key, $data ) {
-		$data['description'] = '<div id="wc_stripe_upe_method_selection"><p><strong>Payments accepted on checkout</strong></p></div>
-			<table class="wc_gateways widefat form-table" cellspacing="0" aria-describedby="wc_stripe_upe_method_selection">
+		$data['description'] = '<table class="wc_gateways widefat form-table" cellspacing="0" aria-describedby="wc_stripe_upe_method_selection">
 			<thead>
 				<tr>
 					<th class="name">Method</th>


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1898

# Description
Adjust the UI under "Stripe UPE" settings. This includes:
- Changing the copy to "New checkout experience" and move it to the bottom
- Move the entire payment method list to the bottom
- Update copy for "Payments accepted on checkout (Early access)" and changed it to a "title"

# Testing instructions
1. Make sure `WC_Stripe_Feature_Flags::is_upe_preview_enabled()` returns `true`
2. Go to `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`
3. The page should look like:
![image](https://user-images.githubusercontent.com/572862/134215987-0729fba2-5af1-4e8a-bada-ba636d6e0ea1.png)

