### PR TITLE
fix: method name in currency notice

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -261,7 +261,7 @@ class WC_Stripe_Admin_Notices {
 			}
 			if ( ! in_array( get_woocommerce_currency(), $upe_method->get_supported_currencies(), true ) ) {
 				/* translators: %1$s Payment method, %2$s List of supported currencies */
-				$this->add_admin_notice( $method . '_upe', 'notice notice-error', sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s', 'woocommerce-gateway-stripe' ), $method, implode( ', ', $upe_method->get_supported_currencies() ) ), true );
+				$this->add_admin_notice( $method . '_upe', 'notice notice-error', sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $upe_method->get_supported_currencies() ) ), true );
 			}
 		}
 	}


### PR DESCRIPTION
# Changes proposed in this Pull Request:

I noticed a slight inconsistency on the method name in the "missing currency" notice.
This change ensures that the name of the payment method is correctly spelled (instead of typing the slug of the payment method).

With UPE disabled:
![Screen Shot 2021-09-24 at 8 52 05 AM](https://user-images.githubusercontent.com/273592/134686089-d4f0e044-310e-4e93-9707-3d4c5e9a9889.png)

With UPE enabled:
![Screen Shot 2021-09-24 at 8 51 41 AM](https://user-images.githubusercontent.com/273592/134686114-c4cb5bdb-514f-4fe2-8fe2-face99526614.png)

After my changes, with UPE enabled:
![Screen Shot 2021-09-24 at 8 50 37 AM](https://user-images.githubusercontent.com/273592/134686156-c376fd24-9d5d-4e6f-940a-5c33289aaa55.png)


# Testing instructions
- Set your store currency to USD
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
- Enable UPE
- The text on the notices should be fixed