### PR TITLE
Add support to debug running PHP tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - ./docker/wordpress:/var/www/html/
       - ./docker/logs/apache2/:/var/log/apache2
       - .:/var/www/html/wp-content/plugins/woocommerce-gateway-stripe
+      - ./tests/phpunit:/var/www/html/wp-content/plugins/woocommerce-gateway-stripe/tests/phpunit
       - ./docker/dev-php.ini:/usr/local/etc/php/conf.d/dev-php.ini
       - ./docker/bin:/var/scripts
   db:


### PR DESCRIPTION
# Changes proposed in this Pull Request:

This PR basically adds support to debug running PHP tests. It's specially useful when we have failing tests and are trying to find out why they're failing or get their context.

It adds the test folder as a volume in the wordpress docker service. That allows Xdebug to track and catch the enabled breakpoints.

# Testing instructions

1. Set up your debug environment with the path mappings (should be already set if you're using VSCode):
```
"/var/www/html/": "${workspaceFolder}/docker/wordpress",
"/var/www/html/wp-content/plugins/woocommerce-gateway-stripe/": "${workspaceFolder}"
```
2. `npm run up` (`npm run down` before if your containers are up).
3. Add a breakpoint to any test under `tests/phpunit`.
4. Start debugging.
5. Run `npm run test:php`.
6. Execution should pause in the breakpoint you set and you should be able to get the entire context of the execution.

![image](https://user-images.githubusercontent.com/10233985/137811291-9a3a7696-ee04-433e-be44-2517ec858503.png)

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
