### PR TITLE
refactor: rename Tooltip to Popover

### DIFF
--- a/client/components/payment-method-capability-status-pill/index.js
+++ b/client/components/payment-method-capability-status-pill/index.js
@@ -2,7 +2,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import Pill from 'wcstripe/components/pill';
-import Tooltip from 'wcstripe/components/tooltip';
+import Popover from 'wcstripe/components/popover';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 import { useGetCapabilities } from 'wcstripe/data/account';
 
@@ -24,7 +24,7 @@ const PaymentMethodCapabilityStatusPill = ( { id, label } ) => {
 	const capabilityStatus = capabilities[ `${ id }_payments` ];
 	if ( capabilityStatus === 'pending' ) {
 		return (
-			<Tooltip
+			<Popover
 				content={ sprintf(
 					/* translators: %s: a payment method name. */
 					__(
@@ -36,7 +36,7 @@ const PaymentMethodCapabilityStatusPill = ( { id, label } ) => {
 				<StyledPill>
 					{ __( 'Pending activation', 'woocommerce-gateway-stripe' ) }
 				</StyledPill>
-			</Tooltip>
+			</Popover>
 		);
 	}
 

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -1,0 +1,6 @@
+## Popover
+
+This component exists because the `Popover` component within Gutenberg doesn't play nicely when rendered within `Modal`s.
+
+See https://github.com/Automattic/woocommerce-payments/pull/2484
+

--- a/client/components/popover/index.js
+++ b/client/components/popover/index.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { noop } from 'lodash';
-import TooltipBase from './tooltip-base';
+import PopoverBase from './popover-base';
 
-const Tooltip = ( { isVisible, onHide = noop, ...props } ) => {
+const Popover = ( { isVisible, onHide = noop, ...props } ) => {
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isClicked, setIsClicked ] = useState( false );
 
@@ -28,16 +28,16 @@ const Tooltip = ( { isVisible, onHide = noop, ...props } ) => {
 
 	return (
 		<button
-			className="wcstripe-tooltip__content-wrapper"
+			className="wcstripe-popover__content-wrapper"
 			// on touch devices there's no mouse enter/leave, so we need to use a separate event (click/focus)
-			// this creates 2 different (desirable) states on non-touch devices: if you hover and then click, the tooltip will persist
+			// this creates 2 different (desirable) states on non-touch devices: if you hover and then click, the popover will persist
 			onMouseEnter={ handleMouseEnter }
 			onMouseLeave={ handleMouseLeave }
 			onFocus={ handleMouseEnter }
 			onBlur={ handleMouseLeave }
 			onClick={ handleMouseClick }
 		>
-			<TooltipBase
+			<PopoverBase
 				{ ...props }
 				onHide={ handleHide }
 				isVisible={ isVisible || isHovered || isClicked }
@@ -46,4 +46,4 @@ const Tooltip = ( { isVisible, onHide = noop, ...props } ) => {
 	);
 };
 
-export default Tooltip;
+export default Popover;

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -1,17 +1,17 @@
 @import '../../styles/abstracts/styles.scss';
 
-.wcstripe-tooltip {
+.wcstripe-popover {
 	&__content-wrapper {
 		// ensures that the element needed for position calculations isn't included in the DOM layout
 		display: contents;
 	}
 
-	&__tooltip-wrapper {
+	&__popover-wrapper {
 		visibility: hidden;
 		position: fixed;
 		opacity: 0;
 		transition: opacity 150ms ease-in;
-		// gotta do it a bit higher than the modal used in Gutenberg, to ensure the tooltip appears on top 😅
+		// gotta do it a bit higher than the modal used in Gutenberg, to ensure the popover appears on top 😅
 		z-index: 100010;
 
 		&.is-hiding {
@@ -20,7 +20,7 @@
 		}
 	}
 
-	&__tooltip {
+	&__popover {
 		position: relative;
 
 		color: $white;
@@ -32,7 +32,7 @@
 			content: ' ';
 			position: absolute;
 
-			// assuming all the tooltips are displayed at the top of the wrapped element.
+			// assuming all the popovers are displayed at the top of the wrapped element.
 			// no need to complicate things since that's the only use case at the moment.
 			bottom: 0;
 			left: 50%;

--- a/client/components/popover/test/index.test.js
+++ b/client/components/popover/test/index.test.js
@@ -1,26 +1,26 @@
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import Tooltip from '..';
+import Popover from '..';
 
 jest.useFakeTimers();
 
-describe( 'Tooltip', () => {
+describe( 'Popover', () => {
 	it( 'does not render its content when hidden', () => {
 		const handleHideMock = jest.fn();
 		render(
-			<Tooltip
+			<Popover
 				isVisible={ false }
-				content="Tooltip content"
+				content="Popover content"
 				onHide={ handleHideMock }
 			>
 				<span>Trigger element</span>
-			</Tooltip>
+			</Popover>
 		);
 
 		jest.runAllTimers();
 
 		expect(
-			screen.queryByText( 'Tooltip content' )
+			screen.queryByText( 'Popover content' )
 		).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Trigger element' ) ).toBeInTheDocument();
 		expect( handleHideMock ).not.toHaveBeenCalled();
@@ -29,18 +29,18 @@ describe( 'Tooltip', () => {
 	it( 'renders its content when opened', () => {
 		const handleHideMock = jest.fn();
 		render(
-			<Tooltip
+			<Popover
 				isVisible
-				content="Tooltip content"
+				content="Popover content"
 				onHide={ handleHideMock }
 			>
 				<span>Trigger element</span>
-			</Tooltip>
+			</Popover>
 		);
 
 		jest.runAllTimers();
 
-		expect( screen.queryByText( 'Tooltip content' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Popover content' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Trigger element' ) ).toBeInTheDocument();
 		expect( handleHideMock ).not.toHaveBeenCalled();
 	} );
@@ -48,22 +48,22 @@ describe( 'Tooltip', () => {
 	it( 'renders its content when clicked', () => {
 		const handleHideMock = jest.fn();
 		render(
-			<Tooltip content="Tooltip content" onHide={ handleHideMock }>
+			<Popover content="Popover content" onHide={ handleHideMock }>
 				<span>Trigger element</span>
-			</Tooltip>
+			</Popover>
 		);
 
 		jest.runAllTimers();
 
 		expect(
-			screen.queryByText( 'Tooltip content' )
+			screen.queryByText( 'Popover content' )
 		).not.toBeInTheDocument();
 
 		userEvent.click( screen.getByText( 'Trigger element' ) );
 
 		jest.runAllTimers();
 
-		expect( screen.queryByText( 'Tooltip content' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Popover content' ) ).toBeInTheDocument();
 		expect( handleHideMock ).not.toHaveBeenCalled();
 
 		userEvent.click( screen.getByText( 'Trigger element' ) );
@@ -72,53 +72,53 @@ describe( 'Tooltip', () => {
 		expect( handleHideMock ).toHaveBeenCalled();
 	} );
 
-	it( 'asks other Tooltips to hide, when multiple are opened', () => {
+	it( 'asks other Popovers to hide, when multiple are opened', () => {
 		const handleHide1Mock = jest.fn();
 		const handleHide2Mock = jest.fn();
 		render(
 			<>
-				<Tooltip content="Tooltip 1 content" onHide={ handleHide1Mock }>
-					<span>Open tooltip 1</span>
-				</Tooltip>
-				<Tooltip content="Tooltip 2 content" onHide={ handleHide2Mock }>
-					<span>Open tooltip 2</span>
-				</Tooltip>
+				<Popover content="Popover 1 content" onHide={ handleHide1Mock }>
+					<span>Open popover 1</span>
+				</Popover>
+				<Popover content="Popover 2 content" onHide={ handleHide2Mock }>
+					<span>Open popover 2</span>
+				</Popover>
 			</>
 		);
 
 		jest.runAllTimers();
 
 		expect(
-			screen.queryByText( 'Tooltip 1 content' )
+			screen.queryByText( 'Popover 1 content' )
 		).not.toBeInTheDocument();
 		expect(
-			screen.queryByText( 'Tooltip 2 content' )
+			screen.queryByText( 'Popover 2 content' )
 		).not.toBeInTheDocument();
 		expect( handleHide1Mock ).not.toHaveBeenCalled();
 		expect( handleHide2Mock ).not.toHaveBeenCalled();
 
-		// opening the first tooltip, no need to call any hide handlers
-		act( () => userEvent.click( screen.getByText( 'Open tooltip 1' ) ) );
+		// opening the first popover, no need to call any hide handlers
+		act( () => userEvent.click( screen.getByText( 'Open popover 1' ) ) );
 
-		expect( screen.queryByText( 'Tooltip 1 content' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Popover 1 content' ) ).toBeInTheDocument();
 		expect(
-			screen.queryByText( 'Tooltip 2 content' )
+			screen.queryByText( 'Popover 2 content' )
 		).not.toBeInTheDocument();
 		expect( handleHide1Mock ).not.toHaveBeenCalled();
 		expect( handleHide2Mock ).not.toHaveBeenCalled();
 
 		jest.runAllTimers();
 
-		// opening the second tooltip, only the first tooltip should not be visible anymore
+		// opening the second popover, only the first popover should not be visible anymore
 		act( () => {
-			userEvent.click( screen.getByText( 'Open tooltip 2' ) );
+			userEvent.click( screen.getByText( 'Open popover 2' ) );
 			jest.runAllTimers();
 		} );
 
 		expect(
-			screen.queryByText( 'Tooltip 1 content' )
+			screen.queryByText( 'Popover 1 content' )
 		).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Tooltip 2 content' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Popover 2 content' ) ).toBeInTheDocument();
 		expect( handleHide1Mock ).toHaveBeenCalled();
 		expect( handleHide2Mock ).not.toHaveBeenCalled();
 	} );

--- a/client/components/popover/test/popover-base.test.js
+++ b/client/components/popover/test/popover-base.test.js
@@ -1,26 +1,26 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import TooltipBase from '../tooltip-base';
+import PopoverBase from '../popover-base';
 
 jest.useFakeTimers();
 
-describe( 'TooltipBase', () => {
+describe( 'PopoverBase', () => {
 	it( 'does not render its content when hidden', () => {
 		const handleHideMock = jest.fn();
 		render(
-			<TooltipBase
+			<PopoverBase
 				isVisible={ false }
-				content="Tooltip content"
+				content="Popover content"
 				onHide={ handleHideMock }
 			>
 				<span>Trigger element</span>
-			</TooltipBase>
+			</PopoverBase>
 		);
 
 		jest.runAllTimers();
 
 		expect(
-			screen.queryByText( 'Tooltip content' )
+			screen.queryByText( 'Popover content' )
 		).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Trigger element' ) ).toBeInTheDocument();
 		expect( handleHideMock ).not.toHaveBeenCalled();
@@ -29,18 +29,18 @@ describe( 'TooltipBase', () => {
 	it( 'renders its content when opened', () => {
 		const handleHideMock = jest.fn();
 		render(
-			<TooltipBase
+			<PopoverBase
 				isVisible
-				content="Tooltip content"
+				content="Popover content"
 				onHide={ handleHideMock }
 			>
 				<span>Trigger element</span>
-			</TooltipBase>
+			</PopoverBase>
 		);
 
 		jest.runAllTimers();
 
-		expect( screen.queryByText( 'Tooltip content' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Popover content' ) ).toBeInTheDocument();
 		expect( screen.queryByText( 'Trigger element' ) ).toBeInTheDocument();
 		expect( handleHideMock ).not.toHaveBeenCalled();
 	} );
@@ -48,16 +48,16 @@ describe( 'TooltipBase', () => {
 	it( 'does not call onHide when an internal element is clicked', () => {
 		const handleHideMock = jest.fn();
 		render(
-			<TooltipBase
+			<PopoverBase
 				isVisible
-				content="Tooltip content"
+				content="Popover content"
 				onHide={ handleHideMock }
 			>
 				<span>Trigger element</span>
-			</TooltipBase>
+			</PopoverBase>
 		);
 
-		userEvent.click( screen.getByText( 'Tooltip content' ) );
+		userEvent.click( screen.getByText( 'Popover content' ) );
 		jest.runAllTimers();
 
 		expect( screen.queryByText( 'Trigger element' ) ).toBeInTheDocument();
@@ -68,13 +68,13 @@ describe( 'TooltipBase', () => {
 		const handleHideMock = jest.fn();
 		render(
 			<>
-				<TooltipBase
+				<PopoverBase
 					isVisible
-					content="Tooltip content"
+					content="Popover content"
 					onHide={ handleHideMock }
 				>
 					<span>Trigger element</span>
-				</TooltipBase>
+				</PopoverBase>
 				<span>External element</span>
 			</>
 		);

--- a/client/components/tooltip/README.md
+++ b/client/components/tooltip/README.md
@@ -1,6 +1,0 @@
-## Tooltip
-
-This component exists because the `Tooltip` component within Gutenberg doesn't play nicely when rendered within `Modal`s.
-
-See https://github.com/Automattic/woocommerce-payments/pull/2484
-

--- a/client/settings/general-settings-section/payment-method-checkbox.js
+++ b/client/settings/general-settings-section/payment-method-checkbox.js
@@ -6,7 +6,7 @@ import { Icon, info } from '@wordpress/icons';
 import UpeToggleContext from '../upe-toggle/context';
 import RemoveMethodConfirmationModal from './remove-method-confirmation-modal';
 import { useEnabledPaymentMethodIds, useManualCapture } from 'wcstripe/data';
-import Tooltip from 'wcstripe/components/tooltip';
+import Popover from 'wcstripe/components/popover';
 
 const StyledCheckbox = styled( CheckboxControl )`
 	.components-base-control__field {
@@ -57,7 +57,7 @@ const PaymentMethodCheckbox = ( { id, label, isAllowingManualCapture } ) => {
 	return (
 		<>
 			{ isManualCaptureEnabled && ! isAllowingManualCapture ? (
-				<Tooltip
+				<Popover
 					content={ sprintf(
 						/* translators: %s: a payment method name. */
 						__(
@@ -67,7 +67,7 @@ const PaymentMethodCheckbox = ( { id, label, isAllowingManualCapture } ) => {
 						label
 					) }
 				>
-					{ /* a span element is added here to ensure the tooltip can get the correct content to position itself */ }
+					{ /* a span element is added here to ensure the popover can get the correct content to position itself */ }
 					<IconWrapper>
 						<AlertIcon icon={ info } />
 						<VisuallyHidden>
@@ -80,7 +80,7 @@ const PaymentMethodCheckbox = ( { id, label, isAllowingManualCapture } ) => {
 							) }
 						</VisuallyHidden>
 					</IconWrapper>
-				</Tooltip>
+				</Popover>
 			) : (
 				<StyledCheckbox
 					label={ <VisuallyHidden>{ label }</VisuallyHidden> }

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/payment-method-checkbox/index.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/payment-method-checkbox/index.js
@@ -5,7 +5,7 @@ import React from 'react';
 import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import PaymentMethodIcon from 'wcstripe/settings/payment-method-icon';
-import Tooltip from 'wcstripe/components/tooltip';
+import Popover from 'wcstripe/components/popover';
 import paymentMethodsMap from 'wcstripe/payment-methods-map';
 import PaymentMethodFeesPill from 'wcstripe/components/payment-method-fees-pill';
 import PaymentMethodCapabilityStatusPill from 'wcstripe/components/payment-method-capability-status-pill';
@@ -28,7 +28,7 @@ const PaymentMethodDescription = ( { id } ) => {
 	}
 
 	return (
-		<Tooltip content={ description }>
+		<Popover content={ description }>
 			<InfoWrapper>
 				<InfoIcon icon={ info } size={ 20 } />
 				<VisuallyHidden>
@@ -38,7 +38,7 @@ const PaymentMethodDescription = ( { id } ) => {
 					) }
 				</VisuallyHidden>
 			</InfoWrapper>
-		</Tooltip>
+		</Popover>
 	);
 };
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Renaming the `Tooltip` component to `Popover` - since it looks like and behaves like a `Popover`.

# Testing instructions
- Hello from the testing instructions
