### PR TITLE
Style confirmation modal to match designs

### DIFF
--- a/client/components/confirmation-modal/style.scss
+++ b/client/components/confirmation-modal/style.scss
@@ -13,11 +13,25 @@
 	// to ensure that the separator extends all the way, even with different versions of Gutenberg
 	.components-modal__content {
 		padding: 0 $grid-unit-30 $grid-unit-30;
+
+		@media ( max-width: 600px ) {
+			display: flex;
+			flex-direction: column;
+			
+			hr:last-of-type {
+				margin-top:  auto;
+			}
+		}
 	}
 
 	.components-modal__header {
 		margin: 0 -#{$grid-unit-30} $grid-unit-30;
 		padding: 0 $grid-unit-30;
+		@media ( max-width: 600px ) {
+			button {
+				display: none;
+			}
+		}
 	}
 
 	&__separator {

--- a/client/components/confirmation-modal/style.scss
+++ b/client/components/confirmation-modal/style.scss
@@ -4,7 +4,10 @@
 	// increasing the specificity of the styles, to ensure it is honored
 	&#{&} {
 		max-width: 600px;
-		min-width: 400px;
+		min-width: 100%;
+		@media ( min-width: 400px ) {
+			min-width: 400px;
+		}
 	}
 
 	// to ensure that the separator extends all the way, even with different versions of Gutenberg

--- a/client/components/confirmation-modal/style.scss
+++ b/client/components/confirmation-modal/style.scss
@@ -26,7 +26,7 @@
 	.components-modal__header {
 		margin: 0 -#{$grid-unit-30} $grid-unit-30;
 		padding: 0 $grid-unit-30;
-		@media ( max-width: 600px ) {
+		@media ( max-width: 599px ) {
 			button {
 				display: none;
 			}

--- a/client/components/confirmation-modal/style.scss
+++ b/client/components/confirmation-modal/style.scss
@@ -4,8 +4,7 @@
 	// increasing the specificity of the styles, to ensure it is honored
 	&#{&} {
 		max-width: 600px;
-		min-width: 100%;
-		@media ( min-width: 400px ) {
+		@media ( min-width: 600px ) {
 			min-width: 400px;
 		}
 	}
@@ -14,7 +13,7 @@
 	.components-modal__content {
 		padding: 0 $grid-unit-30 $grid-unit-30;
 
-		@media ( max-width: 600px ) {
+		@media ( max-width: 599px ) {
 			display: flex;
 			flex-direction: column;
 			

--- a/client/settings/general-settings-section/remove-method-confirmation-modal.js
+++ b/client/settings/general-settings-section/remove-method-confirmation-modal.js
@@ -7,6 +7,16 @@ import AlertTitle from 'wcstripe/components/confirmation-modal/alert-title';
 
 const RemoveMethodConfirmationModal = ( { method, onClose, onConfirm } ) => {
 	const { label } = PaymentMethodsMap[ method ];
+
+	const confirmMethodRemovalString = sprintf(
+		/* translators: %1: payment method name (e.g.: giropay, EPS, Sofort, etc). */
+		__(
+			'Are you sure you want to remove %1$s? Your customers will no longer be able to pay using %1$s.',
+			'woocommerce-gateway-stripe'
+		),
+		`<strong>${ label }</strong>`
+	);
+
 	return (
 		<ConfirmationModal
 			title={
@@ -33,16 +43,11 @@ const RemoveMethodConfirmationModal = ( { method, onClose, onConfirm } ) => {
 				</>
 			}
 		>
-			<p>
-				{ sprintf(
-					/* translators: %1: payment method name (e.g.: giropay, EPS, Sofort, etc). */
-					__(
-						'Are you sure you want to remove %1$s? Your customers will no longer be able to pay using %1$s.',
-						'woocommerce-gateway-stripe'
-					),
-					label
-				) }
-			</p>
+			<p
+				dangerouslySetInnerHTML={ {
+					__html: confirmMethodRemovalString,
+				} }
+			/>
 			<p>
 				{ __(
 					'You can add it again at any time in Stripe settings.',

--- a/client/settings/general-settings-section/remove-method-confirmation-modal.js
+++ b/client/settings/general-settings-section/remove-method-confirmation-modal.js
@@ -1,4 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
 import React from 'react';
 import { Button } from '@wordpress/components';
 import PaymentMethodsMap from '../../payment-methods-map';
@@ -14,7 +15,7 @@ const RemoveMethodConfirmationModal = ( { method, onClose, onConfirm } ) => {
 			'Are you sure you want to remove %1$s? Your customers will no longer be able to pay using %1$s.',
 			'woocommerce-gateway-stripe'
 		),
-		`<strong>${ label }</strong>`
+		`<PaymentMethodTitle>${ label }</PaymentMethodTitle>`
 	);
 
 	return (
@@ -43,11 +44,11 @@ const RemoveMethodConfirmationModal = ( { method, onClose, onConfirm } ) => {
 				</>
 			}
 		>
-			<p
-				dangerouslySetInnerHTML={ {
-					__html: confirmMethodRemovalString,
-				} }
-			/>
+			<p>
+				{ createInterpolateElement( confirmMethodRemovalString, {
+					PaymentMethodTitle: <strong />,
+				} ) }
+			</p>
 			<p>
 				{ __(
 					'You can add it again at any time in Stripe settings.',

--- a/client/settings/general-settings-section/remove-method-confirmation-modal.js
+++ b/client/settings/general-settings-section/remove-method-confirmation-modal.js
@@ -12,10 +12,10 @@ const RemoveMethodConfirmationModal = ( { method, onClose, onConfirm } ) => {
 	const confirmMethodRemovalString = sprintf(
 		/* translators: %1: payment method name (e.g.: giropay, EPS, Sofort, etc). */
 		__(
-			'Are you sure you want to remove %1$s? Your customers will no longer be able to pay using %1$s.',
+			'Are you sure you want to remove <strong>%1$s</strong>? Your customers will no longer be able to pay using <strong>%1$s</strong>.',
 			'woocommerce-gateway-stripe'
 		),
-		`<PaymentMethodTitle>${ label }</PaymentMethodTitle>`
+		label
 	);
 
 	return (
@@ -46,7 +46,7 @@ const RemoveMethodConfirmationModal = ( { method, onClose, onConfirm } ) => {
 		>
 			<p>
 				{ createInterpolateElement( confirmMethodRemovalString, {
-					PaymentMethodTitle: <strong />,
+					strong: <strong />,
 				} ) }
 			</p>
 			<p>

--- a/client/settings/general-settings-section/remove-method-confirmation-modal.js
+++ b/client/settings/general-settings-section/remove-method-confirmation-modal.js
@@ -24,11 +24,11 @@ const RemoveMethodConfirmationModal = ( { method, onClose, onConfirm } ) => {
 			onRequestClose={ onClose }
 			actions={
 				<>
+					<Button isPrimary isDestructive onClick={ onConfirm }>
+						{ __( 'Remove', 'woocommerce-gateway-stripe' ) }
+					</Button>
 					<Button isSecondary onClick={ onClose }>
 						{ __( 'Cancel', 'woocommerce-gateway-stripe' ) }
-					</Button>
-					<Button isPrimary onClick={ onConfirm }>
-						{ __( 'Remove', 'woocommerce-gateway-stripe' ) }
 					</Button>
 				</>
 			}


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #2089 

This PR fixes the styles of the confirmation modal to match the proposed designs.

# Testing instructions

When the user chooses to disable a payment method on http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe, the modal should match the following style:

![image](https://user-images.githubusercontent.com/4153905/138510499-c3a5d63b-5224-4fa9-947f-b7d3f4726da0.png)

