### PR TITLE
Fix account summary API response when no account linked

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.1.0 - 2022-xx-xx =
 * Tweak - Use the newly exposed LoadableMask component provided by WooCommerce Blocks to trigger the loading state for Payment Request Buttons.
 * Fix - Response type for account summary API.
+* Fix - Invalid response in account summary API when missing account data.
 
 = 6.0.0 - 2022-01-05 =
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -106,10 +106,10 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 				'status'                   => $this->account->get_account_status(),
 				'statement_descriptor'     => $account['settings']['payments']['statement_descriptor'] ?? '',
 				'store_currencies'         => [
-					'default'   => $account['default_currency'] ?? '',
+					'default'   => $account['default_currency'] ?? get_woocommerce_currency(),
 					'supported' => $this->account->get_supported_store_currencies(),
 				],
-				'country'                  => $account['country'] ?? '',
+				'country'                  => $account['country'] ?? WC()->countries->get_base_country(),
 			]
 		);
 	}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -14,6 +14,7 @@ class WC_Stripe_Account {
 	const TEST_ACCOUNT_OPTION    = 'wcstripe_account_data_test';
 
 	const STATUS_COMPLETE        = 'complete';
+	const STATUS_NO_ACCOUNT      = 'NOACCOUNT';
 	const STATUS_RESTRICTED_SOON = 'restricted_soon';
 	const STATUS_RESTRICTED      = 'restricted';
 
@@ -153,8 +154,12 @@ class WC_Stripe_Account {
 	 * @return string The account's status.
 	 */
 	public function get_account_status() {
-		$requirements = $this->get_cached_account_data()['requirements'] ?? [];
+		$account = $this->get_cached_account_data();
+		if ( empty( $account ) ) {
+			return self::STATUS_NO_ACCOUNT;
+		}
 
+		$requirements = $account['requirements'] ?? [];
 		if ( empty( $requirements ) ) {
 			return self::STATUS_COMPLETE;
 		}
@@ -189,7 +194,7 @@ class WC_Stripe_Account {
 	public function get_supported_store_currencies(): array {
 		$account = $this->get_cached_account_data();
 		if ( ! isset( $account['external_accounts']['data'] ) ) {
-			return [ $account['default_currency'] ?? '' ];
+			return [ $account['default_currency'] ?? get_woocommerce_currency() ];
 		}
 
 		$currencies = array_filter( array_column( $account['external_accounts']['data'], 'currency' ) );

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 6.x.x - 2022-xx-xx =
 * Tweak - Use the newly exposed LoadableMask component provided by WooCommerce Blocks to trigger the loading state for Payment Request Buttons.
 * Fix - Response type for account summary API.
+* Fix - Invalid response in account summary API when missing account data.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2274

## Changes proposed in this Pull Request:

This PR updates the response from the account summary API to be consistent with how WCPay responds in the case that there's no Stripe account linked to the extension. In particular, if there's no account:

* The `status` should be `NOACCOUNT` instead of `complete`.
* The currency should default to the WC default currency.
* The country should default to the WC base country.

#2269 still needs review as well, so I currently have this PR pointed at that branch instead of develop as the base branch.

## Testing instructions

To make a request to the account summary API, run `curl --user username:password 'http://YOUR_SITE/wp-json/wc/v3/wc_stripe/account/summary'` with [Basic Auth](https://github.com/WP-API/Basic-Auth) installed.

1. In WooCommerce > Settings > Payments > Stripe > Settings, click "Edit account keys" and remove all API keys. Then "Save test keys."
2. Make a request to the account summary API. Verify that the `status` field is `NOACCOUNT`. Verify that the `default` and `supported` store currencies are both your store's default currency. Verify that `country` is your store's country.
3. In WooCommerce > Settings > General, change your store currency and/or country.
4. Repeat step 2, verify that the currency and country are still correct.
5. In WooCommerce > Settings > Payments > Stripe > Settings, click "Edit account keys" and add back valid test keys.
6. Repeat step 2, verify that the `status` is now `complete`.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
