### PR TITLE
Force the UPE toggle option value to 'no' if not set

### DIFF
--- a/includes/admin/class-wc-stripe-payment-gateways-controller.php
+++ b/includes/admin/class-wc-stripe-payment-gateways-controller.php
@@ -17,8 +17,8 @@ class WC_Stripe_Payment_Gateways_Controller {
 	 */
 	public function __construct() {
 		// If UPE is enabled and there are enabled payment methods, we need to load the disable Stripe confirmation modal.
-		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
-		$enabled_upe_payment_methods = $stripe_settings['upe_checkout_experience_accepted_payments'];
+		$stripe_settings              = get_option( 'woocommerce_stripe_settings', [] );
+		$enabled_upe_payment_methods  = $stripe_settings['upe_checkout_experience_accepted_payments'];
 		$upe_payment_requests_enabled = 'yes' === $stripe_settings['payment_request'];
 
 		if ( count( $enabled_upe_payment_methods ) > 0 || $upe_payment_requests_enabled ) {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -457,7 +457,7 @@ function woocommerce_gateway_stripe() {
 			 * @return array New value but with defaults initially filled in for missing settings.
 			 */
 			protected function toggle_upe( $settings, $old_settings ) {
-				if ( false === $old_settings ) {
+				if ( false === $old_settings || ! isset( $old_settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] ) ) {
 					$old_settings = [ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => 'no' ];
 				}
 				if ( ! isset( $settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] ) || $settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] === $old_settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] ) {


### PR DESCRIPTION
Also small lint/cs fix.

## Initial conditions:

- Completely fresh WC+Stripe installation. Go into Stripe settings, change anything (but do NOT enable UPE), and save the settings.

or...

- Existing WC+Stripe install where Stripe settings have been configured long ago but UPE has never been enabled.

---

## Problem

In either of the conditions above, if you now go and try to enable UPE, you'll get a warning:

```
Notice: Undefined index: upe_checkout_experience_enabled in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/woocommerce-gateway-stripe.php on line 463
```

This is because `$old_settings` is set, but the UPE toggle option key does not exist yet. Thus we need the additional `isset()` check in this PR.