### PR TITLE
Bump minimum supported versions of WP and WC

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,18 +16,18 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '7.4.1'
+            woocommerce: '7.6.1'
           - woocommerce_support_policy: L-1
-            woocommerce: '7.2.3'
+            woocommerce: '7.5.1'
           - woocommerce_support_policy: L-2
-            woocommerce: '7.1.1'
+            woocommerce: '7.4.1'
           # WordPress
           - wordpress_support_policy: L
-            wordpress: '6.1'
+            wordpress: '6.2'
           - wordpress_support_policy: L-1
-            wordpress: '6.0'
+            wordpress: '6.1'
           - wordpress_support_policy: L-2
-            wordpress: '5.9'
+            wordpress: '6.0'
           # PHP
           - php_support_policy: L
             php: '8.0'

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -6,10 +6,10 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Version: 7.3.0
- * Requires at least: 5.9
+ * Requires at least: 6.0
  * Tested up to: 6.1.1
- * WC requires at least: 7.1
- * WC tested up to: 7.5
+ * WC requires at least: 7.4
+ * WC tested up to: 7.6
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */
@@ -23,8 +23,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WC_STRIPE_VERSION', '7.3.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.3.0' );
-define( 'WC_STRIPE_MIN_WC_VER', '7.1' );
-define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '7.2' );
+define( 'WC_STRIPE_MIN_WC_VER', '7.4' );
+define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '7.5' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_ABSPATH', __DIR__ . '/' );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugins_url( basename( plugin_dir_path( __FILE__ ) ), basename( __FILE__ ) ) ) );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -7,7 +7,7 @@
  * Author URI: https://woocommerce.com/
  * Version: 7.3.0
  * Requires at least: 6.0
- * Tested up to: 6.1.1
+ * Tested up to: 6.2
  * WC requires at least: 7.4
  * WC tested up to: 7.6
  * Text Domain: woocommerce-gateway-stripe


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

This bumps the supported versions of WordPress and WooCommerce to their latest 2 versions:

- WordPress: `6.2`, `6.1` and `6.0`
- WooCommerce: `7.6.1`, `7.5.1` and `7.4.1`

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

- Make sure all checks in this PR pass.
- Make sure the versions match the L-2 policy

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
