### PR TITLE
UPE: Handle requires_confirmation status for PIs with saved cards

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -647,7 +647,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$this->throw_localized_message( $intent, $order );
 			}
 
-			if ( 'requires_action' === $intent->status ) {
+			if ( 'requires_action' === $intent->status || 'requires_confirmation' === $intent->status ) {
 				if ( isset( $intent->next_action->type ) && 'redirect_to_url' === $intent->next_action->type && ! empty( $intent->next_action->redirect_to_url->url ) ) {
 					return [
 						'result'   => 'success',


### PR DESCRIPTION
# Changes proposed in this Pull Request:

Fixes #2094 

When a 3DS authorization fails with a saved card and you try to pay with the same card the payment intent transitions to a `requires_confirmation` status. To fix the issue we make sure the intent is confirmed when in that state instead of skipping over it like we did before this change.

- Confirm a payment intent when it transitions to the [`requires_confirmation`](https://stripe.com/docs/payments/intents#intent-statuses) status when the following conditions are true:
    - Using the UPE checkout.
    - Using a saved 3DS card.


# Testing instructions

> UPE must be enabled.

Please first make sure you can reproduce the issue in develop by following the reproduction steps in [the issue](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2094).

1. Save `4000000000003220` as a payment method to your account
1. Add any product to your cart and go to the checkout page
2. Checkout with the saved `4000000000003220` card
2. Fail the 3DS auth
3. Checkout again with the same card
4. Complete the 3DS auth successfully
6. Go to **WooCommerce > Orders**
7. Make sure the payment was successful (order status should be **Processing** or **Completed**).
8. Go to your Stripe dashboard
9. Note that the payment has a status of **Succeeded**

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
