### PR TITLE
Add WP 6.0 to the Compatibility workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         woocommerce: [ 'beta' ]
         wordpress:   [ 'latest', '6.0' ]
-        php:         [ '7.0', '7.4', '8.0' ]
+        php:         [ '7.2', '7.4', '8.0' ]
           
     
     name: Beta (PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }})

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         woocommerce: [ 'beta' ]
-        wordpress:   [ 'latest', '6.0' ]
+        wordpress:   [ 'latest', '6.0-RC1' ]
         php:         [ '7.2', '7.4', '8.0' ]
           
     

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         woocommerce: [ 'beta' ]
-        wordpress:   [ 'latest' ]
+        wordpress:   [ 'latest', '6.0' ]
         php:         [ '7.0', '7.4', '8.0' ]
           
     


### PR DESCRIPTION
Fixes #

## Changes proposed in this Pull Request:

This PR adds WP 6.0 to the compatibly workflow.

## Testing instructions
