### PR TITLE
Add REST API to create customer for an order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Fix - Stripe JS is no longer loaded on cart and product pages when PRBs are disabled on those pages.
 * Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
-* Add - Add Stripe API to generate connection tokens, manage terminal locations.
+* Add - Add Stripe API to generate connection tokens, manage terminal locations, create customers.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -90,7 +90,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 				$customer_id = $customer->create_customer( $customer_data );
 			}
 		} catch ( WC_Stripe_Exception $e ) {
-			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+			return new WP_Error( 'stripe_error', $e->getMessage() );
 		}
 
 		$order->update_meta_data( '_stripe_customer_id', $customer_id );

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Class WC_REST_Stripe_Orders_Controller
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST controller for orders.
+ */
+class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'wc_stripe/orders';
+
+	/**
+	 * Stripe payment gateway.
+	 *
+	 * @var WC_Gateway_Stripe
+	 */
+	private $gateway;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Gateway_Stripe $gateway Stripe payment gateway.
+	 */
+	public function __construct( WC_Gateway_Stripe $gateway ) {
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Configure REST API routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<order_id>\d+)/create_customer',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create_customer' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
+	}
+
+	/**
+	 * Create a Stripe customer for an order if needed, or return existing customer.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 */
+	public function create_customer( $request ) {
+		$order_id = $request['order_id'];
+
+		// Ensure order exists.
+		$order = wc_get_order( $order_id );
+		if ( false === $order || ! ( $order instanceof WC_Order ) ) {
+			return new WP_Error( 'wc_stripe', __( 'Order not found', 'woocommerce-gateway-stripe' ), [ 'status' => 404 ] );
+		}
+
+		// Validate order status before creating customer.
+		$disallowed_order_statuses = apply_filters( 'wc_stripe_create_customer_disallowed_order_statuses', [ 'completed', 'cancelled', 'refunded', 'failed' ] );
+		if ( $order->has_status( $disallowed_order_statuses ) ) {
+			return new WP_Error( 'wc_stripe_invalid_order_status', __( 'Invalid order status', 'woocommerce-gateway-stripe' ), [ 'status' => 400 ] );
+		}
+
+		// Get a customer object with the order's user, if available.
+		$order_user = $order->get_user();
+		if ( false === $order_user ) {
+			$order_user = new WP_User();
+		}
+		$customer = new WC_Stripe_Customer( $order_user->ID );
+
+		// Set the customer ID if known but not already set.
+		$customer_id = $this->gateway->get_stripe_customer_id( $order );
+		if ( ! $customer->get_id() && $customer_id ) {
+			$customer->set_id( $customer_id );
+		}
+
+		try {
+			// Update or create Stripe customer.
+			$customer_data = WC_Stripe_Customer::map_customer_data( $order );
+			if ( $customer->get_id() ) {
+				$customer_id = $customer->update_customer( $customer_data );
+			} else {
+				$customer_id = $customer->create_customer( $customer_data );
+			}
+		} catch ( WC_Stripe_Exception $e ) {
+			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
+		}
+
+		$order->update_meta_data( '_stripe_customer_id', $customer_id );
+		$order->save();
+
+		return rest_ensure_response( [ 'id' => $customer_id ] );
+	}
+}

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -76,7 +76,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 		$customer = new WC_Stripe_Customer( $order_user->ID );
 
 		// Set the customer ID if known but not already set.
-		$customer_id = $this->gateway->get_stripe_customer_id( $order );
+		$customer_id = $order->get_meta( '_stripe_customer_id', true );
 		if ( ! $customer->get_id() && $customer_id ) {
 			$customer->set_id( $customer_id );
 		}

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Class WC_REST_Stripe_Orders_Controller.
+ *
+ * @package WooCommerce_Stripe/Tests/WC_REST_Stripe_Orders_Controller
+ */
+
+/**
+ * WC_REST_Stripe_Orders_Controller unit tests.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * Tested REST route.
+	 */
+	const ORDERS_REST_BASE = '/wc/v3/wc_stripe/orders';
+
+	public function test_create_customer_requires_auth() {
+		wp_set_current_user( 0 );
+
+		// Unauthenticated user should not be able to access route.
+		$request = new WP_REST_Request( 'POST', self::ORDERS_REST_BASE . '/1/create_customer' );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	public function test_create_customer_invalid_order_fails() {
+		wp_set_current_user( 1 );
+
+		$request = new WP_REST_Request( 'POST', self::ORDERS_REST_BASE . '/1/create_customer' );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	public function test_create_customer_guest_order() {
+		wp_set_current_user( 1 );
+
+		$order    = WC_Helper_Order::create_order();
+		$endpoint = '/' . strval( $order->get_id() ) . '/create_customer';
+
+		// Mock response from Stripe API using request arguments.
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			// If request is for updating customer, return existing ID; otherwise return 'cus_new'.
+			$matches = [];
+			preg_match( '/customers\/(\d+)/', $url, $matches );
+			$customer_id = $matches ? $matches[1] : 'cus_new';
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id' => $customer_id,
+					]
+				),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$request  = new WP_REST_Request( 'POST', self::ORDERS_REST_BASE . $endpoint );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'cus_new', $response->get_data()['id'] );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
+
+	public function test_create_customer_with_existing_id() {
+		wp_set_current_user( 1 );
+
+		$order    = WC_Helper_Order::create_order();
+		$endpoint = '/' . strval( $order->get_id() ) . '/create_customer';
+		$order->add_meta_data( '_stripe_customer_id', 'cus_12345', true );
+		$order->save();
+		$this->assertEquals( 'cus_12345', $order->get_meta( '_stripe_customer_id', true ) );
+
+		// Mock response from Stripe API using request arguments.
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			// If request is for updating customer, return existing ID; otherwise return 'cus_new'.
+			$matches = [];
+			preg_match( '/customers\/(\d+)/', $url, $matches );
+			$customer_id = $matches ? $matches[1] : 'cus_new';
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode(
+					[
+						'id' => $customer_id,
+					]
+				),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$request  = new WP_REST_Request( 'POST', self::ORDERS_REST_BASE . $endpoint );
+		$response = rest_do_request( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'cus_12345', $response->get_data()['id'] );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
+}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -578,16 +578,19 @@ function woocommerce_gateway_stripe() {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/abstracts/abstract-wc-stripe-connect-rest-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-connection-tokens-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-locations-controller.php';
+				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-orders-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-init-controller.php';
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/connect/class-wc-stripe-connect-rest-oauth-connect-controller.php';
 
 				$connection_tokens_controller = new WC_REST_Stripe_Connection_Tokens_Controller( $this->get_main_stripe_gateway() );
 				$locations_controller         = new WC_REST_Stripe_Locations_Controller();
+				$orders_controller            = new WC_REST_Stripe_Orders_Controller( $this->get_main_stripe_gateway() );
 				$oauth_init                   = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
 				$oauth_connect                = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
 
 				$connection_tokens_controller->register_routes();
 				$locations_controller->register_routes();
+				$orders_controller->register_routes();
 				$oauth_init->register_routes();
 				$oauth_connect->register_routes();
 


### PR DESCRIPTION
Fixes #2124

## Changes proposed in this Pull Request:

For Stripe Terminal in-person payments, the Stripe extension needs a REST API to create a new Stripe customer (or updating an existing Stripe customer) for a given WooCommerce order. This PR adds a `wc/v3/wc_stripe/orders/<order_id>/create_customer` endpoint to handle customer creation.

## Testing instructions

For making API requests, I found it helpful to install the [Basic Auth](https://github.com/WP-API/Basic-Auth) plugin to my test site so that I could make requests of the form `curl -X POST --user username:password 'http://YOUR_SITE/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer'` to test the endpoint (replacing `YOUR_SITE` with your test site and `ORDER_ID` with the order you're testing.

### Test 1: Guest User

1.  Go to `/wp-admin/post-new.php?post_type=shop_order` and create a new order. Leave the customer as "Guest", but fill in a billing name, address, and email address. Click "Create."
2. Take note of the order ID.
3. Submit a POST request to the `/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer` endpoint, with the order ID you took note in (2) as the order ID.
4. Verify that you get back a customer ID beginning with `cus_`. Take note of this customer ID.
5. Go to your Stripe dashboard. Visit the Customers page (https://dashboard.stripe.com/test/customers) and check that your customer was created. Click on the customer and verify that the name, billing details, and email address all match what you entered in (1). Verify that the customer ID matches the one you took note of in (4).
6. Check the `wp_postmeta` table in your database, and look for a row with `post_id` matching the order ID from (2) and a `meta_key` of `_stripe_customer_id`. Verify that the value matches the customer ID that you saw in (4).
7. Make another identical request to `/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer`, again with the same order ID you took note of in (2).
8. Verify that you get back the same customer ID as before.

### Test 2: Registered Customer, No Existing Stripe Customer ID

1. Go to `/wp-admin/user-new.php` and create a new user. Take note of the user ID.
2. Go to `/wp-admin/post-new.php?post_type=shop_order` and create a new order. Set the customer to the user you created in (1), but fill in a billing name, address, and email address. Click "Create."
3. Take note of the order ID.
4. Submit a POST request to the `/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer` endpoint, with the order ID you took note in (3) as the order ID.
5. Verify that you get back a customer ID beginning with `cus_`. Take note of this customer ID.
6. Go to your Stripe dashboard. Verify that the customer is created, has the correct billing information, and has a customer ID that matches what you saw in (5).
7. Check the `wp_postmeta` table for the `_stripe_customer_id` for the order. Verify that it matches the customer ID from (5).
8. Check the `wp_usermeta` table for the user ID from (1) and look for the `wp__stripe_customer_id` meta key. Verify that it matches the customer ID from (5).
9. Make another identical request to `/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer`.
10. Verify that you get back the same customer ID as before.

### Test 3: Registered Customer, Existing Stripe Customer ID

1. Go to `/wp-admin/user-new.php` and create a new user. Take note of the user ID.
2. In another browsing session, sign in to your test site with the user you created in (1). Make a purchase and pay using Stripe and a test card number.
3. Go back to your Stripe dashboard. Check for the customer that was created for your new user and take note of their customer ID.
4. Go to `/wp-admin/post-new.php?post_type=shop_order` and create a new order. Set the customer to the user you created in (1) and click "Create."
5. Take note of the order ID.
6. Submit a POST request to the `/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer` endpoint, with the order ID you took note in (5) as the order ID.
7. Verify that the customer ID you get back matches the one you saw in (3).
8. Check the `wp_postmeta` table for the `_stripe_customer_id` for the order. Verify that it matches the customer ID from (3).

### Test 4: Order Has Invalid Status

1. Go to `/edit.php?post_type=shop_order` and choose any order that is "Completed", "Cancelled", "Refunded", or "Failed" (if no orders match this criterion, create a new order that does). Take note of the order ID.
2. Submit a POST request to the `/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer` endpoint, with the order ID you took note in (1) as the order ID.
3. Verify that you get back an error indicating that the order status is not valid.

### Test 5: Order Does Not Exist

1. Choose an order ID that does not exist in your store. Submit a POST request to the `/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/create_customer` endpoint, with that order ID.
2. Verify that you get back an error indicating that the order was not found.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
