### PR TITLE
Fix duplicate `wc_stripe_params` enqueued variable

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -3,9 +3,7 @@ jQuery( function( $ ) {
 	'use strict';
 
 	var stripe = Stripe( wc_stripe_payment_request_params.stripe.key, {
-		locale: typeof wc_stripe_params !== 'undefined' ? wc_stripe_params.stripe_locale
-			: typeof wc_stripe_upe_params !== 'undefined' ? wc_stripe_upe_params.locale
-			: 'auto'
+		locale: wc_stripe_payment_request_params.stripe.locale
 	} ),
 		paymentRequestType;
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -3,7 +3,9 @@ jQuery( function( $ ) {
 	'use strict';
 
 	var stripe = Stripe( wc_stripe_payment_request_params.stripe.key, {
-		locale: typeof wc_stripe_params !== 'undefined' ? wc_stripe_params.stripe_locale : 'auto',
+		locale: typeof wc_stripe_params !== 'undefined' ? wc_stripe_params.stripe_locale
+			: typeof wc_stripe_upe_params !== 'undefined' ? wc_stripe_upe_params.locale
+			: 'auto'
 	} ),
 		paymentRequestType;
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Add - Add ability to test Stripe account keys' validity.
 * Fix - Fixed full bank statement field description.
 * Fix - Notification messages are placed on top of the account keys modal.
+* Fix - Express checkout with 3DS card on product page when new checkout experience is enabled.
 
 = 6.0.0 - 2022-01-05 =
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Fixed full bank statement field description.
 * Fix - Notification messages are placed on top of the account keys modal.
 * Fix - Express checkout with 3DS card on product page when new checkout experience is enabled.
+* Fix - Remove duplicate call to `payment_scripts`.
 
 = 6.0.0 - 2022-01-05 =
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -773,11 +773,6 @@ class WC_Stripe_Payment_Request {
 		);
 
 		wp_enqueue_script( 'wc_stripe_payment_request' );
-
-		$gateways = WC()->payment_gateways->get_available_payment_gateways();
-		if ( isset( $gateways['stripe'] ) ) {
-			$gateways['stripe']->payment_scripts();
-		}
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -708,6 +708,7 @@ class WC_Stripe_Payment_Request {
 			'stripe'             => [
 				'key'                => $this->publishable_key,
 				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
+				'locale'             => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
 			],
 			'nonce'              => [
 				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -195,7 +195,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * Outputs scripts used for stripe payment
 	 */
 	public function payment_scripts() {
-		if ( ! is_cart() && ! is_checkout() && ! isset( $_GET['pay_for_order'] ) && ! is_add_payment_method_page() ) {
+		if (
+			! is_product()
+			&& ! WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
+			&& ! isset( $_GET['pay_for_order'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			&& ! is_add_payment_method_page() ) {
+			return;
+		}
+
+		if ( is_product() && ! WC_Stripe_Helper::should_load_scripts_on_product_page() ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,5 +138,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Fixed full bank statement field description.
 * Fix - Notification messages are placed on top of the account keys modal.
 * Fix - Express checkout with 3DS card on product page when new checkout experience is enabled.
+* Fix - Remove duplicate call to `payment_scripts`.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -137,5 +137,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Add ability to test Stripe account keys' validity.
 * Fix - Fixed full bank statement field description.
 * Fix - Notification messages are placed on top of the account keys modal.
+* Fix - Express checkout with 3DS card on product page when new checkout experience is enabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Context: p1640219445150700-slack-C01BZUL57SQ

## Changes proposed in this Pull Request:

- Remove call from `payment_scripts` call from the payment request class.

## Testing instructions

- Please test product, cart and checkout pages and make sure the variable `wc_stripe_params` is not present in the source code more than once.
- Make sure the regular checkout and the payment request button checkout works as expected, both blocks and shortcode.