### PR TITLE
Address minor styling issues in settings

### DIFF
--- a/client/components/confirmation-modal/style.scss
+++ b/client/components/confirmation-modal/style.scss
@@ -24,7 +24,6 @@
 	}
 
 	.components-modal__header {
-		margin: 0 -#{$grid-unit-30} $grid-unit-30;
 		padding: 0 $grid-unit-30;
 		@media ( max-width: 599px ) {
 			button {

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -82,17 +82,17 @@ const WebhooksSection = () => {
 			</div>
 			<div className="account-details__desc">
 				<WebhookInformation />
-				<br />
-				<br />
-				{ message }{ ' ' }
-				<Button
-					disabled={ requestStatus === 'pending' }
-					onClick={ refreshMessage }
-					isBusy={ requestStatus === 'pending' }
-					isLink
-				>
-					{ __( 'Refresh', 'woocommerce-gateway-stripe' ) }
-				</Button>
+				<p>
+					{ message }{ ' ' }
+					<Button
+						disabled={ requestStatus === 'pending' }
+						onClick={ refreshMessage }
+						isBusy={ requestStatus === 'pending' }
+						isLink
+					>
+						{ __( 'Refresh', 'woocommerce-gateway-stripe' ) }
+					</Button>
+				</p>
 			</div>
 		</>
 	);

--- a/client/settings/payment-settings/account-keys-modal.js
+++ b/client/settings/payment-settings/account-keys-modal.js
@@ -167,6 +167,7 @@ const StyledConfirmationModal = styled( ConfirmationModal )`
 		margin: 0 -24px 24px;
 	}
 	.wcstripe-inline-notice {
+		margin-top: -24px;
 		margin-bottom: 0;
 	}
 	.wcstripe-confirmation-modal__separator {


### PR DESCRIPTION
336025452f77e9004863d874812b3c71c0e63db2 removes a negative margin causing shifting of the modal header.

Before | After
-- | --
<img width="627" alt="modal-header-before" src="https://user-images.githubusercontent.com/1867547/153105553-1ded9938-89f2-42b2-af86-e19e3c64af4e.png"> | <img width="626" alt="modal-header-after" src="https://user-images.githubusercontent.com/1867547/153105552-4631dd1f-3769-40d4-867f-903e9feafa54.png">

<details><summary>"before" screenshots of all modals, including certain UPE-related ones</summary>
<img width="632" src="https://user-images.githubusercontent.com/1867547/153099996-454cd5ce-729e-477a-a5c2-45741a7a52f0.png">
<img width="632" src="https://user-images.githubusercontent.com/1867547/153099997-1449e60f-591d-4b7f-ad86-6f00c3d83ef1.png">
<img width="627" src="https://user-images.githubusercontent.com/1867547/153099998-30ff7bc0-1855-445f-9feb-d5c6232cf93f.png">
<img width="627" src="https://user-images.githubusercontent.com/1867547/153100000-0464d6eb-aa0f-4550-81a7-c3be45db515a.png">
</details>

Go to Settings » "Account details" » "…" menu » "Disconnect" modal, and verify that the header appears centered and not shifted to the left.

---

2d3bc550c2aea42931bda34eb32c6d2b4710a641 removes extra spacing between paragraphs of webhook information.

Before | After
-- | --
<img width="744" alt="webhook-spacing-before" src="https://user-images.githubusercontent.com/1867547/153105548-3238452e-16fd-4bdc-95f0-c6fce03a221b.png"> | <img width="748" alt="webhook-spacing-after" src="https://user-images.githubusercontent.com/1867547/153105550-e91b1442-d462-4d02-97e4-f90b6409cd86.png">

Under Settings » "Account details", see spacing above "webhooks have been received" message and verify it is reduced.

---

87df2da708db68ee04bda803a8ac934ac4cd3328 removes the top margin in the modal content area, above the notice. cc @jarekmorawski @LevinMedia to veto, especially since the designs I've seen appear to have spacing all around the notice (though the Live / Test tab bar didn't figure into those).

Before | After
-- | --
<img width="628" alt="account-keys-modal-before" src="https://user-images.githubusercontent.com/1867547/153105544-8d282c0f-7aeb-4a05-b244-b698cbb6ac78.png"> | <img width="621" alt="account-keys-modal-after" src="https://user-images.githubusercontent.com/1867547/153105547-59165eb9-cdc0-4fe2-8a4b-256d654128a4.png">

In the Settings » "General" » "Edit account keys" modal, verify reduced spacing above the notice. (Content scrolls only if modal height exceeds 70% of window height.)