### PR TITLE
Correct the Stripe Account link URL on the Update Now Button

### DIFF
--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -114,7 +114,7 @@ const MissingAccountDetailsDescription = () => {
 					'Payments/payouts may be disabled for this account until missing business information is updated. <a>Update now</a>',
 					'woocommerce-gateway-stripe'
 				),
-				{ a: <ExternalLink href="https://stripe.com/support" /> }
+				{ a: <ExternalLink href="https://dashboard.stripe.com/account" /> }
 			) }
 		</div>
 	);

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -114,7 +114,11 @@ const MissingAccountDetailsDescription = () => {
 					'Payments/payouts may be disabled for this account until missing business information is updated. <a>Update now</a>',
 					'woocommerce-gateway-stripe'
 				),
-				{ a: <ExternalLink href="https://dashboard.stripe.com/account" /> }
+				{
+					a: (
+						<ExternalLink href="https://dashboard.stripe.com/account" />
+					),
+				}
 			) }
 		</div>
 	);


### PR DESCRIPTION
Fixes #2241 

## Changes proposed in this Pull Request:

This is a small tweak to update the link used for the 'Update Now' button so that it replaces `https://stripe.com/support` with `https://dashboard.stripe.com/account`

## Screenshots

Before: 
![image](https://user-images.githubusercontent.com/16253818/146007057-d7ee73d9-9263-48a7-a6ba-c8ebae2ba962.png)


After: 

![image](https://user-images.githubusercontent.com/16253818/146007767-da23be21-8a98-4aa8-a749-efc0cafc6430.png)


## Testing instructions

Steps to reproduce the behaviour:

1) You would need to have a Stripe account that has Payments or Payouts disabled so that the error shows. (This can be done on an account that is not activated/verified in Stripe and is in test mode)
2) Link up that account to WooCommerce Stripe via WooCommerce > Settings > Payments > Stripe
3) Go to Stripe > Settings > Account details
4) Click on the 'Update Now' button to update your business information


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
