### PR TITLE
[POC] Use the Store API to add product items to a cart

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -12,7 +12,7 @@ jQuery( function( $ ) {
 			type: 'GET',
 			url: 'https://localhost:8009/wp-json/wc/store/v1/cart',
 			headers: {
-				"Access-Control-Request-Private-Network": true,
+				// "Access-Control-Request-Private-Network": true,
 			}
 		}).then(function (response, textStatus, jqXHR) {
 			var cartToken = jqXHR.getResponseHeader('cart-token');
@@ -31,7 +31,7 @@ jQuery( function( $ ) {
 			type: 'POST',
 			url: 'https://localhost:8009/wp-json/wc/store/v1/cart/add-item',
 			headers: {
-				"Access-Control-Request-Private-Network": true,
+				// "Access-Control-Request-Private-Network": true,
 				"Cart-Token": window.cartToken,
 			},
 			data: data
@@ -54,7 +54,6 @@ jQuery( function( $ ) {
 			headers: {
 				// "Access-Control-Request-Private-Network": true,
 				"Cart-Token": window.cartToken,
-				"Foo-Bar": "Baz",
 			},
 			data: data
 		}).then(function (response, textStatus, jqXHR) {
@@ -717,7 +716,7 @@ jQuery( function( $ ) {
 
 						response.items.forEach(item => {
 							displayItems.push({
-								amount: item.totals.line_total,
+								amount: Number(item.totals.line_total),
 								label: 'A soft cotton shirt',
 							})
 						});
@@ -750,26 +749,26 @@ jQuery( function( $ ) {
 		},
 
 		attachCartPageEventListeners: function ( prButton, paymentRequest ) {
-			// prButton.on( 'click', function ( evt ) {
-			// 	// If login is required for checkout, display redirect confirmation dialog.
-			// 	if ( wc_stripe_payment_request_params.login_confirmation ) {
-			// 		evt.preventDefault();
-			// 		displayLoginConfirmation( paymentRequestType );
-			// 		return;
-			// 	}
+			prButton.on( 'click', function ( evt ) {
+				// If login is required for checkout, display redirect confirmation dialog.
+				if ( wc_stripe_payment_request_params.login_confirmation ) {
+					evt.preventDefault();
+					displayLoginConfirmation( paymentRequestType );
+					return;
+				}
 
-			// 	if (
-			// 		wc_stripe_payment_request.isCustomPaymentRequestButton(
-			// 			prButton
-			// 		) ||
-			// 		wc_stripe_payment_request.isBrandedPaymentRequestButton(
-			// 			prButton
-			// 		)
-			// 	) {
-			// 		evt.preventDefault();
-			// 		paymentRequest.show();
-			// 	}
-			// } );
+				if (
+					wc_stripe_payment_request.isCustomPaymentRequestButton(
+						prButton
+					) ||
+					wc_stripe_payment_request.isBrandedPaymentRequestButton(
+						prButton
+					)
+				) {
+					evt.preventDefault();
+					paymentRequest.show();
+				}
+			} );
 		},
 
 		showPaymentRequestButton: function( prButton ) {


### PR DESCRIPTION
To demonstrate the changes introduced in https://github.com/woocommerce/woocommerce-blocks/pull/5953 will help us to implement https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1563 without problems. We decided to create this proof of concept.

I've found at least one issue when working on this. We can't consume the Store API directly **to create another cart** because the browser will send the cookies on AJAX requests automatically making it imposible to create a separate cart using the `Cart-Token` header only.

To overcome this limitation I created a simple proxy server to act as a mirror of the original server. We would consume the Store API through this new host which then will forward the same request to the original host without the Cookies. This will allow us to consume the Store API to create another cart using the `Cart-Token` header only.

The code I used to create the proxy server can [be found here](https://github.com/asumaran/simple-proxy-server).

A simple way to represent a usual AJAX request would be as follows:

```
client makes request to proxy
             ↓
proxy makes request to store removing the Cookies
             ↓
store responds to proxy
             ↓
proxy responds to client
```

Here's a short video showing the implementation.


https://user-images.githubusercontent.com/1025173/197310809-91bcdc7b-24c0-4594-9802-c6d00cb5221b.mov

Some things to notice:

- We make a request first to get the cart token value
- The product is first added on page load
- Data used by Apple Pay comes from the Store API.
- Notice the _default_ cart wasn't modified and continues to be empty.

## Caveats <a href="#caveats" id="caveats"></a>

- We need to find a way to consume the Store API from the browser without touching the default Cart. There's no way to remove the "Cookies" header so the backend will assume we will be manipulating the default cart.

## TODO

- Currently, the payment process will not work with this approach because the backend is bailing out if the cart is empty. https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e477593aae96546f2c9986da7b29b972069938e0/includes/payment-methods/class-wc-stripe-payment-request.php#L1590-L1592 We need to try with the Store API to process the order.
