### PR TITLE
Hide Enable separate credit card form when UPE is enabled

### DIFF
--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useContext } from 'react';
 import { Card, CheckboxControl, TextControl } from '@wordpress/components';
 import CardBody from '../card-body';
 import TextLengthHelpInputWrapper from './text-length-help-input-wrapper';
@@ -15,6 +15,7 @@ import {
 	useGetSavingError,
 } from 'wcstripe/data';
 import InlineNotice from 'wcstripe/components/inline-notice';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 const PaymentsAndTransactionsSection = () => {
 	const [ isSavedCardsEnabled, setIsSavedCardsEnabled ] = useSavedCards();
@@ -34,6 +35,9 @@ const PaymentsAndTransactionsSection = () => {
 		shortAccountStatementDescriptor,
 		setShortAccountStatementDescriptor,
 	] = useShortAccountStatementDescriptor();
+
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
 	const statementDescriptorErrorMessage = useGetSavingError()?.data?.details
 		?.statement_descriptor?.message;
 	const shortStatementDescriptorErrorMessage = useGetSavingError()?.data
@@ -61,18 +65,20 @@ const PaymentsAndTransactionsSection = () => {
 						'woocommerce-gateway-stripe'
 					) }
 				/>
-				<CheckboxControl
-					checked={ isSeparateCardFormEnabled }
-					onChange={ setIsSeparateCardFormEnabled }
-					label={ __(
-						'Enable separate credit card form',
-						'woocommerce-gateway-stripe'
-					) }
-					help={ __(
-						'If enabled, the credit card form will display separate credit card number field, expiry date field and CVC field.',
-						'woocommerce-gateway-stripe'
-					) }
-				/>
+				{ ! isUpeEnabled && (
+					<CheckboxControl
+						checked={ isSeparateCardFormEnabled }
+						onChange={ setIsSeparateCardFormEnabled }
+						label={ __(
+							'Enable separate credit card form',
+							'woocommerce-gateway-stripe'
+						) }
+						help={ __(
+							'If enabled, the credit card form will display separate credit card number field, expiry date field and CVC field.',
+							'woocommerce-gateway-stripe'
+						) }
+					/>
+				) }
 				<h4>
 					{ __(
 						'Transaction preferences',


### PR DESCRIPTION
Fixes #2184

## Changes proposed in this Pull Request:

This PR hides the option `Enable separate credit card form` when the new checkout experience (UPE) is enabled.
UPE always use separate credit card form fields, and the old settings did not include this option for UPE either.

## Testing instructions
1. Go to **WooCommerce > Settings > Payments > Stripe > Payment Methods**.
2. Make sure `New checkout experience is disabled`.
3. Go to the **Settings** tab.
4. Check that the `Enable separate credit card form` option is present in the `Payments & transactions` section.
5. Go back to **Payment Methods**.
6. Enable the `New checkout experience is disabled`.
7. Go to the **Settings** tab.
8. Check that the `Enable separate credit card form` option is NOT present anymore.