### PR TITLE
Use node version from .nvmrc

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -10,6 +10,10 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      # use the node version defined in nvmrc
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,6 +33,10 @@ jobs:
     steps:
       # clone the repository
       - uses: actions/checkout@v2
+      # use the node version defined in nvmrc
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
       # enable dependencies caching
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
Fixes #

## Changes proposed in this Pull Request:

This PR updates the JS test workflow to use the Node version defined in the `.nvmrc` file.

## Testing instructions
- Verify the status checks in this PR, they all should pass; including `JS tests / JS testing (pull_request) `