### PR TITLE
Bump minimum supported version numbers to L-2 

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '7.3.0'
+            woocommerce: '7.4.1'
           - woocommerce_support_policy: L-1
-            woocommerce: '7.1.1'
+            woocommerce: '7.2.3'
           - woocommerce_support_policy: L-2
-            woocommerce: '6.9.0'
+            woocommerce: '7.1.1'
           # WordPress
           - wordpress_support_policy: L
             wordpress: '6.1'

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -8,8 +8,8 @@
  * Version: 7.1.0
  * Requires at least: 5.9
  * Tested up to: 6.1
- * WC requires at least: 6.9
- * WC tested up to: 7.3
+ * WC requires at least: 7.1
+ * WC tested up to: 7.4
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */
@@ -23,8 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WC_STRIPE_VERSION', '7.1.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.3.0' );
-define( 'WC_STRIPE_MIN_WC_VER', '6.9' );
-define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '7.1' );
+define( 'WC_STRIPE_MIN_WC_VER', '7.1' );
+define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '7.2' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_ABSPATH', __DIR__ . '/' );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Bump minimum supported versions to L-2 — or in the case of WC to the next designated min supported version.
- Bump WC min to `7.1` (or the previously designated "next min WC version").
- Bump next WC min version to `7.2`. – The only thing that bothers me is that we don't test against the previous WC release `7.3` because:

  ```
   L   = 7.4.1 (Latest release)
   L-1 = Either 7.3.0 or 7.2.3 - Chose 7.2.3. Unless it has to be the next future min version then it's OK.
   L-2 = 7.1.1 (Previous future minimum version so we have to support this one)
  ```
- ~Decrease the PHP min supported version to `7.2`~ Kept the "Requires PHP" version since we haven't updated it in a while and don't know exactly why. Latest PHP version is `8.2` and the min PHP version we support (`7.3`) [isn't even supported by PHP](https://www.php.net/supported-versions.php). And there's also this [comment](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2539/files#r1129360828). 
- Keep WP min version to `5.9` since there's no new WP releases since last release.


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Make sure the version numbers match the L-2 expectations.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
