### PR TITLE
Fix "TODO" links

### DIFF
--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -162,7 +162,7 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 						),
 						components: {
 							docsLink: (
-								<ExternalLink href="?TODO">
+								<ExternalLink href="https://woocommerce.com/document/stripe/">
 									{ __(
 										'Stripe docs',
 										'woocommerce-gateway-stripe'

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -61,7 +61,7 @@ const PaymentRequestDescription = () => (
 				'woocommerce-gateway-stripe'
 			) }
 		</p>
-		<ExternalLink href="?TODO">
+		<ExternalLink href="https://woocommerce.com/document/stripe/#payment-request-buttons">
 			{ __( 'Learn more', 'woocommerce-gateway-stripe' ) }
 		</ExternalLink>
 	</>

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -35,12 +35,12 @@ const GeneralSettingsDescription = () => (
 			) }
 		</p>
 		<p>
-			<ExternalLink href="?TODO">
+			<ExternalLink href="https://woocommerce.com/document/stripe/">
 				{ __( 'View Stripe docs', 'woocommerce-gateway-stripe' ) }
 			</ExternalLink>
 		</p>
 		<p>
-			<ExternalLink href="?TODO">
+			<ExternalLink href="https://woocommerce.com/contact-us/">
 				{ __( 'Get support', 'woocommerce-gateway-stripe' ) }
 			</ExternalLink>
 		</p>

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -70,7 +70,7 @@ const PaymentsAndTransactionsDescription = () => (
 				'woocommerce-gateway-stripe'
 			) }
 		</p>
-		<ExternalLink href="?TODO">
+		<ExternalLink href="https://woocommerce.com/document/stripe/#faq">
 			{ __(
 				'View Frequently Asked Questions',
 				'woocommerce-gateway-stripe'

--- a/client/settings/upe-opt-in-banner/index.js
+++ b/client/settings/upe-opt-in-banner/index.js
@@ -74,7 +74,7 @@ const UpeOptInBanner = ( { title, description, Image, ...props } ) => (
 						'woocommerce-gateway-stripe'
 					) }
 				</Button>
-				<ExternalLink href="?TODO">
+				<ExternalLink href="https://woocommerce.com/document/stripe/#new-checkout-experience">
 					{ __( 'Learn more', 'woocommerce-gateway-stripe' ) }
 				</ExternalLink>
 			</Actions>

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
@@ -174,7 +174,9 @@ const AddPaymentMethodsTask = () => {
 							'woocommerce-gateway-stripe'
 						),
 						components: {
-							learnMoreLink: <ExternalLink href="TODO?" />,
+							learnMoreLink: (
+								<ExternalLink href="https://woocommerce.com/document/stripe/#additional-payment-methods" />
+							),
 						},
 					} ) }
 				</p>

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/enable-upe-preview-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/enable-upe-preview-task.js
@@ -76,7 +76,7 @@ const EnableUpePreviewTask = () => {
 						components: {
 							learnMoreLink: (
 								// eslint-disable-next-line max-len
-								<ExternalLink href="TODO?">
+								<ExternalLink href="https://woocommerce.com/document/stripe/#new-checkout-experience">
 									{ __(
 										'Learn more',
 										'woocommerce-gateway-stripe'

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -36,7 +36,7 @@ class WC_Stripe_UPE_Availability_Note {
 		$note       = new $note_class();
 
 		$note->set_title( __( 'Boost your sales with the new payment experience in Stripe', 'woocommerce-gateway-stripe' ) );
-		$note->set_content( __( 'Get early access to an improved checkout experience, now available to select merchants. <a href="?TODO" target="_blank">Learn more</a>.', 'woocommerce-gateway-stripe' ) );
+		$note->set_content( __( 'Get early access to an improved checkout experience, now available to select merchants. <a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">Learn more</a>.', 'woocommerce-gateway-stripe' ) );
 		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );

--- a/tests/phpunit/test-class-wc-stripe-upe-availability-note.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-availability-note.php
@@ -14,7 +14,7 @@ class WC_Stripe_UPE_Availability_Note_Test extends WP_UnitTestCase {
 			$note = WC_Stripe_UPE_Availability_Note::get_note();
 
 			$this->assertSame( 'Boost your sales with the new payment experience in Stripe', $note->get_title() );
-			$this->assertSame( 'Get early access to an improved checkout experience, now available to select merchants. <a href="?TODO" target="_blank">Learn more</a>.', $note->get_content() );
+			$this->assertSame( 'Get early access to an improved checkout experience, now available to select merchants. <a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">Learn more</a>.', $note->get_content() );
 			$this->assertSame( 'info', $note->get_type() );
 			$this->assertSame( 'wc-stripe-upe-availability-note', $note->get_name() );
 			$this->assertSame( 'woocommerce-gateway-stripe', $note->get_source() );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2092 

## Changes proposed in this Pull Request:

It fixes all the missing links in the new settings.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
Make sure all the links mentioned below works.

1. Ensure you have `_wcstripe_feature_upe_settings` option set to `yes`.
2. Go to http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
3. Try to disable UPE and you will see the modal below. Test the "Stripe docs" link.
![image](https://user-images.githubusercontent.com/10233985/138369136-c8a2dd76-c087-4f3a-8e6a-8561e865320e.png)
4. Disable UPE.
5. After disabling UPE you will see the banner below, test the "Learn more" link.
![image](https://user-images.githubusercontent.com/10233985/138368270-324b2065-fb80-4dfe-bfa2-626d3f1760e6.png)
6. Click in the "Enable in your store" button above, that should lead you to the onboarding flow.
7. In the onboarding stepper, test the two "Learn more" links there (you will see one in step 1 and one in step 2).
8. Complete the onboarding flow.
9. Test the "Learn more" link in the Express checkouts section.
![image](https://user-images.githubusercontent.com/10233985/138368823-ea77b819-c32a-490e-86ea-00851a948d8d.png)
10. Test both links in the General section.
![image](https://user-images.githubusercontent.com/10233985/138368989-25bb5f3a-1957-4fef-8844-d095382ebc98.png)
11. Test the "View Frequently Asked Questions" link in Payments & transactions section.
![image](https://user-images.githubusercontent.com/10233985/138369034-9c20a797-bb42-4ce8-9d2c-68fb2e8c1e69.png)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
