### PR TITLE
Fix duplicate charge issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 7.0.1 - 2022-xx-xx =
+= 7.0.1 - 2022-11-11 =
 * Fix - Issue where subscription renewal payments were being charged twice no longer present.
 
 = 7.0.0 - 2022-11-10 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 7.0.1 - 2022-xx-xx =
+* Fix - Issue where subscription renewal payments were being charged twice no longer present.
+
 = 7.0.0 - 2022-11-10 =
 * Add - Update Express Checkout section UI.
 * Add - Auto-complete first and last name on checkout form when using Link payment method.

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -55,7 +55,7 @@ class WC_Stripe_Inbox_Notes {
 		WC_Stripe_UPE_Availability_Note::init();
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-upe-stripelink-note.php';
-		WC_Stripe_UPE_StripeLink_Note::init( new WC_Stripe_UPE_Payment_Gateway() );
+		WC_Stripe_UPE_StripeLink_Note::init( WC_Stripe::get_instance()->get_main_stripe_gateway() );
 	}
 
 	public static function get_campaign_2020_cutoff() {

--- a/includes/notes/class-wc-stripe-upe-stripelink-note.php
+++ b/includes/notes/class-wc-stripe-upe-stripelink-note.php
@@ -67,12 +67,12 @@ class WC_Stripe_UPE_StripeLink_Note {
 	/**
 	 * Init Link payment method notification
 	 *
-	 * @param WC_Stripe_UPE_Payment_Gateway $gateway
+	 * @param WC_Stripe_Payment_Gateway $gateway
 	 *
 	 * @return void
 	 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException
 	 */
-	public static function init( WC_Stripe_UPE_Payment_Gateway $gateway ) {
+	public static function init( WC_Stripe_Payment_Gateway $gateway ) {
 		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return;
 		}
@@ -81,6 +81,10 @@ class WC_Stripe_UPE_StripeLink_Note {
 		$available_upe_payment_methods = $gateway->get_upe_available_payment_methods();
 
 		if ( ! in_array( WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID, $available_upe_payment_methods, true ) ) {
+			return;
+		}
+
+		if ( ! is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
 			return;
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort,
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 7.0.0
+Stable tag: 7.0.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe
@@ -128,7 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.0.1 - 2022-xx-xx =
+= 7.0.1 - 2022-11-11 =
 * Fix - Issue where subscription renewal payments were being charged twice no longer present.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -128,12 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.0.0 - 2022-11-10 =
-* Add - Update Express Checkout section UI.
-* Add - Auto-complete first and last name on checkout form when using Link payment method.
-* Add - Allow subscription orders to be paid with Link payment method.
-* Add - Add inbox notification for Link payment method.
-* Tweak - Adjust texts and links in WC admin advanced settings.
-* Add - Restrict the Link payment method only for US merchants.
+= 7.0.1 - 2022-xx-xx =
+* Fix - Issue where subscription renewal payments were being charged twice no longer present.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -63,14 +63,14 @@ function woocommerce_gateway_stripe() {
 			/**
 			 * The *Singleton* instance of this class
 			 *
-			 * @var Singleton
+			 * @var WC_Stripe
 			 */
 			private static $instance;
 
 			/**
 			 * Returns the *Singleton* instance of this class.
 			 *
-			 * @return Singleton The *Singleton* instance.
+			 * @return WC_Stripe The *Singleton* instance.
 			 */
 			public static function get_instance() {
 				if ( null === self::$instance ) {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 7.0.0
+ * Version: 7.0.1
  * Requires at least: 5.8
  * Tested up to: 6.0
  * WC requires at least: 6.8
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_STRIPE_VERSION', '7.0.0' ); // WRCS: DEFINED_VERSION.
+define( 'WC_STRIPE_VERSION', '7.0.1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.3.0' );
 define( 'WC_STRIPE_MIN_WC_VER', '6.8' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '6.9' );


### PR DESCRIPTION
The problem was that an extra gateway class was instantiated that caused payments to be processed twice. By removing the extra instance of the payment gateway the problem has been fixed.

<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2474 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Use already instantiated gateway in inbox note classes instead of instantiating a new one.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

> **Warning**
> I think the problem is only present for UPE, so you must enable UPE for the tests to be effective.

### Verify original note operations work

* Follow the testing instructions in #2462 

### Verify no duplicate charges

> **Warning**
> These instructions assume you have WooCommerce subscriptions installed and a subscription product already created.

1. Buy a subscription product.
2. Take a note of the subscription ID (not the order ID, but the _subscription ID_).
3. Navigate to **wp-admin** -> **Tools** -> **Scheduled Actions**.
4. Find the `woocommerce_scheduled_subscription_payment` action for the subscription, e.g. by searching for the subscription ID.
5. Run the action.
6. Log into the [Stripe dashboard](https://dashboard.stripe.com).
7. Open the **Payments** list.
8. Verify that only one payment was made for the renewal order.
9. Navigate to **wp-admin** -> **WooCommerce** -> **Orders**
10. Open the details for the renewal order.
11. Verify there are no duplicate notes.
12. Verify there is only one note detailing a payment/charge being made.


### Verify no duplicate order notes

1. Buy any product.
2. Navigate to **wp-admin** -> **WooCommerce** -> **Orders**
3. Open the order details.
4. Verify there is only one set of notes, and no note is duplicated.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
