### PR TITLE
Show Stripe Link button only if link is enabled in the settings

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -377,7 +377,9 @@ jQuery( function( $ ) {
 						return;
 					}
 
-					if ( result.link && ! wc_stripe_payment_request_params.stripe.allow_link ) {
+					const availabeTypeExceptLink = Object.keys( result ).filter( type => result[type] && type !== 'link' );
+
+					if ( availabeTypeExceptLink.length === 0 && result.link && ! wc_stripe_payment_request_params.stripe.allow_link ) {
 						return;
 					}
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -376,6 +376,11 @@ jQuery( function( $ ) {
 					if ( ! result ) {
 						return;
 					}
+
+					if ( result.link && ! wc_stripe_payment_request_params.stripe.allow_link ) {
+						return;
+					}
+
 					if ( result.applePay ) {
 						paymentRequestType = 'apple_pay';
 					} else if ( result.googlePay ) {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -377,9 +377,9 @@ jQuery( function( $ ) {
 						return;
 					}
 
-					const availabeTypeExceptLink = Object.keys( result ).filter( type => result[type] && type !== 'link' );
+					const availablePaymentRequestTypes = Object.keys( result ).filter( type => result[type] );
 
-					if ( availabeTypeExceptLink.length === 0 && result.link && ! wc_stripe_payment_request_params.stripe.allow_link ) {
+					if ( availablePaymentRequestTypes.length === 1 && result.link && ! wc_stripe_payment_request_params.stripe.allow_link ) {
 						return;
 					}
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 7.5.0 - 2023-xx-xx =
 * Fix - Gateway available in live mode without SSL.
+* Fix - Remove Stripe Link PRB when disabled from settings.
 
 = 7.4.0 - 2023-05-03 =
 * Fix - Issue processing renewals for subscriptions without parent orders.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -708,6 +708,7 @@ class WC_Stripe_Payment_Request {
 				'key'                => $this->publishable_key,
 				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
 				'locale'             => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+				'allow_link'         => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
 			],
 			'nonce'              => [
 				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 7.5.0 - 2023-xx-xx =
 * Fix - Gateway available in live mode without SSL.
+* Fix - Remove Stripe Link PRB when disabled from settings.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2479 

## Changes proposed in this Pull Request:
The Link payment request button is showing up in the cart/checkout page irrespective of the settings in the **Stripe -> Express Checkout** section. To prevent this from appearing merchants has to either disable Google/Apple Pay from the **Stripe -> Express Checkout** section or disable the Link from Stripe itself.

The reason behind this issue is when the payment request (Google/Apple) is enabled in **Stripe -> Express Checkout** settings and we check the `canMakePayment` ability in `assets/js/stripe-payment-request.js` from Stripe, it returns the status for all the types (Google Pay, Apple Pay, Link). On an incognito browser or on a browser where Google Pay or Apple Pay is not available, as the fallback it renders the next enabled method (which is Link here) if the Link payment request button is enabled in the Stripe settings.

### How to reproduce the issue
- Test on `develop` branch.
- Enable Link in payment request button on your Stripe dashboard (https://dashboard.stripe.com/settings/link)
- Go to **Stripe -> Express Checkout** settings.
- Enable Google/Apple Pay and disable Link.
- Open the browser in incognito mode (to ensure that Google/Apple Pay is not available) and add a product to the cart.
- Go to the cart page and find the `Pay with Link` button.

<img src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/4b2a6607-c3ab-46cc-ab82-3015003e0ef2" width="50%" height="50%" />


### Testing instructions
- Test on this branch.
- Enable Link in payment request button on your Stripe dashboard (https://dashboard.stripe.com/settings/link)
- Go to **Stripe -> Express Checkout** settings
- Enable Google/Apple Pay and disable Link.
- Open the browser in incognito mode (to ensure that Google/Apple Pay is not available) and add a product to the cart.
- Go to the cart page and ensure the `Pay with Link` button is not there.
- Now enable Link in **Stripe -> Express Checkout** settings.
- Reload the previous cart page incognito and ensure that the `Pay with Link` button is present.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
