### PR TITLE
Compatibility updates for WC >= 6.5.0

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         woocommerce: [ 'beta' ]
-        wordpress:   [ 'latest', '6.0-RC1' ]
+        wordpress:   [ 'latest' ]
         php:         [ '7.2', '7.4', '8.0' ]
           
     

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         woocommerce: [ 'beta' ]
         wordpress:   [ 'latest', '6.0' ]
-        php:         [ '7.0', '7.4', '8.0' ]
+        php:         [ '7.2', '7.4', '8.0' ]
           
     
     name: Beta (PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }})

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         woocommerce: [ 'beta' ]
-        wordpress:   [ 'latest', '6.0' ]
+        wordpress:   [ 'latest', '6.0-RC1' ]
         php:         [ '7.2', '7.4', '8.0' ]
           
     

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         woocommerce: [ 'beta' ]
-        wordpress:   [ 'latest' ]
+        wordpress:   [ 'latest', '6.0' ]
         php:         [ '7.0', '7.4', '8.0' ]
           
     

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '6.2.0'
+            woocommerce: '6.5.0'
           - woocommerce_support_policy: L-1
-            woocommerce: '6.1.0'
+            woocommerce: '6.4.1'
           - woocommerce_support_policy: L-2
-            woocommerce: '6.0.0'
+            woocommerce: '6.3.1'
           # WordPress
           - wordpress_support_policy: L
             wordpress: '5.9'

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -35,6 +35,9 @@ jobs:
             php: '7.4'
           - php_support_policy: L-2
             php: '7.0'
+        exclude:
+          - woocommerce_support_policy: L
+            php_support_policy: L-2
 
     name: Stable (PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }})
     env:

--- a/tests/phpunit/setup.php
+++ b/tests/phpunit/setup.php
@@ -3,3 +3,8 @@
  * Set up shared by all tests.
  */
 update_option( 'woocommerce_default_country', 'US:CA' );
+
+if ( version_compare( WC_VERSION, '6.4.1', '=' ) ) {
+	\Automattic\WooCommerce\Internal\Admin\Install::create_tables();
+	\Automattic\WooCommerce\Internal\Admin\Install::create_events();
+}

--- a/tests/phpunit/test-class-wc-stripe-upe-availability-note.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-availability-note.php
@@ -24,7 +24,9 @@ class WC_Stripe_UPE_Availability_Note_Test extends WP_UnitTestCase {
 			$this->assertSame( 'wc-stripe-upe-availability-note', $enable_upe_action->name );
 			$this->assertSame( 'Enable in your store', $enable_upe_action->label );
 			$this->assertSame( '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-upe', $enable_upe_action->query );
-			$this->assertSame( true, $enable_upe_action->primary );
+			if ( version_compare( WC_VERSION, '6.5.0', '<' ) ) {
+				$this->assertSame( true, $enable_upe_action->primary );
+			}
 		} else {
 			$this->markTestSkipped( 'The used WC components are not backward compatible' );
 		}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -9,7 +9,7 @@
  * Requires at least: 5.6
  * Tested up to: 5.9
  * WC requires at least: 5.7
- * WC tested up to: 6.2
+ * WC tested up to: 6.5
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */


### PR DESCRIPTION
Fixes #2347

The "primary" property was removed from `Automattic\WooCommerce\Admin\Notes\Note` in WC 6.5.0.

This change skips the assertion for the primary property in WC >=6.5.0

See https://github.com/woocommerce/woocommerce-admin/pull/8474/files#r829672400

Also, WooCommerce 6.5.0 now requires PHP >= 7.2. This PR updates the GitHub workflow to account for this and WP 6.0 compat testing.

Finally it includes a small test bootstrap workaround for a bug in WC 6.4.1.

## Testing instructions

Simply run the tests with WC >= 6.5.0. They should pass with this fix.
