### PR TITLE
Remove UPE preview feature flag and all its related code

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 5.6.0 - 2021-xx-xx =
-* Add - New checkout experience using Stripe Universal Payment Element.
+* Add - Pre-release preview of new checkout experience using Stripe Universal Payment Element.
 
 = 5.5.0 - 2021-09-15 =
 * Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 5.6.0 - 2021-xx-xx =
+* Add - New checkout experience using Stripe Universal Payment Element.
+
 = 5.5.0 - 2021-09-15 =
 * Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.
 * Fix - Save payment method during 3D Secure flow for Block-based checkout.

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -245,7 +245,7 @@ class WC_Stripe_Admin_Notices {
 			}
 		}
 
-		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() || ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return;
 		}
 

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -227,11 +227,7 @@ $stripe_settings = apply_filters(
 	]
 );
 
-if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-	unset( $stripe_settings['payment_request_button_size'] );
-}
-
-if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Helper::is_pre_orders_exists() ) {
+if ( ! WC_Stripe_Helper::is_pre_orders_exists() ) {
 	$upe_settings = [
 		WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => [
 			'title'       => __( 'New checkout experience', 'woocommerce-gateway-stripe' ),

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -158,7 +158,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				'isAdmin'                        => is_admin(),
 				'shouldShowPaymentRequestButton' => $this->should_show_payment_request_button(),
 				'button'                         => [
-					'customLabel' => $this->payment_request_configuration->get_button_label(),
+					'customLabel' => '', // TODO: Remove JS related code.
 				],
 			]
 		);

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -7,16 +7,6 @@ class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
 
 	/**
-	 * Checks whether UPE "preview" feature flag is enabled.
-	 * This allows the merchant to enable/disable UPE checkout.
-	 *
-	 * @return bool
-	 */
-	public static function is_upe_preview_enabled() {
-		return 'yes' === get_option( '_wcstripe_feature_upe', 'no' ) || self::is_upe_settings_redesign_enabled();
-	}
-
-	/**
 	 * Checks whether UPE is enabled.
 	 *
 	 * @return bool

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -72,10 +72,6 @@ class WC_Stripe_UPE_Availability_Note {
 		 * - UPE has been manually disabled
 		 * - Stripe is not enabled
 		 */
-		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return;
-		}
-
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return;
 		}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -268,10 +268,6 @@ class WC_Stripe_Payment_Request {
 	 * @return  string
 	 */
 	public function get_button_height() {
-		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return isset( $this->stripe_settings['payment_request_button_height'] ) ? str_replace( 'px', '', $this->stripe_settings['payment_request_button_height'] ) : '64';
-		}
-
 		$height = isset( $this->stripe_settings['payment_request_button_size'] ) ? $this->stripe_settings['payment_request_button_size'] : 'default';
 		if ( 'medium' === $height ) {
 			return '48';
@@ -305,49 +301,6 @@ class WC_Stripe_Payment_Request {
 	 */
 	public function get_button_branded_type() {
 		return isset( $this->stripe_settings['payment_request_button_branded_type'] ) ? $this->stripe_settings['payment_request_button_branded_type'] : 'default';
-	}
-
-	/**
-	 * Checks if the button is custom.
-	 *
-	 * @since   4.4.0
-	 * @version 4.4.0
-	 * @return  boolean
-	 */
-	public function is_custom_button() {
-		// no longer a valid option
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return false;
-		}
-
-		return 'custom' === $this->get_button_type();
-	}
-
-	/**
-	 * Returns custom button css selector.
-	 *
-	 * @since   4.4.0
-	 * @version 4.4.0
-	 * @return  string
-	 */
-	public function custom_button_selector() {
-		return $this->is_custom_button() ? '#wc-stripe-custom-button' : '';
-	}
-
-	/**
-	 * Gets the custom button label.
-	 *
-	 * @since   4.4.0
-	 * @version 4.4.0
-	 * @return  string
-	 */
-	public function get_button_label() {
-		// no longer a valid option
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return '';
-		}
-
-		return isset( $this->stripe_settings['payment_request_button_label'] ) ? $this->stripe_settings['payment_request_button_label'] : 'Buy now';
 	}
 
 	/**
@@ -812,14 +765,6 @@ class WC_Stripe_Payment_Request {
 		?>
 		<div id="wc-stripe-payment-request-wrapper" style="clear:both;padding-top:1.5em;display:none;">
 			<div id="wc-stripe-payment-request-button">
-				<?php
-				if ( $this->is_custom_button() ) {
-					$label      = esc_html( $this->get_button_label() );
-					$class_name = esc_attr( 'button ' . $this->get_button_theme() );
-					$style      = esc_attr( 'height:' . $this->get_button_height() . 'px;' );
-					echo "<button id=\"wc-stripe-custom-button\" class=\"$class_name\" style=\"$style\"> $label </button>";
-				}
-				?>
 				<!-- A Stripe Element will be inserted here. -->
 			</div>
 		</div>
@@ -1652,35 +1597,20 @@ class WC_Stripe_Payment_Request {
 	 * @return array
 	 */
 	public function get_button_settings() {
-		// it would be DRYer to use `array_merge`,
-		// but I thought that this approach might be more straightforward to clean up when we remove the feature flag code.
 		$button_type = $this->get_button_type();
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return [
-				'type'         => $button_type,
-				'theme'        => $this->get_button_theme(),
-				'height'       => $this->get_button_height(),
-				// Default format is en_US.
-				'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
-				'branded_type' => 'default' === $button_type ? 'short' : 'long',
-				// these values are no longer applicable - all the JS relying on them can be removed.
-				'css_selector' => '',
-				'label'        => '',
-				'is_custom'    => false,
-				'is_branded'   => false,
-			];
-		}
-
 		return [
 			'type'         => $button_type,
 			'theme'        => $this->get_button_theme(),
 			'height'       => $this->get_button_height(),
-			'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
 			// Default format is en_US.
-			'is_custom'    => $this->is_custom_button(),
-			'is_branded'   => $this->is_branded_button(),
-			'css_selector' => $this->custom_button_selector(),
-			'branded_type' => $this->get_button_branded_type(),
+			'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
+			'branded_type' => 'default' === $button_type ? 'short' : 'long',
+			// These values are no longer applicable - all the JS relying on them can be removed.
+			// TODO: Remove JS related code.
+			'css_selector' => '',
+			'label'        => '',
+			'is_custom'    => false,
+			'is_branded'   => false,
 		];
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -126,7 +126,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->statement_descriptor = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
 
 		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
+		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
 			$enabled_payment_methods_count = count( $this->get_upe_enabled_payment_method_ids() );
 			/* translators: $1. Count of enabled payment methods. */
 			$this->title = sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count );

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 5.6.0 - 2021-xx-xx =
-* Add - New checkout experience using Stripe Universal Payment Element.
+* Add - Pre-release preview of new checkout experience using Stripe Universal Payment Element.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -126,12 +126,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.5.0 - 2021-09-15 =
-* Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.
-* Fix - Save payment method during 3D Secure flow for Block-based checkout.
-* Fix - Show subtotal on Payment Request dialog.
-* Add - Settings to control Payment Request Button locations in the Stripe plugin settings. Persists changes made through pre-existing filters, or defaults to the Cart and Product pages if no filters are in use.
-* Tweak - Deprecated the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.
-* Add - Notice for WP & WC version compatibility check.
+= 5.6.0 - 2021-xx-xx =
+* Add - New checkout experience using Stripe Universal Payment Element.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -36,8 +36,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		// Set the user so that we can pass the authentication.
 		wp_set_current_user( 1 );
 
-		// The routes in WC_REST_Stripe_Settings_Controller are only registered if `_wcstripe_feature_upe = "yes"`.
-		update_option( '_wcstripe_feature_upe', 'yes' );
 		$this->gateway = WC()->payment_gateways()->payment_gateways()[ WC_Gateway_Stripe::ID ];
 	}
 

--- a/tests/phpunit/test-class-wc-stripe-notes.php
+++ b/tests/phpunit/test-class-wc-stripe-notes.php
@@ -30,7 +30,6 @@ class WC_Stripe_Inbox_Notes_Test extends WP_UnitTestCase {
 		}
 
 		update_option( '_wcstripe_feature_upe_settings', 'yes' );
-		update_option( '_wcstripe_feature_upe', 'yes' );
 		update_option(
 			'woocommerce_stripe_settings',
 			[
@@ -45,7 +44,6 @@ class WC_Stripe_Inbox_Notes_Test extends WP_UnitTestCase {
 
 		woocommerce_gateway_stripe()->connect = $this->stripe_connect_original;
 		delete_option( '_wcstripe_feature_upe_settings' );
-		delete_option( '_wcstripe_feature_upe' );
 		delete_option( 'woocommerce_stripe_settings' );
 	}
 
@@ -55,17 +53,6 @@ class WC_Stripe_Inbox_Notes_Test extends WP_UnitTestCase {
 		$note_id          = WC_Stripe_UPE_Availability_Note::NOTE_NAME;
 		$admin_note_store = WC_Data_Store::load( 'admin-note' );
 		$this->assertSame( 1, count( $admin_note_store->get_notes_with_name( $note_id ) ) );
-	}
-
-	public function test_create_upe_availability_note_does_not_create_note_when_upe_preview_is_disabled() {
-		update_option( '_wcstripe_feature_upe_settings', 'no' );
-		update_option( '_wcstripe_feature_upe', 'no' );
-
-		WC_Stripe_Inbox_Notes::create_upe_availability_note();
-
-		$note_id          = WC_Stripe_UPE_Availability_Note::NOTE_NAME;
-		$admin_note_store = WC_Data_Store::load( 'admin-note' );
-		$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( $note_id ) ) );
 	}
 
 	public function test_create_upe_availability_note_does_not_create_note_when_upe_is_enbled() {

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -75,7 +75,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 
 		$settings = get_option( 'woocommerce_stripe_settings' );
 
-		$this->assertEquals( 'disabled', $settings['upe_checkout_experience_enabled'] );
+		$this->assertEquals( 'no', $settings['upe_checkout_experience_enabled'] );
 	}
 
 	public function test_set_flag_missing_request_returns_status_code_400() {

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -96,14 +96,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 		];
 	}
 
-	private function enableUpeFeatureFlag() {
-		// Force the UPE feature flag on.
-		add_filter(
-			'pre_option__wcstripe_feature_upe',
-			function() {
-				return 'yes';
-			}
-		);
+	private function clearStripeSettings() {
 		delete_option( 'woocommerce_stripe_settings' );
 		$this->reloadPaymentGateways();
 	}
@@ -114,8 +107,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 	}
 
 	public function test_legacy_payment_methods_supported_by_upe_are_not_loaded_when_upe_is_enabled() {
-		$this->enableUpeFeatureFlag();
-		$this->assertTrue( WC_Stripe_Feature_Flags::is_upe_preview_enabled() );
+		$this->clearStripeSettings();
 
 		update_option( 'woocommerce_stripe_settings', [ 'upe_checkout_experience_enabled' => 'yes' ] );
 		$this->reloadPaymentGateways();
@@ -137,7 +129,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 	}
 
 	public function test_turning_on_upe_with_no_stripe_legacy_payment_methods_enabled_will_not_turn_on_the_upe_gateway_and_default_to_card_only() {
-		$this->enableUpeFeatureFlag();
+		$this->clearStripeSettings();
 		// Store default stripe options
 		update_option( 'woocommerce_stripe_settings', [] );
 
@@ -157,7 +149,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 	}
 
 	public function test_turning_on_upe_enables_the_correct_upe_methods_based_on_which_legacy_payment_methods_were_enabled_and_vice_versa() {
-		$this->enableUpeFeatureFlag();
+		$this->clearStripeSettings();
 
 		// Enable Giropay and Ideal LPM gateways.
 		update_option( 'woocommerce_stripe_giropay_settings', [ 'enabled' => 'yes' ] );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -401,8 +401,8 @@ function woocommerce_gateway_stripe() {
 				unset( $sections['stripe_sepa'] );
 				unset( $sections['stripe_multibanco'] );
 
-				$sections['stripe']            = 'Stripe';
-				$sections['stripe_upe']        = 'Stripe checkout experience';
+				$sections['stripe']            = __( 'Stripe', 'woocommerce-gateway-stripe' );
+				$sections['stripe_upe']        = __( 'Stripe checkout experience', 'woocommerce-gateway-stripe' );
 				$sections['stripe_bancontact'] = __( 'Stripe Bancontact', 'woocommerce-gateway-stripe' );
 				$sections['stripe_sofort']     = __( 'Stripe SOFORT', 'woocommerce-gateway-stripe' );
 				$sections['stripe_giropay']    = __( 'Stripe Giropay', 'woocommerce-gateway-stripe' );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -194,7 +194,7 @@ function woocommerce_gateway_stripe() {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-settings-controller.php';
 
-					if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
+					if ( ! WC_Stripe_Feature_Flags::is_upe_settings_redesign_enabled() ) {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-old-settings-upe-toggle-controller.php';
 						new WC_Stripe_Old_Settings_UPE_Toggle_Controller();
 					}
@@ -361,7 +361,7 @@ function woocommerce_gateway_stripe() {
 			 * @version x.x.x
 			 */
 			public function add_gateways( $methods ) {
-				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+				if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 					$methods[] = WC_Stripe_UPE_Payment_Gateway::class;
 				} else {
 					// These payment gateways will be hidden when UPE is enabled:
@@ -390,9 +390,7 @@ function woocommerce_gateway_stripe() {
 			 */
 			public function filter_gateway_order_admin( $sections ) {
 				unset( $sections['stripe'] );
-				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					unset( $sections['stripe_upe'] );
-				}
+				unset( $sections['stripe_upe'] );
 				unset( $sections['stripe_bancontact'] );
 				unset( $sections['stripe_sofort'] );
 				unset( $sections['stripe_giropay'] );
@@ -403,10 +401,8 @@ function woocommerce_gateway_stripe() {
 				unset( $sections['stripe_sepa'] );
 				unset( $sections['stripe_multibanco'] );
 
-				$sections['stripe'] = 'Stripe';
-				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					$sections['stripe_upe'] = 'Stripe checkout experience';
-				}
+				$sections['stripe']            = 'Stripe';
+				$sections['stripe_upe']        = 'Stripe checkout experience';
 				$sections['stripe_bancontact'] = __( 'Stripe Bancontact', 'woocommerce-gateway-stripe' );
 				$sections['stripe_sofort']     = __( 'Stripe SOFORT', 'woocommerce-gateway-stripe' );
 				$sections['stripe_giropay']    = __( 'Stripe Giropay', 'woocommerce-gateway-stripe' );
@@ -436,10 +432,6 @@ function woocommerce_gateway_stripe() {
 					$fields       = $gateway->get_form_fields();
 					$old_settings = array_merge( array_fill_keys( array_keys( $fields ), '' ), wp_list_pluck( $fields, 'default' ) );
 					$settings     = array_merge( $old_settings, $settings );
-				}
-
-				if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					return $settings;
 				}
 
 				return $this->toggle_upe( $settings, $old_settings );
@@ -576,23 +568,21 @@ function woocommerce_gateway_stripe() {
 				$oauth_init->register_routes();
 				$oauth_connect->register_routes();
 
-				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-controller.php';
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-controller.php';
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';
 
-					$upe_flag_toggle_controller = new WC_REST_UPE_Flag_Toggle_Controller();
-					$upe_flag_toggle_controller->register_routes();
+				$upe_flag_toggle_controller = new WC_REST_UPE_Flag_Toggle_Controller();
+				$upe_flag_toggle_controller->register_routes();
 
-					$gateway = WC()->payment_gateways()->payment_gateways()[ WC_Gateway_Stripe::ID ];
+				$gateway = WC()->payment_gateways()->payment_gateways()[ WC_Gateway_Stripe::ID ];
 
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-settings-controller.php';
-					$settings_controller = new WC_REST_Stripe_Settings_Controller( $gateway );
-					$settings_controller->register_routes();
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-settings-controller.php';
+				$settings_controller = new WC_REST_Stripe_Settings_Controller( $gateway );
+				$settings_controller->register_routes();
 
-					$stripe_account_keys_controller = new WC_REST_Stripe_Account_keys_Controller();
-					$stripe_account_keys_controller->register_routes();
-				}
+				$stripe_account_keys_controller = new WC_REST_Stripe_Account_keys_Controller();
+				$stripe_account_keys_controller->register_routes();
 			}
 		}
 


### PR DESCRIPTION
Fixes #1945

# Changes proposed in this Pull Request:

- Remove UPE feature flag, so it's ready to be shipped to users in the next release.

# Testing instructions

- Remove the `_wcstripe_feature_upe` option.
- Ensure you can still see the "New checkout experience" setting under **WooCommerce > Payments > Stripe**.
- Please smoke test the UPE and non-UPE checkout and settings and ensure everything works as expected.
