### PR TITLE
Hide short descriptor fields for release 5.8.0

### DIFF
--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -113,66 +113,74 @@ const PaymentsAndTransactionsSection = () => {
 						maxLength={ 22 }
 					/>
 				</TextLengthHelpInputWrapper>
-				<CheckboxControl
-					checked={ isShortAccountStatementEnabled }
-					onChange={ setIsShortAccountStatementEnabled }
-					label={ __(
-						'Add customer order number to the bank statement',
-						'woocommerce-gateway-stripe'
-					) }
-					help={ __(
-						"When enabled, we'll include the order number for card and express checkout transactions.",
-						'woocommerce-gateway-stripe'
-					) }
-				/>
-				{ isShortAccountStatementEnabled && (
-					<>
-						{ shortStatementDescriptorErrorMessage && (
-							<InlineNotice
-								status="error"
-								isDismissible={ false }
-							>
-								<span
-									dangerouslySetInnerHTML={ {
-										__html: shortStatementDescriptorErrorMessage,
-									} }
-								/>
-							</InlineNotice>
+				{ /* TODO: Hiding the Short Account Statement fields until it's included in the POST to Stripe */ }
+				<div style={ { display: 'none' } }>
+					<CheckboxControl
+						checked={ isShortAccountStatementEnabled }
+						onChange={ setIsShortAccountStatementEnabled }
+						label={ __(
+							'Add customer order number to the bank statement',
+							'woocommerce-gateway-stripe'
 						) }
-						<TextLengthHelpInputWrapper
-							textLength={
-								shortAccountStatementDescriptor.length
-							}
-							maxLength={ 10 }
-						>
-							<TextControl
-								help={ __(
-									"We'll use the short version in combination with the customer order number.",
-									'woocommerce-gateway-stripe'
-								) }
-								label={ __(
-									'Shortened customer bank statement',
-									'woocommerce-gateway-stripe'
-								) }
-								value={ shortAccountStatementDescriptor }
-								onChange={ setShortAccountStatementDescriptor }
-								maxLength={ 10 }
-							/>
-						</TextLengthHelpInputWrapper>
-					</>
-				) }
-				<StatementPreviewsWrapper>
+						help={ __(
+							"When enabled, we'll include the order number for card and express checkout transactions.",
+							'woocommerce-gateway-stripe'
+						) }
+					/>
 					{ isShortAccountStatementEnabled && (
-						<StatementPreview
-							icon="creditCard"
-							title={ __(
-								'Cards & Express Checkouts',
-								'woocommerce-gateway-stripe'
+						<>
+							{ shortStatementDescriptorErrorMessage && (
+								<InlineNotice
+									status="error"
+									isDismissible={ false }
+								>
+									<span
+										dangerouslySetInnerHTML={ {
+											__html: shortStatementDescriptorErrorMessage,
+										} }
+									/>
+								</InlineNotice>
 							) }
-							text={ `${ shortAccountStatementDescriptor }* #123456` }
-							className="shortened-bank-statement"
-						/>
+							<TextLengthHelpInputWrapper
+								textLength={
+									shortAccountStatementDescriptor.length
+								}
+								maxLength={ 10 }
+							>
+								<TextControl
+									help={ __(
+										"We'll use the short version in combination with the customer order number.",
+										'woocommerce-gateway-stripe'
+									) }
+									label={ __(
+										'Shortened customer bank statement',
+										'woocommerce-gateway-stripe'
+									) }
+									value={ shortAccountStatementDescriptor }
+									onChange={
+										setShortAccountStatementDescriptor
+									}
+									maxLength={ 10 }
+								/>
+							</TextLengthHelpInputWrapper>
+						</>
 					) }
+				</div>
+				<StatementPreviewsWrapper>
+					{ /* TODO: Hiding the Short Account Statement fields until it's included in the POST to Stripe */ }
+					<div style={ { display: 'none' } }>
+						{ isShortAccountStatementEnabled && (
+							<StatementPreview
+								icon="creditCard"
+								title={ __(
+									'Cards & Express Checkouts',
+									'woocommerce-gateway-stripe'
+								) }
+								text={ `${ shortAccountStatementDescriptor }* #123456` }
+								className="shortened-bank-statement"
+							/>
+						) }
+					</div>
 					<StatementPreview
 						icon="bank"
 						title={ translatedFullBankPreviewTitle }


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR hides the Short Account Statement fields from the settings.

This PR should be reverted after the field is included in the POST to Stripe.

## Testing instructions
1. Check `release/5.8.0`
2. Go to **WooCommerce > Settings > Payments > Stripe > Settings**
3. Verify that the `Short Account Statement` checkbox is present (and enabling it shows the actual text field)
4. Checkout this branch
5. Go to **WooCommerce > Settings > Payments > Stripe > Settings**
6. Verify that the `Short Account Statement` checkbox is not present
7. Test that changing the Statement and saving changes works ok
8. Test that changing the Statement to an invalid value (less than 5 chars) and saving changes returns an error
9. Test that changing the Statement to an empty string and saving changes works ok