### PR TITLE
[PRB] Fix "Pending" text instead of numeric amount on Apple Pay on iOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 6.6.0 - 2022-xx-xx =
+* Fix - Fix "Pending" text instead of numeric amount on Payment Request button on iOS.
 
 = 6.5.1 - 2022-08-01 =
 * Fix - Stripe Link missing styles and logo for email trigger button.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -441,7 +441,6 @@ class WC_Stripe_Payment_Request {
 		$data['total']        = [
 			'label'   => apply_filters( 'wc_stripe_payment_request_total_label', $this->total_label ),
 			'amount'  => WC_Stripe_Helper::get_stripe_amount( $this->get_product_price( $product ) ),
-			'pending' => true,
 		];
 
 		$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() && 0 !== wc_get_shipping_method_count( true ) );
@@ -1304,7 +1303,6 @@ class WC_Stripe_Payment_Request {
 			$data['total']        = [
 				'label'   => $this->total_label,
 				'amount'  => WC_Stripe_Helper::get_stripe_amount( $total ),
-				'pending' => true,
 			];
 
 			$data['requestShipping'] = ( wc_shipping_enabled() && $product->needs_shipping() );

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.6.0 - 2022-xx-xx =
+* Fix - Fix "Pending" text instead of numeric amount on Payment Request button on iOS.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Addresses p1655201776648499-slack-C7U3Y3VMY for products without tax enabled.

## Changes proposed in this Pull Request:
This worked before but now it shows “Pending” on **iOS** instead of showing the real amount. Although the payment is processed we should show the amount nevertheless.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->


## Testing instructions

- Use a public URL on your WCStripe site otherwise the Apple Pay button might not work.
- Make sure you have a payment method added to your Wallet app on your iOs device.
- Visit a product page using iOS.
- Click the "Buy with  Pay" button.
- The product amount should be visible.
- Payment should be processed successfully.

| Before  | After |
| ------------- | ------------- |
| ![IMG_A187CB251FCF-1](https://user-images.githubusercontent.com/1025173/173984149-827e2283-9bff-44d7-8c22-79ab1e4cd286.jpeg) | ![IMG_664B03A1DFB4-1](https://user-images.githubusercontent.com/1025173/173984198-aab98c5f-aa5c-4be7-81f3-6d58b51b5188.jpeg) |

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)