### PR TITLE
Hide PRB when all variations are out-of-stock

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -453,7 +453,6 @@ jQuery( function( $ ) {
 			} );
 		},
 
-
 		/**
 		 * Creates a wrapper around a function that ensures a function can not
 		 * called in rappid succesion. The function can only be executed once and then agin after
@@ -680,6 +679,16 @@ jQuery( function( $ ) {
 					}
 				} );
 			}));
+
+			if ( $('.variations_form').length ) {
+				$( '.variations_form' ).on( 'found_variation.wc-variation-form', function ( evt, variation ) {
+					if ( variation.is_in_stock ) {
+						wc_stripe_payment_request.unhidePaymentRequestButton();
+					} else {
+						wc_stripe_payment_request.hidePaymentRequestButton();
+					}
+				} );
+			}
 		},
 
 		attachCartPageEventListeners: function ( prButton, paymentRequest ) {
@@ -715,6 +724,20 @@ jQuery( function( $ ) {
 			} else if ( $( '#wc-stripe-payment-request-button' ).length ) {
 				$( '#wc-stripe-payment-request-wrapper, #wc-stripe-payment-request-button-separator' ).show();
 				prButton.mount( '#wc-stripe-payment-request-button' );
+			}
+		},
+
+		hidePaymentRequestButton: function () {
+			$( '#wc-stripe-payment-request-wrapper, #wc-stripe-payment-request-button-separator' ).hide();
+		},
+
+		unhidePaymentRequestButton: function () {
+			const stripe_wrapper = $( '#wc-stripe-payment-request-wrapper' );
+			const stripe_separator = $( '#wc-stripe-payment-request-button-separator' );
+			// If either element is hidden, ensure both show.
+			if ( stripe_wrapper.is(':hidden') || stripe_separator.is(':hidden') ) {
+				stripe_wrapper.show();
+				stripe_separator.show();
 			}
 		},
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
 * Add - New Settings UI.
 * Add - Add Stripe API to generate connection tokens.
+* Fix - Hide payment request button when variations of a variable product are out-of-stock.
 
 = 5.7.0 - 2021-10-20 =
 * Fix - Enable use of saved payment methods converted to SEPA payments.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -906,6 +906,14 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
+		if ( $this->is_product() && in_array( $this->get_product()->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
+			$stock_availability = array_column( $this->get_product()->get_available_variations(), 'is_in_stock' );
+			// Don't show if all product variations are out-of-stock.
+			if ( ! in_array( true, $stock_availability, true ) ) {
+				return false;
+			}
+		}
+
 		return true;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -137,5 +137,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
 * Fix - Add support for MYR (Malaysian ringgit) for Alipay.
 * Add - New Settings UI.
+* Fix - Hide payment request button when variations of a variable product are out-of-stock.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes #1580 

* Don't display the payment request button (PRB) when all variations of the product are out-of-stock.
* Don't display the PRB when an out-of-stock variation is selected.

This PR ensures that the PRB is not displayed when all of a product's variations are out of stock. Additionally, when a product has at least one variation that is not out-of-stock, this PR also ensures that the PRB is not displayed when the user selects a variation that is out-of-stock. 

This fixes an issue where users were seeing an "Out of stock" warning and the PRB, at the same time. Which may have caused some confusion. Now, only the warning is displayed. Also, this fix makes it so that the PRB's behavior in variable product pages matches that of the simple product pages.

At the moment, this entire part of the code is not being tested. Additionally, this change was a small enough not to warrant e2e tests.

<!--
Description: Write a summary of this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Don't display the PRB when all variations of a `variable product` are out-of-stock**
To test this new behavior, we need to create a variable product with at least two variants:

* Create a new product: `Products > Add New`
* Select "Variable product" as `Product data`
* Click `Attributes`, then click `Add` while "Custom product attribute" is selected
* Create "Size" attribute with "Small | Medium" as values
* Ensure `Used for variations` is checked
* Click `Variations` then while "Create variations from all attributes" is selected click `Go`
* Add a `Regular price ($)` for each variation
* Select "Out of stock" on the `Stock status` field, for each variation
* `Save changes` and go to the product's page

Note that the PRB is not visible. Also, note that switching between `Size` variations keeps the PRB hidden.

**Don't display the PRB when an out-of-stock variation is selected, for a `variable product`**
To test this new behavior, go back and edit the variable product created above and do the following:

* Click `Variations`
* Update the `Stock status` of the "small" variation to "In stock"
* `Save changes` and go to the product's page

Note that the PRB is visible, upon loading the product page. Also, note that selecting the "Small" `Size` variation makes the PRB show. But switching to the "Medium" variation makes the PRB hide. 

---

Note: for the following tests, the `WooCommerce Subscriptions` plugin will need to be active.

**Don't display the PRB when all variations of a `variable subscription` are out-of-stock**
To test this new behavior, we need to create a variable subscription with at least two variants:

* Create a new product: `Products > Add New`
* Select "Variable subscription" as `Product data`
* Click `Attributes`, then click `Add` while "Custom product attribute" is selected
* Create "Billing Period" attribute with "1 Month | 2 Months" as values
* Ensure `Used for variations` is checked
* Click `Variations` then while "Create variations from all attributes" is selected click `Go`
* Add a `Subscription price ($)` for each variation
* Select "Out of stock" on the `Stock status` field, for each variation
* `Save changes` and go to the product's page

Note that the PRB is not visible. Also, note that switching between "Billing Period" variations keeps the PRB hidden.

**Don't display the PRB when an out-of-stock variation is selected, for a `variable subscription`**
To test this new behavior, go back and edit the variable subscription created above and do the following:

* Click `Variations`
* Set the `Stock status` of the "1 Month" variation to "In stock"
* `Save changes` and go to the product's page

Note that the PRB is visible, upon loading the product page. Also, note that selecting the "1 Month" `Billing Period` variation makes the PRB show. But switching to the "2 Months" variation makes the PRB hide. 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)