### PR TITLE
Run filters to disable Stripe JS when PRBs are disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 5.8.1 - 2021-xx-xx =
+* Fix - Run filters that disable Stripe JS on cart and product pages when PRBs are disabled.
+
 = 5.8.0 - 2021-11-18 =
 * Fix - Hong Kong addresses are now mapped more thoroughly to WooCommerce addresses when paying with Apple Pay.
 * Fix - Error when changing payment method for a subscription with new checkout experience.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -584,6 +584,15 @@ class WC_Stripe_Helper {
 		return true;
 	}
 
+	/**
+	 * Returns true if the Stripe JS should be loaded on product pages.
+	 *
+	 * The critical part here is running the filter to allow merchants to disable Stripe's JS to
+	 * improve their store's performance when PRBs are disabled.
+	 *
+	 * @since 5.8.0
+	 * @return boolean True if Stripe's JS should be loaded, false otherwise.
+	 */
 	public static function should_load_scripts_on_product_page() {
 		if ( self::should_load_scripts_for_prb_location( 'product' ) ) {
 			return true;
@@ -592,6 +601,15 @@ class WC_Stripe_Helper {
 		return apply_filters( 'wc_stripe_load_scripts_on_product_page_when_prbs_disabled', true );
 	}
 
+	/**
+	 * Returns true if the Stripe JS should be loaded on the cart page.
+	 *
+	 * The critical part here is running the filter to allow merchants to disable Stripe's JS to
+	 * improve their store's performance when PRBs are disabled.
+	 *
+	 * @since 5.8.0
+	 * @return boolean True if Stripe's JS should be loaded, false otherwise.
+	 */
 	public static function should_load_scripts_on_cart_page() {
 		if ( self::should_load_scripts_for_prb_location( 'cart' ) ) {
 			return true;
@@ -600,6 +618,13 @@ class WC_Stripe_Helper {
 		return apply_filters( 'wc_stripe_load_scripts_on_cart_page_when_prbs_disabled', true );
 	}
 
+	/**
+	 * Returns true if the Stripe JS should be loaded for the provided location.
+	 *
+	 * @since 5.8.1
+	 * @param string $location  Either 'product' or 'cart'. Used to specify which location to check.
+	 * @return boolean True if Stripe's JS should be loaded for the provided location, false otherwise.
+	 */
 	private static function should_load_scripts_for_prb_location( $location ) {
 		// Make sure location parameter is sanitized.
 		$location         = in_array( $location, [ 'product', 'cart' ], true ) ? $location : '';

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -590,8 +590,9 @@ class WC_Stripe_Helper {
 
 		// We run the filter when 1 of the following is true:
 		//   1. The PRBs are disabled; or
-		//   2. The PRBs are disabled on product pages.
-		if ( 'yes' !== $are_prbs_enabled || ! in_array( 'product', $prb_locations, true ) ) {
+		//   2. The PRB location settings are emptied and saved in the GUI (results in a non-array value).
+		//   3. The PRBs are disabled on product pages.
+		if ( 'yes' !== $are_prbs_enabled || ! is_array( $prb_locations ) || ! in_array( 'product', $prb_locations, true ) ) {
 			return apply_filters( 'wc_stripe_load_scripts_on_product_page_when_prbs_disabled', true );
 		}
 
@@ -604,8 +605,9 @@ class WC_Stripe_Helper {
 
 		// We run the filter when 1 of the following is true:
 		//   1. The PRBs are disabled; or
-		//   2. The PRBs are disabled on the cart page.
-		if ( 'yes' !== $are_prbs_enabled || ! in_array( 'cart', $prb_locations, true ) ) {
+		//   2. The PRB location settings are emptied and saved in the GUI (results in a non-array value).
+		//   3. The PRBs are disabled on the cart page.
+		if ( 'yes' !== $are_prbs_enabled || ! is_array( $prb_locations ) || ! in_array( 'cart', $prb_locations, true ) ) {
 			return apply_filters( 'wc_stripe_load_scripts_on_cart_page_when_prbs_disabled', true );
 		}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -585,8 +585,13 @@ class WC_Stripe_Helper {
 	}
 
 	public static function should_load_scripts_on_product_page() {
-		$prb_locations = self::get_settings( null, 'payment_request_button_locations' ) ?? [ 'product', 'cart' ];
-		if ( ! in_array( 'product', $prb_locations, true ) ) {
+		$are_prbs_enabled = self::get_settings( null, 'payment_request' ) ?? 'yes';
+		$prb_locations    = self::get_settings( null, 'payment_request_button_locations' ) ?? [ 'product', 'cart' ];
+
+		// We run the filter when 1 of the following is true:
+		//   1. The PRBs are disabled; or
+		//   2. The PRBs are disabled on product pages.
+		if ( 'yes' !== $are_prbs_enabled || ! in_array( 'product', $prb_locations, true ) ) {
 			return apply_filters( 'wc_stripe_load_scripts_on_product_page_when_prbs_disabled', true );
 		}
 
@@ -594,8 +599,13 @@ class WC_Stripe_Helper {
 	}
 
 	public static function should_load_scripts_on_cart_page() {
-		$prb_locations = self::get_settings( null, 'payment_request_button_locations' ) ?? [ 'product', 'cart' ];
-		if ( ! in_array( 'cart', $prb_locations, true ) ) {
+		$are_prbs_enabled = self::get_settings( null, 'payment_request' ) ?? 'yes';
+		$prb_locations    = self::get_settings( null, 'payment_request_button_locations' ) ?? [ 'product', 'cart' ];
+
+		// We run the filter when 1 of the following is true:
+		//   1. The PRBs are disabled; or
+		//   2. The PRBs are disabled on the cart page.
+		if ( 'yes' !== $are_prbs_enabled || ! in_array( 'cart', $prb_locations, true ) ) {
 			return apply_filters( 'wc_stripe_load_scripts_on_cart_page_when_prbs_disabled', true );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,15 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 5.8.0 - 2021-11-18 =
-* Fix - Hong Kong addresses are now mapped more thoroughly to WooCommerce addresses when paying with Apple Pay.
-* Fix - Error when changing payment method for a subscription with new checkout experience.
-* Fix - Payment Requests are now updated correctly when updating items in the Cart Block.
-* Add - Support for WooCommerce Pre-Orders with new checkout experience.
-* Fix - Stripe JS is no longer loaded on cart and product pages when PRBs are disabled on those pages.
-* Tweak - Update the minimum required PHP version to 7.0 to reflect our L-2 support policy.
-* Fix - Add support for MYR (Malaysian ringgit) for Alipay.
-* Add - New Settings UI.
-* Fix - Hide payment request button when variations of a variable product are out-of-stock.
+= 5.8.1 - 2021-xx-xx =
+* Fix - Run filters that disable Stripe JS on cart and product pages when PRBs are disabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Ensure that the filters introduced in #2110 work correctly when the PRBs are disabled, not just when the PRBs are enabled but hidden on product or cart pages.

- Run the filters introduced in #2110 (`wc_stripe_load_scripts_on_product_page_when_prbs_disabled ` and `wc_stripe_load_scripts_on_cart_page_when_prbs_disabled `) when the PRBs are disabled.

## Testing instructions

Same as the ones in #2110 with 1 minor difference: disable the PRBs entirely instead of removing the button locations.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
