### PR TITLE
Prompt message when navigating out Stripe settings with unsaved changes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,11 +4,10 @@
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.
 * Add - Text to explain how to enable webhooks when manually entering your API keys in the new Stripe settings.
 * Tweak - Redirect to the settings tab after an account is connected
+* Tweak - Prompt message when navigating out Stripe settings with unsaved changes
 * Tweak - Show toast when payment methods list is updated with new payment methods.
 * Fix - JS error on checkout when Boleto method was not active
 * Fix - Fixed bug that show "Use new payment method" on pay order page when there were no saved card was.
-
-=======
 
 = 5.9.0 - 2021-12-09 =
 * Add - Add Stripe API to generate connection tokens, manage terminal locations, create customers, get account summary, capture payment.

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -9,8 +9,13 @@ const SaveSettingsSectionWrapper = styled( SettingsSection )`
 	text-align: right;
 `;
 
-const SaveSettingsSection = () => {
+const SaveSettingsSection = ( { onSettingsSave } ) => {
 	const { saveSettings, isSaving, isLoading } = useSettings();
+
+	const onClickHandler = async () => {
+		await saveSettings();
+		onSettingsSave();
+	};
 
 	return (
 		<SaveSettingsSectionWrapper>
@@ -18,7 +23,7 @@ const SaveSettingsSection = () => {
 				isPrimary
 				isBusy={ isSaving }
 				disabled={ isSaving || isLoading }
-				onClick={ saveSettings }
+				onClick={ onClickHandler }
 			>
 				{ __( 'Save changes', 'woocommerce-gateway-stripe' ) }
 			</Button>

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -40,22 +40,16 @@ const SettingsManager = () => {
 		}
 	}, [ isLoading, settings ] );
 
-	const pristine =
+	const isPristine =
 		! isEmpty( initialSettings.current ) &&
 		isEqual( initialSettings.current, settings );
-	const confirmationNavigationCallback = useConfirmNavigation( () => {
-		if ( pristine ) {
-			return;
-		}
-
-		return __(
-			'There are unsaved changes on this page. Are you sure you want to leave and discard the unsaved changes?',
-			'woocommerce-payments'
-		);
-	} );
+	const displayPrompt = ! isPristine;
+	const confirmationNavigationCallback = useConfirmNavigation(
+		displayPrompt
+	);
 
 	useEffect( confirmationNavigationCallback, [
-		pristine,
+		displayPrompt,
 		confirmationNavigationCallback,
 	] );
 

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -1,12 +1,16 @@
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import { useEffect } from '@wordpress/element';
+import React, { useRef } from 'react';
 import { TabPanel } from '@wordpress/components';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
+import { isEmpty, isEqual } from 'lodash';
 import SettingsLayout from '../settings-layout';
 import PaymentSettingsPanel from '../payment-settings';
 import PaymentMethodsPanel from '../payment-methods';
 import SaveSettingsSection from '../save-settings-section';
+import { useSettings } from '../../data';
+import useConfirmNavigation from 'utils/use-confirm-navigation';
 
 const StyledTabPanel = styled( TabPanel )`
 	.components-tab-panel__tabs {
@@ -27,6 +31,34 @@ const TABS_CONTENT = [
 ];
 
 const SettingsManager = () => {
+	const { settings, isLoading } = useSettings();
+	const initialSettings = useRef();
+
+	useEffect( () => {
+		if ( isLoading && ! isEmpty( settings ) ) {
+			initialSettings.current = settings;
+		}
+	}, [ isLoading, settings ] );
+
+	const pristine =
+		! isEmpty( initialSettings.current ) &&
+		isEqual( initialSettings.current, settings );
+	const confirmationNavigationCallback = useConfirmNavigation( () => {
+		if ( pristine ) {
+			return;
+		}
+
+		return __(
+			'There are unsaved changes on this page. Are you sure you want to leave and discard the unsaved changes?',
+			'woocommerce-payments'
+		);
+	} );
+
+	useEffect( confirmationNavigationCallback, [
+		pristine,
+		confirmationNavigationCallback,
+	] );
+
 	// This grabs the "panel" URL query string value to allow for opening a specific tab.
 	const { panel } = getQuery();
 

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
-import React, { useRef } from 'react';
+import React, { useState } from 'react';
 import { TabPanel } from '@wordpress/components';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
@@ -32,17 +32,20 @@ const TABS_CONTENT = [
 
 const SettingsManager = () => {
 	const { settings, isLoading } = useSettings();
-	const initialSettings = useRef();
+	const [ initialSettings, setInitialSettings ] = useState( settings );
 
 	useEffect( () => {
 		if ( isLoading && ! isEmpty( settings ) ) {
-			initialSettings.current = settings;
+			setInitialSettings( settings );
 		}
 	}, [ isLoading, settings ] );
 
+	const onSettingsSave = () => {
+		setInitialSettings( settings );
+	};
+
 	const isPristine =
-		! isEmpty( initialSettings.current ) &&
-		isEqual( initialSettings.current, settings );
+		! isEmpty( initialSettings ) && isEqual( initialSettings, settings );
 	const displayPrompt = ! isPristine;
 	const confirmationNavigationCallback = useConfirmNavigation(
 		displayPrompt
@@ -75,7 +78,9 @@ const SettingsManager = () => {
 						) : (
 							<PaymentMethodsPanel />
 						) }
-						<SaveSettingsSection />
+						<SaveSettingsSection
+							onSettingsSave={ onSettingsSave }
+						/>
 					</div>
 				) }
 			</StyledTabPanel>

--- a/client/utils/use-confirm-navigation.js
+++ b/client/utils/use-confirm-navigation.js
@@ -1,26 +1,26 @@
 import { useEffect, useCallback, useRef } from '@wordpress/element';
-import { getHistory } from '@woocommerce/navigation';
 
 /**
  * Hook for displaying an optional confirmation message.
  *
  * Usage:
- * - const callback = useConfirmNavigation( () => 'Are you sure you want to leave?' );
+ * - const callback = useConfirmNavigation( true );
  *   useEffect( callback , [ callback, otherDependency ] );
  *
- * @param {Function} getMessage returns confirmation message string if one should appear
+ * @param {boolean} displayPrompt Wether we should prompt the message or not
  * @return {Function} The callback to execute
  */
-const useConfirmNavigation = ( getMessage ) => {
-	const savedCallback = useRef();
+const useConfirmNavigation = ( displayPrompt ) => {
+	const savedDisplayPrompt = useRef();
 
 	useEffect( () => {
-		savedCallback.current = getMessage;
+		savedDisplayPrompt.current = displayPrompt;
 	} );
 
 	return useCallback( () => {
-		const message = savedCallback.current();
-		if ( ! message ) {
+		const doDisplayPrompt = savedDisplayPrompt.current;
+
+		if ( ! doDisplayPrompt ) {
 			return;
 		}
 
@@ -29,11 +29,9 @@ const useConfirmNavigation = ( getMessage ) => {
 			event.returnValue = '';
 		};
 		window.addEventListener( 'beforeunload', handler );
-		const unblock = getHistory().block( message );
 
 		return () => {
 			window.removeEventListener( 'beforeunload', handler );
-			unblock();
 		};
 	}, [] );
 };

--- a/client/utils/use-confirm-navigation.js
+++ b/client/utils/use-confirm-navigation.js
@@ -7,7 +7,7 @@ import { useEffect, useCallback, useRef } from '@wordpress/element';
  * - const callback = useConfirmNavigation( true );
  *   useEffect( callback , [ callback, otherDependency ] );
  *
- * @param {boolean} displayPrompt Wether we should prompt the message or not
+ * @param {boolean} displayPrompt Whether we should prompt the message or not
  * @return {Function} The callback to execute
  */
 const useConfirmNavigation = ( displayPrompt ) => {

--- a/client/utils/use-confirm-navigation.js
+++ b/client/utils/use-confirm-navigation.js
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef } from '@wordpress/element';
 
 /**
- * Hook for displaying an optional confirmation message.
+ * Hook for displaying a confirmation message before navigate.
  *
  * Usage:
  * - const callback = useConfirmNavigation( true );

--- a/client/utils/use-confirm-navigation.js
+++ b/client/utils/use-confirm-navigation.js
@@ -1,0 +1,41 @@
+import { useEffect, useCallback, useRef } from '@wordpress/element';
+import { getHistory } from '@woocommerce/navigation';
+
+/**
+ * Hook for displaying an optional confirmation message.
+ *
+ * Usage:
+ * - const callback = useConfirmNavigation( () => 'Are you sure you want to leave?' );
+ *   useEffect( callback , [ callback, otherDependency ] );
+ *
+ * @param {Function} getMessage returns confirmation message string if one should appear
+ * @return {Function} The callback to execute
+ */
+const useConfirmNavigation = ( getMessage ) => {
+	const savedCallback = useRef();
+
+	useEffect( () => {
+		savedCallback.current = getMessage;
+	} );
+
+	return useCallback( () => {
+		const message = savedCallback.current();
+		if ( ! message ) {
+			return;
+		}
+
+		const handler = ( event ) => {
+			event.preventDefault();
+			event.returnValue = '';
+		};
+		window.addEventListener( 'beforeunload', handler );
+		const unblock = getHistory().block( message );
+
+		return () => {
+			window.removeEventListener( 'beforeunload', handler );
+			unblock();
+		};
+	}, [] );
+};
+
+export default useConfirmNavigation;

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 6.x.x - 2022-xx-xx =
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.
 * Add - Text to explain how to enable webhooks when manually entering your API keys in the new Stripe settings.
+* Tweak - Redirect to the settings tab after an account is connected
+* Tweak - Prompt message when navigating out Stripe settings with unsaved changes
+* Tweak - Show toast when payment methods list is updated with new payment methods.
+* Fix - JS error on checkout when Boleto method was not active  
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Redirect to the settings tab after an account is connected
 * Tweak - Prompt message when navigating out Stripe settings with unsaved changes
 * Tweak - Show toast when payment methods list is updated with new payment methods.
-* Fix - JS error on checkout when Boleto method was not active  
+* Fix - JS error on checkout when Boleto method was not active
+* Fix - Fixed bug that show "Use new payment method" on pay order page when there were no saved card was.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2203

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Adds `useConfirmNavigation` hook based on WCPay's `userConfirmNavigation` [hook](https://github.com/Automattic/woocommerce-payments/blob/3fa326bfbca4a4609db2bc02a21dbe1b07b04906/client/utils/use-confirm-navigation.js).

The difference between the two hooks is that the one we are introducing here does not handle navigation triggered by WooCommerce according to issue [requirements](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2203#issuecomment-991011823).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

You'll need to set up WCStripe and be working.

- In the admin area, Go to WooCommerce > Settings > Payments"
- Click the "Manage" button in the Stripe row
- Click any input from the "Payment Methods" tab
- Click the "Settings" tab
- No alert should be displayed.
- Click any link from the sidebar
- Alert should be displayed.
- Go back to Payment Methods by clicking the "Payment Methods" tab
- No alert should be displayed
- Refresh page
- Click the "Settings" tab
- Click any input or enter any tests into to any input text
- Click any link from the sidebar
- Alert should be displayed

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
