### PR TITLE
fix: payment request options update

### DIFF
--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -234,7 +234,21 @@ $stripe_settings = apply_filters(
 	]
 );
 
-if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
+if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
+	// in the new settings, "checkout" is going to be enabled by default (if it is a new WCStripe installation).
+	$stripe_settings['payment_request_button_locations']['default'][] = 'checkout';
+
+	// no longer needed in the new settings.
+	unset( $stripe_settings['payment_request_button_branded_type'] );
+	unset( $stripe_settings['payment_request_button_height'] );
+	unset( $stripe_settings['payment_request_button_label'] );
+	// injecting some of the new options.
+	$stripe_settings['payment_request_button_type']['options']['default'] = __( 'Only icon', 'woocommerce-gateway-stripe' );
+	$stripe_settings['payment_request_button_type']['options']['book']    = __( 'Book', 'woocommerce-gateway-stripe' );
+	// no longer valid options.
+	unset( $stripe_settings['payment_request_button_type']['options']['branded'] );
+	unset( $stripe_settings['payment_request_button_type']['options']['custom'] );
+} else {
 	unset( $stripe_settings['payment_request_button_size'] );
 }
 
@@ -265,20 +279,6 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && ! WC_Stripe_Helper::is
 	}
 	// Insert UPE options below the 'logging' setting.
 	$stripe_settings = array_merge( $stripe_settings, $upe_settings );
-
-	// in the new settings, "checkout" is going to be enabled by default (if it is a new WCStripe installation).
-	$stripe_settings['payment_request_button_locations']['default'][] = 'checkout';
-
-	// no longer needed in the new settings.
-	unset( $stripe_settings['payment_request_button_branded_type'] );
-	unset( $stripe_settings['payment_request_button_height'] );
-	unset( $stripe_settings['payment_request_button_label'] );
-	// injecting some of the new options.
-	$stripe_settings['payment_request_button_type']['options']['default'] = __( 'Only icon', 'woocommerce-gateway-stripe' );
-	$stripe_settings['payment_request_button_type']['options']['book']    = __( 'Book', 'woocommerce-gateway-stripe' );
-	// no longer valid options.
-	unset( $stripe_settings['payment_request_button_type']['options']['branded'] );
-	unset( $stripe_settings['payment_request_button_type']['options']['custom'] );
 }
 
 return apply_filters(


### PR DESCRIPTION
# Changes proposed in this Pull Request:

It looks like when the [pre-orders plugin](https://woocommerce.com/products/woocommerce-pre-orders/) is installed and active (hint: you can also manually tweak the `is_pre_orders_exists()` method), we don't show the correct "Payment request" options.
The check for the pre-orders plugin didn't exist before the "Payment request" options were updated - so we need to change that.

Before:
![Markup 2021-09-24 at 08 06 59](https://user-images.githubusercontent.com/273592/134679286-f3f1a544-f7b7-416b-81a7-71bce4fb45f5.png)

After:
![Markup 2021-09-24 at 08 08 51](https://user-images.githubusercontent.com/273592/134679460-44f7de7c-11dd-402a-a7db-718d19acf31b.png)


# Testing instructions
- Go to the settings page: http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- The options should be the same whether or not the pre-orders plugin is installed