### PR TITLE
Fix selector name

### DIFF
--- a/client/data/payment-gateway/selectors.js
+++ b/client/data/payment-gateway/selectors.js
@@ -16,6 +16,6 @@ export const isSavingPaymentGateway = ( state ) => {
 	return getPaymentGatewayState( state ).isSaving || false;
 };
 
-export const getSavingError = ( state ) => {
+export const getPaymentGatewaySavingError = ( state ) => {
 	return getPaymentGatewayState( state ).savingError;
 };


### PR DESCRIPTION
Renaming selector that was conflicting with `getSavingError`, present in the settings data structure.