### PR TITLE
Fix Subscriptions flows incompatible with HPOS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
-= 7.1.0 - 2022-xx-xx =
+= 7.1.0 - 2023-xx-xx =
+* Fix - Replace some post meta methods with equivalent methods compatible with HPOS.
 
 = 7.0.2 - 2023-01-11 =
 * Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -445,8 +445,10 @@ class WC_Stripe_Helper {
 				[
 					'limit'      => 1,
 					'meta_query' => [
-						'key'   => '_stripe_intent_id',
-						'value' => $intent_id,
+						[
+							'key'   => '_stripe_intent_id',
+							'value' => $intent_id,
+						],
 					],
 				]
 			);

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -380,8 +380,10 @@ class WC_Stripe_Helper {
 				[
 					'limit'      => 1,
 					'meta_query' => [
-						'key'   => '_stripe_source_id',
-						'value' => $source_id,
+						[
+							'key'   => '_stripe_source_id',
+							'value' => $source_id,
+						],
 					],
 				]
 			);
@@ -479,8 +481,10 @@ class WC_Stripe_Helper {
 				[
 					'limit'      => 1,
 					'meta_query' => [
-						'key'   => '_stripe_setup_intent',
-						'value' => $intent_id,
+						[
+							'key'   => '_stripe_setup_intent',
+							'value' => $intent_id,
+						],
 					],
 				]
 			);

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -381,13 +381,15 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		foreach ( $subscriptions as $subscription ) {
 			$subscription_id = $subscription->get_id();
-			update_post_meta( $subscription_id, '_stripe_customer_id', $source->customer );
+			$subscription->update_meta_data( '_stripe_customer_id', $source->customer );
 
 			if ( ! empty( $source->payment_method ) ) {
-				update_post_meta( $subscription_id, '_stripe_source_id', $source->payment_method );
+				$subscription->update_meta_data( '_stripe_source_id', $source->payment_method );
 			} else {
-				update_post_meta( $subscription_id, '_stripe_source_id', $source->source );
+				$subscription->update_meta_data( '_stripe_source_id', $source->source );
 			}
+
+			$subscription->save();
 		}
 	}
 
@@ -397,12 +399,12 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_resubscribe_meta( $resubscribe_order ) {
-		delete_post_meta( $resubscribe_order->get_id(), '_stripe_customer_id' );
-		delete_post_meta( $resubscribe_order->get_id(), '_stripe_source_id' );
+		$resubscribe_order->delete_meta_data( '_stripe_customer_id' );
+		$resubscribe_order->delete_meta_data( '_stripe_source_id' );
 		// For BW compat will remove in future.
-		delete_post_meta( $resubscribe_order->get_id(), '_stripe_card_id' );
+		$resubscribe_order->delete_meta_data( '_stripe_card_id' );
 		// Delete payment intent ID.
-		delete_post_meta( $resubscribe_order->get_id(), '_stripe_intent_id' );
+		$resubscribe_order->delete_meta_data( '_stripe_intent_id' );
 		$this->delete_renewal_meta( $resubscribe_order );
 	}
 
@@ -416,7 +418,7 @@ trait WC_Stripe_Subscriptions_Trait {
 		WC_Stripe_Helper::delete_stripe_net( $renewal_order );
 
 		// Delete payment intent ID.
-		delete_post_meta( $renewal_order->get_id(), '_stripe_intent_id' );
+		$renewal_order->delete_meta_data( '_stripe_intent_id' );
 
 		return $renewal_order;
 	}
@@ -430,8 +432,8 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * @return void
 	 */
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
-		update_post_meta( $subscription->get_id(), '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
-		update_post_meta( $subscription->get_id(), '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
+		$subscription->update_meta_data( '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
+		$subscription->update_meta_data( '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
 	}
 
 	/**
@@ -446,21 +448,22 @@ trait WC_Stripe_Subscriptions_Trait {
 	 */
 	public function add_subscription_payment_meta( $payment_meta, $subscription ) {
 		$subscription_id = $subscription->get_id();
-		$source_id       = get_post_meta( $subscription_id, '_stripe_source_id', true );
+		$source_id       = $subscription->get_meta( '_stripe_source_id', true );
 
 		// For BW compat will remove in future.
 		if ( empty( $source_id ) ) {
-			$source_id = get_post_meta( $subscription_id, '_stripe_card_id', true );
+			$source_id = $subscription->get_meta( '_stripe_card_id', true );
 
 			// Take this opportunity to update the key name.
-			update_post_meta( $subscription_id, '_stripe_source_id', $source_id );
-			delete_post_meta( $subscription_id, '_stripe_card_id', $source_id );
+			$subscription->update_meta_data( '_stripe_source_id', $source_id );
+			$subscription->delete_meta_data( '_stripe_card_id' );
+			$subscription->save();
 		}
 
 		$payment_meta[ $this->id ] = [
 			'post_meta' => [
 				'_stripe_customer_id' => [
-					'value' => get_post_meta( $subscription_id, '_stripe_customer_id', true ),
+					'value' => $subscription->get_meta( '_stripe_customer_id', true ),
 					'label' => 'Stripe Customer ID',
 				],
 				'_stripe_source_id'   => [
@@ -527,18 +530,19 @@ trait WC_Stripe_Subscriptions_Trait {
 			return $payment_method_to_display;
 		}
 
-		$stripe_source_id = get_post_meta( $subscription->get_id(), '_stripe_source_id', true );
+		$stripe_source_id = $subscription->get_meta( '_stripe_source_id', true );
 
 		// For BW compat will remove in future.
 		if ( empty( $stripe_source_id ) ) {
-			$stripe_source_id = get_post_meta( $subscription->get_id(), '_stripe_card_id', true );
+			$stripe_source_id = $subscription->get_meta( '_stripe_card_id', true );
 
 			// Take this opportunity to update the key name.
-			update_post_meta( $subscription->get_id(), '_stripe_source_id', $stripe_source_id );
+			$subscription->update_meta_data( '_stripe_source_id', $stripe_source_id );
+			$subscription->save();
 		}
 
 		$stripe_customer    = new WC_Stripe_Customer();
-		$stripe_customer_id = get_post_meta( $subscription->get_id(), '_stripe_customer_id', true );
+		$stripe_customer_id = $subscription->get_meta( '_stripe_customer_id', true );
 
 		// If we couldn't find a Stripe customer linked to the subscription, fallback to the user meta data.
 		if ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) {
@@ -557,15 +561,16 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		// If we couldn't find a Stripe customer linked to the account, fallback to the order meta data.
 		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->get_parent() ) {
-			$stripe_customer_id = get_post_meta( $subscription->get_parent_id(), '_stripe_customer_id', true );
-			$stripe_source_id   = get_post_meta( $subscription->get_parent_id(), '_stripe_source_id', true );
+			$parent_order = wc_get_order( $subscription->get_parent_id() );
+			$stripe_customer_id = $parent_order->get_meta( '_stripe_customer_id', true );
+			$stripe_source_id   = $parent_order->get_meta( '_stripe_source_id', true );
 
 			// For BW compat will remove in future.
 			if ( empty( $stripe_source_id ) ) {
-				$stripe_source_id = get_post_meta( $subscription->get_parent_id(), '_stripe_card_id', true );
+				$stripe_source_id = $parent_order->get_meta( '_stripe_card_id', true );
 
 				// Take this opportunity to update the key name.
-				update_post_meta( $subscription->get_parent_id(), '_stripe_source_id', $stripe_source_id );
+				$parent_order->update_meta_data( '_stripe_source_id', $stripe_source_id );
 			}
 		}
 

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -406,6 +406,7 @@ trait WC_Stripe_Subscriptions_Trait {
 		// Delete payment intent ID.
 		$resubscribe_order->delete_meta_data( '_stripe_intent_id' );
 		$this->delete_renewal_meta( $resubscribe_order );
+		$resubscribe_order->save();
 	}
 
 	/**
@@ -434,6 +435,7 @@ trait WC_Stripe_Subscriptions_Trait {
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
 		$subscription->update_meta_data( '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
 		$subscription->update_meta_data( '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
+		$subscription->save();
 	}
 
 	/**
@@ -571,6 +573,7 @@ trait WC_Stripe_Subscriptions_Trait {
 
 				// Take this opportunity to update the key name.
 				$parent_order->update_meta_data( '_stripe_source_id', $stripe_source_id );
+				$parent_order->save();
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.1.0 - 2022-xx-xx =
+= 7.1.0 - 2023-xx-xx =
+* Fix - Replace some post meta methods with equivalent methods compatible with HPOS.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2531 

## Changes proposed in this Pull Request:

Replace all post meta usage with subscription methods that deal with the meta tags properly regardless HPOS is enabled or not.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Set up a store with WooCommerce Subscriptions 4.8.0, latest WooCommerce and Stripe in this branch.
2. [Enable HPOS](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Enabling-High-Performance-Order-Storage-(HPOS)).
3. Test and confirm the following flows work as expected:
  - [Shopper - Subscriptions - Change payment method to new card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#change-payment-method-to-new-card).
  - [Shopper - Subscriptions - Change payment method to saved card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#change-payment-method-to-saved-card).
  - [Shopper - Subscriptions - Set default payment method](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#set-default-payment-method).
  - [Shopper - Subscriptions - Change default payment method](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#change-default-payment-method).

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
