### PR TITLE
fix #2394 - get_upe_enabled_payment_method_ids() on null

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -661,7 +661,7 @@ function woocommerce_gateway_stripe() {
 			public function checkout_update_email_field_priority( $fields ) {
 				$is_link_enabled = in_array(
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
-					$this->stripe_gateway->get_upe_enabled_payment_method_ids(),
+					$this->get_main_stripe_gateway()->get_upe_enabled_payment_method_ids(),
 					true
 				);
 


### PR DESCRIPTION
I've tested this on  a single install where this fixed all issues described in #2394 
$this->stripe_gateway can be null so it is safer to always use get_main_stripe_gateway()


Fixes Issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2394

Unlike the issue title itself references this also happens without siteground or wp-fusion.

## Changes proposed in this Pull Request:

A simple fix for when stripe_gateway is undefined by using the helper function instead.

Some pages like wp-login would break without this fix.


## Testing instructions

Apply the patch, test if wp-login works. And test if all features related to checkout_update_email_field_priority and payments work.
