### PR TITLE
chore: remove grouped dependencies

### DIFF
--- a/client/settings/payments-and-transactions-section/statement-preview/index.js
+++ b/client/settings/payments-and-transactions-section/statement-preview/index.js
@@ -1,13 +1,7 @@
-/**
- * External dependencies
- */
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { Icon } from '@wordpress/components';
 import CurrencyFactory from '@woocommerce/currency';
-/**
- * Internal dependencies
- */
 import './style.scss';
 import { CreditCardIcon } from './icons/creditCard';
 import { BankIcon } from './icons/bank.js';

--- a/client/settings/payments-and-transactions-section/statement-previews-wrapper.js
+++ b/client/settings/payments-and-transactions-section/statement-previews-wrapper.js
@@ -1,6 +1,3 @@
-/**
- * External dependencies
- */
 import React from 'react';
 import styled from '@emotion/styled';
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:
We no longer need to import dependencies with the `External dependencies`/`Internal dependencies` headings, we just rely on `import/order`.
