### PR TITLE
Fix Xdebug version on Docker setup

### DIFF
--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -1,5 +1,5 @@
-FROM wordpress:php7.3
-RUN pecl install xdebug \
+FROM wordpress:php7.4
+RUN pecl install xdebug-3.1.6 \
 	&& echo 'xdebug.mode=off' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.start_with_request=yes' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.client_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR addresses the issue of Xdebug version inconsistency in the Docker setup. The Docker image has been updated to use PHP 7.4, and the Xdebug version has been defined as 3.1.6, which is the latest version compatible with PHP 7.4. This ensures compatibility and resolves any conflicts related to Xdebug.

## Testing instructions

1. `npm run up` and ensure the setup works correctly without errors.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
