### PR TITLE
Replace unsupported mysql image in Docker configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ./docker/bin:/var/scripts
   db:
     container_name: woocommerce_stripe_mysql
-    image: mysql:5.7
+    image: mariadb:10.5.8
     ports:
       - "5678:3306"
     env_file:


### PR DESCRIPTION
Fixes #2126

## Changes proposed in this Pull Request:

Replace mysql image in `docker-compose.yml` with an image that supports ARM64. Right now, building the Docker images locally fails on the ARM architecture because of the `mysql:5.7` database image which doesn't support ARM. This PR replaces `mysql:5.7` with `mariadb:10.5.8`, which does support ARM.

For context, see that a similar change was made in https://github.com/Automattic/woocommerce-payments/pull/2021.

## Testing instructions

1. Ensure Docker is running on an ARM machine (e.g. MacBook Pro with the M1 family of chips)
2. Run `npm run up` after cloning this repository.
3. Observe that building the images succeeds, whereas before it would fail.
---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
