### PR TITLE
Fix failed payments with empty source token

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,7 @@
 
 = 5.x.x - 2021-xx-xx =
 * Tweak - Remove animated credit card icons from payment method option on the checkout page.
-
-* Fix - Failed payments for pre-orders and subscriptions with an empty source token.
+* Fix - Payments for pre-orders and subscriptions with an empty source token now work as intended.
 
 = 5.6.1 - 2021-10-04 =
 * Fix - Naming conflict with other plugins on WC_Stripe_REST_Controller.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@
 = 5.x.x - 2021-xx-xx =
 * Tweak - Remove animated credit card icons from payment method option on the checkout page.
 
+* Fix - Failed payments for pre-orders and subscriptions with an empty source token.
+
 = 5.6.1 - 2021-10-04 =
 * Fix - Naming conflict with other plugins on WC_Stripe_REST_Controller.
 * Fix - Fatal error on `WC_REST_Stripe_Settings_Controller` when Elementor and WooFunnels plugins are used.

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -151,6 +151,26 @@ export const useEnabledPaymentMethodIds = () => {
 	return [ methods, handler ];
 };
 
+export const useTestMode = () => {
+	const { updateSettingsValues } = useDispatch( STORE_NAME );
+
+	const methods = useSelect( ( select ) => {
+		const { getSettings } = select( STORE_NAME );
+
+		return getSettings().is_test_mode_enabled || false;
+	} );
+
+	const handler = useCallback(
+		( value ) =>
+			updateSettingsValues( {
+				is_test_mode_enabled: value,
+			} ),
+		[ updateSettingsValues ]
+	);
+
+	return [ methods, handler ];
+};
+
 export const useGetAvailablePaymentMethodIds = () =>
 	useSelect( ( select ) => {
 		const { getSettings } = select( STORE_NAME );

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -3,55 +3,75 @@ import { createInterpolateElement } from '@wordpress/element';
 import React from 'react';
 import SectionStatus from '../../components/section-status';
 import './style.scss';
+import { useAccount, useGetCapabilities } from 'wcstripe/data/account';
 
-const PaymentsSection = ( props ) => {
+const useIsCardPaymentsEnabled = () =>
+	useGetCapabilities().card_payments === 'active';
+
+const useAreDepositsEnabled = () => {
+	const { data } = useAccount();
+
+	return (
+		data.account?.payouts_enabled &&
+		Boolean( data.account?.settings?.payouts?.schedule?.interval )
+	);
+};
+
+const PaymentsSection = () => {
+	const isEnabled = useIsCardPaymentsEnabled();
+
 	return (
 		<div className="account-details__row">
 			<p>{ __( 'Payments:', 'woocommerce-gateway-stripe' ) }</p>
-			<SectionStatus { ...props } />
+			<SectionStatus isEnabled={ isEnabled } />
 		</div>
 	);
 };
 
-const DepositsSection = ( props ) => {
+const DepositsSection = () => {
+	const isEnabled = useAreDepositsEnabled();
+
 	return (
 		<div className="account-details__row">
 			<p>{ __( 'Deposits:', 'woocommerce-gateway-stripe' ) }</p>
-			<SectionStatus { ...props } />
+			<SectionStatus isEnabled={ isEnabled } />
 		</div>
 	);
 };
 
-const MissingAccountDetailsDescription = ( { accountStatus } ) => {
-	const { accountLink, paymentsEnabled, depositsEnabled } = accountStatus;
+const MissingAccountDetailsDescription = () => {
+	const isPaymentsEnabled = useIsCardPaymentsEnabled();
+	const areDepositsEnabled = useAreDepositsEnabled();
 
-	let description = '';
-	if ( ! paymentsEnabled || ! depositsEnabled ) {
-		description = createInterpolateElement(
-			/* translators: <a> - dashboard login URL */
-			__(
-				'Payments/deposits may be disabled for this account until missing business information is updated. <a>Update now</a>',
-				'woocommerce-gateway-stripe'
-			),
-			// eslint-disable-next-line jsx-a11y/anchor-has-content
-			{ a: <a href={ accountLink } /> }
-		);
-	}
-
-	if ( ! description ) {
+	if ( isPaymentsEnabled && areDepositsEnabled ) {
 		return null;
 	}
 
-	return <div className="account-details__desc">{ description }</div>;
+	return (
+		<div className="account-details__desc">
+			{ createInterpolateElement(
+				/* translators: <a> - dashboard login URL */
+				__(
+					'Payments/deposits may be disabled for this account until missing business information is updated. <a>Update now</a>',
+					'woocommerce-gateway-stripe'
+				),
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				{ a: <a href="https://stripe.com/support" /> }
+			) }
+		</div>
+	);
 };
 
-const AccountDetails = ( { accountStatus } ) => {
-	if ( accountStatus.error ) {
+const AccountDetails = () => {
+	const { data } = useAccount();
+
+	const hasAccountError = Object.keys( data.account ?? {} ).length === 0;
+	if ( hasAccountError ) {
 		return (
 			<div>
 				<p className="account-details__error">
 					{ __(
-						'Error determining the connection status.',
+						'Error determining the account connection status.',
 						'woocommerce-gateway-stripe'
 					) }
 				</p>
@@ -62,10 +82,10 @@ const AccountDetails = ( { accountStatus } ) => {
 	return (
 		<div>
 			<div className="account-details__flex-container">
-				<PaymentsSection isEnabled={ accountStatus.paymentsEnabled } />
-				<DepositsSection isEnabled={ accountStatus.depositsEnabled } />
+				<PaymentsSection />
+				<DepositsSection />
 			</div>
-			<MissingAccountDetailsDescription accountStatus={ accountStatus } />
+			<MissingAccountDetailsDescription />
 		</div>
 	);
 };

--- a/client/settings/account-details/test/account-details.test.js
+++ b/client/settings/account-details/test/account-details.test.js
@@ -1,32 +1,67 @@
 import { render, screen } from '@testing-library/react';
-import AccountStatus from '..';
+import AccountDetails from '..';
+import { useAccount, useGetCapabilities } from 'wcstripe/data/account';
 
-describe( 'AccountStatus', () => {
-	const renderAccountStatus = ( accountStatus ) => {
-		return render( <AccountStatus accountStatus={ accountStatus } /> );
-	};
+jest.mock( 'wcstripe/data/account', () => ( {
+	useAccount: jest.fn(),
+	useGetCapabilities: jest.fn(),
+} ) );
 
-	test( 'renders enabled payments and deposits on account', () => {
-		renderAccountStatus( {
-			paymentsEnabled: true,
-			depositsEnabled: true,
-			accountLink: 'https://stripe.com/support',
+describe( 'AccountDetails', () => {
+	it( 'renders enabled payments and deposits on account', () => {
+		useGetCapabilities.mockReturnValue( {
+			card_payments: 'active',
 		} );
-		const warningDescription = screen.queryByText(
-			/Payments and deposits may be disabled for this account until missing business information is updated/i
-		);
-		expect( warningDescription ).not.toBeInTheDocument();
+		useAccount.mockReturnValue( {
+			data: {
+				account: {
+					settings: {
+						payouts: {
+							schedule: { interval: 'daily', delay_days: 2 },
+						},
+					},
+					payouts_enabled: true,
+				},
+			},
+		} );
+		render( <AccountDetails /> );
+
+		expect( screen.queryByText( /error/i ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( /may be disabled/i )
+		).not.toBeInTheDocument();
 	} );
 
-	test( 'renders disabled deposits and payments on account', () => {
-		renderAccountStatus( {
-			paymentsEnabled: false,
-			depositsEnabled: false,
-			accountLink: 'https://stripe.com/support',
+	it( 'renders an error message when the account data is not available', () => {
+		useGetCapabilities.mockReturnValue( {} );
+		useAccount.mockReturnValue( {
+			data: {},
 		} );
-		const warningDescription = screen.getByText(
-			/Payments\/deposits may be disabled for this account until missing business information is updated/i
-		);
-		expect( warningDescription ).toBeInTheDocument();
+		render( <AccountDetails /> );
+
+		expect( screen.queryByText( /error/i ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( /may be disabled/i )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders disabled deposits and payments on account', () => {
+		useGetCapabilities.mockReturnValue( {
+			card_payments: 'disabled',
+		} );
+		useAccount.mockReturnValue( {
+			data: {
+				account: {
+					settings: {
+						payouts: {},
+					},
+					payouts_enabled: false,
+				},
+			},
+		} );
+		render( <AccountDetails /> );
+
+		expect( screen.queryByText( /error/i ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /may be disabled/i ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/loadable-account-section.js
+++ b/client/settings/loadable-account-section.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { LoadableBlock } from '../components/loadable';
+import { useAccount } from 'wcstripe/data/account/hooks';
+import { useAccountKeys } from 'wcstripe/data/account-keys/hooks';
+
+const LoadableAccountSection = ( { children, numLines } ) => {
+	const { isLoading: isAccountLoading } = useAccount();
+	const { isLoading: areAccountKeysLoading } = useAccountKeys();
+
+	return (
+		<LoadableBlock
+			isLoading={ areAccountKeysLoading || isAccountLoading }
+			numLines={ numLines }
+		>
+			{ children }
+		</LoadableBlock>
+	);
+};
+
+export default LoadableAccountSection;

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -1,4 +1,3 @@
-/* global wc_stripe_settings_params */
 import { __ } from '@wordpress/i18n';
 import { React } from 'react';
 import {
@@ -17,6 +16,10 @@ import AdvancedSettingsSection from '../advanced-settings-section';
 import CustomizationOptionsNotice from '../customization-options-notice';
 import GeneralSettingsSection from './general-settings-section';
 import './style.scss';
+import { useTestMode } from 'wcstripe/data';
+import LoadableAccountSection from 'wcstripe/settings/loadable-account-section';
+import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
+import { useAccount } from 'wcstripe/data/account';
 
 const GeneralSettingsDescription = () => (
 	<>
@@ -99,21 +102,26 @@ const AccountSettingsDropdownMenu = () => {
 };
 
 const AccountDetailsSection = () => {
-	const accountStatus = wc_stripe_settings_params.accountStatus;
+	const [ isTestModeEnabled ] = useTestMode();
+	const { data } = useAccount();
 
 	return (
 		<Card className="account-details">
 			<CardHeader className="account-details__header">
-				{ accountStatus.email && (
+				{ data.account?.email && (
 					<h4 className="account-details__header">
-						{ accountStatus.email }
+						{ data.account.email }
 					</h4>
 				) }
-				{ accountStatus.mode === 'test' && <Pill>Test Mode</Pill> }
+				{ isTestModeEnabled && (
+					<Pill>
+						{ __( 'Test Mode', 'woocommerce-gateway-stripe' ) }
+					</Pill>
+				) }
 				<AccountSettingsDropdownMenu />
 			</CardHeader>
 			<CardBody>
-				<AccountStatus accountStatus={ accountStatus } />
+				<AccountStatus />
 			</CardBody>
 		</Card>
 	);
@@ -123,11 +131,17 @@ const PaymentSettingsPanel = () => {
 	return (
 		<>
 			<SettingsSection Description={ GeneralSettingsDescription }>
-				<GeneralSettingsSection />
+				<LoadableSettingsSection numLines={ 20 }>
+					<LoadableAccountSection numLines={ 20 }>
+						<GeneralSettingsSection />
+					</LoadableAccountSection>
+				</LoadableSettingsSection>
 				<CustomizationOptionsNotice />
 			</SettingsSection>
 			<SettingsSection Description={ AccountDetailsDescription }>
-				<AccountDetailsSection />
+				<LoadableAccountSection numLines={ 20 }>
+					<AccountDetailsSection />
+				</LoadableAccountSection>
 			</SettingsSection>
 			<SettingsSection Description={ PaymentsAndTransactionsDescription }>
 				<PaymentsAndTransactionsSection />

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -526,11 +526,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$post_data['customer'] = $prepared_payment_method->customer;
 		}
 
-		if ( ! is_null( $prepared_payment_method->source ) ) {
+		if ( ! empty( $prepared_payment_method->source ) ) {
 			$post_data['source'] = $prepared_payment_method->source;
 		}
 
-		if ( ! is_null( $prepared_payment_method->payment_method ) ) {
+		if ( ! empty( $prepared_payment_method->payment_method ) ) {
 			$post_data['payment_method'] = $prepared_payment_method->payment_method;
 		}
 

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -125,6 +125,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'enabled_payment_method_ids'       => $this->gateway->get_upe_enabled_payment_method_ids(),
 				'available_payment_method_ids'     => $this->gateway->get_upe_available_payment_methods(),
 				'is_payment_request_enabled'       => 'yes' === $this->gateway->get_option( 'payment_request' ),
+				'is_test_mode_enabled'             => 'yes' === $this->gateway->get_option( 'testmode' ),
 				'payment_request_button_type'      => $this->gateway->get_option( 'payment_request_button_type' ),
 				'payment_request_button_theme'     => $this->gateway->get_option( 'payment_request_button_theme' ),
 				'payment_request_button_size'      => $this->gateway->get_option( 'payment_request_button_size' ),
@@ -141,6 +142,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	public function update_settings( WP_REST_Request $request ) {
 		$this->update_enabled_payment_methods( $request );
 		$this->update_is_payment_request_enabled( $request );
+		$this->update_is_test_mode_enabled( $request );
 		$this->update_payment_request_settings( $request );
 
 		return new WP_REST_Response( [], 200 );
@@ -157,6 +159,21 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		$is_payment_request_enabled = $request->get_param( 'is_payment_request_enabled' );
+
+		$this->gateway->update_option( 'testmode', $is_payment_request_enabled ? 'yes' : 'no' );
+	}
+
+	/**
+	 * Updates the "Test mode" enable/disable settings.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_is_test_mode_enabled( WP_REST_Request $request ) {
+		if ( null === $request->get_param( 'is_test_mode_enabled' ) ) {
+			return;
+		}
+
+		$is_payment_request_enabled = $request->get_param( 'is_test_mode_enabled' );
 
 		$this->gateway->update_option( 'payment_request', $is_payment_request_enabled ? 'yes' : 'no' );
 	}

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -102,7 +102,6 @@ class WC_Stripe_Settings_Controller {
 			),
 			'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			'stripe_oauth_url'        => $oauth_url,
-			'accountStatus'           => $this->account->get_account_status(),
 		];
 		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
 

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -103,77 +103,10 @@ class WC_Stripe_Account {
 	}
 
 	/**
-	 * Refetches account data and returns the fresh data.
-	 *
-	 * @return array Either the new account data or empty if unavailable.
-	 */
-	public function refresh_account_data() {
-		$this->clear_cache();
-		return $this->get_cached_account_data();
-	}
-
-	/**
 	 * Wipes the account data option.
 	 */
 	public function clear_cache() {
 		delete_transient( self::LIVE_ACCOUNT_OPTION );
 		delete_transient( self::TEST_ACCOUNT_OPTION );
-	}
-
-	/**
-	 * Indicates whether card payments are enabled for this (Stripe) account.
-	 *
-	 * @return bool True if account can accept card payments, false otherwise.
-	 */
-	private function are_payments_enabled( $account ) {
-		$capabilities = $account['capabilities'] ? $account['capabilities'] : [];
-
-		if ( empty( $capabilities ) ) {
-			return false;
-		}
-
-		return isset( $capabilities['card_payments'] ) && 'active' === $capabilities['card_payments'];
-	}
-
-	/**
-	 * Indicates if payouts are enabled for the (Stripe) account and if there is deposits schedule set.
-	 *
-	 * @return bool Returns 'false' if payouts aren't enabled for the (Stripe) account or of there is no
-	 * deposits schedule set.
-	 */
-	private function are_deposits_enabled( $account ) {
-		$are_payouts_enabled = $account['payouts_enabled'] || false;
-		$payout_settings     = isset( $account['settings']['payouts'] ) ? $account['settings']['payouts'] : [];
-
-		if ( ! $are_payouts_enabled || ! isset( $payout_settings['schedule']['interval'] ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Gets the acoount's status from the acount data that is connected to this site.
-	 *
-	 * @return array Account status data or empty if failed to retrieve account data.
-	 */
-	public function get_account_status() {
-		$account          = json_decode( json_encode( $this->get_cached_account_data() ), true );
-		$settings_options = get_option( 'woocommerce_stripe_settings', [] );
-		$mode             = isset( $settings_options['testmode'] ) && 'yes' === $settings_options['testmode'] ? 'test' : 'live';
-
-		if ( empty( $account ) ) {
-			return [
-				'error' => true,
-			];
-		}
-
-		return [
-			'email'           => isset( $account['email'] ) ? $account['email'] : '',
-			'paymentsEnabled' => $this->are_payments_enabled( $account ),
-			'depositsEnabled' => $this->are_deposits_enabled( $account ),
-			'accountLink'     => 'https://stripe.com/support',
-			'mode'            => $mode,
-		];
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -129,4 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 5.x.x - 2021-xx-xx =
 * Tweak - Remove animated credit card icons from payment method option on the checkout page.
 
+* Fix - Failed payments for pre-orders and subscriptions with an empty source token.
+
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 5.x.x - 2021-xx-xx =
 * Tweak - Remove animated credit card icons from payment method option on the checkout page.
-
-* Fix - Failed payments for pre-orders and subscriptions with an empty source token.
+* Fix - Payments for pre-orders and subscriptions with an empty source token now work as intended.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -22,17 +22,12 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		$this->mock_account = $this->getMockBuilder( 'WC_Stripe_Account' )
+		$mock_account = $this->getMockBuilder( 'WC_Stripe_Account' )
 									->disableOriginalConstructor()
-									->setMethods(
-										[
-											'get_account_status',
-										]
-									)
 									->getMock();
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-settings-controller.php';
-		$this->controller = new WC_Stripe_Settings_Controller( $this->mock_account );
+		$this->controller = new WC_Stripe_Settings_Controller( $mock_account );
 		$this->gateway    = new WC_Gateway_Stripe();
 
 	}

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -91,41 +91,4 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$this->assertFalse( get_transient( 'wcstripe_account_data_test' ) );
 		$this->assertFalse( get_transient( 'wcstripe_account_data_live' ) );
 	}
-
-	public function test_get_account_status() {
-		$this->mock_connect->method( 'is_connected' )->willReturn( true );
-		$account = [
-			'id'              => '1234',
-			'email'           => 'test@example.com',
-			'capabilities'    => [],
-			'payouts_enabled' => false,
-			'settings'        => [
-				'payouts' => [],
-			],
-		];
-		set_transient( 'wcstripe_account_data_test', $account );
-
-		$expected_response = [
-			'email'           => 'test@example.com',
-			'paymentsEnabled' => false,
-			'depositsEnabled' => false,
-			'accountLink'     => 'https://stripe.com/support',
-			'mode'            => 'test',
-		];
-
-		$account_status = $this->account->get_account_status();
-
-		$this->assertSame( $account_status, $expected_response );
-	}
-
-	public function test_get_account_status_with_error_when_account_is_empty() {
-		$this->mock_connect->method( 'is_connected' )->willReturn( false );
-
-		$expected_response = [
-			'error' => true,
-		];
-
-		$account_status = $this->account->get_account_status();
-		$this->assertSame( $account_status, $expected_response );
-	}
 }


### PR DESCRIPTION
Fixes #2029
Also fixes: https://wordpress.org/support/topic/v5-6-0-issue-with-woocommerce-pre-orders

# Changes proposed in this Pull Request:

There was a regression on how the `payment_method` attribute is passed to the request when the order source token is empty. Check [`generate_payment_request` (5.6.0)](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/bef22349b4e9141b539dc8ec4486eb3f580d7699/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L535) vs [`generate_payment_request` (5.5.0)](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/d5448fa217aed0bcb8b77705c50ab31a25e3ede1/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L454) for more details.

This causes an empty `payment_method` to be passed to Stripe, resulting in a failed payment.

AFAICT the `_stripe_source_id` postmeta can be empty if the website has gone through an account migration, so that will result in the issue above.

# Testing instructions

- Ensure WooCommerce Subscriptions is installed.
- [Purchase a subscription product.](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows#purchase-subscription-product)
- Get the ID of the recently purchased subscription and delete the `_stripe_source_id` from the database:
```sql
UPDATE wp_postmeta SET meta_value='' WHERE meta_key='_stripe_source_id' AND post_id=<SUBSCRIPTION_ID>
```
- As a merchant, go to **WooCommerce > Subscriptions** and open the recently purchased subscription.
- Under "Subscription actions", process a renewal.
- Ensure the subscription is renewed and there are no errors on Stripe > [Logs](https://dashboard.stripe.com/test/logs).
