### PR TITLE
Exclude link from disable upe confirmation modal

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Make the gateway unavailable when using it in live mode without SSL.
 * Fix - Remove Stripe Link PRB when disabled from settings.
 * Fix - Lookup existing refunds by refund ID when processing webhooks.
+* Fix - Exclude Link from disable UPE confirmation modal in settings.
 
 = 7.4.0 - 2023-05-03 =
 * Fix - Issue processing renewals for subscriptions without parent orders.

--- a/client/settings/general-settings-section/disable-upe-confirmation-modal.js
+++ b/client/settings/general-settings-section/disable-upe-confirmation-modal.js
@@ -88,6 +88,7 @@ const DisableUpeConfirmationModal = ( { onClose } ) => {
 	const upePaymentMethods = enabledPaymentMethodIds.filter( ( method ) => {
 		return (
 			method !== 'card' &&
+			method !== 'link' &&
 			capabilities.hasOwnProperty( `${ method }_payments` )
 		);
 	} );


### PR DESCRIPTION
## Changes proposed in this Pull Request:
When Link is enabled and a user clicks the `disable` button from the menu of the payment methods, the page goes blank. 
Excluded Link from the payment methods list displayed on the confirmation modal when the user clicks the disable button for UPE.

<img src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/535e8862-d3d2-48de-8882-72a45f5525cc" width="50%" height="50%" />

## Testing instructions
- Go to **WooCommerce -> Settings -> Payments -> Stripe**.
- Enable UPE and some payment methods from the list.
- Enable Link from the express checkout section.
- Click on the extension menu on the payment methods, then click `disable`

<img src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/83812270-809c-4358-8376-a1ea4f3531a8" width="50%" height="50%" />

- The modal should open without any issue
- On the modal, the selected methods should be listed except the express checkout methods.

<img src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/eeb1d8b4-b4a8-4fe5-b14a-ae5f7ecbde92" width="50%" height="50%" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
