### PR TITLE
Update the newly created PM with the customer name and email

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -729,7 +729,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 						$customer_data = WC_Stripe_Customer::map_customer_data( null, new WC_Customer( wp_get_current_user()->ID ) );
 						$this->stripe_request(
-						    'payment_methods/' . $setup_intent->payment_method,
+							'payment_methods/' . $setup_intent->payment_method,
 							[
 								'billing_details' => [
 									'name'    => $customer_data['name'],

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -725,7 +725,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					// billing info will be updated when the customer makes a purchase anyway.
 					try {
 						$setup_intent_id = isset( $_GET['setup_intent'] ) ? wc_clean( wp_unslash( $_GET['setup_intent'] ) ) : '';
-						$setup_intent = WC_Stripe_API::request( [], 'setup_intents/' . $setup_intent_id, 'GET' );
+						$setup_intent    = WC_Stripe_API::request( [], 'setup_intents/' . $setup_intent_id, 'GET' );
 
 						$customer_data = WC_Stripe_Customer::map_customer_data( null, new WC_Customer( wp_get_current_user()->ID ) );
 						WC_Stripe_API::request(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -716,7 +716,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		if ( $this->is_payment_methods_page() ) {
 			if ( $this->is_setup_intent_success_creation_redirection() ) {
 				if ( isset( $_GET['redirect_status'] ) && 'succeeded' === $_GET['redirect_status'] ) {
-					$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
+					$user_id  = wp_get_current_user()->ID;
+					$customer = new WC_Stripe_Customer( $user_id );
 					$customer->clear_cache();
 					wc_add_notice( __( 'Payment method successfully added.', 'woocommerce-gateway-stripe' ) );
 
@@ -725,10 +726,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					// billing info will be updated when the customer makes a purchase anyway.
 					try {
 						$setup_intent_id = isset( $_GET['setup_intent'] ) ? wc_clean( wp_unslash( $_GET['setup_intent'] ) ) : '';
-						$setup_intent    = WC_Stripe_API::request( [], 'setup_intents/' . $setup_intent_id, 'GET' );
+						$setup_intent    = $this->stripe_request( 'setup_intents/' . $setup_intent_id, [], null, 'GET' );
 
-						$customer_data = WC_Stripe_Customer::map_customer_data( null, new WC_Customer( wp_get_current_user()->ID ) );
-						$this->stripe_request(
+						$customer_data         = WC_Stripe_Customer::map_customer_data( null, new WC_Customer( $user_id ) );
+						$payment_method_object = $this->stripe_request(
 							'payment_methods/' . $setup_intent->payment_method,
 							[
 								'billing_details' => [
@@ -739,6 +740,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 								],
 							]
 						);
+
+						do_action( 'woocommerce_stripe_add_payment_method', $user_id, $payment_method_object );
 					} catch ( Exception $e ) {
 						WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 					}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -728,7 +728,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 						$setup_intent    = WC_Stripe_API::request( [], 'setup_intents/' . $setup_intent_id, 'GET' );
 
 						$customer_data = WC_Stripe_Customer::map_customer_data( null, new WC_Customer( wp_get_current_user()->ID ) );
-						WC_Stripe_API::request(
+						$this->stripe_request(
+						    'payment_methods/' . $setup_intent->payment_method,
 							[
 								'billing_details' => [
 									'name'    => $customer_data['name'],
@@ -736,8 +737,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 									'phone'   => $customer_data['phone'],
 									'address' => $customer_data['address'],
 								],
-							],
-							'payment_methods/' . $setup_intent->payment_method
+							]
 						);
 					} catch ( Exception $e ) {
 						WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #1802 

When adding a new payment method the freshly saved payment method in Stripe's dashboard does not contain the customer name nor the email (it gets however linked to the customer correctly), this PR adds a call to Stripe's `update payment method` API with the customer billing info stored in WC.

## Before
![68747470733a2f2f63646e2d7374642e64726f706c722e6e65742f66696c65732f6163635f313130343230362f767a7130764d](https://user-images.githubusercontent.com/407542/132569199-1ecac182-ee25-4082-b1ba-3a08fa4c38e0.png)

## After
<img width="1243" alt="Screen Shot 2021-10-15 at 12 14 03" src="https://user-images.githubusercontent.com/407542/137511533-87c69d23-9869-401d-afb0-a6242afff04b.png">

# Testing instructions

0. Make sure UPE is enabled (`Try the new payment experience (Early access)` is checked)
1. Go to My account -> Add payment method
2. Click on `Add payment method`
3. Fill the form with any test credit card
4. Go to the Stripe dashboard -> Customers (https://dashboard.stripe.com/test/customers)
5. Select the customer used to add the new payment method
6. Expand the newly created payment method, and check that `Name`, `Email` and `Billing address` are not empty