### PR TITLE
Remove the payment method links inside Stripe UPE

### DIFF
--- a/assets/css/stripe-admin-styles.css
+++ b/assets/css/stripe-admin-styles.css
@@ -1,0 +1,1 @@
+/* Admin styles will go here */

--- a/assets/css/stripe-admin-styles.css
+++ b/assets/css/stripe-admin-styles.css
@@ -1,1 +1,1 @@
-/* Admin styles will go here */
+.wc-stripe-upe-method-selection .wc-stripe-upe-method-selection__name,.wc-stripe-upe-method-selection .wc-stripe-upe-method-selection__description,.wc-stripe-upe-method-selection .wc-stripe-upe-method-selection__status{vertical-align:middle}

--- a/assets/css/stripe-admin-styles.scss
+++ b/assets/css/stripe-admin-styles.scss
@@ -1,1 +1,5 @@
-/* Admin styles will go here */
+.wc-stripe-upe-method-selection .wc-stripe-upe-method-selection__name,
+.wc-stripe-upe-method-selection .wc-stripe-upe-method-selection__description,
+.wc-stripe-upe-method-selection .wc-stripe-upe-method-selection__status {
+	vertical-align: middle;
+}

--- a/assets/css/stripe-admin-styles.scss
+++ b/assets/css/stripe-admin-styles.scss
@@ -1,0 +1,1 @@
+/* Admin styles will go here */

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -66,9 +66,14 @@ class WC_Stripe_Settings_Controller {
 				[ 'wc-components' ],
 				$script_asset['version']
 			);
-			wp_enqueue_style( 'woocommerce_stripe_admin' );
 		} else {
 			wp_register_script( 'woocommerce_stripe_admin', plugins_url( 'assets/js/stripe-admin' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION, true );
+			wp_register_style(
+				'woocommerce_stripe_admin',
+				plugins_url( 'assets/css/stripe-admin-styles' . $suffix . '.css', WC_STRIPE_MAIN_FILE ),
+				[],
+				WC_STRIPE_VERSION
+			);
 		}
 
 		$oauth_url = woocommerce_gateway_stripe()->connect->get_oauth_url();
@@ -88,5 +93,6 @@ class WC_Stripe_Settings_Controller {
 		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
 
 		wp_enqueue_script( 'woocommerce_stripe_admin' );
+		wp_enqueue_style( 'woocommerce_stripe_admin' );
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -987,9 +987,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		<table class="wc_gateways widefat form-table" cellspacing="0" aria-describedby="wc_stripe_upe_method_selection">
 			<thead>
 				<tr>
-					<th class="name">Method</th>
-					<th class="status">Enabled</th>
-					<th class="description">Description</th>
+					<th class="name">' . esc_html__( 'Method', 'woocommerce-gateway-stripe' ) . '</th>
+					<th class="status">' . esc_html__( 'Enabled', 'woocommerce-gateway-stripe' ) . '</th>
+					<th class="description">' . esc_html__( 'Description', 'woocommerce-gateway-stripe' ) . '</th>
 				</tr>
 			</thead>
 			<tbody>';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -984,12 +984,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_account      = WC_Stripe_API::retrieve( 'account' );
 		$stripe_capabilities = isset( $stripe_account->capabilities ) ? (array) $stripe_account->capabilities : [];
 		$data['description'] = '<p>' . __( "Select payments available to customers at checkout. We'll only show your customers the most relevant payment methods based on their currency and location.", 'woocommerce-gateway-stripe' ) . '</p>
-		<table class="wc_gateways widefat form-table" cellspacing="0" aria-describedby="wc_stripe_upe_method_selection">
+		<table class="wc_gateways widefat form-table wc-stripe-upe-method-selection" cellspacing="0" aria-describedby="wc_stripe_upe_method_selection">
 			<thead>
 				<tr>
-					<th class="name">' . esc_html__( 'Method', 'woocommerce-gateway-stripe' ) . '</th>
-					<th class="status">' . esc_html__( 'Enabled', 'woocommerce-gateway-stripe' ) . '</th>
-					<th class="description">' . esc_html__( 'Description', 'woocommerce-gateway-stripe' ) . '</th>
+					<th class="name wc-stripe-upe-method-selection__name">' . esc_html__( 'Method', 'woocommerce-gateway-stripe' ) . '</th>
+					<th class="status wc-stripe-upe-method-selection__status">' . esc_html__( 'Enabled', 'woocommerce-gateway-stripe' ) . '</th>
+					<th class="description wc-stripe-upe-method-selection__description">' . esc_html__( 'Description', 'woocommerce-gateway-stripe' ) . '</th>
 				</tr>
 			</thead>
 			<tbody>';
@@ -1007,18 +1007,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$method_enabled_label
 			);
 			$data['description'] .= '<tr data-upe_method_id="' . $method_id . '">
-					<td class="name" width="">
+					<td class="name wc-stripe-upe-method-selection__name" width="">
 						' . $method->get_label() . '
 						' . ( empty( $subtext_messages ) ? '' : '<span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;' . $subtext_messages . '</span>' ) . '
 					</td>
-					<td class="status" width="1%">
+					<td class="status wc-stripe-upe-method-selection__status" width="1%">
 						<a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#">
 							<span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="' . $aria_label . '">
 							' . ( 'enabled' === $method_enabled ? __( 'Yes', 'woocommerce-gateway-stripe' ) : __( 'No', 'woocommerce-gateway-stripe' ) ) . '
 							</span>
 						</a>
 					</td>
-					<td class="description" width="">' . $method->get_description() . '</td>
+					<td class="description wc-stripe-upe-method-selection__description" width="">' . $method->get_description() . '</td>
 				</tr>';
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -996,15 +996,28 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		foreach ( $this->payment_methods as $method_id => $method ) {
 			$method_enabled       = in_array( $method_id, $this->get_upe_enabled_payment_method_ids(), true ) ? 'enabled' : 'disabled';
+			$method_enabled_label = 'enabled' === $method_enabled ? __( 'enabled', 'woocommerce-gateway-stripe' ) : __( 'disabled', 'woocommerce-gateway-stripe' );
 			$capability_id        = "{$method_id}_payments"; // "_payments" is a suffix that comes from Stripe API, except when it is "transfers", which does not apply here
 			$method_status        = isset( $stripe_capabilities[ $capability_id ] ) ? $stripe_capabilities[ $capability_id ] : 'inactive';
 			$subtext_messages     = $method->get_subtext_messages( $method_status );
+			$aria_label           = sprintf(
+				/* translators: $1%s payment method ID, $2%s "enabled" or "disabled" */
+				esc_attr__( 'The &quot;%1$s&quot; payment method is currently %2$s', 'woocommerce-gateway-stripe' ),
+				$method_id,
+				$method_enabled_label
+			);
 			$data['description'] .= '<tr data-upe_method_id="' . $method_id . '">
 					<td class="name" width="">
 						' . $method->get_label() . '
 						' . ( empty( $subtext_messages ) ? '' : '<span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;' . $subtext_messages . '</span>' ) . '
 					</td>
-					<td class="status" width="1%"><a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#"><span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="The &quot;' . $method_id . '&quot; payment method is currently ' . $method_enabled . '">' . ( 'enabled' === $method_enabled ? 'Yes' : 'No' ) . '</span></a></td>
+					<td class="status" width="1%">
+						<a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#">
+							<span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="' . $aria_label . '">
+							' . ( 'enabled' === $method_enabled ? __( 'Yes', 'woocommerce-gateway-stripe' ) : __( 'No', 'woocommerce-gateway-stripe' ) ) . '
+							</span>
+						</a>
+					</td>
 					<td class="description" width="">' . $method->get_description() . '</td>
 				</tr>';
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1001,7 +1001,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$subtext_messages     = $method->get_subtext_messages( $method_status );
 			$data['description'] .= '<tr data-upe_method_id="' . $method_id . '">
 					<td class="name" width="">
-						<a href="#" class="wc-payment-gateway-method-title">' . $method->get_label() . '</a>
+						' . $method->get_label() . '
 						' . ( empty( $subtext_messages ) ? '' : '<span class="wc-payment-gateway-method-name">&nbsp;–&nbsp;' . $subtext_messages . '</span>' ) . '
 					</td>
 					<td class="status" width="1%"><a class="wc-payment-upe-method-toggle-' . $method_enabled . '" href="#"><span class="woocommerce-input-toggle woocommerce-input-toggle--' . $method_enabled . '" aria-label="The &quot;' . $method_id . '&quot; payment method is currently ' . $method_enabled . '">' . ( 'enabled' === $method_enabled ? 'Yes' : 'No' ) . '</span></a></td>

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "wp": "docker run -it --env-file default.env --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli",
     "presass": "rm -f $npm_package_assets_styles_css",
     "sass": "node_modules/.bin/node-sass $npm_package_assets_styles_cssfolder --output $npm_package_assets_styles_cssfolder --output-style compressed",
-    "watchsass": "node_modules/.bin/node-sass $npm_package_assets_styles_sass --output $npm_package_assets_styles_css --output-style compressed --watch",
+    "watchsass": "node_modules/.bin/node-sass $npm_package_assets_styles_sass --output $npm_package_assets_styles_cssfolder --output-style compressed --watch",
     "postsass": "for f in $npm_package_assets_styles_css; do file=${f%.css}; node_modules/.bin/cleancss -o $file.css $f; done",
     "makepot": "wpi18n addtextdomain woocommerce-gateway-stripe --exclude node_modules,tests,docs,docker,release; wpi18n makepot --domain-path languages --pot-file woocommerce-gateway-stripe.pot --type plugin --main-file woocommerce-gateway-stripe.php --exclude node_modules,tests,docs,docker,release",
     "test": "cross-env NODE_CONFIG_DIR='./tests/e2e/config' BABEL_ENV=commonjs mocha \"tests/e2e\" --require babel-register --recursive",


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1928

Removed the links and added a vertical alignment to middle to reflect the designs in the issue.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

![Markup on 2021-09-23 at 15:52:30](https://user-images.githubusercontent.com/1759681/134519785-bfa74c6e-0406-4056-b3dd-6d4ff51c8184.png)

</td>
<td>

![Markup on 2021-09-23 at 15:52:04](https://user-images.githubusercontent.com/1759681/134519832-24b46628-40c4-45d2-a4b2-aadfb798d141.png)

</td>
</tr>
</table>

# Testing instructions

1. Set feature flags to:
   * UPE preview: `yes`
   * UPE enabled by user: `yes`
   * UPE redesign (new settings): `no`
1. Go to **WooCommerce > Settings > Payments > Stripe UPE**.
1. The "Payments accepted on checkout (Early access)" table at the bottom should look as in the "After" screenshot above (no links on payment method names and items are vertically aligned to center).
