### PR TITLE
Add connection token API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Error when changing payment method for a subscription with new checkout experience.
 * Fix - Payment Requests are now updated correctly when updating items in the Cart Block.
 * Add - Support for WooCommerce Pre-Orders with new checkout experience.
+* Add - Add Stripe API to generate connection tokens.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
+++ b/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
@@ -61,6 +61,6 @@ class WC_REST_Stripe_Connection_Tokens_Controller extends WC_Stripe_REST_Base_Co
 		}
 
 		$response->test_mode = $this->gateway->is_in_test_mode();
-		return $response;
+		return rest_ensure_response( $response );
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
+++ b/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
@@ -60,13 +60,7 @@ class WC_REST_Stripe_Connection_Tokens_Controller extends WC_Stripe_REST_Base_Co
 			return new WP_Error( 'wc_stripe_no_token', __( 'Stripe API did not return a connection token.', 'woocommerce-gateway-stripe' ) );
 		}
 
-		return new WP_Rest_Response(
-			[
-				'data' => [
-					'secret'    => $response->secret,
-					'test_mode' => $this->gateway->is_in_test_mode(),
-				],
-			]
-		);
+		$response->test_mode = $this->gateway->is_in_test_mode();
+		return $response;
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
+++ b/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Class WC_REST_Stripe_Connection_Tokens_Controller
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for connection tokens.
+ */
+class WC_REST_Stripe_Connection_Tokens_Controller extends WC_Stripe_REST_Base_Controller {
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc_stripe/connection_tokens';
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_token' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+	}
+
+	/**
+	 * Create a connection token via API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function create_token( $request ) {
+		return WC_Stripe_API::request( [], 'terminal/connection_tokens' );
+	}
+}

--- a/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
+++ b/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php
@@ -57,7 +57,7 @@ class WC_REST_Stripe_Connection_Tokens_Controller extends WC_Stripe_REST_Base_Co
 		$response = WC_Stripe_API::request( [], 'terminal/connection_tokens' );
 
 		if ( ! isset( $response->secret ) ) {
-			return new WP_Error( 'wc_stripe_no_token', __( 'Stripe API did not return a connection token.', 'woocommerce-gateway-stripe' ) );
+			return rest_ensure_response( new WP_Error( 'wc_stripe_no_token', __( 'Stripe API did not return a connection token.', 'woocommerce-gateway-stripe' ) ) );
 		}
 
 		$response->test_mode = $this->gateway->is_in_test_mode();

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-connection-tokens-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-connection-tokens-controller.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Class WC_REST_Stripe_Connection_Tokens_Controller.
+ *
+ * @package WooCommerce_Stripe/Tests/WC_REST_Stripe_Connection_Tokens_Controller
+ */
+
+/**
+ * WC_REST_Stripe_Connection_Tokens_Controller unit tests.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class WC_REST_Stripe_Connection_Tokens_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * Tested REST route.
+	 */
+	const CONNECTION_TOKENS_ROUTE = '/wc/v3/wc_stripe/connection_tokens';
+
+	public function test_token_request_requires_auth() {
+		wp_set_current_user( 0 );
+
+		// Unauthenticated user should not be able to access route.
+		$request = new WP_REST_Request( 'POST', self::CONNECTION_TOKENS_ROUTE );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_token_request_success() {
+		wp_set_current_user( 1 );
+
+		// Mock response from Stripe API.
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'object' => 'terminal.connection_token',
+						'secret' => 'pst_test_12345678901234567890123',
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		// Request for a token should succeed.
+		$request = new WP_REST_Request( 'POST', self::CONNECTION_TOKENS_ROUTE );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'pst_test_12345678901234567890123', $response->get_data()['data']['secret'] );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
+}

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-connection-tokens-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-connection-tokens-controller.php
@@ -49,7 +49,7 @@ class WC_REST_Stripe_Connection_Tokens_Controller_Test extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', self::CONNECTION_TOKENS_ROUTE );
 		$response = rest_do_request( $request );
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'pst_test_12345678901234567890123', $response->get_data()['data']['secret'] );
+		$this->assertEquals( 'pst_test_12345678901234567890123', $response->get_data()->secret );
 
 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -574,18 +574,21 @@ function woocommerce_gateway_stripe() {
 			 */
 			public function register_routes() {
 				/** API includes */
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-base-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/abstracts/abstract-wc-stripe-connect-rest-controller.php';
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-init-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-connect-controller.php';
 
-				$oauth_init    = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
-				$oauth_connect = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
+				$connection_tokens_controller = new WC_REST_Stripe_Connection_Tokens_Controller();
+				$oauth_init                   = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
+				$oauth_connect                = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
 
+				$connection_tokens_controller->register_routes();
 				$oauth_init->register_routes();
 				$oauth_connect->register_routes();
 
 				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-base-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-settings-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -580,7 +580,7 @@ function woocommerce_gateway_stripe() {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-init-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-connect-controller.php';
 
-				$connection_tokens_controller = new WC_REST_Stripe_Connection_Tokens_Controller();
+				$connection_tokens_controller = new WC_REST_Stripe_Connection_Tokens_Controller( $this->get_main_stripe_gateway() );
 				$oauth_init                   = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
 				$oauth_connect                = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
 


### PR DESCRIPTION
Fixes #2123

## Changes proposed in this Pull Request:

This PR adds an API endpoint (`/wp-json/wc/v3/wc_stripe/connection_tokens`) for connection tokens, for use by mobile apps. For the mobile app to connect to a card reader, the Stripe extension needs to [request a connection token object](https://stripe.com/docs/api/terminal/connection_tokens) and send it back to the mobile app.

## Testing instructions

Below is a test plugin that can be added to your site to test the new API endpoint, adapted from a [similar test plugin](https://github.com/Automattic/woocommerce-payments/pull/1283) from when WCPay implemented this same endpoint.

```php
<?php
/*
Plugin Name: Stripe Connection Token Test
*/

function stripe_connection_token_test() {
?>
    <div class="notice">
		<span id="test">Loading...</span>
		<script>
			document.addEventListener( 'DOMContentLoaded', function() {
				fetch( '/wp-json/wc/v3/wc_stripe/connection_tokens', {
					method: 'POST',
					headers: { 'X-WP-Nonce': wpApiSettings.nonce },
				} )
				.then( response => response.json() )
				.then( data => {
					document.querySelector('#test').innerHTML = JSON.stringify( data );
				} )
				.catch( error => {
					document.querySelector('#test').innerHTML = 'Error: ' + error;
				} );
			} );
		</script>
	</div>
<?php
}

add_action( 'admin_notices', 'stripe_connection_token_test' );
```

1. Activate Stripe extension, add Stripe API credentials to settings.
2. Activate the above test plugin.
3. Visit any admin page.
4. Verify that you can see a connection token generated by Stripe.
5. Verify that the structure of the JSON data returned matches the sample response under "Fetch Connection Token" in pdfdoF-er-p2.
6. Remove Stripe API credentials from settings.
7. Verify that the API returns an error indicating that Stripe did not return a connection token.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
