### PR TITLE
Undeprecate the PRB location filters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.3.0 - 2022-xx-xx =
 * Tweak - Remove html from translatable strings
+* Tweak - Revert the deprecation of the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters.
 
 = 6.2.0 - 2022-02-17 =
 * Add - Add onboarding payment gateway setup methods.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -922,19 +922,11 @@ class WC_Stripe_Payment_Request {
 	 * @return  boolean  True if PRBs are enabled on the cart page, false otherwise
 	 */
 	public function should_show_prb_on_cart_page() {
-		// Message we show for the deprecated PRB location filters. Intended for support so we
-		// don't provide translations.
-		$deprecation_message      =
-			'Please configure Payment Request Button locations through the Stripe plugin settings.';
 		$should_show_on_cart_page = in_array( 'cart', $this->get_button_locations(), true );
 
-		// Respect the deprecated filters, but add a deprecation notice.
-		return apply_filters_deprecated(
+		return apply_filters(
 			'wc_stripe_show_payment_request_on_cart',
-			[ $should_show_on_cart_page ],
-			'5.5.0',
-			'', // There is no replacement.
-			$deprecation_message
+			$should_show_on_cart_page
 		);
 	}
 
@@ -949,19 +941,12 @@ class WC_Stripe_Payment_Request {
 	public function should_show_prb_on_checkout_page() {
 		global $post;
 
-		// Message we show for the deprecated PRB location filters. Intended for support so we
-		// don't provide translations.
-		$deprecation_message          =
-			'Please configure Payment Request Button locations through the Stripe plugin settings.';
 		$should_show_on_checkout_page = in_array( 'checkout', $this->get_button_locations(), true );
 
-		// Respect the deprecated filters, but add a deprecation notice.
-		return apply_filters_deprecated(
+		return apply_filters(
 			'wc_stripe_show_payment_request_on_checkout',
-			[ $should_show_on_checkout_page, $post ],
-			'5.5.0',
-			'', // There is no replacement.
-			$deprecation_message
+			$should_show_on_checkout_page,
+			$post
 		);
 	}
 
@@ -976,20 +961,13 @@ class WC_Stripe_Payment_Request {
 	public function should_show_prb_on_product_pages() {
 		global $post;
 
-		// Message we show for the deprecated PRB location filters. Intended for support so we
-		// don't provide translations.
-		$deprecation_message         =
-			'Please configure Payment Request Button locations through the Stripe plugin settings.';
 		$should_show_on_product_page = in_array( 'product', $this->get_button_locations(), true );
 
-		// Respect the deprecated filters, but add a deprecation notice.
 		// Note the negation because if the filter returns `true` that means we should hide the PRB.
-		return ! apply_filters_deprecated(
+		return ! apply_filters(
 			'wc_stripe_hide_payment_request_on_product_page',
-			[ ! $should_show_on_product_page, $post ],
-			'5.5.0',
-			'', // There is no replacement.
-			$deprecation_message
+			! $should_show_on_product_page,
+			$post
 		);
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.3.0 - 2022-xx-xx =
+* Tweak - Revert the deprecation of the 'wc_stripe_hide_payment_request_on_product_page', 'wc_stripe_show_payment_request_on_checkout', and 'wc_stripe_show_payment_request_on_cart' filters.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2099

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Undeprecate the PRB location filter that we previously deprecated in favor of a UI based approach. The filters should remain undeprecated until we've solved #2321.

- Undeprecate `wc_stripe_show_payment_request_on_cart`
- Undeprecate `wc_stripe_show_payment_request_on_checkout`
- Undeprecate `wc_stripe_hide_payment_request_on_product_page`

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

1. Checkout this PR.
2. Install the Code Snippets plugin on your test store.
3. Add a snippet with `add_filter( 'wc_stripe_hide_payment_request_on_product_page', '__return_true' );`
4. Make sure the PRB is hidden on product pages no matter which setting you use in the UI (i.e. make sure the filter works as intended).
5. Make sure no deprecation notice is logged in the site's logs.


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
