### PR TITLE
Fix terminal location creation if site title is missing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 6.5.0 - 2022-xx-xx =
+* Fix - Fix terminal location creation if site title is missing.
 
 = 6.4.1 - 2022-06-01 =
 * Fix - Ensure proper URL formatting.

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -179,7 +179,8 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 */
 	public function get_store_location( $request ) {
 		// Originally `get_bloginfo` was used for location name, later switched to `site_url` as the former may be blank.
-		$possible_names = [ get_bloginfo(), site_url() ];
+		$store_hostname = str_replace( [ 'https://', 'http://' ], '', get_site_url() );
+		$possible_names = [ get_bloginfo(), $store_hostname ];
 		$store_address = WC()->countries;
 		$address       = array_filter(
 			[
@@ -224,7 +225,7 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 			// Create new location if no location matches display name and address.
 			$response = WC_Stripe_API::request(
 				[
-					'display_name' => site_url(),
+					'display_name' => $store_hostname,
 					'address'      => $address,
 				],
 				'terminal/locations'

--- a/includes/admin/class-wc-rest-stripe-locations-controller.php
+++ b/includes/admin/class-wc-rest-stripe-locations-controller.php
@@ -178,7 +178,8 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function get_store_location( $request ) {
-		$name          = get_bloginfo();
+		// Originally `get_bloginfo` was used for location name, later switched to `site_url` as the former may be blank.
+		$possible_names = [ get_bloginfo(), site_url() ];
 		$store_address = WC()->countries;
 		$address       = array_filter(
 			[
@@ -213,7 +214,7 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 		try {
 			foreach ( $this->fetch_locations() as $location ) {
 				if (
-					$location->display_name === $name
+					in_array( $location->display_name, $possible_names, true )
 					&& count( array_intersect( (array) $location->address, $address ) ) === count( $address )
 				) {
 					return rest_ensure_response( $location );
@@ -223,7 +224,7 @@ class WC_REST_Stripe_Locations_Controller extends WC_Stripe_REST_Base_Controller
 			// Create new location if no location matches display name and address.
 			$response = WC_Stripe_API::request(
 				[
-					'display_name' => $name,
+					'display_name' => site_url(),
 					'address'      => $address,
 				],
 				'terminal/locations'

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.5.0 - 2022-xx-xx =
+* Fix - Fix terminal location creation if site title is missing.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2356

## Changes proposed in this Pull Request:

For Stripe in-person-payments, when a terminal location object is created, we previously used `get_bloginfo` (the site title) as the location name. Since this can be blank (causing a Stripe API error), this PR instead uses `site_url`. This is consistent with how we're planning to resolve the same issue in WCPay: https://github.com/Automattic/woocommerce-payments/pull/4304

Additional context: pdfdoF-QQ-p2

## Testing instructions

- First, go to the [Locations page of your Stripe dashboard](https://dashboard.stripe.com/test/terminal/locations) and delete any existing locations, if there are any.
- Make a `GET` request to your store's `/wp-json/wc/v3/wc_stripe/terminal/locations/store` endpoint. Verify that you get back a `terminal.location` object whose `display_name` is your site's URL. Take note of the location's `id`.
- Make another `GET` request to the same endpoint. You should get back the same object (with the same `id`).
- Refresh your Stripe dashboard, click on the location object, and change its name to match your site's title exactly.
- Make another `GET` request to the endpoint. You should get back the same object (with the same `id`), but the display name should now be your site's title.
- On your Stripe dashboard, change the name to something totally different (i.e., not your site's title and not your site's URL).
- Make another `GET` request to the endpoint. You should get back a new object (with a new `id`), and a `display_name` set to your site's URL.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
