### PR TITLE
Set UPE preview feature flag default value to `yes`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 5.6.0 - 2021-xx-xx =
+* Add - Pre-release preview of new checkout experience using Stripe Universal Payment Element.
+
 = 5.5.0 - 2021-09-15 =
 * Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.
 * Fix - Save payment method during 3D Secure flow for Block-based checkout.

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -13,7 +13,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_preview_enabled() {
-		return 'yes' === get_option( '_wcstripe_feature_upe', 'no' ) || self::is_upe_settings_redesign_enabled();
+		return 'yes' === get_option( '_wcstripe_feature_upe', 'yes' ) || self::is_upe_settings_redesign_enabled();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -126,12 +126,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.5.0 - 2021-09-15 =
-* Tweak - Moved the `WC_Gateway_Stripe::admin_scripts` method to `WC_Stripe_Settings_Controller::admin_scripts`.
-* Fix - Save payment method during 3D Secure flow for Block-based checkout.
-* Fix - Show subtotal on Payment Request dialog.
-* Add - Settings to control Payment Request Button locations in the Stripe plugin settings. Persists changes made through pre-existing filters, or defaults to the Cart and Product pages if no filters are in use.
-* Tweak - Deprecated the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters in favor of the UI-driven approach in the plugin settings.
-* Add - Notice for WP & WC version compatibility check.
+= 5.6.0 - 2021-xx-xx =
+* Add - Pre-release preview of new checkout experience using Stripe Universal Payment Element.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -75,7 +75,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 
 		$settings = get_option( 'woocommerce_stripe_settings' );
 
-		$this->assertEquals( 'disabled', $settings['upe_checkout_experience_enabled'] );
+		$this->assertEquals( 'no', $settings['upe_checkout_experience_enabled'] );
 	}
 
 	public function test_set_flag_missing_request_returns_status_code_400() {


### PR DESCRIPTION
# Changes proposed in this Pull Request:

- Set UPE option `_wcstripe_feature_upe` default value to `yes`.

# Testing instructions

- Remove the `_wcstripe_feature_upe` option.
- Ensure you can still see the "New checkout experience" setting under **WooCommerce > Payments > Stripe**.
- Please smoke test the UPE and non-UPE checkout and settings and ensure everything works as expected.
