### PR TITLE
Update payment request when billing data changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 5.x.x - 2021-xx-xx =
 * Fix - Hong Kong addresses are now mapped more thoroughly to WooCommerce addresses when paying with Apple Pay.
 * Fix - Error when changing payment method for a subscription with new checkout experience.
+* Fix - Payment Requests are now updated correctly when updating items in the Cart Block.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/client/blocks/payment-request/hooks.js
+++ b/client/blocks/payment-request/hooks.js
@@ -88,7 +88,6 @@ export const usePaymentRequest = ( stripe, needsShipping, billing ) => {
  * the error state, syncs the payment request with the block, and calls the provided click handler.
  *
  * @param {string} paymentRequestType - The payment request type.
- * @param {boolean} isUpdatingPaymentRequest - True if the payment request is being updated.
  * @param {Function} setExpressPaymentError - Used to set the error state.
  * @param {Function} onClick - The onClick function that should be called on click.
  *
@@ -96,7 +95,6 @@ export const usePaymentRequest = ( stripe, needsShipping, billing ) => {
  */
 export const useOnClickHandler = (
 	paymentRequestType,
-	isUpdatingPaymentRequest,
 	setExpressPaymentError,
 	onClick
 ) => {
@@ -106,12 +104,6 @@ export const useOnClickHandler = (
 			if ( getBlocksConfiguration()?.login_confirmation ) {
 				evt.preventDefault();
 				displayLoginConfirmation( paymentRequestType );
-				return;
-			}
-
-			// If the payment request is being updated, prevent clicks.
-			if ( isUpdatingPaymentRequest ) {
-				evt.preventDefault();
 				return;
 			}
 
@@ -126,12 +118,7 @@ export const useOnClickHandler = (
 				pr.show();
 			}
 		},
-		[
-			paymentRequestType,
-			isUpdatingPaymentRequest,
-			setExpressPaymentError,
-			onClick,
-		]
+		[ paymentRequestType, setExpressPaymentError, onClick ]
 	);
 };
 

--- a/client/blocks/payment-request/hooks.js
+++ b/client/blocks/payment-request/hooks.js
@@ -8,6 +8,7 @@ import { displayLoginConfirmation } from './login-confirmation';
 import {
 	getBlocksConfiguration,
 	createPaymentRequestUsingCart,
+	updatePaymentRequestUsingCart,
 } from 'wcstripe/blocks/utils';
 import { getCartDetails } from 'wcstripe/api/blocks';
 
@@ -55,9 +56,20 @@ export const usePaymentRequest = ( stripe, needsShipping, billing ) => {
 			}
 		};
 		createPaymentRequest();
+	}, [ stripe, needsShipping ] );
+
+	useEffect( () => {
+		if ( ! paymentRequest ) {
+			return;
+		}
+
+		const updatePaymentRequest = async () => {
+			const cart = await getCartDetails();
+			updatePaymentRequestUsingCart( paymentRequest, cart );
+		};
+		updatePaymentRequest();
 	}, [
-		stripe,
-		needsShipping,
+		paymentRequest,
 		billing.cartTotal,
 		billing.cartTotalItems,
 		billing.currency.code,

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -47,11 +47,11 @@ const PaymentRequestExpressComponent = ( {
 	const { needsShipping } = shippingData;
 
 	/* Set up payment request and its event handlers. */
-	const [ paymentRequest, paymentRequestType ] = usePaymentRequest(
-		stripe,
-		needsShipping,
-		billing
-	);
+	const [
+		paymentRequest,
+		paymentRequestType,
+		isUpdatingPaymentRequest,
+	] = usePaymentRequest( stripe, needsShipping, billing );
 	useShippingAddressUpdateHandler( paymentRequest, paymentRequestType );
 	useShippingOptionChangeHandler( paymentRequest, paymentRequestType );
 	useProcessPaymentHandler(
@@ -62,6 +62,7 @@ const PaymentRequestExpressComponent = ( {
 	);
 	const onPaymentRequestButtonClick = useOnClickHandler(
 		paymentRequestType,
+		isUpdatingPaymentRequest,
 		setExpressPaymentError,
 		onClick
 	);
@@ -120,13 +121,31 @@ const PaymentRequestExpressComponent = ( {
 	}
 
 	return (
-		<PaymentRequestButtonElement
-			onClick={ onPaymentRequestButtonClick }
-			options={ {
-				style: paymentRequestButtonStyle,
-				paymentRequest,
-			} }
-		/>
+		// We wrap using a div because we can't pass a 'style' prop to PaymentRequestButtonElement.
+		// The pointerEvents hack here is an attempt to improve the UX while we're sending an API
+		// request for the cart. Instead of the button not being clickable and showing a mouse pointer
+		// that indicates that the button is clickable (the hand), instead we just show the regular
+		// mouse pointer.
+		// We'd prefer to just disable the ExpressPaymentButton through the Blocks API, but that's not
+		// possible at the moment.
+		// - @reykjalin
+		<div
+			style={
+				isUpdatingPaymentRequest
+					? {
+							pointerEvents: 'none',
+					  }
+					: {}
+			}
+		>
+			<PaymentRequestButtonElement
+				onClick={ onPaymentRequestButtonClick }
+				options={ {
+					style: paymentRequestButtonStyle,
+					paymentRequest,
+				} }
+			/>
+		</div>
 	);
 };
 

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -62,7 +62,6 @@ const PaymentRequestExpressComponent = ( {
 	);
 	const onPaymentRequestButtonClick = useOnClickHandler(
 		paymentRequestType,
-		isUpdatingPaymentRequest,
 		setExpressPaymentError,
 		onClick
 	);
@@ -94,21 +93,47 @@ const PaymentRequestExpressComponent = ( {
 
 	if ( isCustom ) {
 		return (
-			<CustomButton
-				onButtonClicked={ ( evt ) => {
-					onPaymentRequestButtonClick( evt, paymentRequest );
-				} }
-			/>
+			<div
+				className={
+					isUpdatingPaymentRequest
+						? 'wc-block-components-loading-mask'
+						: ''
+				}
+			>
+				<CustomButton
+					className={
+						isUpdatingPaymentRequest
+							? 'wc-block-components-loading-mask__children'
+							: ''
+					}
+					onButtonClicked={ ( evt ) => {
+						onPaymentRequestButtonClick( evt, paymentRequest );
+					} }
+				/>
+			</div>
 		);
 	}
 
 	if ( isBranded && shouldUseGooglePayBrand() ) {
 		return (
-			<GooglePayButton
-				onButtonClicked={ ( evt ) => {
-					onPaymentRequestButtonClick( evt, paymentRequest );
-				} }
-			/>
+			<div
+				className={
+					isUpdatingPaymentRequest
+						? 'wc-block-components-loading-mask'
+						: ''
+				}
+			>
+				<GooglePayButton
+					className={
+						isUpdatingPaymentRequest
+							? 'wc-block-components-loading-mask__children'
+							: ''
+					}
+					onButtonClicked={ ( evt ) => {
+						onPaymentRequestButtonClick( evt, paymentRequest );
+					} }
+				/>
+			</div>
 		);
 	}
 
@@ -121,24 +146,23 @@ const PaymentRequestExpressComponent = ( {
 	}
 
 	return (
-		// We wrap using a div because we can't pass a 'style' prop to PaymentRequestButtonElement.
-		// The pointerEvents hack here is an attempt to improve the UX while we're sending an API
-		// request for the cart. Instead of the button not being clickable and showing a mouse pointer
-		// that indicates that the button is clickable (the hand), instead we just show the regular
-		// mouse pointer.
-		// We'd prefer to just disable the ExpressPaymentButton through the Blocks API, but that's not
-		// possible at the moment.
+		// The classNames here manually trigger the loading state for the PRB. Hopefully we'll
+		// see an API introduced to WooCommerce Blocks that will let us control this without
+		// relying on a CSS class.
 		// - @reykjalin
 		<div
-			style={
+			className={
 				isUpdatingPaymentRequest
-					? {
-							pointerEvents: 'none',
-					  }
-					: {}
+					? 'wc-block-components-loading-mask'
+					: ''
 			}
 		>
 			<PaymentRequestButtonElement
+				className={
+					isUpdatingPaymentRequest
+						? 'wc-block-components-loading-mask__children'
+						: ''
+				}
 				onClick={ onPaymentRequestButtonClick }
 				options={ {
 					style: paymentRequestButtonStyle,

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -123,9 +123,7 @@ const PaymentRequestExpressComponent = ( {
 		<PaymentRequestButtonElement
 			onClick={ onPaymentRequestButtonClick }
 			options={ {
-				// @ts-ignore
 				style: paymentRequestButtonStyle,
-				// @ts-ignore
 				paymentRequest,
 			} }
 		/>

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -41,6 +41,22 @@ export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 };
 
 /**
+ * Updates the given PaymentRequest using the data in the cart object.
+ *
+ * @param {Object} paymentRequest  The payment request object.
+ * @param {Object} cart  The cart data response from the store's AJAX API.
+ */
+export const updatePaymentRequestUsingCart = ( paymentRequest, cart ) => {
+	const options = {
+		total: cart.order_data.total,
+		currency: cart.order_data.currency,
+		displayItems: cart.order_data.displayItems,
+	};
+
+	paymentRequest.update( options );
+};
+
+/**
  * Returns the public api key for the stripe payment method
  *
  * @throws Error

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 5.x.x - 2021-xx-xx =
 * Fix - Hong Kong addresses are now mapped more thoroughly to WooCommerce addresses when paying with Apple Pay.
 * Fix - Error when changing payment method for a subscription with new checkout experience.
+* Fix - Payment Requests are now updated correctly when updating items in the Cart Block.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #1830 


# Changes proposed in this Pull Request:

- Update the `PaymentRequest` object when billing data changes in the cart block instead of recreating it.

The `PaymentRequestButtonElement` doesn't support re-assigning the `paymentRequest` prop, and as such we have to update the payment request instead.

We achieve this by sending an API request for the cart information to make sure all normalizations are correctly applied, and use that data to update the `PaymentRequest` object.

# Testing instructions

## Make sure Cart Block updates are applied to the Payment Request

> **Note:** This test requires that you have the [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/) extension installed on your store.

1. Add a product to your cart.
2. Go to the page containing the Cart Block.
3. Click the Payment Request Button (Apple Pay/Google Pay/Chrome Payment Request).
4. Note the list of items and the total.
5. Click **Cancel** to cancel the payment.
6. Change the number of items in the cart.
7. Click the Payment Request Button again.
8. Make sure the list of items and the total have been updated.

## Make sure Payment Requests can be cancelled multiple times in the Cart Block

> **Note:** This test requires that you have the [WooCommerce Blocks](https://wordpress.org/plugins/woo-gutenberg-products-block/) extension installed on your store.

1. Add a product to your cart.
2. Go to the page containing the Cart Block.
3. Click the Payment Request Button (Apple Pay/Google Pay/Chrome Payment Request).
4. Click **Cancel** to cancel the payment.
5. Click the Payment Request Button again.
6. Click **Cancel** to cancel the payment.
7. Change the number of items in the cart.
8. Click the Payment Request Button again.
9. Click **Cancel** to cancel the payment.
10. Click the Payment Request Button again.
11. Click **Cancel** to cancel the payment.
12. Make sure you can interact with the Payment Request Button (i.e. button is clickable, and not greyed out).
13. Change the number of items in the cart.
14. Again, make sure the Payment Request Button is still active (i.e. button is clickable, and not greyed out).

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

