### PR TITLE
Check if $intent->last_payment_error->source exists

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -133,8 +133,10 @@ class WC_Stripe_Intent_Controller {
 					// Currently, Stripe saves the payment method even if the authentication fails for 3DS cards.
 					// Although, the card is not stored in DB we need to remove the source from the customer on Stripe
 					// in order to keep the sources in sync with the data in DB.
-					$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
-					$customer->delete_source( $intent->last_payment_error->source->id );
+					if ( isset($intent->last_payment_error->source) ) {
+						$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
+						$customer->delete_source( $intent->last_payment_error->source->id );
+					}
 				} else {
 					$metadata = $intent->metadata;
 					if ( isset( $metadata->save_payment_method ) && 'true' === $metadata->save_payment_method ) {


### PR DESCRIPTION
Fixes #2615

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Set up a vanilla installation of Woo and Stripe.
Ensure debug is enabled and logging to debug.log.
Before merging those changes, and while in test mode use cards 4000000000003220 or 4000000000003063, and when the 3ds modal comes up fail the validation.
That will result in a payment intent response from the API with an last_payment_error object that does not contain the source. Check debug.log.

Try the above after merging the proposed changes.