### PR TITLE
Use isset to prevent warning when payouts is undefined

### DIFF
--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -74,10 +74,9 @@ class WC_Stripe_Account {
 	private function cache_account() {
 		$expiration = 2 * HOUR_IN_SECONDS;
 
-		// We must do it this way so the static method can be mocked.
-		$static_call = $this->stripe_api . '::retrieve';
 		try {
-			$account = $static_call( 'account' );
+			// need call_user_func() as (  $this->stripe_api )::retrieve this syntax is not supported in php < 5.2
+			$account = call_user_func( [ $this->stripe_api, 'retrieve' ], 'account' );
 		} catch ( WC_Stripe_Exception $e ) {
 			return [];
 		}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -21,12 +21,21 @@ class WC_Stripe_Account {
 	private $connect;
 
 	/**
+	 * The Stripe API class to access the static method.
+	 *
+	 * @var WC_Stripe_API
+	 */
+	private $stripe_api;
+
+	/**
 	 * Constructor
 	 *
 	 * @param WC_Stripe_Connect $connect Stripe connect
+	 * @param $stripe_api Stripe API class
 	 */
-	public function __construct( WC_Stripe_Connect $connect ) {
-		$this->connect = $connect;
+	public function __construct( WC_Stripe_Connect $connect, $stripe_api ) {
+		$this->connect    = $connect;
+		$this->stripe_api = $stripe_api;
 	}
 
 	/**
@@ -66,7 +75,7 @@ class WC_Stripe_Account {
 		$expiration = 2 * HOUR_IN_SECONDS;
 
 		try {
-			$account = WC_Stripe_API::retrieve( 'account' );
+			$account = $this->stripe_api::retrieve( 'account' );
 		} catch ( WC_Stripe_Exception $e ) {
 			return [];
 		}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -21,21 +21,12 @@ class WC_Stripe_Account {
 	private $connect;
 
 	/**
-	 * The Stripe API class to access the static method.
-	 *
-	 * @var WC_Stripe_API
-	 */
-	private $stripe_api;
-
-	/**
 	 * Constructor
 	 *
 	 * @param WC_Stripe_Connect $connect Stripe connect
-	 * @param $stripe_api Stripe API class
 	 */
-	public function __construct( WC_Stripe_Connect $connect, $stripe_api ) {
-		$this->connect    = $connect;
-		$this->stripe_api = $stripe_api;
+	public function __construct( WC_Stripe_Connect $connect ) {
+		$this->connect = $connect;
 	}
 
 	/**
@@ -75,8 +66,7 @@ class WC_Stripe_Account {
 		$expiration = 2 * HOUR_IN_SECONDS;
 
 		try {
-			// need call_user_func() as (  $this->stripe_api )::retrieve this syntax is not supported in php < 5.2
-			$account = call_user_func( [ $this->stripe_api, 'retrieve' ], 'account' );
+			$account = WC_Stripe_API::retrieve( 'account' );
 		} catch ( WC_Stripe_Exception $e ) {
 			return [];
 		}
@@ -143,7 +133,7 @@ class WC_Stripe_Account {
 	 */
 	private function are_deposits_enabled( $account ) {
 		$are_payouts_enabled = $account['payouts_enabled'] || false;
-		$payout_settings     = $account['settings']['payouts'] ? $account['settings']['payouts'] : [];
+		$payout_settings     = isset( $account['settings']['payouts'] ) ? $account['settings']['payouts'] : [];
 
 		if ( ! $are_payouts_enabled || ! isset( $payout_settings['schedule']['interval'] ) ) {
 			return false;

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -74,8 +74,10 @@ class WC_Stripe_Account {
 	private function cache_account() {
 		$expiration = 2 * HOUR_IN_SECONDS;
 
+		// We must do it this way so the static method can be mocked.
+		$static_call = $this->stripe_api . '::retrieve';
 		try {
-			$account = $this->stripe_api::retrieve( 'account' );
+			$account = $static_call( 'account' );
 		} catch ( WC_Stripe_Exception $e ) {
 			return [];
 		}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -212,7 +212,7 @@ function woocommerce_gateway_stripe() {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();
 					} else {
-						$this->account = new WC_Stripe_Account( $this->connect );
+						$this->account = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
 						new WC_Stripe_Settings_Controller( $this->account );
 					}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -212,7 +212,7 @@ function woocommerce_gateway_stripe() {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();
 					} else {
-						$this->account = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
+						$this->account = new WC_Stripe_Account( $this->connect );
 						new WC_Stripe_Settings_Controller( $this->account );
 					}
 


### PR DESCRIPTION
Fixes 
Warning	Undefined array key "payouts" in  includes/class-wc-stripe-account.php:146

Also removed an ugly hack used for PHP 5.2 compatibility. 