### PR TITLE
Use the default UPE title when custom payment method name is empty

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -121,7 +121,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->maybe_init_pre_orders();
 
 		$main_settings              = get_option( 'woocommerce_stripe_settings' );
-		$this->title                = $this->get_option( 'title_upe' );
+		$this->title                = ! empty( $this->get_option( 'title_upe' ) ) ? $this->get_option( 'title_upe' ) : $this->form_fields['title_upe']['default'];
 		$this->description          = '';
 		$this->enabled              = $this->get_option( 'enabled' );
 		$this->saved_cards          = 'yes' === $this->get_option( 'saved_cards' );


### PR DESCRIPTION
Fixes #2214

## Changes proposed in this Pull Request:

This PR changes the UPE gateway to use the default title ("Popular payment methods") if the merchant's custom payment name is empty in the Settings page.

## Testing instructions
0. Checkout the `develop` branch.
1. Go to **WooCommerce > Settings > Payments > Stripe > Payment Methods**.
2. Make sure the New checkout experience is enabled.
3. Go to **WooCommerce > Settings > Payments > Stripe > Settings**.
4. In the **General** section, empty the field **Name** and save changes.
5. Go to the Store, add any product and go to the **Checkout** page.
6. Verify that the payment section does not have a title:
<img width="350" alt="Screen Shot 2021-12-02 at 15 46 23" src="https://user-images.githubusercontent.com/407542/144483876-93f71521-5dc1-4947-b032-2a3683d2545d.png">

7. Checkout this branch `fix/2214-custom-payment-method-name-empty-in-upe-checkout`.
8. Reload the **Checkout** page.
9. Verify that this time the payment section does have the default title ("Popular payment methods"):
<img width="343" alt="Screen Shot 2022-01-20 at 11 42 29" src="https://user-images.githubusercontent.com/407542/150360508-9622989b-8b0e-427e-b52f-df978b6ad221.png">
