### PR TITLE
Fix Translations not loaded in admin (UPE / JSON)

### DIFF
--- a/includes/admin/class-wc-stripe-old-settings-upe-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-old-settings-upe-toggle-controller.php
@@ -69,6 +69,10 @@ class WC_Stripe_Old_Settings_UPE_Toggle_Controller {
 				'is_upe_enabled'  => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			]
 		);
+		wp_set_script_translations(
+			'woocommerce_stripe_old_settings_upe_toggle',
+			'woocommerce-gateway-stripe'
+		);
 		wp_enqueue_script( 'woocommerce_stripe_old_settings_upe_toggle' );
 	}
 }

--- a/includes/admin/class-wc-stripe-payment-gateways-controller.php
+++ b/includes/admin/class-wc-stripe-payment-gateways-controller.php
@@ -43,6 +43,10 @@ class WC_Stripe_Payment_Gateways_Controller {
 			$payment_gateways_script_asset['version'],
 			true
 		);
+		wp_set_script_translations(
+			'woocommerce_stripe_payment_gateways_page',
+			'woocommerce-gateway-stripe'
+		);
 		wp_register_style(
 			'woocommerce_stripe_payment_gateways_page',
 			plugins_url( 'build/payment_gateways.css', WC_STRIPE_MAIN_FILE ),

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -33,6 +33,10 @@ class WC_Stripe_Payment_Requests_Controller {
 			$asset_metadata['version'],
 			true
 		);
+		wp_set_script_translations(
+			'wc-stripe-payment-request-settings',
+			'woocommerce-gateway-stripe'
+		);
 		wp_enqueue_script( 'wc-stripe-payment-request-settings' );
 
 		wp_register_style(

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -112,6 +112,7 @@ class WC_Stripe_Settings_Controller {
 			'stripe_oauth_url'        => $oauth_url,
 		];
 		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
+		wp_set_script_translations( 'woocommerce_stripe_admin', 'woocommerce-gateway-stripe' );
 
 		wp_enqueue_script( 'woocommerce_stripe_admin' );
 		wp_enqueue_style( 'woocommerce_stripe_admin' );

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -111,8 +111,15 @@ class WC_Stripe_Settings_Controller {
 			'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			'stripe_oauth_url'        => $oauth_url,
 		];
-		wp_localize_script( 'woocommerce_stripe_admin', 'wc_stripe_settings_params', $params );
-		wp_set_script_translations( 'woocommerce_stripe_admin', 'woocommerce-gateway-stripe' );
+		wp_localize_script(
+			'woocommerce_stripe_admin',
+			'wc_stripe_settings_params',
+			$params
+		);
+		wp_set_script_translations(
+			'woocommerce_stripe_admin',
+			'woocommerce-gateway-stripe'
+		);
 
 		wp_enqueue_script( 'woocommerce_stripe_admin' );
 		wp_enqueue_style( 'woocommerce_stripe_admin' );


### PR DESCRIPTION
Fixes #2285

## Changes proposed in this Pull Request:

This PR adds the missing `wp_set_script_translations(...)` calls for the registered scripts from the `/build` folder.

## Testing instructions
0. Checkout the `develop` branch.
1. Go to **Settings** and change the Site Language to French or Spanish (only 100% complete on translate.wordpress.org).
2. Go to **Dashboard > Updates** and click Update translations (this will be shown in the selected language).
3. Go to ** WooCommerce > Settings > Payments**  and select **Stripe** from the list.
4. See that all text strings are untranslated (both in `Payment Methods` and in the `Settings` tabs).
5. Checkout this branch `fix/2285-translation-not-loaded-in-admin`
6. Go to ** WooCommerce > Settings > Payments**  and select **Stripe** from the list (again).
7. See that this time the strings are correctly translated (check in both tabs: `Payment Methods` and `Settings`).
