### PR TITLE
[UPE - settings] Update manual capture implementation on enabled payment methods

### DIFF
--- a/includes/admin/class-wc-stripe-payment-gateways-controller.php
+++ b/includes/admin/class-wc-stripe-payment-gateways-controller.php
@@ -17,8 +17,8 @@ class WC_Stripe_Payment_Gateways_Controller {
 	 */
 	public function __construct() {
 		// If UPE is enabled and there are enabled payment methods, we need to load the disable Stripe confirmation modal.
-		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
-		$enabled_upe_payment_methods = $stripe_settings['upe_checkout_experience_accepted_payments'];
+		$stripe_settings              = get_option( 'woocommerce_stripe_settings', [] );
+		$enabled_upe_payment_methods  = $stripe_settings['upe_checkout_experience_accepted_payments'];
 		$upe_payment_requests_enabled = 'yes' === $stripe_settings['payment_request'];
 
 		if ( count( $enabled_upe_payment_methods ) > 0 || $upe_payment_requests_enabled ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -321,10 +321,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return string[]
 	 */
 	public function get_upe_enabled_payment_method_ids() {
-		$capture = ! empty( $this->get_option( 'capture' ) ) && $this->get_option( 'capture' ) === 'yes';
-		if ( ! $capture ) {
-			return [ 'card' ];
-		}
 		return $this->get_option( 'upe_checkout_experience_accepted_payments', [ 'card' ] );
 	}
 
@@ -335,8 +331,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return string[]
 	 */
 	public function get_upe_enabled_at_checkout_payment_method_ids( $order_id = null ) {
-		$available_method_ids = [];
-		foreach ( $this->get_upe_enabled_payment_method_ids() as $payment_method_id ) {
+		$capture                 = empty( $this->get_option( 'capture' ) ) || $this->get_option( 'capture' ) === 'yes';
+		$enabled_payment_methods = $capture ? $this->get_upe_enabled_payment_method_ids() : [ 'card' ];
+		$available_method_ids    = [];
+		foreach ( $enabled_payment_methods as $payment_method_id ) {
 			if ( isset( $this->payment_methods[ $payment_method_id ] ) && $this->payment_methods[ $payment_method_id ]->is_enabled_at_checkout( $order_id ) ) {
 				$available_method_ids[] = $payment_method_id;
 			}


### PR DESCRIPTION
# Changes proposed in this Pull Request:

This PR is moving the implementation of the manual capture on the enabled payment methods. The previous implementation, introduced on #1789, was affecting both checkout and settings. With the changes in this PR, we're limiting that behavior to checkout, leaving the payment methods table intact.

The reasoning for this change is basically we **should not** affect visually the status (active or not) of the payment methods in the settings whether the manual capture is enabled.

# Testing instructions

1. Ensure you have `_wcstripe_feature_upe` set to `yes` in `wp_options` table.
2. Visit the store and log in as admin.
3. Go to the [Stripe settings page](http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe).
4. Untick the `Capture charge immediately` option, make sure you have card and at least one more payment method enabled, and save.
5. After saving, you should see all the methods you chose visually enabled, card and the others.
6. Go to the store > Shop and add a product to the cart
7. Go to Checkout and in the available payment methods section you should see only card.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.