### PR TITLE
Add E2E test for full order refund

### DIFF
--- a/tests/e2e/config/global-setup.js
+++ b/tests/e2e/config/global-setup.js
@@ -117,7 +117,7 @@ module.exports = async ( config ) => {
 		page: adminPage,
 		username: ADMIN_USER,
 		password: ADMIN_PASSWORD,
-		statePath: ADMINSTATE,
+		statePath: process.env.ADMINSTATE,
 		retries: 5,
 	} )
 		.then( async () => {

--- a/tests/e2e/tests/order/full-refund.spec.js
+++ b/tests/e2e/tests/order/full-refund.spec.js
@@ -1,0 +1,105 @@
+import stripe from 'stripe';
+import { test, expect } from '@playwright/test';
+import config from 'config';
+import { payments } from '../../utils';
+
+const {
+	emptyCart,
+	setupProductCheckout,
+	setupCheckout,
+	fillCardDetails,
+} = payments;
+
+test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
+	let orderId, stripeChargeId, stripeRefundId;
+
+	const adminContext = await browser.newContext( {
+		storageState: process.env.ADMINSTATE,
+	} );
+	const adminPage = await adminContext.newPage();
+
+	const userContext = await browser.newContext();
+	const userPage = await userContext.newPage();
+
+	await test.step( 'customer checkout with Stripe', async () => {
+		await emptyCart( userPage );
+
+		await setupProductCheckout( userPage );
+		await setupCheckout(
+			userPage,
+			config.get( 'addresses.customer.billing' )
+		);
+
+		await fillCardDetails( userPage, config.get( 'cards.basic' ) );
+		await userPage.locator( 'text=Place order' ).click();
+		await userPage.waitForNavigation();
+
+		await expect( userPage.locator( 'h1.entry-title' ) ).toHaveText(
+			'Order received'
+		);
+
+		const orderUrl = await userPage.url();
+		orderId = orderUrl.split( 'order-received/' )[ 1 ].split( '/?' )[ 0 ];
+	} );
+
+	await test.step(
+		'merchant issue a full refund in the dashboard',
+		async () => {
+			await adminPage.goto(
+				`/wp-admin/post.php?post=${ orderId }&action=edit`
+			);
+
+			// Ensure this isn't already refunded.
+			await expect( adminPage.locator( '.order_notes' ) ).not.toHaveText(
+				/Refunded .* – Refund ID: .* – Reason:.*/
+			);
+
+			stripeChargeId = await adminPage
+				.locator( '.woocommerce-order-data__meta a' )
+				.innerText();
+
+			await adminPage
+				.locator( '#woocommerce-order-items button.refund-items' )
+				.click();
+			await adminPage.locator( '.refund_order_item_qty' ).fill( '1' );
+
+			adminPage.on( 'dialog', ( dialog ) => dialog.accept() );
+			await adminPage
+				.locator( '.refund-actions .button.do-api-refund' )
+				.filter( { hasText: /Refund.*via Stripe/ } )
+				.click();
+
+			await adminPage.waitForNavigation();
+
+			// Ensure the order status is updated.
+			await expect( adminPage.locator( '#order_status' ) ).toHaveValue(
+				'wc-refunded'
+			);
+
+			// Ensure the refund note is present.
+			await expect( adminPage.locator( '.order_notes' ) ).toHaveText(
+				/Refunded .* – Refund ID: .* – Reason:.*/
+			);
+
+			stripeRefundId = await adminPage
+				.locator( '.order_notes' )
+				.filter( {
+					hasText: /Refunded .* – Refund ID: .* – Reason:.*/,
+				} )
+				.innerText()
+				.then(
+					( text ) =>
+						text.match( /(?<=Refund ID: ).*?(?= – Reason)/ )[ 0 ]
+				);
+		}
+	);
+
+	await test.step( 'check Stripe payment status ', async () => {
+		const stripeClient = stripe( process.env.STRIPE_SECRET_KEY );
+
+		const charge = await stripeClient.charges.retrieve( stripeChargeId );
+
+		expect( charge.refunded ).toBeTruthy();
+		expect( charge.refunds.data[ 0 ].id ).toBe( stripeRefundId );
+	} );
+} );


### PR DESCRIPTION
Closes #2504

## Changes proposed in this Pull Request:

This PR adds the [Merchant - Order: Full refund](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#full-refund) E2E test case.

## Testing instructions

1. Follow the instructions [here](https://github.com/woocommerce/woocommerce-gateway-stripe/tree/develop/tests/e2e)  to setup a new E2E environment using a jurassic ninja site.

`npm run test:e2e-setup -- --base_url=https://testsite.url`

2. Run all the E2E tests:

`npm run test:e2e -- --base_url=https://testsite.url`

**All tests should pass**

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
