### PR TITLE
Replace trim with ! empty

### DIFF
--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -44,7 +44,7 @@ class WC_Stripe_Settings_Controller {
 
 		$settings = get_option( WC_Stripe_Connect::SETTINGS_OPTION, [] );
 
-		$account_data_exists = ( trim( $settings['publishable_key'] ) && trim( $settings['secret_key'] ) ) || ( trim( $settings['test_publishable_key'] ) && trim( $settings['test_secret_key'] ) );
+		$account_data_exists = ( ! empty( $settings['publishable_key'] ) && ! empty( $settings['secret_key'] ) ) || ( ! empty( $settings['test_publishable_key'] ) && ! empty( $settings['test_secret_key'] ) );
 		echo $account_data_exists ? '<div id="wc-stripe-account-settings-container"></div>' : '<div id="wc-stripe-new-account-container"></div>';
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

The very first install of the plug does not have the plugin settings populated, so there is no `$settings['publishable_key']`, this PR replaces the `trim( $settings['publishable_key'] )` with `! empty( $settings['publishable_key'] )`

## Testing instructions
1. Checkout branch `release/5.8.0`
2. Remove the entry `woocommerce_stripe_settings` form the `wp_options` table
3. Go to **WooCommerce > Settings > Payments > Stripe**
4. Verify that a notice is dispalyed above the connect card
5. Checkout this branch
6. Go to **WooCommerce > Settings > Payments > Stripe**
7. Verify that no error notice is displayed