### PR TITLE
Fix E2E tests for UPE checkout and WC Blocks < 10.0.0

### DIFF
--- a/tests/e2e/config/global-setup.js
+++ b/tests/e2e/config/global-setup.js
@@ -9,6 +9,7 @@ import {
 	setupWoo,
 	setupStripe,
 	installWooSubscriptionsFromRepo,
+	checkWooGutenbergProductsBlockVersion,
 } from '../utils/playwright-setup';
 
 dotenv.config( {
@@ -124,11 +125,13 @@ module.exports = async ( config ) => {
 	} )
 		.then( async () => {
 			const apiTokensPage = await adminContext.newPage();
+			const wooBlocksVersionPage = await adminContext.newPage();
 			const updatePluginPage = await adminContext.newPage();
 			const wooSubscriptionsInstallPage = await adminContext.newPage();
 
 			// create consumer token and update plugin in parallel.
 			let restApiKeysFinished = false;
+			let wooBlocksVersionFinished = false;
 			let pluginUpdateFinished = false;
 			let wooSubscriptionsInstallFinished = false;
 			let stripeSetupFinished = false;
@@ -140,6 +143,17 @@ module.exports = async ( config ) => {
 				.catch( () => {
 					console.error(
 						'Cannot proceed e2e test, as we could not create a WC REST API key. Please check if the test site has been setup correctly.'
+					);
+					process.exit( 1 );
+				} );
+
+			checkWooGutenbergProductsBlockVersion( wooBlocksVersionPage )
+				.then( () => {
+					wooBlocksVersionFinished = true;
+				} )
+				.catch( () => {
+					console.error(
+						'Cannot proceed e2e test, as we could not find the WC Blocks plugin version. Please check if the test site has been setup correctly.'
 					);
 					process.exit( 1 );
 				} );
@@ -208,6 +222,7 @@ module.exports = async ( config ) => {
 			while (
 				! pluginUpdateFinished ||
 				! restApiKeysFinished ||
+				! wooBlocksVersionFinished ||
 				! stripeSetupFinished ||
 				! wooSubscriptionsInstallFinished
 			) {

--- a/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
+++ b/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
@@ -43,10 +43,10 @@ const testCard = async ( page, cardKey ) => {
 		let errorSelector =
 			'.wc-block-store-notice.is-error .wc-block-components-notice-banner__content';
 
-		// Checking if the WC_BLOCKS version is defined and is smaller than 10.0.0.
+		// Checking if the WC_BLOCKS_VERSION is defined and is smaller than 10.0.0.
 		if (
-			process.env.WC_BLOCKS &&
-			parseFloat( process.env.WC_BLOCKS ) < 10.0
+			process.env.WC_BLOCKS_VERSION &&
+			parseFloat( process.env.WC_BLOCKS_VERSION ) < 10.0
 		) {
 			// If the version is smaller than 10.0.0, change the selector.
 			errorSelector =

--- a/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
+++ b/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
@@ -40,10 +40,23 @@ const testCard = async ( page, cardKey ) => {
 			.locator( '#Field-numberError' )
 			.innerText();
 	} else {
+		let errorSelector =
+			'.wc-block-store-notice.is-error .wc-block-components-notice-banner__content';
+
+		// Checking if the WC_BLOCKS version is defined and is smaller than 10.0.0.
+		if (
+			process.env.WC_BLOCKS &&
+			parseFloat( process.env.WC_BLOCKS ) < 10.0
+		) {
+			// If the version is smaller than 10.0.0, change the selector.
+			errorSelector =
+				'.wc-block-checkout__payment-method .woocommerce-error';
+		}
+
 		expected = await page.innerText(
 			cardKey === 'cards.declined-incorrect'
 				? '.wc-card-number-element .wc-block-components-validation-error'
-				: '.wc-block-store-notice.is-error .wc-block-components-notice-banner__content'
+				: errorSelector
 		);
 	}
 	expect

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -83,6 +83,10 @@ export async function fillCardDetails( page, card ) {
 			'#payment #wc-stripe-upe-element iframe'
 		);
 
+		page.locator(
+			'#payment #wc-stripe-upe-element iframe'
+		).scrollIntoViewIfNeeded();
+
 		const stripeFrame = await frameHandle.contentFrame();
 
 		await stripeFrame.fill( '[name="number"]', card.number );

--- a/tests/e2e/utils/playwright-setup.js
+++ b/tests/e2e/utils/playwright-setup.js
@@ -138,7 +138,7 @@ export const createApiTokens = ( page ) =>
 
 /**
  * Helper function to check the version of WC Blocks
- * and save it to the WC_BLOCKS env variable.
+ * and save it to the WC_BLOCKS_VERSION env variable.
  * This function is used when the admin user is already logged in.
  * @param {Page} page Playwright page object.
  * @return {Promise} Promise object represents the state of the operation.
@@ -173,7 +173,7 @@ export const checkWooGutenbergProductsBlockVersion = ( page ) =>
 						);
 					}
 
-					process.env.WC_BLOCKS = versionNumber;
+					process.env.WC_BLOCKS_VERSION = versionNumber;
 					console.log(
 						`\u2714 Checked WC Blocks version successfully. The version is ${ versionNumber }.`
 					);

--- a/tests/e2e/utils/playwright-setup.js
+++ b/tests/e2e/utils/playwright-setup.js
@@ -137,6 +137,62 @@ export const createApiTokens = ( page ) =>
 	} );
 
 /**
+ * Helper function to check the version of the 'woo-gutenberg-products-block' plugin
+ * and save it to the WC_BLOCKS env variable.
+ * This function is used when the admin user is already logged in.
+ * @param {Page} page Playwright page object.
+ * @return {Promise} Promise object represents the state of the operation.
+ */
+export const checkWooGutenbergProductsBlockVersion = ( page ) =>
+	new Promise( ( resolve, reject ) => {
+		( async () => {
+			const nRetries = 5;
+			for ( let i = 0; i < nRetries; i++ ) {
+				try {
+					console.log(
+						'- Trying to check woo-gutenberg-products-block version...'
+					);
+					await page.goto( `/wp-admin/admin.php?page=wc-status` );
+
+					await page.waitForSelector(
+						'td[data-export-label="WC Blocks Version"]'
+					);
+
+					// Use $eval to find the table cell with data-export-label="WC Blocks Version" and extract the text.
+					const versionElement = await page.$eval(
+						'td[data-export-label="WC Blocks Version"] + td + td',
+						( el ) => el.innerText
+					);
+
+					// Split and get the version number. Assuming the version text is formatted like: "9.8.2 /some/path/to/version"
+					const versionNumber = versionElement
+						.trim()
+						.split( ' ' )[ 0 ];
+
+					if ( isNaN( parseFloat( versionNumber ) ) ) {
+						throw new Error(
+							`Failed to parse woo-gutenberg-products-block version number. Got: ${ versionElement }`
+						);
+					}
+
+					process.env.WC_BLOCKS = versionNumber;
+					console.log(
+						`\u2714 Checked woo-gutenberg-products-block version successfully. The version is ${ versionNumber }.`
+					);
+					resolve();
+					return;
+				} catch ( e ) {
+					console.log(
+						`Failed to check woo-gutenberg-products-block version. Retrying... ${ i }/${ nRetries }`
+					);
+					console.log( e );
+				}
+			}
+			reject();
+		} )();
+	} );
+
+/**
  * Helper function to download the Stripe plugin from the repository and install it on the site.
  * This is useful when we want to test a specific version of the plugin.
  * If the plugin is already installed, it will be updated to the specified version.

--- a/tests/e2e/utils/playwright-setup.js
+++ b/tests/e2e/utils/playwright-setup.js
@@ -137,7 +137,7 @@ export const createApiTokens = ( page ) =>
 	} );
 
 /**
- * Helper function to check the version of the 'woo-gutenberg-products-block' plugin
+ * Helper function to check the version of WC Blocks
  * and save it to the WC_BLOCKS env variable.
  * This function is used when the admin user is already logged in.
  * @param {Page} page Playwright page object.
@@ -149,9 +149,7 @@ export const checkWooGutenbergProductsBlockVersion = ( page ) =>
 			const nRetries = 5;
 			for ( let i = 0; i < nRetries; i++ ) {
 				try {
-					console.log(
-						'- Trying to check woo-gutenberg-products-block version...'
-					);
+					console.log( '- Trying to check WC Blocks version...' );
 					await page.goto( `/wp-admin/admin.php?page=wc-status` );
 
 					await page.waitForSelector(
@@ -171,19 +169,19 @@ export const checkWooGutenbergProductsBlockVersion = ( page ) =>
 
 					if ( isNaN( parseFloat( versionNumber ) ) ) {
 						throw new Error(
-							`Failed to parse woo-gutenberg-products-block version number. Got: ${ versionElement }`
+							`Failed to parse WC Blocks version number. Got: ${ versionElement }`
 						);
 					}
 
 					process.env.WC_BLOCKS = versionNumber;
 					console.log(
-						`\u2714 Checked woo-gutenberg-products-block version successfully. The version is ${ versionNumber }.`
+						`\u2714 Checked WC Blocks version successfully. The version is ${ versionNumber }.`
 					);
 					resolve();
 					return;
 				} catch ( e ) {
 					console.log(
-						`Failed to check woo-gutenberg-products-block version. Retrying... ${ i }/${ nRetries }`
+						`Failed to check WC Blocks version. Retrying... ${ i }/${ nRetries }`
 					);
 					console.log( e );
 				}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

In this PR, we've made two key enhancements to our end-to-end (e2e) tests:

1. **CSS Selector Adjustment Based on WC Blocks Version:** Our card failure tests now select the appropriate CSS selector for error messages dynamically, according to the version of WooCommerce Blocks active on the site.

2. **UPE Form Auto-scrolling into view**: For the classic checkout, we've ensured the UPE form is scrolled into view during the tests (It does not load if it is not into the view).

These changes improve our e2e tests' reliability across different WC Blocks versions and enhance interaction with the UPE form.

## Testing instructions

1. Ensure all E2E tests pass in a test environment using WC Blocks < 10.0.0.
2. Ensure all E2E tests pass in a test environment using WC Blocks >= 10.0.0.
3. Ensure all E2E tests pass when UPE is enabled.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
