### PR TITLE
Fixed customers receive English emails from Stripe if site uses formal German locale.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 6.5.0 - 2022-xx-xx =
+* Fix - Missing mapping for formal German locale (de_DE_formal).
 
 = 6.4.0 - 2022-05-20 =
 * Fix - Changed logic for how 'Enabled/Disabled' statuses are shown for payments and payouts capabilities in settings.

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -625,6 +625,7 @@ class WC_Stripe_Customer {
 			'ar'    => 'ar-AR',
 			'da_DK' => 'da-DK',
 			'de_DE' => 'de-DE',
+			'de_DE_formal' => 'de-DE',
 			'en'    => 'en-US',
 			'es_ES' => 'es-ES',
 			'es_CL' => 'es-419',

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.5.0 - 2022-xx-xx =
+* Fix - Missing mapping for formal German locale (de_DE_formal).
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2114

## Changes proposed in this Pull Request:

If a site uses the formal German locale (de_DE_formal), then the locale is not sent to Stripe. This causes all emails from Stripe to be in English instead of German.

## Testing instructions

1. Configure the site locale de_DE_formal in the WordPress language settings.
2. Place an order.
3. The emails sent from Stripe should be in German.

Notes

- Stripe does not send emails when testing/sandbox mode is enabled.

- Testing an array key lookup does not make sense. Therefore no automated tests are added.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] ~Tested on mobile (or does not apply)~

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
