### PR TITLE
Check payment method before updating payment method title

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.6.0 - 2022-xx-xx =
 * Fix - Fix "Pending" text instead of numeric amount on Payment Request button on iOS.
+* Fix - Check payment method before updating payment method title.
 
 = 6.5.1 - 2022-08-01 =
 * Fix - Stripe Link missing styles and logo for email trigger button.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -522,7 +522,7 @@ class WC_Stripe_Payment_Request {
 	 * @return  void
 	 */
 	public function add_order_meta( $order_id, $posted_data ) {
-		if ( empty( $_POST['payment_request_type'] ) ) {
+		if ( empty( $_POST['payment_request_type'] ) || ! isset( $_POST['payment_method'] ) || 'stripe' !== $_POST['payment_method'] ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #2409 

## Changes proposed in this Pull Request:
Check if there is a payment request and check if the payment method is Stripe payments before updating the payment method title

## Testing instructions
1. Update [the order process](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/502446775da0fc778e63d31fe8e1c7b526a9657b/includes/payment-methods/class-wc-stripe-payment-request.php#L239) from 10 to 20 to mimic creating a payment gateway registered before stripe (alphabetically)
1. Enable the Google Pay checkout method for both gateways
1. Buy something at the shop and place order with WooCommerce Payments Google Pay
1. See that Stripe is not on the order details

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [X] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
