### PR TITLE
Adjust modal z-index's overlay to be able to see messages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - Add filter call when updating an existent intent (wc_stripe_update_existing_intent_request).
 * Add - Add ability to test Stripe account keys' validity.
 * Fix - Fixed full bank statement field description.
+* Fix - Notification messages are placed on top of the account keys modal.
 
 = 6.0.0 - 2022-01-05 =
 * Fix - Fixed capitalization for payment method names: iDEAL, giropay, and Sofort.

--- a/client/settings/payment-settings/style.scss
+++ b/client/settings/payment-settings/style.scss
@@ -44,3 +44,9 @@
 		}
 	}
 }
+
+.components-modal__screen-overlay {
+	// This value should be lower than .woocommerce-transient-notices's z-index
+	// to be able to see snackbar's messages
+	z-index: 99998;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Add filter call when updating an existent intent (wc_stripe_update_existing_intent_request).
 * Add - Add ability to test Stripe account keys' validity.
 * Fix - Fixed full bank statement field description.
+* Fix - Notification messages are placed on top of the account keys modal.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2282 

## Changes proposed in this Pull Request:

Adjusts the z-index value for the `.components-modal__screen-overlay` class so it's placed behind the snackbar's messages.

<img width="686" alt="Screen Shot 2022-01-17 at 11 39 42 PM" src="https://user-images.githubusercontent.com/1025173/149872030-326bc096-81cb-4aec-a1f6-a0e6b6eb596f.png">


## Testing instructions

1. As a merchant, go to `WooCommerce > Settings > Payments > Stripe` and click on the `Settings` tab (at the top).
2. Click on the `Edit account keys` button in order to open the **Edit test account keys & webhooks** modal.
3. Enter invalid publishable (`pk_invalid_key_0000`) and secret (`sk_invalid_key_0000`) keys and click on the `Test connection` link.
4. Notice the notification message appears in front of the modal.


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)