### PR TITLE
Add is_live and test_mode to account summary API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.1.0 - 2022-xx-xx =
 * Tweak - Use the newly exposed LoadableMask component provided by WooCommerce Blocks to trigger the loading state for Payment Request Buttons.
 * Fix - Response type for account summary API.
+* Add - Live and test mode information in account summary API.
 
 = 6.0.0 - 2022-01-05 =
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -110,7 +110,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 					'supported' => $this->account->get_supported_store_currencies(),
 				],
 				'country'                  => $account['country'] ?? '',
-				'is_live'                  => $account['charges_enabled'],
+				'is_live'                  => $account['charges_enabled'] ?? false,
 				'test_mode'                => WC_Stripe_Webhook_State::get_testmode(),
 			]
 		);

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -110,6 +110,8 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 					'supported' => $this->account->get_supported_store_currencies(),
 				],
 				'country'                  => $account['country'] ?? '',
+				'is_live'                  => $account['charges_enabled'],
+				'test_mode'                => WC_Stripe_Webhook_State::get_testmode(),
 			]
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 6.x.x - 2022-xx-xx =
 * Tweak - Use the newly exposed LoadableMask component provided by WooCommerce Blocks to trigger the loading state for Payment Request Buttons.
 * Fix - Response type for account summary API.
+* Add - Live and test mode information in account summary API.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2262

## Changes proposed in this Pull Request:

For card reader payments, the account summary API needs to provide mobile apps with `is_live` and `test_mode`. This PR adds those API fields to the endpoint.

* `is_live` should represent whether the underlying Stripe account is activated and able to accept live payments. After talking with Stripe about the best way to determine this, their recommendation is to use the `charges_enabled` field on the Stripe account object. This PR uses that approach.
* `test_mode` represents whether test API keys or live API keys should be used. The extension already has a function to check the settings for this.

## Testing instructions

Make a GET request to `/wp-json/wc/v3/wc_stripe/account/summary` (e.g. by running `curl --user username:password 'http://YOUR_SITE/wp-json/wc/v3/wc_stripe/account/summary'` with [Basic Auth](https://github.com/WP-API/Basic-Auth) installed). Verify that you get back a valid JSON response that includes both `is_live` and `test_mode` with values consistent with your account's settings.

#2269 still needs review as well, so I currently have this PR pointed at that branch instead of develop as the base branch.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
