### PR TITLE
[UPE Checkout] Set the logged in cookie after a guest customer has been created to fix orders stuck pending

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** Changelog ***
 
 = 7.5.0 - 2023-xx-xx =
-*
+* Fix - Resolved an issue with orders getting stuck on Pending Payment status when UPE is enabled and customer creates account during checkout.
+* Fix - Stripe source and customer tokens not being saved on subscriptions when UPE is enabled and subscription is purchased by guest customer.
 
 = 7.4.0 - 2023-05-03 =
 * Fix - Issue processing renewals for subscriptions without parent orders.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -163,6 +163,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Needed for 3DS compatibility when checking out with PRBs..
 		// Copied from WC_Gateway_Stripe::__construct().
 		add_filter( 'woocommerce_payment_successful_result', [ $this, 'modify_successful_payment_result' ], 99999, 2 );
+
+		// Update the current request logged_in cookie after a guest user is created to avoid nonce inconsistencies.
+		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
+	}
+
+	/**
+	 * Proceed with current request using new login session (to ensure consistent nonce).
+	 *
+	 * @param string $cookie New cookie value.
+	 */
+	public function set_cookie_on_current_request( $cookie ) {
+		$_COOKIE[ LOGGED_IN_COOKIE ] = $cookie;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2559 
Fixes #2317 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When using the New Checkout Experience (UPE) and guest checkout is not enabled, but account creation is allowed during checkout, orders will get stuck with Pending Payment. The payment is however successfully processed in Stripe.

This issue is caused by [this nonce check](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/b154ad8c9f72721716ca2d761861be505871b48c/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L841-L844) failing when processing the redirect payment, which then prevents the `$order->payment_complete()` from being called leaving it as pending.

The problem is very specific to the guest checkout flow when a customer is created on checkout. 

In these situations, the [nonce is created](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/b154ad8c9f72721716ca2d761861be505871b48c/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L615) after the newly created customer is logged in, but the logged_in `$_COOKIE` doesn't exist yet as we're still in the same request. Then on the redirect payment flow, we're now in a separate request and the logged-in `$_COOKIE` exists and then we try to verify the nonce.

The solution to this problem is to manually set the `$_COOKIE` when [`setcookie( LOGGED_IN_COOKIE )`](https://github.com/WordPress/wordpress-develop/blob/6.2/src/wp-includes/pluggable.php#L1067) is called (when the new guest customer is created and logged in on process checkout).

The same workaround is done in [WooCommerce Payments here](https://github.com/Automattic/woocommerce-payments/blob/d45c765c3220d4a9516d7ad0e65c96f943a4bb83/includes/class-wc-payment-gateway-wcpay.php#L441-L448).

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Make sure the WC Payments plugin is deactivated (this plugin includes the same code to manually set the cookie)
2. Enable the New Checkout Experience
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/15b45325-c2b5-4475-80ae-864152113583)
3. Navigate to the **WooCommerce > Settings > Accounts & Privacy** page and set the following settings:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/2d235a51-8f38-4e5d-828c-faf4cd89d83a)
4. While on `develop`, open a new incognito page and place an order for a regular product.
6. You will be taken to the order confirmation/thank you page
7. :x: Check the order status on the **WooCommerce > Orders** page. It will have a status of `Pending Payment`
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/05a8b5fc-02b9-4fe5-b7ee-990c24344109)
8. Check the payment in the Stripe dashboard.
9. Checkout this branch and close the incognito window and open a new one.
10. ✅ Repeat the purchase of a product as a new guest to confirm the order is set to processing in WooCommerce and payment is taken in Stripe.
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/895c69bc-219b-4221-b6f6-42e7189e5db3)



---

### Other tests I've performed

1. Purchase a regular product as a logged-in customer
2. Purchase a subscription product as guest and test renewing subscription
3. Purchase a subscription product as logged in and process renewal

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
