### PR TITLE
Fix compatibility issue with incoming webhooks in Stripe API version 2022-11-15

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 7.1.0 - 2022-xx-xx =
+* Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.
 
 = 7.0.1 - 2022-11-11 =
 * Fix - Issue where subscription renewal payments were being charged twice no longer present.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -621,7 +621,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Get source object by source id.
+	 * Get source object by source ID.
 	 *
 	 * @since 4.0.3
 	 * @param string $source_id The source ID to get source object for.
@@ -638,6 +638,47 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		return $source_object;
+	}
+
+	/**
+	 * Get charge object by charge ID.
+	 *
+	 * @since x.x.x
+	 * @param string $charge_id The charge ID to get charge object for.
+	 *
+	 * @return object
+	 */
+	public function get_charge_object( $charge_id = '' ) {
+		if ( empty( $charge_id ) ) {
+			return '';
+		}
+
+		$charge_object = WC_Stripe_API::retrieve( 'charges/' . $charge_id );
+
+		if ( ! empty( $charge_object->error ) ) {
+			throw new WC_Stripe_Exception( print_r( $charge_object, true ), $charge_object->error->message );
+		}
+
+		return $charge_object;
+	}
+
+	/**
+	 * Get latest charge object from payment intent.
+	 *
+	 * Since API version 2022-11-15, the `charges` property was replaced with `latest_charge`.
+	 * We can remove this method once we drop support for API versions prior to 2022-11-15.
+	 *
+	 * @since x.x.x
+	 * @param object $intent Stripe's API Payment Intent object.
+	 *
+	 * @return object
+	 */
+	public function get_latest_charge_from_intent( $intent ) {
+		if ( ! empty( $intent->charges->data ) ) {
+			return end( $intent->charges->data );
+		} else {
+			return $this->get_charge_object( $intent->latest_charge );
+		}
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -625,6 +625,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 4.0.3
 	 * @param string $source_id The source ID to get source object for.
+	 *
+	 * @throws WC_Stripe_Exception Error while retrieving source object.
+	 * @return string|object
 	 */
 	public function get_source_object( $source_id = '' ) {
 		if ( empty( $source_id ) ) {
@@ -646,7 +649,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @since x.x.x
 	 * @param string $charge_id The charge ID to get charge object for.
 	 *
-	 * @return object
+	 * @throws WC_Stripe_Exception Error while retrieving charge object.
+	 * @return string|object
 	 */
 	public function get_charge_object( $charge_id = '' ) {
 		if ( empty( $charge_id ) ) {
@@ -669,7 +673,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * We can remove this method once we drop support for API versions prior to 2022-11-15.
 	 *
 	 * @since x.x.x
-	 * @param object $intent Stripe's API Payment Intent object.
+	 * @param object $intent Stripe API Payment Intent object response.
 	 *
 	 * @return object
 	 */

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -845,7 +845,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 			case 'payment_intent.succeeded':
 			case 'payment_intent.amount_capturable_updated':
-				$charge = end( $intent->charges->data );
+				$charge = $this->get_latest_charge_from_intent( $intent );
+
 				WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
 
 				do_action( 'wc_gateway_stripe_process_payment', $charge, $order );

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.1.0 - 2022-xx-xx =
+* Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2488
More context: p1670013028525619/1668541074.915399-slack-CHG7MTCAF

**TL;DR:** Starting from [API version 2022-11-15](https://stripe.com/docs/upgrades#2022-11-15), the `charges` prop was removed from the PaymentIntent object.

In the plugin, the API version is [overwritten](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/1833465bc14d3a699abec9ec7d4f64b0fbdb4f24/includes/class-wc-stripe-api.php#L17) when making requests to the Stripe API, but for incoming webhooks, there's no way to overwrite the version. This PR makes the webhook handler compatible with the `charges` prop removal.

## Changes proposed in this Pull Request:

- If the `charges` prop is missing, make a request to the `charges` endpoint to expand the ID from `latest_charge`.

## Testing instructions

You'll need a standard Stripe account with its [API version](https://dashboard.stripe.com/developers) set to anything prior to [2022-11-15](https://stripe.com/docs/upgrades#2022-11-15) (not marked as default in the dashboard). The WCPay Dev (Express) account can be used if you don't have a personal test account.

1. Expose your local environment publicly. You can use Ngrok or JT. (For valet: `cd valet/stripe && valet unsecure && valet share`.
2. Create a new webhook endpoint from the [Stripe dashboard](https://dashboard.stripe.com/test/webhooks).
   i. Use the URL from the **Stripe plugin settings > Settings > Account details**.
   ii. **Add events > Select all events**.
   iii. Select API version 2022-11-15.
4. Add the endpoint and copy the webhook signing secret. Paste the secret into the plugin test webhook secret.
5. Enable UPE.
6. Test the checkout with Bancontact, a regular card and a 3DS card. Ensure the checkout doesn't return any errors, the charge succeeds in Stripe and there are no errors in the order notes from WC.

**Note:** There might be duplicate order notes for card payments processed from webhooks using the latest API version I'm investigating this as a separate issue.

If you test the above from `develop`, an error is thrown for Bancontact checkouts, and the order remains on-hold in WC.

You can make sure this is BW compatible with the previous versions by disabling the 2022-11-15 webhook and testing this PR with a different endpoint with an older version.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)