### PR TITLE
Prevent saving the bank statement if it contains non-Latin characters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 7.6.0 - xxxx-xx-xx =
+* Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.
 * Fix - Missing mapping for formal German (de_DE_formal), Swiss German (de_CH), and informal Swiss German (de_CH_informal) locales for Stripe emails.
 * Tweak - Skip Apple Pay registration for accounts from India.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1089,12 +1089,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		/*
-		 * Doesn't contain a non-Latin character. A character that's not:
-		 * - Standard ASCII characters (numbers, special characters, and regular Latin letters)
-		 * - Extended ASCII characters (which cover most of the accented Latin characters)
-		 * - White spaces
+		 * Doesn't contain a non-Latin character.
+		 * We're not matching accentuated Latin characters, numbers, whitespace, or special characters.
 		 */
-		if ( preg_match( '/[^\x00-\x7F\xA0-\xFFa-zA-Z0-9\s]/', $value ) ) {
+		if ( preg_match( '/[^a-zA-Z0-9\s\x{00C0}-\x{00FF}\p{P}]/u', $value, $matches ) ) {
 			$error_messages[] = __( '- Contains only Latin characters', 'woocommerce-gateway-stripe' );
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1078,10 +1078,19 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$has_one_letter = '/^.*[a-zA-Z]+/';
 		$no_specials    = '/^[^*"\'<>]*$/';
 
+		/*
+		 * Matches characters that are not:
+		 * - Standard ASCII characters (numbers, special characters, and regular Latin letters)
+		 * - Extended ASCII characters (which cover most of the accented Latin characters)
+		 * - White spaces
+		 */
+		$non_latin = '/[^\x00-\x7F\xA0-\xFFa-zA-Z0-9\s]/';
+
 		if (
 			! preg_match( $valid_length, $value ) ||
 			! preg_match( $has_one_letter, $value ) ||
-			! preg_match( $no_specials, $value )
+			! preg_match( $no_specials, $value ) ||
+			preg_match( $non_latin, $value )
 		) {
 			throw new InvalidArgumentException(
 				sprintf(

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1107,7 +1107,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			}
 
 			$error_message = sprintf(
-				/* translators: %1 The field name */
+				/* translators: %1 The field name, %2 <br> tag, %3 Validation error messages */
 				__( 'The %1$s is invalid. Please make sure it: %2$s%3$s', 'woocommerce-gateway-stripe' ),
 				$field,
 				'<br>',

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1086,7 +1086,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			throw new InvalidArgumentException(
 				sprintf(
 					/* translators: %1 field name, %2 Number of the maximum characters allowed */
-					__( 'The %1$s is invalid. The bank statement must contain only Latin characters, be between 5 and %2$u characters, contain at least one letter, and not contain any of the special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ),
+					__( 'The %1$s is invalid. The bank statement must contain only Latin characters, be between 5 and %2$u characters, contain at least one letter, and not contain any of the following special characters: \' " * &lt; &gt;', 'woocommerce-gateway-stripe' ),
 					$field,
 					$max_length
 				)

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -586,6 +586,9 @@ class WC_Stripe_Helper {
 		// Next, remove any remaining disallowed characters.
 		$statement_descriptor = str_replace( $disallowed_characters, '', $statement_descriptor );
 
+		// Remove non-Latin characters, excluding numbers, whitespaces and especial characters.
+		$statement_descriptor = preg_replace( '/[^a-zA-Z0-9\s\x{00C0}-\x{00FF}\p{P}]/u', '', $statement_descriptor );
+
 		// Trim any whitespace at the ends and limit to 22 characters.
 		$statement_descriptor = substr( trim( $statement_descriptor ), 0, 22 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.6.0 - xxxx-xx-xx =
+* Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.
 * Fix - Missing mapping for formal German (de_DE_formal), Swiss German (de_CH), and informal Swiss German (de_CH_informal) locales for Stripe emails.
 * Tweak - Skip Apple Pay registration for accounts from India.

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -104,6 +104,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 			'mixed length, \' and >' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
 			'mixed length, \' and <' => [ 'Test\'s Store < Driving Course Range', 'Tests Store  Driving C' ],
 			'mixed length, \' and "' => [ 'Test\'s Store " Driving Course Range', 'Tests Store  Driving C' ],
+			'removes non-Latin'      => [ 'Test-Storeシ Drהiving?12', 'Test-Store Driving?12' ],
 		];
 	}
 


### PR DESCRIPTION
Fixes #2189 

## Changes proposed in this Pull Request:

- Throw a validation error when saving an statement descriptor that contains a character that's none of the following to target non-Latin characters:
  - Standard ASCII characters (numbers, special characters, and regular Latin letters)
  - Extended ASCII characters (which cover most of the accented Latin characters)
  - White spaces
- Display the error messages that are relevant to the validation errors that were found, instead of displaying all of the requirements when any validation fails.  We could update the current approach if showing these differently is better.
- Remove non-Latin characters from the statement descriptor in `WC_Stripe_Helper::clean_statement_descriptor`

## Testing instructions

- Go to the Stripe plugin settings page `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
- Go to Payments & transactions -> Customer bank statement
- Enable "Add customer order number to the bank statement" and save

**Testing the non-Latin chars validation**
- Fill the full and shortened bank statement fields with values containing non-Latin characters. For example: `dashopシ`, `جَdashop`, `daהshجَopシ`, `daה shجَopシ`. Try any other variations containing non-Latin characters
- Confirm that an error message shows up for both fields saying, "Please make sure it: - Contains only Latin characters"

**Testing the non-Latin chars removal**
- Comment out the non-Latin chars validation so you can save these characters (lines https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2682/files#diff-8c1f01376167e4e75ce4eee534a35f3082229236433132282465407f7ff244edR1095-R1097)
- Ensure Stripe's login is enabled. Settings page (/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings) -> Advanced settings -> Enable "Log error messages"
- Save a statement descriptor that contains non-Latin characters, numbers, whitespace, and allowed special chars. For example: `d-aה shجَoöpシ12?`
- As a shopper, place an order using a 3DS card
- Go to Stripe's log file at `/wp-content/uploads/wc-logs/woocommerce-gateway-stripe-{date}.log`
- Look for the "statement_descriptor" property in the requests for the purchase
- Confirm that it doesn't contain the non-Latin characters (ה, シ, جَ) but that everything else remains (numbers, accentuated characters, whitespace, allowed special chars)

**Regression tests**
1. Confirm that using Latin characters, accentuated Latin characters, spaces, and allowed special characters doesn't trigger the "Make sure it contains only Latin characters" error
2. Trigger a different validation error for the full descriptor and the short descriptor, and confirm the error message for each fields matches its validation error 
3. Confirm that the previously existing validations are triggered as expected:
  - Its length is valid: Must be between 5 and 22 characters for the full descriptor, and between 5 and 10 for the shortened descriptor.
  - It contains at least one letter
  - It doesn't contain any of the following special characters: ' " * < >

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)