### PR TITLE
Remove Еxpress Checkout section extra spacing

### DIFF
--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -51,7 +51,7 @@ const PaymentRequestSection = () => {
 
 	return (
 		<Card className="express-checkouts">
-			<CardBody>
+			<CardBody size={ 0 }>
 				<ul className="express-checkouts-list">
 					<li className="express-checkout has-icon-border">
 						<div className="express-checkout__checkbox">


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Removes extra spacing on the Express Checkout section by mistake.

<img width="770" alt="Screenshot 2022-11-01 at 13 48 38" src="https://user-images.githubusercontent.com/8667118/199307422-b540711d-8cbc-499a-828a-134a3658bec4.png">

## Testing instructions
- Navigate to `WooCommerce` -> `Settings` -> `Payments` -> `Stripe`.
- Verify there is no extra spacing added to the Express Checkout section.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
