### PR TITLE
Adjustments for COT compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 6.8.0 - 2022-xx-xx =
+* Fix - Minor adjustments for Custom Order Tables compatibility.
 
 = 6.7.0 - 2022-09-06 =
 * Fix - Check payment method before updating payment method title.

--- a/includes/admin/class-wc-stripe-privacy.php
+++ b/includes/admin/class-wc-stripe-privacy.php
@@ -405,7 +405,7 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 		$retention  = wc_parse_relative_date_option( get_option( 'woocommerce_gateway_stripe_retention' ) );
 		$is_expired = false;
 		$time_span  = time() - strtotime( $created_date );
-		if ( empty( $retention ) || empty( $created_date ) ) {
+		if ( empty( $retention['number'] ) || empty( $created_date ) ) {
 			return false;
 		}
 		switch ( $retention['unit'] ) {

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -411,7 +411,17 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $charge_id, '_transaction_id' ) );
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$orders   = wc_get_orders(
+				[
+					'transaction_id' => $charge_id,
+					'limit'          => 1,
+				]
+			);
+			$order_id = current( $orders )->get_id();
+		} else {
+			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $charge_id, '_transaction_id' ) );
+		}
 
 		if ( ! empty( $order_id ) ) {
 			return wc_get_order( $order_id );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -375,7 +375,7 @@ class WC_Stripe_Helper {
 	public static function get_order_by_source_id( $source_id ) {
 		global $wpdb;
 
-		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'limit'      => 1,
@@ -411,7 +411,7 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'transaction_id' => $charge_id,
@@ -440,7 +440,7 @@ class WC_Stripe_Helper {
 	public static function get_order_by_intent_id( $intent_id ) {
 		global $wpdb;
 
-		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'limit'      => 1,
@@ -472,7 +472,7 @@ class WC_Stripe_Helper {
 	public static function get_order_by_setup_intent_id( $intent_id ) {
 		global $wpdb;
 
-		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'limit'      => 1,

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -375,7 +375,7 @@ class WC_Stripe_Helper {
 	public static function get_order_by_source_id( $source_id ) {
 		global $wpdb;
 
-		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'limit'      => 1,
@@ -411,7 +411,7 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'transaction_id' => $charge_id,
@@ -440,7 +440,7 @@ class WC_Stripe_Helper {
 	public static function get_order_by_intent_id( $intent_id ) {
 		global $wpdb;
 
-		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'limit'      => 1,
@@ -472,7 +472,7 @@ class WC_Stripe_Helper {
 	public static function get_order_by_setup_intent_id( $intent_id ) {
 		global $wpdb;
 
-		if ( class_exists( 'OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
+		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
 					'limit'      => 1,

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -385,7 +385,7 @@ class WC_Stripe_Helper {
 					],
 				]
 			);
-			$order_id = current( $orders )->get_id();
+			$order_id = current( $orders ) ? current( $orders )->get_id() : false;
 		} else {
 			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $source_id, '_stripe_source_id' ) );
 		}
@@ -418,7 +418,7 @@ class WC_Stripe_Helper {
 					'limit'          => 1,
 				]
 			);
-			$order_id = current( $orders )->get_id();
+			$order_id = current( $orders ) ? current( $orders )->get_id() : false;
 		} else {
 			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $charge_id, '_transaction_id' ) );
 		}
@@ -450,7 +450,7 @@ class WC_Stripe_Helper {
 					],
 				]
 			);
-			$order_id = current( $orders )->get_id();
+			$order_id = current( $orders ) ? current( $orders )->get_id() : false;
 		} else {
 			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $intent_id, '_stripe_intent_id' ) );
 		}
@@ -482,7 +482,7 @@ class WC_Stripe_Helper {
 					],
 				]
 			);
-			$order_id = current( $orders )->get_id();
+			$order_id = current( $orders ) ? current( $orders )->get_id() : false;
 		} else {
 			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $intent_id, '_stripe_setup_intent' ) );
 		}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -472,7 +472,20 @@ class WC_Stripe_Helper {
 	public static function get_order_by_setup_intent_id( $intent_id ) {
 		global $wpdb;
 
-		$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $intent_id, '_stripe_setup_intent' ) );
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$orders   = wc_get_orders(
+				[
+					'limit'      => 1,
+					'meta_query' => [
+						'key'   => '_stripe_setup_intent',
+						'value' => $intent_id,
+					],
+				]
+			);
+			$order_id = current( $orders )->get_id();
+		} else {
+			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $intent_id, '_stripe_setup_intent' ) );
+		}
 
 		if ( ! empty( $order_id ) ) {
 			return wc_get_order( $order_id );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -440,7 +440,20 @@ class WC_Stripe_Helper {
 	public static function get_order_by_intent_id( $intent_id ) {
 		global $wpdb;
 
-		$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $intent_id, '_stripe_intent_id' ) );
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$orders   = wc_get_orders(
+				[
+					'limit'      => 1,
+					'meta_query' => [
+						'key'   => '_stripe_intent_id',
+						'value' => $intent_id,
+					],
+				]
+			);
+			$order_id = current( $orders )->get_id();
+		} else {
+			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $intent_id, '_stripe_intent_id' ) );
+		}
 
 		if ( ! empty( $order_id ) ) {
 			return wc_get_order( $order_id );

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Utilities\OrderUtil;
+
 /**
  * Provides static methods as helpers.
  *
@@ -373,7 +375,20 @@ class WC_Stripe_Helper {
 	public static function get_order_by_source_id( $source_id ) {
 		global $wpdb;
 
-		$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $source_id, '_stripe_source_id' ) );
+		if ( OrderUtil::custom_orders_table_usage_is_enabled() ) {
+			$orders   = wc_get_orders(
+				[
+					'limit'      => 1,
+					'meta_query' => [
+						'key'   => '_stripe_source_id',
+						'value' => $source_id,
+					],
+				]
+			);
+			$order_id = current( $orders )->get_id();
+		} else {
+			$order_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts as posts LEFT JOIN $wpdb->postmeta as meta ON posts.ID = meta.post_id WHERE meta.meta_value = %s AND meta.meta_key = %s", $source_id, '_stripe_source_id' ) );
+		}
 
 		if ( ! empty( $order_id ) ) {
 			return wc_get_order( $order_id );

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -226,7 +226,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 		if ( ! $sent_to_admin && 'stripe_multibanco' === $payment_method && $order->has_status( 'on-hold' ) ) {
 			WC_Stripe_Logger::log( 'Sending multibanco email for order #' . $order_id );
 
-			$this->get_instructions( $order_id, $plain_text );
+			$this->get_instructions( $order, $plain_text );
 		}
 	}
 
@@ -235,10 +235,14 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.1.0
 	 * @version 4.1.0
-	 * @param int $order_id
+	 * @param int|WC_Order $order
 	 */
-	public function get_instructions( $order_id, $plain_text = false ) {
-		$data = get_post_meta( $order_id, '_stripe_multibanco', true );
+	public function get_instructions( $order, $plain_text = false ) {
+		if ( true === is_int( $order ) ) {
+			$order = wc_get_order( $order );
+		}
+
+		$data = $order->get_meta( '_stripe_multibanco' );
 
 		if ( $plain_text ) {
 			esc_html_e( 'MULTIBANCO INFORMAÇÕES DE ENCOMENDA:', 'woocommerce-gateway-stripe' ) . "\n\n";

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -289,7 +289,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 
 		$order_id = $order->get_id();
 
-		update_post_meta( $order_id, '_stripe_multibanco', $data );
+		$order->update_meta_data( '_stripe_multibanco', $data );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 6.8.0 - 2022-xx-xx =
+* Fix - Minor adjustments for Custom Order Tables compatibility.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/helpers/class-wc-helper-product.php
+++ b/tests/phpunit/helpers/class-wc-helper-product.php
@@ -383,14 +383,4 @@ class WC_Helper_Product {
 		];
 		return wp_insert_comment( $data );
 	}
-
-	/**
-	 * A helper function for hooking into save_post during the test_product_meta_save_post test.
-	 * @since 3.0.1
-	 *
-	 * @param int $id ID to update.
-	 */
-	public static function save_post_test_update_meta_data_direct( $id ) {
-		update_post_meta( $id, '_test2', 'world' );
-	}
 }

--- a/tests/phpunit/helpers/class-wc-helper-product.php
+++ b/tests/phpunit/helpers/class-wc-helper-product.php
@@ -346,23 +346,6 @@ class WC_Helper_Product {
 	}
 
 	/**
-	 * Delete an attribute.
-	 *
-	 * @param int $attribute_id ID to delete.
-	 *
-	 * @since 2.3
-	 */
-	public static function delete_attribute( $attribute_id ) {
-		global $wpdb;
-
-		$attribute_id = absint( $attribute_id );
-
-		$wpdb->query(
-			$wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_id = %d", $attribute_id )
-		);
-	}
-
-	/**
 	 * Creates a new product review on a specific product.
 	 *
 	 * @since 3.0


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Part of #2407

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Minor adjustments suggested by the [COT upgrade recipe book](https://github.com/Automattic/woocommerce/wiki/COT-Upgrade-Recipe-Book#apis-for-gettingsetting-posts-and-postmeta).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

---
**To test this PR you need to install the specific WooCommerce testing version that introduces the Custom Order Table implementation. You can [download it from here](https://github.com/woocommerce/woocommerce/releases/tag/feature-custom-order-table). Then follow [this steps to enable COT](https://github.com/Automattic/woocommerce/wiki/COT-Upgrade-Recipe-Book#easy-way).** There's also another [option using GIT](https://github.com/Automattic/woocommerce/wiki/COT-Upgrade-Recipe-Book#using-gh).

Then go to "WooCommerce > Settings > Advanced > Custom data stores" and make sure "Use the WooCommerce order tables" is selected and "Keep the posts table and the orders tables synchronized" is unchecked.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/1025173/187348641-6fcb67b3-642c-4235-b61f-8fd095fe8571.png">


---

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->


### Changes in the `get_instructions` in the `WC_Gateway_Stripe_Multibanco` class can be tested with the following steps:

- Switch currency to Euro.
- Enable Multibanco.
- Checkout using Multibanco.
- Verify the Multibanco details are visible on the "Order received" page and the email sent to the buyer.

### Fix in the `is_retention_expired` in the `WC_Stripe_Privacy` class can be tested with:

(Note that this fails on PHP 8 only. On PHP 7 the undefined array item return `null` and the multiplication will pass. On PHP 8 though it will end up throwing a fatal error because the undefined `$retention['number']` will return `""`.)

```
2022-08-30T03:44:08+00:00 CRITICAL Uncaught TypeError: Unsupported operand types: string * int in /Users/asumaran/www/woocommerce-gateway-stripe/includes/admin/class-wc-stripe-privacy.php:413
```

- You'll need to generate an order by buying a product or you can use existing orders.
- Go to Tools > Erase Personal Data
- Enter an existing customer email (check the email is not used by an already registered user in your WP install) then click the "Send Request" button.
- Hover the table row with the customer email then click "Force erase personal data"
- Make sure the request finishes without errors.

### Removed method from the `WC_Helper_Product` class can be tested with:

- `npm run up`
- `npm run test:php`
- Make sure the tests run without errors.

### Fix in the `get_order_by_source_id` method:

- Switch currency to Euro.
- Enable Multibanco.
- Create a simple product.
- Add the simple product to the cart
- Checkout using Multibanco.
- Make sure the order status is set to "Processing"
- Make sure there's no "Could not find order via source ID: seti_xyz..." message in the WC Stripe logs.

### Fix in the `get_order_by_charge_id` method:

- Create a simple product.
- Add the simple product to the cart
- Checkout using the card `4000000000000259` to [simulate disputed transaction](https://stripe.com/docs/testing#disputes).
- Make sure the order status is set to "On hold".
- Make sure there's no "Could not find order via charge ID: xyz" message in the WC Stripe logs.

### Fix in the `get_order_by_intent_id` method:

- Create a simple product.
- Add the simple product to the cart.
- Checkout using simple test card `4242424242424242`.
- Make sure the order is created successfully.
- Make sure there's no "Could not find order via intent ID: pi_xyz" message in the WC Stripe logs.

### Fix in the `get_order_by_setup_intent_id` method:

Given that WC Subscriptions is not currently supported by Custom Order Tables there's no way to test this while COT is enabled.

One way to check the fix works is to **switch back to WP post tables**, edit the `includes/class-wc-stripe-helper.php` file and negate the condition in the line 475 so the path of the fix is executed.

```php
if ( ! OrderUtil::custom_orders_table_usage_is_enabled() ) {
```

These steps are partly based on the testing steps from [the original PR](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1024) that introduced the `get_order_by_setup_intent_id` method.

- Create a subscription with free trial.
- Sign up for that subscription, go to the checkout.
- Use `4000002500003155` credit card, see that the order is created normally and the subscription too.
- Make sure there's no "Could not find order via setup intent ID: xyz" message in the WC Stripe logs.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
