### PR TITLE
feat: manual capture confirmation modal

### DIFF
--- a/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
+++ b/client/settings/payments-and-transactions-section/__tests__/manual-capture-control.test.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useManualCapture } from '../data-mock';
+import ManualCaptureControl from '../manual-capture-control';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
+
+jest.mock( '../data-mock', () => ( {
+	useManualCapture: jest.fn(),
+} ) );
+
+describe( 'ManualCaptureControl', () => {
+	beforeEach( () => {
+		useManualCapture.mockReturnValue( [ false, () => null ] );
+	} );
+
+	it( 'should not render the confirmation modal when UPE is disabled', () => {
+		const manualCaptureToggleMock = jest.fn();
+		useManualCapture.mockReturnValue( [ false, manualCaptureToggleMock ] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<ManualCaptureControl />
+			</UpeToggleContext.Provider>
+		);
+
+		userEvent.click(
+			screen.getByLabelText(
+				'Issue an authorization on checkout, and capture later'
+			)
+		);
+
+		expect( manualCaptureToggleMock ).toHaveBeenCalledWith( true );
+		expect(
+			screen.queryByText( 'Enable manual capture' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the confirmation modal when UPE is enabled', () => {
+		const manualCaptureToggleMock = jest.fn();
+		useManualCapture.mockReturnValue( [ false, manualCaptureToggleMock ] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<ManualCaptureControl />
+			</UpeToggleContext.Provider>
+		);
+
+		userEvent.click(
+			screen.getByLabelText(
+				'Issue an authorization on checkout, and capture later'
+			)
+		);
+
+		expect( manualCaptureToggleMock ).not.toHaveBeenCalled();
+		expect(
+			screen.queryByText( 'Enable manual capture' )
+		).toBeInTheDocument();
+
+		userEvent.click( screen.getByText( 'Cancel' ) );
+
+		expect(
+			screen.queryByText( 'Enable manual capture' )
+		).not.toBeInTheDocument();
+		expect( manualCaptureToggleMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should toggle the flag when UPE is enabled', () => {
+		const manualCaptureToggleMock = jest.fn();
+		useManualCapture.mockReturnValue( [ false, manualCaptureToggleMock ] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<ManualCaptureControl />
+			</UpeToggleContext.Provider>
+		);
+
+		userEvent.click(
+			screen.getByLabelText(
+				'Issue an authorization on checkout, and capture later'
+			)
+		);
+
+		expect( manualCaptureToggleMock ).not.toHaveBeenCalled();
+		expect(
+			screen.queryByText( 'Enable manual capture' )
+		).toBeInTheDocument();
+
+		userEvent.click( screen.getByText( 'Enable' ) );
+
+		expect(
+			screen.queryByText( 'Enable manual capture' )
+		).not.toBeInTheDocument();
+		expect( manualCaptureToggleMock ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'should not show the modal when manual capture is already enabled', () => {
+		const manualCaptureToggleMock = jest.fn();
+		useManualCapture.mockReturnValue( [ true, manualCaptureToggleMock ] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<ManualCaptureControl />
+			</UpeToggleContext.Provider>
+		);
+
+		userEvent.click(
+			screen.getByLabelText(
+				'Issue an authorization on checkout, and capture later'
+			)
+		);
+
+		expect( manualCaptureToggleMock ).toHaveBeenCalledWith( false );
+		expect(
+			screen.queryByText( 'Enable manual capture' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/client/settings/payments-and-transactions-section/data-mock.js
+++ b/client/settings/payments-and-transactions-section/data-mock.js
@@ -11,7 +11,7 @@ const makeToggleHook = ( initialValue = false ) => () => {
 	return [ value, toggleValue ];
 };
 
-export const useManualCapture = makeToggleHook( true );
+export const useManualCapture = makeToggleHook( false );
 
 export const useSavedCards = makeToggleHook( true );
 

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -6,19 +6,15 @@ import TextLengthHelpInputWrapper from './text-length-help-input-wrapper';
 import StatementPreviewsWrapper from './statement-previews-wrapper';
 import StatementPreview from './statement-preview';
 import {
-	useManualCapture,
 	useSavedCards,
 	useShortAccountStatement,
 	useSeparateCardForm,
 	useAccountStatementDescriptor,
 	useShortAccountStatementDescriptor,
 } from './data-mock';
+import ManualCaptureControl from './manual-capture-control';
 
 const PaymentsAndTransactionsSection = () => {
-	const [
-		isManualCaptureEnabled,
-		setIsManualCaptureEnabled,
-	] = useManualCapture();
 	const [ isSavedCardsEnabled, setIsSavedCardsEnabled ] = useSavedCards();
 	const [
 		isSeparateCardFormEnabled,
@@ -77,18 +73,7 @@ const PaymentsAndTransactionsSection = () => {
 						'woocommerce-gateway-stripe'
 					) }
 				</h4>
-				<CheckboxControl
-					checked={ isManualCaptureEnabled }
-					onChange={ setIsManualCaptureEnabled }
-					label={ __(
-						'Issue an authorization on checkout, and capture later',
-						'woocommerce-gateway-stripe'
-					) }
-					help={ __(
-						'Charge must be captured on the order details screen within 7 days of authorization, otherwise the authorization and order will be canceled.',
-						'woocommerce-gateway-stripe'
-					) }
-				/>
+				<ManualCaptureControl />
 				<h4>
 					{ __(
 						'Customer bank statement',

--- a/client/settings/payments-and-transactions-section/manual-capture-control.js
+++ b/client/settings/payments-and-transactions-section/manual-capture-control.js
@@ -1,0 +1,127 @@
+import { __ } from '@wordpress/i18n';
+import styled from '@emotion/styled';
+import React, { useContext, useState } from 'react';
+import { CheckboxControl, Button } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
+import { useManualCapture } from './data-mock';
+import ConfirmationModal from 'wcstripe/components/confirmation-modal';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
+
+const AlertIcon = styled( Icon )`
+	fill: #afafaf;
+	position: absolute;
+	left: -2.2em;
+	width: 1.8em;
+	height: auto;
+`;
+
+const WarningList = styled.ul`
+	padding-left: 2.5em;
+
+	> li {
+		position: relative;
+
+		&:first-of-type svg {
+			fill: #ffc83f;
+		}
+	}
+`;
+
+const WarningListElement = ( { children } ) => (
+	<li>
+		<AlertIcon icon={ info } />
+		{ children }
+	</li>
+);
+
+const ManualCaptureControl = () => {
+	const [
+		isManualCaptureEnabled,
+		setIsManualCaptureEnabled,
+	] = useManualCapture();
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
+	const [ isConfirmationModalOpen, setIsConfirmationModalOpen ] = useState(
+		false
+	);
+
+	const handleCheckboxToggle = ( isChecked ) => {
+		// toggling from "manual" capture to "automatic" capture - no need to show the modal.
+		if ( ! isChecked || ! isUpeEnabled ) {
+			setIsManualCaptureEnabled( isChecked );
+			return;
+		}
+		setIsConfirmationModalOpen( true );
+	};
+
+	const handleModalCancel = () => {
+		setIsConfirmationModalOpen( false );
+	};
+
+	const handleModalConfirmation = () => {
+		setIsManualCaptureEnabled( true );
+		setIsConfirmationModalOpen( false );
+	};
+
+	return (
+		<>
+			<CheckboxControl
+				onChange={ handleCheckboxToggle }
+				checked={ isManualCaptureEnabled }
+				label={ __(
+					'Issue an authorization on checkout, and capture later',
+					'woocommerce-gateway-stripe'
+				) }
+				help={ __(
+					'Charge must be captured on the order details screen within 7 days of authorization, otherwise the authorization and order will be canceled.',
+					'woocommerce-gateway-stripe'
+				) }
+			/>
+			{ isConfirmationModalOpen && (
+				<ConfirmationModal
+					onRequestClose={ handleModalCancel }
+					title={ __(
+						'Enable manual capture',
+						'woocommerce-gateway-stripe'
+					) }
+					actions={
+						<>
+							<Button onClick={ handleModalCancel } isSecondary>
+								{ __( 'Cancel', 'woocommerce-gateway-stripe' ) }
+							</Button>
+							<Button
+								onClick={ handleModalConfirmation }
+								isPrimary
+							>
+								{ __( 'Enable', 'woocommerce-gateway-stripe' ) }
+							</Button>
+						</>
+					}
+				>
+					<strong>
+						{ __(
+							'Are you sure you want to enable manual capture of payments?',
+							'woocommerce-gateway-stripe'
+						) }
+					</strong>
+					<WarningList>
+						<WarningListElement>
+							{ __(
+								'Only cards support manual capture. When enabled, all other payment methods will be hidden from checkout.',
+								'woocommerce-gateway-stripe'
+							) }
+						</WarningListElement>
+						<WarningListElement>
+							{ __(
+								'You must capture the payment on the order details screen within 7 days of authorization, otherwise the money will return to the shopper.',
+								'woocommerce-gateway-stripe'
+							) }
+						</WarningListElement>
+					</WarningList>
+				</ConfirmationModal>
+			) }
+		</>
+	);
+};
+
+export default ManualCaptureControl;


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Display a confirmation modal when UPE is enabled and the merchant intends to use the "manual" capture method.

![2021-09-30 11 04 54](https://user-images.githubusercontent.com/273592/135491132-8b8d6601-d0bc-4df2-80ab-1e051b1093d1.gif)



# Testing instructions
- Ensure you have the `_wcstripe_feature_upe_settings` flag enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings
- The confirmation modal should display when enabling "manual" capture and UPE is enabled
