### PR TITLE
Tweak description name when updating payment intents inside pay order page

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -407,7 +407,8 @@ class WC_Stripe_Intent_Controller {
 				'amount'      => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
 				'currency'    => strtolower( $currency ),
 				'metadata'    => $gateway->get_metadata_from_order( $order ),
-				'description' => __( 'Stripe - Order', 'woocommerce-gateway-stripe' ) . ' ' . $order->get_id(),
+				/* translators: 1) blog name 2) order number */
+				'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
 			];
 
 			if ( '' !== $selected_upe_payment_type ) {


### PR DESCRIPTION
Fixes #2292 

## Changes proposed in this Pull Request:
This PR fixed the description of a payment intent when paying via Pay Order page( My account > Order > Pay)

## Testing instructions
- As a shopper add a product to cart
- During checkout use an invalid card `4000000000000002`
- Go to Stripe dashboard > [Payments](https://dashboard.stripe.com/test/payments)
- Notice the description of the last payment intent. It will be `<blog name> - Order <order number>`
- Go to My Account > Orders > Pay Order
- Use a valid card `4242 4242 4242 4242`
- Go to Stripe dashboard > [Payments](https://dashboard.stripe.com/test/payments)
- Notice the description of the last payment intent. Make sure it looks like `<blog name> - Order <order number>`