### PR TITLE
Move the email field to the top of the Checkout page when StripeLink is enabled

### DIFF
--- a/assets/css/stripe-link.css
+++ b/assets/css/stripe-link.css
@@ -1,0 +1,16 @@
+.stripe-gateway-checkout-email-field {
+	position: relative;
+}
+
+.stripe-gateway-checkout-email-field button.stripe-gateway-stripelink-modal-trigger {
+	display: none;
+	position: absolute;
+	right: 5px;
+	width: 64px;
+	height: 40px;
+	background: no-repeat
+		url( '../../client/payment-method-icons/link/icon.svg' );
+	background-color: none;
+	cursor: pointer;
+	border: none;
+}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -260,6 +260,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		wp_enqueue_script( 'wc-stripe-upe-classic' );
 		wp_enqueue_style( 'wc-stripe-upe-classic' );
+
+		wp_register_style( 'stripelink_styles', plugins_url( 'assets/css/stripe-link.css', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION );
+		wp_enqueue_style( 'stripelink_styles' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2368 

#### Changes proposed in this Pull Request
Moving the billing email field to the top of the Checkout page when StripeLink is enabled.

#### Testing instructions
- Navigate to WooCommerce -> Settings -> Payments.
- Navigate to Stripe -> Payment Methods.
- Enable StripeLink gateway under **Payments accepted on checkout.**
- Add a Product to your Cart and navigate to the Checkout page.
- Verify the Email field is the first field under the Billing information section.