### PR TITLE
Add Invalid keys notice

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -204,7 +204,7 @@ class WC_Stripe_Admin_Notices {
 
 				// Check if Stripe Account data was successfully fetched.
 				$account_data = WC_Stripe::get_instance()->account->get_cached_account_data();
-				if ( empty( $account_data ) ) {
+				if ( ! empty( $secret ) && empty( $account_data ) ) {
 					$setting_link = $this->get_setting_link();
 					/* translators: 1) link */
 					$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Your customers cannot use Stripe on checkout, because we couldn\'t connect to your account. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -201,6 +201,14 @@ class WC_Stripe_Admin_Notices {
 						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in live mode however your live keys may not be valid. Live keys start with pk_live and sk_live or rk_live. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );
 					}
 				}
+
+				// Check if Stripe Account data was successfully fetched.
+				$account_data = WC_Stripe::get_instance()->account->get_cached_account_data();
+				if ( empty( $account_data ) ) {
+					$setting_link = $this->get_setting_link();
+					/* translators: 1) link */
+					$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Your customers cannot use Stripe on checkout, because we couldn\'t connect to your account. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );
+				}
 			}
 
 			if ( empty( $show_ssl_notice ) ) {
@@ -356,7 +364,7 @@ class WC_Stripe_Admin_Notices {
 	 * @return string Setting link
 	 */
 	public function get_setting_link() {
-		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
+		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings' );
 	}
 
 	/**

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -5,6 +5,21 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';
+
+		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
+				->disableOriginalConstructor()
+				->setMethods(
+					[
+						'get_cached_account_data',
+					]
+				)
+				->getMock();
+
+		WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn(
+			[
+				'test' => 'test',
+			]
+		);
 	}
 
 	public function test_no_notices_are_shown_when_user_is_not_admin() {
@@ -106,6 +121,48 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'giropay_upe', $notices->notices );
 		$this->assertArrayHasKey( 'bancontact_upe', $notices->notices );
 		$this->assertArrayHasKey( 'eps_upe', $notices->notices );
+	}
+
+	public function test_invalid_keys_notice_is_shown_when_account_data_is_not_valid() {
+		// We need to re-create the mock object to override the mocked 'get_cached_account_data' function.
+		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
+			->disableOriginalConstructor()
+			->setMethods(
+				[
+					'get_cached_account_data',
+				]
+			)
+			->getMock();
+		WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn( null );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'         => 'yes',
+				'testmode'        => 'no',
+				'publishable_key' => 'pk_live_invalid_test_key',
+				'secret_key'      => 'sk_live_invalid_test_secret',
+			]
+		);
+		update_option( 'wc_stripe_show_style_notice', 'no' );
+		update_option( 'wc_stripe_show_sca_notice', 'no' );
+		update_option( 'home', 'https://...' );
+
+		$notices = new WC_Stripe_Admin_Notices();
+		ob_start();
+		$notices->admin_notices();
+		ob_end_clean();
+
+		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
+			$this->assertCount( 2, $notices->notices );
+			$this->assertArrayHasKey( 'wcver', $notices->notices );
+		} else {
+			$this->assertCount( 1, $notices->notices );
+		}
+
+		$this->assertArrayHasKey( 'keys', $notices->notices );
+		$this->assertRegexp( '/Your customers cannot use Stripe on checkout/', $notices->notices['keys']['message'] );
 	}
 
 	public function options_to_notices_map() {


### PR DESCRIPTION
Fixes #1807

## Changes proposed in this Pull Request:

This PR adds a notice in the Gateway setting page If the account keys are not invalid (`secret_key` is present, but no `account data` was received from Stripe).

The notice includes a link to the settings page to allow the merchant to modify their connection keys.

<img width="1106" alt="Screen Shot 2021-11-17 at 17 42 14" src="https://user-images.githubusercontent.com/407542/142279262-b2381787-38ec-4467-924c-52a6272722ee.png">

## Testing instructions

1. Go to **WooCommece > Settings > Payments > Stripe > Settings**
2. Update the `live` keys, using valid stripe keys.
3. Disable `Test mode`
4. Verify that no notice is displayed.
5. Update the the live keys again, this time using: `pk_live_not_valid` and `sk_live_not_valid`
6. Verify that under Account Details the following message is displayed: `Seems like the live keys we've saved for you are no longer valid. If you recently updated them, enter the new live keys from your Stripe Account.`
7. Go to **WooCommece > Settings > Payments**
8. Verify that an error notice is displayed (like in the screenshot above), with the following message: `Your customers cannot use Stripe on checkout, because we couldn't connect to your account. Please go to your settings and, set your Stripe account keys.`