### PR TITLE
[WIP] Add/1515 dynamic prices - Support for updating/filtering response for extenstion compat

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -63,6 +63,17 @@ jQuery( function( $ ) {
 			};
 		},
 
+		/**
+		 * Get add to cart custom fields data.
+		 *
+		 * @since 7.0.0
+		 *
+		 * @return string
+		 */
+		getCustomData: function() {
+			return $( 'form.cart' ).find( 'input[name!="variation_id"][name!="product_id"][name!="add-to-cart"][name!="quantity"], select, textarea' ).not('[name^="attribute_"]').serialize();
+		},
+
 		processSource: function( source, paymentRequestType ) {
 			var data = wc_stripe_payment_request.getOrderData( source, paymentRequestType );
 
@@ -444,6 +455,7 @@ jQuery( function( $ ) {
 				qty: $( '.quantity .qty' ).val(),
 				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
 				addon_value: addon_value,
+				custom_data: wc_stripe_payment_request.getCustomData()
 			};
 
 			return $.ajax( {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -638,7 +638,7 @@ jQuery( function( $ ) {
 				wc_stripe_payment_request.blockPaymentRequestButton( 'wc_request_button_is_disabled' );
 			} );
 
-			$( document.body ).on( 'woocommerce_variation_has_changed', function () {
+			$( document.body ).on( 'wc_stripe_update_selected_product_data woocommerce_variation_has_changed', function () {
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -287,25 +287,9 @@ jQuery( function( $ ) {
 				security: wc_stripe_payment_request_params.nonce.add_to_cart,
 				product_id: product_id,
 				qty: $( '.quantity .qty' ).val(),
-				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : []
+				attributes: $( '.variations_form' ).length ? wc_stripe_payment_request.getAttributes().data : [],
+				custom_data: wc_stripe_payment_request.getCustomData()
 			};
-
-			// add addons data to the POST body
-			var formData = $( 'form.cart' ).serializeArray();
-			$.each( formData, function( i, field ) {
-				if ( /^addon-/.test( field.name ) ) {
-					if ( /\[\]$/.test( field.name ) ) {
-						var fieldName = field.name.substring( 0, field.name.length - 2);
-						if ( data[ fieldName ] ) {
-							data[ fieldName ].push( field.value );
-						} else {
-							data[ fieldName ] = [ field.value ];
-						}
-					} else {
-						data[ field.name ] = field.value;
-					}
-				}
-			} );
 
 			return $.ajax( {
 				type: 'POST',
@@ -624,7 +608,7 @@ jQuery( function( $ ) {
 					return;
 				}
 
-				if ( 0 < paymentRequestError.length ) {
+				if ( 'string' === typeof paymentRequestError ) {
 					evt.preventDefault();
 					window.alert( paymentRequestError );
 					return;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1312,6 +1312,16 @@ class WC_Stripe_Payment_Request {
 			$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );
 			$data['currency']        = strtolower( get_woocommerce_currency() );
 			$data['country_code']    = substr( get_option( 'woocommerce_default_country' ), 0, 2 );
+			
+			/**
+			 * `wc_stripe_payment_request_get_selected_product_data` filter.
+			 *
+			 * @since   7.0.0
+			 * @param   array $data The formatted response data.
+			 * @param   object $product WC_Product_* The product being purchased.
+			 * @return  array
+			 */
+			$data = apply_filters( 'wc_stripe_payment_request_get_selected_product_data', $data, $product );
 
 			wp_send_json( $data );
 		} catch ( Exception $e ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -369,14 +369,14 @@ class WC_Stripe_Payment_Request {
 		}
 
 		/**
-		 * `wc_stripe_payment_request_product_amount` filter.
+		 * `wc_stripe_payment_request_product_price` filter.
 		 *
 		 * @since   7.0.0
 		 * @param   integer $product_price The total price.
 		 * @param   object $product WC_Product_* The product being purchased.
 		 * @return  integer
 		 */
-		return apply_filters( 'wc_stripe_payment_request_product_amount', $product_price, $product );
+		return apply_filters( 'wc_stripe_payment_request_product_price', $product_price, $product );
 	}
 
 	/**
@@ -770,7 +770,7 @@ class WC_Stripe_Payment_Request {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		wp_register_script( 'stripe', 'https://js.stripe.com/v3/', '', '3.0', true );
-		wp_register_script( 'wc_stripe_payment_request', plugins_url( 'assets/js/stripe-payment-request' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [ 'jquery', 'stripe' ], WC_STRIPE_VERSION, true );
+		wp_register_script( 'wc_stripe_payment_request', plugins_url( 'assets/js/stripe-payment-request' . $suffix . '.js', WC_STRIPE_MAIN_FILE ), [ 'jquery', 'stripe' ], time(), true );
 
 		wp_localize_script(
 			'wc_stripe_payment_request',

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1239,6 +1239,8 @@ class WC_Stripe_Payment_Request {
 			$product      = wc_get_product( $product_id );
 			$variation_id = null;
 
+			$this->populate_post();
+
 			if ( ! is_a( $product, 'WC_Product' ) ) {
 				/* translators: 1) The product Id */
 				throw new Exception( sprintf( __( 'Product with the ID (%1$s) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
@@ -1880,5 +1882,32 @@ class WC_Stripe_Payment_Request {
 		}
 
 		return $this->stripe_settings['payment_request_button_locations'];
+	}
+
+
+	/**
+	 * Populate $_POST with all form input data to allow 3rd party code to validate.
+	 *
+	 * @since   7.0.0
+	 */
+	private function populate_post() {
+		if ( isset( $_POST['custom_data'] ) ) {
+
+			parse_str( $_POST['custom_data'], $custom_data );
+
+			if ( $custom_data ) {
+
+				foreach ( $custom_data as $input_name => $input_value ) {
+
+					// Write to $_POST only if key does not exist
+					if ( ! isset( $_POST[ $input_name ] ) ) {
+						$_REQUEST[ $input_name ] = $input_value;
+						$_POST[ $input_name ]    = $input_value;
+					}
+				}
+			}
+			
+			unset( $_POST['custom_data'] );
+		}
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1351,6 +1351,8 @@ class WC_Stripe_Payment_Request {
 			define( 'WOOCOMMERCE_CART', true );
 		}
 
+		$this->populate_post();
+
 		WC()->shipping->reset_shipping();
 
 		$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -368,7 +368,15 @@ class WC_Stripe_Payment_Request {
 			$product_price = $product->get_price() + WC_Subscriptions_Product::get_sign_up_fee( $product );
 		}
 
-		return $product_price;
+		/**
+		 * `wc_stripe_payment_request_product_amount` filter.
+		 *
+		 * @since   7.0.0
+		 * @param   integer $product_price The total price.
+		 * @param   object $product WC_Product_* The product being purchased.
+		 * @return  integer
+		 */
+		return apply_filters( 'wc_stripe_payment_request_product_amount', $product_price, $product );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1515
Replaces #1563

## Changes proposed in this Pull Request:

Introduce extensibility points for plugins that have custom product types or otherwise modify the price of the product on the single product page.

Needs re-testing with Product Addons.

## Testing instructions

With Name Your Price... if you enter the price and _Tab_ out of the field, the payment request is updated with the entered price. This needs further modification so that we prevent and/or delay the click event to give time for the update to happen. See current [demo](https://mnm.kathyisawesome.com/product/simple-nyp/)

![Screen Recording 2022-06-01 at 02 43 49 79 PM](https://user-images.githubusercontent.com/507025/171498217-05f8c27d-e664-412c-9b1c-74862d4fb315.gif)

Example snippet for filtering the response via:

```
/**
 * Update request response.
 *
 * @param   array $data
 * @param   obj WC_Product
 * @return  array
 */
function wc_nyp_add_nyp_response( $data, $product ) {
	
	if ( class_exists( 'WC_Name_Your_Price_Helpers' ) && WC_Name_Your_Price_Helpers::is_nyp( $product ) ) {
	    $posted_price = WC_Name_Your_Price_Helpers::get_posted_price( $product );
	    $data['displayItems'][0]['amount'] = WC_Stripe_Helper::get_stripe_amount( $posted_price );
	    $data['total']['amount'] =  WC_Stripe_Helper::get_stripe_amount( $posted_price );
	}
	return $data;
}
add_filter( 'wc_stripe_payment_request_get_selected_product_data', 'wc_nyp_add_nyp_response', 10, 2 );
```

OR

```
/**
 * Update request price.
 *
 * @param   string $price
 * @param   obj WC_Product
 * @return  string
 */
function wc_nyp_add_nyp_amount( $price, $product ) {
	
	if ( class_exists( 'WC_Name_Your_Price_Helpers' ) && WC_Name_Your_Price_Helpers::is_nyp( $product ) ) {
	    $price = WC_Name_Your_Price_Helpers::get_posted_price( $product );
	}
	return $price;
}
add_filter( 'wc_stripe_payment_request_product_price', 'wc_nyp_add_nyp_amount', 10, 2 );
```



---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
