### PR TITLE
Add the tasks.json file back for xdebug in vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "shell",
+			"command": "npm run xdebug:start",
+			"label": "enable:xdebug"
+		},
+		{
+			"type": "shell",
+			"command": "npm run xdebug:stop",
+			"label": "disable:xdebug"
+		}
+	]
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Add the tasks.json file back, needed for xdebug to work in VS Code.

Discussed in p1687286940216639-slack-C01BZUL57SQ

## Testing instructions
If you don't use VS Code, passing this review to someone else is probably better.

- Open the Stripe extension directory in VS Code
- Open the debug tab (Cmd + Shift + D) and start debugging
- Confirm xdebug starts with no errors 

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)