### PR TITLE
Fix npm run xdebug:stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "up": "docker-compose up --build --force-recreate -d && ./bin/docker-setup.sh",
     "down": "docker-compose down",
     "xdebug:start": "docker-compose exec wordpress sh -c 'sed -i \"/xdebug.mode=off/c\\xdebug.mode=debug\" /usr/local/etc/php/php.ini && /etc/init.d/apache2 reload'",
-    "xdebug:stop": "docker-compose exec wordpress sh -c 'sed -i \"/xdebug.mode=debug/c\\xdebug.mode=off\" /usr/local/etc/php/php.ini && /etc/init.d/apache2 reload",
+    "xdebug:stop": "docker-compose exec wordpress sh -c 'sed -i \"/xdebug.mode=debug/c\\xdebug.mode=off\" /usr/local/etc/php/php.ini && /etc/init.d/apache2 reload'",
     "wp": "docker run -it --env-file default.env --rm --user xfs --volumes-from woocommerce_stripe_wordpress --network container:woocommerce_stripe_wordpress wordpress:cli",
     "listen": "stripe listen --forward-to 'http://localhost:8082/?wc-api=wc_stripe'",
     "presass": "rm -f $npm_package_assets_styles_css",


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR adds the missing `'` character at the end of the `xdebug:stop` npm script.

<img width="1579" alt="Screen Shot 2022-01-18 at 15 08 06" src="https://user-images.githubusercontent.com/407542/149993951-1684aed9-5297-414c-8893-f1d9aca0e16c.png">

## Testing instructions
0. Checkout `develop`
1. Run: `npm run xdebug:stop` and check that it results in the following error:
```
> woocommerce-gateway-stripe@6.0.0 xdebug:stop /Users/diego/A8C/woocommerce-gateway-stripe
> docker-compose exec wordpress sh -c 'sed -i "/xdebug.mode=debug/c\xdebug.mode=off" /usr/local/etc/php/php.ini && /etc/init.d/apache2 reload

sh: -c: line 0: unexpected EOF while looking for matching `''
sh: -c: line 1: syntax error: unexpected end of file
```

2. Checkout this branch: `chore/fix-npm-xdebug-stop`
3. Run: `npm run xdebug:stop` again, and check that this time the commands succeeds.
```
> woocommerce-gateway-stripe@6.0.0 xdebug:start /Users/diego/A8C/woocommerce-gateway-stripe
> docker-compose exec wordpress sh -c 'sed -i "/xdebug.mode=off/c\xdebug.mode=debug" /usr/local/etc/php/php.ini && /etc/init.d/apache2 reload'

Reloading Apache httpd web server: apache2.
```