### PR TITLE
Extract is_link_enabled in separate static method to fix compatibility issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@
 
 = 6.6.0 - 2022-xx-xx =
 
+= 6.5.1 - 2022-08-01 =
+* Fix - Stripe Link fatal error on `get_upe_enabled_payment_method_ids` method.
+
 = 6.5.0 - 2022-07-28 =
 * Add - Stripe Link: Add beta headers for Stripe server requests
 * Add - Stripe Link payment method option in admin

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -32,7 +32,6 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	 *
 	 * @return bool
 	 */
-
 	public static function is_link_enabled() {
 		// Assume Link is disabled if UPE is disabled.
 		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -26,4 +26,23 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 			'woocommerce-gateway-stripe'
 		);
 	}
+
+	/**
+	 * Return if Stripe Link is enabled
+	 *
+	 * @return bool
+	 */
+
+	public static function is_link_enabled() {
+		// Assume Link is disabled if UPE is disabled.
+		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			return false;
+		}
+
+		return in_array(
+			self::STRIPE_ID,
+			woocommerce_gateway_stripe()->get_main_stripe_gateway()->get_upe_enabled_payment_method_ids(),
+			true
+		);
+	}
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -242,8 +242,10 @@ function woocommerce_gateway_stripe() {
 				add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), [ $this, 'plugin_action_links' ] );
 				add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
 
-				// Update the email field position.
-				add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
+				if ( ! is_admin() ) {
+					// Update the email field position.
+					add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
+				}
 
 				// Modify emails emails.
 				add_filter( 'woocommerce_email_classes', [ $this, 'add_emails' ], 20 );
@@ -659,13 +661,7 @@ function woocommerce_gateway_stripe() {
 			 * @return array WooCommerce checkout fields.
 			 */
 			public function checkout_update_email_field_priority( $fields ) {
-				$is_link_enabled = in_array(
-					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
-					$this->stripe_gateway->get_upe_enabled_payment_method_ids(),
-					true
-				);
-
-				if ( $is_link_enabled ) {
+				if ( isset( $fields['billing_email'] ) && WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() ) {
 					// Update the field priority.
 					$fields['billing_email']['priority'] = 1;
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -242,8 +242,8 @@ function woocommerce_gateway_stripe() {
 				add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), [ $this, 'plugin_action_links' ] );
 				add_filter( 'plugin_row_meta', [ $this, 'plugin_row_meta' ], 10, 2 );
 
+				// Update the email field position.
 				if ( ! is_admin() ) {
-					// Update the email field position.
 					add_filter( 'woocommerce_billing_fields', [ $this, 'checkout_update_email_field_priority' ], 50 );
 				}
 


### PR DESCRIPTION
Fixes #2394 

## Changes proposed in this Pull Request:
The Stripe Link release from 6.5.0 has caused compatibility issues with other extensions, which this PR aims to resolve by extracting the is Link enabled logic to separate method and adding additional checks.

## Testing instructions

**Scenario 1**
- Enable UPE and enable Stripe Link
- Go to the checkout screen and verify the email field is moved to the top

**Scenario 2**
- Enable UPE and enable Stripe Link
- Add and enable Checkout Field Editor
- Goto CFE settings and disable the email field
- Go to the checkout screen and you should see a PHP Warning alongside a poorly rendered email field
- Load this PR
- Go to the checkout screen and you should see a proper checkout experience ( albeit with no email and no Stripe Link )

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
