### PR TITLE
Ensure payment has captured before setting order's payment as complete

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -439,6 +439,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		// When the plugin's "Issue an authorization on checkout, and capture later"
+		// setting is enabled, Stripe API still sends a "charge.succeeded" webhook but
+		// the payment has not been captured, yet. This ensures that the payment has been
+		// captured, before completing the payment.
+		if ( ! $notification->data->object->captured ) {
+			return;
+		}
+
 		// Store other data such as fees
 		$order->set_transaction_id( $notification->data->object->id );
 


### PR DESCRIPTION


<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Before, even if Stripe had not captured the payment, the plugin would set the order's payment as complete. This PR ensures that the payment has been captured by Stripe, before setting the order's payment status as complete.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

> **Note:** It's important that [webhooks are set up correctly](https://woocommerce.com/document/stripe/#webhooks) for the manual capture to work correctly.

1. Using a Merchant account, enable **capture later** in the **WooCommerce > Settings > Payments > Stripe** page and save settings.

<img width="650" alt="image" src="https://user-images.githubusercontent.com/10233985/143888924-84dbae24-82ea-481f-b54d-7def0b78f1d6.png">

2. Follow normal card checkout flow as a Shopper to make a purchase. Take a note of the order number created.
3. Using Merchant account go to the **WooCommerce > Orders** page and open the order created above. The order should have the status `On Hold`.
4. Go to your [Stripe's account dashboard](https://dashboard.stripe.com)
5. Make sure **Viewing test data** is enabled and navigate to the **Payments** page.

<img width="266" alt="image" src="https://user-images.githubusercontent.com/13835680/125149041-0a22ed00-e126-11eb-840d-1a859f1adb0a.png">

6. Locate the payment for the order you just made

<img width="1352" alt="image" src="https://user-images.githubusercontent.com/13835680/125149120-96351480-e126-11eb-9e5c-d2c5fd48f59e.png">

7. Open the order details, click the **Capture** button, and capture the full amount.

<img width="1363" alt="image" src="https://user-images.githubusercontent.com/13835680/125149173-f330ca80-e126-11eb-9127-e8b193ebe585.png">

8. Go back to the order detail screens in your WooCommerce store and observe that the payment should now be captured (the order notes will say **Stripe charge complete (Charge ID: ch_abc...)**), and the order status should be set to **Processing**.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
