### PR TITLE
Add custom PHP Unit version (9.5) when testing with PHP 8

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -1,35 +1,47 @@
-name: Compatibility (WC, WP, PHP)
+name: PHP tests
 
 on:
   pull_request
 
 jobs:
-  # a dedicated job, as allowed to fail
-  compatibility-woocommerce-beta:
-    name:    Beta
+  beta-compatibility:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
         woocommerce: [ 'beta' ]
         wordpress:   [ 'latest' ]
-        php:         [ '7.1', '8.0' ]
+        php:         [ '7.0', '7.4', '8.0' ]
+          
+    
+    name: Beta (PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }})
     env:
-      WP_VERSION: ${{ matrix.wordpress }}
-      WC_VERSION: ${{ matrix.woocommerce }}
+      PHP_VERSION: ${{ matrix.php }}
+      WP_VERSION:  ${{ matrix.wordpress }}
+      WC_VERSION:  ${{ matrix.woocommerce }}
     steps:
-      # clone the repository
-      - uses: actions/checkout@v2
-      # enable dependencies caching
-      - uses: actions/cache@v2
+      - name: Testing with PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
+        uses: actions/checkout@v2
+
+      - name: Set up dependencies caching
+        uses: actions/cache@v2
         with:
           path: ~/.cache/composer/
           key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      # setup PHP, but without debug extensions for reasonable performance
-      - uses: shivammathur/setup-php@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools:       composer
           coverage:    none
-      # run CI checks
-      - run: bash bin/run-ci-tests.bash
+          
+      - name: If PHP 7.0, set up PHPUnit 6.5 for legacy compatibility
+        if: ${{ matrix.php == '7.0' }}
+        run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
+
+      - name: If PHP 8.0 and WP 5.9, set up PHPUnit 9.5 for compatibility
+        if: ${{ matrix.php == '8.0' && matrix.wordpress == '5.9' }}
+        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
+
+      - name: Run CI checks
+        run: bash bin/run-ci-tests.bash

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -39,8 +39,8 @@ jobs:
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
-      - name: If PHP 8.0 and WP 5.9, set up PHPUnit 9.5 for compatibility
-        if: ${{ matrix.php == '8.0' && matrix.wordpress == '5.9' }}
+      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
+        if: ${{ matrix.php == '8.0' }}
         run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -62,7 +62,7 @@ jobs:
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
       - name: If PHP 8.0 and WP 5.9, set up PHPUnit 9.5 for compatibility
-        if: ${{ matrix.php == '8.0' && matrix.wordpress == '5.9' }}
+        if: ${{ matrix.php == '8.0' && matrix.wordpress >= '5.9' }}
         run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -55,12 +55,15 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          tools: phpunit-polyfills
           coverage:    none
 
       - name: If PHP 7.0, set up PHPUnit 6.5 for legacy compatibility
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
+
+      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
+        if: ${{ matrix.php == '8.0' }}
+        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks
         run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -61,8 +61,8 @@ jobs:
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
-      - name: If PHP 8.0 and WP 5.9, set up PHPUnit 9.5 for compatibility
-        if: ${{ matrix.php == '8.0' && matrix.wordpress == '5.9' }}
+      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
+        if: ${{ matrix.php == '8.0' }}
         run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Testing with PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
         uses: actions/checkout@v2
 
-      - name: Set up dependencies caching
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/composer/
-          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+#      - name: Set up dependencies caching
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/.cache/composer/
+#          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -61,8 +61,8 @@ jobs:
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
-      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
-        if: ${{ matrix.php == '8.0' }}
+      - name: If PHP 8.0 and WP 5.9, set up PHPUnit 9.5 for compatibility
+        if: ${{ matrix.php == '8.0' && matrix.wordpress == '5.9' }}
         run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -61,5 +61,9 @@ jobs:
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
+      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
+        if: ${{ matrix.php == '8.0' }}
+        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
+
       - name: Run CI checks
         run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -55,15 +55,12 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: phpunit-polyfills
           coverage:    none
 
       - name: If PHP 7.0, set up PHPUnit 6.5 for legacy compatibility
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
-
-      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
-        if: ${{ matrix.php == '8.0' }}
-        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks
         run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '6.1.0'
+            woocommerce: '6.2.0'
           - woocommerce_support_policy: L-1
-            woocommerce: '6.0.0'
+            woocommerce: '6.1.0'
           - woocommerce_support_policy: L-2
-            woocommerce: '5.9.0'
+            woocommerce: '6.0.0'
           # WordPress
           - wordpress_support_policy: L
             wordpress: '5.9'

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Testing with PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }}
         uses: actions/checkout@v2
 
-#      - name: Set up dependencies caching
-#        uses: actions/cache@v2
-#        with:
-#          path: ~/.cache/composer/
-#          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+      - name: Set up dependencies caching
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/composer/
+          key:  ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -61,9 +61,9 @@ jobs:
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
-      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
-        if: ${{ matrix.php == '8.0' }}
-        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
+#      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
+#        if: ${{ matrix.php == '8.0' && }}
+#        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks
         run: bash bin/run-ci-tests.bash

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,18 +16,18 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: 'latest'
+            woocommerce: '6.1.0'
           - woocommerce_support_policy: L-1
-            woocommerce: '5.8.0'
+            woocommerce: '6.0.0'
           - woocommerce_support_policy: L-2
-            woocommerce: '5.7.1'
+            woocommerce: '5.9.0'
           # WordPress
           - wordpress_support_policy: L
-            wordpress: 'latest'
+            wordpress: '5.9'
           - wordpress_support_policy: L-1
-            wordpress: '5.7'
+            wordpress: '5.8'
           - wordpress_support_policy: L-2
-            wordpress: '5.6'
+            wordpress: '5.7'
           # PHP
           - php_support_policy: L
             php: '8.0'
@@ -61,9 +61,9 @@ jobs:
         if: ${{ matrix.php == '7.0' }}
         run: wget https://phar.phpunit.de/phpunit-6.5.14.phar && mv phpunit-6.5.14.phar phpunit.phar
 
-#      - name: If PHP 8.0, set up PHPUnit 9.5 for compatibility
-#        if: ${{ matrix.php == '8.0' && }}
-#        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
+      - name: If PHP 8.0 and WP 5.9, set up PHPUnit 9.5 for compatibility
+        if: ${{ matrix.php == '8.0' && matrix.wordpress == '5.9' }}
+        run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar
 
       - name: Run CI checks
         run: bash bin/run-ci-tests.bash

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
 				"composer/installers": "1.9.0",
 				"phpunit/phpunit": "7.5.20",
-				"yoast/phpunit-polyfills": "1.0.2",
+				"yoast/phpunit-polyfills": "^1.0",
 				"woocommerce/woocommerce-sniffs": "0.1.0",
 				"wp-cli/wp-cli-bundle": "2.5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae8469c95f3acb4e891fdf2ec35518cb",
+    "content-hash": "a58e594bfa45d2c239363eaeccd8ae04",
     "packages": [],
     "packages-dev": [
         {
@@ -5916,16 +5916,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f"
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a582ab1d91e86aa450340c4d35631a85314ff9f",
-                "reference": "1a582ab1d91e86aa450340c4d35631a85314ff9f",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
+                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
                 "shasum": ""
             },
             "require": {
@@ -5973,7 +5973,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-10-03T08:40:26+00:00"
+            "time": "2021-11-23T01:37:03+00:00"
         }
     ],
     "aliases": [],

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -525,7 +525,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		$settings = get_option( 'woocommerce_stripe_settings', [] );
 		$settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = $is_upe_enabled ? 'yes' : 'disabled';
-
 		update_option( 'woocommerce_stripe_settings', $settings );
 
 		// including the class again because otherwise it's not present.

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -187,17 +187,17 @@ class WC_Stripe_Admin_Notices {
 
 				// Check if keys are entered properly per live/test mode.
 				if ( $testmode ) {
-					if (
-						! empty( $test_pub_key ) && ! preg_match( '/^pk_test_/', $test_pub_key )
-						|| ! empty( $test_secret_key ) && ! preg_match( '/^[rs]k_test_/', $test_secret_key ) ) {
+					$is_test_pub_key    = ! empty( $test_pub_key ) && preg_match( '/^pk_test_/', $test_pub_key );
+					$is_test_secret_key = ! empty( $test_secret_key ) && preg_match( '/^[rs]k_test_/', $test_secret_key );
+					if ( ! $is_test_pub_key || ! $is_test_secret_key ) {
 						$setting_link = $this->get_setting_link();
 						/* translators: 1) link */
 						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in test mode however your test keys may not be valid. Test keys start with pk_test and sk_test or rk_test. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );
 					}
 				} else {
-					if (
-						! empty( $live_pub_key ) && ! preg_match( '/^pk_live_/', $live_pub_key )
-						|| ! empty( $live_secret_key ) && ! preg_match( '/^[rs]k_live_/', $live_secret_key ) ) {
+					$is_live_pub_key    = ! empty( $live_pub_key ) && preg_match( '/^pk_live_/', $live_pub_key );
+					$is_live_secret_key = ! empty( $live_secret_key ) && preg_match( '/^[rs]k_live_/', $live_secret_key );
+					if ( ! $is_live_pub_key || ! $is_live_secret_key ) {
 						$setting_link = $this->get_setting_link();
 						/* translators: 1) link */
 						$this->add_admin_notice( 'keys', 'notice notice-error', sprintf( __( 'Stripe is in live mode however your live keys may not be valid. Live keys start with pk_live and sk_live or rk_live. Please go to your settings and, <a href="%s">set your Stripe account keys</a>.', 'woocommerce-gateway-stripe' ), $setting_link ), true );

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -23,7 +23,8 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_upe_checkout_enabled() {
 		$stripe_settings = get_option( 'woocommerce_stripe_settings', null );
-		return ! empty( $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] ) && 'yes' === $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ];
+		return ! empty( $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] )
+			&& 'yes' === $stripe_settings[ self::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ];
 	}
 
 	/**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,6 +6,7 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="false"
 	>
 	<testsuites>
 		<testsuite name="WCStripe">

--- a/tests/phpunit/admin/migrations/test-class-allowed-payment-request-button-types-update.php
+++ b/tests/phpunit/admin/migrations/test-class-allowed-payment-request-button-types-update.php
@@ -22,8 +22,8 @@ class Allowed_Payment_Request_Button_Types_Update_Test extends WP_UnitTestCase {
 	 */
 	private $migration;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		if ( version_compare( WC_VERSION, '3.4.0', '<' ) ) {
 			$this->markTestSkipped( 'The class is not compatible with older WC versions, due to the missing `update_option` method on the gateway.' );

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-payment-gateway-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-payment-gateway-controller.php
@@ -36,8 +36,8 @@ class WC_REST_Stripe_Payment_Gateway_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Pre-test setup
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->gateway = WC()->payment_gateways()->payment_gateways()[ WC_Gateway_Stripe_Alipay::ID ];
 

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -26,13 +26,13 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Enable UPE and store gateway instance.
 	 *
-	 * We are doing this here because if we did it in setUp(), the method body would get called before every single test
+	 * We are doing this here because if we did it in set_up(), the method body would get called before every single test
 	 * however the REST controller is instantiated only once. If we reloaded gateways then, WC()->payment_gateways()
 	 * would contain another gateway instance than the controller.
 	 *
 	 * @see UPE_Test_Utils::reload_payment_gateways()
 	 */
-	public static function setUpBeforeClass() {
+	public static function set_up_before_class() {
 		$upe_helper = new UPE_Test_Helper();
 
 		// All tests assume UPE is enabled.
@@ -45,8 +45,8 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Pre-test setup
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		if ( version_compare( WC_VERSION, '3.4.0', '<' ) ) {
 			$this->markTestSkipped( 'The controller is not compatible with older WC versions, due to the missing `update_option` method on the gateway.' );

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -33,6 +33,8 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	 * @see UPE_Test_Utils::reload_payment_gateways()
 	 */
 	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
 		$upe_helper = new UPE_Test_Helper();
 
 		// All tests assume UPE is enabled.

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -33,8 +33,9 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
 		delete_option( 'woocommerce_stripe_settings' );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -19,8 +19,8 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	 */
 	private $gateway;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$mock_account = $this->getMockBuilder( 'WC_Stripe_Account' )
 									->disableOriginalConstructor()
@@ -32,8 +32,8 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		delete_option( 'woocommerce_stripe_settings' );
 	}
 

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -2,8 +2,8 @@
 
 class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';
 
 		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -64,7 +64,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		}
 
 		if ( $expected_output ) {
-			$this->assertRegexp( $expected_output, ob_get_contents() );
+			$this->assertMatchesRegularExpression( $expected_output, ob_get_contents() );
 		}
 		ob_end_clean();
 		$this->assertCount( count( $expected_notices ), $notices->notices );
@@ -162,7 +162,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertArrayHasKey( 'keys', $notices->notices );
-		$this->assertRegexp( '/Your customers cannot use Stripe on checkout/', $notices->notices['keys']['message'] );
+		$this->assertMatchesRegularExpression( '/Your customers cannot use Stripe on checkout/', $notices->notices['keys']['message'] );
 	}
 
 	public function options_to_notices_map() {

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -202,8 +202,10 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 			[
 				[
 					'woocommerce_stripe_settings' => [
-						'enabled'        => 'yes',
-						'three_d_secure' => 'yes',
+						'enabled'         => 'yes',
+						'three_d_secure'  => 'yes',
+						'publishable_key' => 'pk_live_valid_test_key',
+						'secret_key'      => 'sk_live_valid_test_key',
 					],
 					'wc_stripe_show_style_notice' => 'no',
 					'wc_stripe_show_sca_notice'   => 'no',
@@ -235,7 +237,9 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 			[
 				[
 					'woocommerce_stripe_settings'    => [
-						'enabled' => 'yes',
+						'enabled'         => 'yes',
+						'publishable_key' => 'pk_live_valid_test_key',
+						'secret_key'      => 'sk_live_valid_test_key',
 					],
 					'wc_stripe_show_style_notice'    => 'no',
 					'wc_stripe_show_sca_notice'      => 'no',

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -18,6 +18,14 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	exit( 1 );
 }
 
+if ( PHP_VERSION_ID >= 80000 && file_exists( $_tests_dir . '/includes/phpunit7/MockObject' ) ) {
+	// WP Core test library includes patches for PHPUnit 7 to make it compatible with PHP8.
+	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/NamespaceMatch.php';
+	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/ParametersMatch.php';
+	require_once $_tests_dir . '/includes/phpunit7/MockObject/InvocationMocker.php';
+	require_once $_tests_dir . '/includes/phpunit7/MockObject/MockMethod.php';
+}
+
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -18,14 +18,6 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	exit( 1 );
 }
 
-//if ( PHP_VERSION_ID >= 80000 && file_exists( $_tests_dir . '/includes/phpunit7/MockObject' ) ) {
-//	// WP Core test library includes patches for PHPUnit 7 to make it compatible with PHP8.
-//	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/NamespaceMatch.php';
-//	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/ParametersMatch.php';
-//	require_once $_tests_dir . '/includes/phpunit7/MockObject/InvocationMocker.php';
-//	require_once $_tests_dir . '/includes/phpunit7/MockObject/MockMethod.php';
-//}
-
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -18,13 +18,13 @@ if ( ! file_exists( $_tests_dir . '/includes/functions.php' ) ) {
 	exit( 1 );
 }
 
-if ( PHP_VERSION_ID >= 80000 && file_exists( $_tests_dir . '/includes/phpunit7/MockObject' ) ) {
-	// WP Core test library includes patches for PHPUnit 7 to make it compatible with PHP8.
-	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/NamespaceMatch.php';
-	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/ParametersMatch.php';
-	require_once $_tests_dir . '/includes/phpunit7/MockObject/InvocationMocker.php';
-	require_once $_tests_dir . '/includes/phpunit7/MockObject/MockMethod.php';
-}
+//if ( PHP_VERSION_ID >= 80000 && file_exists( $_tests_dir . '/includes/phpunit7/MockObject' ) ) {
+//	// WP Core test library includes patches for PHPUnit 7 to make it compatible with PHP8.
+//	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/NamespaceMatch.php';
+//	require_once $_tests_dir . '/includes/phpunit7/MockObject/Builder/ParametersMatch.php';
+//	require_once $_tests_dir . '/includes/phpunit7/MockObject/InvocationMocker.php';
+//	require_once $_tests_dir . '/includes/phpunit7/MockObject/MockMethod.php';
+//}
 
 // Give access to tests_add_filter() function.
 require_once $_tests_dir . '/includes/functions.php';

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -16,8 +16,8 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	 */
 	private $account;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$stripe_settings                         = get_option( 'woocommerce_stripe_settings' );
 		$stripe_settings['enabled']              = 'yes';
@@ -39,8 +39,8 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$this->account = new WC_Stripe_Account( $this->mock_connect, 'WC_Helper_Stripe_Api' );
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 
 		delete_transient( 'wcstripe_account_data_test' );
 		delete_transient( 'wcstripe_account_data_live' );

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -40,11 +40,11 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
 		delete_transient( 'wcstripe_account_data_test' );
 		delete_transient( 'wcstripe_account_data_live' );
 		delete_option( 'woocommerce_stripe_settings' );
+
+		parent::tear_down();
 	}
 
 	public function test_get_cached_account_data_returns_empty_when_stripe_is_not_connected() {

--- a/tests/phpunit/test-class-wc-stripe-notes.php
+++ b/tests/phpunit/test-class-wc-stripe-notes.php
@@ -40,11 +40,11 @@ class WC_Stripe_Inbox_Notes_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
 		woocommerce_gateway_stripe()->connect = $this->stripe_connect_original;
 		delete_option( '_wcstripe_feature_upe' );
 		delete_option( 'woocommerce_stripe_settings' );
+
+		parent::tear_down();
 	}
 
 	public function test_create_upe_availability_note() {

--- a/tests/phpunit/test-class-wc-stripe-notes.php
+++ b/tests/phpunit/test-class-wc-stripe-notes.php
@@ -14,8 +14,8 @@ class WC_Stripe_Inbox_Notes_Test extends WP_UnitTestCase {
 	public $stripe_connect_mock;
 	public $stripe_connect_original;
 
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// overriding the `WC_Stripe_Connect` in woocommerce_gateway_stripe(),
 		// because the method we're calling is static and we don't really have a way of injecting it all the way down to this class.
@@ -39,8 +39,8 @@ class WC_Stripe_Inbox_Notes_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 
 		woocommerce_gateway_stripe()->connect = $this->stripe_connect_original;
 		delete_option( '_wcstripe_feature_upe' );

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -83,8 +83,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	/**
 	 * Initial setup.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->mock_gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
 			->setMethods(

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -217,9 +217,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertTrue( $response['payment_needed'] );
 		$this->assertEquals( $order_id, $response['order_id'] );
-		$this->assertRegExp( "/order_id=$order_id/", $response['redirect_url'] );
-		$this->assertRegExp( '/wc_payment_method=stripe/', $response['redirect_url'] );
-		$this->assertRegExp( '/save_payment_method=no/', $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( "/order_id=$order_id/", $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( '/wc_payment_method=stripe/', $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( '/save_payment_method=no/', $response['redirect_url'] );
 	}
 
 	/**
@@ -271,7 +271,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Credit card / debit card', $final_order->get_payment_method_title() );
 		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
 		$this->assertTrue( (bool) $final_order->get_meta( '_stripe_upe_redirect_processed', true ) );
-		$this->assertRegExp( '/Charge ID: ch_mock/', $note->content );
+		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
 	/**
@@ -325,7 +325,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Credit card / debit card', $success_order->get_payment_method_title() );
 		$this->assertEquals( $payment_intent_id, $success_order->get_meta( '_stripe_intent_id', true ) );
 		$this->assertTrue( (bool) $success_order->get_meta( '_stripe_upe_redirect_processed', true ) );
-		$this->assertRegExp( '/Charge ID: ch_mock/', $note->content );
+		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 
 		// simulate an order getting marked as failed as if from a webhook
 		$order->set_status( 'failed' );
@@ -564,7 +564,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			// Test exception thrown.
 			$exception = $e;
 		}
-		$this->assertRegExp( '/not able to process this payment./', $exception->getMessage() );
+		$this->assertMatchesRegularExpression( '/not able to process this payment./', $exception->getMessage() );
 
 		$exception = null;
 		$order->set_total( 0 );
@@ -575,7 +575,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			// Test exception thrown.
 			$exception = $e;
 		}
-		$this->assertRegExp( '/not able to process this payment./', $exception->getMessage() );
+		$this->assertMatchesRegularExpression( '/not able to process this payment./', $exception->getMessage() );
 	}
 
 	/**
@@ -641,8 +641,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				'limit'    => 1,
 			]
 		)[0];
-		$this->assertRegExp( '/Payment processing failed./', $note->content );
-		$this->assertRegExp( '/Payment processing failed./', $exception->getLocalizedMessage() );
+		$this->assertMatchesRegularExpression( '/Payment processing failed./', $note->content );
+		$this->assertMatchesRegularExpression( '/Payment processing failed./', $exception->getLocalizedMessage() );
 	}
 
 	/**
@@ -708,7 +708,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
 		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
 		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
-		$this->assertRegExp( '/Charge ID: ch_mock/', $note->content );
+		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
 	/**
@@ -766,7 +766,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
 		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
 		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
-		$this->assertRegExp( "/#wc-stripe-confirm-pi:$order_id:$client_secret/", $response['redirect'] );
+		$this->assertMatchesRegularExpression( "/#wc-stripe-confirm-pi:$order_id:$client_secret/", $response['redirect'] );
 	}
 
 	/**
@@ -893,7 +893,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
 		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
 		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
-		$this->assertRegExp( '/Charge ID: ch_mock/', $note->content );
+		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
 	/**
@@ -1022,9 +1022,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertTrue( $response['payment_needed'] );
 		$this->assertEquals( $order_id, $response['order_id'] );
-		$this->assertRegExp( "/order_id=$order_id/", $response['redirect_url'] );
-		$this->assertRegExp( '/wc_payment_method=stripe/', $response['redirect_url'] );
-		$this->assertRegExp( '/save_payment_method=yes/', $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( "/order_id=$order_id/", $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( '/wc_payment_method=stripe/', $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( '/save_payment_method=yes/', $response['redirect_url'] );
 	}
 
 	/**
@@ -1055,9 +1055,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertFalse( $response['payment_needed'] );
 		$this->assertEquals( $order_id, $response['order_id'] );
-		$this->assertRegExp( "/order_id=$order_id/", $response['redirect_url'] );
-		$this->assertRegExp( '/wc_payment_method=stripe/', $response['redirect_url'] );
-		$this->assertRegExp( '/save_payment_method=yes/', $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( "/order_id=$order_id/", $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( '/wc_payment_method=stripe/', $response['redirect_url'] );
+		$this->assertMatchesRegularExpression( '/save_payment_method=yes/', $response['redirect_url'] );
 	}
 
 	/**
@@ -1133,7 +1133,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		)[0];
 
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertRegExp( '/Charge ID: ch_mock/', $note->content );
+		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 		// Assert: Our hook was called once.
 		$this->assertEquals( 1, $mock_action_process_payment->get_call_count() );
 		// Assert: Only our hook was called.
@@ -1222,7 +1222,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'failed', $final_order->get_status() );
 		$this->assertEquals( 'ch_mock', $final_order->get_transaction_id() );
-		$this->assertRegExp( '/pending/i', $note->content );
+		$this->assertMatchesRegularExpression( '/pending/i', $note->content );
 		// Assert: Our hook was called once.
 		$this->assertEquals( 1, $mock_action_process_payment->get_call_count() );
 		// Assert: Only our hook was called.

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -285,6 +285,11 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$this->set_mock_payment_method_return_value( 'is_subscription_item_in_cart', false );
 		$this->set_mock_payment_method_return_value( 'get_capabilities_response', self::MOCK_INACTIVE_CAPABILITIES_RESPONSE );
 
+		// Disable testmode.
+		$stripe_settings             = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['testmode'] = 'no';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
 		$card_method       = $this->mock_payment_methods['card'];
 		$giropay_method    = $this->mock_payment_methods['giropay'];
 		$p24_method        = $this->mock_payment_methods['p24'];
@@ -312,6 +317,11 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	 * Payment method is only enabled when capability response contains active for payment method.
 	 */
 	public function test_payment_methods_are_only_enabled_when_capability_is_active() {
+		// Disable testmode.
+		$stripe_settings             = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['testmode'] = 'no';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
 		foreach ( $payment_method_ids as $id ) {
 			if ( 'card' === $id || 'boleto' === $id || 'oxxo' === $id ) {

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -82,8 +82,8 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	/**
 	 * Initial setup
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->reset_payment_method_mocks();
 	}
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -186,10 +186,10 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$mock_ideal_details      = [
 			'type' => 'ideal',
 		];
-		$mock_boleto_details      = [
+		$mock_boleto_details     = [
 			'type' => 'boleto',
 		];
-		$mock_oxxo_details      = [
+		$mock_oxxo_details       = [
 			'type' => 'oxxo',
 		];
 
@@ -293,8 +293,8 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$sofort_method     = $this->mock_payment_methods['sofort'];
 		$bancontact_method = $this->mock_payment_methods['bancontact'];
 		$ideal_method      = $this->mock_payment_methods['ideal'];
-		$boleto_method      = $this->mock_payment_methods['boleto'];
 		$oxxo_method      = $this->mock_payment_methods['boleto'];
+		$boleto_method     = $this->mock_payment_methods['boleto'];
 
 		$this->assertTrue( $card_method->is_enabled_at_checkout() );
 		$this->assertFalse( $giropay_method->is_enabled_at_checkout() );

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -298,8 +298,8 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$sofort_method     = $this->mock_payment_methods['sofort'];
 		$bancontact_method = $this->mock_payment_methods['bancontact'];
 		$ideal_method      = $this->mock_payment_methods['ideal'];
-		$oxxo_method      = $this->mock_payment_methods['boleto'];
 		$boleto_method     = $this->mock_payment_methods['boleto'];
+		$oxxo_method       = $this->mock_payment_methods['oxxo'];
 
 		$this->assertTrue( $card_method->is_enabled_at_checkout() );
 		$this->assertFalse( $giropay_method->is_enabled_at_checkout() );

--- a/tests/phpunit/test-wc-rest-stripe-account-keys-controller.php
+++ b/tests/phpunit/test-wc-rest-stripe-account-keys-controller.php
@@ -24,8 +24,8 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Pre-test setup
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// Set the user so that we can pass the authentication.
 		wp_set_current_user( 1 );

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -80,7 +80,7 @@ class WC_Stripe_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 
 		$settings = get_option( 'woocommerce_stripe_settings' );
 
-		$this->assertEquals( 'no', $settings['upe_checkout_experience_enabled'] );
+		$this->assertEquals( 'disabled', $settings['upe_checkout_experience_enabled'] );
 	}
 
 	public function test_set_flag_missing_request_returns_status_code_400() {

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -24,8 +24,8 @@ class WC_Stripe_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Pre-test setup
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
 

--- a/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
+++ b/tests/phpunit/test-wc-rest-upe-flag-toggle-controller.php
@@ -32,6 +32,11 @@ class WC_Stripe_REST_UPE_Flag_Toggle_Controller_Test extends WP_UnitTestCase {
 		// Set the user so that we can pass the authentication.
 		wp_set_current_user( 1 );
 
+		// Disable UPE.
+		$stripe_settings = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = 'no';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
 		$this->controller = new WC_Stripe_REST_UPE_Flag_Toggle_Controller();
 	}
 

--- a/tests/phpunit/test-wc-stripe-apple-pay-registration.php
+++ b/tests/phpunit/test-wc-stripe-apple-pay-registration.php
@@ -34,8 +34,8 @@ class WC_Stripe_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 	/**
 	 * Pre-test setup
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->wc_apple_pay_registration = new WC_Stripe_Apple_Pay_Registration();
 
@@ -43,8 +43,8 @@ class WC_Stripe_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 		$this->initial_file_contents = file_get_contents( WC_STRIPE_PLUGIN_PATH . '/' . $this->file_name ); // @codingStandardsIgnoreLine
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 
 		$path     = untrailingslashit( ABSPATH );
 		$dir      = '.well-known';

--- a/tests/phpunit/test-wc-stripe-apple-pay-registration.php
+++ b/tests/phpunit/test-wc-stripe-apple-pay-registration.php
@@ -44,13 +44,13 @@ class WC_Stripe_Apple_Pay_Registration_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
 		$path     = untrailingslashit( ABSPATH );
 		$dir      = '.well-known';
 		$fullpath = $path . '/' . $dir . '/' . $this->file_name;
 		// Unlink domain association file before tests.
 		@unlink( $fullpath ); // @codingStandardsIgnoreLine
+
+		parent::tear_down();
 	}
 
 	public function test_update_domain_association_file() {

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -30,8 +30,8 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up things all tests need.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->order           = WC_Helper_Order::create_order();
 		$this->gateway         = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -23,8 +23,8 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up things all tests need.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->gateway         = new WC_Gateway_Stripe();
 		$this->giropay_gateway = new WC_Gateway_Stripe_Giropay();

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -55,8 +55,8 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up things all tests need.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->pr = new WC_Stripe_Payment_Request();
 
@@ -81,8 +81,8 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 		WC()->cart->calculate_totals();
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		WC()->cart->empty_cart();
 		WC()->session->cleanup_sessions();
 		$this->zone->delete();

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -82,10 +82,11 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
 		WC()->cart->empty_cart();
 		WC()->session->cleanup_sessions();
 		$this->zone->delete();
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -53,8 +53,9 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 	 * Tears down the stuff we set up.
 	 */
 	public function tear_down() {
-		parent::tear_down();
 		delete_option( 'woocommerce_stripe_settings' );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -31,8 +31,8 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up things all tests need.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->wc_gateway_stripe = $this->getMockBuilder( 'WC_Gateway_Stripe' )
 			->disableOriginalConstructor()
@@ -52,8 +52,8 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 	/**
 	 * Tears down the stuff we set up.
 	 */
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		delete_option( 'woocommerce_stripe_settings' );
 	}
 

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -60,9 +60,9 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 	 * Tears down the stuff we set up.
 	 */
 	public function tear_down() {
-		parent::tear_down();
-
 		delete_option( 'woocommerce_stripe_settings' );
+
+		parent::tear_down();
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -48,16 +48,12 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 			);
 
 		$this->statement_descriptor = 'This is a statement descriptor.';
-		add_option(
-			'woocommerce_stripe_settings',
-			[
-				'statement_descriptor' => $this->statement_descriptor,
-			]
-		);
 
 		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
 		// Disable UPE.
 		$stripe_settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = 'no';
+		// Set statement descriptor.
+		$stripe_settings['statement_descriptor'] = $this->statement_descriptor;
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 	}
 

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -31,8 +31,8 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up things all tests need.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		$this->wc_gateway_stripe = $this->getMockBuilder( 'WC_Gateway_Stripe' )
 			->disableOriginalConstructor()
@@ -59,8 +59,8 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 	/**
 	 * Tears down the stuff we set up.
 	 */
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 
 		delete_option( 'woocommerce_stripe_settings' );
 	}

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -54,6 +54,11 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 				'statement_descriptor' => $this->statement_descriptor,
 			]
 		);
+
+		$stripe_settings = get_option( 'woocommerce_stripe_settings', [] );
+		// Disable UPE.
+		$stripe_settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = 'no';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -36,7 +36,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		$this->wc_gateway_stripe = $this->getMockBuilder( 'WC_Gateway_Stripe' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'prepare_order_source', 'has_subscription', 'ensure_subscription_has_customer_id' ] )
+			->setMethods( [ 'prepare_order_source', 'has_subscription' ] )
 			->getMock();
 
 		// Mocked in order to get metadata[payment_type] = recurring in the HTTP request.

--- a/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
+++ b/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
@@ -22,8 +22,8 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * Pre-test setup
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 
 		// saving these values to that they can be restored after the test runs
 		global $wp_version;
@@ -37,8 +37,8 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 								 ->getMock();
 	}
 
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 
 		// restore the overwritten values
 		global $wp_version;

--- a/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
+++ b/tests/phpunit/test-wc-stripe-upe-compatibility-controller.php
@@ -38,11 +38,11 @@ class WC_Stripe_UPE_Compatibility_Controller_Test extends WP_UnitTestCase {
 	}
 
 	public function tear_down() {
-		parent::tear_down();
-
 		// restore the overwritten values
 		global $wp_version;
 		$wp_version = $this->initial_wp_version;
+
+		parent::tear_down();
 	}
 
 	protected function overwrite_wp_version( $version ) {

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -41,8 +41,8 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up things all tests need.
 	 */
-	public function setUp() {
-		parent::setUp();
+	public function set_up() {
+		parent::set_up();
 		$this->webhook_secret            = 'whsec_123';
 		$this->wc_stripe_webhook_handler = new WC_Stripe_Webhook_Handler();
 	}
@@ -50,8 +50,8 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	/**
 	 * Tears down the stuff we set up.
 	 */
-	public function tearDown() {
-		parent::tearDown();
+	public function tear_down() {
+		parent::tear_down();
 		$stripe_settings                        = get_option( 'woocommerce_stripe_settings', [] );
 		$stripe_settings['webhook_secret']      = $this->webhook_secret;
 		$stripe_settings['test_webhook_secret'] = $this->webhook_secret;

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -51,7 +51,6 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	 * Tears down the stuff we set up.
 	 */
 	public function tear_down() {
-		parent::tear_down();
 		$stripe_settings                        = get_option( 'woocommerce_stripe_settings', [] );
 		$stripe_settings['webhook_secret']      = $this->webhook_secret;
 		$stripe_settings['test_webhook_secret'] = $this->webhook_secret;
@@ -70,6 +69,8 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_SUCCESS_AT );
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_FAILURE_AT );
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_ERROR );
+
+		parent::tear_down();
 	}
 
 	private function cleanup_webhook_secret() {

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -135,12 +135,12 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		// Live
 		$this->process_webhook();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'live', $expected_message ), $message );
 		// Test
 		$this->set_testmode();
 		$this->process_webhook();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'test', $expected_message ), $message );
 	}
 
 	// Case 2: No webhooks received yet.
@@ -149,11 +149,11 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 
 		// Live
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'live', $expected_message ), $message );
 		// Test
 		$this->set_testmode();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'test', $expected_message ), $message );
 	}
 
 	// Case 3: Failure after success.
@@ -167,7 +167,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->request_headers = [];
 		$this->process_webhook();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'live', $expected_message ), $message );
 
 		// Test
 		$this->set_testmode();
@@ -178,7 +178,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->request_headers = [];
 		$this->process_webhook();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'test', $expected_message ), $message );
 	}
 
 	// Case 4: Failure with no prior success.
@@ -190,14 +190,14 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->request_headers = [];
 		$this->process_webhook();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'live', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'live', $expected_message ), $message );
 
 		// Test
 		$this->set_testmode();
 		// Fail webhook.
 		$this->process_webhook();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
-		$this->assertRegExp( str_replace( '[mode]', 'test', $expected_message ), $message );
+		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'test', $expected_message ), $message );
 	}
 
 	// Test failure reason: no error.
@@ -212,7 +212,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->set_valid_request_data();
 		$this->request_headers = [];
 		$this->process_webhook();
-		$this->assertRegExp( '/missing expected headers/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertMatchesRegularExpression( '/missing expected headers/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test failure reason: empty body.
@@ -220,7 +220,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->set_valid_request_data();
 		$this->request_body = '';
 		$this->process_webhook();
-		$this->assertRegExp( '/missing expected body/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertMatchesRegularExpression( '/missing expected body/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test custom user agent validator
@@ -235,7 +235,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 
 		$this->set_valid_request_data();
 		$this->process_webhook();
-		$this->assertRegExp( '/did not come from Stripe/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertMatchesRegularExpression( '/did not come from Stripe/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test user agent validation ignored
@@ -260,7 +260,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->set_valid_request_data();
 		$this->request_headers['USER-AGENT'] = 'Other';
 		$this->process_webhook();
-		$this->assertRegExp( '/did not come from Stripe/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertMatchesRegularExpression( '/did not come from Stripe/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test failure reason: invalid signature.
@@ -268,7 +268,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->set_valid_request_data();
 		$this->request_headers['STRIPE-SIGNATURE'] = 'foo';
 		$this->process_webhook();
-		$this->assertRegExp( '/signature was missing or was incorrectly formatted/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertMatchesRegularExpression( '/signature was missing or was incorrectly formatted/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test failure reason: timestamp mismatch.
@@ -276,7 +276,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$timestamp = time() - 600; // 10 minutes ago.
 		$this->set_valid_request_data( $timestamp );
 		$this->process_webhook();
-		$this->assertRegExp( '/timestamp in the webhook differed more than five minutes/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertMatchesRegularExpression( '/timestamp in the webhook differed more than five minutes/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test failure reason: signature mismatch.
@@ -284,6 +284,6 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->set_valid_request_data();
 		$this->request_headers['STRIPE-SIGNATURE'] = 't=' . time() . ',v1=0';
 		$this->process_webhook();
-		$this->assertRegExp( '/was not signed with the expected signing secret/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertMatchesRegularExpression( '/was not signed with the expected signing secret/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 }

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -8,6 +8,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 	private $upe_helper;
 
 	public function set_up() {
+		parent::set_up();
 		$this->upe_helper = new UPE_Test_Helper();
 	}
 

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -29,7 +29,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 10050, 'JPY' ) );
 		$this->assertEquals( 100, WC_Stripe_Helper::get_stripe_amount( 100.50, 'JPY' ) );
 		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 100.50 ) );
-		$this->assertInternalType( 'int', WC_Stripe_Helper::get_stripe_amount( 100.50, 'USD' ) );
+		$this->assertIsInt( WC_Stripe_Helper::get_stripe_amount( 100.50, 'USD' ) );
 	}
 
 	/**
@@ -73,7 +73,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 105.00, WC_Stripe_Helper::format_balance_fee( $balance_fee5 ) );
 
-		$this->assertInternalType( 'string', WC_Stripe_Helper::format_balance_fee( $balance_fee5 ) );
+		$this->assertIsString( WC_Stripe_Helper::format_balance_fee( $balance_fee5 ) );
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -7,7 +7,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 	 */
 	private $upe_helper;
 
-	public function setUp() {
+	public function set_up() {
 		$this->upe_helper = new UPE_Test_Helper();
 	}
 

--- a/tests/phpunit/wp-unit-test-case.php
+++ b/tests/phpunit/wp-unit-test-case.php
@@ -8,6 +8,6 @@
 /**
  * WP_UnitTestCase class
  */
-class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {
+class WP_UnitTestCase extends \Yoast\PHPUnitPolyfills\TestCases\TestCase {
 
 }


### PR DESCRIPTION
Fixes #

## Changes proposed in this Pull Request:

The PR updates the test workflow to use PHPUnit 9.5 when using testing with PHP 8 and WP 5.9 (or newer).
It also renames the Beta compatibility tests to have the same format as the other PHP tests (using `Beta` instead of `Stable` as prefix).

## Testing instructions
- Verify that all checks in the PR succeed
<img width="840" alt="Screen Shot 2022-02-15 at 16 28 10" src="https://user-images.githubusercontent.com/407542/154134653-f47be344-9eb6-43cd-b29c-3cc5c3bca2db.png">
