### PR TITLE
Fix error when account is created during checkout

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -681,7 +681,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
-		$is_nonce_valid = check_admin_referer( 'wc_stripe_process_redirect_order_nonce' );
+		$is_nonce_valid = isset( $_GET['_wpnonce'] ) && wp_verify_nonce( wc_clean( wp_unslash( $_GET['_wpnonce'] ) ), 'wc_stripe_process_redirect_order_nonce' );
 		if ( ! $is_nonce_valid || empty( $_GET['wc_payment_method'] ) ) {
 			return;
 		}


### PR DESCRIPTION
Fixes #1944

# Changes proposed in this Pull Request:

When WooCommerce creates and logs the user upon checkout, `check_admin_referer` will not work and should throw a CSRF error. This PR simply replaces `check_admin_referer` with `wp_verify_nonce`.

# Testing instructions

1. Enable "Allow customers to create an account during checkout" under WooCommerce > Settings > Accounts & Privacy.
2. Make sure you're not logged in.
3. Add any product to the cart and proceed to checkout.
4. At the bottom of the checkout page, enable "Create an account?".
5. Procceed with the checkout.
6. Ensure you're redirected to the "Order received" page, as expected.
