### PR TITLE
Fix gateway accessible in live mode without SSL

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 7.5.0 - 2023-xx-xx =
-*
+* Fix - Gateway available in live mode without SSL.
 
 = 7.4.0 - 2023-05-03 =
 * Fix - Issue processing renewals for subscriptions without parent orders.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1836,7 +1836,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		// If no SSL bail.
-		if ( ! $this->testmode && ! is_ssl() ) {
+		if ( $this->needs_ssl_setup() ) {
 			WC_Stripe_Logger::log( 'Stripe live mode requires SSL.' );
 			return;
 		}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -268,10 +268,22 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Check if we need to make gateways available.
 	 *
 	 * @since 4.1.3
+	 * @return bool
 	 */
 	public function is_available() {
 		if ( 'yes' === $this->enabled ) {
-			return $this->are_keys_set();
+
+			// Not available if the keys aren't set.
+			if ( ! $this->are_keys_set() ) {
+				return false;
+			}
+
+			// Not available if using live mode without SSL.
+			if ( $this->needs_ssl_setup() ) {
+				return false;
+			}
+
+			return true;
 		}
 
 		return parent::is_available();
@@ -1923,5 +1935,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$stripe_params = array_merge( $stripe_params, WC_Stripe_Helper::get_localized_messages() );
 
 		return $stripe_params;
+	}
+
+	/**
+	 * Whether the store needs to use SSL.
+	 *
+	 * @return bool True if SSL is needed but not set.
+	 */
+	private function needs_ssl_setup() {
+		return ! $this->testmode && ! is_ssl();
 	}
 }

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1940,6 +1940,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	/**
 	 * Whether the store needs to use SSL.
 	 *
+	 * @since 7.5.0
 	 * @return bool True if SSL is needed but not set.
 	 */
 	private function needs_ssl_setup() {

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.5.0 - 2023-xx-xx =
-*
+* Fix - Gateway available in live mode without SSL.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -146,4 +146,72 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		remove_filter( 'pre_http_request', $callback );
 	}
+
+	public function test_are_keys_set_returns_true_in_test_mode() {
+		$this->gateway->testmode        = true;
+		$this->gateway->publishable_key = 'pk_test_key';
+		$this->gateway->secret_key      = 'sk_test_key';
+
+		$this->assertTrue( $this->gateway->are_keys_set() );
+	}
+
+	public function test_are_keys_set_returns_false_when_invalid_in_test_mode() {
+		$this->gateway->testmode        = true;
+		$this->gateway->publishable_key = 'pk_invalid_key';
+		$this->gateway->secret_key      = 'sk_invalid_key';
+
+		$this->assertFalse( $this->gateway->are_keys_set() );
+	}
+
+	public function test_are_keys_set_returns_true_in_live_mode() {
+		$this->gateway->testmode        = false;
+		$this->gateway->publishable_key = 'pk_live_key';
+		$this->gateway->secret_key      = 'sk_live_key';
+
+		$this->assertTrue( $this->gateway->are_keys_set() );
+	}
+
+	public function test_are_keys_set_returns_false_when_invalid_in_live_mode() {
+		$this->gateway->testmode        = false;
+		$this->gateway->publishable_key = 'pk_invalid_key';
+		$this->gateway->secret_key      = 'sk_invalid_key';
+
+		$this->assertFalse( $this->gateway->are_keys_set() );
+	}
+
+	public function test_is_available_returns_true_in_live_mode_with_ssl() {
+		$this->gateway->testmode        = false;
+		$this->gateway->enabled         = 'yes';
+		$this->gateway->publishable_key = 'pk_live_key';
+		$this->gateway->secret_key      = 'sk_live_key';
+
+		// Using this to manipulate is_ssl().
+		$_SERVER['HTTPS'] = 'on';
+
+		$this->assertTrue( $this->gateway->is_available() );
+	}
+
+	public function test_is_available_returns_false_in_live_mode_with_no_ssl() {
+		$this->gateway->testmode        = false;
+		$this->gateway->enabled         = 'yes';
+		$this->gateway->publishable_key = 'pk_live_key';
+		$this->gateway->secret_key      = 'sk_live_key';
+
+		// Using this to manipulate is_ssl().
+		$_SERVER['HTTPS'] = false;
+
+		$this->assertFalse( $this->gateway->is_available() );
+	}
+
+	public function test_is_available_returns_true_in_test_mode_with_no_ssl() {
+		$this->gateway->testmode        = true;
+		$this->gateway->enabled         = 'yes';
+		$this->gateway->publishable_key = 'pk_test_key';
+		$this->gateway->secret_key      = 'sk_test_key';
+
+		// Using this to manipulate is_ssl().
+		$_SERVER['HTTPS'] = false;
+
+		$this->assertTrue( $this->gateway->is_available() );
+	}
 }


### PR DESCRIPTION
Fixes #1346

## Changes proposed in this Pull Request:

* Make the gateway unavailable when in live mode and not using SSL.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

**Confirming the gateway isn't available in live mode with no SSL**
1. Set up a site with no SSL, which could be local.
2. Go to the Stripe plugin settings page ( `{site}/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` ) 
3. Enter both test and live credentials. 
  For live creds, replacing the "test" string in the test keys with "live" seems to do the trick just for testing this.
4. Use the live credentials by ensuring that the "General" -> "Enable test mode" checkbox isn't checked off.
5. As a shopper, add a product to the cart and go to the checkout page.
6. Confirm that Stripe isn't an available payment gateway.

**Confirming test mode continues to work with no SSL**
1. Continue on this site with no SSL
2. Go to the Stripe plugin settings page
4. Enable test mode by checking off the "General" -> "Enable test mode" checkbox.
5. As a shopper, add a product to the cart and go to the checkout page.
6. Confirm that Stripe is an available payment gateway and that you can place an order.

**Confirming live mode continues to work with SSL**
1. Set up a site with SSL, like a jurassic ninja one.
2. Under the Stripe plugin settings page, enter the live credentials and ensure the "Enable test mode" checkbox isn't checked off.
3. As a shopper, add a product to the cart and go to the checkout page.
4. Confirm Stripe is an available payment method.

**Confirm these behaviors stay the same with UPE enabled**
Toggle UPE under the settings page -> Advanced settings -> Enable the updated checkout experience.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
