### PR TITLE
Use admin theme color

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Tweak - Use admin theme color in selectors.
 
 = 7.6.0 - 2023-09-14 =
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.

--- a/client/settings/payments-and-transactions-section/statement-preview/style.scss
+++ b/client/settings/payments-and-transactions-section/statement-preview/style.scss
@@ -45,7 +45,7 @@
 		color: #757575;
 
 		&.description {
-			color: #007cba;
+			color: var(--wp-admin-theme-color);
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Tweak - Use admin theme color in selectors.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2680 

## Changes proposed in this Pull Request:
- Used `var( --wp-admin-theme-color )` for the text in the card preview.

## Testing instructions
- Go to `<your_site/wp-admin/profile.php` and choose an `Admin Color Scheme` except for `default`. (I have used Modern in the screenshots)
- Go to **WooCommerce > Settings > Payments > Stripe > Settings** and scroll down to `Payments & transactions` section.
- The text in the card preview for the bank statement should follow the admin theme color.

**Before**
![card preview](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/3fdc779a-aa22-4574-8a2a-16c3f4b9b922)


**After**

<img src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/043c8e4e-7712-4c40-acb7-17fe253c2f7a" />


### Note
The other two issues mentioned in #2680 need to be fixed in other repositories. The back icon issue will be fixed in WooCommerce plugin and the info icon in the Payments page will be fixed in the [Subscription plugin](https://github.com/Automattic/woocommerce-subscriptions-core/pull/508).