### PR TITLE
Fix refunds on Stripe API 2022-11-15

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.1.0 - 2022-xx-xx =
 * Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.
+* Fix - Expand refunds on charge object from incoming webhooks using Stripe API version 2022-11-15.
 
 = 7.0.1 - 2022-11-11 =
 * Fix - Issue where subscription renewal payments were being charged twice no longer present.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -648,16 +648,17 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since x.x.x
 	 * @param string $charge_id The charge ID to get charge object for.
+	 * @param array  $params    The parameters to pass to the request.
 	 *
 	 * @throws WC_Stripe_Exception Error while retrieving charge object.
 	 * @return string|object
 	 */
-	public function get_charge_object( $charge_id = '' ) {
+	public function get_charge_object( $charge_id = '', $params = [] ) {
 		if ( empty( $charge_id ) ) {
 			return '';
 		}
 
-		$charge_object = WC_Stripe_API::retrieve( 'charges/' . $charge_id );
+		$charge_object = WC_Stripe_API::request( $params, 'charges/' . $charge_id, 'GET' );
 
 		if ( ! empty( $charge_object->error ) ) {
 			throw new WC_Stripe_Exception( print_r( $charge_object, true ), $charge_object->error->message );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -771,7 +771,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Gets the refund object from notification.
+	 * Gets the first refund object from charge notification.
 	 *
 	 * @since x.x.x
 	 * @param object $notification
@@ -779,14 +779,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return object
 	 */
 	public function get_refund_object( $notification ) {
+		// Since API version 2022-11-15, the Charge object no longer expands `refunds` by default.
+		// We can remove this once we drop support for API versions prior to 2022-11-15.
 		if ( ! empty( $notification->data->object->refunds->data[0] ) ) {
 			return $notification->data->object->refunds->data[0];
 		}
 
-		if ( ! empty( $notification->data->object->id ) ) {
-			$charge = $this->get_charge_object( $notification->data->object->id, [ 'expand' => [ 'refunds' ] ] );
-			return $charge->refunds->data[0];
-		}
+		$charge = $this->get_charge_object( $notification->data->object->id, [ 'expand' => [ 'refunds' ] ] );
+		return $charge->refunds->data[0];
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 7.1.0 - 2022-xx-xx =
 * Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.
+* Fix - Expand refunds on charge object from incoming webhooks using Stripe API version 2022-11-15.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2497 
Related to #2493

TL;DR: Starting from [API version 2022-11-15](https://stripe.com/docs/upgrades#2022-11-15), the Charge object no longer auto-expands refunds by default.

In the plugin, the API version is [overwritten](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/1833465bc14d3a699abec9ec7d4f64b0fbdb4f24/includes/class-wc-stripe-api.php#L17) when making requests to the Stripe API, but for incoming webhooks, there's no way to overwrite the version, causing the webhooks to fail. This PR makes the webhook handler compatible with refunds.

## Changes proposed in this Pull Request:

- Explicitly expand `refunds` when retrieving a Charge object from a webhook notification.

## Testing instructions

You'll need a standard Stripe account with its [API version](https://dashboard.stripe.com/developers) set to anything prior to [2022-11-15](https://stripe.com/docs/upgrades#2022-11-15) (not marked as default in the dashboard). The WCPay Dev (Express) account can be used if you don't have a personal test account.

1. Expose your local environment publicly. You can use Ngrok or JT. (For valet: `cd valet/stripe && valet unsecure && valet share`).
2. Create a new webhook endpoint from the [Stripe dashboard](https://dashboard.stripe.com/test/webhooks).
   i. Use the URL from the **Stripe plugin settings > Settings > Account details**.
   ii. **Add events > Select all events**.
   iii. Select API version `2022-11-15`.
3. Add the endpoint and copy the webhook signing secret. Paste the secret into the plugin test webhook secret.
4. As a shopper, checkout with card.
5. Ensure refunds work:
   a. Ensure refunding from the Stripe dashboard works (Click the charge ID from the WC order and click "Refund" from the Stripe dashboard).
   b. Ensure refunding from "Edit order" works (**WC > Orders > Edit order > Refund > Refund `X` via Stripe**).
   c. Ensure partial refunds work from the Stripe dashboard and from Edit order. (Once the order is completely refunded, its status is changed to "Refunded").
   d. Ensure refunding a charge authorization works. ("Issue an authorization on checkout, and capture later" must be enabled from WC Stripe settings).

**Note:** To make sure a refund works:
- The charge status must be set to "refunded" in the Stripe dashboard;
- No errors should be thrown in Stripe logs;
- The status must be changed to "Refunded" when the order is completely refunded, and;
- There must be no errors in the order notes.

To make sure the changes are BW compatible with API versions prior to `2022-11-15`, please disable the `2022-11-15` webhook endpoint, create a new one using a previous API version (don't forget to change the webhook signing secret), and test steps 4 and 5.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
