### PR TITLE
Ensure APMs are available for UPE in test mode

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -172,6 +172,15 @@ abstract class WC_Stripe_UPE_Payment_Method {
 	 * @return bool
 	 */
 	public function is_capability_active() {
+		// Treat all capabilities as active when in test mode.
+		$plugin_settings   = get_option( 'woocommerce_stripe_settings' );
+		$test_mode_setting = ! empty( $plugin_settings['testmode'] ) ? $plugin_settings['testmode'] : 'no';
+
+		if ( 'yes' === $test_mode_setting ) {
+			return true;
+		}
+
+		// Otherwise, make sure the capability is available.
 		$capabilities = $this->get_capabilities_response();
 		if ( empty( $capabilities ) ) {
 			return false;


### PR DESCRIPTION
# Changes proposed in this Pull Request:

- When in test mode, treat all capabilities as active for testing purposes.

# Testing instructions

This is a bit difficult to test since you need an account with at least 1 of the APM capabilities inactive. Assuming you have one of those, follow these testing instructions:

- Enable UPE and any (or all) APMs where you know the capability is inactive or not present.
- Switch to `develop`.
- Add any product to your cart.
- Go to the checkout page and choose to pay with a new payment method.
- Make sure the APMs that don't have the associated capabilities active don't show up.
- Switch to `fix/apms-not-available-in-test-mode-when-lacking-capabilities`.
- Make sure the APMs now show up.

## How do I check my account's capabilites?

Send an API request for your Stripe account information and check the value in the `capabilities` array:

```
$ curl https://api.stripe.com/v1/accounts/<stripe_account_id> -u <test_secret_key>

Enter host password for user '<test_secret_key>':
{
  "id": "<stripe_account_id>",
  "object": "account",
  "capabilities": {    # Check if this is empty or has "inactive" capabilities.
  },

  # Some more account info stuff...

}
```

## How do I make sure capabilities are inactive in my Stripe account?

I don't know. Mine just happens to have no capabilities 🤷‍♂️ 

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
