### PR TITLE
Update test workflow to run for each WP/WC/PHP version supported

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -4,43 +4,6 @@ on:
   pull_request
 
 jobs:
-  woocommerce-compatibility:
-    name:    Release
-    runs-on: ubuntu-18.04
-    strategy:
-      fail-fast:    false
-      max-parallel: 10
-      matrix:
-        woocommerce: [ '4.0.0', '4.3.0', '4.4.0', '4.5.0', '4.6.0', '4.7.0', '4.8.0', '4.9.0' ]
-        wordpress:   [ 'latest' ]
-        php:         [ '7.4' ]
-        include:
-          # Edge case: oldest dependencies compatibility
-          - woocommerce: '3.3.0'
-            wordpress:   '4.7'
-            php:         '5.6'
-    env:
-      WP_VERSION: ${{ matrix.wordpress }}
-      WC_VERSION: ${{ matrix.woocommerce }}
-    steps:
-      # clone the repository
-      - uses: actions/checkout@v2
-      # enable dependencies caching
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      # setup PHP, but without debug extensions for reasonable performance
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools:       composer
-          coverage:    none
-      # run CI checks
-      - run: if [[ "${{ matrix.php }}" == '5.6' ]]; then wget https://phar.phpunit.de/phpunit-5.7.27.phar && mv phpunit-5.7.27.phar phpunit.phar; fi;
-      - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
-      - run: bash bin/run-ci-tests.bash
-
   # a dedicated job, as allowed to fail
   compatibility-woocommerce-beta:
     name:    Beta

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   WP_VERSION: latest
-  WC_VERSION: 4.5.0  # the most used version here
+  WC_VERSION: latest
 
 jobs:
   php_lint:

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -11,12 +11,9 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-#        woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
-#        wordpress:   [ 'latest', '5.7', '5.6' ]
-#        php:         [ '8.0', '7.4', '7.0' ]
-        woocommerce: [ '5.6.1' ]
-        wordpress:   [ '5.6' ]
-        php:         [ '7.0' ]
+        woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
+        wordpress:   [ 'latest', '5.7', '5.6' ]
+        php:         [ '8.0', '7.4', '7.0' ]
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -17,7 +17,6 @@ jobs:
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}
-      WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -11,12 +11,16 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
-        wordpress:   [ 'latest', '5.7', '5.6' ]
-        php:         [ '8.0', '7.4', '7.0' ]
+#        woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
+#        wordpress:   [ 'latest', '5.7', '5.6' ]
+#        php:         [ '8.0', '7.4', '7.0' ]
+        woocommerce: [ '5.6.1' ]
+        wordpress:   [ '5.6' ]
+        php:         [ '7.0' ]
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}
+      WP_TESTS_PHPUNIT_POLYFILLS_PATH: vendor/yoast/phpunit-polyfills
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -32,5 +36,8 @@ jobs:
           tools:       composer, phpunit-polyfills
           coverage:    none
       # run CI checks
+      - run: pwd
+      - run: ls -la
+      - run: echo ${{ github.workspace }}
       - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
       - run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -13,11 +13,7 @@ jobs:
       matrix:
         woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
         wordpress:   [ 'latest', '5.7', '5.6' ]
-        php:         [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
-        exclude:
-          # Latest WooCommerce (5.8+) requires PHP 7.0+
-          - woocommerce: 'latest'
-            php: '5.6'
+        php:         [ '8.0', '7.4', '7.0' ]
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}
@@ -36,6 +32,6 @@ jobs:
           tools:       composer
           coverage:    none
       # run CI checks
-      - run: if [[ "${{ matrix.php }}" == '5.6' ]]; then wget https://phar.phpunit.de/phpunit-5.7.27.phar && mv phpunit-5.7.27.phar phpunit.phar; fi;
       - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
+      - run: if [[ "${{ matrix.wordpress }}" >= '5.7' ]]; then composer require --dev yoast/phpunit-polyfills; fi;
       - run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -5,7 +5,6 @@ on:
 
 jobs:
   test:
-    name:    PHP testing
     runs-on: ubuntu-18.04
     strategy:
       fail-fast:    false
@@ -14,6 +13,7 @@ jobs:
         woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
         wordpress:   [ 'latest', '5.7', '5.6' ]
         php:         [ '8.0', '7.4', '7.0' ]
+    name: Stable [PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}]
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -33,5 +33,5 @@ jobs:
           coverage:    none
       # run CI checks
       - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
-      - run: if [[ "${{ matrix.wordpress }}" >= '5.7' ]]; then composer require --dev yoast/phpunit-polyfills; fi;
+      - run: composer require --dev yoast/phpunit-polyfills
       - run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -29,9 +29,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools:       composer
+          tools:       composer, phpunit-polyfills
           coverage:    none
       # run CI checks
       - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
-      - run: composer require --dev yoast/phpunit-polyfills
       - run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -1,4 +1,4 @@
-name: PHP unit tests
+name: PHP tests
 
 on:
   pull_request
@@ -11,9 +11,13 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        woocommerce: [ 'latest', '5.7', '5.6' ]
+        woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
         wordpress:   [ 'latest', '5.7', '5.6' ]
         php:         [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
+        exclude:
+          # Latest WooCommerce (5.8+) requires PHP 7.0+
+          - woocommerce: 'latest'
+            php: '5.6'
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -36,5 +36,4 @@ jobs:
           coverage:    none
       # run CI checks
       - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
-      - run: composer require --dev yoast/phpunit-polyfills
       - run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       WP_VERSION: ${{ matrix.wordpress }}
       WC_VERSION: ${{ matrix.woocommerce }}
-      WP_TESTS_PHPUNIT_POLYFILLS_PATH: vendor/yoast/phpunit-polyfills
+      WP_TESTS_PHPUNIT_POLYFILLS_PATH: ${{ github.workspace }}/vendor/yoast/phpunit-polyfills
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -33,11 +33,8 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools:       composer, phpunit-polyfills
           coverage:    none
       # run CI checks
-      - run: pwd
-      - run: ls -la
-      - run: echo ${{ github.workspace }}
       - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
+      - run: composer require --dev yoast/phpunit-polyfills
       - run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -3,10 +3,6 @@ name: PHP unit tests
 on:
   pull_request
 
-env:
-  WP_VERSION: latest
-  WC_VERSION: 4.5.0  # the most used version here
-
 jobs:
   test:
     name:    PHP testing
@@ -15,7 +11,12 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        php: [ '7.1', '7.2', '7.3', '7.4' ]
+        woocommerce: [ 'latest', '5.7', '5.6' ]
+        wordpress:   [ 'latest', '5.7', '5.6' ]
+        php:         [ '8.0', '7.4', '7.3', '7.2', '7.1', '7.0', '5.6' ]
+    env:
+      WP_VERSION: ${{ matrix.wordpress }}
+      WC_VERSION: ${{ matrix.woocommerce }}
     steps:
       # clone the repository
       - uses: actions/checkout@v2
@@ -31,4 +32,6 @@ jobs:
           tools:       composer
           coverage:    none
       # run CI checks
+      - run: if [[ "${{ matrix.php }}" == '5.6' ]]; then wget https://phar.phpunit.de/phpunit-5.7.27.phar && mv phpunit-5.7.27.phar phpunit.phar; fi;
+      - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
       - run: bash bin/run-ci-tests.bash

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "woocommerce/woocommerce-gateway-stripe",
     "description": "Take credit card payments on your store using Stripe.",
     "homepage": "https://woocommerce.com/products/woocommerce-gateway-stripe/",
-		"license": "GPL-3.0-or-later",
+		"license": "GPL-2.0-or-later",
 		"config": {
       "platform": {
         "php": "7.1"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "woocommerce/woocommerce-gateway-stripe",
     "description": "Take credit card payments on your store using Stripe.",
     "homepage": "https://woocommerce.com/products/woocommerce-gateway-stripe/",
-		"license": "GPL-2.0",
+		"license": "GPL-3.0-or-later",
 		"config": {
       "platform": {
         "php": "7.1"
@@ -11,6 +11,7 @@
     "require-dev": {
 				"composer/installers": "1.9.0",
 				"phpunit/phpunit": "7.5.20",
+				"yoast/phpunit-polyfills": "1.0.2",
 				"woocommerce/woocommerce-sniffs": "0.1.0"
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae505169168a111870c8a470e9736e81",
+    "content-hash": "6516599c58af91340eeed87ecd65d1f3",
     "packages": [],
     "packages-dev": [
         {
@@ -923,16 +923,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
-                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/28af674ff175d0768a5a978e6de83f697d4a7f05",
+                "reference": "28af674ff175d0768a5a978e6de83f697d4a7f05",
                 "shasum": ""
             },
             "require": {
@@ -971,7 +971,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.3"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.4"
             },
             "funding": [
                 {
@@ -979,7 +979,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-11-30T08:25:21+00:00"
+            "time": "2021-07-19T06:46:01+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1087,16 +1087,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
-                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9c1da83261628cb24b6a6df371b6e312b3954768",
+                "reference": "9c1da83261628cb24b6a6df371b6e312b3954768",
                 "shasum": ""
             },
             "require": {
@@ -1134,7 +1134,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
-                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.2"
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/3.1.3"
             },
             "funding": [
                 {
@@ -1143,7 +1143,7 @@
                 }
             ],
             "abandoned": true,
-            "time": "2020-11-30T08:38:46+00:00"
+            "time": "2021-07-26T12:15:06+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1899,16 +1899,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
@@ -1951,20 +1951,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -1976,7 +1976,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2014,7 +2014,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2030,7 +2030,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2223,6 +2223,67 @@
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
             "time": "2020-05-13T23:57:56+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "require-dev": {
+                "yoast/yoastcs": "^2.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2021-10-03T08:40:26+00:00"
         }
     ],
     "aliases": [],
@@ -2235,5 +2296,5 @@
     "platform-overrides": {
         "php": "7.1"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Stripe
  */
 
-require_once '../../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+require_once __DIR__ . '/../../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
 
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -5,6 +5,8 @@
  * @package WooCommerce\Stripe
  */
 
+require_once '../../vendor/yoast/phpunit-polyfills/phpunitpolyfills-autoload.php';
+
 $_tests_dir = getenv( 'WP_TESTS_DIR' );
 
 if ( ! $_tests_dir ) {


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Currently tests are run using:
- PHP versions: `7.1`, `7.2`, `7.3` and `7.4`, with only the `latest` WP and WC `4.5.0`.
- PHP `7.4` using the `latest` WP, and WC versions `4.0.0`, `4.3.0`, `4.4.0`, `4.5.0`, `4.6.0`, `4.7.0`, `4.8.0`, `4.9.0`.
- PHP `5.6`, WP `4.7` and WC `3.3.0`.

This PR updates the workflows to run tests for all the supported version combinations:

For both WordPress and WooCommerce, we aim to support the current and latest 2 versions (L-2).
WooCommerce 5.6 (the current L-2) supports PHP 7.0+, so we test in each major supported version (and in 7.0 as we requiere a legacy PHPUnit runner for that version)

WP: 5.8, 5.7, 5.6
WC: 5.8, 5.7, 5.6
PHP: 8.0, 7.4, 7.0

__NOTE__: The new pipeline will run 27 combinations (up from 15)

# Testing instructions

Verify the PR checks:
- Linting / PHP linting
- Linting / JS & CSS linting
- JS tests / JS testing
- PHP tests / PHP testing (WC, WP, PHP)

The `4 expected checks` are there because of the repository config... they are required in order to merge, we will replace that `required` checks with the new ones once we are ready to merge.