### PR TITLE
feat: add select all payment methods

### DIFF
--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
@@ -81,12 +81,17 @@ describe( 'AddPaymentMethodsTask', () => {
 
 		userEvent.click( screen.getByText( 'Select all' ) );
 
+		expect( screen.queryByText( 'Select all' ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Credit/ } )
 		).toBeChecked();
 		expect(
 			screen.getByRole( 'checkbox', { name: 'giropay' } )
 		).toBeChecked();
+
+		userEvent.click( screen.getByRole( 'checkbox', { name: 'giropay' } ) );
+
+		expect( screen.queryByText( 'Select all' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should move forward when the payment methods are selected', async () => {

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
@@ -81,17 +81,12 @@ describe( 'AddPaymentMethodsTask', () => {
 
 		userEvent.click( screen.getByText( 'Select all' ) );
 
-		expect( screen.queryByText( 'Select all' ) ).not.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'checkbox', { name: /Credit/ } )
 		).toBeChecked();
 		expect(
 			screen.getByRole( 'checkbox', { name: 'giropay' } )
 		).toBeChecked();
-
-		userEvent.click( screen.getByRole( 'checkbox', { name: 'giropay' } ) );
-
-		expect( screen.queryByText( 'Select all' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should move forward when the payment methods are selected', async () => {

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
@@ -63,6 +63,32 @@ describe( 'AddPaymentMethodsTask', () => {
 		expect( screen.getByText( 'Add payment methods' ) ).not.toBeEnabled();
 	} );
 
+	it( 'should allow to select all payment methods', () => {
+		render(
+			<SettingsContextProvider>
+				<WizardTaskContext.Provider value={ { isActive: true } }>
+					<AddPaymentMethodsTask />
+				</WizardTaskContext.Provider>
+			</SettingsContextProvider>
+		);
+
+		expect(
+			screen.queryByRole( 'checkbox', { name: /Credit/ } )
+		).toBeChecked();
+		expect(
+			screen.getByRole( 'checkbox', { name: 'giropay' } )
+		).not.toBeChecked();
+
+		userEvent.click( screen.getByText( 'Select all' ) );
+
+		expect(
+			screen.queryByRole( 'checkbox', { name: /Credit/ } )
+		).toBeChecked();
+		expect(
+			screen.getByRole( 'checkbox', { name: 'giropay' } )
+		).toBeChecked();
+	} );
+
 	it( 'should move forward when the payment methods are selected', async () => {
 		const setCompletedMock = jest.fn();
 		const updateEnabledPaymentMethodsMock = jest.fn();

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
@@ -156,11 +156,6 @@ const AddPaymentMethodsTask = () => {
 		} );
 	};
 
-	const areAllPaymentMethodsSelected =
-		Object.entries( paymentMethodsState )
-			.map( ( [ method, enabled ] ) => enabled && method )
-			.filter( Boolean ).length === availablePaymentMethods.length;
-
 	return (
 		<WizardTaskItem
 			className="add-payment-methods-task"
@@ -195,18 +190,16 @@ const AddPaymentMethodsTask = () => {
 										'woocommerce-gateway-stripe'
 									) }
 								</p>
-								{ ! areAllPaymentMethodsSelected && (
-									<Button
-										isLink
-										onClick={ handleSelectAllClick }
-										className="add-payment-methods-task__select-all-button"
-									>
-										{ __(
-											'Select all',
-											'woocommerce-gateway-stripe'
-										) }
-									</Button>
-								) }
+								<Button
+									isLink
+									onClick={ handleSelectAllClick }
+									className="add-payment-methods-task__select-all-button"
+								>
+									{ __(
+										'Select all',
+										'woocommerce-gateway-stripe'
+									) }
+								</Button>
 							</HeadingWrapper>
 
 							<PaymentMethodCheckboxes>

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
@@ -156,6 +156,11 @@ const AddPaymentMethodsTask = () => {
 		} );
 	};
 
+	const areAllPaymentMethodsSelected =
+		Object.entries( paymentMethodsState )
+			.map( ( [ method, enabled ] ) => enabled && method )
+			.filter( Boolean ).length === availablePaymentMethods.length;
+
 	return (
 		<WizardTaskItem
 			className="add-payment-methods-task"
@@ -190,16 +195,18 @@ const AddPaymentMethodsTask = () => {
 										'woocommerce-gateway-stripe'
 									) }
 								</p>
-								<Button
-									isLink
-									onClick={ handleSelectAllClick }
-									className="add-payment-methods-task__select-all-button"
-								>
-									{ __(
-										'Select all',
-										'woocommerce-gateway-stripe'
-									) }
-								</Button>
+								{ ! areAllPaymentMethodsSelected && (
+									<Button
+										isLink
+										onClick={ handleSelectAllClick }
+										className="add-payment-methods-task__select-all-button"
+									>
+										{ __(
+											'Select all',
+											'woocommerce-gateway-stripe'
+										) }
+									</Button>
+								) }
 							</HeadingWrapper>
 
 							<PaymentMethodCheckboxes>

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
@@ -6,6 +6,7 @@ import React, {
 	useEffect,
 	useMemo,
 } from 'react';
+import styled from '@emotion/styled';
 import { Button, Card, CardBody, ExternalLink } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 import WizardTaskContext from '../wizard/task/context';
@@ -19,6 +20,16 @@ import {
 import PaymentMethodCheckboxes from '../../components/payment-methods-checkboxes';
 import PaymentMethodCheckbox from '../../components/payment-methods-checkboxes/payment-method-checkbox';
 import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
+
+const HeadingWrapper = styled.div`
+	display: flex;
+	margin-bottom: 1em;
+	gap: 8px;
+
+	> * {
+		margin: 0;
+	}
+`;
 
 const usePaymentMethodsCheckboxState = () => {
 	const [ initialEnabledPaymentMethodIds ] = useEnabledPaymentMethodIds();
@@ -139,6 +150,12 @@ const AddPaymentMethodsTask = () => {
 		handlePaymentMethodChange,
 	] = usePaymentMethodsCheckboxState();
 
+	const handleSelectAllClick = () => {
+		availablePaymentMethods.forEach( ( method ) => {
+			handlePaymentMethodChange( method, true );
+		} );
+	};
+
 	return (
 		<WizardTaskItem
 			className="add-payment-methods-task"
@@ -164,15 +181,27 @@ const AddPaymentMethodsTask = () => {
 				</p>
 				<Card className="add-payment-methods-task__payment-selector-wrapper">
 					<CardBody>
-						{ /* eslint-disable-next-line max-len */ }
-						<p className="add-payment-methods-task__payment-selector-title wcstripe-wizard-task__description-element is-headline">
-							{ __(
-								'Payments accepted at checkout',
-								'woocommerce-gateway-stripe'
-							) }
-						</p>
-
 						<LoadableSettingsSection numLines={ 20 }>
+							<HeadingWrapper>
+								{ /* eslint-disable-next-line max-len */ }
+								<p className="add-payment-methods-task__payment-selector-title wcstripe-wizard-task__description-element is-headline">
+									{ __(
+										'Payments accepted at checkout',
+										'woocommerce-gateway-stripe'
+									) }
+								</p>
+								<Button
+									isLink
+									onClick={ handleSelectAllClick }
+									className="add-payment-methods-task__select-all-button"
+								>
+									{ __(
+										'Select all',
+										'woocommerce-gateway-stripe'
+									) }
+								</Button>
+							</HeadingWrapper>
+
 							<PaymentMethodCheckboxes>
 								{ availablePaymentMethods.map(
 									( paymentMethodId ) => (


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1765

Adds the "select all" button on the onboarding wizard to select all the payment methods.

![2021-09-30 13 44 57](https://user-images.githubusercontent.com/273592/135512978-189530b2-3ab5-4f3a-bee5-8aa6fbf3bca8.gif)


# Testing instructions
- Ensure you have the `_wcstripe_feature_upe_settings` flag enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc_stripe-onboarding_wizard
- On the second step, click "Select all"
- All the payment methods should be selected