### PR TITLE
refactor: confirmation modal heading reuse

### DIFF
--- a/client/components/confirmation-modal/alert-title.js
+++ b/client/components/confirmation-modal/alert-title.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Icon, info } from '@wordpress/icons';
+
+const AlertIcon = styled( Icon )`
+	fill: #d94f4f;
+	margin-right: 4px;
+`;
+
+const Wrapper = styled.span`
+	display: inline-flex;
+	align-items: center;
+`;
+
+const AlertTitle = ( { title } ) => (
+	<Wrapper>
+		<AlertIcon icon={ info } />
+		{ title }
+	</Wrapper>
+);
+
+export default AlertTitle;

--- a/client/entrypoints/payment-gateways/disable-confirmation-modal.js
+++ b/client/entrypoints/payment-gateways/disable-confirmation-modal.js
@@ -1,13 +1,14 @@
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { Button } from '@wordpress/components';
-import './style.scss';
 import {
 	useEnabledPaymentMethodIds,
 	usePaymentRequestEnabledSettings,
 } from '../../data';
 import PaymentMethodIcon from '../../settings/payment-method-icon';
-import ConfirmationModal from '../../components/confirmation-modal';
+import ConfirmationModal from 'wcstripe/components/confirmation-modal';
+import './style.scss';
+import AlertTitle from 'wcstripe/components/confirmation-modal/alert-title';
 
 const DisableConfirmationModal = ( { onClose, onConfirm } ) => {
 	const [ enabledPaymentMethodIds ] = useEnabledPaymentMethodIds();
@@ -28,8 +29,15 @@ const DisableConfirmationModal = ( { onClose, onConfirm } ) => {
 
 	return (
 		<ConfirmationModal
-			title={ __( 'Disable Stripe', 'woocommerce-payments' ) }
-			className="alert"
+			title={
+				<AlertTitle
+					title={ __(
+						'Disable Stripe',
+						'woocommerce-gateway-stripe'
+					) }
+				/>
+			}
+			className="disable-confirmation-modal"
 			onRequestClose={ onClose }
 			actions={
 				<>

--- a/client/entrypoints/payment-gateways/style.scss
+++ b/client/entrypoints/payment-gateways/style.scss
@@ -7,27 +7,10 @@
 				margin-bottom: 12px;
 			}
 		}
-	}
-}
 
-.wcstripe-confirmation-modal {
-	&.alert {
-		h1 {
-			display: grid;
-			grid-template-columns: max-content max-content;
-			grid-column-gap: 10px;
-			align-items: center;
-
-			&::before {
-				content: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20Z' stroke='%23D94F4F' stroke-width='1.5' /%3E%3Cpath d='M13 7H11V13H13V7Z' fill='%23D94F4F' /%3E%3Cpath d='M13 15H11V17H13V15Z' fill='%23D94F4F' /%3E%3C/svg%3E");
-				height: 24px;
-			}
+		// Hotfix for Stripe Gateway - might need to be fixed in WCPay as well.
+		.woocommerce-gateway-stripe__payment-method-icon {
+			max-width: inherit;
 		}
 	}
-
-	// Hotfix for Stripe Gateway - might need to be fixed in WCPay as well.
-	.woocommerce-gateway-stripe__payment-method-icon {
-		max-width: inherit;
-	}
 }
-

--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -4,22 +4,12 @@ import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import { Button, ExternalLink } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
-import { Icon, info } from '@wordpress/icons';
 import PaymentMethodsMap from '../../payment-methods-map';
 import UpeToggleContext from '../upe-toggle/context';
 import ConfirmationModal from 'wcstripe/components/confirmation-modal';
 import InlineNotice from 'wcstripe/components/inline-notice';
 import { useEnabledPaymentMethodIds } from 'wcstripe/data';
-
-const AlertIcon = styled( Icon )`
-	fill: #d94f4f;
-	margin-right: 4px;
-`;
-
-const ModalTitleWrapper = styled.span`
-	display: inline-flex;
-	align-items: center;
-`;
+import AlertTitle from 'wcstripe/components/confirmation-modal/alert-title';
 
 const DeactivatingPaymentMethodsList = styled.ul`
 	min-height: 150px;
@@ -46,18 +36,6 @@ const PaymentMethodListItemContent = styled.div`
 		}
 	}
 `;
-
-const ModalTitle = () => {
-	return (
-		<ModalTitleWrapper>
-			<AlertIcon icon={ info } />
-			{ __(
-				'Disable the new payments experience',
-				'woocommerce-gateway-stripe'
-			) }
-		</ModalTitleWrapper>
-	);
-};
 
 const DisableUpeConfirmationModal = ( { onClose } ) => {
 	const { status, setIsUpeEnabled } = useContext( UpeToggleContext );
@@ -111,7 +89,14 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 	return (
 		<>
 			<ConfirmationModal
-				title={ <ModalTitle /> }
+				title={
+					<AlertTitle
+						title={ __(
+							'Disable the new payments experience',
+							'woocommerce-gateway-stripe'
+						) }
+					/>
+				}
 				onRequestClose={ onClose }
 				actions={
 					<>


### PR DESCRIPTION
# Changes proposed in this Pull Request:

I noticed that the heading of the confirmation modal could benefit from a little bit of reuse, since it's used in multiple places.

# Testing instructions
- Ensure the `_wcstripe_feature_upe_settings` flag is enabled
- Ensure the `woocommerce_stripe_settings.upe_checkout_experience_enabled` flag is enabled
- Ensure Stripe is enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout
- When disabling Stripe, the confirmation modal should appear, with its reused heading


![Screen Shot 2021-09-23 at 11 44 03 AM](https://user-images.githubusercontent.com/273592/134549647-f6f53223-b9ca-405d-b958-35518ec997c2.png)
