### PR TITLE
Declare HPOS as compatible

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 7.1.0 - 2022-xx-xx =
+* Update – Declare compatibility with HPOS.
 
 = 7.0.2 - 2023-01-11 =
 * Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.1.0 - 2022-xx-xx =
+* Update – Declare compatibility with HPOS.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -777,7 +777,7 @@ add_action(
 	'before_woocommerce_init',
 	function() {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 		}
 	}
 );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2407

## Changes proposed in this Pull Request:

Declares the Stripe plugin compatible with HPOS/COT after testing the plugin and its integration with WC Subscriptions.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

- Make sure you have the latest WooCommerce version installed.
- Pull this branch.
- Run the following command to know if WC Stripe is declared as compatible. You'll need [wp cli](https://wp-cli.org/)

```bash
wp eval 'do_action("before_woocommerce_init"); print_r(Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_features_for_plugin("woocommerce-gateway-stripe/woocommerce-gateway-stripe.php"));'
```

The output should be similar to this:

```
Array
(
    [incompatible] => Array
        (
        )

    [compatible] => Array
        (
            [0] => custom_order_tables
        )

)
```

- We can clearly see the feature is declared as compatible with our plugin.
- Run the following command to get the list of compatible plugins with HPOS/COT.

```bash
wp eval 'do_action("before_woocommerce_init"); print_r(Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_plugins_for_feature("custom_order_tables"));'
```

The output should be similar to this:

```
Array
(
    [compatible] => Array
        (
            [0] => woocommerce-gateway-stripe/woocommerce-gateway-stripe.php
        )

    [incompatible] => Array
        (
        )

)
```

You should see the path of the plugin main file in the "compatible" group.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)