### PR TITLE
Add requires currency notice in onboarding and APMs

### DIFF
--- a/client/components/payment-method-missing-currency-pill/__tests__/index.test.js
+++ b/client/components/payment-method-missing-currency-pill/__tests__/index.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import PaymentMethodMissingCurrencyPill from '..';
-import UpeToggleContext from '../../../settings/upe-toggle/context';
 
 jest.mock( '../../../payment-methods-map', () => ( {
 	card: { currencies: [] },
@@ -15,39 +14,16 @@ describe( 'PaymentMethodMissingCurrencyPill', () => {
 
 	it( 'should render the "Requires currency" text', () => {
 		render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<PaymentMethodMissingCurrencyPill
-					id="giropay"
-					label="giropay"
-				/>
-			</UpeToggleContext.Provider>
+			<PaymentMethodMissingCurrencyPill id="giropay" label="giropay" />
 		);
 
 		expect( screen.queryByText( 'Requires currency' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should not render when UPE is disabled', () => {
-		const { container } = render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
-				<PaymentMethodMissingCurrencyPill
-					id="giropay"
-					label="giropay"
-				/>
-			</UpeToggleContext.Provider>
-		);
-
-		expect( container.firstChild ).toBeNull();
-	} );
-
 	it( 'should not render when currency matches', () => {
 		global.wcSettings = { currency: { code: 'EUR' } };
 		const { container } = render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<PaymentMethodMissingCurrencyPill
-					id="giropay"
-					label="giropay"
-				/>
-			</UpeToggleContext.Provider>
+			<PaymentMethodMissingCurrencyPill id="giropay" label="giropay" />
 		);
 
 		expect( container.firstChild ).toBeNull();
@@ -55,12 +31,7 @@ describe( 'PaymentMethodMissingCurrencyPill', () => {
 
 	it( 'should render when currency differs', () => {
 		render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<PaymentMethodMissingCurrencyPill
-					id="giropay"
-					label="giropay"
-				/>
-			</UpeToggleContext.Provider>
+			<PaymentMethodMissingCurrencyPill id="giropay" label="giropay" />
 		);
 
 		expect( screen.queryByText( 'Requires currency' ) ).toBeInTheDocument();

--- a/client/components/payment-method-missing-currency-pill/index.js
+++ b/client/components/payment-method-missing-currency-pill/index.js
@@ -1,10 +1,9 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
-import React, { useContext } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import PaymentMethodsMap from '../../payment-methods-map';
 import Pill from 'wcstripe/components/pill';
 import Tooltip from 'wcstripe/components/tooltip';
-import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 const StyledPill = styled( Pill )`
 	border: 1px solid #f0b849;
@@ -14,13 +13,8 @@ const StyledPill = styled( Pill )`
 `;
 
 const PaymentMethodMissingCurrencyPill = ( { id, label } ) => {
-	const { isUpeEnabled } = useContext( UpeToggleContext );
 	const paymentMethodCurrencies = PaymentMethodsMap[ id ]?.currencies || [];
 	const storeCurrency = window?.wcSettings?.currency?.code;
-
-	if ( ! isUpeEnabled ) {
-		return null;
-	}
 
 	if (
 		id !== 'card' &&

--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -98,4 +98,37 @@ export default {
 		currencies: [ 'EUR', 'PLN' ],
 		capability: 'p24_payments',
 	},
+	alipay: {
+		id: 'alipay',
+		label: __( 'Alipay', 'woocommerce-gateway-stripe' ),
+		description: __(
+			'Alipay is a popular wallet in China, operated by Ant Financial Services Group, a financial services provider affiliated with Alibaba.',
+			'woocommerce-gateway-stripe'
+		),
+		Icon: () => null,
+		currencies: [
+			'AUD',
+			'CAD',
+			'CNY',
+			'EUR',
+			'GBP',
+			'HKD',
+			'JPY',
+			'MYR',
+			'NZD',
+			'USD',
+		],
+		capability: undefined,
+	},
+	multibanco: {
+		id: 'multibanco',
+		label: __( 'Multibanco', 'woocommerce-gateway-stripe' ),
+		description: __(
+			'Multibanco is an interbank network that links the ATMs of all major banks in Portugal, allowing customers to pay through either their ATM or online banking environment.',
+			'woocommerce-gateway-stripe'
+		),
+		Icon: () => null,
+		currencies: [ 'EUR' ],
+		capability: undefined,
+	},
 };

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -13,6 +13,7 @@ import styled from '@emotion/styled';
 import CardBody from '../card-body';
 import { gatewaysInfo } from '../payment-gateway-manager/constants';
 import LoadablePaymentGatewaySection from '../loadable-payment-gateway-section';
+import PaymentMethodMissingCurrencyPill from '../../components/payment-method-missing-currency-pill';
 import { useAccount } from '../../data/account/hooks';
 import useWebhookStateMessage from '../account-details/use-webhook-state-message';
 import {
@@ -68,6 +69,10 @@ const PaymentGatewaySection = () => {
 								) }
 
 								<PaymentMethodCapabilityStatusPill
+									id={ info.id }
+									label={ info.title }
+								/>
+								<PaymentMethodMissingCurrencyPill
 									id={ info.id }
 									label={ info.title }
 								/>

--- a/client/upe-onboarding-wizard/upe-preview-methods-selector/payment-method-checkbox/index.js
+++ b/client/upe-onboarding-wizard/upe-preview-methods-selector/payment-method-checkbox/index.js
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import React from 'react';
 import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
+import PaymentMethodMissingCurrencyPill from '../../../components/payment-method-missing-currency-pill';
 import PaymentMethodIcon from 'wcstripe/settings/payment-method-icon';
 import Tooltip from 'wcstripe/components/tooltip';
 import paymentMethodsMap from 'wcstripe/payment-methods-map';
@@ -53,6 +54,7 @@ const PaymentMethodCheckbox = ( { onChange, id, checked = false } ) => {
 	const label = useMemo( () => <PaymentMethodIcon name={ id } showName />, [
 		id,
 	] );
+	const pillLabel = paymentMethodsMap[ id ]?.label;
 
 	return (
 		<li className="payment-method-checkbox">
@@ -64,7 +66,11 @@ const PaymentMethodCheckbox = ( { onChange, id, checked = false } ) => {
 				/>
 				<PaymentMethodCapabilityStatusPill
 					id={ id }
-					label={ paymentMethodsMap[ id ]?.label }
+					label={ pillLabel }
+				/>
+				<PaymentMethodMissingCurrencyPill
+					id={ id }
+					label={ pillLabel }
 				/>
 			</div>
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -91,7 +91,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->id           = self::ID;
 		$this->method_title = __( 'Stripe', 'woocommerce-gateway-stripe' );
 		/* translators: link */
-		$this->method_description = __( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay.', 'woocommerce-gateway-stripe' );
+		$this->method_description = __( 'Accept debit and credit cards in 135+ currencies, methods such as SEPA, and one-touch checkout with Apple Pay.', 'woocommerce-gateway-stripe' );
 		$this->has_fields         = true;
 		$this->supports           = [
 			'products',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2151 

## Changes proposed in this Pull Request:

This PR adds the missing currency pill in two more places: in the new checkout experience onboarding and in the APM page, which attends for both non-UPE methods and UPE methods when the new checkout experience is disabled.

It also removes the UPE condition within the pill that determined whether the pill should render or not. Since we're displaying the pill in the non-UPE methods too, it doesn't make sense to impose that condition. The tests were updated accordingly. 

It also includes two new payment methods in the payment method mapper: Alipay and Multibanco. They were not available because we were looking after UPE methods only.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Make sure the new settings feature flag is enabled: `_wcstripe_feature_upe_settings` option set to yes.
2. Disable UPE.
3. Set your store currency to USD. 
4. Go to a non-UPE payment method page (e.g. Multibanco (EUR) – Alipay is harder to test because it supports many currencies, including USD and EUR).
5. You should see the notice near to the Enable checkbox.
<img width="1062" alt="Screen Shot 2021-11-15 at 20 26 43" src="https://user-images.githubusercontent.com/10233985/141875342-ddcd1dc6-ba36-47e3-af48-11a5f28d2707.png">

6. Go to a UPE payment method page (e.g. SEPA).
7. You should see the notice near to the Enable checkbox.
<img width="1055" alt="Screen Shot 2021-11-15 at 20 36 46" src="https://user-images.githubusercontent.com/10233985/141875347-f19e7e42-774b-46e2-85c0-953070e98771.png">

8. Try to enable the new checkout experience in any opt-in banner and you will be led to the onboarding.
9. Enable it.
10. In the second step, you should see the notice in the payment method list.
<img width="641" alt="Screen Shot 2021-11-15 at 20 25 54" src="https://user-images.githubusercontent.com/10233985/141875335-4b064349-c299-42a2-82b7-f15a72c0b0f1.png">
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

## Notes

- This branch is based on #2143's branch and it will contain duplicate code, for this reason, it must be reviewed and merged after #2143 gets merged into the release branch.
- The behavior can be tested, tho. It should work regardless of #2143's work.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
