### PR TITLE
Add stripe link headers to requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 6.5.0 - 2022-xx-xx =
+* Add - Stripe Link: Add beta headers for Stripe server requests
 
 = 6.4.3 - 2022-06-30 =
 * Fix - Replace unnecessary throws with empty string when keys are invalid.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -58,7 +58,8 @@ export default class WCStripeAPI {
 	 * @return {Object} The Stripe Object.
 	 */
 	getStripe() {
-		const { key, locale, isUPEEnabled, paymentMethodsConfig } = this.options;
+		const { key, locale, isUPEEnabled, paymentMethodsConfig } =
+			this.options;
 		const isStripeLinkEnabled =
 			undefined !== paymentMethodsConfig.card &&
 			undefined !== paymentMethodsConfig.link;
@@ -87,7 +88,7 @@ export default class WCStripeAPI {
 	createStripe( key, locale, betas = [] ) {
 		const options = { locale };
 
-		if ( betas ) {
+		if ( betas.length ) {
 			options.betas = betas;
 		}
 

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -58,8 +58,12 @@ export default class WCStripeAPI {
 	 * @return {Object} The Stripe Object.
 	 */
 	getStripe() {
-		const { key, locale, isUPEEnabled, paymentMethodsConfig } =
-			this.options;
+		const {
+			key,
+			locale,
+			isUPEEnabled,
+			paymentMethodsConfig
+		} = this.options;
 		const isStripeLinkEnabled =
 			undefined !== paymentMethodsConfig.card &&
 			undefined !== paymentMethodsConfig.link;

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -58,8 +58,7 @@ export default class WCStripeAPI {
 	 * @return {Object} The Stripe Object.
 	 */
 	getStripe() {
-		const { key, locale, isUPEEnabled, paymentMethodsConfig } =
-			this.options;
+		const { key, locale, isUPEEnabled, paymentMethodsConfig } = this.options;
 		const isStripeLinkEnabled =
 			undefined !== paymentMethodsConfig.card &&
 			undefined !== paymentMethodsConfig.link;

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -70,10 +70,7 @@ export default class WCStripeAPI {
 
 		if ( ! this.stripe ) {
 			if ( isUPEEnabled ) {
-				let betas = [];
-				if ( isUPEEnabled ) {
-					betas.push( 'payment_element_beta_1' );
-				}
+				let betas = [ 'payment_element_beta_1' ];
 				if ( isStripeLinkEnabled ) {
 					betas = betas.concat( [
 						'link_autofill_modal_beta_1',

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -62,7 +62,7 @@ export default class WCStripeAPI {
 			key,
 			locale,
 			isUPEEnabled,
-			paymentMethodsConfig
+			paymentMethodsConfig,
 		} = this.options;
 		const isStripeLinkEnabled =
 			undefined !== paymentMethodsConfig.card &&

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.5.0 - 2022-xx-xx =
+* Add - Stripe Link: Add beta headers for Stripe server requests
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2366 

## Changes proposed in this Pull Request:
When Stripe Link is enabled, the requests to Stripe should have `link_autofill_modal_beta_1` and `link_beta_2` headers. Also api version should be `2020-08-27;link_beta=v1`.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
- all tests should pass. 
- create orders with and without UPE enabled. We should not encounter any errors.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
