### PR TITLE
Move add boleto expiration setting changelog entry from 6.7.0 to 6.9.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 6.9.0 - 2022-xx-xx =
 * Tweak - Remove remaining traces of old Stripe settings.
+* Add - Add Boleto expiration setting.
 
 = 6.8.0 - 2022-09-28 =
 * Fix - Minor adjustments for Custom Order Tables compatibility.
@@ -10,7 +11,6 @@
 = 6.7.0 - 2022-09-06 =
 * Fix - Check payment method before updating payment method title.
 * Fix - Use the eslint config at the root of the repo.
-* Add - Add Boleto expiration setting.
 
 = 6.6.0 - 2022-08-17 =
 * Fix - Fix "Pending" text instead of numeric amount on Payment Request button on iOS.

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 6.9.0 - 2022-xx-xx =
 * Tweak - Remove remaining traces of old Stripe settings.
+* Add - Add Boleto expiration setting.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION

Fixes PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2412

## Changes proposed in this Pull Request:
Move add boleto expiration setting changelog entry from 6.7.0 to 6.9.0
<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Go to WooCommerce > Payments > All payment Methods > Stripe Boleto
1. See expiration field
1. Try to update the expiration
1. Refresh the page
1. See the expiration persists
1. Go to WooCommerce > Payments > All payment Methods > select any payment gateways ( ex. Stripe Bancontact )
1. Should not see expiration field

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [X] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [X] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-testing-instructions-for-the-WooCommerce-Stripe-payment-gateway-6.9.0)
