### PR TITLE
Fix ESLint warnings

### DIFF
--- a/client/components/tooltip/tooltip-base.js
+++ b/client/components/tooltip/tooltip-base.js
@@ -81,14 +81,16 @@ const useHideDelay = (
 			onHideCallbackRef.current();
 		};
 
-		document.addEventListener( 'click', handleDocumentClick );
+		const { ownerDocument } = triggerRef.current;
+
+		ownerDocument.addEventListener( 'click', handleDocumentClick );
 		rootElement.addEventListener(
 			'wcstripe-tooltip-open',
 			handleHideElement
 		);
 
 		return () => {
-			document.removeEventListener( 'click', handleDocumentClick );
+			ownerDocument.removeEventListener( 'click', handleDocumentClick );
 			rootElement.removeEventListener(
 				'wcstripe-tooltip-open',
 				handleHideElement
@@ -185,14 +187,22 @@ const TooltipBase = ( {
 
 		const debouncedCalculation = debounce( calculateTooltipPosition, 150 );
 
-		window.addEventListener( 'resize', debouncedCalculation );
-		document.addEventListener( 'scroll', debouncedCalculation );
+		const { ownerDocument } = wrapperRef.current;
+
+		ownerDocument.defaultView.addEventListener(
+			'resize',
+			debouncedCalculation
+		);
+		ownerDocument.addEventListener( 'scroll', debouncedCalculation );
 
 		return () => {
-			window.removeEventListener( 'resize', debouncedCalculation );
-			document.removeEventListener( 'scroll', debouncedCalculation );
+			ownerDocument.defaultView.removeEventListener(
+				'resize',
+				debouncedCalculation
+			);
+			ownerDocument.removeEventListener( 'scroll', debouncedCalculation );
 		};
-	}, [ isTooltipVisible, maxWidth ] );
+	}, [ isTooltipVisible, maxWidth, wrapperRef ] );
 
 	return (
 		<>

--- a/client/utils/use-confirm-navigation.js
+++ b/client/utils/use-confirm-navigation.js
@@ -28,9 +28,12 @@ const useConfirmNavigation = ( displayPrompt ) => {
 			event.preventDefault();
 			event.returnValue = '';
 		};
+
+		// eslint-disable-next-line @wordpress/no-global-event-listener
 		window.addEventListener( 'beforeunload', handler );
 
 		return () => {
+			// eslint-disable-next-line @wordpress/no-global-event-listener
 			window.removeEventListener( 'beforeunload', handler );
 		};
 	}, [] );


### PR DESCRIPTION
Fixes a few ESLint warnings that were being displayed by GitHub on PRs - [Here's one example](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2245/files#diff-da5028968b7361040f4e935cd5e7aa89f6d563014d8df670dcd39ef4a88b5af8).