### PR TITLE
fix: Stripe controller naming conflict

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 5.x.x - 2021-xx-xx =
+* Fix - Naming conflict with other plugins on WC_Stripe_REST_Controller.
 
 = 5.6.0 - 2021-09-30 =
 * Add - Pre-release preview of new checkout experience using Stripe Universal Payment Element.

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 5.6.0
  */
-class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Controller {
+class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Controller {
 	const STRIPE_GATEWAY_SETTINGS_OPTION_NAME = 'woocommerce_stripe_settings';
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST controller for settings.
  */
-class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Controller {
+class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller {
 
 	/**
 	 * Endpoint path.

--- a/includes/admin/class-wc-stripe-rest-base-controller.php
+++ b/includes/admin/class-wc-stripe-rest-base-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class WC_Stripe_REST_Controller
+ * Class WC_Stripe_REST_Base_Controller
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST controller for transactions.
  */
-class WC_Stripe_REST_Controller extends WP_REST_Controller {
+class WC_Stripe_REST_Base_Controller extends WP_REST_Controller {
 
 	/**
 	 * Endpoint namespace.

--- a/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
@@ -8,7 +8,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST controller for UPE feature flag.
  */
-class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Controller {
+class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Base_Controller {
 	/**
 	 * Endpoint path.
 	 *

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -38,7 +38,7 @@ function _manually_load_plugin() {
 	$_plugin_dir = __DIR__ . '/../../';
 	require $_plugin_dir . 'woocommerce-gateway-stripe.php';
 
-	require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-controller.php';
+	require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-base-controller.php';
 	require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';
 }
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -586,7 +586,7 @@ function woocommerce_gateway_stripe() {
 				$oauth_connect->register_routes();
 
 				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-controller.php';
+					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-base-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

It looks like the `WC_Stripe_Rest_Controller` is already taken in the global namespace by the `woo-stripe-payment/includes/abstract/abstract-wc-stripe-rest-controller.php` file in this plugin: https://wordpress.org/plugins/woo-stripe-payment/

See: https://plugins.trac.wordpress.org/browser/woo-stripe-payment/trunk/includes/abstract/abstract-wc-stripe-rest-controller.php

Renaming ours, since we're late to the party.

I ensured that there's no `WC_Stripe_REST_Base_Controller` conflict.

# Testing instructions
Installing https://wordpress.org/plugins/woo-stripe-payment/ alongside with Stripe no longer causes a fatal error.
