### PR TITLE
fix: UPE controller name clash

### DIFF
--- a/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class WC_REST_UPE_Flag_Toggle_Controller
+ * Class WC_Stripe_REST_UPE_Flag_Toggle_Controller
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST controller for UPE feature flag.
  */
-class WC_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Controller {
+class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Controller {
 	/**
 	 * Endpoint path.
 	 *

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -42,7 +42,6 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_settings_redesign_enabled() {
-		return true;
 		return 'yes' === get_option( '_wcstripe_feature_upe_settings', 'no' );
 	}
 }

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -42,6 +42,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_settings_redesign_enabled() {
+		return true;
 		return 'yes' === get_option( '_wcstripe_feature_upe_settings', 'no' );
 	}
 }

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * These tests make assertions against class WC_REST_UPE_Flag_Toggle_Controller.
+ * These tests make assertions against class WC_Stripe_REST_UPE_Flag_Toggle_Controller.
  *
- * @package WooCommerce_Stripe/Tests/WC_REST_UPE_Flag_Toggle_Controller
+ * @package WooCommerce_Stripe/Tests/WC_Stripe_REST_UPE_Flag_Toggle_Controller
  */
 
 /**
- * WC_REST_UPE_Flag_Toggle_Controller unit tests.
+ * WC_Stripe_REST_UPE_Flag_Toggle_Controller unit tests.
  */
-class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
+class WC_Stripe_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Tested REST route.
 	 */
@@ -17,7 +17,7 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * The system under test.
 	 *
-	 * @var WC_REST_UPE_Flag_Toggle_Controller
+	 * @var WC_Stripe_REST_UPE_Flag_Toggle_Controller
 	 */
 	private $controller;
 
@@ -27,12 +27,12 @@ class WC_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
 
 		// Set the user so that we can pass the authentication.
 		wp_set_current_user( 1 );
 
-		$this->controller = new WC_REST_UPE_Flag_Toggle_Controller();
+		$this->controller = new WC_Stripe_REST_UPE_Flag_Toggle_Controller();
 	}
 
 	public function test_get_flag_request_returns_status_code_200() {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -588,10 +588,10 @@ function woocommerce_gateway_stripe() {
 
 				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-controller.php';
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-upe-flag-toggle-controller.php';
+					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';
 
-					$upe_flag_toggle_controller = new WC_REST_UPE_Flag_Toggle_Controller();
+					$upe_flag_toggle_controller = new WC_Stripe_REST_UPE_Flag_Toggle_Controller();
 					$upe_flag_toggle_controller->register_routes();
 
 					$gateway = WC()->payment_gateways()->payment_gateways()[ WC_Gateway_Stripe::ID ];


### PR DESCRIPTION
# Changes proposed in this Pull Request:

We have a naming clash with the same `WC_REST_UPE_Flag_Toggle_Controller` in WCPay, when the 2 plugins are installed together.
Renaming the controller to `WC_Stripe_REST_UPE_Flag_Toggle_Controller`.

# Testing instructions
The changes would need to ensure that the controller still works.

- Ensure you have UPE disabled
- Enable the `_wcstripe_feature_upe_settings` feature flag
- Go to http://localhost:8082/wp-admin/admin.php?page=wc_stripe-onboarding_wizard
- Enable UPE
- Still works!