### PR TITLE
Bump latest supported version for woocommerce

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -21,7 +21,7 @@ jobs:
             woocommerce: '5.8.0'
           - woocommerce_L: L-2
             woocommerce: '5.7.1'
-          # Worpress
+          # WordPress
           - wordpress_L: L
             wordpress: 'latest'
           - wordpress_L: L-1
@@ -42,7 +42,7 @@ jobs:
       WP_VERSION:  ${{ matrix.wordpress }}
       WC_VERSION:  ${{ matrix.woocommerce }}
     steps:
-      - name: Testing with [PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
+      - name: Testing with PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
         uses: actions/checkout@v2
 
       - name: Set up dependencies caching
@@ -57,7 +57,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage:    none
 
-      - name: Set up PHPUnit 6.5 for PHP 7.0 compatibility
+      - name: If PHP 7.0, set up PHPUnit 6.5 for legacy compatibility
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,31 +10,31 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        woocommerce_L: [ 'L0', 'L1', 'L2' ]
-        wordpress_L:   [ 'L0', 'L1', 'L2' ]
-        php_L:         [ 'L0', 'L1', 'L2' ]
+        woocommerce_L: [ 'L', 'L-1', 'L-2' ]
+        wordpress_L:   [ 'L', 'L-1', 'L-2' ]
+        php_L:         [ 'L', 'L-1', 'L-2' ]
         include:
           # WooCommerce
-          - woocommerce_L: L0
-            woocommerce: latest
-          - woocommerce_L: L1
-            woocommerce: 5.8.0
-          - woocommerce_L: L2
-            woocommerce: 5.7.1
+          - woocommerce_L: L
+            woocommerce: 'latest'
+          - woocommerce_L: L-1
+            woocommerce: '5.8.0'
+          - woocommerce_L: L-2
+            woocommerce: '5.7.1'
           # Worpress
-          - wordpress_L: L0
-            wordpress: latest
-          - wordpress_L: L1
-            wordpress: 5.7
-          - wordpress_L: L2
-            wordpress: 5.6
+          - wordpress_L: L
+            wordpress: 'latest'
+          - wordpress_L: L-1
+            wordpress: '5.7'
+          - wordpress_L: L-2
+            wordpress: '5.6'
           # PHP
-          - php_L: L0
-            php: 8.0
-          - php_L: L1
-            php: 7.4
-          - php_L: L2
-            php: 7.0
+          - php_L: L
+            php: '8.0'
+          - php_L: L-1
+            php: '7.4'
+          - php_L: L-2
+            php: '7.0'
 
     name: Stable [PHP=${{ matrix.php_L }}, WP=${{ matrix.wordpress_L }}, WC=${{ matrix.woocommerce_L }}]
     env:
@@ -42,18 +42,24 @@ jobs:
       WP_VERSION:  ${{ matrix.wordpress }}
       WC_VERSION:  ${{ matrix.woocommerce }}
     steps:
-      # clone the repository
-      - uses: actions/checkout@v2
-      # enable dependencies caching
-      - uses: actions/cache@v2
+      - name: Testing with [PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
+        uses: actions/checkout@v2
+
+      - name: Set up dependencies caching
+        uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      # setup PHP, but without debug extensions for reasonable performance
-      - uses: shivammathur/setup-php@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage:    none
-      # run CI checks
-      - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
-      - run: bash bin/run-ci-tests.bash
+
+      - name: Set up PHPUnit 6.5 for PHP 7.0 compatibility
+        if: ${{ matrix.php == '7.0' }}
+        run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
+
+      - name: Run CI checks
+        run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Set up PHPUnit 6.5 for PHP 7.0 compatibility
         if: ${{ matrix.php == '7.0' }}
-        run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
+        run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
       - name: Run CI checks
         run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,33 +10,33 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        woocommerce_L: [ 'L', 'L-1', 'L-2' ]
-        wordpress_L:   [ 'L', 'L-1', 'L-2' ]
-        php_L:         [ 'L', 'L-1', 'L-2' ]
+        woocommerce_support_policy: [ 'L', 'L-1', 'L-2' ]
+        wordpress_support_policy:   [ 'L', 'L-1', 'L-2' ]
+        php_support_policy:         [ 'L', 'L-1', 'L-2' ]
         include:
           # WooCommerce
-          - woocommerce_L: L
+          - woocommerce_support_policy: L
             woocommerce: 'latest'
-          - woocommerce_L: L-1
+          - woocommerce_support_policy: L-1
             woocommerce: '5.8.0'
-          - woocommerce_L: L-2
+          - woocommerce_support_policy: L-2
             woocommerce: '5.7.1'
           # WordPress
-          - wordpress_L: L
+          - wordpress_support_policy: L
             wordpress: 'latest'
-          - wordpress_L: L-1
+          - wordpress_support_policy: L-1
             wordpress: '5.7'
-          - wordpress_L: L-2
+          - wordpress_support_policy: L-2
             wordpress: '5.6'
           # PHP
-          - php_L: L
+          - php_support_policy: L
             php: '8.0'
-          - php_L: L-1
+          - php_support_policy: L-1
             php: '7.4'
-          - php_L: L-2
+          - php_support_policy: L-2
             php: '7.0'
 
-    name: Stable [PHP=${{ matrix.php_L }}, WP=${{ matrix.wordpress_L }}, WC=${{ matrix.woocommerce_L }}]
+    name: Stable [PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }}]
     env:
       PHP_VERSION: ${{ matrix.php }} 
       WP_VERSION:  ${{ matrix.wordpress }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,13 +10,37 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
-        wordpress:   [ 'latest', '5.7', '5.6' ]
-        php:         [ '8.0', '7.4', '7.0' ]
-    name: Stable [PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}]
+        woocommerce_L: [ 'L0', 'L1', 'L2' ]
+        wordpress_L:   [ 'L0', 'L1', 'L2' ]
+        php_L:         [ 'L0', 'L1', 'L2' ]
+        include:
+          # WooCommerce
+          - woocommerce_L: L0
+            woocommerce: latest
+          - woocommerce_L: L1
+            woocommerce: 5.8.0
+          - woocommerce_L: L2
+            woocommerce: 5.7.1
+          # Worpress
+          - wordpress_L: L0
+            wordpress: latest
+          - wordpress_L: L1
+            wordpress: 5.7
+          - wordpress_L: L2
+            wordpress: 5.6
+          # PHP
+          - php_L: L0
+            php: 8.0
+          - php_L: L1
+            php: 7.4
+          - php_L: L2
+            php: 7.0
+
+    name: Stable [PHP=${{ matrix.php_L }}, WP=${{ matrix.wordpress_L }}, WC=${{ matrix.woocommerce_L }}]
     env:
-      WP_VERSION: ${{ matrix.wordpress }}
-      WC_VERSION: ${{ matrix.woocommerce }}
+      PHP_VERSION: ${{ matrix.php }} 
+      WP_VERSION:  ${{ matrix.wordpress }}
+      WC_VERSION:  ${{ matrix.woocommerce }}
     steps:
       # clone the repository
       - uses: actions/checkout@v2

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -8,8 +8,8 @@
  * Version: 5.8.0
  * Requires at least: 5.6
  * Tested up to: 5.8
- * WC requires at least: 5.6
- * WC tested up to: 5.8
+ * WC requires at least: 5.7
+ * WC tested up to: 5.9
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */
@@ -23,8 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WC_STRIPE_VERSION', '5.8.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.0.0' );
-define( 'WC_STRIPE_MIN_WC_VER', '5.6' );
-define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '5.7' );
+define( 'WC_STRIPE_MIN_WC_VER', '5.7' );
+define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '5.8' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_ABSPATH', __DIR__ . '/' );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );


### PR DESCRIPTION
Fixes: #2178

## Changes proposed in this Pull Request:

This PR updates the oldest supported version of WooCommerce from 5.6 to 5.7.

It also updates the test workflow to use `L`, `L-1` and `L-2` instead of the actual version number in the status check title:

<img width="872" alt="Screen Shot 2021-11-22 at 16 07 26" src="https://user-images.githubusercontent.com/407542/142920915-5d919e7f-9ba8-4a89-94be-257b299bff30.png">

This was done so each time a version is bumped there is no need to update the required checks in the repo settings. 

Currently GitHub doesn't allow the use wildcards (or partial matches) in the status checks, so without this change each time we update the supported versions, we need to go to the repo settings remove the 9 status checks for the version no longer supported and add the new 9 status checks for the newly added version.

Currently for WC we test: `latest`, `5.7.1` and `5.6.1`; for each of those we have 9 status checks (because of the WP and PHP possible combinations), so now that `5.9.0` is released we need to support: `latest`, `5.8.0` and `5.7.1`, that means removing the 9 status checks with `5.6.1` in the name and adding the new 9 with `5.8.0` in it.

<img width="796" alt="Screen Shot 2021-11-22 at 16 03 38" src="https://user-images.githubusercontent.com/407542/142921331-bdbdebfe-dca0-47d9-80f7-c7dddb8da880.png">

It also updates the flow step names to be more self explanatory (`Run shivammathur/setup-php@v2` becomes `Set up PHP`, and it now shows the versions used by the test: `Testing with PHP=8.0, WP=5.8, WC=5.7.1`, so when a status cehck fails, we can easily see the versions used without to dig in the workflow variables:

<img width="488" alt="Screen Shot 2021-11-22 at 16 07 54" src="https://user-images.githubusercontent.com/407542/142922963-c9cb1a3f-976a-451a-a2dc-5a5a79fcfe12.png">

Next time we want to change the versions we test on, we just need to update the versions in the corresponding `matrix.include` in the workflow, no need to update the `required` checks in the repo.

__Note__: This PR has several (9) status checks `Waiting for status to be reported`... those are the ones currently configured as `required` in the repo, after merging this PR those will be changed to the new format `Stable [PHP=L, WP=L-2, WC=L-2]`


## Testing instructions
- Check the `status checks` for this PR.
