### PR TITLE
Add comment to don't use platform Stripe account for E2E tests

### DIFF
--- a/tests/e2e/config/local.env.example
+++ b/tests/e2e/config/local.env.example
@@ -11,7 +11,7 @@ SSH_USER=user
 SSH_PASSWORD=password
 SSH_PATH=/the/wp/directory/path/inside/server/
 
-# Stripe keys (TEST MODE ONLY). 
-# Please do not use keys for the WCPay platform acccount.
+# Stripe keys (TEST MODE). 
+# IMPORTANT: Please only use API keys from your personal Stripe account when running E2E tests.
 STRIPE_PUB_KEY=pk_test_xxx
 STRIPE_SECRET_KEY=rk_test_xxx

--- a/tests/e2e/config/local.env.example
+++ b/tests/e2e/config/local.env.example
@@ -11,6 +11,7 @@ SSH_USER=user
 SSH_PASSWORD=password
 SSH_PATH=/the/wp/directory/path/inside/server/
 
-# Stripe keys (TEST MODE ONLY)
+# Stripe keys (TEST MODE ONLY). 
+# Please do not use keys for the WCPay platform acccount.
 STRIPE_PUB_KEY=pk_test_xxx
 STRIPE_SECRET_KEY=rk_test_xxx


### PR DESCRIPTION


## Changes proposed in this Pull Request:
Adds message instructing to don't use the WCPay platform account.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

N/A

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
