### PR TITLE
Reload page after saving keys

### DIFF
--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -53,8 +53,12 @@ const ButtonWrapper = styled.div`
 const ConnectStripeAccount = ( { oauthUrl } ) => {
 	// @todo - deconstruct modalType and setModalType from useModalType custom hook
 	const [ modalType, setModalType ] = useState( '' );
-	const handleModalDismiss = () => {
-		setModalType( '' );
+	const handleModalDismiss = ( { saveSuccess } ) => {
+		if ( saveSuccess ) {
+			window.location.reload();
+		} else {
+			setModalType( '' );
+		}
 	};
 
 	return (

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -53,12 +53,8 @@ const ButtonWrapper = styled.div`
 const ConnectStripeAccount = ( { oauthUrl } ) => {
 	// @todo - deconstruct modalType and setModalType from useModalType custom hook
 	const [ modalType, setModalType ] = useState( '' );
-	const handleModalDismiss = ( { saveSuccess } ) => {
-		if ( saveSuccess ) {
-			window.location.reload();
-		} else {
-			setModalType( '' );
-		}
+	const handleModalDismiss = () => {
+		setModalType( '' );
 	};
 
 	return (
@@ -67,6 +63,7 @@ const ConnectStripeAccount = ( { oauthUrl } ) => {
 				<AccountKeysModal
 					type={ modalType }
 					onClose={ handleModalDismiss }
+					forcePageReloadOnSave
 				/>
 			) }
 			<CardWrapper>

--- a/client/settings/payment-settings/account-keys-modal.js
+++ b/client/settings/payment-settings/account-keys-modal.js
@@ -184,7 +184,7 @@ export const AccountKeysModal = ( { type, onClose } ) => {
 			return { ...acc, [ name ]: value };
 		}, {} );
 		await saveAccountKeys( keysToSave );
-		onClose();
+		onClose( { saveSuccess: true } );
 	};
 
 	const onTabSelect = ( tabName ) => {

--- a/client/settings/payment-settings/general-settings-section.js
+++ b/client/settings/payment-settings/general-settings-section.js
@@ -27,6 +27,7 @@ const GeneralSettingsSection = () => {
 				<AccountKeysModal
 					type={ modalType }
 					onClose={ handleModalDismiss }
+					forcePageReloadOnSave
 				/>
 			) }
 			<StyledCard>

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -165,6 +165,7 @@ const PaymentSettingsPanel = () => {
 				<AccountKeysModal
 					type={ modalType }
 					onClose={ handleModalDismiss }
+					forcePageReloadOnSave
 				/>
 			) }
 			<SettingsSection Description={ GeneralSettingsDescription }>

--- a/client/settings/payment-settings/test-mode-checkbox.js
+++ b/client/settings/payment-settings/test-mode-checkbox.js
@@ -11,25 +11,20 @@ const TestModeCheckbox = () => {
 	const [ isTestModeEnabled, setTestMode ] = useTestMode();
 	const { accountKeys } = useAccountKeys();
 
+	const missingLiveKeys =
+		! accountKeys.publishable_key || ! accountKeys.secret_key;
+	const missingTestKeys =
+		! accountKeys.test_publishable_key || ! accountKeys.test_secret_key;
+
 	const handleCheckboxChange = ( isChecked ) => {
 		// are we enabling test mode without the necessary keys?
-		if (
-			isChecked &&
-			( ! accountKeys.test_publishable_key ||
-				! accountKeys.test_secret_key ||
-				! accountKeys.test_webhook_secret )
-		) {
+		if ( isChecked && missingTestKeys ) {
 			setModalType( 'test' );
 			return;
 		}
 
 		// are we enabling live mode without the necessary keys?
-		if (
-			! isChecked &&
-			( ! accountKeys.publishable_key ||
-				! accountKeys.secret_key ||
-				! accountKeys.webhook_secret )
-		) {
+		if ( ! isChecked && missingLiveKeys ) {
 			setModalType( 'live' );
 			return;
 		}

--- a/client/settings/payment-settings/test-mode-checkbox.js
+++ b/client/settings/payment-settings/test-mode-checkbox.js
@@ -43,6 +43,7 @@ const TestModeCheckbox = () => {
 				<AccountKeysModal
 					type={ modalType }
 					onClose={ handleModalDismiss }
+					forcePageReloadOnSave
 				/>
 			) }
 			<CheckboxControl

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { TabPanel } from '@wordpress/components';
-import { getQuery } from '@woocommerce/navigation';
+import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
 import SettingsLayout from '../settings-layout';
 import PaymentSettingsPanel from '../payment-settings';
@@ -30,12 +30,17 @@ const SettingsManager = () => {
 	// This grabs the "panel" URL query string value to allow for opening a specific tab.
 	const { panel } = getQuery();
 
+	const updatePanelUri = ( tabName ) => {
+		updateQueryString( { panel: tabName }, '/', getQuery() );
+	};
+
 	return (
 		<SettingsLayout>
 			<StyledTabPanel
 				className="wc-stripe-account-settings-panel"
 				initialTabName={ panel === 'settings' ? 'settings' : 'methods' }
 				tabs={ TABS_CONTENT }
+				onSelect={ updatePanelUri }
 			>
 				{ ( tab ) => (
 					<div data-testid={ `${ tab.name }-tab` }>

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -198,10 +198,13 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		$settings['test_secret_key']      = is_null( $test_secret_key ) ? $settings['test_secret_key'] : $test_secret_key;
 		$settings['test_webhook_secret']  = is_null( $test_webhook_secret ) ? $settings['test_webhook_secret'] : $test_webhook_secret;
 
-		// If we have a live key but no test key, then disable testmode.
+		// If we only have test keys, enable testmode.
 		if ( ! trim( $settings['publishable_key'] ) && ! trim( $settings['secret_key'] ) && trim( $settings['test_publishable_key'] ) && trim( $settings['test_secret_key'] ) ) {
 			$settings['testmode'] = 'yes';
-		} else {
+		}
+
+		// If we only have live keys, disable testmode.
+		if ( trim( $settings['publishable_key'] ) && trim( $settings['secret_key'] ) && ! trim( $settings['test_publishable_key'] ) && ! trim( $settings['test_secret_key'] ) ) {
 			$settings['testmode'] = 'no';
 		}
 

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -198,6 +198,13 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		$settings['test_secret_key']      = is_null( $test_secret_key ) ? $settings['test_secret_key'] : $test_secret_key;
 		$settings['test_webhook_secret']  = is_null( $test_webhook_secret ) ? $settings['test_webhook_secret'] : $test_webhook_secret;
 
+		// If we have a live key but no test key, then disable testmode.
+		if ( ! trim( $settings['publishable_key'] ) && ! trim( $settings['secret_key'] ) && trim( $settings['test_publishable_key'] ) && trim( $settings['test_secret_key'] ) ) {
+			$settings['testmode'] = 'yes';
+		} else {
+			$settings['testmode'] = 'no';
+		}
+
 		update_option( self::STRIPE_GATEWAY_SETTINGS_OPTION_NAME, $settings );
 		$this->account->clear_cache();
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes a few details in the save keys modal:
- Reload the Stripe onboarding page after saving the keys
- Set `testmode` to `yes` if test keys were saved, or to `no` if live keys were saved.
- When enabling/disabling `test mode`, don't show the missing keys popup when only the `webhook secret` is missing

## Testing instructions
1. Go to **WooCommerce > Payments > Stripe**
2. Click `Enter account keys`, fill the live keys, and click `Save live keys`
3. Check that the page reload after saving.
4. Check that after reloading, the settings page is loaded (and not the onboarding card)
5. Select the `Settings` tab
6. Check `Enable test mode`
7. Verify that the missing keys popup loads
8. Fill the `test` keys, and click `Save test keys`
9. Uncheck `Enable test mode`
10. Verify that the missing keys popup is not loaded