### PR TITLE
Handle account data retrieval error

### DIFF
--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -80,6 +80,10 @@ class WC_Stripe_Account {
 			return [];
 		}
 
+		if ( is_wp_error( $account ) ) {
+			return [];
+		}
+
 		// Add the account data and mode to the array we're caching.
 		$account_cache = $account;
 
@@ -161,7 +165,7 @@ class WC_Stripe_Account {
 		$settings_options = get_option( 'woocommerce_stripe_settings', [] );
 		$mode             = isset( $settings_options['testmode'] ) && 'yes' === $settings_options['testmode'] ? 'test' : 'live';
 
-		if ( empty( $account ) || ! empty( $account['errors'] ) ) {
+		if ( empty( $account ) ) {
 			return [
 				'error' => true,
 			];

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -161,7 +161,7 @@ class WC_Stripe_Account {
 		$settings_options = get_option( 'woocommerce_stripe_settings', [] );
 		$mode             = isset( $settings_options['testmode'] ) && 'yes' === $settings_options['testmode'] ? 'test' : 'live';
 
-		if ( empty( $account ) || isset( $account['errors'] ) ) {
+		if ( empty( $account ) || ! empty( $account['errors'] ) ) {
 			return [
 				'error' => true,
 			];

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -161,7 +161,7 @@ class WC_Stripe_Account {
 		$settings_options = get_option( 'woocommerce_stripe_settings', [] );
 		$mode             = isset( $settings_options['testmode'] ) && 'yes' === $settings_options['testmode'] ? 'test' : 'live';
 
-		if ( empty( $account ) ) {
+		if ( empty( $account ) || isset( $account['errors'] ) ) {
 			return [
 				'error' => true,
 			];

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -80,7 +80,7 @@ class WC_Stripe_Account {
 			return [];
 		}
 
-		if ( is_wp_error( $account ) ) {
+		if ( is_wp_error( $account ) || isset( $account->error->message ) ) {
 			return [];
 		}
 

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -76,9 +76,6 @@ class WC_Stripe_Account {
 
 		// need call_user_func() as (  $this->stripe_api )::retrieve this syntax is not supported in php < 5.2
 		$account = call_user_func( [ $this->stripe_api, 'retrieve' ], 'account' );
-		if ( is_wp_error( $account ) ) {
-			return [];
-		}
 
 		if ( is_wp_error( $account ) || isset( $account->error->message ) ) {
 			return [];


### PR DESCRIPTION
### Description
When there is an `errors` object returned by Stripe instead of `account` data, a warning message appears on the screen.

![undefined capabilities](https://user-images.githubusercontent.com/33387139/134648990-2463df28-0599-424a-854b-c5c7684bb0f9.png)


# Testing instructions
- Easiest way to reproduce the warning would to return `WP_Error` from the `retrieve` method [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/538d9c2dd236f96cb5fdce789fab37bb3d35eef6/includes/class-wc-stripe-api.php#L168)
