### PR TITLE
Fix UPE form validation check

### DIFF
--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -407,7 +407,7 @@ jQuery( function ( $ ) {
 			const { error } = await api.getStripe().confirmPayment( {
 				element: upeElement,
 				confirmParams: {
-					return_url: '',
+					return_url: '#',
 				},
 			} );
 			$form.removeClass( 'processing' ).unblock();


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1940

With UPE the field validation doesn't occur until something has been entered in to one of the fields. To capture instances where a user may not have interacted with all the fields and instead just hit submit, we run a sort of "mock" confirmPayment call to trigger the validation. We only run this when we have not received an event.complete from the UPE element. That event only fires once all required fields have been filled in.

There may have been a change the Stripe API that now requires a non-empty value for the confirmParams.return_url. Previously with that value empty the confirm would work and trigger validation, but now it throws an error. This PR adds a hash to that parameter to now avoid the error. This should be a safe workaround as we already know at this point that the confirmation will fail due to the fact that not all fields have been provided. 

Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.

**Before**
![CheckoutError-Before](https://user-images.githubusercontent.com/68524302/134539026-b6a6d625-bb85-4790-b125-87eb031cc32a.png)

**After**
![CheckoutError-After](https://user-images.githubusercontent.com/68524302/134539039-15a751c9-da2a-4a96-b8a7-911ca8836640.png)

# Testing instructions

Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?

- Start with this branch and UPE enabled with at least CC and SEPA enabled within UPE.
- Make sure to build the JS with either `npm run build:webpack` or `npm run start:webpack` to be sure the latest update is found.
- As a customer, add a product to the cart and go to checkout. Confirm UPE loads.
- Without entering any payment information, click the Place Order button.
- Confirm that error messages are displayed for the invalid fields.
- Refresh the checkout page.
- Enter a full CC number, but do not enter any expiration or CVV and click Place Order.
- Confirm that error messages are displayed for the invalid fields and no console errors are shown.
- Complete all payment fields and click Place Order.
- Confirm that the order was successfully placed.
- Repeat the checkout steps with SEPA and an empty/partially filled/then fully field IBAN (`DE89370400440532013000` as an example IBAN).
- Next as a logged in customer visit the My Account > Payment Methods page.
- Click Add Payment Method button (ensure saved cards are enabled if it is not present).
- Run through some of the same tests listed above with empty/partially filled/then fully filled fields on both CC and SEPA and confirm that the proper error messages are displayed and no console errors are shown.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.