### PR TITLE
Update documentation links

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -218,7 +218,7 @@ class WC_Stripe_Admin_Notices {
 
 			if ( 'yes' === $changed_keys_notice ) {
 				// translators: %s is a the URL for the link.
-				$this->add_admin_notice( 'changed_keys', 'notice notice-warning', sprintf( __( 'The public and/or secret keys for the Stripe gateway have been changed. This might cause errors for existing customers and saved payment methods. <a href="%s" target="_blank">Click here to learn more</a>.', 'woocommerce-gateway-stripe' ), 'https://docs.woocommerce.com/document/stripe-fixing-customer-errors/' ), true );
+				$this->add_admin_notice( 'changed_keys', 'notice notice-warning', sprintf( __( 'The public and/or secret keys for the Stripe gateway have been changed. This might cause errors for existing customers and saved payment methods. <a href="%s" target="_blank">Click here to learn more</a>.', 'woocommerce-gateway-stripe' ), 'https://woocommerce.com/document/stripe-fixing-customer-errors' ), true );
 			}
 		}
 	}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -138,7 +138,7 @@ class WC_Stripe_Admin_Notices {
 
 			if ( empty( $show_style_notice ) ) {
 				/* translators: 1) int version 2) int version */
-				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://docs.woocommerce.com/document/stripe/#styling" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );
+				$message = __( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">instructions</a> to fix.', 'woocommerce-gateway-stripe' );
 
 				$this->add_admin_notice( 'style', 'notice notice-warning', $message, true );
 

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -157,7 +157,7 @@ class WC_Stripe_Inbox_Notes {
 			$note->add_action(
 				'learn-more',
 				__( 'Learn more', 'woocommerce-gateway-stripe' ),
-				'https://docs.woocommerce.com/document/stripe/#apple-pay'
+				'https://woocommerce.com/document/stripe/#apple-pay'
 			);
 			$note->save();
 		} catch ( Exception $e ) {} // @codingStandardsIgnoreLine.

--- a/includes/admin/class-wc-stripe-privacy.php
+++ b/includes/admin/class-wc-stripe-privacy.php
@@ -90,7 +90,7 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 	 */
 	public function get_privacy_message() {
 		/* translators: %s URL to docs */
-		return wpautop( sprintf( __( 'By using this extension, you may be storing personal data or sharing data with an external service. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-gateway-stripe' ), 'https://docs.woocommerce.com/document/privacy-payments/#woocommerce-gateway-stripe' ) );
+		return wpautop( sprintf( __( 'By using this extension, you may be storing personal data or sharing data with an external service. <a href="%s" target="_blank">Learn more about how this works, including what you may want to include in your privacy policy.</a>', 'woocommerce-gateway-stripe' ), 'https://woocommerce.com/document/privacy-payments/#section-3' ) );
 	}
 
 	/**

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -261,7 +261,7 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 				__( 'Try the new payment experience (Early access) %1$sGet early access to a new, smarter payment experience on checkout and let us know what you think by %2$s. We recommend this feature for experienced merchants as the functionality is currently limited. %3$s', 'woocommerce-gateway-stripe' ),
 				'<br />',
 				'<a href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" target="_blank">submitting your feedback</a>',
-				'<a href="https://docs.woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">Learn more</a>'
+				'<a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">Learn more</a>'
 			),
 			'type'        => 'checkbox',
 			'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),

--- a/languages/woocommerce-gateway-stripe.pot
+++ b/languages/woocommerce-gateway-stripe.pot
@@ -122,7 +122,7 @@ msgstr ""
 
 #. translators: 1) int version 2) int version
 #: includes/admin/class-wc-stripe-admin-notices.php:141
-msgid "WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href=\"https://docs.woocommerce.com/document/stripe/#styling\" target=\"_blank\">instructions</a> to fix."
+msgid "WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these <a href=\"https://woocommerce.com/document/stripe/#new-checkout-experience\" target=\"_blank\">instructions</a> to fix."
 msgstr ""
 
 #. translators: 1) int version 2) int version

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ Yes, it does - production and Test (sandbox) mode is driven by the API keys you 
 
 = Where can I find documentation? =
 
-For help setting up and configuring, please refer to our [documentation](https://docs.woocommerce.com/document/stripe/).
+For help setting up and configuring, please refer to our [documentation](https://woocommerce.com/document/stripe/).
 
 = Where can I get support or talk to other users? =
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -355,7 +355,7 @@ function woocommerce_gateway_stripe() {
 			public function plugin_row_meta( $links, $file ) {
 				if ( plugin_basename( __FILE__ ) === $file ) {
 					$row_meta = [
-						'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_stripe_docs_url', 'https://docs.woocommerce.com/document/stripe/' ) ) . '" title="' . esc_attr( __( 'View Documentation', 'woocommerce-gateway-stripe' ) ) . '">' . __( 'Docs', 'woocommerce-gateway-stripe' ) . '</a>',
+						'docs'    => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_stripe_docs_url', 'https://woocommerce.com/document/stripe/' ) ) . '" title="' . esc_attr( __( 'View Documentation', 'woocommerce-gateway-stripe' ) ) . '">' . __( 'Docs', 'woocommerce-gateway-stripe' ) . '</a>',
 						'support' => '<a href="' . esc_url( apply_filters( 'woocommerce_gateway_stripe_support_url', 'https://woocommerce.com/my-account/create-a-ticket?select=18627' ) ) . '" title="' . esc_attr( __( 'Open a support request at WooCommerce.com', 'woocommerce-gateway-stripe' ) ) . '">' . __( 'Support', 'woocommerce-gateway-stripe' ) . '</a>',
 					];
 					return array_merge( $links, $row_meta );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2149
* Redirects documentation links from `docs.woocommerce.com` to `woocommerce.com/document`.

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR updates all of the documentation links so that they are directed to `woocommerce.com/document`. Additionally, it addresses some links that were not properly connected (e.g. `https://woocommerce.com/document/stripe/#styling` and `https://woocommerce.com/document/privacy-payments/#woocommerce-gateway-stripe`).

It should be noted that tests were not added for this minor update. Although, the newly updated links should be manually tested for proper connectivity (see testing instructions below).

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

**Desired URL: `https://woocommerce.com/document/stripe`**
1. In the `readme.txt`, ensure the `documentation` link goes to the desired URL.
2. In `wp-admin > Plugins`, look for the `WooCommerce Stripe Gateway` plugin, and ensure the `Docs` link goes to the desired URL.

**Desired URL: `https://woocommerce.com/document/stripe-fixing-customer-errors`**
1. In `wp-admin > WooCommerce > Settings`, update `Test Publishable Key`, find the new notice at the top (see image below) of the page, and ensure the `Click here to learn more` link goes to the desired URL.
![image](https://user-images.githubusercontent.com/6844516/142059149-b59b1db3-81b7-4bc8-95bf-bc3086f6e3f9.png)

**Desired URL: `https://woocommerce.com/document/stripe/#new-checkout-experience`**
1. In `wp-admin > WooCommerce > Settings`, look for `New checkout experience` field, and ensure `Learn more` link goes to the desired URL.

**Desired URL: `https://woocommerce.com/document/privacy-payments/#section-3`**
1. In `wp-admin > Settings > Privacy`, `Policy Guide` tab (at the top), open the `Stripe` accordion element (see image below), and ensure the `Learn more about how this works, including what you may want to include in your privacy policy` link goes to the desired URL.

![image](https://user-images.githubusercontent.com/6844516/142066933-4f0e126b-36cb-406d-8ed0-f431d6ad565f.png)

**Desired URL: `https://woocommerce.com/document/stripe/#apple-pay`**
1. This URL seems to be only testable on a live account when verifying if a domain is configured to Stripe correctly.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
