### PR TITLE
Add Compatibility With Woocommerce 6.6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = 6.5.0 - 2022-xx-xx =
 * Fix - Fix terminal location creation if site title is missing.
-* Fix - Add compatibility with Woocommerce 6.6.
+* Fix - Add compatibility with WooCommerce 6.6.
 
 = 6.4.1 - 2022-06-01 =
 * Fix - Ensure proper URL formatting.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.5.0 - 2022-xx-xx =
 * Fix - Fix terminal location creation if site title is missing.
+* Fix - Add compatibility with Woocommerce 6.6.
 
 = 6.4.1 - 2022-06-01 =
 * Fix - Ensure proper URL formatting.

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -276,13 +276,11 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @param WP_REST_Request $request Full data about the request.
 	 */
 	public function update_settings( WP_REST_Request $request ) {
-		$form_fields = $this->gateway->get_form_fields();
-
 		/* Settings > General */
 		$this->update_is_stripe_enabled( $request );
-		$this->update_title( $request, $form_fields );
-		$this->update_title_upe( $request, $form_fields );
-		$this->update_description( $request, $form_fields );
+		$this->update_title( $request );
+		$this->update_title_upe( $request );
+		$this->update_description( $request );
 		$this->update_is_test_mode_enabled( $request );
 
 		/* Settings > Payments accepted on checkout */
@@ -296,9 +294,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$this->update_is_manual_capture_enabled( $request );
 		$this->update_is_saved_cards_enabled( $request );
 		$this->update_is_separate_card_form_enabled( $request );
-		$this->update_account_statement_descriptor( $request, $form_fields );
+		$this->update_account_statement_descriptor( $request );
 		$this->update_is_short_account_statement_enabled( $request );
-		$this->update_short_account_statement_descriptor( $request, $form_fields );
+		$this->update_short_account_statement_descriptor( $request );
 
 		/* Settings > Advanced settings */
 		$this->update_is_debug_log_enabled( $request );
@@ -330,16 +328,15 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * Updates title.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @param array $form_fields stripe form fields.
 	 */
-	private function update_title( WP_REST_Request $request, array $form_fields ) {
+	private function update_title( WP_REST_Request $request ) {
 		$title = $request->get_param( 'title' );
 
 		if ( null === $title ) {
 			return;
 		}
 
-		$validated_title = $this->validate_field( 'title', $title, $form_fields );
+		$validated_title = $this->validate_field( 'title', $title );
 
 		$this->gateway->update_option( 'title', $validated_title );
 	}
@@ -349,15 +346,15 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 *
 	 * @param string $field_key the form field key.
 	 * @param string $field_value the form field value.
-	 * @param array $form_fields stripe form fields.
 	 *
 	 * @return string validated field value.
 	 */
-	private function validate_field( $field_key, $field_value, $form_fields ) {
+	private function validate_field( $field_key, $field_value ) {
 		if ( is_callable( [ $this->gateway, 'validate_' . $field_key . '_field' ] ) ) {
 			return $this->gateway->{'validate_' . $field_key . '_field'}( $field_key, $field_value );
 		}
 
+		$form_fields = $this->gateway->get_form_fields();
 		if ( key_exists( $field_key, $form_fields ) ) {
 			$field_type = $form_fields[ $field_key ]['type'];
 
@@ -373,16 +370,15 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * Updates UPE title.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @param array $form_fields stripe form fields.
 	 */
-	private function update_title_upe( WP_REST_Request $request, array $form_fields ) {
+	private function update_title_upe( WP_REST_Request $request ) {
 		$title_upe = $request->get_param( 'title_upe' );
 
 		if ( null === $title_upe ) {
 			return;
 		}
 
-		$validated_title_upe = $this->validate_field( 'title_upe', $title_upe, $form_fields );
+		$validated_title_upe = $this->validate_field( 'title_upe', $title_upe );
 
 		$this->gateway->update_option( 'title_upe', $validated_title_upe );
 	}
@@ -391,16 +387,15 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * Updates description.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @param array $form_fields stripe form fields.
 	 */
-	private function update_description( WP_REST_Request $request, array $form_fields ) {
+	private function update_description( WP_REST_Request $request ) {
 		$description = $request->get_param( 'description' );
 
 		if ( null === $description ) {
 			return;
 		}
 
-		$validated_description = $this->validate_field( 'description', $description, $form_fields );
+		$validated_description = $this->validate_field( 'description', $description );
 
 		$this->gateway->update_option( 'description', $validated_description );
 	}
@@ -484,9 +479,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * Updates account statement descriptor.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @param array $form_fields stripe form fields.
 	 */
-	private function update_account_statement_descriptor( WP_REST_Request $request, array $form_fields ) {
+	private function update_account_statement_descriptor( WP_REST_Request $request ) {
 		$account_statement_descriptor = $request->get_param( 'statement_descriptor' );
 
 		if ( null === $account_statement_descriptor ) {
@@ -495,8 +489,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		$validated_account_statement_descriptor = $this->validate_field(
 			'statement_descriptor',
-			$account_statement_descriptor,
-			$form_fields
+			$account_statement_descriptor
 		);
 
 		$this->gateway->update_option( 'statement_descriptor', $validated_account_statement_descriptor );
@@ -521,9 +514,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * Updates short account statement descriptor.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @param array $form_fields stripe form fields.
 	 */
-	private function update_short_account_statement_descriptor( WP_REST_Request $request, array $form_fields ) {
+	private function update_short_account_statement_descriptor( WP_REST_Request $request ) {
 		$is_short_account_statement_enabled = $request->get_param( 'is_short_statement_descriptor_enabled' );
 		$short_account_statement_descriptor = $request->get_param( 'short_statement_descriptor' );
 
@@ -538,8 +530,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		$validated_short_account_statement_descriptor = $this->validate_field(
 			'short_statement_descriptor',
-			$short_account_statement_descriptor,
-			$form_fields
+			$short_account_statement_descriptor
 		);
 
 		$this->gateway->update_option( 'short_statement_descriptor', $validated_short_account_statement_descriptor );

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -240,9 +240,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > General */
 				'is_stripe_enabled'                     => $this->gateway->is_enabled(),
 				'is_test_mode_enabled'                  => $this->gateway->is_in_test_mode(),
-				'title'                                 => $this->gateway->get_option( 'title' ),
-				'title_upe'                             => $this->gateway->get_option( 'title_upe' ),
-				'description'                           => $this->gateway->get_option( 'description' ),
+				'title'                                 => $this->gateway->get_validated_option( 'title' ),
+				'title_upe'                             => $this->gateway->get_validated_option( 'title_upe' ),
+				'description'                           => $this->gateway->get_validated_option( 'description' ),
 
 				/* Settings > Payments accepted on checkout */
 				'enabled_payment_method_ids'            => $this->gateway->get_upe_enabled_payment_method_ids(),
@@ -250,18 +250,18 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 				/* Settings > Express checkouts */
 				'is_payment_request_enabled'            => 'yes' === $this->gateway->get_option( 'payment_request' ),
-				'payment_request_button_type'           => $this->gateway->get_option( 'payment_request_button_type' ),
-				'payment_request_button_theme'          => $this->gateway->get_option( 'payment_request_button_theme' ),
-				'payment_request_button_size'           => $this->gateway->get_option( 'payment_request_button_size' ),
-				'payment_request_button_locations'      => $this->gateway->get_option( 'payment_request_button_locations' ),
+				'payment_request_button_type'           => $this->gateway->get_validated_option( 'payment_request_button_type' ),
+				'payment_request_button_theme'          => $this->gateway->get_validated_option( 'payment_request_button_theme' ),
+				'payment_request_button_size'           => $this->gateway->get_validated_option( 'payment_request_button_size' ),
+				'payment_request_button_locations'      => $this->gateway->get_validated_option( 'payment_request_button_locations' ),
 
 				/* Settings > Payments & transactions */
 				'is_manual_capture_enabled'             => ! $this->gateway->is_automatic_capture_enabled(),
 				'is_saved_cards_enabled'                => 'yes' === $this->gateway->get_option( 'saved_cards' ),
 				'is_separate_card_form_enabled'         => 'no' === $this->gateway->get_option( 'inline_cc_form' ),
-				'statement_descriptor'                  => $this->gateway->get_option( 'statement_descriptor' ),
+				'statement_descriptor'                  => $this->gateway->get_validated_option( 'statement_descriptor' ),
 				'is_short_statement_descriptor_enabled' => 'yes' === $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ),
-				'short_statement_descriptor'            => $this->gateway->get_option( 'short_statement_descriptor' ),
+				'short_statement_descriptor'            => $this->gateway->get_validated_option( 'short_statement_descriptor' ),
 
 				/* Settings > Advanced settings */
 				'is_debug_log_enabled'                  => 'yes' === $this->gateway->get_option( 'logging' ),
@@ -336,34 +336,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$validated_title = $this->validate_field( 'title', $title );
-
-		$this->gateway->update_option( 'title', $validated_title );
-	}
-
-	/**
-	 * Ensures validated values.
-	 *
-	 * @param string $field_key the form field key.
-	 * @param string $field_value the form field value.
-	 *
-	 * @return string validated field value.
-	 */
-	private function validate_field( $field_key, $field_value ) {
-		if ( is_callable( [ $this->gateway, 'validate_' . $field_key . '_field' ] ) ) {
-			return $this->gateway->{'validate_' . $field_key . '_field'}( $field_key, $field_value );
-		}
-
-		$form_fields = $this->gateway->get_form_fields();
-		if ( key_exists( $field_key, $form_fields ) ) {
-			$field_type = $form_fields[ $field_key ]['type'];
-
-			if ( is_callable( [ $this->gateway, 'validate_' . $field_type . '_field' ] ) ) {
-				return $this->gateway->{'validate_' . $field_type . '_field'}( $field_key, $field_value );
-			}
-		}
-
-		return $this->gateway->validate_text_field( $field_key, $field_value );
+		$this->gateway->update_validated_option( 'title', $title );
 	}
 
 	/**
@@ -378,9 +351,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$validated_title_upe = $this->validate_field( 'title_upe', $title_upe );
-
-		$this->gateway->update_option( 'title_upe', $validated_title_upe );
+		$this->gateway->update_validated_option( 'title_upe', $title_upe );
 	}
 
 	/**
@@ -395,9 +366,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$validated_description = $this->validate_field( 'description', $description );
-
-		$this->gateway->update_option( 'description', $validated_description );
+		$this->gateway->update_validated_option( 'description', $description );
 	}
 
 	/**
@@ -487,12 +456,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$validated_account_statement_descriptor = $this->validate_field(
-			'statement_descriptor',
-			$account_statement_descriptor
-		);
-
-		$this->gateway->update_option( 'statement_descriptor', $validated_account_statement_descriptor );
+		$this->gateway->update_validated_option( 'statement_descriptor', $account_statement_descriptor );
 	}
 
 	/**
@@ -528,12 +492,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$validated_short_account_statement_descriptor = $this->validate_field(
-			'short_statement_descriptor',
-			$short_account_statement_descriptor
-		);
-
-		$this->gateway->update_option( 'short_statement_descriptor', $validated_short_account_statement_descriptor );
+		$this->gateway->update_validated_option( 'short_statement_descriptor', $short_account_statement_descriptor );
 	}
 
 	/**
@@ -594,7 +553,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			}
 
 			$value = $request->get_param( $request_key );
-			$this->gateway->update_option( $attribute, $value );
+			$this->gateway->update_validated_option( $attribute, $value );
 		}
 	}
 

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$is_gte_wc6_6 = defined( WC_VERSION ) && version_compare( WC_VERSION, '6.6', '>=' );
+
 $stripe_settings = apply_filters(
 	'wc_stripe_settings',
 	[
@@ -15,14 +17,14 @@ $stripe_settings = apply_filters(
 		],
 		'title'                               => [
 			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
-			'type'        => 'safe_text',
+			'type'        => $is_gte_wc6_6 ? 'safe_text' : 'text',
 			'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-gateway-stripe' ),
 			'default'     => __( 'Credit Card (Stripe)', 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,
 		],
 		'title_upe'                           => [
 			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
-			'type'        => 'safe_text',
+			'type'        => $is_gte_wc6_6 ? 'safe_text' : 'text',
 			'description' => __( 'This controls the title which the user sees during checkout when multiple payment methods are enabled.', 'woocommerce-gateway-stripe' ),
 			'default'     => __( 'Popular payment methods', 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -15,14 +15,14 @@ $stripe_settings = apply_filters(
 		],
 		'title'                               => [
 			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
-			'type'        => 'text',
+			'type'        => 'safe_text',
 			'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce-gateway-stripe' ),
 			'default'     => __( 'Credit Card (Stripe)', 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,
 		],
 		'title_upe'                           => [
 			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
-			'type'        => 'text',
+			'type'        => 'safe_text',
 			'description' => __( 'This controls the title which the user sees during checkout when multiple payment methods are enabled.', 'woocommerce-gateway-stripe' ),
 			'default'     => __( 'Popular payment methods', 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -107,6 +107,13 @@ $stripe_settings = apply_filters(
 			'default'     => '',
 			'desc_tip'    => true,
 		],
+		'short_statement_descriptor'          => [
+			'title'       => __( 'Short Statement Descriptor', 'woocommerce-gateway-stripe' ),
+			'type'        => 'text',
+			'description' => __( 'Shortened version of the statement descriptor in combination with the customer order number.', 'woocommerce-gateway-stripe' ),
+			'default'     => '',
+			'desc_tip'    => true,
+		],
 		'capture'                             => [
 			'title'       => __( 'Capture', 'woocommerce-gateway-stripe' ),
 			'label'       => __( 'Capture charge immediately', 'woocommerce-gateway-stripe' ),

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -191,7 +191,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Processses the orders that are redirected.
+	 * Processes the orders that are redirected.
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 6.5.0 - 2022-xx-xx =
 * Fix - Fix terminal location creation if site title is missing.
+* Fix - Add compatibility with Woocommerce 6.6.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 6.5.0 - 2022-xx-xx =
 * Fix - Fix terminal location creation if site title is missing.
-* Fix - Add compatibility with Woocommerce 6.6.
+* Fix - Add compatibility with WooCommerce 6.6.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes n/a.

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR allows WCStripe's form field settings to be compatible with WooCommerce 6.6. 

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

0. Ensure WooCommerce 6.6 has been installed.
1. As a merchant, navigate to `WooCommerce > Settings > Payments` and click on the `Stripe` row.
2. Click on the `Settings` tab.
3. Update the `Name` and `Description` fields and click `Save changes`.

![image](https://user-images.githubusercontent.com/6844516/173426011-d47ab9f7-969e-41cd-b531-df4ce87f70e1.png)

5. As a customer, navigate to the shop, add an item to your cart, and navigate to checkout.
6. Ensure the changes to the `Name` and `Description` fields are reflected in the payment section.

![image](https://user-images.githubusercontent.com/6844516/173425918-4e1d0779-df03-4bd7-a611-5210d21550c4.png)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
