### PR TITLE
Provide default.env file to wp command

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "uglify": "for f in $npm_package_assets_js_js; do file=${f%.js}; node_modules/.bin/uglifyjs $f -c -m > $file.min.js; done",
     "up": "docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh",
     "down": "docker-compose down",
-    "wp": "docker run -it --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli",
+    "wp": "docker run -it --env-file default.env --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli",
     "presass": "rm -f $npm_package_assets_styles_css",
     "sass": "node_modules/.bin/node-sass $npm_package_assets_styles_cssfolder --output $npm_package_assets_styles_cssfolder --output-style compressed",
     "watchsass": "node_modules/.bin/node-sass $npm_package_assets_styles_sass --output $npm_package_assets_styles_css --output-style compressed --watch",


### PR DESCRIPTION
This small fix is similar to #1506. The `docker run` commands need to load the defined env vars from the "default.env" file in order to work properly.

### Testing instructions

- Pull the `fix/wp-command` branch
- Run the Stripe instance `npm run up`
- Run the following command: `npm run wp option get siteurl` 

It should return URL of the site:

```
$ npm run wp option get siteurl

> woocommerce-gateway-stripe@5.5.0 wp /Users/asumaran/www/woocommerce-gateway-stripe
> docker run -it --env-file default.env --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli "option" "get" "siteurl"

http://localhost
```

Switching back to the `develop` branch the command should fail

```
~/www/woocommerce-gateway-stripe ‹fix/wp-command› » gco develop
Switched to branch 'develop'
Your branch is up to date with 'origin/develop'.
Generating autoload files
Generated autoload files
~/www/woocommerce-gateway-stripe ‹develop› » npm run wp option get siteurl

> woocommerce-gateway-stripe@5.5.0 wp /Users/asumaran/www/woocommerce-gateway-stripe
> docker run -it --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli "option" "get" "siteurl"

Warning: mysqli_real_connect(): (HY000/1045): Access denied for user 'example username'@'172.25.0.4' (using password: YES) in /var/www/html/wp-includes/wp-db.php on line 1653
Error: `Access denied for user 'example username'@'172.25.0.4' (using password: YES)`
Error establishing a database connection
This either means that the username and password information in your `wp-config.php` file is incorrect or we can’t contact the database server at `mysql`. This could mean your host’s database server is down.

Are you sure you have the correct username and password?
Are you sure you have typed the correct hostname?
Are you sure the database server is running?

If you’re unsure what these terms mean you should probably contact your host. If you still need help you can always visit the WordPress Support Forums. `Access denied for user 'example username'@'172.25.0.4' (using password: YES)`
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! woocommerce-gateway-stripe@5.5.0 wp: `docker run -it --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli "option" "get" "siteurl"`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the woocommerce-gateway-stripe@5.5.0 wp script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/asumaran/.npm/_logs/2021-09-21T23_57_50_737Z-debug.log
```