### PR TITLE
Fix UPE payment webhook race condition

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.1.0 - 2023-xx-xx =
 * Fix - Replace some post meta methods with equivalent methods compatible with HPOS.
+* Fix - Rare cases of payment processing failing when webhooks arrive before customer is redirected when UPE is enabled will no longer occur.
 
 = 7.0.2 - 2023-01-11 =
 * Fix - Expand charges object from incoming webhooks using Stripe API version 2022-11-15.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -851,6 +851,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		// TODO: This is a stop-gap to fix a critical issue, see
+		// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
+		// be better if we removed the need for additional meta data in favor of refactoring
+		// this part of the payment processing.
+		if ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) {
+			return;
+		}
+
 		if ( $this->lock_order_payment( $order, $intent ) ) {
 			return;
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -851,14 +851,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		// TODO: This is a stop-gap to fix a critical issue, see
-		// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
-		// be better if we removed the need for additional meta data in favor of refactoring
-		// this part of the payment processing.
-		if ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) {
-			return;
-		}
-
 		if ( $this->lock_order_payment( $order, $intent ) ) {
 			return;
 		}
@@ -878,6 +870,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$charge = $this->get_latest_charge_from_intent( $intent );
 
 				WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
+
+				// TODO: This is a stop-gap to fix a critical issue, see
+				// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
+				// be better if we removed the need for additional meta data in favor of refactoring
+				// this part of the payment processing.
+				if ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) {
+					return;
+				}
 
 				do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -575,6 +575,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				WC_Stripe_Helper::add_payment_intent_to_order( $payment_intent_id, $order );
 				$order->update_status( 'pending', __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
 				$order->update_meta_data( '_stripe_upe_payment_type', $selected_upe_payment_type );
+
+				// TODO: This is a stop-gap to fix a critical issue, see
+				// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
+				// be better if we removed the need for additional meta data in favor of refactoring
+				// this part of the payment processing.
+				$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
+
 				$order->save();
 
 				$this->stripe_request(
@@ -943,6 +950,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->save_intent_to_order( $order, $intent );
 		$this->set_payment_method_title_for_order( $order, $payment_method_type );
 		$order->update_meta_data( '_stripe_upe_redirect_processed', true );
+
+		// TODO: This is a stop-gap to fix a critical issue, see
+		// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
+		// be better if we removed the need for additional meta data in favor of refactoring
+		// this part of the payment processing.
+		$order->delete_meta_data( '_stripe_upe_waiting_for_redirect' );
+
 		$order->save();
 	}
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -239,6 +239,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
 		$order->update_meta_data( '_stripe_upe_payment_type', '' );
+		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 		$order->save();
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
@@ -1038,6 +1039,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
 		$order->update_meta_data( '_stripe_upe_payment_type', '' );
+		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 		$order->save();
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Stop-gap fix for https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536.

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

- Add `_stripe_upe_waiting_for_redirect` meta to orders before sending a `POST /intents` request to the Stripe API in the `UPE::process_payment()` function.
- Delete `_stripe_upe_waiting_for_redirect` meta from orders after successfully processing a redirect to the **Order Received** page following a payment via UPE.
- Check the order meta for the presence of a `_stripe_upe_waiting_for_redirect` meta value that's `true` before processing a `payment_intent.succeeded` event.

No automated tests since it's difficult to simulate the conditions under which this issue occurs.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

> **Warning**
> You **must** be using UPE on your test store to reproduce the issue.

> **Warning**
> You **must** have webhooks set up correctly on your test store to reproduce the issue.

1. Set a breakpoint [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/cb47c373ee53a5378227b25c637bc2b455226308/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L813) and start your debugger.
2. Add a subscription product to your cart.
3. Go to the checkout and complete a payment successfully, e.g. with `4242 4242 4242 4242`.
4. Let the debugger sit on the breakpoint until you're sure the webhook has been processed. Check your Stripe dashboard or Stripe CLI logs to be extra sure.
5. Once the webhook is processed you can safely `continue` the debugger and stop it.
6. Now go check **My Account** &rarr; **Payment Methods**; the card you just used should be saved there.
7. Follow the [Merchant - Renew subscription automatically](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#renew-subscription-automatically) critical flow; the renewal should succeed.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
