### PR TITLE
fix: account details when toggling test mode

### DIFF
--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -108,16 +108,18 @@ const AccountDetailsSection = () => {
 	return (
 		<Card className="account-details">
 			<CardHeader className="account-details__header">
-				{ data.account?.email && (
-					<h4 className="account-details__header">
-						{ data.account.email }
-					</h4>
-				) }
-				{ isTestModeEnabled && (
-					<Pill>
-						{ __( 'Test Mode', 'woocommerce-gateway-stripe' ) }
-					</Pill>
-				) }
+				<div>
+					{ data.account?.email && (
+						<h4 className="account-details__header">
+							{ data.account.email }
+						</h4>
+					) }
+					{ isTestModeEnabled && (
+						<Pill>
+							{ __( 'Test Mode', 'woocommerce-gateway-stripe' ) }
+						</Pill>
+					) }
+				</div>
 				<AccountSettingsDropdownMenu />
 			</CardHeader>
 			<CardBody>

--- a/client/settings/payment-settings/style.scss
+++ b/client/settings/payment-settings/style.scss
@@ -2,6 +2,17 @@
 	&__header {
 		justify-content: space-between;
 
+		> :first-child {
+			display: flex;
+			align-items: center;
+
+			> * {
+				&:not( :last-child ) {
+					margin-right: 4px;
+				}
+			}
+		}
+
 		.components-dropdown-menu__toggle.has-icon {
 			padding: 0;
 			min-width: unset;


### PR DESCRIPTION
# Changes proposed in this Pull Request:

A few aesthetical issues on the account section can happen when toggling "test mode".

Before:
![2021-10-07 17 00 07](https://user-images.githubusercontent.com/273592/136468077-ff6a5c17-cc0d-4e87-9643-ef2790fce5ba.gif)
![2021-10-07 17 07 27](https://user-images.githubusercontent.com/273592/136468812-fd6ea595-a970-42f7-8464-a9b6956f5804.gif)


After:

![2021-10-07 16 58 13](https://user-images.githubusercontent.com/273592/136468060-9ff0223d-7786-4bb0-be3d-0a90f6ad19a0.gif)
![2021-10-07 16 57 53](https://user-images.githubusercontent.com/273592/136468069-235e841c-a653-4fe0-89d1-b30c559621fc.gif)

Resolving them could improve the feedback loop with UX.



# Testing instructions

- Ensure you have the `_wcstripe_feature_upe_settings` flag enabled
- Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings
- Toggle "test mode" and save the settings
- After saving, the section should be updated with/without the email address (the email address is not provided by the Stripe API when in test mode)
- Toggle again
- No more little issues!