### PR TITLE
Check if cart is not null before getting total

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -304,7 +304,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 		}
 
-		$amount = WC()->cart->get_total( false );
+		$amount = is_null( WC()->cart ) ? 0 : WC()->cart->get_total( false );
 		$order  = isset( $order_id ) ? wc_get_order( $order_id ) : null;
 		if ( is_a( $order, 'WC_Order' ) ) {
 			$amount = $order->get_total();


### PR DESCRIPTION
Fixes fatal error when creating or editing a page when WooCommerce Blocks is installed

### Testing instructions

- Install WooCommerce blocks
- Go to pages, click "Add new"
- Editor should be displayed and work as usual.
- Switch to `develop` branch
- Refresh page
- Error should show up.