### PR TITLE
Hide connect button if oauth link is falsy

### DIFF
--- a/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
+++ b/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
@@ -14,18 +14,6 @@ describe( 'ConnectStripeAccount', () => {
 				'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDeal, SEPA, Sofort, and more international payment methods.'
 			)
 		).toBeInTheDocument();
-		expect( screen.queryByText( 'Terms of service.' ) ).toBeInTheDocument();
-	} );
-
-	it( 'should render the buttons', () => {
-		render( <ConnectStripeAccount /> );
-
-		expect(
-			screen.queryByText( 'Create or connect an account' )
-		).toBeInTheDocument();
-		expect(
-			screen.queryByText( 'Enter account keys (advanced)' )
-		).toBeInTheDocument();
 	} );
 
 	it( 'should have a Stripe OAuth link for "Create or connect an account" button', () => {
@@ -33,19 +21,27 @@ describe( 'ConnectStripeAccount', () => {
 			<ConnectStripeAccount oauthUrl="https://connect.stripe.com/oauth/v2/authorize?response_type=code&client_id=ca_1234&scope=read_write&state=1234" />
 		);
 
+		expect( screen.queryByText( 'Terms of service.' ) ).toBeInTheDocument();
 		expect(
 			screen.getByText( 'Create or connect an account' )
 		).toHaveAttribute(
 			'href',
 			'https://connect.stripe.com/oauth/v2/authorize?response_type=code&client_id=ca_1234&scope=read_write&state=1234'
 		);
+		expect(
+			screen.queryByText( 'Enter account keys (advanced)' )
+		).toBeInTheDocument();
 	} );
 
-	it( 'should not be able to click button "Create or connect an account" if OAuth URL is blank', () => {
+	it( 'should only have the "Enter account keys" button if OAuth URL is blank', () => {
 		render( <ConnectStripeAccount oauthUrl="" /> );
 
 		expect(
-			screen.getByText( 'Create or connect an account' )
-		).toBeDisabled();
+			screen.queryByText( 'Terms of service.' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Create or connect an account' )
+		).not.toBeInTheDocument();
+		expect( screen.getByText( 'Enter account keys' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -50,75 +50,7 @@ const ButtonWrapper = styled.div`
 	}
 `;
 
-const ConnectStripeAccount = ( props ) => {
-	const renderWithConnectEnabled = (
-		<>
-			<InformationText>
-				{ __(
-					'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDeal, SEPA, Sofort, and more international payment methods.',
-					'woocommerce-gateway-stripe'
-				) }
-			</InformationText>
-			<TermsOfServiceText>
-				{ interpolateComponents( {
-					mixedString: __(
-						'By clicking "Create or connect an account", you agree to the {{tosLink}}Terms of service.{{/tosLink}}',
-						'woocommerce-gateway-stripe'
-					),
-					components: {
-						tosLink: (
-							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a
-								target="_blank"
-								rel="noreferrer"
-								href="https://wordpress.com/tos"
-							/>
-						),
-					},
-				} ) }
-			</TermsOfServiceText>
-			<ButtonWrapper>
-				<Button isPrimary href={ props.oauthUrl }>
-					{ __(
-						'Create or connect an account',
-						'woocommerce-gateway-stripe'
-					) }
-				</Button>
-				<Button
-					isSecondary
-					// eslint-disable-next-line no-alert, no-undef
-					onClick={ () => alert( 'Modal will be implemented later' ) }
-				>
-					{ __(
-						'Enter account keys (advanced)',
-						'woocommerce-gateway-stripe'
-					) }
-				</Button>
-			</ButtonWrapper>
-		</>
-	);
-
-	const renderWithManualKeysOnly = (
-		<>
-			<InformationText>
-				{ __(
-					'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDeal, SEPA, Sofort, and more international payment methods.',
-					'woocommerce-gateway-stripe'
-				) }
-			</InformationText>
-
-			<ButtonWrapper>
-				<Button
-					isPrimary
-					// eslint-disable-next-line no-alert, no-undef
-					onClick={ () => alert( 'Modal will be implemented later' ) }
-				>
-					{ __( 'Enter account keys', 'woocommerce-gateway-stripe' ) }
-				</Button>
-			</ButtonWrapper>
-		</>
-	);
-
+const ConnectStripeAccount = ( { oauthUrl } ) => {
 	return (
 		<CardWrapper>
 			<StripeBanner />
@@ -129,9 +61,60 @@ const ConnectStripeAccount = ( props ) => {
 						'woocommerce-gateway-stripe'
 					) }
 				</h2>
-				{ props.oauthUrl
-					? renderWithConnectEnabled
-					: renderWithManualKeysOnly }
+				<InformationText>
+					{ __(
+						'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDeal, SEPA, Sofort, and more international payment methods.',
+						'woocommerce-gateway-stripe'
+					) }
+				</InformationText>
+				{ oauthUrl && (
+					<TermsOfServiceText>
+						{ interpolateComponents( {
+							mixedString: __(
+								'By clicking "Create or connect an account", you agree to the {{tosLink}}Terms of service.{{/tosLink}}',
+								'woocommerce-gateway-stripe'
+							),
+							components: {
+								tosLink: (
+									// eslint-disable-next-line jsx-a11y/anchor-has-content
+									<a
+										target="_blank"
+										rel="noreferrer"
+										href="https://wordpress.com/tos"
+									/>
+								),
+							},
+						} ) }
+					</TermsOfServiceText>
+				) }
+				<ButtonWrapper>
+					{ oauthUrl && (
+						<Button isPrimary href={ oauthUrl }>
+							{ __(
+								'Create or connect an account',
+								'woocommerce-gateway-stripe'
+							) }
+						</Button>
+					) }
+					<Button
+						isPrimary={ ! oauthUrl }
+						isSecondary={ !! oauthUrl }
+						onClick={ () =>
+							// eslint-disable-next-line no-alert, no-undef
+							alert( 'Modal will be implemented later' )
+						}
+					>
+						{ oauthUrl
+							? __(
+									'Enter account keys (advanced)',
+									'woocommerce-gateway-stripe'
+							  )
+							: __(
+									'Enter account keys',
+									'woocommerce-gateway-stripe'
+							  ) }
+					</Button>
+				</ButtonWrapper>
 			</CardBody>
 		</CardWrapper>
 	);

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -50,16 +50,9 @@ const ButtonWrapper = styled.div`
 	}
 `;
 
-const ConnectStripeAccount = ( props ) => (
-	<CardWrapper>
-		<StripeBanner />
-		<CardBody>
-			<h2>
-				{ __(
-					'Get started with Stripe',
-					'woocommerce-gateway-stripe'
-				) }
-			</h2>
+const ConnectStripeAccount = ( props ) => {
+	const renderWithConnectEnabled = (
+		<>
 			<InformationText>
 				{ __(
 					'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDeal, SEPA, Sofort, and more international payment methods.',
@@ -85,11 +78,7 @@ const ConnectStripeAccount = ( props ) => (
 				} ) }
 			</TermsOfServiceText>
 			<ButtonWrapper>
-				<Button
-					isPrimary
-					href={ props.oauthUrl }
-					disabled={ ! props.oauthUrl }
-				>
+				<Button isPrimary href={ props.oauthUrl }>
 					{ __(
 						'Create or connect an account',
 						'woocommerce-gateway-stripe'
@@ -106,8 +95,46 @@ const ConnectStripeAccount = ( props ) => (
 					) }
 				</Button>
 			</ButtonWrapper>
-		</CardBody>
-	</CardWrapper>
-);
+		</>
+	);
+
+	const renderWithManualKeysOnly = (
+		<>
+			<InformationText>
+				{ __(
+					'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDeal, SEPA, Sofort, and more international payment methods.',
+					'woocommerce-gateway-stripe'
+				) }
+			</InformationText>
+
+			<ButtonWrapper>
+				<Button
+					isPrimary
+					// eslint-disable-next-line no-alert, no-undef
+					onClick={ () => alert( 'Modal will be implemented later' ) }
+				>
+					{ __( 'Enter account keys', 'woocommerce-gateway-stripe' ) }
+				</Button>
+			</ButtonWrapper>
+		</>
+	);
+
+	return (
+		<CardWrapper>
+			<StripeBanner />
+			<CardBody>
+				<h2>
+					{ __(
+						'Get started with Stripe',
+						'woocommerce-gateway-stripe'
+					) }
+				</h2>
+				{ props.oauthUrl
+					? renderWithConnectEnabled
+					: renderWithManualKeysOnly }
+			</CardBody>
+		</CardWrapper>
+	);
+};
 
 export default ConnectStripeAccount;


### PR DESCRIPTION
# Changes proposed in this Pull Request:
Hide "Terms of service" and the connect button if OAuth link fails to load. If OAuth link loads, it will display: 
![image](https://user-images.githubusercontent.com/572862/136598006-6824d364-ae6d-4390-8df8-1b999ecb3c44.png)

Otherwise:
![image](https://user-images.githubusercontent.com/572862/136598055-4d717d13-350f-4865-ba12-658875227c54.png)

Issue: Link to the GitHub issue this PR addresses (if appropriate).
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1863

# Testing instructions
1. Make sure you removed your `test_publishable_key` and `test_secret_key` keys. 
2. Enable `_wcstripe_feature_upe_settings`
3. Setup connect-server and points the plugin to use it. (please ping me if you need help with this)
4. Go to `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`, confirm both `Create or connect an account` and `Enter account keys (advanced)` show up.
5. Shut down/disconnect your connect-server.
6. Go to `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`, confirm only `Enter account keys` shows up.

