### PR TITLE
Replace unnecessary throws with empty strings when input is invalid

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 6.5.0 - 2022-xx-xx =
+* Fix - Replace unnecessary throws with empty string when keys are invalid.
 
 = 6.4.2 - 2022-06-29 =
 * Fix - Fix terminal location creation if site title is missing.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -992,7 +992,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_publishable_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^pk_live_/', $value ) ) {
-			throw new Exception( __( 'The "Live Publishable Key" should start with "pk_live", enter the correct key.', 'woocommerce-gateway-stripe' ) );
+			return '';
 		}
 		return $value;
 	}
@@ -1000,7 +1000,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_secret_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^[rs]k_live_/', $value ) ) {
-			throw new Exception( __( 'The "Live Secret Key" should start with "sk_live" or "rk_live", enter the correct key.', 'woocommerce-gateway-stripe' ) );
+			return '';
 		}
 		return $value;
 	}
@@ -1008,7 +1008,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_test_publishable_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^pk_test_/', $value ) ) {
-			throw new Exception( __( 'The "Test Publishable Key" should start with "pk_test", enter the correct key.', 'woocommerce-gateway-stripe' ) );
+			return '';
 		}
 		return $value;
 	}
@@ -1016,7 +1016,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function validate_test_secret_key_field( $key, $value ) {
 		$value = $this->validate_text_field( $key, $value );
 		if ( ! empty( $value ) && ! preg_match( '/^[rs]k_test_/', $value ) ) {
-			throw new Exception( __( 'The "Test Secret Key" should start with "sk_test" or "rk_test", enter the correct key.', 'woocommerce-gateway-stripe' ) );
+			return '';
 		}
 		return $value;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.5.0 - 2022-xx-xx =
+* Fix - Replace unnecessary throws with empty string when keys are invalid.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

* Fixes #2373

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Before, if the Stripe key input was invalid an error was thrown. In some cases, the error was not caught and was throwing fatal exceptions. Now, an empty string is returned when a key input is invalid. This follows the same pattern that exists in the validators of: 'woocommerce/includes/abstracts/abstract-wc-settings-api.php'.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

0. Ensure you are using the following versions: `WordPress 6.0` and `WooCommerce 6.6.1`.
1. As a merchant, navigate to `WooCommerce > Settings > Payments > Stripe`.
2. If needed, click `Enter account keys (advanced)`, go to `Test` tab in the modal, and enter test keys.
3. Ensure successful redirect to `WooCommerce > Settings > Payments > Stripe > Settings`.
4. Click `Edit account keys > Test` and enter invalid input.
5. Ensure "Error saving account keys." is displayed.
6. Enter valid keys and save.
7. Ensure "Account keys saved." is displayed.
8. Delete input for both `Test publishable key` and `Test secret key` and then click `Save test keys`.
9. Refresh the page and ensure navigation to `WooCommerce > Settings > Payments > Stripe`.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
