### PR TITLE
Change method name from `Stripe UPE` to `Stripe`

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -89,7 +89,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function __construct() {
 		$this->id           = self::ID;
-		$this->method_title = __( 'Stripe UPE', 'woocommerce-gateway-stripe' );
+		$this->method_title = __( 'Stripe', 'woocommerce-gateway-stripe' );
 		/* translators: link */
 		$this->method_description = __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-gateway-stripe' );
 		$this->has_fields         = true;


### PR DESCRIPTION
Fixes #1954

### Description
The Stripe payment method is displayed as "Stripe UPE" when the UPE flag is enabled. Changed the name to "Stripe"

Before
![before](https://user-images.githubusercontent.com/33387139/134547782-9fc2cdf8-98ac-4db9-8c59-128afa809bf0.png)

After
![after](https://user-images.githubusercontent.com/33387139/134547795-a0e3df59-9138-44d0-9714-7275dc0e2f87.png)

