### PR TITLE
Update the UPE Gateway title in the checkout depending the enabled methods

### DIFF
--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -20,6 +20,13 @@ $stripe_settings = apply_filters(
 			'default'     => __( 'Credit Card (Stripe)', 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,
 		],
+		'title_upe'                           => [
+			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
+			'type'        => 'text',
+			'description' => __( 'This controls the title which the user sees during checkout when multiple payment methods are enabled.', 'woocommerce-gateway-stripe' ),
+			'default'     => __( 'Popular payment methods', 'woocommerce-gateway-stripe' ),
+			'desc_tip'    => true,
+		],
 		'description'                         => [
 			'title'       => __( 'Description', 'woocommerce-gateway-stripe' ),
 			'type'        => 'text',

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -193,6 +193,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		$this->form_fields = require dirname( __FILE__ ) . '/admin/stripe-settings.php';
+		unset( $this->form_fields['title_upe'] );
 	}
 
 	/**
@@ -342,6 +343,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		global $wp;
 
 		$stripe_params = [
+			'title'                => $this->title,
 			'key'                  => $this->publishable_key,
 			'i18n_terms'           => __( 'Please accept the terms and conditions first', 'woocommerce-gateway-stripe' ),
 			'i18n_required_fields' => __( 'Please fill in required checkout fields first', 'woocommerce-gateway-stripe' ),

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -150,7 +150,6 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			$this->get_payment_request_javascript_params(),
 			// Blocks-specific options
 			[
-				'title'                          => $this->get_title(),
 				'icons'                          => $this->get_icons(),
 				'supports'                       => $this->get_supported_features(),
 				'showSavedCards'                 => $this->get_show_saved_cards(),

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -476,6 +476,8 @@ class WC_Stripe_Payment_Request {
 			if ( 'Chrome Payment Request (Stripe)' === $method_title ) {
 				return 'Payment Request (Stripe)';
 			}
+
+			return $method_title;
 		}
 
 		return $title;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -116,14 +116,19 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->maybe_init_subscriptions();
 
 		$main_settings              = get_option( 'woocommerce_stripe_settings' );
-		$this->title                = $this->get_option( 'title' );
-		$this->description          = $this->get_option( 'description' );
+		$this->title                = $this->get_option( 'title_upe' );
+		$this->description          = '';
 		$this->enabled              = $this->get_option( 'enabled' );
 		$this->saved_cards          = 'yes' === $this->get_option( 'saved_cards' );
 		$this->testmode             = ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'];
 		$this->publishable_key      = ! empty( $main_settings['publishable_key'] ) ? $main_settings['publishable_key'] : '';
 		$this->secret_key           = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
 		$this->statement_descriptor = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
+
+		$enabled_at_checkout_payment_methods = $this->get_upe_enabled_at_checkout_payment_method_ids();
+		if ( count( $enabled_at_checkout_payment_methods ) === 1 ) {
+			$this->title = $this->payment_methods[ $enabled_at_checkout_payment_methods[0] ]->get_title();
+		}
 
 		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
@@ -153,6 +158,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public function init_form_fields() {
 		$this->form_fields = require WC_STRIPE_PLUGIN_PATH . '/includes/admin/stripe-settings.php';
 		unset( $this->form_fields['inline_cc_form'] );
+		unset( $this->form_fields['title'] );
+		unset( $this->form_fields['description'] );
 	}
 
 	/**
@@ -227,6 +234,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		global $wp;
 
 		$stripe_params = [
+			'title'        => $this->title,
 			'isUPEEnabled' => true,
 			'key'          => $this->publishable_key,
 			'locale'       => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -976,7 +976,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
-		$payment_method_title = $this->payment_methods[ $payment_method_type ]->get_title( $payment_method_details );
+		$payment_method_title = $this->payment_methods[ $payment_method_type ]->get_label();
 
 		$order->set_payment_method( self::ID );
 		$order->set_payment_method_title( $payment_method_title );

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -224,7 +224,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		)[0];
 
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertEquals( 'Visa credit card', $final_order->get_payment_method_title() );
+		$this->assertEquals( 'Credit card / debit card', $final_order->get_payment_method_title() );
 		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
 		$this->assertRegExp( '/Charge ID: ch_mock/', $note->content );
 	}

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -71,7 +71,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					'generate_payment_request',
 					'get_return_url',
 					'get_stripe_customer_id',
-					'get_upe_enabled_payment_method_ids',
 					'stripe_request',
 				]
 			)
@@ -81,16 +80,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_return_url' )
 			->will(
 				$this->returnValue( self::MOCK_RETURN_URL )
-			);
-
-		$enabled_payment_method_ids = [];
-		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $payment_method_class ) {
-			$enabled_payment_method_ids[] = $payment_method_class::STRIPE_ID;
-		}
-		$this->mock_gateway->expects( $this->any() )
-			->method( 'get_upe_enabled_payment_method_ids' )
-			->will(
-				$this->returnValue( $enabled_payment_method_ids )
 			);
 	}
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Issue: #1919
Fixes #1919 and #1933

This PR replaces:  #1930

This PR changes the UPE gateway title in the checkout depending on the enabled payment methods.
If there is more than one (1) payment method enabled the title is: Popular payment methods, but if there is only one, then that payment method title is used (ex: Pay with giropay)

**BEFORE:**
<img width="630" alt="Screen Shot 2021-09-21 at 13 57 07" src="https://user-images.githubusercontent.com/407542/134225447-f8c90dc0-1d61-4f55-a523-e53bcb6e5db1.png">

**AFTER:**
<img width="335" alt="Screen Shot 2021-09-22 at 14 05 54" src="https://user-images.githubusercontent.com/407542/134389563-a2c0955c-d3e1-4e34-91ee-f1d96ab81bae.png"><img width="340" alt="Screen Shot 2021-09-22 at 14 06 54" src="https://user-images.githubusercontent.com/407542/134389595-055572a3-20a6-4734-945e-d72ae25cb19f.png">


# Testing instructions

_Custom title for the UPE gateway in Settings_:
1. Go to  Settings > Payments > Stripe
2. Enable UPE (check `Try the new payment experience (Early access)` and then click `save`)
3. Check that the `title` field value is: `Popular payment methods` and the tooltip is: `This controls the title which the user sees during checkout when multiple payment methods are enabled.`
4. Check that there is no `description` field
5. Disable UPE
6. Check that the `title` field value is restored to its previous value (by default: `Credit Card (Stripe)`), and the tooltip is: `This controls the title which the user sees during checkout.`
7. Check that the `description` field is present

_Custom UPE gateway title in checkout_: 
1. Make sure UPE is enabled 
2. Enable at least 2 payment methods
3. Go to the Shop and add at least one product to the cart
4. Go to the Shortcode Checkout
5. Check that the Gateway title is `Popular payment methods` (like in the screenshot above)
6. Also check that the description `Pay with your credit card via Stripe` is not present below the tile; it should only say: `Test mode...`
7. 4. Go to the Blocks Checkout
8. Check that the Gateway title is `Popular payment methods`
9. Go to the Stripe payment settings, and enable only the `giropay` payment method (disable the rest)
10. Go to the Shortcode Checkout
11. Check that the Gateway title is `Pay with giropay` (like in the screenshot above)
12. Go to the Blocks Checkout
13. Check that the Gateway title is `Pay with giropay` (like in the screenshot above)

_Specific payment method title displayed in order details_:
1. Complete purchase with any UPE payment method (take note of the Payment Method shown in the order confirmation page)
2. Go to Orders > `newly created order`
3. Check that the `Payment via...` text below the order title has the specific payment method used (and that is the same as the one shown on the order confirmation page)
<img width="411" alt="Screen Shot 2021-09-23 at 18 38 40" src="https://user-images.githubusercontent.com/407542/134587690-7007489b-f355-4a89-8902-a144cfc209f8.png">


