### PR TITLE
Make UPE method titles consistent and translatable.

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -22,7 +22,7 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id   = self::STRIPE_ID;
-		$this->title       = 'Credit card / debit card';
+		$this->title       = __( 'Pay with credit card / debit card', 'woocommerce-gateway-stripe' );
 		$this->is_reusable = true;
 		$this->label       = __( 'Credit card / debit card', 'woocommerce-gateway-stripe' );
 		$this->description = __(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-eps.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-eps.php
@@ -18,7 +18,7 @@ class WC_Stripe_UPE_Payment_Method_Eps extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = 'Pay with EPS';
+		$this->title                = __( 'Pay with EPS', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'EPS', 'woocommerce-gateway-stripe' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php
@@ -18,7 +18,7 @@ class WC_Stripe_UPE_Payment_Method_Giropay extends WC_Stripe_UPE_Payment_Method 
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = 'Pay with giropay';
+		$this->title                = __( 'Pay with giropay', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'giropay', 'woocommerce-gateway-stripe' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
@@ -18,7 +18,7 @@ class WC_Stripe_UPE_Payment_Method_Ideal extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = 'Pay with iDEAL';
+		$this->title                = __( 'Pay with iDEAL', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'iDEAL', 'woocommerce-gateway-stripe' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-p24.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-p24.php
@@ -18,7 +18,7 @@ class WC_Stripe_UPE_Payment_Method_P24 extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = 'Pay with Przelewy24';
+		$this->title                = __( 'Pay with Przelewy24', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'EUR', 'PLN' ];
 		$this->label                = __( 'Przelewy24', 'woocommerce-gateway-stripe' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -20,10 +20,10 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = 'Pay with SEPA Direct Debit';
+		$this->title                = __( 'Pay with SEPA Direct Debit', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
-		$this->label                = __( 'Sepa Direct Debit', 'woocommerce-gateway-stripe' );
+		$this->label                = __( 'SEPA Direct Debit', 'woocommerce-gateway-stripe' );
 		$this->description          = __(
 			'Reach 500 million customers and over 20 million businesses across the European Union.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -18,7 +18,7 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = 'Pay with SOFORT';
+		$this->title                = __( 'Pay with SOFORT', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = true; // Supported through Stripe via SEPA Direct Debit
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'SOFORT', 'woocommerce-gateway-stripe' );


### PR DESCRIPTION
This simply addresses #1967.