### PR TITLE
Declare HPOS compatibility

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 6.9.0 - 2022-xx-xx =
 * Tweak - Remove remaining traces of old Stripe settings.
 * Add - Add Boleto expiration setting.
+* Add - Declare incompatibility with HPOS.
 
 = 6.8.0 - 2022-09-28 =
 * Fix - Minor adjustments for Custom Order Tables compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 6.9.0 - 2022-xx-xx =
 * Tweak - Remove remaining traces of old Stripe settings.
 * Add - Add Boleto expiration setting.
+* Add - Declare incompatibility with HPOS.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -785,7 +785,15 @@ function declare_hpos_compatibility() {
 
 		// If WC Subscription is compatible then WC Stripe will also be compatible.
 		Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, $is_wc_subsriptions_compatible );
+
+		if ( ! $is_wc_subsriptions_compatible ) {
+			add_action( 'admin_notices', 'woocommerce_stripe_not_compatible_with_wc_subs_and_hpos' );
+		}
 	} else {
 		Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 	}
+}
+
+function woocommerce_stripe_not_compatible_with_wc_subs_and_hpos() {
+	echo '<div class="error"><p><strong>' . sprintf( __( 'WooCommerce Stripe Gateway is not compatible with WooCommerce Subscriptions when High Performance Order Storage is enabled.', 'woocommerce-gateway-stripe' ) ) . '</strong></p></div>';
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -772,5 +772,20 @@ function woocommerce_gateway_stripe_woocommerce_block_support() {
 add_action( 'before_woocommerce_init', 'declare_hpos_compatibility' );
 
 function declare_hpos_compatibility() {
-	\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
+	if ( ! class_exists( 'Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+		return;
+	}
+
+	$is_wc_subscriptions_active = is_plugin_active( 'woocommerce-subscriptions/woocommerce-subscriptions.php' );
+
+	if ( $is_wc_subscriptions_active ) {
+		$plugins_compatible_with_cot = Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_plugins_for_feature( 'custom_order_tables' );
+
+		$is_wc_subsriptions_compatible = in_array( 'woocommerce-subscriptions/woocommerce-subscriptions.php', $plugins_compatible_with_cot['compatible'] );
+
+		// If WC Subscription is compatible then WC Stripe will also be compatible.
+		Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, $is_wc_subsriptions_compatible );
+	} else {
+		Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+	}
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -769,31 +769,11 @@ function woocommerce_gateway_stripe_woocommerce_block_support() {
 	}
 }
 
-add_action( 'before_woocommerce_init', 'declare_hpos_compatibility' );
-
-function declare_hpos_compatibility() {
-	if ( ! class_exists( 'Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-		return;
-	}
-
-	$is_wc_subscriptions_active = is_plugin_active( 'woocommerce-subscriptions/woocommerce-subscriptions.php' );
-
-	if ( $is_wc_subscriptions_active ) {
-		$plugins_compatible_with_cot = Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_plugins_for_feature( 'custom_order_tables' );
-
-		$is_wc_subsriptions_compatible = in_array( 'woocommerce-subscriptions/woocommerce-subscriptions.php', $plugins_compatible_with_cot['compatible'] );
-
-		// If WC Subscription is compatible then WC Stripe will also be compatible.
-		Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, $is_wc_subsriptions_compatible );
-
-		if ( ! $is_wc_subsriptions_compatible ) {
-			add_action( 'admin_notices', 'woocommerce_stripe_not_compatible_with_wc_subs_and_hpos' );
+add_action(
+	'before_woocommerce_init',
+	function() {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
 		}
-	} else {
-		Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 	}
-}
-
-function woocommerce_stripe_not_compatible_with_wc_subs_and_hpos() {
-	echo '<div class="error"><p><strong>' . sprintf( __( 'WooCommerce Stripe Gateway is not compatible with WooCommerce Subscriptions when High Performance Order Storage is enabled.', 'woocommerce-gateway-stripe' ) ) . '</strong></p></div>';
-}
+);

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -768,3 +768,9 @@ function woocommerce_gateway_stripe_woocommerce_block_support() {
 		);
 	}
 }
+
+add_action( 'before_woocommerce_init', 'declare_hpos_compatibility' );
+
+function declare_hpos_compatibility() {
+	\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
+}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Part of #2407

## Changes proposed in this Pull Request:

Declares the Stripe plugin incompatible with HPOS/COT due to WC Subscriptions not being compatible with HPOS/COT yet. Although [some work has been done](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2420) to support HPOS this is not enough to declare the plugin as fully compatible. More info here: pcShBQ-oY-p2#comment-1013

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

- Make sure you have the latest WooCommerce version installed.
- Pull this branch.
- Run the following command to know if WC Stripe is declared as incompatible. You'll need [wp cli](https://wp-cli.org/)

```bash
wp eval 'do_action("before_woocommerce_init"); print_r(Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_features_for_plugin("woocommerce-gateway-stripe/woocommerce-gateway-stripe.php"));'
```

The output should be similar to this:

```
Array
(
    [incompatible] => Array
        (
            [0] => custom_order_tables
        )

    [compatible] => Array
        (
        )

)
```

- We can clearly see the feature is declared as incompatible with our plugin.
- Run the following command to get the list of incompatible plugins with HPOS/COT.

```bash
wp eval 'do_action("before_woocommerce_init"); print_r(Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_plugins_for_feature("custom_order_tables"));'
```

The output should be similar to this:

```
Array
(
    [compatible] => Array
        (
        )

    [incompatible] => Array
        (
            [0] => woocommerce-gateway-stripe/woocommerce-gateway-stripe.php
        )

)
```

You should see the path of the plugin main file in the "incompatible" group.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)