### PR TITLE
Make sure strings don’t make it into is_array()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 5.x.x - 2021-xx-xx =
 * Add - Add Stripe API to generate connection tokens, manage terminal locations.
+* Fix - Make sure string in PRB doesn’t throw a warning to users
 
 = 5.8.1 - 2021-11-23 =
 * Fix - Run filters that disable Stripe JS on cart and product pages when PRBs are disabled.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -631,6 +631,10 @@ class WC_Stripe_Helper {
 		$are_prbs_enabled = self::get_settings( null, 'payment_request' ) ?? 'yes';
 		$prb_locations    = self::get_settings( null, 'payment_request_button_locations' ) ?? [ 'product', 'cart' ];
 
+		if ( getType($prb_locations) == 'string') {
+			$prb_locations = array($prb_locations);
+		}
+
 		// The scripts should be loaded when all of the following are true:
 		//   1. The PRBs are enabled; and
 		//   2. The PRB location settings have an array value (saving an empty option in the GUI results in non-array value); and


### PR DESCRIPTION
This is occurring for multiple plugin users, seen here:
- https://wordpress.org/support/topic/new-5-8-0-bug-on-single-product-pages/#post-15101530
- https://wordpress.org/support/topic/error-en-la-linea-589/
- https://wordpress.org/support/topic/warning-in_array-expects-parameter-2-to-be-array-string-given-in-2/

and can be fixed with a simple type check and conditional.

## Testing instructions


This is being tested on a live site in the top linked case above. It could be reproduced by installing WordPress, WooCommerce, WooCommerce Gateway Stripe, and the theme Go, then navigating to any simple product’s single.php page view. A warning should appear in the unfixed state, and should not in the fixed state.

The setup for an automated test for this would be a lot of work for little gain. The implementation is dead simple, and the setup requires a full site be spun up.

-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)
