### PR TITLE
Prevent duplicate payment processing

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -536,14 +536,16 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				$order->payment_complete( $response->id );
 
 				/* translators: transaction id */
-				$message = sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $response->id );
-				$order->add_order_note( $message );
+				$note = sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $response->id );
 			}
 
 			if ( 'failed' === $response->status ) {
-				$localized_message = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
-				$order->add_order_note( $localized_message );
-				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
+				$note = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
+				throw new WC_Stripe_Exception( print_r( $response, true ), $note );
+			}
+
+			if ( isset( $note ) && ! WC_Stripe_Helper::order_note_exists( $order, $note ) ) {
+				$order->add_order_note( $note );
 			}
 		} else {
 			$order->set_transaction_id( $response->id );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -695,4 +695,27 @@ class WC_Stripe_Helper {
 		$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
 		$order->save();
 	}
+
+	/**
+	 * Check if a note content does already exist in the order.
+	 *
+	 * @param WC_Order $order        The order object to add the note.
+	 * @param string   $note_content Note content.
+	 *
+	 * @return bool true if the note content exists, false otherwise.
+	 */
+	public static function order_note_exists( WC_Order $order, string $note_content ): bool {
+		// Get current notes of the order.
+		$current_notes = wc_get_order_notes(
+			[ 'order_id' => $order->get_id() ]
+		);
+
+		foreach ( $current_notes as $current_note ) {
+			if ( $current_note->content === $note_content ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2331 

## Changes proposed in this Pull Request:

So far, this is just addressing duplicate notes on the orders. I could confirm the behavior [Hector pointed out](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2331#issuecomment-1111361275), and I was investigating what effects that's causing and possible solutions. There's certainly more involved than just the notes being duplicated.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

TBD

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
