### PR TITLE
Use account.charges_enabled to show if Stripe payments are available

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 6.4.0 - 2022-xx-xx =
+* Fix - Changed logic for how 'Enabled/Disabled' statuses are shown for payments and payouts capabilities in settings.
 
 = 6.3.0 - 2022-03-10 =
 * Tweak - Remove html from translatable strings.

--- a/client/settings/account-details/__tests__/account-details.test.js
+++ b/client/settings/account-details/__tests__/account-details.test.js
@@ -16,9 +16,6 @@ jest.mock( 'wcstripe/data/account-keys', () => ( {
 
 describe( 'AccountDetails', () => {
 	it( 'renders enabled payments and payouts on account', () => {
-		useGetCapabilities.mockReturnValue( {
-			card_payments: 'active',
-		} );
 		useAccount.mockReturnValue( {
 			data: {
 				account: {
@@ -28,6 +25,7 @@ describe( 'AccountDetails', () => {
 						},
 					},
 					payouts_enabled: true,
+					charges_enabled: true,
 				},
 			},
 		} );
@@ -53,9 +51,6 @@ describe( 'AccountDetails', () => {
 	} );
 
 	it( 'renders disabled payouts and payments on account', () => {
-		useGetCapabilities.mockReturnValue( {
-			card_payments: 'disabled',
-		} );
 		useAccount.mockReturnValue( {
 			data: {
 				account: {
@@ -63,6 +58,7 @@ describe( 'AccountDetails', () => {
 						payouts: {},
 					},
 					payouts_enabled: false,
+					charges_enabled: false,
 				},
 			},
 		} );

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -6,15 +6,18 @@ import { Button, ExternalLink } from '@wordpress/components';
 import interpolateComponents from 'interpolate-components';
 import useWebhookStateMessage from './use-webhook-state-message';
 import SectionStatus from './section-status';
-import { useAccount, useGetCapabilities } from 'wcstripe/data/account';
+import { useAccount } from 'wcstripe/data/account';
 import {
 	useAccountKeysTestWebhookSecret,
 	useAccountKeysWebhookSecret,
 } from 'wcstripe/data/account-keys';
 import { WebhookInformation } from 'wcstripe/components/webhook-information';
 
-const useIsCardPaymentsEnabled = () =>
-	useGetCapabilities().card_payments === 'active';
+const useIsCardPaymentsEnabled = () => {
+	const { data } = useAccount();
+
+	return data.account?.charges_enabled;
+};
 
 const useArePayoutsEnabled = () => {
 	const { data } = useAccount();

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -22,10 +22,7 @@ const useIsCardPaymentsEnabled = () => {
 const useArePayoutsEnabled = () => {
 	const { data } = useAccount();
 
-	return (
-		data.account?.payouts_enabled &&
-		Boolean( data.account?.settings?.payouts?.schedule?.interval )
-	);
+	return data.account?.payouts_enabled;
 };
 
 const PaymentsSection = () => {

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.4.0 - 2022-xx-xx =
+* Fix - Changed logic for how 'Enabled/Disabled' statuses are shown for payments and payouts capabilities in settings.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Partially fixes #2175. This fixes the "Payments" status but #2175 also has people mentioning that the "Payouts" status is showing "Disabled" incorrectly, which this PR does not address.

## Changes proposed in this Pull Request:

According to Stripe, due to some historical inconsistencies in their systems, the `card_payments` capability is not always returned for accounts of certain ages or circumstance, even if those accounts are in fact able to receive card payments.

This pull request changes how the "Payments: Enabled/Disabled" status is shown in the "Account details" panel within the Stripe settings. Instead of checking for the `card_payments` capability, we now simply check for the `charges_enabled` Stripe account property.

Additionally, some merchants have payouts "enabled" but do not have a payout schedule configured in Stripe. However prior to this fix, the Stripe settings would only show payouts as enabled if the merchant had a payout schedule configured in Stripe, even if manual payouts were enabled/available.

This fix also makes the Stripe settings show payouts as Enabled if the `payouts_enabled` property is true in their Stripe account even if they do not have a payout schedule set up.

## Screenshots

Before fix when Stripe account has `charges_enabled`: `true` but does not have the `card_payments` capability:

![](https://caps.evan.pro/1e44d2.png)

After fix when Stripe account has `charges_enabled`: `true` but does not have the `card_payments` capability:

![](https://caps.evan.pro/e8b26c.png)

## Testing instructions

This is particularly tricky to test because to _truly_ test it requires a Stripe account created before a certain date or under some specific unknown circumstances.

However, a hacky way to fake the condition is to temporarily add `unset( $account->capabilities );` [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/137b14f6896e369d0d8265b34d66ec6474772e28/includes/class-wc-stripe-account.php#L88) then clear the `_transient_wcstripe_account_data_test` and `_transient_wcstripe_account_data_live` transients from the db.

With that hack in place, before this patch it will show Payments: Disabled... After the patch it will show Payments: Enabled.