### PR TITLE
Update pending activation flow and hide UPE payment methods when not available

### DIFF
--- a/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
+++ b/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
@@ -14,9 +14,28 @@ describe( 'PaymentMethodCapabilityStatusPill', () => {
 		useGetCapabilities.mockReturnValue( {} );
 	} );
 
-	it( 'should render the "Pending activation" text', () => {
+	it( 'should render for "pending" statuses', () => {
 		useGetCapabilities.mockReturnValue( {
 			giropay_payments: 'pending',
+			card_payments: 'active',
+		} );
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<PaymentMethodCapabilityStatusPill
+					id="giropay"
+					label="giropay"
+				/>
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByText( 'Pending activation' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render for "inactive" statuses', () => {
+		useGetCapabilities.mockReturnValue( {
+			giropay_payments: 'inactive',
 			card_payments: 'active',
 		} );
 		render(

--- a/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
+++ b/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
@@ -5,7 +5,6 @@ import { useGetCapabilities } from 'wcstripe/data/account';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 jest.mock( 'wcstripe/data/account', () => ( {
-	useAccount: jest.fn().mockReturnValue( {} ),
 	useGetCapabilities: jest.fn(),
 } ) );
 

--- a/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
+++ b/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
@@ -29,7 +29,7 @@ describe( 'PaymentMethodCapabilityStatusPill', () => {
 		);
 
 		expect(
-			screen.queryByText( 'Pending activation' )
+			screen.queryByText( 'Requires activation' )
 		).toBeInTheDocument();
 	} );
 
@@ -48,7 +48,7 @@ describe( 'PaymentMethodCapabilityStatusPill', () => {
 		);
 
 		expect(
-			screen.queryByText( 'Pending activation' )
+			screen.queryByText( 'Requires activation' )
 		).toBeInTheDocument();
 	} );
 

--- a/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
+++ b/client/components/payment-method-capability-status-pill/__tests__/payment-method-capability-status-pill.test.js
@@ -5,6 +5,7 @@ import { useGetCapabilities } from 'wcstripe/data/account';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 jest.mock( 'wcstripe/data/account', () => ( {
+	useAccount: jest.fn().mockReturnValue( {} ),
 	useGetCapabilities: jest.fn(),
 } ) );
 
@@ -30,23 +31,6 @@ describe( 'PaymentMethodCapabilityStatusPill', () => {
 		expect(
 			screen.queryByText( 'Pending activation' )
 		).toBeInTheDocument();
-	} );
-
-	it( 'should not render when UPE is disabled', () => {
-		useGetCapabilities.mockReturnValue( {
-			giropay_payments: 'pending',
-			card_payments: 'pending',
-		} );
-		const { container } = render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
-				<PaymentMethodCapabilityStatusPill
-					id="giropay"
-					label="giropay"
-				/>
-			</UpeToggleContext.Provider>
-		);
-
-		expect( container.firstChild ).toBeNull();
 	} );
 
 	it( 'should not render when the capability is "active"', () => {

--- a/client/components/payment-method-capability-status-pill/index.js
+++ b/client/components/payment-method-capability-status-pill/index.js
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import interpolateComponents from 'interpolate-components';
 import Pill from 'wcstripe/components/pill';
 import Tooltip from 'wcstripe/components/tooltip';
-import { useAccount, useGetCapabilities } from 'wcstripe/data/account';
+import { useGetCapabilities } from 'wcstripe/data/account';
 
 const StyledPill = styled( Pill )`
 	border: 1px solid #f0b849;
@@ -24,7 +24,6 @@ const StyledLink = styled.a`
 const PaymentMethodCapabilityStatusPill = ( { id, label } ) => {
 	const capabilities = useGetCapabilities();
 	const capabilityStatus = capabilities[ `${ id }_payments` ];
-	const { refreshAccount } = useAccount();
 
 	if ( capabilityStatus === 'pending' || capabilityStatus === 'inactive' ) {
 		return (
@@ -33,7 +32,7 @@ const PaymentMethodCapabilityStatusPill = ( { id, label } ) => {
 					mixedString: sprintf(
 						/* translators: %s: a payment method name. */
 						__(
-							"%s must be activated from the {{stripeDashboardLink}}Stripe dashboard{{/stripeDashboardLink}}. Once it's activated, click {{refreshPaymentMethods}}here{{/refreshPaymentMethods}} to dismiss this notice.",
+							'%s requires activation in your {{stripeDashboardLink}}Stripe dashboard{{/stripeDashboardLink}}. Follow the instructions there and check back soon.',
 							'woocommerce-gateway-stripe'
 						),
 						label
@@ -49,9 +48,6 @@ const PaymentMethodCapabilityStatusPill = ( { id, label } ) => {
 									ev.stopPropagation();
 								} }
 							/>
-						),
-						refreshPaymentMethods: (
-							<StyledLink href="#" onClick={ refreshAccount } />
 						),
 					},
 				} ) }

--- a/client/components/payment-method-capability-status-pill/index.js
+++ b/client/components/payment-method-capability-status-pill/index.js
@@ -14,8 +14,7 @@ const StyledPill = styled( Pill )`
 `;
 
 const StyledLink = styled.a`
-	color: white;
-
+	&,
 	&:hover,
 	&:visited {
 		color: white;

--- a/client/components/payment-method-capability-status-pill/index.js
+++ b/client/components/payment-method-capability-status-pill/index.js
@@ -57,7 +57,10 @@ const PaymentMethodCapabilityStatusPill = ( { id, label } ) => {
 				} ) }
 			>
 				<StyledPill>
-					{ __( 'Pending activation', 'woocommerce-gateway-stripe' ) }
+					{ __(
+						'Requires activation',
+						'woocommerce-gateway-stripe'
+					) }
 				</StyledPill>
 			</Tooltip>
 		);

--- a/client/settings/general-settings-section/__tests__/disable-upe-confirmation-modal.test.js
+++ b/client/settings/general-settings-section/__tests__/disable-upe-confirmation-modal.test.js
@@ -50,7 +50,26 @@ describe( 'DisableUpeConfirmationModal', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should not render the list of payment methods when there are multiple payments enabled', () => {
+	it( 'should not render payment methods that are not part of the account capabilities', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [
+			[ 'giropay' ],
+			jest.fn(),
+		] );
+
+		useGetCapabilities.mockReturnValue( {
+			card_payments: 'active',
+		} );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<DisableUpeConfirmationModal />
+			</UpeToggleContext.Provider>
+		);
+
+		expect( screen.queryByText( /giropay/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the list of payment methods when there are multiple payments enabled', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( [
 			[ 'giropay' ],
 			jest.fn(),

--- a/client/settings/general-settings-section/__tests__/disable-upe-confirmation-modal.test.js
+++ b/client/settings/general-settings-section/__tests__/disable-upe-confirmation-modal.test.js
@@ -8,6 +8,7 @@ import {
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,
 } from 'wcstripe/data';
+import { useGetCapabilities } from 'wcstripe/data/account';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn(),
@@ -19,6 +20,9 @@ jest.mock( '@wordpress/data', () => ( {
 	register: jest.fn(),
 	combineReducers: jest.fn(),
 } ) );
+jest.mock( 'wcstripe/data/account', () => ( {
+	useGetCapabilities: jest.fn(),
+} ) );
 
 describe( 'DisableUpeConfirmationModal', () => {
 	beforeEach( () => {
@@ -26,6 +30,10 @@ describe( 'DisableUpeConfirmationModal', () => {
 			'card',
 			'giropay',
 		] );
+		useGetCapabilities.mockReturnValue( {
+			card_payments: 'active',
+			giropay_payments: 'active',
+		} );
 		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card' ], jest.fn() ] );
 		useDispatch.mockReturnValue( {} );
 	} );

--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -8,16 +8,16 @@ import {
 	useGetAvailablePaymentMethodIds,
 	useManualCapture,
 } from 'wcstripe/data';
-import { useAccount } from 'wcstripe/data/account';
+import { useAccount, useGetCapabilities } from 'wcstripe/data/account';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn(),
 	useEnabledPaymentMethodIds: jest.fn(),
 	useManualCapture: jest.fn(),
 } ) );
-
 jest.mock( 'wcstripe/data/account', () => ( {
 	useAccount: jest.fn(),
+	useGetCapabilities: jest.fn(),
 } ) );
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: jest.fn().mockReturnValue( {} ),
@@ -35,6 +35,10 @@ jest.mock( '../../loadable-settings-section', () => ( { children } ) =>
 
 describe( 'GeneralSettingsSection', () => {
 	beforeEach( () => {
+		useGetCapabilities.mockReturnValue( {
+			card_payments: 'active',
+			giropay_payments: 'active',
+		} );
 		useManualCapture.mockReturnValue( [ false ] );
 		useGetAvailablePaymentMethodIds.mockReturnValue( [ 'card' ] );
 		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card' ], jest.fn() ] );

--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -353,4 +353,26 @@ describe( 'GeneralSettingsSection', () => {
 			} )
 		).toBeInTheDocument();
 	} );
+
+	it( 'should not render payment methods that are not part of the account capabilities', () => {
+		useGetAvailablePaymentMethodIds.mockReturnValue( [
+			'card',
+			'giropay',
+		] );
+		useGetCapabilities.mockReturnValue( {
+			card_payments: 'active',
+		} );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: 'giropay',
+			} )
+		).not.toBeInTheDocument();
+	} );
 } );

--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -8,8 +8,9 @@ import PaymentMethodsMap from '../../payment-methods-map';
 import UpeToggleContext from '../upe-toggle/context';
 import ConfirmationModal from 'wcstripe/components/confirmation-modal';
 import InlineNotice from 'wcstripe/components/inline-notice';
-import { useEnabledPaymentMethodIds } from 'wcstripe/data';
 import AlertTitle from 'wcstripe/components/confirmation-modal/alert-title';
+import { useEnabledPaymentMethodIds } from 'wcstripe/data';
+import { useGetCapabilities } from 'wcstripe/data/account';
 
 const DeactivatingPaymentMethodsList = styled.ul`
 	min-height: 150px;
@@ -82,9 +83,14 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 	};
 
 	const [ enabledPaymentMethodIds ] = useEnabledPaymentMethodIds();
-	const upePaymentMethods = enabledPaymentMethodIds.filter(
-		( method ) => method !== 'card'
-	);
+	const capabilities = useGetCapabilities();
+
+	const upePaymentMethods = enabledPaymentMethodIds.filter( ( method ) => {
+		return (
+			method !== 'card' &&
+			capabilities.hasOwnProperty( `${ method }_payments` )
+		);
+	} );
 
 	return (
 		<>

--- a/client/settings/general-settings-section/index.js
+++ b/client/settings/general-settings-section/index.js
@@ -15,7 +15,7 @@ const StyledCard = styled( Card )`
 	margin-bottom: 12px;
 `;
 
-export const AccountRefreshingOverlay = styled.div`
+const AccountRefreshingOverlay = styled.div`
 	position: relative;
 	&.has-overlay {
 		animation: loading-fade 1.6s ease-in-out infinite;

--- a/client/settings/general-settings-section/index.js
+++ b/client/settings/general-settings-section/index.js
@@ -15,7 +15,7 @@ const StyledCard = styled( Card )`
 	margin-bottom: 12px;
 `;
 
-const AccountRefreshingOverlay = styled.div`
+export const AccountRefreshingOverlay = styled.div`
 	position: relative;
 	&.has-overlay {
 		animation: loading-fade 1.6s ease-in-out infinite;

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -9,6 +9,7 @@ import {
 	useGetAvailablePaymentMethodIds,
 	useManualCapture,
 } from 'wcstripe/data';
+import { useGetCapabilities } from 'wcstripe/data/account';
 import PaymentMethodFeesPill from 'wcstripe/components/payment-method-fees-pill';
 
 const List = styled.ul`
@@ -73,8 +74,14 @@ const StyledFees = styled( PaymentMethodFeesPill )`
 
 const GeneralSettingsSection = () => {
 	const { isUpeEnabled } = useContext( UpeToggleContext );
-	const availablePaymentMethods = useGetAvailablePaymentMethodIds();
+	const upePaymentMethods = useGetAvailablePaymentMethodIds();
+	const capabilities = useGetCapabilities();
 	const [ isManualCaptureEnabled ] = useManualCapture();
+
+	// Hide payment methods that are not part of the account capabilities.
+	const availablePaymentMethods = upePaymentMethods.filter( ( method ) =>
+		capabilities.hasOwnProperty( `${ method }_payments` )
+	);
 
 	return (
 		<List>

--- a/client/settings/general-settings-section/section-footer.js
+++ b/client/settings/general-settings-section/section-footer.js
@@ -7,7 +7,7 @@ const SectionFooter = () => (
 	<CardFooter>
 		<ExternalLink
 			className="components-button is-secondary"
-			href="https://dashboard.stripe.com/account/payments/settings"
+			href="https://dashboard.stripe.com/settings/payments"
 		>
 			{ __( 'Get more payment methods', 'woocommerce-gateway-stripe' ) }
 		</ExternalLink>

--- a/client/settings/payment-gateway-manager/constants.js
+++ b/client/settings/payment-gateway-manager/constants.js
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 
 export const gatewaysInfo = {
 	stripe_sepa: {
+		id: 'sepa_debit',
 		title: __( 'SEPA Direct Debit', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: France, Germany, Spain, Belgium, Netherlands, Luxembourg, Italy, Portugal, Austria, Ireland.',
@@ -11,6 +12,7 @@ export const gatewaysInfo = {
 			'https://stripe.com/payments/payment-methods-guide#sepa-direct-debit',
 	},
 	stripe_giropay: {
+		id: 'giropay',
 		title: __( 'giropay', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: Germany.',
@@ -19,6 +21,7 @@ export const gatewaysInfo = {
 		guide: 'https://stripe.com/payments/payment-methods-guide#giropay',
 	},
 	stripe_ideal: {
+		id: 'ideal',
 		title: __( 'iDeal', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: The Netherlands.',
@@ -27,6 +30,7 @@ export const gatewaysInfo = {
 		guide: 'https://stripe.com/payments/payment-methods-guide#ideal',
 	},
 	stripe_bancontact: {
+		id: 'bancontact',
 		title: __( 'Bancontact', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: Belgium.',
@@ -35,6 +39,7 @@ export const gatewaysInfo = {
 		guide: 'https://stripe.com/payments/payment-methods-guide#bancontact',
 	},
 	stripe_eps: {
+		id: 'eps',
 		title: __( 'EPS', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: Austria.',
@@ -43,6 +48,7 @@ export const gatewaysInfo = {
 		guide: 'https://stripe.com/payments/payment-methods-guide#eps',
 	},
 	stripe_sofort: {
+		id: 'sofort',
 		title: __( 'SOFORT', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: Germany, Austria.',
@@ -51,6 +57,7 @@ export const gatewaysInfo = {
 		guide: 'https://stripe.com/payments/payment-methods-guide#sofort',
 	},
 	stripe_p24: {
+		id: 'p24',
 		title: __( 'P24', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: Poland.',
@@ -59,6 +66,7 @@ export const gatewaysInfo = {
 		guide: 'https://stripe.com/payments/payment-methods-guide#p24',
 	},
 	stripe_alipay: {
+		id: 'alipay',
 		title: __( 'Alipay', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: China.',
@@ -67,6 +75,7 @@ export const gatewaysInfo = {
 		guide: 'https://stripe.com/payments/payment-methods-guide#alipay',
 	},
 	stripe_multibanco: {
+		id: 'multibanco',
 		title: __( 'Multibanco', 'woocommerce-gateway-stripe' ),
 		geography: __(
 			'Customer Geography: Portugal.',

--- a/client/settings/payment-gateway-manager/index.js
+++ b/client/settings/payment-gateway-manager/index.js
@@ -18,7 +18,7 @@ const GatewayDescription = () => {
 			<p>{ info.geography }</p>
 			<p>
 				<ExternalLink
-					href="https://dashboard.stripe.com/account/payments/settings"
+					href="https://dashboard.stripe.com/settings/payments"
 					target="_blank"
 				>
 					{ __(

--- a/client/settings/payment-gateway-section/__tests__/index.test.js
+++ b/client/settings/payment-gateway-section/__tests__/index.test.js
@@ -7,9 +7,10 @@ import {
 	usePaymentGatewayName,
 	usePaymentGatewayDescription,
 } from '../../../data/payment-gateway/hooks';
+import { useGetCapabilities } from 'wcstripe/data/account';
 
 jest.mock( '@woocommerce/navigation', () => ( {
-	getQuery: jest.fn().mockReturnValue( { section: 'stripe_alipay' } ),
+	getQuery: jest.fn().mockReturnValue( { section: 'stripe_ideal' } ),
 } ) );
 
 jest.mock( '../../../data/account/hooks', () => ( {
@@ -39,9 +40,9 @@ jest.mock( '../../loadable-payment-gateway-section', () => ( { children } ) =>
 describe( 'PaymentGatewaySection', () => {
 	beforeEach( () => {
 		useEnabledPaymentGateway.mockReturnValue( [ false ] );
-		usePaymentGatewayName.mockReturnValue( [ 'Alipay' ] );
+		usePaymentGatewayName.mockReturnValue( [ 'iDeal' ] );
 		usePaymentGatewayDescription.mockReturnValue( [
-			'You will be redirected to Alipay',
+			'You will be redirected to iDeal',
 		] );
 	} );
 
@@ -49,6 +50,14 @@ describe( 'PaymentGatewaySection', () => {
 		render( <PaymentGatewaySection /> );
 		expect( screen.getAllByRole( 'checkbox' ).length ).toEqual( 1 );
 		expect( screen.getAllByRole( 'textbox' ).length ).toEqual( 2 );
+	} );
+
+	it( 'should render "pending" capability status pill', () => {
+		useGetCapabilities.mockReturnValue( { ideal_payments: 'pending' } );
+		render( <PaymentGatewaySection /> );
+		expect(
+			screen.queryByText( 'Pending activation' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should contain the webhook monitoring status', () => {
@@ -68,7 +77,7 @@ describe( 'PaymentGatewaySection', () => {
 		render( <PaymentGatewaySection /> );
 
 		const enableCheckbox = screen.getByRole( 'checkbox', {
-			name: /Enable Alipay/,
+			name: /Enable iDeal/,
 		} );
 
 		expect( enableGatewayMock ).not.toHaveBeenCalled();
@@ -92,9 +101,9 @@ describe( 'PaymentGatewaySection', () => {
 		expect( setGatewayNameMock ).not.toHaveBeenCalled();
 		expect( nameInput.value ).toEqual( '' );
 
-		userEvent.type( nameInput, 'Buy with Alipay' ); // 15 characters
+		userEvent.type( nameInput, 'Buy with iDeal' ); // 14 characters
 
-		expect( setGatewayNameMock ).toHaveBeenCalledTimes( 15 );
+		expect( setGatewayNameMock ).toHaveBeenCalledTimes( 14 );
 	} );
 
 	it( 'should be possible to update the gateway description', () => {
@@ -113,8 +122,8 @@ describe( 'PaymentGatewaySection', () => {
 		expect( setGatewayDescriptionMock ).not.toHaveBeenCalled();
 		expect( descriptionInput.value ).toEqual( '' );
 
-		userEvent.type( descriptionInput, 'You will be redirected to Alipay' ); // 32 characters
+		userEvent.type( descriptionInput, 'You will be redirected to iDeal' ); // 31 characters
 
-		expect( setGatewayDescriptionMock ).toHaveBeenCalledTimes( 32 );
+		expect( setGatewayDescriptionMock ).toHaveBeenCalledTimes( 31 );
 	} );
 } );

--- a/client/settings/payment-gateway-section/__tests__/index.test.js
+++ b/client/settings/payment-gateway-section/__tests__/index.test.js
@@ -14,6 +14,7 @@ jest.mock( '@woocommerce/navigation', () => ( {
 
 jest.mock( '../../../data/account/hooks', () => ( {
 	useAccount: jest.fn().mockReturnValue( { data: {} } ),
+	useGetCapabilities: jest.fn().mockReturnValue( {} ),
 } ) );
 
 jest.mock( '../../account-details/use-webhook-state-message', () => ( {

--- a/client/settings/payment-gateway-section/__tests__/index.test.js
+++ b/client/settings/payment-gateway-section/__tests__/index.test.js
@@ -56,7 +56,7 @@ describe( 'PaymentGatewaySection', () => {
 		useGetCapabilities.mockReturnValue( { ideal_payments: 'pending' } );
 		render( <PaymentGatewaySection /> );
 		expect(
-			screen.queryByText( 'Pending activation' )
+			screen.queryByText( 'Requires activation' )
 		).toBeInTheDocument();
 	} );
 

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -10,7 +10,6 @@ import {
 } from '@wordpress/components';
 import { getQuery } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
-import classNames from 'classnames';
 import CardBody from '../card-body';
 import { gatewaysInfo } from '../payment-gateway-manager/constants';
 import LoadablePaymentGatewaySection from '../loadable-payment-gateway-section';
@@ -21,7 +20,6 @@ import {
 	usePaymentGatewayName,
 	usePaymentGatewayDescription,
 } from '../../data/payment-gateway/hooks';
-import { AccountRefreshingOverlay } from '../general-settings-section';
 import PaymentMethodCapabilityStatusPill from 'wcstripe/components/payment-method-capability-status-pill';
 
 const StyledCard = styled( Card )`
@@ -50,112 +48,102 @@ const PaymentGatewaySection = () => {
 	] = usePaymentGatewayDescription();
 	const { data } = useAccount();
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
-	const { isRefreshing } = useAccount();
 
 	return (
 		<StyledCard>
 			<LoadablePaymentGatewaySection numLines={ 34 }>
 				<CardBody>
-					<AccountRefreshingOverlay
-						className={ classNames( {
-							'has-overlay': isRefreshing,
-						} ) }
-					>
-						<CheckboxControl
-							checked={ enableGateway }
-							onChange={ setEnableGateway }
-							label={
-								<StyledCheckboxLabel>
-									{ sprintf(
-										/* translators: %s: Payment Gateway name */
-										__(
-											'Enable %s',
-											'woocommerce-gateway-stripe'
-										),
-										info.title
-									) }
-
-									<PaymentMethodCapabilityStatusPill
-										id={ info.id }
-										label={ info.title }
-									/>
-								</StyledCheckboxLabel>
-							}
-							help={ sprintf(
-								/* translators: %s: Payment Gateway name */
-								__(
-									'When enabled, %s will appear on checkout.',
-									'woocommerce-gateway-stripe'
-								),
-								info.title
-							) }
-						/>
-						<h4>
-							{ __(
-								'Display settings',
-								'woocommerce-gateway-stripe'
-							) }
-						</h4>
-						<TextControl
-							help={ __(
-								'Enter a name which customers will see during checkout.',
-								'woocommerce-gateway-stripe'
-							) }
-							label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
-							value={ gatewayName }
-							onChange={ setGatewayName }
-						/>
-						<TextControl
-							help={ __(
-								'Describe how customers should use this payment method during checkout.',
-								'woocommerce-gateway-stripe'
-							) }
-							label={ __(
-								'Description',
-								'woocommerce-gateway-stripe'
-							) }
-							value={ gatewayDescription }
-							onChange={ setGatewayDescription }
-						/>
-						<h4>
-							{ __(
-								'Webhook endpoints',
-								'woocommerce-gateway-stripe'
-							) }
-						</h4>
-						<p>
-							{ createInterpolateElement(
-								__(
-									"You must add the following webhook endpoint <webhookEndpoint /> to your <a>Stripe account settings</a> (if there isn't one already enabled). This will enable you to receive notifications on the charge statuses.",
-									'woocommerce-gateway-stripe'
-								),
-								{
-									webhookEndpoint: (
-										<WebhookEndpointText>
-											{ data.webhook_url }
-										</WebhookEndpointText>
+					<CheckboxControl
+						checked={ enableGateway }
+						onChange={ setEnableGateway }
+						label={
+							<StyledCheckboxLabel>
+								{ sprintf(
+									/* translators: %s: Payment Gateway name */
+									__(
+										'Enable %s',
+										'woocommerce-gateway-stripe'
 									),
-									a: (
-										<ExternalLink href="https://dashboard.stripe.com/account/webhooks" />
-									),
-								}
-							) }
-						</p>
-						<p>
-							{ message }{ ' ' }
-							<Button
-								disabled={ requestStatus === 'pending' }
-								onClick={ refreshMessage }
-								isBusy={ requestStatus === 'pending' }
-								isLink
-							>
-								{ __(
-									'Refresh',
-									'woocommerce-gateway-stripe'
+									info.title
 								) }
-							</Button>
-						</p>
-					</AccountRefreshingOverlay>
+
+								<PaymentMethodCapabilityStatusPill
+									id={ info.id }
+									label={ info.title }
+								/>
+							</StyledCheckboxLabel>
+						}
+						help={ sprintf(
+							/* translators: %s: Payment Gateway name */
+							__(
+								'When enabled, %s will appear on checkout.',
+								'woocommerce-gateway-stripe'
+							),
+							info.title
+						) }
+					/>
+					<h4>
+						{ __(
+							'Display settings',
+							'woocommerce-gateway-stripe'
+						) }
+					</h4>
+					<TextControl
+						help={ __(
+							'Enter a name which customers will see during checkout.',
+							'woocommerce-gateway-stripe'
+						) }
+						label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
+						value={ gatewayName }
+						onChange={ setGatewayName }
+					/>
+					<TextControl
+						help={ __(
+							'Describe how customers should use this payment method during checkout.',
+							'woocommerce-gateway-stripe'
+						) }
+						label={ __(
+							'Description',
+							'woocommerce-gateway-stripe'
+						) }
+						value={ gatewayDescription }
+						onChange={ setGatewayDescription }
+					/>
+					<h4>
+						{ __(
+							'Webhook endpoints',
+							'woocommerce-gateway-stripe'
+						) }
+					</h4>
+					<p>
+						{ createInterpolateElement(
+							__(
+								"You must add the following webhook endpoint <webhookEndpoint /> to your <a>Stripe account settings</a> (if there isn't one already enabled). This will enable you to receive notifications on the charge statuses.",
+								'woocommerce-gateway-stripe'
+							),
+							{
+								webhookEndpoint: (
+									<WebhookEndpointText>
+										{ data.webhook_url }
+									</WebhookEndpointText>
+								),
+								a: (
+									<ExternalLink href="https://dashboard.stripe.com/account/webhooks" />
+								),
+							}
+						) }
+					</p>
+					<p>
+						{ message }{ ' ' }
+						<Button
+							disabled={ requestStatus === 'pending' }
+							onClick={ refreshMessage }
+							isBusy={ requestStatus === 'pending' }
+							isLink
+						>
+							{ __( 'Refresh', 'woocommerce-gateway-stripe' ) }
+						</Button>
+					</p>
 				</CardBody>
 			</LoadablePaymentGatewaySection>
 		</StyledCard>

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -10,6 +10,7 @@ import {
 } from '@wordpress/components';
 import { getQuery } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
+import classNames from 'classnames';
 import CardBody from '../card-body';
 import { gatewaysInfo } from '../payment-gateway-manager/constants';
 import LoadablePaymentGatewaySection from '../loadable-payment-gateway-section';
@@ -20,6 +21,8 @@ import {
 	usePaymentGatewayName,
 	usePaymentGatewayDescription,
 } from '../../data/payment-gateway/hooks';
+import { AccountRefreshingOverlay } from '../general-settings-section';
+import PaymentMethodCapabilityStatusPill from 'wcstripe/components/payment-method-capability-status-pill';
 
 const StyledCard = styled( Card )`
 	margin-bottom: 12px;
@@ -28,6 +31,12 @@ const StyledCard = styled( Card )`
 const WebhookEndpointText = styled.strong`
 	padding: 0 2px;
 	background-color: #f6f7f7; // $studio-gray-0
+`;
+
+const StyledCheckboxLabel = styled.span`
+	display: inline-flex;
+	gap: 8px;
+	align-items: center;
 `;
 
 const PaymentGatewaySection = () => {
@@ -41,89 +50,112 @@ const PaymentGatewaySection = () => {
 	] = usePaymentGatewayDescription();
 	const { data } = useAccount();
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
+	const { isRefreshing } = useAccount();
+
 	return (
 		<StyledCard>
 			<LoadablePaymentGatewaySection numLines={ 34 }>
 				<CardBody>
-					<CheckboxControl
-						checked={ enableGateway }
-						onChange={ setEnableGateway }
-						label={ sprintf(
-							/* translators: %s: Payment Gateway name */
-							__( 'Enable %s', 'woocommerce-gateway-stripe' ),
-							info.title
-						) }
-						help={ sprintf(
-							/* translators: %s: Payment Gateway name */
-							__(
-								'When enabled, %s will appear on checkout.',
-								'woocommerce-gateway-stripe'
-							),
-							info.title
-						) }
-					/>
-					<h4>
-						{ __(
-							'Display settings',
-							'woocommerce-gateway-stripe'
-						) }
-					</h4>
-					<TextControl
-						help={ __(
-							'Enter a name which customers will see during checkout.',
-							'woocommerce-gateway-stripe'
-						) }
-						label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
-						value={ gatewayName }
-						onChange={ setGatewayName }
-					/>
-					<TextControl
-						help={ __(
-							'Describe how customers should use this payment method during checkout.',
-							'woocommerce-gateway-stripe'
-						) }
-						label={ __(
-							'Description',
-							'woocommerce-gateway-stripe'
-						) }
-						value={ gatewayDescription }
-						onChange={ setGatewayDescription }
-					/>
-					<h4>
-						{ __(
-							'Webhook endpoints',
-							'woocommerce-gateway-stripe'
-						) }
-					</h4>
-					<p>
-						{ createInterpolateElement(
-							__(
-								"You must add the following webhook endpoint <webhookEndpoint /> to your <a>Stripe account settings</a> (if there isn't one already enabled). This will enable you to receive notifications on the charge statuses.",
-								'woocommerce-gateway-stripe'
-							),
-							{
-								webhookEndpoint: (
-									<WebhookEndpointText>
-										{ data.webhook_url }
-									</WebhookEndpointText>
-								),
-								a: (
-									<ExternalLink href="https://dashboard.stripe.com/account/webhooks" />
-								),
+					<AccountRefreshingOverlay
+						className={ classNames( {
+							'has-overlay': isRefreshing,
+						} ) }
+					>
+						<CheckboxControl
+							checked={ enableGateway }
+							onChange={ setEnableGateway }
+							label={
+								<StyledCheckboxLabel>
+									{ sprintf(
+										/* translators: %s: Payment Gateway name */
+										__(
+											'Enable %s',
+											'woocommerce-gateway-stripe'
+										),
+										info.title
+									) }
+
+									<PaymentMethodCapabilityStatusPill
+										id={ info.id }
+										label={ info.title }
+									/>
+								</StyledCheckboxLabel>
 							}
-						) }
-					</p>
-					<p>
-						{ message }{ ' ' }
-						<Button
-							disabled={ requestStatus === 'pending' }
-							onClick={ refreshMessage }
-							isBusy={ requestStatus === 'pending' }
-							isLink
-						>
-							{ __( 'Refresh', 'woocommerce-gateway-stripe' ) }
-						</Button>
-					</p>
+							help={ sprintf(
+								/* translators: %s: Payment Gateway name */
+								__(
+									'When enabled, %s will appear on checkout.',
+									'woocommerce-gateway-stripe'
+								),
+								info.title
+							) }
+						/>
+						<h4>
+							{ __(
+								'Display settings',
+								'woocommerce-gateway-stripe'
+							) }
+						</h4>
+						<TextControl
+							help={ __(
+								'Enter a name which customers will see during checkout.',
+								'woocommerce-gateway-stripe'
+							) }
+							label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
+							value={ gatewayName }
+							onChange={ setGatewayName }
+						/>
+						<TextControl
+							help={ __(
+								'Describe how customers should use this payment method during checkout.',
+								'woocommerce-gateway-stripe'
+							) }
+							label={ __(
+								'Description',
+								'woocommerce-gateway-stripe'
+							) }
+							value={ gatewayDescription }
+							onChange={ setGatewayDescription }
+						/>
+						<h4>
+							{ __(
+								'Webhook endpoints',
+								'woocommerce-gateway-stripe'
+							) }
+						</h4>
+						<p>
+							{ createInterpolateElement(
+								__(
+									"You must add the following webhook endpoint <webhookEndpoint /> to your <a>Stripe account settings</a> (if there isn't one already enabled). This will enable you to receive notifications on the charge statuses.",
+									'woocommerce-gateway-stripe'
+								),
+								{
+									webhookEndpoint: (
+										<WebhookEndpointText>
+											{ data.webhook_url }
+										</WebhookEndpointText>
+									),
+									a: (
+										<ExternalLink href="https://dashboard.stripe.com/account/webhooks" />
+									),
+								}
+							) }
+						</p>
+						<p>
+							{ message }{ ' ' }
+							<Button
+								disabled={ requestStatus === 'pending' }
+								onClick={ refreshMessage }
+								isBusy={ requestStatus === 'pending' }
+								isLink
+							>
+								{ __(
+									'Refresh',
+									'woocommerce-gateway-stripe'
+								) }
+							</Button>
+						</p>
+					</AccountRefreshingOverlay>
 				</CardBody>
 			</LoadablePaymentGatewaySection>
 		</StyledCard>

--- a/client/upe-onboarding-wizard/__tests__/onboarding-wizard.test.js
+++ b/client/upe-onboarding-wizard/__tests__/onboarding-wizard.test.js
@@ -13,6 +13,10 @@ jest.mock( 'wcstripe/data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn().mockReturnValue( [] ),
 } ) );
 
+jest.mock( 'wcstripe/data/account', () => ( {
+	useGetCapabilities: jest.fn(),
+} ) );
+
 describe( 'OnboardingWizard', () => {
 	it( 'should render the onboarding wizard', () => {
 		render( <OnboardingWizard /> );

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/add-payment-methods-task.test.js
@@ -9,6 +9,7 @@ import {
 	useEnabledPaymentMethodIds,
 	useSettings,
 } from 'wcstripe/data';
+import { useGetCapabilities } from 'wcstripe/data/account';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn(),
@@ -16,6 +17,11 @@ jest.mock( 'wcstripe/data', () => ( {
 	useSettings: jest.fn(),
 	useCurrencies: jest.fn(),
 } ) );
+
+jest.mock( 'wcstripe/data/account', () => ( {
+	useGetCapabilities: jest.fn().mockReturnValue( {} ),
+} ) );
+
 jest.mock(
 	'wcstripe/components/payment-method-capability-status-pill',
 	() => () => null
@@ -31,6 +37,10 @@ const SettingsContextProvider = ( { children } ) => (
 
 describe( 'AddPaymentMethodsTask', () => {
 	beforeEach( () => {
+		useGetCapabilities.mockReturnValue( {
+			card_payments: 'active',
+			giropay_payments: 'active',
+		} );
 		useGetAvailablePaymentMethodIds.mockReturnValue( [
 			'card',
 			'bancontact',

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/enable-upe-preview-task.test.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/__tests__/enable-upe-preview-task.test.js
@@ -11,6 +11,10 @@ jest.mock( 'wcstripe/data', () => ( {
 	useManualCapture: jest.fn(),
 } ) );
 
+jest.mock( 'wcstripe/data/account', () => ( {
+	useGetCapabilities: jest.fn(),
+} ) );
+
 describe( 'EnableUpePreviewTask', () => {
 	it( 'disables the "Enable" button while "Manual capture" is enabled', async () => {
 		const setCompletedMock = jest.fn();

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/add-payment-methods-task.js
@@ -18,6 +18,7 @@ import {
 	useSettings,
 } from '../../data';
 import PaymentMethodCheckbox from './payment-method-checkbox';
+import { useGetCapabilities } from 'wcstripe/data/account';
 import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
 
 const HeadingWrapper = styled.div`
@@ -138,7 +139,13 @@ const ContinueButton = ( { paymentMethodsState } ) => {
 };
 
 const AddPaymentMethodsTask = () => {
-	const availablePaymentMethods = useGetAvailablePaymentMethodIds();
+	const upePaymentMethods = useGetAvailablePaymentMethodIds();
+	const capabilities = useGetCapabilities();
+
+	// Hide payment methods that are not part of the account capabilities.
+	const availablePaymentMethods = upePaymentMethods.filter( ( method ) =>
+		capabilities.hasOwnProperty( `${ method }_payments` )
+	);
 
 	// I am using internal state in this component
 	// and committing the changes on `initialEnabledPaymentMethodIds` only when the "continue" button is clicked.


### PR DESCRIPTION
Fixes #2090

## Changes proposed in this Pull Request:

- Allow "pending activation" pill to be displayed for APMs outside of the UPE context. Except for Alipay and Multibanco - Ref: p1636521248095300-slack-C9976E5MJ.
- Revert small regression from #2037 where in the old settings an `inactive` capability could be considered as "pending activation" for a recently created account.
- Tweak copy of Tooltip and allow for links.
- Don't show UPE payment method if it's not available under the account capabilities hash.

## Testing instructions

- Make sure the new settings feature flag is enabled: `_wcstripe_feature_upe_settings` option set to `yes`.
- Make sure UPE is enabled.
- Add test account keys from a US account, e.g WCPay Dev, and notice all payment methods are available.
- Either connect a different account with pending/missing capabilities or modify the capabilities hash from the transient `_transient_wcstripe_account_data_test` - You can do it via the DB directly or via WP CLI: `wp transient get wcstripe_account_data_test` and `wp transient set wcstripe_account_data_test "contents" 9999`.
- Change a capability status to `pending` or `inactive` and ensure there's a "pending activation" pill next to the payment method on the new settings page.
- You can refresh the capabilities status by clicking "Refresh payment methods" under the payment methods menu, or from the pending activation pill tooltip CTA ("here").
- Make sure the pending activation pill also shows up when UPE is disabled on other payment methods such as SEPA.

### Notes
- Note<sup>i</sup>: We're not hiding non-UPE payment methods if they're not available for the Stripe account, so we keep current behavior.
- Note<sup>ii</sup>: Alipay and Multibanco apparently are not associated with any capability, so I'm waiting on Stripe's response to see if there's a simple way to detect their availability. p1636521248095300-slack-C9976E5MJ - For the time being the "pending activation" notice doesn't apply to them.
- Note<sup>iii</sup>: I'm checking with the design team to see if the copy and flow makes sense. Unfortunately the design specs are outdated.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)