### PR TITLE
Use the eslint config at the root of the repo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	root: true,
 	parser: '@babel/eslint-parser',
 	extends: [ 'plugin:@woocommerce/eslint-plugin/recommended' ],
 	globals: {

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.7.0 - 2022-xx-xx
 * Fix - Check payment method before updating payment method title.
+* Fix - Use the eslint config at the root of the repo.
 
 = 6.6.0 - 2022-08-17 =
 * Fix - Fix "Pending" text instead of numeric amount on Payment Request button on iOS.

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 6.7.0 - 2022-xx-xx =
 * Fix - Check payment method before updating payment method title.
+* Fix - Use the eslint config at the root of the repo.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2413 

## Changes proposed in this Pull Request:
Eslint uses both the parent and the current repo's eslint config file.  It should ignore parent .eslintrc configuration.  
The change uses the eslint config at the root of the repo.

## Screenshot
<img width="883" alt="Screen Shot 2022-08-17 at 6 26 55 PM" src="https://user-images.githubusercontent.com/56378160/185271950-e684e0d5-3f29-4822-be03-e3cde10a2a25.png">

## Testing instructions
1. Create a `woocommerce-payments` docker instance
1. Clone the `woocommerce-gateway-stripe` plugin to `woocommerce-payments/docker/wordpress/wp-content/plugins/woocommerce-gateway-stripe`
1. Run `npx eslint --debug .eslintrc.js` to see eslint is not using the config file from `woocommerce-payments`


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
