### PR TITLE
Allow `card_` prefixed payment method IDs when attaching to a payment request

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Remove Stripe Link PRB when disabled from settings.
 * Fix - Lookup existing refunds by refund ID when processing webhooks.
 * Fix - Exclude Link from disable UPE confirmation modal in settings.
+* Fix - Resolved an issue that prevented customers using saved `card_` prefixed payment methods on checkout.
 
 = 7.4.1 - 2023-05-30 =
 * Fix - Add Order Key Validation.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -801,10 +801,17 @@ class WC_Stripe_Helper {
 	 * @return array  The updated request array.
 	 */
 	public static function add_payment_method_to_request_array( string $payment_method_id, array $request ): array {
-		if ( 0 === strpos( $payment_method_id, 'src_' ) ) {
-			$request['source'] = $payment_method_id;
-		} elseif ( 0 === strpos( $payment_method_id, 'pm_' ) ) {
-			$request['payment_method'] = $payment_method_id;
+		// Extract the payment method prefix using the first '_' character
+		$payment_method_type = substr( $payment_method_id, 0, strpos( $payment_method_id, '_' ) );
+
+		switch ( $payment_method_type ) {
+			case 'src':
+				$request['source'] = $payment_method_id;
+				break;
+			case 'pm':
+			case 'card':
+				$request['payment_method'] = $payment_method_id;
+				break;
 		}
 
 		return $request;

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 7.5.0 - 2023-xx-xx =
 * Fix - Make the gateway unavailable when using it in live mode without SSL.
 * Fix - Remove Stripe Link PRB when disabled from settings.
+* Fix - Resolved an issue that prevented customers using saved `card_` prefixed payment methods on checkout.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -57,6 +57,14 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		$this->assertEquals( $payment_method_id, $request['payment_method'] );
 	}
 
+	public function test_add_payment_method_to_request_array_should_add_card_id_to_request() {
+		$payment_method_id = 'card_mock';
+		$request           = WC_Stripe_Helper::add_payment_method_to_request_array( $payment_method_id, [] );
+
+		$this->assertArrayHasKey( 'payment_method', $request, 'Card ID was not added to request array' );
+		$this->assertEquals( $payment_method_id, $request['payment_method'] );
+	}
+
 	public function test_add_payment_method_to_request_array_should_not_add_non_source_or_payment_method_to_request() {
 		$not_a_payment_method_id = 'cus_mock';
 		$request                 = WC_Stripe_Helper::add_payment_method_to_request_array( $not_a_payment_method_id, [] );


### PR DESCRIPTION
Fixes #2608 

## Changes proposed in this Pull Request:

This PR simply allows `card_` prefixed Stripe payment method IDs to be attached to payment requests. 

As far as I am aware, `card_` prefixed payment methods were generated using legacy Stripe APIs and are no longer issued using newer versions of the Stripe plugin, however, it is possible that existing customers still have these as saved tokens.

With this in mind we do need to ensure that customers making purchases using a saved token with a the `card_` prefix are able to continue using that token.

## Testing instructions

You'll need to get your hands on a old `card_` payment method token. If you have been using the same Stripe account for many years it is possible to find one still lingering around. If not, internal a12s can reach out to me in Slack to get a set of Stripe API creds and customer tokens for testing.

### Saving a `card_` token

1. Go into your database and the `usermeta` table.
2. Make sure the `wp__stripe_customer_id` meta value matches with the customer ID in your Stripe dashboard.
3. Go into the tokens database table and make sure there's a token with the `card_` prefixed key. For example see this [screenshot](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/d1a72cb3-b3c3-48bb-82f8-110a2da7a620).
4. Lastly if you've had to get this `card_` ID from a different Stripe account, make sure the API credentials in your Stripe settings match with the account this customer and payment method are associated with. 

<p align="center">
<img width="700" alt="Screenshot 2023-07-25 at 5 36 30 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/e72a84b5-2224-44ab-9978-718b3f97358e">
<br>
<sup><strong>Stripe Dashboard</strong> - Example customer and `card_` payment method ID</sup>
</p>

### Replicating the issue

1. Make sure UPE is disabled.
   - Go to WooCommerce → Settings → Payments → Stripe → Settings. 
   - Scroll down to advanced and deactivate **"Enable the updated checkout experience"**


<p align="center">
<img width="400" alt="Screenshot 2023-07-25 at 5 43 33 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/b09f00c8-2ad7-4dae-a74b-c2d3cc714061">
</p>

2. Place a product in your cart. 
3. Go to checkout and select the saved payment method that is associated with the `card_` PM. 
4. Complete the checkout. 
5. You will land on the order received page, however if you view the order, it will be on-hold. 
6. Looking in the Stripe Dashboard and you'll see something like this: 

| WC Dashboard | Stripe |
|--------|--------|
| <img width="674" alt="Screenshot 2023-07-25 at 5 46 55 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/5873868c-fdf6-472e-ae1c-55e21af97c78"> | <img width="448" alt="Screenshot 2023-07-25 at 5 45 30 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/98671e75-80b3-4457-8e37-13d07497456c"> |
| <img width="150" alt="Screenshot 2023-07-25 at 5 47 44 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/f60a3735-dc4d-4915-a915-1b1f617bc46d"> | <img width="1010" alt="Screenshot 2023-07-25 at 5 45 36 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/3c115a76-99cc-4f1b-b0ca-8c43859caddd"> |

The cause of this issue is the payment method token with a `card_` prefix wasn't passing the logic in the `add_payment_method_to_request_array()` function and so wasn't being passed to Stripe in the request.

This doesn't impact UPE because it uses a completely different function for generating the payment request (see `process_payment_with_saved_payment_method()`) and it doesn't check source type (`pm`, `src` or `card_`) - it just [inserts the source ID directly](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/2608/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L669) which comes from the [stored token ID](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/2608/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L648). 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)