### PR TITLE
Alipay: Support MYR currency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Error when changing payment method for a subscription with new checkout experience.
 * Fix - Payment Requests are now updated correctly when updating items in the Cart Block.
 * Add - Support for WooCommerce Pre-Orders with new checkout experience.
+* Fix - Add support for MYR (Malaysian ringgit) for Alipay.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -98,7 +98,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 	 * Returns all supported currencies for this payment method.
 	 *
 	 * @since 4.0.0
-	 * @version 4.0.0
+	 * @version x.x.x
 	 * @return array
 	 */
 	public function get_supported_currency() {
@@ -115,6 +115,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 				'NZD',
 				'SGD',
 				'USD',
+				'MYR',
 			]
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Error when changing payment method for a subscription with new checkout experience.
 * Fix - Payment Requests are now updated correctly when updating items in the Cart Block.
 * Add - Support for WooCommerce Pre-Orders with new checkout experience.
+* Fix - Add support for MYR (Malaysian ringgit) for Alipay.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2067

## Changes proposed in this Pull Request:

- Simply add `MYR` to Alipay's supported list of currencies.

## Testing instructions

1. Change your store currency to Malaysian ringgit (RM).
2. Navigate to **WooCommerce > Settings > Payments** and Enable Alipay.
3. Add a product to your cart and try to checkout with Alipay.

If your Stripe account country is set to Malaysia, you should be able to checkout:

<img width="943" alt="Screen Shot 2021-11-03 at 18 59 38" src="https://user-images.githubusercontent.com/5509901/140201946-964c2109-ae46-4c0b-a191-bb1d8c7de01d.png">

Tip: You can create a temporary Stripe account via the top-left dropdown menu > New account, and later delete it from the [account settings](https://dashboard.stripe.com/settings/account). It doesn't need to be activated to perform a test payment with its test keys.

<img width="271" alt="Screen Shot 2021-11-03 at 19 24 34" src="https://user-images.githubusercontent.com/5509901/140203748-0a2c8ac6-cd62-42c9-bfb0-f60ca41b3e83.png">