### PR TITLE
Hide PRB when all variations are out-of-stock

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -774,12 +774,12 @@ jQuery( function( $ ) {
 		},
 
 		unhidePaymentRequestButton: function () {
-			const stripe_wrapper_ele = $( '#wc-stripe-payment-request-wrapper' );
-			const stripe_separator_ele = $( '#wc-stripe-payment-request-button-separator' );
+			const stripe_wrapper = $( '#wc-stripe-payment-request-wrapper' );
+			const stripe_separator = $( '#wc-stripe-payment-request-button-separator' );
 			// If either element is hidden, ensure both show.
-			if ( stripe_wrapper_ele.is(':hidden') || stripe_separator_ele.is(':hidden') ) {
-				stripe_wrapper_ele.show();
-				stripe_separator_ele.show();
+			if ( stripe_wrapper.is(':hidden') || stripe_separator.is(':hidden') ) {
+				stripe_wrapper.show();
+				stripe_separator.show();
 			}
 		},
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -631,6 +631,10 @@ jQuery( function( $ ) {
 				wc_stripe_payment_request.unblockPaymentRequestButton();
 			} );
 
+			$( document.body ).on( 'wc_stripe_hide_payment_request_button', function () {
+				wc_stripe_payment_request.hidePaymentRequestButton();
+			} );
+
 			$( document.body ).on( 'wc_stripe_block_payment_request_button', function () {
 				wc_stripe_payment_request.blockPaymentRequestButton( 'wc_request_button_is_blocked' );
 			} );
@@ -649,7 +653,11 @@ jQuery( function( $ ) {
 							displayItems: response.displayItems,
 						} )
 					).then( function () {
-						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+						if (response.is_in_stock) {
+							$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+						} else {
+							$( document.body ).trigger( 'wc_stripe_hide_payment_request_button' );
+						}
 					} );
 				});
 			} );
@@ -675,7 +683,11 @@ jQuery( function( $ ) {
 								displayItems: response.displayItems,
 							} )
 						).then( function () {
-							$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+							if (response.is_in_stock) {
+								$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+							} else {
+								$( document.body ).trigger( 'wc_stripe_hide_payment_request_button' );
+							}
 						});
 					}
 				} );
@@ -718,6 +730,20 @@ jQuery( function( $ ) {
 			}
 		},
 
+		hidePaymentRequestButton: function () {
+			$( '#wc-stripe-payment-request-wrapper, #wc-stripe-payment-request-button-separator' ).hide();
+		},
+
+		unhidePaymentRequestButton: function () {
+			const stripe_wrapper_ele = $( '#wc-stripe-payment-request-wrapper' );
+			const stripe_separator_ele = $( '#wc-stripe-payment-request-button-separator' );
+			// If either element is hidden, ensure both show.
+			if ( stripe_wrapper_ele.is(':hidden') || stripe_separator_ele.is(':hidden') ) {
+				stripe_wrapper_ele.show();
+				stripe_separator_ele.show();
+			}
+		},
+
 		blockPaymentRequestButton: function( cssClassname ) {
 			// check if element isn't already blocked before calling block() to avoid blinking overlay issues
 			// blockUI.isBlocked is either undefined or 0 when element is not blocked
@@ -731,6 +757,9 @@ jQuery( function( $ ) {
 		},
 
 		unblockPaymentRequestButton: function() {
+			// Assure PRB is showing.
+			wc_stripe_payment_request.unhidePaymentRequestButton();
+
 			$( '#wc-stripe-payment-request-button' )
 				.removeClass( ['wc_request_button_is_blocked', 'wc_request_button_is_disabled'] )
 				.unblock();

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
 * Add - Add Stripe API to generate connection tokens, manage terminal locations.
+* Fix - Hide payment request button when variations of a variable product are out-of-stock.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1354,6 +1354,7 @@ class WC_Stripe_Payment_Request {
 			$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 			$data['currency']        = strtolower( get_woocommerce_currency() );
 			$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+			$data['is_in_stock']     = $product->is_in_stock();
 
 			wp_send_json( $data );
 		} catch ( Exception $e ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -907,27 +907,9 @@ class WC_Stripe_Payment_Request {
 		}
 
 		if ( $this->is_product() && in_array( $this->get_product()->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
-			$valid_stock_statuses = array_filter(
-				array_keys( wc_get_product_stock_status_options() ),
-				function ( $stock_status ) {
-					return 'outofstock' !== $stock_status;
-				}
-			);
-			$product_args         = [
-				'status'       => 'publish',
-				'parent'       => $this->get_product()->get_id(),
-				'type'         => 'variation',
-				'stock_status' => $valid_stock_statuses,
-				// All we need is for 1 variation to exist to determine
-				// whether product is "instock" or "onbackorder".
-				'limit'        => 1,
-			];
-
-			// Retrieve variable product's variations that are not 'outofstock' (e.g. 'instock', 'onbackorder').
-			$variations = wc_get_products( $product_args );
-
-			// Don't show if product doesn't have any variations in stock.
-			if ( count( $variations ) === 0 ) {
+			$stock_availability = array_column( $this->get_product()->get_available_variations(), 'is_in_stock' );
+			// Don't show if all product variations are out-of-stock.
+			if ( ! in_array( true, $stock_availability, true ) ) {
 				return false;
 			}
 		}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -906,7 +906,7 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
-		if ( $this->is_product() && $this->get_product()->get_type() === 'variable' ) {
+		if ( $this->is_product() && in_array( $this->get_product()->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
 			$valid_stock_statuses = array_filter(
 				array_keys( wc_get_product_stock_status_options() ),
 				function ( $stock_status ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -906,6 +906,32 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
+		if ( $this->is_product() && $this->get_product()->get_type() === 'variable' ) {
+			$valid_stock_statuses = array_filter(
+				array_keys( wc_get_product_stock_status_options() ),
+				function ( $stock_status ) {
+					return 'outofstock' !== $stock_status;
+				}
+			);
+			$product_args         = [
+				'status'       => 'publish',
+				'parent'       => $this->get_product()->get_id(),
+				'type'         => 'variation',
+				'stock_status' => $valid_stock_statuses,
+				// All we need is for 1 variation to exist to determine
+				// whether product is "instock" or "onbackorder".
+				'limit'        => 1,
+			];
+
+			// Retrieve variable product's variations that are not 'outofstock' (e.g. 'instock', 'onbackorder').
+			$variations = wc_get_products( $product_args );
+
+			// Don't show if product doesn't have any variations in stock.
+			if ( count( $variations ) === 0 ) {
+				return false;
+			}
+		}
+
 		return true;
 	}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1336,7 +1336,6 @@ class WC_Stripe_Payment_Request {
 			$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 			$data['currency']        = strtolower( get_woocommerce_currency() );
 			$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
-			$data['is_in_stock']     = $product->is_in_stock();
 
 			wp_send_json( $data );
 		} catch ( Exception $e ) {

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Stripe JS is no longer loaded on cart and product pages when PRBs are disabled on those pages.
 * Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
+* Fix - Hide payment request button when variations of a variable product are out-of-stock.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes #1580 

* Don't display the payment request button (PRB) when all variations of the product are out-of-stock.
* Don't display the PRB when an out-of-stock variation is selected.

This PR ensures that the PRB is not displayed when all of a product's variations are out of stock. Additionally, when a product has at least one variation that is not out-of-stock, this PR also ensures that the PRB is not displayed when the user selects a variation that is out-of-stock. 

This fixes an issue where users were seeing an "Out of stock" warning and the PRB, at the same time. Which may have caused some confusion. Now, only the warning is displayed. Also, this fix makes it so that the PRB's behavior in variable product pages matches that of the simple product pages.

At the moment, this entire part of the code is not being tested. Additionally, this change was a small enough not to warrant e2e tests.

<!--
Description: Write a summary of this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Don't display the PRB when all variations of a `variable product` are out-of-stock**
To test this new behavior, we need to create a variable product with at least two variants:

* Create a new product: `Products > Add New`
* Select "Variable product" as `Product data`
* Click `Attributes`, then click `Add` while "Custom product attribute" is selected
* Create "Size" attribute with "Small | Medium" as values
* Ensure `Used for variations` is checked
* Click `Variations` then while "Create variations from all attributes" is selected click `Go`
* Add a `Regular price ($)` for each variation
* Select "Out of stock" on the `Stock status` field, for each variation
* `Save changes` and go to the product's page

Note that the PRB is not visible. Also, note that switching between `Size` variations keeps the PRB hidden.

**Don't display the PRB when an out-of-stock variation is selected, for a `variable product`**
To test this new behavior, go back and edit the variable product created above and do the following:

* Click `Variations`
* Update the `Stock status` of the "small" variation to "In stock"
* `Save changes` and go to the product's page

Note that the PRB is visible, upon loading the product page. Also, note that selecting the "Small" `Size` variation makes the PRB show. But switching to the "Medium" variation makes the PRB hide. 

---

Note: for the following tests, the `WooCommerce Subscriptions` plugin will need to be active.

**Don't display the PRB when all variations of a `variable subscription` are out-of-stock**
To test this new behavior, we need to create a variable subscription with at least two variants:

* Create a new product: `Products > Add New`
* Select "Variable subscription" as `Product data`
* Click `Attributes`, then click `Add` while "Custom product attribute" is selected
* Create "Billing Period" attribute with "1 Month | 2 Months" as values
* Ensure `Used for variations` is checked
* Click `Variations` then while "Create variations from all attributes" is selected click `Go`
* Add a `Subscription price ($)` for each variation
* Select "Out of stock" on the `Stock status` field, for each variation
* `Save changes` and go to the product's page

Note that the PRB is not visible. Also, note that switching between "Billing Period" variations keeps the PRB hidden.

**Don't display the PRB when an out-of-stock variation is selected, for a `variable subscription`**
To test this new behavior, go back and edit the variable subscription created above and do the following:

* Click `Variations`
* Set the `Stock status` of the "1 Month" variation to "In stock"
* `Save changes` and go to the product's page

Note that the PRB is visible, upon loading the product page. Also, note that selecting the "1 Month" `Billing Period` variation makes the PRB show. But switching to the "2 Months" variation makes the PRB hide. 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)