### PR TITLE
Center <Pill> contents when wrapping occurs

### DIFF
--- a/client/components/pill/index.js
+++ b/client/components/pill/index.js
@@ -9,6 +9,7 @@ const Pill = styled.span`
 	font-weight: 400;
 	line-height: 1.4em;
 	padding: 2px 8px;
+	text-align: center;
 	width: fit-content;
 `;
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

When the browser window is too narrow so that text is wrapped, pill contents get aligned to the left. This PR changes that alignment to center.

## Before

![Markup on 2021-10-08 at 00:17:33](https://user-images.githubusercontent.com/1759681/136470535-75e9f58f-44e6-4430-ad59-b9f1887c08d0.png)

## After

![Markup on 2021-10-08 at 00:26:29](https://user-images.githubusercontent.com/1759681/136470594-af67f5d0-0f96-47be-be81-6a3a4fd0f389.png)

# Testing instructions

1. Enable UPE redesign: `_wcstripe_feature_upe_settings`
1. Try shrinking the browser window.
1. The pill content should look like in the "After" screenshot above.