### PR TITLE
Fix / Allow statement descriptor to be empty

### DIFF
--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -196,6 +196,10 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return $string_validation_result;
 		}
 
+		if ( '' === $value ) {
+			return true;
+		}
+
 		try {
 			$this->gateway->validate_account_statement_descriptor_field( $param, $value, $max_length );
 		} catch ( Exception $exception ) {

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -196,6 +196,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return $string_validation_result;
 		}
 
+		// Relaxing validation because it's blocking the user from saving it when they're on another tab of the settings screen
+		// TODO: work that out with either a UX approach or handling the validations of each tab separately
 		if ( '' === $value ) {
 			return true;
 		}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR restores the previous save settings behavior and allow the Statement Descriptor to have an empty value.

## Testing instructions

1. Checkout the `develop` branch
2. Go to **WooCommerce > Payments > Stripe > Settings**
3. Empty the field `Full bank statement` and Save changes
4. Check that `Save changes` failed
5. Checkout this branch (`fix/allow-statement-descriptor-to-be-empty`)
2. Go to **WooCommerce > Payments > Stripe > Settings**
3. Empty the field `Full bank statement` and Save changes
4. Check that `Save changes` succeeds 