### PR TITLE
Add checks billing fields and call get_main_stripe_gateway

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -243,7 +243,9 @@ function woocommerce_gateway_stripe() {
 				add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
 
 				// Update the email field position.
-				add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
+				if ( ! is_admin() && WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+					add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
+				}
 
 				// Modify emails emails.
 				add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
@@ -661,11 +663,11 @@ function woocommerce_gateway_stripe() {
 			public function checkout_update_email_field_priority( $fields ) {
 				$is_link_enabled = in_array(
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
-					$this->stripe_gateway->get_upe_enabled_payment_method_ids(),
+					$this->get_main_stripe_gateway()->get_upe_enabled_payment_method_ids(),
 					true
 				);
 
-				if ( $is_link_enabled ) {
+				if ( isset( $fields['billing_email'] ) && $is_link_enabled ) {
 					// Update the field priority.
 					$fields['billing_email']['priority'] = 1;
 


### PR DESCRIPTION
The Stripe Link release from 6.5.0 has caused compatibility issues with other extensions which this PR aims to resolve by adding additional checks and a call to `get_main_stripe_gateway` ensuring we always have an instance available during the email field placement. This is also [similar to the issue we experienced last year](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2023) which we resolved in a similar manner. 

Lastly, this PR also ensures that the email field is actually available prior to acting on it since there are extensions that allow that field to be modified or removed entirely e.g. Checkout Field Editor

## Testing instructions

Unfortunately, I have been unable to reproduce this issue reliably without a brute force method. That being said here are the steps that have worked for me to reproduce:

1. Load Stripe v6.5.0
2. Enable UPE and enable Stripe Link
3. Add `$this->stripe_gateway = null;` to the first line in the `checkout_update_email_field_priority` method
4. Go to your checkout and you should have a Fatal Error
5. Load this PR
6. Add `$this->stripe_gateway = null;` to the first line in the `checkout_update_email_field_priority` method
7. Go to your checkout and you should have a proper checkout experience

---
1. Load Stripe v6.5.0
2. Enable UPE and enable Stripe Link
3. Add and enable Checkout Field Editor
4. Goto CFE settings and disable the email field
5. Go to the checkout screen and you should see a PHP Warning alongside a poorly rendered email field
6. Load this PR
7. Go to the checkout screen and you should see a proper checkout experience ( albeit with no email and no Stripe Link )
---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
