### PR TITLE
Bump minimum supported version numbers to L-2

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,18 +16,18 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '7.0.0'
+            woocommerce: '7.3.0'
           - woocommerce_support_policy: L-1
-            woocommerce: '6.9.4'
+            woocommerce: '7.2.3'
           - woocommerce_support_policy: L-2
-            woocommerce: '6.8.2'
+            woocommerce: '7.1.1'
           # WordPress
           - wordpress_support_policy: L
-            wordpress: '6.0'
+            wordpress: '6.1'
           - wordpress_support_policy: L-1
-            wordpress: '5.9'
+            wordpress: '6.0'
           - wordpress_support_policy: L-2
-            wordpress: '5.8'
+            wordpress: '5.9'
           # PHP
           - php_support_policy: L
             php: '8.0'

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -18,9 +18,9 @@ jobs:
           - woocommerce_support_policy: L
             woocommerce: '7.3.0'
           - woocommerce_support_policy: L-1
-            woocommerce: '7.2.3'
-          - woocommerce_support_policy: L-2
             woocommerce: '7.1.1'
+          - woocommerce_support_policy: L-2
+            woocommerce: '6.9.0'
           # WordPress
           - wordpress_support_policy: L
             wordpress: '6.1'

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.1.0 - 2023-xx-xx =
 * Fix - Replace some post meta methods with equivalent methods compatible with HPOS.
+* Tweak - Update minimum supported versions for WordPress, WooCommerce, and PHP.
 
 = 7.0.2 - 2023-01-11 =
 * Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
 Requires at least: 5.9
 Tested up to: 6.1
-Requires PHP: 7.1
+Requires PHP: 7.3
 Stable tag: 7.0.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === WooCommerce Stripe Payment Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, sofort, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
-Requires at least: 5.7
-Tested up to: 6.0
-Requires PHP: 7.0
+Requires at least: 5.9
+Tested up to: 6.1
+Requires PHP: 7.1
 Stable tag: 7.0.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -6,10 +6,10 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Version: 7.0.2
- * Requires at least: 5.8
- * Tested up to: 6.0
- * WC requires at least: 6.8
- * WC tested up to: 7.0
+ * Requires at least: 5.9
+ * Tested up to: 6.1
+ * WC requires at least: 6.9
+ * WC tested up to: 7.3
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */
@@ -23,8 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WC_STRIPE_VERSION', '7.0.2' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.3.0' );
-define( 'WC_STRIPE_MIN_WC_VER', '6.8' );
-define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '6.9' );
+define( 'WC_STRIPE_MIN_WC_VER', '6.9' );
+define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '7.1' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_ABSPATH', __DIR__ . '/' );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );


### PR DESCRIPTION
## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Bump minimum supported versions to L-2 — or in the case of WC to the next designated min supported version.
    - Bump WC min to 6.9.0; that was the previously designated "next min WC version".
    - Bump next WC min version to 7.1.0.
    - Bump PHP min version from 7.0 to 7.3.
    - Bump WP min version to 5.9.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Make sure the version numbers match the L-2 expectations.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
