### PR TITLE
Fix validation error message in settings

### DIFF
--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -197,7 +197,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		try {
-			$this->gateway->validate_account_statement_descriptor_field( $value, $max_length );
+			$this->gateway->validate_account_statement_descriptor_field( $param, $value, $max_length );
 		} catch ( Exception $exception ) {
 			return new WP_Error(
 				'rest_invalid_pattern',

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -169,6 +169,13 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return true|WP_Error
 	 */
 	public function validate_short_statement_descriptor( $value, $request, $param ) {
+		$is_short_account_statement_enabled = $request->get_param( 'is_short_statement_descriptor_enabled' );
+
+		// bypassing validation to avoid errors in the client, it won't be updated under this condition
+		if ( ! $is_short_account_statement_enabled ) {
+			return true;
+		}
+
 		return $this->validate_statement_descriptor( $value, $request, $param, 10 );
 	}
 
@@ -399,7 +406,13 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @param WP_REST_Request $request Request object.
 	 */
 	private function update_short_account_statement_descriptor( WP_REST_Request $request ) {
+		$is_short_account_statement_enabled = $request->get_param( 'is_short_statement_descriptor_enabled' );
 		$short_account_statement_descriptor = $request->get_param( 'short_statement_descriptor' );
+
+		// since we're bypassing the validation on the same condition, we shouldn't update it
+		if ( ! $is_short_account_statement_enabled ) {
+			return;
+		}
 
 		if ( null === $short_account_statement_descriptor ) {
 			return;

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1277,8 +1277,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function validate_account_statement_descriptor_field( $param, $value, $max_length ) {
 		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
-		$field = __( 'Customer bank statement', 'woocommerce-gateway-stripe' );
 		$value = trim( stripslashes( $value ) );
+		$field = __( 'Customer bank statement', 'woocommerce-gateway-stripe' );
 
 		if ( 'short_statement_descriptor' === $param ) {
 			$field = __( 'Shortened customer bank statement', 'woocommerce-gateway-stripe' );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1268,15 +1268,21 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Validates statement descriptor value
 	 *
+	 * @param string $param Param name.
 	 * @param string $value Posted Value.
 	 * @param int    $max_length Maximum statement length.
 	 *
 	 * @return string                   Sanitized statement descriptor.
 	 * @throws InvalidArgumentException When statement descriptor is invalid.
 	 */
-	public function validate_account_statement_descriptor_field( $value, $max_length ) {
+	public function validate_account_statement_descriptor_field( $param, $value, $max_length ) {
 		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
+		$field = __( 'Customer bank statement', 'woocommerce-gateway-stripe' );
 		$value = trim( stripslashes( $value ) );
+
+		if ( 'short_statement_descriptor' === $param ) {
+			$field = __( 'Shortened customer bank statement', 'woocommerce-gateway-stripe' );
+		}
 
 		// Validation can be done with a single regex but splitting into multiple for better readability.
 		$valid_length   = '/^.{5,' . $max_length . '}$/';
@@ -1290,8 +1296,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		) {
 			throw new InvalidArgumentException(
 				sprintf(
-					/* translators: %u Number of the maximum characters allowed */
-					__( 'Customer bank statement is invalid. Statement should be between 5 and %u characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ),
+					/* translators: %1 field name, %2 Number of the maximum characters allowed */
+					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ),
+					$field,
 					$max_length
 				)
 			);

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1288,7 +1288,13 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			! preg_match( $has_one_letter, $value ) ||
 			! preg_match( $no_specials, $value )
 		) {
-			throw new InvalidArgumentException( __( 'Customer bank statement is invalid. Statement should be between 5 and 22 characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ) );
+			throw new InvalidArgumentException(
+				sprintf(
+					/* translators: %u Number of the maximum characters allowed */
+					__( 'Customer bank statement is invalid. Statement should be between 5 and %u characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ),
+					$max_length
+				)
+			);
 		}
 
 		return $value;

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -158,6 +158,9 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->get_gateway()->update_option( $option_name, 'foobar' );
 
 		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		if ( 'short_statement_descriptor' === $option_name ) {
+			$request->set_param( 'is_short_statement_descriptor_enabled', true );
+		}
 		$request->set_param( $option_name, 'quuxcorge' );
 		$response = rest_do_request( $request );
 
@@ -269,28 +272,28 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 
 	public function enum_field_provider() {
 		return [
-			'enabled_payment_method_ids' => [
+			'enabled_payment_method_ids'       => [
 				'enabled_payment_method_ids',
 				'upe_checkout_experience_accepted_payments',
 				[ 'card' ],
 				[ 'card', 'giropay' ],
 				[ 'foo' ],
 			],
-			'payment_request_button_theme' => [
+			'payment_request_button_theme'     => [
 				'payment_request_button_theme',
 				'payment_request_button_theme',
 				'dark',
 				'light',
 				'foo',
 			],
-			'payment_request_button_size' => [
+			'payment_request_button_size'      => [
 				'payment_request_button_size',
 				'payment_request_button_size',
 				'default',
 				'large',
 				'foo',
 			],
-			'payment_request_button_type' => [
+			'payment_request_button_type'      => [
 				'payment_request_button_type',
 				'payment_request_button_type',
 				'buy',
@@ -318,6 +321,9 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->get_gateway()->update_option( $option_name, 'foobar' );
 
 		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		if ( 'short_statement_descriptor' === $option_name ) {
+			$request->set_param( 'is_short_statement_descriptor_enabled', true );
+		}
 		$request->set_param( $option_name, $new_invalid_value );
 
 		$response = rest_do_request( $request );

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -207,6 +207,24 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_short_statement_descriptor_is_not_updated() {
+		// It returns option value under expected key with HTTP code 200.
+		$this->get_gateway()->update_option( 'short_statement_descriptor', 'foobar' );
+		$response = $this->rest_get_settings();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'foobar', $response->get_data()['short_statement_descriptor'] );
+
+		// test update does not fail since is_short_statement_descriptor_enabled is disabled
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param( 'is_short_statement_descriptor_enabled', false );
+		$request->set_param( 'short_statement_descriptor', '123' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'foobar', $this->get_gateway()->get_option( 'short_statement_descriptor' ) );
+	}
+
 	public function test_get_settings_returns_available_payment_method_ids() {
 		$response = $this->rest_get_settings();
 


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #2047 

This PR addresses a fix for the validation in the settings REST controller. The field `short_statement_descriptor` is supposed to rely on `is_short_statement_descriptor_enabled` and it was being validated and erroring. The changes here enforces that relation in the validation, and only applies proper validation when `is_short_statement_descriptor_enabled` is `true`, keeping it untouched when `is_short_statement_descriptor_enabled` is `false`.

This also includes a small fix for the validation error message.

# Testing instructions
1. Ensure you have `_wcstripe_feature_upe_settings` option set to `yes`.
2. Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings
3. Tick the `Add customer order number to the bank statement` box.
4. Clear the `Shortened customer bank statement` field and save.
5. You should see the notice and exact error below (attention to the "...5 and 10 characters long..." part):
![image](https://user-images.githubusercontent.com/10233985/137756342-a1dbfc3c-3663-48d8-a29d-c3290464148e.png)
6. Fill in `Shortened customer bank statement` with at least 5 characters and save.
7. You should receive a `Settings saved.` notice.
8. Clear the `Shortened customer bank statement` field.
9. Untick the `Add customer order number to the bank statement` box and save.
10. You should receive a `Settings saved.` notice.


-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
