### PR TITLE
Add pre-push hook when pushing to develop, trunk and release branches

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,23 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+RED="\033[1;31m"
+NC="\033[0m"
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+PROTECTED_BRANCHES="^(trunk|develop|release/*)"
+
+# Only show warning for 'develop', 'trunk' and 'release/...' branches.
+if ! [[ "$BRANCH" =~ $PROTECTED_BRANCHES ]]; then
+	exit 0
+fi
+
+# Ask for confirmation, anything other than 'y' or 'Y' is considered as a NO.
+echo "\nYou're about to push to ${RED}${BRANCH}${NC} 😱, is that what you intended? [y|n] \c"
+read -n 1 -r < /dev/tty
+echo "\n"
+if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then
+	exit 0
+fi
+
+exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,7 +2,7 @@
 . "$(dirname "$0")/_/husky.sh"
 
 RED="\033[1;31m"
-NC="\033[0m"
+NO_COLOR="\033[0m"
 
 BRANCH=`git rev-parse --abbrev-ref HEAD`
 PROTECTED_BRANCHES="^(trunk|develop|release/*)"
@@ -13,7 +13,7 @@ if ! [[ "$BRANCH" =~ $PROTECTED_BRANCHES ]]; then
 fi
 
 # Ask for confirmation, anything other than 'y' or 'Y' is considered as a NO.
-echo "\nYou're about to push to ${RED}${BRANCH}${NC} 😱, is that what you intended? [y|n] \c"
+echo "\nYou're about to push to ${RED}${BRANCH}${NO_COLOR} 😱, is that what you intended? [y|n] \c"
 read -n 1 -r < /dev/tty
 echo "\n"
 if echo $REPLY | grep -E '^[Yy]$' > /dev/null; then


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR add a Husky pre-push hook to show a warning and ask for confirmation when pushing to `develop`, `trunk` and `release/...` branches.

![Screen Shot 2022-07-21 at 17 20 53](https://user-images.githubusercontent.com/407542/180308909-9dbe3fa5-6f6a-4271-8918-4bd7d45a5e25.png)


## Testing instructions
- Checkout this branch
- Add `chore/show-warning-when-pushing-to-trunk` to the `PROTECTED_BRANCHES` variable (line 8)
- Run `git push` (no need to create a commit, just push with no changes)