### PR TITLE
Use settings statement descriptor in account summary API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 6.2.0 - 2022-xx-xx =
-
+* Fix - Missing statement descriptor in account summary API when not set in Stripe.
 
 = 6.1.0 - 2022-01-26 =
 * Tweak - Use the newly exposed LoadableMask component provided by WooCommerce Blocks to trigger the loading state for Payment Request Buttons.

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -25,7 +25,15 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 	 */
 	private $account;
 
-	public function __construct( WC_Stripe_Account $account ) {
+	/**
+	 * Stripe payment gateway.
+	 *
+	 * @var WC_Gateway_Stripe
+	 */
+	private $gateway;
+
+	public function __construct( WC_Gateway_Stripe $gateway, WC_Stripe_Account $account ) {
+		$this->gateway = $gateway;
 		$this->account = $account;
 	}
 
@@ -98,13 +106,19 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 	public function get_account_summary() {
 		$account = $this->account->get_cached_account_data();
 
+		// Use statement descriptor from settings, falling back to Stripe account statement descriptor if needed.
+		$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $this->gateway->get_option( 'statement_descriptor' ) );
+		if ( empty( $statement_descriptor ) ) {
+			$statement_descriptor = $account['settings']['payments']['statement_descriptor'] ?? '';
+		}
+
 		return new WP_REST_Response(
 			[
 				'has_pending_requirements' => $this->account->has_pending_requirements(),
 				'has_overdue_requirements' => $this->account->has_overdue_requirements(),
 				'current_deadline'         => $account['requirements']['current_deadline'] ?? null,
 				'status'                   => $this->account->get_account_status(),
-				'statement_descriptor'     => $account['settings']['payments']['statement_descriptor'] ?? '',
+				'statement_descriptor'     => $statement_descriptor,
 				'store_currencies'         => [
 					'default'   => $account['default_currency'] ?? get_woocommerce_currency(),
 					'supported' => $this->account->get_supported_store_currencies(),

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -112,7 +112,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 			$statement_descriptor = $account['settings']['payments']['statement_descriptor'];
 		}
 		if ( empty( $statement_descriptor ) ) {
-			$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( get_bloginfo( 'name' ) );
+			$statement_descriptor = null;
 		}
 
 		return new WP_REST_Response(

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -109,7 +109,10 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 		// Use statement descriptor from settings, falling back to Stripe account statement descriptor if needed.
 		$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $this->gateway->get_option( 'statement_descriptor' ) );
 		if ( empty( $statement_descriptor ) ) {
-			$statement_descriptor = $account['settings']['payments']['statement_descriptor'] ?? '';
+			$statement_descriptor = $account['settings']['payments']['statement_descriptor'];
+		}
+		if ( empty( $statement_descriptor ) ) {
+			$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( get_bloginfo( 'name' ) );
 		}
 
 		return new WP_REST_Response(

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.2.0 - 2022-xx-xx =
+* Fix - Missing statement descriptor in account summary API when not set in Stripe.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -592,7 +592,7 @@ function woocommerce_gateway_stripe() {
 				$stripe_tokens_controller     = new WC_REST_Stripe_Tokens_Controller();
 				$oauth_init                   = new WC_Stripe_Connect_REST_Oauth_Init_Controller( $this->connect, $this->api );
 				$oauth_connect                = new WC_Stripe_Connect_REST_Oauth_Connect_Controller( $this->connect, $this->api );
-				$stripe_account_controller    = new WC_REST_Stripe_Account_Controller( $this->account );
+				$stripe_account_controller    = new WC_REST_Stripe_Account_Controller( $this->get_main_stripe_gateway(), $this->account );
 
 				$connection_tokens_controller->register_routes();
 				$locations_controller->register_routes();


### PR DESCRIPTION
Fixes #2297

## Changes proposed in this Pull Request:

There are currently two ways a merchant can set their statement descriptor. They can do so via the **Payments & transactions** settings for the extension (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`), and they can also do so via the **Account details** settings on their Stripe account (https://dashboard.stripe.com/settings/account). According to the [Stripe documentation](https://woocommerce.com/document/stripe/#setup-and-configuration), we use the descriptor from the extension settings if it's present, falling back to the Stripe account's statement descriptor only if the descriptor in the extension settings is left blank.

Currently, the account summary API returns only data (e.g. statement descriptor) from Stripe's account API. This PR updates the API to obey the same default/fallback behavior for statement descriptors as the rest of the extension: default to the extension settings descriptor and fall back to the Stripe descriptor if needed. Per a suggestion from @allendav, if both the extension settings descriptor and Stripe descriptor are both blank, this PR also adds a default descriptor which is a sanitized version of the site title. 

## Testing instructions

To make a request to the account summary API, run `curl --user username:password 'http://YOUR_SITE/wp-json/wc/v3/wc_stripe/account/summary'` with [Basic Auth](https://github.com/WP-API/Basic-Auth) installed.

* In the **Stripe extension settings** on the merchant store, set the statement descriptor to something (e.g. `Test Descriptor A`) and "Save changes."
* Make a request to the account summary API, verify that you see `Test Descriptor A`.
* In the **Stripe dashboard account settings** at https://dashboard.stripe.com/settings/account, set the statement descriptor to something else (e.g. `Test Descriptor B`) and "Save."
* Make a request to the account summary API, verify that you still see `Test Descriptor A` and not `Test Descriptor B`.
* In the **Stripe extension settings** on the merchant store, set the statement descriptor to `Test (Descriptor) C`. Note the parentheses, which are invalid characters in a statement descriptor.
* Make a request to the account summary API, verify that you see `Test Descriptor C` without the parentheses.
* In the **Stripe extension settings** on the merchant store, set the statement descriptor to the empty string and "Save changes."
* Make a request to the account summary API, verify that you see `Test Descriptor B`. (Note that here you may instead see an older value from your Stripe account's settings. If you do, you can delete the `_transient_wcstripe_account_data_test` transient to clear the extension's cached data and re-run the API.)
* Testing what happens when both descriptor fields are blank is trickier because Stripe doesn't allow you to update the descriptor to be blank. Instead, create a new Stripe account and give it a name. It will by default have no statement descriptor. Copy the new keys into the Stripe extension settings.
* Make a request to the account summary API, verify that the descriptor is now your site's title.
* To ensure that the site title is being sanitized, set the site title to a string longer than 22 characters with at least one special character (e.g. parentheses).
* Make a request to the account summary API, verify that the descriptor is truncated to 22 characters and doesn't contain special characters.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
