### PR TITLE
Fix issue in processing a 0 amount subscription.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Lookup existing refunds by refund ID when processing webhooks.
 * Fix - Exclude Link from disable UPE confirmation modal in settings.
 * Fix - Fix JS (ES5) compatibility on older browsers for the shortcode checkout.
+* Fix - Unable to process 0 amount subscription.
 
 = 7.4.1 - 2023-05-30 =
 * Fix - Add Order Key Validation.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -592,6 +592,10 @@ trait WC_Stripe_Subscriptions_Trait {
 			$sub_amount += WC_Stripe_Helper::get_stripe_amount( $sub->get_total() );
 		}
 
+		if ( 0 === $sub_amount ) {
+			return $request;
+		}
+
 		// Get the first subscription associated with this order.
 		$sub = reset( $subscriptions );
 

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -592,6 +592,8 @@ trait WC_Stripe_Subscriptions_Trait {
 			$sub_amount += WC_Stripe_Helper::get_stripe_amount( $sub->get_total() );
 		}
 
+		// If the amount is 0 we don't need to create a mandate since we won't be charging anything.
+		// And there won't be any renewal for this free subscription.
 		if ( 0 === $sub_amount ) {
 			return $request;
 		}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2607

If a store has any free subscription product (subscription price 0), purchasing the subscription fails. This happens for both regular, 3DS cards and 3DS cards that need a mandate. It also happens for all currencies. 
This PR fixes the main issue by avoiding setting mandate options when the subscription amount is 0. It will unblock the merchants using all other currencies which do not need a mandate but are blocked because of this error.

Stores using INR and cards that need to create a mandate will require the mandate options later if the subscription is updated to have a price (from free). This part of the fix will be implemented in [a separate PR](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2633).

## Changes proposed in this Pull Request:
- avoid setting mandate options when the subscription amount is 0.

## Testing instructions
- Create a subscription with 0 amount and a sign-up fee.
- As a shopper go to the shop page and purchase the subscription.
- Test with UPE enabled and disabled both.
- Test with different store currencies like USD, Euro, INR, etc.
- Test with regular card and 3DS card.

