### PR TITLE
Add launch config for debugging a local WP site with Xdebug in VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Listen for Xdebug",
+            "name": "Listen for Xdebug (remote/docker)",
             "type": "php",
             "request": "launch",
             "port": 9000,
@@ -13,6 +13,12 @@
                 "/var/www/html/": "${workspaceFolder}/docker/wordpress",
                 "/var/www/html/wp-content/plugins/woocommerce-gateway-stripe/": "${workspaceFolder}"
             }
+        },
+        {
+            "name": "Listen for Xdebug (local)",
+            "type": "php",
+            "request": "launch",
+            "port": 9000,
         }
     ]
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Add a config to `.vscode/launch.json` that can be used with local setups of Xdebug

## Testing instructions

1. Set up a local WP install (e.g. following @ismaeldcom's guide in pcqRLn-nG-p2)
2. Set a breakpoint in some place you know it will be triggered (e.g. in `woocommerce-gateway-stripe.php`)
3. Load your local test site and make sure you can trigger the breakpoint

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

