### PR TITLE
Remove method count text when no method is enabled

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -128,8 +128,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
 			$enabled_payment_methods_count = count( $this->get_upe_enabled_payment_method_ids() );
-			/* translators: $1. Count of enabled payment methods. */
-			$this->title = sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count );
+			$this->title                   = $enabled_payment_methods_count ?
+				/* translators: $1. Count of enabled payment methods. */
+				sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count )
+				: $this->method_title;
 		}
 
 		if ( $this->testmode ) {


### PR DESCRIPTION
Fixes #1960

### Description
When any payment method is enabled the count shows beside the title in `http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout` page

![after](https://user-images.githubusercontent.com/33387139/134560416-47125957-58a6-445a-989c-b4811af5d2a7.png)

When no method is enabled it shows `0 payment method`. In this PR the count has been hidden when no payment method is enabled. 

### Testing instructions
- Enable UPE preview and UPE checkout
- Disable all payment methods from `http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`
- If you can not disable the `credit card` option, return `[]` (empty) from [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L328) and [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/admin/stripe-settings.php#L256)
