### PR TITLE
E2E: update selector for error messages in card-failure tests

### DIFF
--- a/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
+++ b/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
@@ -43,7 +43,7 @@ const testCard = async ( page, cardKey ) => {
 		expected = await page.innerText(
 			cardKey === 'cards.declined-incorrect'
 				? '.wc-card-number-element .wc-block-components-validation-error'
-				: '.wc-block-checkout__payment-method .woocommerce-error'
+				: '.wc-block-store-notice.is-error .wc-block-components-notice-banner__content'
 		);
 	}
 	expect


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Update selector for error messages in card-failure tests for the blocks plugin.

## Testing instructions

- Ensure E2E tests are working with the latest WooCommerce version.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
