### PR TITLE
Add localized error message to result (e.g. Card declined)

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -503,8 +503,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$order->update_status( 'failed' );
 
 			return [
-				'result'   => 'fail',
-				'redirect' => '',
+				'result'     => 'fail',
+				'result_msg' => $e->getLocalizedMessage(),
+				'redirect'   => '',
 			];
 		}
 	}


### PR DESCRIPTION
<!--
Stripe Response Message on fail
-->

<!--
https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2495
-->

Fixes #

Add Response Message why Creditcard is not accepted.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

No test needed just add the same data, already added into woocommerce notices (now also as return)

-   [X] Covered with tests