### PR TITLE
Revert "Bump latest supported version for woocommerce"

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -10,56 +10,26 @@ jobs:
       fail-fast:    false
       max-parallel: 10
       matrix:
-        woocommerce_support_policy: [ 'L', 'L-1', 'L-2' ]
-        wordpress_support_policy:   [ 'L', 'L-1', 'L-2' ]
-        php_support_policy:         [ 'L', 'L-1', 'L-2' ]
-        include:
-          # WooCommerce
-          - woocommerce_support_policy: L
-            woocommerce: 'latest'
-          - woocommerce_support_policy: L-1
-            woocommerce: '5.8.0'
-          - woocommerce_support_policy: L-2
-            woocommerce: '5.7.1'
-          # WordPress
-          - wordpress_support_policy: L
-            wordpress: 'latest'
-          - wordpress_support_policy: L-1
-            wordpress: '5.7'
-          - wordpress_support_policy: L-2
-            wordpress: '5.6'
-          # PHP
-          - php_support_policy: L
-            php: '8.0'
-          - php_support_policy: L-1
-            php: '7.4'
-          - php_support_policy: L-2
-            php: '7.0'
-
-    name: Stable [PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }}]
+        woocommerce: [ 'latest', '5.7.1', '5.6.1' ]
+        wordpress:   [ 'latest', '5.7', '5.6' ]
+        php:         [ '8.0', '7.4', '7.0' ]
+    name: Stable [PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}]
     env:
-      PHP_VERSION: ${{ matrix.php }} 
-      WP_VERSION:  ${{ matrix.wordpress }}
-      WC_VERSION:  ${{ matrix.woocommerce }}
+      WP_VERSION: ${{ matrix.wordpress }}
+      WC_VERSION: ${{ matrix.woocommerce }}
     steps:
-      - name: Testing with PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
-        uses: actions/checkout@v2
-
-      - name: Set up dependencies caching
-        uses: actions/cache@v2
+      # clone the repository
+      - uses: actions/checkout@v2
+      # enable dependencies caching
+      - uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      # setup PHP, but without debug extensions for reasonable performance
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage:    none
-
-      - name: If PHP 7.0, set up PHPUnit 6.5 for legacy compatibility
-        if: ${{ matrix.php == '7.0' }}
-        run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
-
-      - name: Run CI checks
-        run: bash bin/run-ci-tests.bash
+      # run CI checks
+      - run: if [[ "${{ matrix.php }}" == '7.0' ]]; then wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar; fi;
+      - run: bash bin/run-ci-tests.bash

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -8,8 +8,8 @@
  * Version: 5.8.0
  * Requires at least: 5.6
  * Tested up to: 5.8
- * WC requires at least: 5.7
- * WC tested up to: 5.9
+ * WC requires at least: 5.6
+ * WC tested up to: 5.8
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */
@@ -23,8 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WC_STRIPE_VERSION', '5.8.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.0.0' );
-define( 'WC_STRIPE_MIN_WC_VER', '5.7' );
-define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '5.8' );
+define( 'WC_STRIPE_MIN_WC_VER', '5.6' );
+define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '5.7' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_ABSPATH', __DIR__ . '/' );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );


### PR DESCRIPTION
Reverts woocommerce/woocommerce-gateway-stripe#2177

GitHub fails when updating the required status checks to merge, reverting this PR until the checks can be updated:

<img width="647" alt="Screen Shot 2021-11-24 at 10 18 18" src="https://user-images.githubusercontent.com/407542/143245682-b93b5c49-5e7f-4215-ab30-6ef05fe9689c.png">

