### PR TITLE
Fix full bank statement field description

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Tweak - Use the newly exposed LoadableMask component provided by WooCommerce Blocks to trigger the loading state for Payment Request Buttons.
 * Add - Add filter call when updating an existent intent (wc_stripe_update_existing_intent_request).
 * Add - Add ability to test Stripe account keys' validity.
+* Fix - Fixed full bank statement field description.
 
 = 6.0.0 - 2022-01-05 =
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -107,7 +107,7 @@ const PaymentsAndTransactionsSection = () => {
 				>
 					<TextControl
 						help={ __(
-							'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. the legal entity name or website address–to avoid potential disputes and chargebacks.',
+							'Enter the name your customers will see on their transactions. Use a recognizable name – e.g. the legal entity name or website address – to avoid potential disputes and chargebacks.',
 							'woocommerce-gateway-stripe'
 						) }
 						label={ __(

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -22,7 +22,7 @@ import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 const TooltipBankStatementHelp = () => (
 	<Tooltip
 		content={ __(
-			'Bank statement must consist of at least 1 Latin letter and cannot contain special characters.',
+			'The bank statement must contain only Latin characters, be between 5 and 22 characters, and not contain any of the special characters: \' " * < >',
 			'woocommerce-gateway-stripe'
 		) }
 	>

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -26,7 +26,7 @@ const TooltipBankStatementHelp = () => (
 			'woocommerce-gateway-stripe'
 		) }
 	>
-		<span style={ { flexShrink: 0 } }>
+		<span>
 			<Icon style={ { fill: '#949494' } } icon={ help } />
 		</span>
 	</Tooltip>

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -1,11 +1,13 @@
 import { __ } from '@wordpress/i18n';
 import React, { useContext } from 'react';
 import { Card, CheckboxControl, TextControl } from '@wordpress/components';
+import { Icon, help } from '@wordpress/icons';
 import CardBody from '../card-body';
 import TextLengthHelpInputWrapper from './text-length-help-input-wrapper';
 import StatementPreviewsWrapper from './statement-previews-wrapper';
 import StatementPreview from './statement-preview';
 import ManualCaptureControl from './manual-capture-control';
+import Tooltip from 'wcstripe/components/tooltip';
 import {
 	useSavedCards,
 	useSeparateCardForm,
@@ -16,6 +18,19 @@ import {
 } from 'wcstripe/data';
 import InlineNotice from 'wcstripe/components/inline-notice';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
+
+const TooltipBankStatementHelp = () => (
+	<Tooltip
+		content={ __(
+			'Bank statement must consist of at least 1 Latin letter and cannot contain special characters.',
+			'woocommerce-gateway-stripe'
+		) }
+	>
+		<span style={ { flexShrink: 0 } }>
+			<Icon style={ { fill: '#949494' } } icon={ help } />
+		</span>
+	</Tooltip>
+);
 
 const PaymentsAndTransactionsSection = () => {
 	const [ isSavedCardsEnabled, setIsSavedCardsEnabled ] = useSavedCards();
@@ -104,6 +119,7 @@ const PaymentsAndTransactionsSection = () => {
 				<TextLengthHelpInputWrapper
 					textLength={ accountStatementDescriptor.length }
 					maxLength={ 22 }
+					iconSlot={ <TooltipBankStatementHelp /> }
 				>
 					<TextControl
 						help={ __(

--- a/client/settings/payments-and-transactions-section/text-length-help-input-wrapper.js
+++ b/client/settings/payments-and-transactions-section/text-length-help-input-wrapper.js
@@ -29,16 +29,32 @@ const HelpText = styled.span`
 	}
 `;
 
+const DivIcon = styled.div`
+	position: absolute;
+	top: 33px;
+	right: -24px;
+
+	width: 1.5rem;
+	height: 1.5rem;
+
+	@media ( min-width: 783px ) {
+		top: 28px;
+		right: calc( 50% - 28px );
+	}
+`;
+
 const TextLengthHelpInputWrapper = ( {
 	children,
 	textLength = 0,
 	maxLength,
+	iconSlot = null,
 } ) => (
-	<Wrapper>
+	<Wrapper style={ { width: iconSlot ? 'calc( 100% - 24px )' : null } }>
 		{ children }
 		<HelpText aria-hidden="true">
 			{ `${ textLength } / ${ maxLength }` }
 		</HelpText>
+		{ iconSlot && <DivIcon>{ iconSlot }</DivIcon> }
 	</Wrapper>
 );
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1134,10 +1134,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_account_statement_descriptor_field( $param, $value, $max_length ) {
 		// Since the value is escaped, and we are saving in a place that does not require escaping, apply stripslashes.
 		$value = trim( stripslashes( $value ) );
-		$field = __( 'Customer bank statement', 'woocommerce-gateway-stripe' );
+		$field = __( 'customer bank statement', 'woocommerce-gateway-stripe' );
 
 		if ( 'short_statement_descriptor' === $param ) {
-			$field = __( 'Shortened customer bank statement', 'woocommerce-gateway-stripe' );
+			$field = __( 'shortened customer bank statement', 'woocommerce-gateway-stripe' );
 		}
 
 		// Validation can be done with a single regex but splitting into multiple for better readability.
@@ -1153,7 +1153,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			throw new InvalidArgumentException(
 				sprintf(
 					/* translators: %1 field name, %2 Number of the maximum characters allowed */
-					__( '%1$s is invalid. Statement should be between 5 and %2$u characters long, contain at least single Latin character and does not contain special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ),
+					__( 'The %1$s is invalid. The bank statement must contain only Latin characters, be between 5 and %2$u characters, contain at least one letter, and not contain any of the special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ),
 					$field,
 					$max_length
 				)

--- a/readme.txt
+++ b/readme.txt
@@ -132,5 +132,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Use the newly exposed LoadableMask component provided by WooCommerce Blocks to trigger the loading state for Payment Request Buttons.
 * Add - Add filter call when updating an existent intent (wc_stripe_update_existing_intent_request).
 * Add - Add ability to test Stripe account keys' validity.
+* Fix - Fixed full bank statement field description.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2180

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR helps clarify what input is valid in the **Full bank statement** field. In order to convey this info, a tooltip was placed next to the input. This approach was selected because it was cleaner than adding more text in the description below the input field.

Because this was a minor UI update, no tests were added to this PR.

![image](https://user-images.githubusercontent.com/6844516/149678120-f63e6b90-4c8a-461e-a03d-9ebe873bca89.png)

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. As a merchant, go to `WooCommerce > Settings > Payments > Stripe` and click on the `Settings` tab (at the top).
2. Scroll down to `Payments & transactions > Customer bank statement`.
3. Hover over the **question mark** icon, next to the input field of **Full bank statement.**
4. Ensure the following text is displayed: `The bank statement must contain only Latin characters, be between 5 and 22 characters, and not contain any of the special characters: \' " * < >`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
