### PR TITLE
Fix secret key getter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Fixed bug that would send outdated data when using Blocks Checkout.
 * Add - List of payment methods that are not included for the merchant.
 * Tweak - Update how the new checkout experience is enabled.
+* Fix - Error on checkout depending on the account keys set.
 
 = 5.8.1 - 2021-11-23 =
 * Fix - Run filters that disable Stripe JS on cart and product pages when PRBs are disabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Fix - Fixed bug that would send outdated data when using Blocks Checkout.
 * Add - List of payment methods that are not included for the merchant.
 * Tweak - Update how the new checkout experience is enabled.
-* Fix - Error on checkout depending on the account keys set.
+* Fix - Error on UPE checkout depending on the account keys set.
 
 = 5.8.1 - 2021-11-23 =
 * Fix - Run filters that disable Stripe JS on cart and product pages when PRBs are disabled.

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -39,10 +39,12 @@ class WC_Stripe_API {
 	 */
 	public static function get_secret_key() {
 		if ( ! self::$secret_key ) {
-			$options = get_option( 'woocommerce_stripe_settings' );
+			$options         = get_option( 'woocommerce_stripe_settings' );
+			$secret_key      = strval( $options['secret_key'] );
+			$test_secret_key = strval( $options['test_secret_key'] );
 
-			if ( isset( $options['testmode'], $options['secret_key'], $options['test_secret_key'] ) ) {
-				self::set_secret_key( 'yes' === $options['testmode'] ? $options['test_secret_key'] : $options['secret_key'] );
+			if ( isset( $options['testmode'], $secret_key, $test_secret_key ) ) {
+				self::set_secret_key( 'yes' === $options['testmode'] ? $test_secret_key : $secret_key );
 			}
 		}
 		return self::$secret_key;

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -40,10 +40,10 @@ class WC_Stripe_API {
 	public static function get_secret_key() {
 		if ( ! self::$secret_key ) {
 			$options         = get_option( 'woocommerce_stripe_settings' );
-			$secret_key      = strval( $options['secret_key'] );
-			$test_secret_key = strval( $options['test_secret_key'] );
+			$secret_key      = $options['secret_key'] ?? '';
+			$test_secret_key = $options['test_secret_key'] ?? '';
 
-			if ( isset( $options['testmode'], $secret_key, $test_secret_key ) ) {
+			if ( isset( $options['testmode'] ) ) {
 				self::set_secret_key( 'yes' === $options['testmode'] ? $test_secret_key : $secret_key );
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -135,5 +135,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Fixed bug that would send outdated data when using Blocks Checkout.
 * Add - List of payment methods that are not included for the merchant.
 * Tweak - Update how the new checkout experience is enabled.
+* Fix - Error on checkout depending on the account keys set.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -135,6 +135,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Fixed bug that would send outdated data when using Blocks Checkout.
 * Add - List of payment methods that are not included for the merchant.
 * Tweak - Update how the new checkout experience is enabled.
-* Fix - Error on checkout depending on the account keys set.
+* Fix - Error on UPE checkout depending on the account keys set.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

It basically adds a string coercion when retrieving the secret key. On a fresh installation, if we set only the test keys, the getter ends up raising the error below because the `isset` check is returning `false`.

![image](https://user-images.githubusercontent.com/10233985/145257476-cededad2-c22f-4559-bc30-80b980a705fe.png)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

```sql
DELETE FROM `wp_options` WHERE option_name LIKE '%stripe%';
```
1. Checkout to `release/5.9.0`
2. Run the SQL query above to simulate a new installation locally.
3. Visit http://localhost:8082/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
4. Choose to enter the keys.
5. Type in your **test** Stripe account keys. Do not click on Save in the live keys tab in any circumstance.
6. Save the test keys.
7. Enable Stripe and UPE.
8. Go to the store and add something to the cart.
9. Go to checkout.
10. You should the same error from the screenshot above.
11. Checkout to `fix/secret-key-getter`.
12. Repeat the steps 2-9.
13. You should not see any error.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
