### PR TITLE
fix: clear account cache on keys update

### DIFF
--- a/client/data/account-keys/__tests__/actions.test.js
+++ b/client/data/account-keys/__tests__/actions.test.js
@@ -19,7 +19,7 @@ describe( 'Account keys actions tests', () => {
 					return noticesDispatch;
 				}
 
-				return {};
+				return { invalidateResolutionForStoreSelector: () => null };
 			} );
 			select.mockImplementation( () => ( {
 				getAccountKeys: jest.fn(),

--- a/client/data/account-keys/actions.js
+++ b/client/data/account-keys/actions.js
@@ -39,6 +39,12 @@ export function* saveAccountKeys() {
 			data: accountKeys,
 		} );
 
+		// When new keys have been set, the user might have entered keys for a new account.
+		// So we need to clear the cached account information.
+		yield dispatch( STORE_NAME ).invalidateResolutionForStoreSelector(
+			'getAccountData'
+		);
+
 		yield dispatch( 'core/notices' ).createSuccessNotice(
 			__( 'Account keys saved.', 'woocommerce-gateway-stripe' )
 		);

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -23,6 +23,22 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 	protected $rest_base = 'wc_stripe/account_keys';
 
 	/**
+	 * The instance of the Stripe account.
+	 *
+	 * @var WC_Stripe_Account
+	 */
+	private $account;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Stripe_Account $account The instance of the Stripe account.
+	 */
+	public function __construct( WC_Stripe_Account $account ) {
+		$this->account = $account;
+	}
+
+	/**
 	 * Configure REST API routes.
 	 */
 	public function register_routes() {
@@ -183,6 +199,7 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		$settings['test_webhook_secret']  = is_null( $test_webhook_secret ) ? $settings['test_webhook_secret'] : $test_webhook_secret;
 
 		update_option( self::STRIPE_GATEWAY_SETTINGS_OPTION_NAME, $settings );
+		$this->account->clear_cache();
 
 		return new WP_REST_Response( [], 200 );
 	}

--- a/tests/phpunit/test-wc-rest-stripe-account-keys-controller.php
+++ b/tests/phpunit/test-wc-rest-stripe-account-keys-controller.php
@@ -36,7 +36,11 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WP_UnitTestCase {
 		$settings['test_publishable_key'] = 'original-test-key-9999';
 		update_option( 'woocommerce_stripe_settings', $settings );
 
-		$this->controller = new WC_REST_Stripe_Account_Keys_Controller();
+		$mock_account = $this->getMockBuilder( WC_Stripe_Account::class )
+							 ->disableOriginalConstructor()
+							 ->getMock();
+
+		$this->controller = new WC_REST_Stripe_Account_Keys_Controller( $mock_account );
 	}
 
 	public function test_get_account_keys_returns_status_code_200() {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -604,7 +604,7 @@ function woocommerce_gateway_stripe() {
 					$settings_controller = new WC_REST_Stripe_Settings_Controller( $this->get_main_stripe_gateway() );
 					$settings_controller->register_routes();
 
-					$stripe_account_keys_controller = new WC_REST_Stripe_Account_Keys_Controller();
+					$stripe_account_keys_controller = new WC_REST_Stripe_Account_Keys_Controller( $this->account );
 					$stripe_account_keys_controller->register_routes();
 
 					$stripe_account_controller = new WC_REST_Stripe_Account_Controller( $this->account );


### PR DESCRIPTION
# Changes proposed in this Pull Request:

If some new account keys have been set, then it means that the cached account is not longer valid.
We need to update it.

Otherwise a user might enter new keys and get information for the previous account, until the cache expires.