### PR TITLE
Enable Link PM for subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Tweak - Remove remaining traces of old Stripe settings.
 * Add - Add Boleto expiration setting.
 * Add - Declare incompatibility with HPOS.
+* Add - Allow subscription orders to be paid with Link payment method.
 
 = 6.8.0 - 2022-09-28 =
 * Fix - Minor adjustments for Custom Order Tables compatibility.

--- a/client/blocks/upe/fields.js
+++ b/client/blocks/upe/fields.js
@@ -25,8 +25,11 @@ const useCustomerData = () => {
 			isInitialized: store.hasFinishedResolution( 'getCartData' ),
 		};
 	} );
-	const { setShippingAddress, setBillingAddress, setBillingData } =
-		useDispatch( WC_STORE_CART );
+	const {
+		setShippingAddress,
+		setBillingAddress,
+		setBillingData,
+	} = useDispatch( WC_STORE_CART );
 
 	let customerBillingAddress = customerData.billingData;
 	let setCustomerBillingAddress = setBillingData;
@@ -62,8 +65,9 @@ const UPEField = ( {
 	const stripe = useStripe();
 	const elements = useElements();
 
-	const [ selectedUpePaymentType, setSelectedUpePaymentType ] =
-		useState( '' );
+	const [ selectedUpePaymentType, setSelectedUpePaymentType ] = useState(
+		''
+	);
 	const [ isUpeComplete, setIsUpeComplete ] = useState( false );
 
 	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;
@@ -236,8 +240,7 @@ const UPEField = ( {
 						paymentMethodData: {
 							paymentMethod: PAYMENT_METHOD_NAME,
 							wc_payment_intent_id: paymentIntentId,
-							wc_stripe_selected_upe_payment_type:
-								selectedUpePaymentType,
+							wc_stripe_selected_upe_payment_type: selectedUpePaymentType,
 						},
 					},
 				};

--- a/includes/class-wc-stripe-link-payment-token.php
+++ b/includes/class-wc-stripe-link-payment-token.php
@@ -1,0 +1,95 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+// phpcs:disable WordPress.Files.FileName
+
+/**
+ * WooCommerce Stripe Link Payment Token.
+ *
+ * Representation of a payment token for Link.
+ *
+ * @class    WC_Payment_Token_Link
+ */
+class WC_Payment_Token_Link extends WC_Payment_Token {
+
+	/**
+	 * Stores payment type.
+	 *
+	 * @var string
+	 */
+	protected $type = 'link';
+
+	/**
+	 * Stores Link payment token data.
+	 *
+	 * @var array
+	 */
+	protected $extra_data = [
+		'email'  => '',
+	];
+
+	/**
+	 * Get type to display to user.
+	 *
+	 * @param  string $deprecated Deprecated since WooCommerce 3.0
+	 * @return string
+	 */
+	public function get_display_name( $deprecated = '' ) {
+		$display = sprintf(
+			/* translators: customer email */
+			__( 'Stripe Link email %s', 'woocommerce-gateway-stripe' ),
+			$this->get_email()
+		);
+
+		return $display;
+	}
+
+	/**
+	 * Hook prefix
+	 */
+	protected function get_hook_prefix() {
+		return 'woocommerce_payment_token_link_get_';
+	}
+
+	/**
+	 * Set Stripe payment method type.
+	 *
+	 * @param string $type Payment method type.
+	 */
+	public function set_payment_method_type( $type ) {
+		$this->set_prop( 'payment_method_type', $type );
+	}
+
+	/**
+	 * Returns Stripe payment method type.
+	 *
+	 * @param string $context What the value is for. Valid values are view and edit.
+	 * @return string $payment_method_type
+	 */
+	public function get_payment_method_type( $context = 'view' ) {
+		return $this->get_prop( 'payment_method_type', $context );
+	}
+
+	/**
+	 * Returns the customer email.
+	 *
+	 * @param string $context What the value is for. Valid values are view and edit.
+	 *
+	 * @return string Customer email.
+	 */
+	public function get_email( $context = 'view' ) {
+		return $this->get_prop( 'email', $context );
+	}
+
+	/**
+	 * Set the customer email.
+	 *
+	 * @param string $email Customer email.
+	 */
+	public function set_email( $email ) {
+		$this->set_prop( 'email', $email );
+	}
+}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -17,7 +17,7 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
 		$this->title                = __( 'Pay with Link', 'woocommerce-gateway-stripe' );
-		$this->is_reusable          = false;
+		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'USD' ];
 		$this->label                = __( 'Stripe Link', 'woocommerce-gateway-stripe' );
 		$this->description          = __(
@@ -43,5 +43,32 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 			woocommerce_gateway_stripe()->get_main_stripe_gateway()->get_upe_enabled_payment_method_ids(),
 			true
 		);
+	}
+
+	/**
+	 * Returns string representing payment method type
+	 * to query to retrieve saved payment methods from Stripe.
+	 */
+	public function get_retrievable_type() {
+		return $this->get_id();
+	}
+
+	/**
+	 * Create new WC payment token and add to user.
+	 *
+	 * @param int $user_id        WP_User ID
+	 * @param object $payment_method Stripe payment method object
+	 *
+	 * @return WC_Payment_Token_Link
+	 */
+	public function create_payment_token_for_user( $user_id, $payment_method ) {
+		$token = new WC_Payment_Token_Link();
+		$token->set_email( $payment_method->link->email );
+		$token->set_gateway_id( WC_Stripe_UPE_Payment_Gateway::ID );
+		$token->set_token( $payment_method->id );
+		$token->set_payment_method_type( $this->get_id() );
+		$token->set_user_id( $user_id );
+		$token->save();
+		return $token;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -132,5 +132,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Remove remaining traces of old Stripe settings.
 * Add - Add Boleto expiration setting.
 * Add - Declare incompatibility with HPOS.
+* Add - Allow subscription orders to be paid with Link payment method.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -27,6 +27,17 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	];
 
 	/**
+	 * Base template for Stripe link payment method.
+	 */
+	const MOCK_LINK_PAYMENT_METHOD_TEMPLATE = [
+		'id'   => 'pm_mock_payment_method_id',
+		'type' => 'link',
+		'link' => [
+			'email' => 'test@test.com',
+		],
+	];
+
+	/**
 	 * Base template for Stripe SEPA payment method.
 	 */
 	const MOCK_SEPA_PAYMENT_METHOD_TEMPLATE = [
@@ -387,8 +398,12 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$this->set_mock_payment_method_return_value( 'get_capabilities_response', self::MOCK_ACTIVE_CAPABILITIES_RESPONSE );
 
 		foreach ( $this->mock_payment_methods as $payment_method_id => $payment_method ) {
-			$currency = 'link' === $payment_method_id ? 'USD' : 'EUR';
-			$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', $currency );
+			$payment_method
+				->expects( $this->any() )
+				->method( 'get_woocommerce_currency' )
+				->will(
+					$this->returnValue( WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID === $payment_method_id ? 'USD' : 'EUR' )
+				);
 
 			if ( $payment_method->is_reusable() ) {
 				$this->assertTrue( $payment_method->is_enabled_at_checkout() );
@@ -409,18 +424,27 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 				continue;
 			}
 
-			if ( 'card' === $payment_method_id ) {
-				$card_payment_method_mock = $this->array_to_object( self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE );
-				$token                    = $payment_method->create_payment_token_for_user( $user_id, $card_payment_method_mock );
-				$this->assertTrue( 'WC_Payment_Token_CC' === get_class( $token ) );
-				$this->assertEquals( $token->get_last4(), $card_payment_method_mock->card->last4 );
-				$this->assertEquals( $token->get_token(), $card_payment_method_mock->id );
-			} else {
-				$sepa_payment_method_mock = $this->array_to_object( self::MOCK_SEPA_PAYMENT_METHOD_TEMPLATE );
-				$token                    = $payment_method->create_payment_token_for_user( $user_id, $sepa_payment_method_mock );
-				$this->assertTrue( 'WC_Payment_Token_SEPA' === get_class( $token ) );
-				$this->assertEquals( $token->get_last4(), $sepa_payment_method_mock->sepa_debit->last4 );
-				$this->assertEquals( $token->get_token(), $sepa_payment_method_mock->id );
+			switch ( $payment_method_id ) {
+				case WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID:
+					$card_payment_method_mock = $this->array_to_object( self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE );
+					$token                    = $payment_method->create_payment_token_for_user( $user_id, $card_payment_method_mock );
+					$this->assertTrue( 'WC_Payment_Token_CC' === get_class( $token ) );
+					$this->assertEquals( $token->get_last4(), $card_payment_method_mock->card->last4 );
+					$this->assertEquals( $token->get_token(), $card_payment_method_mock->id );
+					break;
+				case WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID:
+					$link_payment_method_mock = $this->array_to_object( self::MOCK_LINK_PAYMENT_METHOD_TEMPLATE );
+					$token                    = $payment_method->create_payment_token_for_user( $user_id, $link_payment_method_mock );
+					$this->assertTrue( 'WC_Payment_Token_Link' === get_class( $token ) );
+					$this->assertEquals( $token->get_email(), $link_payment_method_mock->link->email );
+					break;
+				default:
+					$sepa_payment_method_mock = $this->array_to_object( self::MOCK_SEPA_PAYMENT_METHOD_TEMPLATE );
+					$token                    = $payment_method->create_payment_token_for_user( $user_id, $sepa_payment_method_mock );
+					$this->assertTrue( 'WC_Payment_Token_SEPA' === get_class( $token ) );
+					$this->assertEquals( $token->get_last4(), $sepa_payment_method_mock->sepa_debit->last4 );
+					$this->assertEquals( $token->get_token(), $sepa_payment_method_mock->id );
+
 			}
 		}
 	}

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -429,21 +429,21 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 					$card_payment_method_mock = $this->array_to_object( self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE );
 					$token                    = $payment_method->create_payment_token_for_user( $user_id, $card_payment_method_mock );
 					$this->assertTrue( 'WC_Payment_Token_CC' === get_class( $token ) );
-					$this->assertEquals( $token->get_last4(), $card_payment_method_mock->card->last4 );
-					$this->assertEquals( $token->get_token(), $card_payment_method_mock->id );
+					$this->assertSame( $token->get_last4(), $card_payment_method_mock->card->last4 );
+					$this->assertSame( $token->get_token(), $card_payment_method_mock->id );
 					break;
 				case WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID:
 					$link_payment_method_mock = $this->array_to_object( self::MOCK_LINK_PAYMENT_METHOD_TEMPLATE );
 					$token                    = $payment_method->create_payment_token_for_user( $user_id, $link_payment_method_mock );
 					$this->assertTrue( 'WC_Payment_Token_Link' === get_class( $token ) );
-					$this->assertEquals( $token->get_email(), $link_payment_method_mock->link->email );
+					$this->assertSame( $token->get_email(), $link_payment_method_mock->link->email );
 					break;
 				default:
 					$sepa_payment_method_mock = $this->array_to_object( self::MOCK_SEPA_PAYMENT_METHOD_TEMPLATE );
 					$token                    = $payment_method->create_payment_token_for_user( $user_id, $sepa_payment_method_mock );
 					$this->assertTrue( 'WC_Payment_Token_SEPA' === get_class( $token ) );
-					$this->assertEquals( $token->get_last4(), $sepa_payment_method_mock->sepa_debit->last4 );
-					$this->assertEquals( $token->get_token(), $sepa_payment_method_mock->id );
+					$this->assertSame( $token->get_last4(), $sepa_payment_method_mock->sepa_debit->last4 );
+					$this->assertSame( $token->get_token(), $sepa_payment_method_mock->id );
 
 			}
 		}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -167,6 +167,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-state.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-handler.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-sepa-payment-token.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-link-payment-token.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-apple-pay-registration.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-stripe.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php';
@@ -205,7 +206,6 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
 				require_once dirname( __FILE__ ) . '/includes/migrations/class-allowed-payment-request-button-types-update.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-account.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-link-payment-token.php';
 				new Allowed_Payment_Request_Button_Types_Update();
 
 				$this->api                           = new WC_Stripe_Connect_API();

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -205,6 +205,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
 				require_once dirname( __FILE__ ) . '/includes/migrations/class-allowed-payment-request-button-types-update.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-account.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-link-payment-token.php';
 				new Allowed_Payment_Request_Button_Types_Update();
 
 				$this->api                           = new WC_Stripe_Connect_API();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2446

## Changes proposed in this Pull Request:
Link payment method can be reused. For subscriptions, the payment method token should be saved in order to be re-used for subscription renewal.
This PR updates Link payment method to save the token.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
**Scenario 1**
* Install [Woocommerce Subscriptions](https://woocommerce.com/products/woocommerce-subscriptions/)
* Create a new subscription order and pay it using Link
* Payment should be completed
* The payment of renewal for the subscription should be processed without errors.
* In order to trigger subscription renewals, you can follow the steps [ [here](https://woocommerce.com/document/testing-subscription-renewal-payments/) ]

**Scenario 2**
* Create a new subscription with 1 day trial version order and pay it using Link
* Payment should be completed
* The payment for the subscription should be processed without errors after the trial ends.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
