### PR TITLE
Track upe toggle in old settings page

### DIFF
--- a/client/entrypoints/old-settings-upe-toggle/index.js
+++ b/client/entrypoints/old-settings-upe-toggle/index.js
@@ -2,6 +2,7 @@
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import domReady from '@wordpress/dom-ready';
+import { recordEvent } from 'wcstripe/tracking';
 
 domReady( () => {
 	// eslint-disable-next-line camelcase
@@ -10,6 +11,7 @@ domReady( () => {
 	}
 
 	const {
+		was_upe_enabled: wasUpeEnabled,
 		is_upe_enabled: isUpeEnabled,
 		// eslint-disable-next-line camelcase
 	} = wc_stripe_old_settings_param;
@@ -33,5 +35,12 @@ domReady( () => {
 				],
 			}
 		);
+	}
+
+	if ( wasUpeEnabled !== isUpeEnabled ) {
+		const eventName = isUpeEnabled
+			? 'wcstripe_upe_enabled'
+			: 'wcstripe_upe_disabled';
+		recordEvent( eventName );
 	}
 } );


### PR DESCRIPTION
Fixes #1888

### Description
Tracks UPE enabling/disabling events in the old settings page.

### Testing instructions
- UPE preview should be enabled (return `true` from `is_upe_preview_enabled()`
- Ensure you have the necessary settings mentioned [here](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1859). Mainly
-- Ensure you have "Enables WooCommerce Analytics" enabled at http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=advanced&section=features (if available)
-- Ensure you have "Allow usage of WooCommerce to be tracked" enabled at http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com
- Go to `http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe` and enable/disable the checkbox `Enable new checkout experience`
- In the network tab a new request for the tracked event would be there. 

![tracking](https://user-images.githubusercontent.com/33387139/134181609-fa370fa4-df12-4280-90eb-b93ae42faf82.png)
