### PR TITLE
Reload page while keeping "Disconnect Stripe account" modal open after submit

### DIFF
--- a/client/settings/loadable-account-section.js
+++ b/client/settings/loadable-account-section.js
@@ -3,15 +3,21 @@ import { LoadableBlock } from '../components/loadable';
 import { useAccount } from 'wcstripe/data/account/hooks';
 import { useAccountKeys } from 'wcstripe/data/account-keys/hooks';
 
-const LoadableAccountSection = ( { children, numLines } ) => {
+const LoadableAccountSection = ( {
+	children,
+	numLines,
+	keepContent = false,
+} ) => {
 	const { isLoading: isAccountLoading } = useAccount();
 	const { isLoading: areAccountKeysLoading } = useAccountKeys();
+	let isLoading = areAccountKeysLoading || isAccountLoading;
+
+	if ( keepContent ) {
+		isLoading = false;
+	}
 
 	return (
-		<LoadableBlock
-			isLoading={ areAccountKeysLoading || isAccountLoading }
-			numLines={ numLines }
-		>
+		<LoadableBlock isLoading={ isLoading } numLines={ numLines }>
 			{ children }
 		</LoadableBlock>
 	);

--- a/client/settings/payment-settings/__tests__/disconnect-stripe-confirmation-modal.test.js
+++ b/client/settings/payment-settings/__tests__/disconnect-stripe-confirmation-modal.test.js
@@ -18,10 +18,12 @@ jest.mock( 'wcstripe/data/account-keys/hooks', () => ( {
 
 describe( 'DisconnectStripeConfirmationModal', () => {
 	const windowLocation = window.location;
-	let handleCloseMock, saveAccountKeysMock;
+	let handleCloseMock, saveAccountKeysMock, setKeepModalContentMock;
 
 	beforeEach( () => {
 		handleCloseMock = jest.fn();
+		setKeepModalContentMock = jest.fn();
+
 		saveAccountKeysMock = jest
 			.fn()
 			.mockImplementation( () => Promise.resolve() );
@@ -44,7 +46,10 @@ describe( 'DisconnectStripeConfirmationModal', () => {
 
 	it( 'should render the message for confirmation', () => {
 		render(
-			<DisconnectStripeConfirmationModal onClose={ handleCloseMock } />
+			<DisconnectStripeConfirmationModal
+				onClose={ handleCloseMock }
+				setKeepModalContent={ setKeepModalContentMock }
+			/>
 		);
 
 		expect(
@@ -64,7 +69,10 @@ describe( 'DisconnectStripeConfirmationModal', () => {
 
 	it( 'should call onClose when the action is cancelled', () => {
 		render(
-			<DisconnectStripeConfirmationModal onClose={ handleCloseMock } />
+			<DisconnectStripeConfirmationModal
+				onClose={ handleCloseMock }
+				setKeepModalContent={ setKeepModalContentMock }
+			/>
 		);
 
 		expect( handleCloseMock ).not.toHaveBeenCalled();
@@ -74,16 +82,24 @@ describe( 'DisconnectStripeConfirmationModal', () => {
 		expect( handleCloseMock ).toHaveBeenCalled();
 	} );
 
-	it( 'should disconnect the account and close the modal', () => {
+	it( 'should disconnect the account and reload the page', async () => {
 		render(
-			<DisconnectStripeConfirmationModal onClose={ handleCloseMock } />
+			<DisconnectStripeConfirmationModal
+				onClose={ handleCloseMock }
+				setKeepModalContent={ setKeepModalContentMock }
+			/>
 		);
 
 		expect( handleCloseMock ).not.toHaveBeenCalled();
 		expect( saveAccountKeysMock ).not.toHaveBeenCalled();
+		expect( setKeepModalContentMock ).not.toHaveBeenCalled();
 
 		userEvent.click( screen.getByRole( 'button', { name: 'Disconnect' } ) );
 
-		expect( saveAccountKeysMock ).toHaveBeenCalled();
+		await expect( saveAccountKeysMock ).toHaveBeenCalled();
+
+		expect( handleCloseMock ).not.toHaveBeenCalled();
+		expect( window.location.reload ).toHaveBeenCalled();
+		expect( setKeepModalContentMock ).toHaveBeenCalled();
 	} );
 } );

--- a/client/settings/payment-settings/disconnect-stripe-confirmation-modal.js
+++ b/client/settings/payment-settings/disconnect-stripe-confirmation-modal.js
@@ -1,14 +1,21 @@
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@wordpress/components';
 import ConfirmationModal from 'wcstripe/components/confirmation-modal';
 import AlertTitle from 'wcstripe/components/confirmation-modal/alert-title';
 import { useAccountKeys } from 'wcstripe/data/account-keys/hooks';
 
-const DisconnectStripeConfirmationModal = ( { onClose } ) => {
+const DisconnectStripeConfirmationModal = ( {
+	onClose,
+	setKeepModalContent,
+} ) => {
 	const { saveAccountKeys } = useAccountKeys();
+	const [ status, setStatus ] = useState( false );
 
-	const handleDisconnect = () => {
+	const handleDisconnect = async () => {
+		setStatus( 'pending' );
+		setKeepModalContent( true );
+
 		const accountKeys = {
 			publishable_key: '',
 			secret_key: '',
@@ -17,7 +24,9 @@ const DisconnectStripeConfirmationModal = ( { onClose } ) => {
 			test_secret_key: '',
 			test_webhook_secret: '',
 		};
-		saveAccountKeys( accountKeys );
+		await saveAccountKeys( accountKeys );
+
+		window.location.reload();
 	};
 
 	return (
@@ -31,7 +40,14 @@ const DisconnectStripeConfirmationModal = ( { onClose } ) => {
 						) }
 					/>
 				}
-				onRequestClose={ onClose }
+				onRequestClose={ () => {
+					// Do not allow to close the modal after clicking the "Disconnect" button
+					if ( status === 'pending' ) {
+						return;
+					}
+
+					onClose();
+				} }
 				actions={
 					<>
 						<Button

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -80,7 +80,10 @@ const PaymentsAndTransactionsDescription = () => (
 );
 
 // @todo - remove setModalType as prop
-const AccountSettingsDropdownMenu = ( { setModalType } ) => {
+const AccountSettingsDropdownMenu = ( {
+	setModalType,
+	setKeepModalContent,
+} ) => {
 	// @todo - deconstruct setModalType from useModalType custom hook
 	const [ isTestModeEnabled ] = useTestMode();
 	const [
@@ -102,13 +105,11 @@ const AccountSettingsDropdownMenu = ( { setModalType } ) => {
 							'Edit account keys',
 							'woocommerce-gateway-stripe'
 						),
-						// eslint-disable-next-line no-console
 						onClick: () =>
 							setModalType( isTestModeEnabled ? 'test' : 'live' ),
 					},
 					{
 						title: __( 'Disconnect', 'woocommerce-gateway-stripe' ),
-						// eslint-disable-next-line no-console
 						onClick: () => setIsConfirmationModalVisible( true ),
 					},
 				] }
@@ -116,6 +117,7 @@ const AccountSettingsDropdownMenu = ( { setModalType } ) => {
 			{ isConfirmationModalVisible && (
 				<DisconnectStripeConfirmationModal
 					onClose={ () => setIsConfirmationModalVisible( false ) }
+					setKeepModalContent={ setKeepModalContent }
 				/>
 			) }
 		</>
@@ -123,7 +125,7 @@ const AccountSettingsDropdownMenu = ( { setModalType } ) => {
 };
 
 // @todo - remove setModalType as prop
-const AccountDetailsSection = ( { setModalType } ) => {
+const AccountDetailsSection = ( { setModalType, setKeepModalContent } ) => {
 	const [ isTestModeEnabled ] = useTestMode();
 	const { data } = useAccount();
 
@@ -142,7 +144,10 @@ const AccountDetailsSection = ( { setModalType } ) => {
 						</Pill>
 					) }
 				</div>
-				<AccountSettingsDropdownMenu setModalType={ setModalType } />
+				<AccountSettingsDropdownMenu
+					setModalType={ setModalType }
+					setKeepModalContent={ setKeepModalContent }
+				/>
 			</CardHeader>
 			<CardBody>
 				<AccountStatus />
@@ -154,6 +159,7 @@ const AccountDetailsSection = ( { setModalType } ) => {
 const PaymentSettingsPanel = () => {
 	// @todo - deconstruct modalType and setModalType from useModalType custom hook
 	const [ modalType, setModalType ] = useState( '' );
+	const [ keepModalContent, setKeepModalContent ] = useState( false );
 
 	const handleModalDismiss = () => {
 		setModalType( '' );
@@ -177,8 +183,14 @@ const PaymentSettingsPanel = () => {
 				<CustomizationOptionsNotice />
 			</SettingsSection>
 			<SettingsSection Description={ AccountDetailsDescription }>
-				<LoadableAccountSection numLines={ 20 }>
-					<AccountDetailsSection setModalType={ setModalType } />
+				<LoadableAccountSection
+					numLines={ 20 }
+					keepContent={ keepModalContent }
+				>
+					<AccountDetailsSection
+						setModalType={ setModalType }
+						setKeepModalContent={ setKeepModalContent }
+					/>
 				</LoadableAccountSection>
 			</SettingsSection>
 			<SettingsSection Description={ PaymentsAndTransactionsDescription }>


### PR DESCRIPTION
Closes #2152

## Changes proposed in this Pull Request:

Adds the `setKeepModalContent` prop to the `DisconnectStripeConfirmationModal` component. This prop will be called when the user clicks the "Disconnect" button.

Adds the `keepContent` prop to the `LoadableAccountSection` component. It will be used to prevent the `LoadableAccountSection` component from unloading the child component `AccountDetailsSection`.

This is the most straightforward way to avoid closing the modal after disconnect because the `LoadableAccountSection` will unload the child `AccountDetailsSection` component after `saveAccountKeys` is called.

Note `setKeepModalContent ` is passed from `PaymentSettingsPanel` all the way down to `DisconnectStripeConfirmationModal`. This is necessary because `DisconnectStripeConfirmationModal` is inside `AccountSettingsDropdownMenu`. Another option would be to move `DisconnectStripeConfirmationModal` to `PaymentSettingsPanel` but I preferred to keep `DisconnectStripeConfirmationModal` near to where it's used.


## Testing instructions

You'll need WooCommerce extension up and running. Finish onboarding.

- Install WooCommerce Stripe extension
- Enable new UI in case you haven't. You can use the following command `wp option update _wcstripe_feature_upe_settings yes` or `npm run wp option update _wcstripe_feature_upe_settings yes` if you're running Stripe environment locally.
- Go to "WooCommerce > Settings > Payments", enable Stripe then Click "Manage" button.
- Click "Enter account keys (advanced)". Enter valid Stripe keys then click "Save test keys".
- Refresh the page then click "Settings" tab.
- Click the `⋮` menu in the "Account details" section. Then click "Disconnect" menu option.
- <img width="1007" alt="Screen Shot 2021-11-16 at 8 52 35 PM" src="https://user-images.githubusercontent.com/1025173/142094673-6f8b8ac5-174e-4d87-9ed0-fd2450146fd1.png">
- Click the "Disconnect" button in the "Disconnect Stripe account" modal.
- "Disconnect" button should be in "loading" state and modal should not close.
- Page should refresh and "Get started with Stripe" view should be displayed.
- <img width="832" alt="Screen Shot 2021-11-16 at 8 59 25 PM" src="https://user-images.githubusercontent.com/1025173/142095385-9c8e1157-e7dc-4ff3-b314-45d0dba0e8e4.png">





<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
