### PR TITLE
Allow customization of the payment method title

### DIFF
--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -84,6 +84,9 @@ export const usePaymentRequestLocations = makeSettingsHook(
 	EMPTY_ARR
 );
 export const useIsStripeEnabled = makeSettingsHook( 'is_stripe_enabled' );
+export const useTitle = makeSettingsHook( 'title', '' );
+export const useUpeTitle = makeSettingsHook( 'title_upe', '' );
+export const useDescription = makeSettingsHook( 'description', '' );
 export const useTestMode = makeSettingsHook( 'is_test_mode_enabled' );
 export const useSavedCards = makeSettingsHook( 'is_saved_cards_enabled' );
 export const useManualCapture = makeSettingsHook( 'is_manual_capture_enabled' );

--- a/client/settings/payment-settings/__tests__/general-settings-section.test.js
+++ b/client/settings/payment-settings/__tests__/general-settings-section.test.js
@@ -2,7 +2,13 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import GeneralSettingsSection from '../general-settings-section';
-import { useIsStripeEnabled, useTestMode } from 'wcstripe/data';
+import {
+	useIsStripeEnabled,
+	useTestMode,
+	useTitle,
+	useUpeTitle,
+	useDescription,
+} from 'wcstripe/data';
 import {
 	useAccountKeys,
 	useAccountKeysPublishableKey,
@@ -12,10 +18,14 @@ import {
 	useAccountKeysTestSecretKey,
 	useAccountKeysTestWebhookSecret,
 } from 'wcstripe/data/account-keys/hooks';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useIsStripeEnabled: jest.fn(),
 	useTestMode: jest.fn(),
+	useTitle: jest.fn().mockReturnValue( [] ),
+	useUpeTitle: jest.fn().mockReturnValue( [] ),
+	useDescription: jest.fn().mockReturnValue( [] ),
 } ) );
 
 jest.mock( 'wcstripe/data/account-keys/hooks', () => ( {
@@ -108,5 +118,30 @@ describe( 'GeneralSettingsSection', () => {
 			/edit test account keys & webhooks/i
 		);
 		expect( accountKeysModal ).toBeInTheDocument();
+	} );
+
+	it( 'should render gateway title and description fields when UPE is disabled', () => {
+		useTitle.mockReturnValue( [ 'Title', jest.fn() ] );
+		useUpeTitle.mockReturnValue( [ 'UPE title', jest.fn() ] );
+		useDescription.mockReturnValue( [ 'Description', jest.fn() ] );
+
+		render( <GeneralSettingsSection /> );
+
+		expect( screen.getByDisplayValue( 'Title' ) ).toBeInTheDocument();
+		expect( screen.getByDisplayValue( 'Description' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render UPE title field when UPE is enabled', () => {
+		useTitle.mockReturnValue( [ 'Title', jest.fn() ] );
+		useUpeTitle.mockReturnValue( [ 'UPE title', jest.fn() ] );
+		useDescription.mockReturnValue( [ 'Description', jest.fn() ] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
+		expect( screen.getByDisplayValue( 'UPE title' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/payment-settings/__tests__/general-settings-section.test.js
+++ b/client/settings/payment-settings/__tests__/general-settings-section.test.js
@@ -143,5 +143,6 @@ describe( 'GeneralSettingsSection', () => {
 		);
 
 		expect( screen.getByDisplayValue( 'UPE title' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Description' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/settings/payment-settings/general-settings-section.js
+++ b/client/settings/payment-settings/general-settings-section.js
@@ -71,10 +71,15 @@ const GeneralSettingsSection = () => {
 						) }
 					</h4>
 					<Description>
-						{ __(
-							'Enter payment method details that will be displayed at checkout, in the order confirmation screen and in the order notes.',
-							'woocommerce-gateway-stripe'
-						) }
+						{ isUpeEnabled
+							? __(
+									'Enter the payment method name that will be displayed at checkout when there are multiple available payment methods.',
+									'woocommerce-gateway-stripe'
+							  )
+							: __(
+									'Enter payment method details that will be displayed at checkout, in the order confirmation screen and in the order notes.',
+									'woocommerce-gateway-stripe'
+							  ) }
 					</Description>
 					<TextControl
 						label={ __( 'Name', 'woocommerce-gateway-stripe' ) }

--- a/client/settings/payment-settings/general-settings-section.js
+++ b/client/settings/payment-settings/general-settings-section.js
@@ -1,21 +1,42 @@
 import { __ } from '@wordpress/i18n';
-import { React, useState } from 'react';
-import { Button, Card, CheckboxControl } from '@wordpress/components';
+import { React, useState, useContext } from 'react';
+import {
+	Button,
+	Card,
+	CheckboxControl,
+	TextControl,
+} from '@wordpress/components';
 import styled from '@emotion/styled';
 import CardBody from '../card-body';
 import CardFooter from '../card-footer';
 import { AccountKeysModal } from './account-keys-modal';
 import TestModeCheckbox from './test-mode-checkbox';
-import { useTestMode, useIsStripeEnabled } from 'wcstripe/data';
+import {
+	useTestMode,
+	useIsStripeEnabled,
+	useTitle,
+	useUpeTitle,
+	useDescription,
+} from 'wcstripe/data';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 const StyledCard = styled( Card )`
 	margin-bottom: 12px;
 `;
 
+const Description = styled.div`
+	color: #757575;
+	font-size: 12px;
+`;
+
 const GeneralSettingsSection = () => {
 	const [ isTestMode ] = useTestMode();
 	const [ isStripeEnabled, setIsStripeEnabled ] = useIsStripeEnabled();
+	const [ title, setTitle ] = useTitle();
+	const [ upeTitle, setUpeTitle ] = useUpeTitle();
+	const [ description, setDescription ] = useDescription();
 	const [ modalType, setModalType ] = useState( '' );
+	const { isUpeEnabled } = useContext( UpeToggleContext );
 
 	const handleModalDismiss = () => {
 		setModalType( '' );
@@ -43,6 +64,33 @@ const GeneralSettingsSection = () => {
 							'woocommerce-gateway-stripe'
 						) }
 					/>
+					<h4>
+						{ __(
+							'Display settings',
+							'woocommerce-gateway-stripe'
+						) }
+					</h4>
+					<Description>
+						{ __(
+							'Enter payment method details that will be displayed at checkout, in the order confirmation screen and in the order notes.',
+							'woocommerce-gateway-stripe'
+						) }
+					</Description>
+					<TextControl
+						label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
+						value={ isUpeEnabled ? upeTitle : title }
+						onChange={ isUpeEnabled ? setUpeTitle : setTitle }
+					/>
+					{ ! isUpeEnabled && (
+						<TextControl
+							label={ __(
+								'Description',
+								'woocommerce-gateway-stripe'
+							) }
+							value={ description }
+							onChange={ setDescription }
+						/>
+					) }
 					<TestModeCheckbox />
 				</CardBody>
 				<CardFooter>

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/enable-upe-preview-task.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/enable-upe-preview-task.js
@@ -128,7 +128,7 @@ const EnableUpePreviewTask = () => {
 								</li>
 								<li>
 									{ __(
-										'Customers see only payment methods most relevent for them.',
+										'Customers see only payment methods most relevant for them.',
 										'woocommerce-gateway-stripe'
 									) }
 								</li>

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -219,6 +219,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > General */
 				'is_stripe_enabled'                     => $this->gateway->is_enabled(),
 				'is_test_mode_enabled'                  => $this->gateway->is_in_test_mode(),
+				'title'                                 => $this->gateway->get_option( 'title' ),
+				'title_upe'                             => $this->gateway->get_option( 'title_upe' ),
+				'description'                           => $this->gateway->get_option( 'description' ),
 
 				/* Settings > Payments accepted on checkout */
 				'enabled_payment_method_ids'            => $this->gateway->get_upe_enabled_payment_method_ids(),

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -66,6 +66,21 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'title'                            => [
+						'description'       => __( 'Stripe display title.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'string',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'title_upe'                        => [
+						'description'       => __( 'New checkout experience title.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'string',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
+					'description'                      => [
+						'description'       => __( 'Stripe display description.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'string',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 					'enabled_payment_method_ids'       => [
 						'description'       => __( 'Payment method IDs that should be enabled. Other methods will be disabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'array',
@@ -256,6 +271,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	public function update_settings( WP_REST_Request $request ) {
 		/* Settings > General */
 		$this->update_is_stripe_enabled( $request );
+		$this->update_title( $request );
+		$this->update_title_upe( $request );
+		$this->update_description( $request );
 		$this->update_is_test_mode_enabled( $request );
 
 		/* Settings > Payments accepted on checkout */
@@ -296,6 +314,51 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		} else {
 			$this->gateway->disable();
 		}
+	}
+
+	/**
+	 * Updates title.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_title( WP_REST_Request $request ) {
+		$title = $request->get_param( 'title' );
+
+		if ( null === $title ) {
+			return;
+		}
+
+		$this->gateway->update_option( 'title', $title );
+	}
+
+	/**
+	 * Updates UPE title.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_title_upe( WP_REST_Request $request ) {
+		$title_upe = $request->get_param( 'title_upe' );
+
+		if ( null === $title_upe ) {
+			return;
+		}
+
+		$this->gateway->update_option( 'title_upe', $title_upe );
+	}
+
+	/**
+	 * Updates description.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_description( WP_REST_Request $request ) {
+		$description = $request->get_param( 'description' );
+
+		if ( null === $description ) {
+			return;
+		}
+
+		$this->gateway->update_option( 'description', $description );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2145
Fixes #2039

## Changes proposed in this Pull Request:

- Add title, UPE title and description fields according to the design.

## Testing instructions

- Make sure the settings feature flag is enabled.
- Navigate to WooCommerce > Settings > Payments > Stripe.
- Click the settings tab.
- When UPE is enabled, notice there is an input field "Name" with value "Popular payment methods".
- When UPE is disabled, notice there are two fields for the credit card gateway display: "Name" and "Description", similar to other payment methods such as Alipay.
- Try updating the name and description fields both with UPE enabled and disabled, and notice the old value is preserved, fixing #2039.
- As a shopper, go to the checkout page and notice the gateway name and description are changed.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
