### PR TITLE
Add mandate data to setup intents created with saved payment method

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -603,6 +603,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				];
 				if ( false === $intent ) {
 					$request['confirm'] = 'true';
+					// SEPA setup intents require mandate data.
+					if ( in_array( 'sepa_debit', array_values( $enabled_payment_methods ), true ) ) {
+						$request['mandate_data'] = [
+							'customer_acceptance' => [
+								'type'   => 'online',
+								'online' => [
+									'ip_address' => WC_Geolocation::get_ip_address(),
+									'user_agent' => isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '', // @codingStandardsIgnoreLine
+								],
+							],
+						];
+					}
 				}
 
 				$intent = $this->stripe_request( $endpoint, $request );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
@@ -19,7 +19,7 @@ class WC_Stripe_UPE_Payment_Method_Bancontact extends WC_Stripe_UPE_Payment_Meth
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
 		$this->title                = 'Pay with Bancontact';
-		$this->is_reusable          = true;
+		$this->is_reusable          = false; // TODO: Enable it in a future release - Supported through Stripe via SEPA Direct Debit.
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'Bancontact', 'woocommerce-gateway-stripe' );
 		$this->description          = __(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
@@ -19,7 +19,7 @@ class WC_Stripe_UPE_Payment_Method_Ideal extends WC_Stripe_UPE_Payment_Method {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
 		$this->title                = __( 'Pay with iDEAL', 'woocommerce-gateway-stripe' );
-		$this->is_reusable          = false;
+		$this->is_reusable          = false; // TODO: Enable it in a future release - Supported through Stripe via SEPA Direct Debit.
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'iDEAL', 'woocommerce-gateway-stripe' );
 		$this->description          = __(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -19,7 +19,7 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
 		$this->title                = __( 'Pay with SOFORT', 'woocommerce-gateway-stripe' );
-		$this->is_reusable          = true; // Supported through Stripe via SEPA Direct Debit
+		$this->is_reusable          = false; // TODO: Enable it in a future release - Supported through Stripe via SEPA Direct Debit.
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'SOFORT', 'woocommerce-gateway-stripe' );
 		$this->description          = __(


### PR DESCRIPTION
# Changes proposed in this Pull Request:

- Add `mandate_data` attribute to the request, similar to how it's done in WCPay.

# Testing instructions

- Ensure UPE and SEPA are enabled.
- Save a SEPA payment method.
- Add a free trial subscription to the cart.
- Proceed to checkout and pay using a saved SEPA payment method.
- Checkout should work as expected in this branch, while in `develop` a `parameter_missing` error is logged in Stripe.