### PR TITLE
Add Boleto expiration setting

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.7.0 - 2022-xx-xx
 * Fix - Check payment method before updating payment method title.
 * Fix - Use the eslint config at the root of the repo.
+* Add - Add Boleto expiration setting.
 
 = 6.6.0 - 2022-08-17 =
 * Fix - Fix "Pending" text instead of numeric amount on Payment Request button on iOS.

--- a/client/data/payment-gateway/hooks.js
+++ b/client/data/payment-gateway/hooks.js
@@ -84,3 +84,8 @@ export const usePaymentGatewayDescription = makePaymentGatewayHook(
 	makeFieldName( '%s_description' ),
 	''
 );
+
+export const usePaymentGatewayExpiration = makePaymentGatewayHook(
+	makeFieldName( '%s_expiration' ),
+	''
+);

--- a/client/data/payment-gateway/hooks.js
+++ b/client/data/payment-gateway/hooks.js
@@ -3,40 +3,38 @@ import { useCallback } from 'react';
 import { getQuery } from '@woocommerce/navigation';
 import { STORE_NAME } from '../constants';
 
-const makeReadOnlyPaymentGatewayHook = (
-	fieldName,
-	fieldDefaultValue = false
-) => () =>
-	useSelect(
-		( select ) => {
-			const { getPaymentGateway } = select( STORE_NAME );
+const makeReadOnlyPaymentGatewayHook =
+	( fieldName, fieldDefaultValue = false ) =>
+	() =>
+		useSelect(
+			( select ) => {
+				const { getPaymentGateway } = select( STORE_NAME );
 
-			return getPaymentGateway()[ fieldName ] || fieldDefaultValue;
-		},
-		[ fieldName, fieldDefaultValue ]
-	);
+				return getPaymentGateway()[ fieldName ] || fieldDefaultValue;
+			},
+			[ fieldName, fieldDefaultValue ]
+		);
 
-const makePaymentGatewayHook = (
-	fieldName,
-	fieldDefaultValue = false
-) => () => {
-	const { updatePaymentGatewayValues } = useDispatch( STORE_NAME );
+const makePaymentGatewayHook =
+	( fieldName, fieldDefaultValue = false ) =>
+	() => {
+		const { updatePaymentGatewayValues } = useDispatch( STORE_NAME );
 
-	const field = makeReadOnlyPaymentGatewayHook(
-		fieldName,
-		fieldDefaultValue
-	)();
+		const field = makeReadOnlyPaymentGatewayHook(
+			fieldName,
+			fieldDefaultValue
+		)();
 
-	const handler = useCallback(
-		( value ) =>
-			updatePaymentGatewayValues( {
-				[ fieldName ]: value,
-			} ),
-		[ updatePaymentGatewayValues ]
-	);
+		const handler = useCallback(
+			( value ) =>
+				updatePaymentGatewayValues( {
+					[ fieldName ]: value,
+				} ),
+			[ updatePaymentGatewayValues ]
+		);
 
-	return [ field, handler ];
-};
+		return [ field, handler ];
+	};
 
 export const usePaymentGateway = () => {
 	const { savePaymentGateway } = useDispatch( STORE_NAME );

--- a/client/data/payment-gateway/hooks.js
+++ b/client/data/payment-gateway/hooks.js
@@ -3,38 +3,40 @@ import { useCallback } from 'react';
 import { getQuery } from '@woocommerce/navigation';
 import { STORE_NAME } from '../constants';
 
-const makeReadOnlyPaymentGatewayHook =
-	( fieldName, fieldDefaultValue = false ) =>
-	() =>
-		useSelect(
-			( select ) => {
-				const { getPaymentGateway } = select( STORE_NAME );
+const makeReadOnlyPaymentGatewayHook = (
+	fieldName,
+	fieldDefaultValue = false
+) => () =>
+	useSelect(
+		( select ) => {
+			const { getPaymentGateway } = select( STORE_NAME );
 
-				return getPaymentGateway()[ fieldName ] || fieldDefaultValue;
-			},
-			[ fieldName, fieldDefaultValue ]
-		);
+			return getPaymentGateway()[ fieldName ] || fieldDefaultValue;
+		},
+		[ fieldName, fieldDefaultValue ]
+	);
 
-const makePaymentGatewayHook =
-	( fieldName, fieldDefaultValue = false ) =>
-	() => {
-		const { updatePaymentGatewayValues } = useDispatch( STORE_NAME );
+const makePaymentGatewayHook = (
+	fieldName,
+	fieldDefaultValue = false
+) => () => {
+	const { updatePaymentGatewayValues } = useDispatch( STORE_NAME );
 
-		const field = makeReadOnlyPaymentGatewayHook(
-			fieldName,
-			fieldDefaultValue
-		)();
+	const field = makeReadOnlyPaymentGatewayHook(
+		fieldName,
+		fieldDefaultValue
+	)();
 
-		const handler = useCallback(
-			( value ) =>
-				updatePaymentGatewayValues( {
-					[ fieldName ]: value,
-				} ),
-			[ updatePaymentGatewayValues ]
-		);
+	const handler = useCallback(
+		( value ) =>
+			updatePaymentGatewayValues( {
+				[ fieldName ]: value,
+			} ),
+		[ updatePaymentGatewayValues ]
+	);
 
-		return [ field, handler ];
-	};
+	return [ field, handler ];
+};
 
 export const usePaymentGateway = () => {
 	const { savePaymentGateway } = useDispatch( STORE_NAME );

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -4,38 +4,34 @@ import { STORE_NAME } from '../constants';
 
 const EMPTY_ARR = [];
 
-const makeReadOnlySettingsHook =
-	( fieldName, fieldDefaultValue = false ) =>
-	() =>
-		useSelect(
-			( select ) => {
-				const { getSettings } = select( STORE_NAME );
+const makeReadOnlySettingsHook = (
+	fieldName,
+	fieldDefaultValue = false
+) => () =>
+	useSelect(
+		( select ) => {
+			const { getSettings } = select( STORE_NAME );
 
-				return getSettings()[ fieldName ] || fieldDefaultValue;
-			},
-			[ fieldName, fieldDefaultValue ]
-		);
+			return getSettings()[ fieldName ] || fieldDefaultValue;
+		},
+		[ fieldName, fieldDefaultValue ]
+	);
 
-const makeSettingsHook =
-	( fieldName, fieldDefaultValue = false ) =>
-	() => {
-		const { updateSettingsValues } = useDispatch( STORE_NAME );
+const makeSettingsHook = ( fieldName, fieldDefaultValue = false ) => () => {
+	const { updateSettingsValues } = useDispatch( STORE_NAME );
 
-		const field = makeReadOnlySettingsHook(
-			fieldName,
-			fieldDefaultValue
-		)();
+	const field = makeReadOnlySettingsHook( fieldName, fieldDefaultValue )();
 
-		const handler = useCallback(
-			( value ) =>
-				updateSettingsValues( {
-					[ fieldName ]: value,
-				} ),
-			[ updateSettingsValues ]
-		);
+	const handler = useCallback(
+		( value ) =>
+			updateSettingsValues( {
+				[ fieldName ]: value,
+			} ),
+		[ updateSettingsValues ]
+	);
 
-		return [ field, handler ];
-	};
+	return [ field, handler ];
+};
 
 export const useSettings = () => {
 	const { saveSettings } = useDispatch( STORE_NAME );

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -4,34 +4,38 @@ import { STORE_NAME } from '../constants';
 
 const EMPTY_ARR = [];
 
-const makeReadOnlySettingsHook = (
-	fieldName,
-	fieldDefaultValue = false
-) => () =>
-	useSelect(
-		( select ) => {
-			const { getSettings } = select( STORE_NAME );
+const makeReadOnlySettingsHook =
+	( fieldName, fieldDefaultValue = false ) =>
+	() =>
+		useSelect(
+			( select ) => {
+				const { getSettings } = select( STORE_NAME );
 
-			return getSettings()[ fieldName ] || fieldDefaultValue;
-		},
-		[ fieldName, fieldDefaultValue ]
-	);
+				return getSettings()[ fieldName ] || fieldDefaultValue;
+			},
+			[ fieldName, fieldDefaultValue ]
+		);
 
-const makeSettingsHook = ( fieldName, fieldDefaultValue = false ) => () => {
-	const { updateSettingsValues } = useDispatch( STORE_NAME );
+const makeSettingsHook =
+	( fieldName, fieldDefaultValue = false ) =>
+	() => {
+		const { updateSettingsValues } = useDispatch( STORE_NAME );
 
-	const field = makeReadOnlySettingsHook( fieldName, fieldDefaultValue )();
+		const field = makeReadOnlySettingsHook(
+			fieldName,
+			fieldDefaultValue
+		)();
 
-	const handler = useCallback(
-		( value ) =>
-			updateSettingsValues( {
-				[ fieldName ]: value,
-			} ),
-		[ updateSettingsValues ]
-	);
+		const handler = useCallback(
+			( value ) =>
+				updateSettingsValues( {
+					[ fieldName ]: value,
+				} ),
+			[ updateSettingsValues ]
+		);
 
-	return [ field, handler ];
-};
+		return [ field, handler ];
+	};
 
 export const useSettings = () => {
 	const { saveSettings } = useDispatch( STORE_NAME );

--- a/client/settings/payment-gateway-manager/constants.js
+++ b/client/settings/payment-gateway-manager/constants.js
@@ -96,18 +96,29 @@ export const gatewaysInfo = {
 				usePaymentGatewayExpiration();
 
 			return (
-				<TextControl
-					type="number"
-					min="0"
-					max="60"
-					help={ __(
-						'Set the number of days until expiration from 0 to 60 days. The default is 3 days.',
-						'woocommerce-gateway-stripe'
-					) }
-					label={ __( 'Expiration', 'woocommerce-gateway-stripe' ) }
-					value={ gatewayExpiration }
-					onChange={ setGatewayExpiration }
-				/>
+				<>
+					<h4>
+						{ __(
+							'Voucher settings',
+							'woocommerce-gateway-stripe'
+						) }
+					</h4>
+					<TextControl
+						type="number"
+						min="0"
+						max="60"
+						help={ __(
+							'Set the number of days until expiration from 0 to 60 days. The default is 3 days.',
+							'woocommerce-gateway-stripe'
+						) }
+						label={ __(
+							'Expiration',
+							'woocommerce-gateway-stripe'
+						) }
+						value={ gatewayExpiration }
+						onChange={ setGatewayExpiration }
+					/>
+				</>
 			);
 		},
 	},

--- a/client/settings/payment-gateway-manager/constants.js
+++ b/client/settings/payment-gateway-manager/constants.js
@@ -1,4 +1,6 @@
 import { __ } from '@wordpress/i18n';
+import { TextControl } from '@wordpress/components';
+import { usePaymentGatewayExpiration } from '../../data/payment-gateway/hooks';
 
 export const gatewaysInfo = {
 	stripe_sepa: {
@@ -91,6 +93,30 @@ export const gatewaysInfo = {
 		),
 		guide:
 			'https://stripe.com/docs/payments/payment-methods/overview#vouchers',
+		Fields: () => {
+			const [
+				gatewayExpiration,
+				setGatewayExpiration,
+			] = usePaymentGatewayExpiration();
+
+			return (
+				<TextControl
+					type="number"
+					min="0"
+					max="60"
+					help={ __(
+						'Set the number of days until expiration from 0 to 60 days. The default is 3 days.',
+						'woocommerce-gateway-stripe'
+					) }
+					label={ __(
+						'Expiration',
+						'woocommerce-gateway-stripe'
+					) }
+					value={ gatewayExpiration }
+					onChange={ setGatewayExpiration }
+				/>
+			);
+		}
 	},
 	stripe_oxxo: {
 		title: __( 'OXXO', 'woocommerce-gateway-stripe' ),

--- a/client/settings/payment-gateway-manager/constants.js
+++ b/client/settings/payment-gateway-manager/constants.js
@@ -10,8 +10,7 @@ export const gatewaysInfo = {
 			'Customer Geography: France, Germany, Spain, Belgium, Netherlands, Luxembourg, Italy, Portugal, Austria, Ireland.',
 			'woocommerce-gateway-stripe'
 		),
-		guide:
-			'https://stripe.com/payments/payment-methods-guide#sepa-direct-debit',
+		guide: 'https://stripe.com/payments/payment-methods-guide#sepa-direct-debit',
 	},
 	stripe_giropay: {
 		id: 'giropay',
@@ -91,13 +90,10 @@ export const gatewaysInfo = {
 			'Customer Geography: Brazil.',
 			'woocommerce-gateway-stripe'
 		),
-		guide:
-			'https://stripe.com/docs/payments/payment-methods/overview#vouchers',
+		guide: 'https://stripe.com/docs/payments/payment-methods/overview#vouchers',
 		Fields: () => {
-			const [
-				gatewayExpiration,
-				setGatewayExpiration,
-			] = usePaymentGatewayExpiration();
+			const [ gatewayExpiration, setGatewayExpiration ] =
+				usePaymentGatewayExpiration();
 
 			return (
 				<TextControl
@@ -108,15 +104,12 @@ export const gatewaysInfo = {
 						'Set the number of days until expiration from 0 to 60 days. The default is 3 days.',
 						'woocommerce-gateway-stripe'
 					) }
-					label={ __(
-						'Expiration',
-						'woocommerce-gateway-stripe'
-					) }
+					label={ __( 'Expiration', 'woocommerce-gateway-stripe' ) }
 					value={ gatewayExpiration }
 					onChange={ setGatewayExpiration }
 				/>
 			);
-		}
+		},
 	},
 	stripe_oxxo: {
 		title: __( 'OXXO', 'woocommerce-gateway-stripe' ),

--- a/client/settings/payment-gateway-manager/constants.js
+++ b/client/settings/payment-gateway-manager/constants.js
@@ -10,7 +10,8 @@ export const gatewaysInfo = {
 			'Customer Geography: France, Germany, Spain, Belgium, Netherlands, Luxembourg, Italy, Portugal, Austria, Ireland.',
 			'woocommerce-gateway-stripe'
 		),
-		guide: 'https://stripe.com/payments/payment-methods-guide#sepa-direct-debit',
+		guide:
+			'https://stripe.com/payments/payment-methods-guide#sepa-direct-debit',
 	},
 	stripe_giropay: {
 		id: 'giropay',
@@ -90,10 +91,13 @@ export const gatewaysInfo = {
 			'Customer Geography: Brazil.',
 			'woocommerce-gateway-stripe'
 		),
-		guide: 'https://stripe.com/docs/payments/payment-methods/overview#vouchers',
+		guide:
+			'https://stripe.com/docs/payments/payment-methods/overview#vouchers',
 		Fields: () => {
-			const [ gatewayExpiration, setGatewayExpiration ] =
-				usePaymentGatewayExpiration();
+			const [
+				gatewayExpiration,
+				setGatewayExpiration,
+			] = usePaymentGatewayExpiration();
 
 			return (
 				<>

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -112,6 +112,9 @@ const PaymentGatewaySection = () => {
 						onChange={ setGatewayDescription }
 					/>
 					<TextControl
+						type="number"
+						min="0"
+						max="60"
 						help={ __(
 							'Set the number of days until expiration from 0 to 60 days. The default is 3 days.',
 							'woocommerce-gateway-stripe'

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -17,6 +17,7 @@ import {
 	useEnabledPaymentGateway,
 	usePaymentGatewayName,
 	usePaymentGatewayDescription,
+	usePaymentGatewayExpiration,
 } from '../../data/payment-gateway/hooks';
 import PaymentMethodCapabilityStatusPill from 'wcstripe/components/payment-method-capability-status-pill';
 import { WebhookInformation } from 'wcstripe/components/webhook-information';
@@ -40,6 +41,10 @@ const PaymentGatewaySection = () => {
 		gatewayDescription,
 		setGatewayDescription,
 	] = usePaymentGatewayDescription();
+	const [
+		gatewayExpiration,
+		setGatewayExpiration,
+	] = usePaymentGatewayExpiration();
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
 
 	return (
@@ -105,6 +110,18 @@ const PaymentGatewaySection = () => {
 						) }
 						value={ gatewayDescription }
 						onChange={ setGatewayDescription }
+					/>
+					<TextControl
+						help={ __(
+							'Set the number of days until expiration from 0 to 60 days. The default is 3 days.',
+							'woocommerce-gateway-stripe'
+						) }
+						label={ __(
+							'Expiration',
+							'woocommerce-gateway-stripe'
+						) }
+						value={ gatewayExpiration }
+						onChange={ setGatewayExpiration }
 					/>
 					<h4>
 						{ __(

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -35,16 +35,13 @@ const StyledCheckboxLabel = styled.span`
 const PaymentGatewaySection = () => {
 	const { section } = getQuery();
 	const info = gatewaysInfo[ section ];
+	const { Fields } = info;
 	const [ enableGateway, setEnableGateway ] = useEnabledPaymentGateway();
 	const [ gatewayName, setGatewayName ] = usePaymentGatewayName();
 	const [
 		gatewayDescription,
 		setGatewayDescription,
 	] = usePaymentGatewayDescription();
-	const [
-		gatewayExpiration,
-		setGatewayExpiration,
-	] = usePaymentGatewayExpiration();
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
 
 	return (
@@ -111,21 +108,7 @@ const PaymentGatewaySection = () => {
 						value={ gatewayDescription }
 						onChange={ setGatewayDescription }
 					/>
-					<TextControl
-						type="number"
-						min="0"
-						max="60"
-						help={ __(
-							'Set the number of days until expiration from 0 to 60 days. The default is 3 days.',
-							'woocommerce-gateway-stripe'
-						) }
-						label={ __(
-							'Expiration',
-							'woocommerce-gateway-stripe'
-						) }
-						value={ gatewayExpiration }
-						onChange={ setGatewayExpiration }
-					/>
+					{ Fields && <Fields /> }
 					<h4>
 						{ __(
 							'Webhook endpoints',

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -17,7 +17,6 @@ import {
 	useEnabledPaymentGateway,
 	usePaymentGatewayName,
 	usePaymentGatewayDescription,
-	usePaymentGatewayExpiration,
 } from '../../data/payment-gateway/hooks';
 import PaymentMethodCapabilityStatusPill from 'wcstripe/components/payment-method-capability-status-pill';
 import { WebhookInformation } from 'wcstripe/components/webhook-information';
@@ -38,10 +37,8 @@ const PaymentGatewaySection = () => {
 	const { Fields } = info;
 	const [ enableGateway, setEnableGateway ] = useEnabledPaymentGateway();
 	const [ gatewayName, setGatewayName ] = usePaymentGatewayName();
-	const [
-		gatewayDescription,
-		setGatewayDescription,
-	] = usePaymentGatewayDescription();
+	const [ gatewayDescription, setGatewayDescription ] =
+		usePaymentGatewayDescription();
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
 
 	return (

--- a/client/settings/payment-gateway-section/index.js
+++ b/client/settings/payment-gateway-section/index.js
@@ -37,8 +37,10 @@ const PaymentGatewaySection = () => {
 	const { Fields } = info;
 	const [ enableGateway, setEnableGateway ] = useEnabledPaymentGateway();
 	const [ gatewayName, setGatewayName ] = usePaymentGatewayName();
-	const [ gatewayDescription, setGatewayDescription ] =
-		usePaymentGatewayDescription();
+	const [
+		gatewayDescription,
+		setGatewayDescription,
+	] = usePaymentGatewayDescription();
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
 
 	return (

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
@@ -313,7 +313,7 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 			'description'          => __( 'stripe - Order', 'woocommerce-gateway-stripe' ) . ' ' . $order->get_id(),
 		];
 
-		if ( method_exists( $this, 'update_request_body_on_create_or_update_payment_intent' )) {
+		if ( method_exists( $this, 'update_request_body_on_create_or_update_payment_intent' ) ) {
 			$body = $this->update_request_body_on_create_or_update_payment_intent( $body );
 		}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
@@ -306,13 +306,19 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 			$intent_to_be_updated = '/' . $intent->id;
 		}
 
+		$body = [
+			'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
+			'currency'             => strtolower( $currency ),
+			'payment_method_types' => [ $this->stripe_id ],
+			'description'          => __( 'stripe - Order', 'woocommerce-gateway-stripe' ) . ' ' . $order->get_id(),
+		];
+
+		if ( method_exists( $this, 'update_request_body_on_create_or_update_payment_intent' )) {
+			$body = $this->update_request_body_on_create_or_update_payment_intent( $body );
+		}
+
 		$payment_intent = WC_Stripe_API::request(
-			[
-				'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
-				'currency'             => strtolower( $currency ),
-				'payment_method_types' => [ $this->stripe_id ],
-				'description'          => __( 'stripe - Order', 'woocommerce-gateway-stripe' ) . ' ' . $order->get_id(),
-			],
+			$body,
 			'payment_intents' . $intent_to_be_updated
 		);
 

--- a/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
+++ b/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
@@ -187,6 +187,8 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 		}
 
 		$value = absint( $expiration );
+		$value = min( 60, $value );
+		$value = max( 0, $value );
 		$this->gateway->update_option( 'expiration', $value );
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
+++ b/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
@@ -91,6 +91,7 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 					'is_' . $id . '_enabled' => $this->gateway->is_enabled(),
 					$id . '_name'            => $this->gateway->get_option( 'title' ),
 					$id . '_description'     => $this->gateway->get_option( 'description' ),
+					$id . '_expiration'      => $this->gateway->get_option( 'expiration' ),
 				]
 			);
 		} catch ( Exception $exception ) {
@@ -110,6 +111,7 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 			$this->update_is_gateway_enabled( $request );
 			$this->update_gateway_name( $request );
 			$this->update_gateway_description( $request );
+			$this->update_gateway_expiration( $request );
 
 			return new WP_REST_Response( [], 200 );
 		} catch ( Exception $exception ) {
@@ -155,7 +157,7 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 	}
 
 	/**
-	 * Updates payment gateway title.
+	 * Updates payment gateway description.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 */
@@ -169,5 +171,22 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 
 		$value = sanitize_text_field( $description );
 		$this->gateway->update_option( 'description', $value );
+	}
+
+	/**
+	 * Updates payment gateway voucher expiration.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_gateway_expiration( WP_REST_Request $request ) {
+		$field_name  = $this->gateway->id . '_expiration';
+		$expiration = $request->get_param( $field_name );
+
+		if ( null === $expiration ) {
+			return;
+		}
+
+		$value = absint( $expiration );
+		$this->gateway->update_option( 'expiration', $value );
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
+++ b/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
@@ -141,10 +141,6 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 		}
 	}
 
-	function update_unique_settings( WP_REST_Request $request) {
-		$this->gateway->update_unique_settings( $request );
-	}
-
 	/**
 	 * Updates payment gateway title.
 	 *

--- a/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
+++ b/includes/admin/class-wc-rest-stripe-payment-gateway-controller.php
@@ -92,7 +92,7 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 				$id . '_description'     => $this->gateway->get_option( 'description' ),
 			];
 			if ( method_exists( $this->gateway, 'get_unique_settings' ) ) {
-				$settings = $this->$gateway->get_unique_settings( $settings );
+				$settings = $this->gateway->get_unique_settings( $settings );
 			}
 			return new WP_REST_Response( $settings );
 		} catch ( Exception $exception ) {
@@ -113,7 +113,7 @@ class WC_REST_Stripe_Payment_Gateway_Controller extends WC_Stripe_REST_Base_Cont
 			$this->update_gateway_name( $request );
 			$this->update_gateway_description( $request );
 			if ( method_exists( $this->gateway, 'update_unique_settings' ) ) {
-				$this->$gateway->update_unique_settings( $request );
+				$this->gateway->update_unique_settings( $request );
 			}
 			return new WP_REST_Response( [], 200 );
 		} catch ( Exception $exception ) {

--- a/includes/admin/stripe-boleto-settings.php
+++ b/includes/admin/stripe-boleto-settings.php
@@ -40,6 +40,13 @@ return apply_filters(
 			'default'     => __( "You'll be able to download or print the Boleto after checkout.", 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,
 		],
+		'expiration' => [
+			'title'       => __( 'Expiration', 'woocommerce-gateway-stripe' ),
+			'type'        => 'number',
+			'description' => __( 'This controls the expiration in number of days for the voucher.', 'woocommerce-gateway-stripe' ),
+			'default'     => 3,
+			'desc_tip'    => true,
+		],
 		'webhook'     => [
 			'title'       => __( 'Webhook Endpoints', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -66,11 +66,12 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 	 * @return array
 	 */
 	public function add_expires_after_days( $request, $api ) {
-		if ( $api === 'payment_intents' && isset( $request[ 'payment_method_types' ] ) && in_array( $this->id, $request[ 'payment_method_types' ] ) ) {
-			$request[ 'payment_method_options' ] = [
+		$api_pieces = explode( '/', $api );
+		if ( 'payment_intents' === $api_pieces[0] && isset( $request[ 'payment_method_types' ] ) && in_array( $this->stripe_id, $request['payment_method_types'] ) ) {
+			$request['payment_method_options'] = [
 				'boleto' => [
-					'expires_after_days' => $gateway->get_option( 'expiration' ),
-				]
+					'expires_after_days' => $this->get_option( 'expiration' ),
+				],
 			];
 		}
 		return $request;

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -53,26 +53,21 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 		parent::__construct();
 
 		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
-		add_filter( 'woocommerce_stripe_request_body', [ $this, 'add_expires_after_days' ], 10, 2 );
 	}
 
 	/**
 	 * Add payment gateway voucher expiration to API request body.
 	 *
-	 * @param array $request API request body.
-	 * @param string $api API endpoint.
+	 * @param array $body API request body.
 	 * @return array
 	 */
-	public function add_expires_after_days( $request, $api ) {
-		$api_pieces = explode( '/', $api );
-		if ( 'payment_intents' === $api_pieces[0] && isset( $request['payment_method_types'] ) && in_array( $this->stripe_id, $request['payment_method_types'] ) ) {
-			$request['payment_method_options'] = [
-				'boleto' => [
-					'expires_after_days' => $this->get_option( 'expiration' ),
-				],
-			];
-		}
-		return $request;
+	public function update_request_body_on_create_or_update_payment_intent( $body ) {
+		$body['payment_method_options'] = [
+			'boleto' => [
+				'expires_after_days' => $this->get_option( 'expiration' ),
+			],
+		];
+		return $body;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -55,6 +55,25 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
 		add_filter( 'wc_stripe_payment_gateway_settings', [ $this, 'add_expiration_option' ], 10, 2 );
 		add_action( 'wc_stripe_update_payment_gateway_settings', [ $this, 'update_expiration_option' ], 10, 2 );
+		add_filter( 'woocommerce_stripe_request_body', [ $this, 'add_expires_after_days' ], 10, 2 );
+	}
+
+	/**
+	 * Add payment gateway voucher expiration to API request body.
+	 *
+	 * @param array $request API request body.
+	 * @param string $api API endpoint.
+	 * @return array
+	 */
+	public function add_expires_after_days( $request, $api ) {
+		if ( $api === 'payment_intents' && isset( $request[ 'payment_method_types' ] ) && in_array( $this->id, $request[ 'payment_method_types' ] ) ) {
+			$request[ 'payment_method_options' ] = [
+				'boleto' => [
+					'expires_after_days' => $gateway->get_option( 'expiration' ),
+				]
+			];
+		}
+		return $request;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -65,7 +65,7 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 	 */
 	public function add_expires_after_days( $request, $api ) {
 		$api_pieces = explode( '/', $api );
-		if ( 'payment_intents' === $api_pieces[0] && isset( $request[ 'payment_method_types' ] ) && in_array( $this->stripe_id, $request['payment_method_types'] ) ) {
+		if ( 'payment_intents' === $api_pieces[0] && isset( $request['payment_method_types'] ) && in_array( $this->stripe_id, $request['payment_method_types'] ) ) {
 			$request['payment_method_options'] = [
 				'boleto' => [
 					'expires_after_days' => $this->get_option( 'expiration' ),

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -53,8 +53,6 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 		parent::__construct();
 
 		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
-		add_filter( 'wc_stripe_payment_gateway_settings', [ $this, 'add_expiration_option' ], 10, 2 );
-		add_action( 'wc_stripe_update_payment_gateway_settings', [ $this, 'update_expiration_option' ], 10, 2 );
 		add_filter( 'woocommerce_stripe_request_body', [ $this, 'add_expires_after_days' ], 10, 2 );
 	}
 
@@ -80,29 +78,21 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 	/**
 	 * Add payment gateway voucher expiration.
 	 *
-	 * @param array $options Payment gateway options.
-	 * @param string $id Payment gateway ID.
+	 * @param array $settings Settings array.
 	 * @return array
 	 */
-	public function add_expiration_option( $options, $id ) {
-		if ( $id === $this->id ) {
-			$options[ $id . '_expiration' ] = $this->get_option( 'expiration' );
-		}
-		return $options;
+	public function get_unique_settings( $settings ) {
+		$settings[ $this->id . '_expiration' ] = $this->get_option( 'expiration' );
+		return $settings;
 	}
 
 	/**
 	 * Updates payment gateway voucher expiration.
 	 *
 	 * @param WP_REST_Request $request Request object.
-	 * @param string $id Payment gateway ID.
 	 * @return void
 	 */
-	public function update_expiration_option( WP_REST_Request $request, $id ) {
-		if ( $id !== $this->id ) {
-			return;
-		}
-
+	public function update_unique_settings( WP_REST_Request $request ) {
 		$field_name  = $this->id . '_expiration';
 		$expiration = $request->get_param( $field_name );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -61,7 +61,7 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 	 * @param array $body API request body.
 	 * @return array
 	 */
-	public function update_request_body_on_create_or_update_payment_intent( $body ) {
+	protected function update_request_body_on_create_or_update_payment_intent( $body ) {
 		$body['payment_method_options'] = [
 			'boleto' => [
 				'expires_after_days' => $this->get_option( 'expiration' ),

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -54,12 +54,12 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 
 		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
 		add_filter( 'wc_stripe_payment_gateway_settings', [ $this, 'add_expiration_option' ], 10, 2 );
-		add_action( 'wc_stripe_update_payment_gateway_settings', [ $this, 'update_expiration_option'], 10, 2 );
+		add_action( 'wc_stripe_update_payment_gateway_settings', [ $this, 'update_expiration_option' ], 10, 2 );
 	}
 
 	/**
 	 * Add payment gateway voucher expiration.
-	 * 
+	 *
 	 * @param array $options Payment gateway options.
 	 * @param string $id Payment gateway ID.
 	 * @return array
@@ -82,7 +82,7 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 		if ( $id !== $this->id ) {
 			return;
 		}
-		
+
 		$field_name  = $this->id . '_expiration';
 		$expiration = $request->get_param( $field_name );
 


### PR DESCRIPTION
Fixes #2198

## Changes proposed in this Pull Request:
I found if you go to WooCommerce > Payments > All payment Methods > Stripe Boleto, there’s a display settings section.
I added the voucher expiration field to the Stripe Boleto display settings and set the default to 3 days.

I also added some extensibility to the payment gateways controller.

I'm not sure if this is the right way to handle this, but open to feedback on how we do this.

## Other solutions considered:
- Add a new section under "Display Settings" for gateway settings
Or
- Add another settings page for each payment method
- Could use [`NumberControl`](https://github.com/WordPress/gutenberg/tree/trunk/packages/components/src/number-control) but it is still at an experimental stage 

## Screenshots
<img width="645" alt="Screen Shot 2022-08-17 at 10 06 51 PM" src="https://user-images.githubusercontent.com/56378160/185298571-ab88817b-9a21-46c2-9ea5-eb83002e415b.png">

<img width="444" alt="Screen Shot 2022-08-16 at 3 29 23 PM" src="https://user-images.githubusercontent.com/56378160/185004521-b11c5e10-783d-4485-a69a-f96fedf2be73.png">

## Testing instructions
1. Go to WooCommerce > Payments > All payment Methods > Stripe Boleto
2. See expiration field
3. Try to update the expiration
4. Refresh the page
5. See the expiration persists
6. Go to WooCommerce > Payments > All payment Methods > select any payment gateways ( ex. Stripe Bancontact )
7. Should not see expiration field


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
