### PR TITLE
Add Stripe Link button if email is pre-filled

### DIFF
--- a/assets/css/stripe-link.css
+++ b/assets/css/stripe-link.css
@@ -10,7 +10,7 @@
 	height: 40px;
 	background: no-repeat
 		url( '../../client/payment-method-icons/link/icon.svg' );
-	background-color: none;
+	background-color: transparent !important;
 	cursor: pointer;
 	border: none;
 }

--- a/client/stripe-link/index.js
+++ b/client/stripe-link/index.js
@@ -4,19 +4,22 @@ const showLinkButton = ( linkAutofill ) => {
 		const linkButtonTop =
 			jQuery( '#billing_email' ).position().top +
 			( jQuery( '#billing_email' ).outerHeight() - 40 ) / 2;
-		jQuery( '.wcpay-stripelink-modal-trigger' ).show();
-		jQuery( '.wcpay-stripelink-modal-trigger' ).css(
+		jQuery( '.stripe-gateway-stripelink-modal-trigger' ).show();
+		jQuery( '.stripe-gateway-stripelink-modal-trigger' ).css(
 			'top',
 			linkButtonTop + 'px'
 		);
 	}
 
 	// Handle StripeLink button click.
-	jQuery( '.wcpay-stripelink-modal-trigger' ).on( 'click', ( event ) => {
-		event.preventDefault();
-		// Trigger modal.
-		linkAutofill.launch( { email: jQuery( '#billing_email' ).val() } );
-	} );
+	jQuery( '.stripe-gateway-stripelink-modal-trigger' ).on(
+		'click',
+		( event ) => {
+			event.preventDefault();
+			// Trigger modal.
+			linkAutofill.launch( { email: jQuery( '#billing_email' ).val() } );
+		}
+	);
 };
 
 const enableStripeLinkPaymentMethod = ( options ) => {


### PR DESCRIPTION
Fixes #2369

## Changes proposed in this Pull Request:
Add a button inside the email field that triggers the Stripe Link functionality when the email field is prefilled. 

<img width="544" alt="Screenshot 2022-07-19 at 14 04 27" src="https://user-images.githubusercontent.com/8667118/179736571-c189386e-88c4-43bb-ba19-2f1882aa9a13.png">


## Testing instructions
- Navigate to `Settings` -> `Payment Methods` and enable `Link` payment method.
- Make an order to save your email address for the next order.
- Add another product and navigate to the checkout page.
- Verify the Link button is displayed next to the email field when the email is prefilled.


-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)