### PR TITLE
Add support for Stripe Location API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Fix - Stripe JS is no longer loaded on cart and product pages when PRBs are disabled on those pages.
 * Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
-* Add - Add Stripe API to generate connection tokens.
+* Add - Add Stripe API to generate connection tokens, manage terminal locations.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -67,6 +67,15 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 			$this->namespace,
 			'/' . $this->rest_base . '/(?P<location_id>\w+)',
 			[
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'delete_location' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<location_id>\w+)',
+			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_location' ],
 				'permission_callback' => [ $this, 'check_permission' ],
@@ -116,6 +125,16 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 */
 	public function get_all_locations( $request ) {
 		return rest_ensure_response( $this->fetch_locations() );
+	}
+
+	/**
+	 * Delete a terminal location via Stripe API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function delete_location( $request ) {
+		$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ), 'DELETE' );
+		return rest_ensure_response( $response );
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -37,7 +37,16 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 						'type'     => 'object',
 						'required' => true,
 					],
-                ],
+				],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<location_id>\w+)',
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_location' ],
+				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
 	}
@@ -48,13 +57,23 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function create_location( $request ) {
-        $response = WC_Stripe_API::request(
-            [
-                'display_name' => $request['display_name'],
-                'address'      => $request['address'],
-            ],
-            'terminal/locations',
-        );
+		$response = WC_Stripe_API::request(
+			[
+				'display_name' => $request['display_name'],
+				'address'      => $request['address'],
+			],
+			'terminal/locations'
+		);
+		return new WP_Rest_Response( [ 'data' => $response ] );
+	}
+
+	/**
+	 * Get a terminal location via Stripe API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function get_location( $request ) {
+		$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ) );
 		return new WP_Rest_Response( [ 'data' => $response ] );
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -42,6 +42,20 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 		);
 		register_rest_route(
 			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_all_locations' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [
+					'ending_before'  => [ 'type' => 'string' ],
+					'limit'          => [ 'type' => 'integer' ],
+					'starting_after' => [ 'type' => 'string' ],
+				],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
 			'/' . $this->rest_base . '/(?P<location_id>\w+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
@@ -64,7 +78,16 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 			],
 			'terminal/locations'
 		);
-		return new WP_Rest_Response( [ 'data' => $response ] );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Get all terminal locations via Stripe API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function get_all_locations( $request ) {
+		return rest_ensure_response( $this->fetch_locations() );
 	}
 
 	/**
@@ -73,7 +96,15 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_location( $request ) {
-		$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ) );
-		return new WP_Rest_Response( [ 'data' => $response ] );
+		$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ), 'GET' );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Fetch terminal locations from Stripe API.
+	 */
+	private function fetch_locations() {
+		$response = WC_Stripe_API::request( [], 'terminal/locations', 'GET' );
+		return $response->data;
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -117,14 +117,18 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function create_location( $request ) {
-		$response = WC_Stripe_API::request(
-			[
-				'display_name' => $request['display_name'],
-				'address'      => $request['address'],
-			],
-			'terminal/locations'
-		);
-		return rest_ensure_response( $response );
+		try {
+			$response = WC_Stripe_API::request(
+				[
+					'display_name' => $request['display_name'],
+					'address'      => $request['address'],
+				],
+				'terminal/locations'
+			);
+			return rest_ensure_response( $response );
+		} catch ( WC_Stripe_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+		}
 	}
 
 	/**
@@ -133,7 +137,11 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_all_locations( $request ) {
-		return rest_ensure_response( $this->fetch_locations() );
+		try {
+			return rest_ensure_response( $this->fetch_locations() );
+		} catch ( WC_Stripe_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+		}
 	}
 
 	/**
@@ -142,8 +150,12 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function delete_location( $request ) {
-		$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ), 'DELETE' );
-		return rest_ensure_response( $response );
+		try {
+			$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ), 'DELETE' );
+			return rest_ensure_response( $response );
+		} catch ( WC_Stripe_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+		}
 	}
 
 	/**
@@ -152,8 +164,12 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_location( $request ) {
-		$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ), 'GET' );
-		return rest_ensure_response( $response );
+		try {
+			$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ), 'GET' );
+			return rest_ensure_response( $response );
+		} catch ( WC_Stripe_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+		}
 	}
 
 	/**
@@ -194,24 +210,28 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 			);
 		}
 
-		foreach ( $this->fetch_locations() as $location ) {
-			if (
-				$location->display_name === $name
-				&& count( array_intersect( (array) $location->address, $address ) ) === count( $address )
-			) {
-				return rest_ensure_response( $location );
+		try {
+			foreach ( $this->fetch_locations() as $location ) {
+				if (
+					$location->display_name === $name
+					&& count( array_intersect( (array) $location->address, $address ) ) === count( $address )
+				) {
+					return rest_ensure_response( $location );
+				}
 			}
-		}
 
-		// Create new location if no location matches display name and address.
-		$response = WC_Stripe_API::request(
-			[
-				'display_name' => $name,
-				'address' => $address,
-			],
-			'terminal/locations'
-		);
-		return rest_ensure_response( $response );
+			// Create new location if no location matches display name and address.
+			$response = WC_Stripe_API::request(
+				[
+					'display_name' => $name,
+					'address' => $address,
+				],
+				'terminal/locations'
+			);
+			return rest_ensure_response( $response );
+		} catch ( WC_Stripe_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+		}
 	}
 
 	/**
@@ -227,8 +247,12 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 		if ( isset( $request['address'] ) ) {
 			$body['address'] = $request['address'];
 		}
-		$response = WC_Stripe_API::request( $body, 'terminal/locations/' . urlencode( $request['location_id'] ), 'POST' );
-		return rest_ensure_response( $response );
+		try {
+			$response = WC_Stripe_API::request( $body, 'terminal/locations/' . urlencode( $request['location_id'] ), 'POST' );
+			return rest_ensure_response( $response );
+		} catch ( WC_Stripe_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class WC_REST_Stripe_Locations_Controller
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for terminal locations.
+ */
+class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller {
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc_stripe/terminal/locations';
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_location' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [
+					'display_name' => [
+						'type'     => 'string',
+						'required' => true,
+					],
+					'address'      => [
+						'type'     => 'object',
+						'required' => true,
+					],
+                ],
+			]
+		);
+	}
+
+	/**
+	 * Create a terminal location via Stripe API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function create_location( $request ) {
+        $response = WC_Stripe_API::request(
+            [
+                'display_name' => $request['display_name'],
+                'address'      => $request['address'],
+            ],
+            'terminal/locations',
+        );
+		return new WP_Rest_Response( [ 'data' => $response ] );
+	}
+}

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -48,9 +48,18 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 				'callback'            => [ $this, 'get_all_locations' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
-					'ending_before'  => [ 'type' => 'string' ],
-					'limit'          => [ 'type' => 'integer' ],
-					'starting_after' => [ 'type' => 'string' ],
+					'ending_before'  => [
+						'type' => 'string',
+						'required' => false,
+					],
+					'limit'          => [
+						'type' => 'integer',
+						'required' => false,
+					],
+					'starting_after' => [
+						'type' => 'string',
+						'required' => false,
+					],
 				],
 			]
 		);
@@ -61,6 +70,25 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_location' ],
 				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<location_id>\w+)',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'update_location' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+				'args'                => [
+					'display_name' => [
+						'type'     => 'string',
+						'required' => false,
+					],
+					'address'      => [
+						'type'     => 'object',
+						'required' => false,
+					],
+				],
 			]
 		);
 	}
@@ -97,6 +125,23 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 */
 	public function get_location( $request ) {
 		$response = WC_Stripe_API::request( [], 'terminal/locations/' . urlencode( $request['location_id'] ), 'GET' );
+		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Update a terminal location via Stripe API.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function update_location( $request ) {
+		$body = [];
+		if ( isset( $request['display_name'] ) ) {
+			$body['display_name'] = $request['display_name'];
+		}
+		if ( isset( $request['address'] ) ) {
+			$body['address'] = $request['address'];
+		}
+		$response = WC_Stripe_API::request( $body, 'terminal/locations/' . urlencode( $request['location_id'] ), 'POST' );
 		return rest_ensure_response( $response );
 	}
 

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-locations-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-locations-controller.php
@@ -1,183 +1,189 @@
 <?php
- /**
-  * Class WC_REST_Stripe_Locations_Controller.
-  *
-  * @package WooCommerce_Stripe/Tests/WC_REST_Stripe_Locations_Controller
-  */
+/**
+ * Class WC_REST_Stripe_Locations_Controller.
+ *
+ * @package WooCommerce_Stripe/Tests/WC_REST_Stripe_Locations_Controller
+ */
 
- /**
-  * WC_REST_Stripe_Locations_Controller unit tests.
-  *
-  * @runTestsInSeparateProcesses
-  * @preserveGlobalState disabled
-  */
- class WC_REST_Stripe_Locations_Controller_Test extends WP_UnitTestCase {
+/**
+ * WC_REST_Stripe_Locations_Controller unit tests.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class WC_REST_Stripe_Locations_Controller_Test extends WP_UnitTestCase {
 
- 	/**
- 	 * Tested REST route.
- 	 */
- 	const LOCATIONS_REST_BASE = '/wc/v3/wc_stripe/terminal/locations';
+	/**
+	 * Tested REST route.
+	 */
+	const LOCATIONS_REST_BASE = '/wc/v3/wc_stripe/terminal/locations';
 
-	 public function test_create_location_missing_params_fails() {
+	public function test_create_location_missing_params_fails() {
 		wp_set_current_user( 1 );
 
 		// Missing display_name or address parameter should be a bad request.
-		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
+		$request  = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
 		$response = rest_do_request( $request );
 		$this->assertEquals( 400, $response->get_status() );
 	}
 
- 	public function test_create_location_requires_auth() {
- 		wp_set_current_user( 0 );
-
- 		// Unauthenticated user should not be able to access route.
- 		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
-		$request->set_param( 'display_name', 'Test Store' );
-		$request->set_param( 'address', [
-			'line1'       => '1 Example St.',
-			'city'        => 'Example City',
-			'country'     => 'US',
-			'state'       => 'CA',
-			'postal_code' => '12345',
-		] );
- 		$response = rest_do_request( $request );
- 		$this->assertEquals( 401, $response->get_status() );
- 	}
-
- 	public function test_create_location_success() {
- 		wp_set_current_user( 1 );
-
- 		// Mock response from Stripe API using request arguments.
- 		$test_request = function ( $preempt, $parsed_args, $url ) {
- 			return [
- 				'response' => 200,
- 				'headers'  => [ 'Content-Type' => 'application/json' ],
- 				'body'     => json_encode(
- 					[
- 						'id'           => 'tml_12345678901234567890123',
- 						'object'       => 'terminal.location',
- 						'display_name' => $parsed_args['body']['display_name'],
- 						'address'      => [
-							'line1' => $parsed_args['body']['address']['line1'],
-						]
- 					]
- 				),
- 			];
- 		};
- 		add_filter( 'pre_http_request', $test_request, 10, 3 );
-
- 		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
-		$request->set_param( 'display_name', 'Test Store' );
-		$request->set_param( 'address', [
-			'line1'       => '1 Example St.',
-		 	'city'        => 'Example City',
-		 	'country'     => 'US',
-		 	'state'       => 'CA',
-		 	'postal_code' => '12345',
-		 ] );
-
- 		$response = rest_do_request( $request );
- 		$this->assertEquals( 200, $response->get_status() );
- 		$this->assertEquals( 'terminal.location', $response->get_data()->object );
- 		$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
- 		$this->assertEquals( 'Test Store', $response->get_data()->display_name );
- 		$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
-
- 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
- 	}
-
- 	public function test_update_location_requires_auth() {
+	public function test_create_location_requires_auth() {
 		wp_set_current_user( 0 );
 
 		// Unauthenticated user should not be able to access route.
-		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
+		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
+		$request->set_param( 'display_name', 'Test Store' );
+		$request->set_param(
+			'address',
+			[
+				'line1'       => '1 Example St.',
+				'city'        => 'Example City',
+				'country'     => 'US',
+				'state'       => 'CA',
+				'postal_code' => '12345',
+			]
+		);
 		$response = rest_do_request( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
 
- 	public function test_update_location_succeeds() {
- 		wp_set_current_user( 1 );
+	public function test_create_location_success() {
+		wp_set_current_user( 1 );
 
- 		// Mock response from Stripe API using request arguments.
- 		$test_request = function ( $preempt, $parsed_args, $url ) {
- 			return [
- 				'response' => 200,
- 				'headers'  => [ 'Content-Type' => 'application/json' ],
- 				'body'     => json_encode(
- 					[
- 						'id'           => 'tml_12345678901234567890123',
- 						'object'       => 'terminal.location',
- 						'display_name' => isset( $parsed_args['body']['display_name'] ) ? $parsed_args['body']['display_name'] : 'Not Changed',
- 						'address'      => isset( $parsed_args['body']['address'] ) ? $parsed_args['body']['address'] : [ 'line1' => 'Not Changed' ],
- 					]
- 				),
- 			];
- 		};
- 		add_filter( 'pre_http_request', $test_request, 10, 3 );
+		// Mock response from Stripe API using request arguments.
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id'           => 'tml_12345678901234567890123',
+						'object'       => 'terminal.location',
+						'display_name' => $parsed_args['body']['display_name'],
+						'address'      => [
+							'line1' => $parsed_args['body']['address']['line1'],
+						],
+					]
+				),
+			];
+		};
+			add_filter( 'pre_http_request', $test_request, 10, 3 );
 
- 		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
-		$request->set_param( 'display_name', 'New Store Name' );
+			$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
+			$request->set_param( 'display_name', 'Test Store' );
+			$request->set_param(
+				'address',
+				[
+					'line1'       => '1 Example St.',
+					'city'        => 'Example City',
+					'country'     => 'US',
+					'state'       => 'CA',
+					'postal_code' => '12345',
+				]
+			);
 
- 		$response = rest_do_request( $request );
- 		$this->assertEquals( 200, $response->get_status() );
- 		$this->assertEquals( 'terminal.location', $response->get_data()->object );
- 		$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
- 		$this->assertEquals( 'New Store Name', $response->get_data()->display_name );
- 		$this->assertEquals( 'Not Changed', $response->get_data()->address->line1 );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'terminal.location', $response->get_data()->object );
+		$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
+		$this->assertEquals( 'Test Store', $response->get_data()->display_name );
+		$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
 
- 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
- 	}
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
 
- 	public function test_get_store_location_requires_auth() {
+	public function test_update_location_requires_auth() {
 		wp_set_current_user( 0 );
 
 		// Unauthenticated user should not be able to access route.
-		$request = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+		$request  = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
 		$response = rest_do_request( $request );
 		$this->assertEquals( 401, $response->get_status() );
-	 }
+	}
 
- 	public function test_get_store_location_returns_correct_location() {
- 		wp_set_current_user( 1 );
+	public function test_update_location_succeeds() {
+		wp_set_current_user( 1 );
 
- 		// Mock response from Stripe API using request arguments.
- 		$test_request = function ( $preempt, $parsed_args, $url ) {
-			// Mock response for getting existing locations.
+		// Mock response from Stripe API using request arguments.
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id'           => 'tml_12345678901234567890123',
+						'object'       => 'terminal.location',
+						'display_name' => isset( $parsed_args['body']['display_name'] ) ? $parsed_args['body']['display_name'] : 'Not Changed',
+						'address'      => isset( $parsed_args['body']['address'] ) ? $parsed_args['body']['address'] : [ 'line1' => 'Not Changed' ],
+					]
+				),
+			];
+		};
+			add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+			$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
+			$request->set_param( 'display_name', 'New Store Name' );
+
+			$response = rest_do_request( $request );
+			$this->assertEquals( 200, $response->get_status() );
+			$this->assertEquals( 'terminal.location', $response->get_data()->object );
+			$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
+			$this->assertEquals( 'New Store Name', $response->get_data()->display_name );
+			$this->assertEquals( 'Not Changed', $response->get_data()->address->line1 );
+
+			remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
+
+	public function test_get_store_location_requires_auth() {
+		wp_set_current_user( 0 );
+
+		// Unauthenticated user should not be able to access route.
+		$request  = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_get_store_location_returns_correct_location() {
+		wp_set_current_user( 1 );
+
+		// Mock response from Stripe API using request arguments.
+		$test_request = function ( $preempt, $parsed_args, $url ) {
 			if ( 'GET' === $parsed_args['method'] ) {
+				// Mock response for getting existing locations.
 				return [
 					'response' => 200,
 					'headers'  => [ 'Content-Type' => 'application/json' ],
-					'body'     => json_encode( [
-						'data' => [
-							[
-								'id'           => 'tml_00001',
-								'display_name' => 'Unused Test Store',
-								'address'      => [
-									'city'        => 'Example City',
-									'country'     => 'US',
-									'line1'       => '2 Example St.',
-									'postal_code' => '12345',
-									'state'       => 'CA',
+					'body'     => json_encode(
+						[
+							'data' => [
+								[
+									'id'           => 'tml_00001',
+									'display_name' => 'Unused Test Store',
+									'address'      => [
+										'city'        => 'Example City',
+										'country'     => 'US',
+										'line1'       => '2 Example St.',
+										'postal_code' => '12345',
+										'state'       => 'CA',
+									],
 								],
-							],
-							[
-								'id'           => 'tml_00002',
-								'display_name' => 'Test Store',
-								'address'      => [
-									'city'        => 'Example City',
-									'country'     => 'US',
-									'line1'       => '1 Example St.',
-									'postal_code' => '12345',
-									'state'       => 'CA',
+								[
+									'id'           => 'tml_00002',
+									'display_name' => 'Test Store',
+									'address'      => [
+										'city'        => 'Example City',
+										'country'     => 'US',
+										'line1'       => '1 Example St.',
+										'postal_code' => '12345',
+										'state'       => 'CA',
+									],
 								],
 							],
 						]
-					] ),
+					),
 				];
-			}
-
-			// Mock response for creating new locations.
-			else {
+			} else {
+				// Mock response for generating new location.
 				return [
 					'response' => 200,
 					'headers'  => [ 'Content-Type' => 'application/json' ],
@@ -196,36 +202,36 @@
 					),
 				];
 			}
- 		};
+		};
 
- 		add_filter( 'pre_http_request', $test_request, 10, 3 );
+			add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-		// Test an existing store, ensure existing location is returned.
-		update_option( 'blogname', 'Test Store' );
-		update_option( 'woocommerce_store_address', '1 Example St.' );
-		update_option( 'woocommerce_store_city', 'Example City' );
-		update_option( 'woocommerce_store_postcode', '12345' );
-		update_option( 'woocommerce_default_country', 'US:CA' );
+			// Test an existing store, ensure existing location is returned.
+			update_option( 'blogname', 'Test Store' );
+			update_option( 'woocommerce_store_address', '1 Example St.' );
+			update_option( 'woocommerce_store_city', 'Example City' );
+			update_option( 'woocommerce_store_postcode', '12345' );
+			update_option( 'woocommerce_default_country', 'US:CA' );
 
- 		$request = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
- 		$response = rest_do_request( $request );
- 		$this->assertEquals( 200, $response->get_status() );
- 		$this->assertEquals( 'tml_00002', $response->get_data()->id );
- 		$this->assertEquals( 'Test Store', $response->get_data()->display_name );
- 		$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
+			$request  = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+			$response = rest_do_request( $request );
+			$this->assertEquals( 200, $response->get_status() );
+			$this->assertEquals( 'tml_00002', $response->get_data()->id );
+			$this->assertEquals( 'Test Store', $response->get_data()->display_name );
+			$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
 
-		// Test a new store, ensure a new location is returned.
-		update_option( 'blogname', 'New Test Store' );
-		update_option( 'woocommerce_store_address', '3 Example St.' );
+			// Test a new store, ensure a new location is returned.
+			update_option( 'blogname', 'New Test Store' );
+			update_option( 'woocommerce_store_address', '3 Example St.' );
 
- 		$request = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
- 		$response = rest_do_request( $request );
- 		$this->assertEquals( 200, $response->get_status() );
- 		$this->assertEquals( 'tml_00003', $response->get_data()->id );
- 		$this->assertEquals( 'New Test Store', $response->get_data()->display_name );
- 		$this->assertEquals( '3 Example St.', $response->get_data()->address->line1 );
+			$request  = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+			$response = rest_do_request( $request );
+			$this->assertEquals( 200, $response->get_status() );
+			$this->assertEquals( 'tml_00003', $response->get_data()->id );
+			$this->assertEquals( 'New Test Store', $response->get_data()->display_name );
+			$this->assertEquals( '3 Example St.', $response->get_data()->address->line1 );
 
- 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
- 	}
+			remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
 
- }
+}

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-locations-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-locations-controller.php
@@ -59,28 +59,29 @@ class WC_REST_Stripe_Locations_Controller_Test extends WP_UnitTestCase {
 					[
 						'id'           => 'tml_12345678901234567890123',
 						'object'       => 'terminal.location',
-						'display_name' => $parsed_args['body']['display_name'],
+						'display_name' => isset( $parsed_args['body']['display_name'] ) ? $parsed_args['body']['display_name'] : 'No Display Name',
 						'address'      => [
-							'line1' => $parsed_args['body']['address']['line1'],
+							'line1' => isset( $parsed_args['body']['address']['line1'] ) ? $parsed_args['body']['address']['line1'] : 'No Address',
 						],
 					]
 				),
 			];
 		};
-			add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-			$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
-			$request->set_param( 'display_name', 'Test Store' );
-			$request->set_param(
-				'address',
-				[
-					'line1'       => '1 Example St.',
-					'city'        => 'Example City',
-					'country'     => 'US',
-					'state'       => 'CA',
-					'postal_code' => '12345',
-				]
-			);
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
+		$request->set_param( 'display_name', 'Test Store' );
+		$request->set_param(
+			'address',
+			[
+				'line1'       => '1 Example St.',
+				'city'        => 'Example City',
+				'country'     => 'US',
+				'state'       => 'CA',
+				'postal_code' => '12345',
+			]
+		);
 
 		$response = rest_do_request( $request );
 		$this->assertEquals( 200, $response->get_status() );
@@ -119,19 +120,20 @@ class WC_REST_Stripe_Locations_Controller_Test extends WP_UnitTestCase {
 				),
 			];
 		};
-			add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-			$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
-			$request->set_param( 'display_name', 'New Store Name' );
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-			$response = rest_do_request( $request );
-			$this->assertEquals( 200, $response->get_status() );
-			$this->assertEquals( 'terminal.location', $response->get_data()->object );
-			$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
-			$this->assertEquals( 'New Store Name', $response->get_data()->display_name );
-			$this->assertEquals( 'Not Changed', $response->get_data()->address->line1 );
+		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
+		$request->set_param( 'display_name', 'New Store Name' );
 
-			remove_filter( 'pre_http_request', $test_request, 10, 3 );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'terminal.location', $response->get_data()->object );
+		$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
+		$this->assertEquals( 'New Store Name', $response->get_data()->display_name );
+		$this->assertEquals( 'Not Changed', $response->get_data()->address->line1 );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}
 
 	public function test_get_store_location_requires_auth() {
@@ -204,34 +206,34 @@ class WC_REST_Stripe_Locations_Controller_Test extends WP_UnitTestCase {
 			}
 		};
 
-			add_filter( 'pre_http_request', $test_request, 10, 3 );
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
-			// Test an existing store, ensure existing location is returned.
-			update_option( 'blogname', 'Test Store' );
-			update_option( 'woocommerce_store_address', '1 Example St.' );
-			update_option( 'woocommerce_store_city', 'Example City' );
-			update_option( 'woocommerce_store_postcode', '12345' );
-			update_option( 'woocommerce_default_country', 'US:CA' );
+		// Test an existing store, ensure existing location is returned.
+		update_option( 'blogname', 'Test Store' );
+		update_option( 'woocommerce_store_address', '1 Example St.' );
+		update_option( 'woocommerce_store_city', 'Example City' );
+		update_option( 'woocommerce_store_postcode', '12345' );
+		update_option( 'woocommerce_default_country', 'US:CA' );
 
-			$request  = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
-			$response = rest_do_request( $request );
-			$this->assertEquals( 200, $response->get_status() );
-			$this->assertEquals( 'tml_00002', $response->get_data()->id );
-			$this->assertEquals( 'Test Store', $response->get_data()->display_name );
-			$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
+		$request  = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'tml_00002', $response->get_data()->id );
+		$this->assertEquals( 'Test Store', $response->get_data()->display_name );
+		$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
 
-			// Test a new store, ensure a new location is returned.
-			update_option( 'blogname', 'New Test Store' );
-			update_option( 'woocommerce_store_address', '3 Example St.' );
+		// Test a new store, ensure a new location is returned.
+		update_option( 'blogname', 'New Test Store' );
+		update_option( 'woocommerce_store_address', '3 Example St.' );
 
-			$request  = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
-			$response = rest_do_request( $request );
-			$this->assertEquals( 200, $response->get_status() );
-			$this->assertEquals( 'tml_00003', $response->get_data()->id );
-			$this->assertEquals( 'New Test Store', $response->get_data()->display_name );
-			$this->assertEquals( '3 Example St.', $response->get_data()->address->line1 );
+		$request  = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'tml_00003', $response->get_data()->id );
+		$this->assertEquals( 'New Test Store', $response->get_data()->display_name );
+		$this->assertEquals( '3 Example St.', $response->get_data()->address->line1 );
 
-			remove_filter( 'pre_http_request', $test_request, 10, 3 );
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}
 
 }

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-locations-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-locations-controller.php
@@ -1,0 +1,231 @@
+<?php
+ /**
+  * Class WC_REST_Stripe_Locations_Controller.
+  *
+  * @package WooCommerce_Stripe/Tests/WC_REST_Stripe_Locations_Controller
+  */
+
+ /**
+  * WC_REST_Stripe_Locations_Controller unit tests.
+  *
+  * @runTestsInSeparateProcesses
+  * @preserveGlobalState disabled
+  */
+ class WC_REST_Stripe_Locations_Controller_Test extends WP_UnitTestCase {
+
+ 	/**
+ 	 * Tested REST route.
+ 	 */
+ 	const LOCATIONS_REST_BASE = '/wc/v3/wc_stripe/terminal/locations';
+
+	 public function test_create_location_missing_params_fails() {
+		wp_set_current_user( 1 );
+
+		// Missing display_name or address parameter should be a bad request.
+		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 400, $response->get_status() );
+	}
+
+ 	public function test_create_location_requires_auth() {
+ 		wp_set_current_user( 0 );
+
+ 		// Unauthenticated user should not be able to access route.
+ 		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
+		$request->set_param( 'display_name', 'Test Store' );
+		$request->set_param( 'address', [
+			'line1'       => '1 Example St.',
+			'city'        => 'Example City',
+			'country'     => 'US',
+			'state'       => 'CA',
+			'postal_code' => '12345',
+		] );
+ 		$response = rest_do_request( $request );
+ 		$this->assertEquals( 401, $response->get_status() );
+ 	}
+
+ 	public function test_create_location_success() {
+ 		wp_set_current_user( 1 );
+
+ 		// Mock response from Stripe API using request arguments.
+ 		$test_request = function ( $preempt, $parsed_args, $url ) {
+ 			return [
+ 				'response' => 200,
+ 				'headers'  => [ 'Content-Type' => 'application/json' ],
+ 				'body'     => json_encode(
+ 					[
+ 						'id'           => 'tml_12345678901234567890123',
+ 						'object'       => 'terminal.location',
+ 						'display_name' => $parsed_args['body']['display_name'],
+ 						'address'      => [
+							'line1' => $parsed_args['body']['address']['line1'],
+						]
+ 					]
+ 				),
+ 			];
+ 		};
+ 		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+ 		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE );
+		$request->set_param( 'display_name', 'Test Store' );
+		$request->set_param( 'address', [
+			'line1'       => '1 Example St.',
+		 	'city'        => 'Example City',
+		 	'country'     => 'US',
+		 	'state'       => 'CA',
+		 	'postal_code' => '12345',
+		 ] );
+
+ 		$response = rest_do_request( $request );
+ 		$this->assertEquals( 200, $response->get_status() );
+ 		$this->assertEquals( 'terminal.location', $response->get_data()->object );
+ 		$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
+ 		$this->assertEquals( 'Test Store', $response->get_data()->display_name );
+ 		$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
+
+ 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+ 	}
+
+ 	public function test_update_location_requires_auth() {
+		wp_set_current_user( 0 );
+
+		// Unauthenticated user should not be able to access route.
+		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+ 	public function test_update_location_succeeds() {
+ 		wp_set_current_user( 1 );
+
+ 		// Mock response from Stripe API using request arguments.
+ 		$test_request = function ( $preempt, $parsed_args, $url ) {
+ 			return [
+ 				'response' => 200,
+ 				'headers'  => [ 'Content-Type' => 'application/json' ],
+ 				'body'     => json_encode(
+ 					[
+ 						'id'           => 'tml_12345678901234567890123',
+ 						'object'       => 'terminal.location',
+ 						'display_name' => isset( $parsed_args['body']['display_name'] ) ? $parsed_args['body']['display_name'] : 'Not Changed',
+ 						'address'      => isset( $parsed_args['body']['address'] ) ? $parsed_args['body']['address'] : [ 'line1' => 'Not Changed' ],
+ 					]
+ 				),
+ 			];
+ 		};
+ 		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+ 		$request = new WP_REST_Request( 'POST', self::LOCATIONS_REST_BASE . '/tml_12345' );
+		$request->set_param( 'display_name', 'New Store Name' );
+
+ 		$response = rest_do_request( $request );
+ 		$this->assertEquals( 200, $response->get_status() );
+ 		$this->assertEquals( 'terminal.location', $response->get_data()->object );
+ 		$this->assertEquals( 'tml_12345678901234567890123', $response->get_data()->id );
+ 		$this->assertEquals( 'New Store Name', $response->get_data()->display_name );
+ 		$this->assertEquals( 'Not Changed', $response->get_data()->address->line1 );
+
+ 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+ 	}
+
+ 	public function test_get_store_location_requires_auth() {
+		wp_set_current_user( 0 );
+
+		// Unauthenticated user should not be able to access route.
+		$request = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	 }
+
+ 	public function test_get_store_location_returns_correct_location() {
+ 		wp_set_current_user( 1 );
+
+ 		// Mock response from Stripe API using request arguments.
+ 		$test_request = function ( $preempt, $parsed_args, $url ) {
+			// Mock response for getting existing locations.
+			if ( 'GET' === $parsed_args['method'] ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( [
+						'data' => [
+							[
+								'id'           => 'tml_00001',
+								'display_name' => 'Unused Test Store',
+								'address'      => [
+									'city'        => 'Example City',
+									'country'     => 'US',
+									'line1'       => '2 Example St.',
+									'postal_code' => '12345',
+									'state'       => 'CA',
+								],
+							],
+							[
+								'id'           => 'tml_00002',
+								'display_name' => 'Test Store',
+								'address'      => [
+									'city'        => 'Example City',
+									'country'     => 'US',
+									'line1'       => '1 Example St.',
+									'postal_code' => '12345',
+									'state'       => 'CA',
+								],
+							],
+						]
+					] ),
+				];
+			}
+
+			// Mock response for creating new locations.
+			else {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode(
+						[
+							'id'           => 'tml_00003',
+							'display_name' => 'New Test Store',
+							'address'      => [
+								'city'        => 'Example City',
+								'country'     => 'US',
+								'line1'       => '3 Example St.',
+								'postal_code' => '12345',
+								'state'       => 'CA',
+							],
+						]
+					),
+				];
+			}
+ 		};
+
+ 		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		// Test an existing store, ensure existing location is returned.
+		update_option( 'blogname', 'Test Store' );
+		update_option( 'woocommerce_store_address', '1 Example St.' );
+		update_option( 'woocommerce_store_city', 'Example City' );
+		update_option( 'woocommerce_store_postcode', '12345' );
+		update_option( 'woocommerce_default_country', 'US:CA' );
+
+ 		$request = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+ 		$response = rest_do_request( $request );
+ 		$this->assertEquals( 200, $response->get_status() );
+ 		$this->assertEquals( 'tml_00002', $response->get_data()->id );
+ 		$this->assertEquals( 'Test Store', $response->get_data()->display_name );
+ 		$this->assertEquals( '1 Example St.', $response->get_data()->address->line1 );
+
+		// Test a new store, ensure a new location is returned.
+		update_option( 'blogname', 'New Test Store' );
+		update_option( 'woocommerce_store_address', '3 Example St.' );
+
+ 		$request = new WP_REST_Request( 'GET', self::LOCATIONS_REST_BASE . '/store' );
+ 		$response = rest_do_request( $request );
+ 		$this->assertEquals( 200, $response->get_status() );
+ 		$this->assertEquals( 'tml_00003', $response->get_data()->id );
+ 		$this->assertEquals( 'New Test Store', $response->get_data()->display_name );
+ 		$this->assertEquals( '3 Example St.', $response->get_data()->address->line1 );
+
+ 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+ 	}
+
+ }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -574,18 +574,21 @@ function woocommerce_gateway_stripe() {
 			 */
 			public function register_routes() {
 				/** API includes */
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-base-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/abstracts/abstract-wc-stripe-connect-rest-controller.php';
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-locations-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-init-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-connect-controller.php';
 
-				$oauth_init    = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
-				$oauth_connect = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
+				$locations_controller = new WC_REST_Stripe_Locations_Controller();
+				$oauth_init           = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
+				$oauth_connect        = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
 
+				$locations_controller->register_routes();
 				$oauth_init->register_routes();
 				$oauth_connect->register_routes();
 
 				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-base-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-settings-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
 					require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';


### PR DESCRIPTION
Fixes #2122

## Changes proposed in this Pull Request:

This PR adds support for the following API endpoints for dealing with [terminal locations](https://stripe.com/docs/api/terminal/locations). These endpoints will be used by mobile apps to assign card readers to Stripe locations.

The following endpoints are added:
* `GET /wc/v3/wc_stripe/terminal/locations`: Get all locations
* `POST /wc/v3/wc_stripe/terminal/locations`: Create a new location
* `GET /wc/v3/wc_stripe/terminal/locations/store`: Get the default store location
* `GET /wc/v3/wc_stripe/terminal/locations/<id>`: Get a location
* `POST /wc/v3/wc_stripe/terminal/locations/<id>`: Update a location
* `DELETE /wc/v3/wc_stripe/terminal/locations/<id>`: Delete a location

These endpoints are designed to mimic the behavior of the same endpoints on WCPay, so that the mobile app can easily switch between which payment gateway to use for in-person payments.

One difference between the two: in WCPay, transients are used to cache the location list to avoid making subsequent calls to Stripe for them. This works in part because, since WCPay merchants don't have their own Stripe dashboard, they can't add new locations to Stripe manually and get out of sync. With the Stripe extension, this isn't true, so I didn't implement the transients for now (though I'm open to it if making too many requests to Stripe becomes a problem.)

Known issue:
- In WCPay, the `GET /terminal/locations` endpoint uses Stripe's API to return just the first page of locations. Stripe's API includes a `has_more` property to indicate whether there is an additional page of locations, but since WCPay returns an array of locations, there's no place to include the `has_more` property. This is likely fine for now since the mobile app uses only a single default location, but I think we should eventually update this endpoint to handle pagination and have WCPay do the same for consistency.

## Testing instructions

For making API requests, I found it helpful to install the [Basic Auth](https://github.com/WP-API/Basic-Auth) plugin to my test site so that I could make requests of the form `curl --user username:password 'URL'` to test the endpoints. But other options (e.g. token authentication) are possible for testing these routes.

1. Activate the Stripe extension, add Stripe API credentials to settings.
2. Perform a request to `GET /wc/v3/wc_stripe/terminal/locations`, ensure that you get back an empty list since there are no locations yet.
3. Perform a request to `POST /wc/v3/wc_stripe/terminal/locations` with a JSON payload of `{"display_name": "Test Location 1", "address": {"line1": "1 Example St.", "city": "Example City", "country": "US", "state": "CA", "postal_code": 94111}}`.
4. Verify that you get back a response from Stripe that includes all of the fields listed under the `data` key for "Create Location" in pdfdoF-er-p2. The response will also include an `id` for the terminal location: take note of this for use in future API requests.
5. Visit the Locations page of your Stripe dashboard: https://dashboard.stripe.com/test/terminal/locations
6. Verify that you see the `Test Location 1` location on your dashboard.
7. Perform a request to `GET /wc/v3/wc_stripe/terminal/locations`, ensure that you get back a list with the single location you created in (3). Verify that the response from Stripe includes all of the fields listed under the `data` key for "Get Locations" in pdfdoF-er-p2.
8. Perform a request to `GET /wc/v3/wc_stripe/terminal/locations/<ID>` where `<ID>` is the location ID you took note of in (4). Verify that the response from Stripe includes all of the fields listed under the `data` key for "Get Location" in pdfdoF-er-p2.
9. Perform a request to `POST /wc/v3/wc_stripe/terminal/locations/<ID>` where `<ID>` is the location ID you took note of in (4). Use the JSON payload `{"display_name": "Test Location 2", "address": {"line1": "2 Example St.", "city": "Example City", "country": "US", "state": "CA", "postal_code": 94111}}`. Verify that the response from Stripe includes all of the fields listed under the `data` key for "Update Location" in pdfdoF-er-p2.
10. Go back to your Stripe dashboard. Verify that the location is now called "Test Location 2". Click on the location and verify that the address for the location is now "2 Example St."
11. Perform a request to `DELETE /wc/v3/wc_stripe/terminal/locations/<ID>` where `<ID>` is the location ID you took note of in (4). Verify that the response from Stripe includes all of the fields listed under the `data` key for "Delete Location" in pdfdoF-er-p2.
12. Go back to your Stripe dashboard. Verify that the location is no longer present.
13. Go to WooCommerce settings (`/wp-admin/admin.php?page=wc-settings`) and clear out any address text fields if present.
13. Perform a request to `GET /wc/v3/wc_stripe/terminal/locations/store`.  Verify that the response from Stripe matches the "Missing Store Address" response under "Get Default Location" in pdfdoF-er-p2. 
14. Go back to WooCommerce settings and add an example address.
15. Perform a request to `GET /wc/v3/wc_stripe/terminal/locations/store`.  Verify that the response from Stripe includes the fields listed under the `data` key for "Success" in "Get Default Location" in pdfdoF-er-p2. Verify that the response contains your store's name and the address you added in (14). Take note of the ID of the location given back to you in this step.
16. Check your Stripe dashboard and verify that your store's location is now present there.
17. Perform another request to `GET /wc/v3/wc_stripe/terminal/locations/store`. Verify that the response is the same as the response you got in (15), including the same ID.
18. Check your Stripe dashboard and verify that there's still just the one location there.
19. Change the address for your WooCommerce store.
20. Perform another request to `GET /wc/v3/wc_stripe/terminal/locations/store`. Verify that you now get back a different ID for your new store location.
21. Check your Stripe dashboard and verify that a second location has been added.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
