### PR TITLE
Reword "Stripe docs" to "Stripe plugin docs"

### DIFF
--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -170,7 +170,7 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 							docsLink: (
 								<ExternalLink href="https://woocommerce.com/document/stripe/">
 									{ __(
-										'Stripe docs',
+										'Stripe plugin docs',
 										'woocommerce-gateway-stripe'
 									) }
 								</ExternalLink>

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -36,7 +36,10 @@ const GeneralSettingsDescription = () => (
 		</p>
 		<p>
 			<ExternalLink href="https://woocommerce.com/document/stripe/">
-				{ __( 'View Stripe docs', 'woocommerce-gateway-stripe' ) }
+				{ __(
+					'View Stripe plugin docs',
+					'woocommerce-gateway-stripe'
+				) }
 			</ExternalLink>
 		</p>
 		<p>


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2187

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Rewording "Stripe docs" to "Stripe plugin docs" in order to avoid any confusion as to which documentation these links will navigate to. At the moment, there do not exist any tests for this minor change.

## Testing instructions

#### Make sure the "Stripe plugin docs" is worded correctly in the `Settings` tab

- As a merchant, go to `WooCommerce > Settings > Payments`
- Select the `Stripe` payment method
- If account keys have not been entered, make sure to enter them
- Click on the `Settings` tab, at the top of the page
- Ensure that the link to the plugin docs reads "View Stripe plugin docs" (see image below)

![image](https://user-images.githubusercontent.com/6844516/144923053-c1ac0acf-c617-4f9d-90ae-962899d6e15d.png)

#### Make sure the "Stripe plugin docs" is worded correctly in the `Disable the new payments experience` modal

- As a merchant, go to `WooCommerce > Settings > Payments`
- Select the `Stripe` payment method
- If account keys have not been entered, make sure to enter them
- In the `Payment Methods` tab, click the `Enable in your store` button in the `Enable the new Stripe checkout experience` section
- In the Stripe `Onboarding wizard`, click the `Enable` button, click `Add payment methods` button, and click the `Go to Stripe settings` button
- Next, in the `Payment methods` section, click the 3 vertical dots button (top, right-hand side) and select `Disable`
- Ensure that the link to the plugin docs reads "Stipe plugin docs" (see image below)

![image](https://user-images.githubusercontent.com/6844516/144923584-8782544d-c6d9-4e94-a7e7-103e58e673f3.png)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
