### PR TITLE
feat: survey prompt on UPE disable

### DIFF
--- a/client/entrypoints/old-settings-upe-toggle/index.js
+++ b/client/entrypoints/old-settings-upe-toggle/index.js
@@ -1,0 +1,37 @@
+/* global wc_stripe_old_settings_param */
+import { dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import domReady from '@wordpress/dom-ready';
+
+domReady( () => {
+	// eslint-disable-next-line camelcase
+	if ( ! wc_stripe_old_settings_param ) {
+		return;
+	}
+
+	const {
+		is_upe_enabled: isUpeEnabled,
+		// eslint-disable-next-line camelcase
+	} = wc_stripe_old_settings_param;
+
+	if ( isUpeEnabled !== '1' ) {
+		dispatch( 'core/notices' ).createSuccessNotice(
+			__(
+				'🤔 What made you disable the new payments experience?',
+				'woocommerce-gateway-stripe'
+			),
+			{
+				actions: [
+					{
+						label: __(
+							'Share feedback (1 min)',
+							'woocommerce-gateway-stripe'
+						),
+						url:
+							'https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey',
+					},
+				],
+			}
+		);
+	}
+} );

--- a/includes/admin/class-wc-stripe-old-settings-upe-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-old-settings-upe-toggle-controller.php
@@ -1,0 +1,74 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enqueues some JS to ensure that some needed UI elements for the old settings are available.
+ *
+ * @since 5.5.0
+ */
+class WC_Stripe_Old_Settings_UPE_Toggle_Controller {
+	protected $was_upe_checkout_enabled = null;
+
+	public function __construct() {
+		add_filter( 'pre_update_option_woocommerce_stripe_settings', [ $this, 'pre_options_save' ] );
+		add_action( 'update_option_woocommerce_stripe_settings', [ $this, 'maybe_enqueue_script' ] );
+	}
+
+	/**
+	 * Stores whether UPE was enabled before saving the options.
+	 *
+	 * @param mixed $value
+	 *
+	 * @return mixed
+	 */
+	public function pre_options_save( $value ) {
+		$this->was_upe_checkout_enabled = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
+
+		return $value;
+	}
+
+	/**
+	 * Determines what to do after the options have been saved.
+	 */
+	public function maybe_enqueue_script() {
+		$is_upe_checkout_enabled = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
+
+		if ( $this->was_upe_checkout_enabled !== $is_upe_checkout_enabled ) {
+			add_action( 'admin_enqueue_scripts', [ $this, 'upe_toggle_script' ] );
+		}
+	}
+
+	/**
+	 * Enqueues the script to determine what to do once UPE has been toggled.
+	 */
+	public function upe_toggle_script() {
+		// Webpack generates an assets file containing a dependencies array for our built JS file.
+		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/old_settings_upe_toggle.asset.php';
+		$script_asset      = file_exists( $script_asset_path )
+			? require $script_asset_path
+			: [
+				'dependencies' => [],
+				'version'      => WC_STRIPE_VERSION,
+			];
+
+		wp_register_script(
+			'woocommerce_stripe_old_settings_upe_toggle',
+			plugins_url( 'build/old_settings_upe_toggle.js', WC_STRIPE_MAIN_FILE ),
+			$script_asset['dependencies'],
+			$script_asset['version'],
+			true
+		);
+		wp_localize_script(
+			'woocommerce_stripe_old_settings_upe_toggle',
+			'wc_stripe_old_settings_param',
+			[
+				'was_upe_enabled' => $this->was_upe_checkout_enabled,
+				'is_upe_enabled'  => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+			]
+		);
+		wp_enqueue_script( 'woocommerce_stripe_old_settings_upe_toggle' );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,8 @@ module.exports = {
 	},
 	entry: {
 		index: './client/blocks/index.js',
+		old_settings_upe_toggle:
+			'./client/entrypoints/old-settings-upe-toggle/index.js',
 		payment_requests_settings:
 			'./client/entrypoints/payment-request-settings/index.js',
 		upe_classic: './client/classic/upe/index.js',

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -191,6 +191,11 @@ function woocommerce_gateway_stripe() {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-settings-controller.php';
 
+					if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
+						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-old-settings-upe-toggle-controller.php';
+						new WC_Stripe_Old_Settings_UPE_Toggle_Controller();
+					}
+
 					if ( isset( $_GET['area'] ) && 'payment_requests' === $_GET['area'] ) {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1909

Display a notice when UPE is disabled.
Same notice as https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1801 , unfortunately we can't open it in a new tab.

![Screen Shot 2021-09-20 at 8 17 34 PM](https://user-images.githubusercontent.com/273592/134097761-a1055d54-7fcf-4e8c-bf04-a9aff7e5fedf.png)


# Testing instructions
- Ensure you have the `_wcstripe_feature_upe` flag enabled
- Enable UPE
- Save the settings
- Disable UPE
- Save the settings
- Survey notification is displayed
