### PR TITLE
Update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,13 @@
 Did I add a title? A descriptive, yet concise, title.
 -->
 
-# Changes proposed in this Pull Request:
-
 <!--
 Issue: Link to the GitHub issue this PR addresses (if appropriate).
 -->
 
 Fixes #
+
+## Changes proposed in this Pull Request:
 
 <!--
 Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
@@ -24,7 +24,7 @@ Questions for the PR author:
 Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
 -->
 
-# Testing instructions
+## Testing instructions
 
 <!--
 Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
@@ -41,7 +41,6 @@ Please follow the following guidelines when writing testing instructions:
 
 ---
 
--   [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
 -   [ ] Covered with tests (or have a good reason not to test in description ☝️)
 -   [ ] Added changelog entry (or does not apply)
 -   [ ] Tested on mobile (or does not apply)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,29 +1,51 @@
+<!--
+Did I add a title? A descriptive, yet concise, title.
+-->
+
 # Changes proposed in this Pull Request:
 
+<!--
 Issue: Link to the GitHub issue this PR addresses (if appropriate).
+-->
+
 Fixes #
 
+<!--
 Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
+-->
 
+<!--
+Questions for the PR author:
+- How can this code break?
+- What are we doing to make sure this code doesn't break?
+-->
+
+<!--
 Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-
+-->
 
 # Testing instructions
 
+<!--
 Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
+-->
 
-(remove me) Please follow the following guidelines when writing testing instructions:
+<!--
+Please follow the following guidelines when writing testing instructions:
 
-- Include screenshots if there is no similar flow in the [Critical flows](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows).
-- Assume instructions will be copied over to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions).
+- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
+- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
 - Assume instructions will be followed by external testers.
 - Assume tester does not have intimate knowledge of Stripe.
+-->
 
--------------------
-- [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
-- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
+---
 
-(remove me)
-- [ ] Did I add a title? A descriptive, yet concise, title.
-- [ ] How can this code break?
-- [ ] What are we doing to make sure this code doesn't break?
+-   [ ] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
+-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
+-   [ ] Added changelog entry (or does not apply)
+-   [ ] Tested on mobile (or does not apply)
+
+**Post merge**
+
+-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)


### PR DESCRIPTION
# Changes proposed in this Pull Request:

This PR is proposing some changes to the pull request template (inspired on WCPay PR template):

- Move the title hint to the beginning because that's usually the first thing we change.
- Wrap all text around comments tags so we don't need to remove it. IMO, is a good thing to keep it there so that we keep the recommendations in mind while we write the PR, as well as when editing it.
- Add a "Covered with tests?" box.
- Add a "Added changelog entry?" box.
- Add a "Tested on mobile?" box.
- Add a box to remind adding testing instructions to the Release Testing Instructions wiki page after merge
- Remove the "run grunt" box reminder (AFAIK we don't use it).

Discussion in p1634597804017400-slack-C01BZUL57SQ.