### PR TITLE
Remove [ and ] from the status check name

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -36,7 +36,7 @@ jobs:
           - php_support_policy: L-2
             php: '7.0'
 
-    name: Stable PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }}
+    name: Stable (PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }})
     env:
       PHP_VERSION: ${{ matrix.php }} 
       WP_VERSION:  ${{ matrix.wordpress }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -36,7 +36,7 @@ jobs:
           - php_support_policy: L-2
             php: '7.0'
 
-    name: Stable [PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }}]
+    name: Stable PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }}
     env:
       PHP_VERSION: ${{ matrix.php }} 
       WP_VERSION:  ${{ matrix.wordpress }}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR replaces the `[` and `]` characters from the status check names with `(` and `)`.

`Stable [PHP=L, WP=L, WC=L]` --> `Stable (PHP=L, WP=L, WC=L])`

This is necessary because the GitHub `Branch protection rules` page no longer allow those characters:
`I see errors in the logs indicating the required Status Checks field contained invalid characters. Can you verify that the values you are updating do not contain characters that might potentially be rejected?`

## Testing instructions
- Verify that all tests still pass
