### PR TITLE
Update readme and changelog to remove pre-release preview for new settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Fix - Stripe JS is no longer loaded on cart and product pages when PRBs are disabled on those pages.
 * Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
-* Add - Pre-release preview of new settings experience.
+* Add - New Settings UI.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Stripe JS is no longer loaded on cart and product pages when PRBs are disabled on those pages.
 * Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
-* Add - Pre-release preview of new settings experience.
+* Add - New Settings UI.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
The feature flag for the new settings is now `on` by default, this PR removes the `pre-release preview` from the Settings entries in the changelog and readme files