### PR TITLE
Fix subscription renewal for subscriptions without parent orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 7.4.0 - 2023-xx-xx =
-* 
+* Fix - Issue processing renewals for subscriptions without parent orders.
 
 = 7.3.0 - 2023-04-12 =
 * Fix - The payment requests are updated when product add-ons are changed (Product Add-ons extension).

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -569,10 +569,12 @@ trait WC_Stripe_Subscriptions_Trait {
 			$parent_order_id = $renewal_order->get_parent_id();
 			$parent_order    = wc_get_order( $parent_order_id );
 
-			$mandate = $parent_order->get_meta( '_stripe_mandate_id', true );
-			if ( isset( $request['confirm'] ) && filter_var( $request['confirm'], FILTER_VALIDATE_BOOL ) && ! empty( $mandate ) ) {
-				$request['mandate'] = $mandate;
-				return $request;
+			if ( $parent_order ) {
+				$mandate = $parent_order->get_meta( '_stripe_mandate_id', true );
+				if ( ! empty( $mandate ) ) {
+					$request['mandate'] = $mandate;
+					return $request;
+				}
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.4.0 - 2023-xx-xx =
-* 
+* Fix - Issue processing renewals for subscriptions without parent orders.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2595 

## Changes proposed in this Pull Request:

Fixes a fatal error introduced with eMandates support that prevents a subscription renewal without a parent order.

## Testing instructions

### Testing the fix
1. Create a new subscription in the wp-admin and do not assign a parent order.
2. Add the Stripe payment method to the newly created subscription.
3. Save the subscription.
4. Go to the subscription edit page and click on Subscription Actions, then choose Process renewal.
5. Verify that the renewal order can be paid and that the subscription is updated accordingly.

### Testing eMandates for subscriptions in INR
- Test [these flows](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-testing-instructions-for-the-WooCommerce-Stripe-payment-gateway-7.3.0#testing-support-for-emandates-for-recurring-payments-using-inr-as-the-currency) from the `7.3.0` release. _(Not all the critical flows, only the subscription ones listed in the instructions)_

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
