### PR TITLE
Auto-complete first and last name when using Link PM

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Tweak - Remove remaining traces of old Stripe settings.
 * Add - Add Boleto expiration setting.
 * Add - Declare incompatibility with HPOS.
+* Add - Auto-complete first and last name on checkout form when using Link payment method.
 
 = 6.8.0 - 2022-09-28 =
 * Fix - Minor adjustments for Custom Order Tables compatibility.

--- a/client/blocks/upe/fields.js
+++ b/client/blocks/upe/fields.js
@@ -25,11 +25,8 @@ const useCustomerData = () => {
 			isInitialized: store.hasFinishedResolution( 'getCartData' ),
 		};
 	} );
-	const {
-		setShippingAddress,
-		setBillingAddress,
-		setBillingData,
-	} = useDispatch( WC_STORE_CART );
+	const { setShippingAddress, setBillingAddress, setBillingData } =
+		useDispatch( WC_STORE_CART );
 
 	let customerBillingAddress = customerData.billingData;
 	let setCustomerBillingAddress = setBillingData;
@@ -65,9 +62,8 @@ const UPEField = ( {
 	const stripe = useStripe();
 	const elements = useElements();
 
-	const [ selectedUpePaymentType, setSelectedUpePaymentType ] = useState(
-		''
-	);
+	const [ selectedUpePaymentType, setSelectedUpePaymentType ] =
+		useState( '' );
 	const [ isUpeComplete, setIsUpeComplete ] = useState( false );
 
 	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;
@@ -85,6 +81,8 @@ const UPEField = ( {
 				state: 'components-form-token-input-1',
 				postal_code: 'shipping-postcode',
 				country: 'components-form-token-input-0',
+				first_name: 'shipping-first_name',
+				last_name: 'shipping-last_name',
 			};
 			const billingAddressFields = {
 				line1: 'billing-address_1',
@@ -93,6 +91,8 @@ const UPEField = ( {
 				state: 'components-form-token-input-3',
 				postal_code: 'billing-postcode',
 				country: 'components-form-token-input-2',
+				first_name: 'billing-first_name',
+				last_name: 'billing-last_name',
 			};
 
 			enableStripeLinkPaymentMethod( {
@@ -236,7 +236,8 @@ const UPEField = ( {
 						paymentMethodData: {
 							paymentMethod: PAYMENT_METHOD_NAME,
 							wc_payment_intent_id: paymentIntentId,
-							wc_stripe_selected_upe_payment_type: selectedUpePaymentType,
+							wc_stripe_selected_upe_payment_type:
+								selectedUpePaymentType,
 						},
 					},
 				};

--- a/client/blocks/upe/fields.js
+++ b/client/blocks/upe/fields.js
@@ -25,8 +25,11 @@ const useCustomerData = () => {
 			isInitialized: store.hasFinishedResolution( 'getCartData' ),
 		};
 	} );
-	const { setShippingAddress, setBillingAddress, setBillingData } =
-		useDispatch( WC_STORE_CART );
+	const {
+		setShippingAddress,
+		setBillingAddress,
+		setBillingData,
+	} = useDispatch( WC_STORE_CART );
 
 	let customerBillingAddress = customerData.billingData;
 	let setCustomerBillingAddress = setBillingData;
@@ -62,8 +65,9 @@ const UPEField = ( {
 	const stripe = useStripe();
 	const elements = useElements();
 
-	const [ selectedUpePaymentType, setSelectedUpePaymentType ] =
-		useState( '' );
+	const [ selectedUpePaymentType, setSelectedUpePaymentType ] = useState(
+		''
+	);
 	const [ isUpeComplete, setIsUpeComplete ] = useState( false );
 
 	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;
@@ -236,8 +240,7 @@ const UPEField = ( {
 						paymentMethodData: {
 							paymentMethod: PAYMENT_METHOD_NAME,
 							wc_payment_intent_id: paymentIntentId,
-							wc_stripe_selected_upe_payment_type:
-								selectedUpePaymentType,
+							wc_stripe_selected_upe_payment_type: selectedUpePaymentType,
 						},
 					},
 				};

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -268,6 +268,8 @@ jQuery( function ( $ ) {
 							state: 'shipping_state',
 							postal_code: 'shipping_postcode',
 							country: 'shipping_country',
+							first_name: 'shipping_first_name',
+							last_name: 'shipping_last_name',
 						},
 						billing_fields: {
 							line1: 'billing_address_1',
@@ -276,6 +278,8 @@ jQuery( function ( $ ) {
 							state: 'billing_state',
 							postal_code: 'billing_postcode',
 							country: 'billing_country',
+							first_name: 'billing_first_name',
+							last_name: 'billing_last_name',
 						},
 					} );
 				}

--- a/client/stripe-link/index.js
+++ b/client/stripe-link/index.js
@@ -52,39 +52,75 @@ const enableStripeLinkPaymentMethod = ( options ) => {
 			  };
 
 		if ( options.complete_shipping() ) {
+			const shippingNames = shippingAddress.name.split( / (.*)/s, 2 );
+			shippingAddress.address.last_name = shippingNames[ 1 ];
+			shippingAddress.address.first_name = shippingNames[ 0 ];
+
 			fillWith( shippingAddress, options.shipping_fields.line1, 'line1' );
 			fillWith( shippingAddress, options.shipping_fields.line2, 'line2' );
 			fillWith( shippingAddress, options.shipping_fields.city, 'city' );
+			fillWith(
+				shippingAddress,
+				options.shipping_fields.country,
+				'country'
+			);
+			fillWith(
+				shippingAddress,
+				options.shipping_fields.first_name,
+				'first_name'
+			);
+			fillWith(
+				shippingAddress,
+				options.shipping_fields.last_name,
+				'last_name'
+			);
+			jQuery(
+				'#billing_country, #billing_state, #shipping_country, #shipping_state'
+			).trigger( 'change' );
 			fillWith( shippingAddress, options.shipping_fields.state, 'state' );
 			fillWith(
 				shippingAddress,
 				options.shipping_fields.postal_code,
 				'postal_code'
 			);
-			fillWith(
-				shippingAddress,
-				options.shipping_fields.country,
-				'country'
-			);
 		}
 
 		if ( options.complete_billing() ) {
+			const billingNames = billingAddress.name.split( / (.*)/s, 2 );
+			billingAddress.address.last_name = billingNames[ 1 ];
+			billingAddress.address.first_name = billingNames[ 0 ];
+
 			fillWith( billingAddress, options.billing_fields.line1, 'line1' );
 			fillWith( billingAddress, options.billing_fields.line2, 'line2' );
 			fillWith( billingAddress, options.billing_fields.city, 'city' );
+			fillWith(
+				billingAddress,
+				options.billing_fields.country,
+				'country'
+			);
+			fillWith(
+				billingAddress,
+				options.billing_fields.first_name,
+				'first_name'
+			);
+			fillWith(
+				billingAddress,
+				options.billing_fields.last_name,
+				'last_name'
+			);
+			jQuery(
+				'#billing_country, #billing_state, #shipping_country, #shipping_state'
+			).trigger( 'change' );
 			fillWith( billingAddress, options.billing_fields.state, 'state' );
 			fillWith(
 				billingAddress,
 				options.billing_fields.postal_code,
 				'postal_code'
 			);
-			fillWith(
-				billingAddress,
-				options.billing_fields.country,
-				'country'
-			);
 		}
-		jQuery( 'select' ).trigger( 'change' );
+		jQuery(
+			'#billing_country, #billing_state, #shipping_country, #shipping_state'
+		).trigger( 'change' );
 	} );
 };
 

--- a/client/stripe-link/index.js
+++ b/client/stripe-link/index.js
@@ -53,7 +53,7 @@ const enableStripeLinkPaymentMethod = ( options ) => {
 
 		if ( options.complete_shipping() ) {
 			const shippingNames = shippingAddress.name.split( / (.*)/s, 2 );
-			shippingAddress.address.last_name = shippingNames[ 1 ];
+			shippingAddress.address.last_name = shippingNames[ 1 ] ?? '';
 			shippingAddress.address.first_name = shippingNames[ 0 ];
 
 			fillWith( shippingAddress, options.shipping_fields.line1, 'line1' );
@@ -87,7 +87,7 @@ const enableStripeLinkPaymentMethod = ( options ) => {
 
 		if ( options.complete_billing() ) {
 			const billingNames = billingAddress.name.split( / (.*)/s, 2 );
-			billingAddress.address.last_name = billingNames[ 1 ];
+			billingAddress.address.last_name = billingNames[ 1 ] ?? '';
 			billingAddress.address.first_name = billingNames[ 0 ];
 
 			fillWith( billingAddress, options.billing_fields.line1, 'line1' );

--- a/readme.txt
+++ b/readme.txt
@@ -132,5 +132,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Remove remaining traces of old Stripe settings.
 * Add - Add Boleto expiration setting.
 * Add - Declare incompatibility with HPOS.
+* Add - Auto-complete first and last name on checkout form when using Link payment method.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2444

## Changes proposed in this Pull Request:
This PR updates the Link functionality, in order to pre-fill first and last name fields on the checkout form, along with other user details.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
* Navigate to Settings -> Payment Methods and enable Link payment method.
* create an order, go to checkout page and complete all checkout fields. Select also 1click payment under credit card fields
* finish the order
* create another order, go to checkout page and fill the email
*  a pop-up should be shown to type the pin ( 0 0 0 0 0 0 for tests )
* first and last name should be filled for both billing and shipping address
* check if first and last name fields are filled also for blocks checkout page
* test the above scenarios for all options in `Woo -> Settings -> Shipping -> Shipping options -> Shipping destination`
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
