### PR TITLE
Follow the PRB settings for displaying wallets under the payment method options

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,8 +2,9 @@
 
 = 7.6.0 - xxxx-xx-xx =
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.
+* Fix - Prevent Apple Pay and Google Pay from showing up as payment methods when their PRBs are disabled.
 * Fix - Missing mapping for formal German (de_DE_formal), Swiss German (de_CH), and informal Swiss German (de_CH_informal) locales for Stripe emails.
-* Fix - Set failed order as pre order
+* Fix - Set failed order as pre order.
 * Tweak - Skip Apple Pay registration for accounts from India.
 
 = 7.5.0 - 2023-08-10 =

--- a/client/blocks/upe/fields.js
+++ b/client/blocks/upe/fields.js
@@ -339,6 +339,15 @@ const UPEField = ( {
 		},
 	};
 
+	// Prevent Apple Pay and Google Pay from showing up in
+	// the payment method options when Payment Request Buttons are disabled.
+	if ( getBlocksConfiguration()?.isPaymentRequestEnabled !== true ) {
+		elementOptions.wallets = {
+			applePay: 'never',
+			googlePay: 'never',
+		};
+	}
+
 	return (
 		<div className="wc-block-gateway-container">
 			<PaymentElement

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -297,6 +297,15 @@ jQuery( function ( $ ) {
 					} );
 				}
 
+				// Prevent Apple Pay and Google Pay from showing up in
+				// the payment method options when Payment Request Buttons are disabled.
+				if ( getStripeServerData()?.isPaymentRequestEnabled !== '1' ) {
+					upeSettings.wallets = {
+						googlePay: 'never',
+						applePay: 'never',
+					};
+				}
+
 				upeElement = elements.create( 'payment', upeSettings );
 				upeElement.mount( '#wc-stripe-upe-element' );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -315,6 +315,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['accountDescriptor']        = $this->statement_descriptor;
 		$stripe_params['addPaymentReturnURL']      = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']     = $enabled_billing_fields;
+		$stripe_params['isPaymentRequestEnabled']  = 'yes' === $this->get_option( 'payment_request' );
 
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
 			if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {

--- a/readme.txt
+++ b/readme.txt
@@ -130,8 +130,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 7.6.0 - xxxx-xx-xx =
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.
+* Fix - Prevent Apple Pay and Google Pay from showing up as payment methods when their PRBs are disabled.
 * Fix - Missing mapping for formal German (de_DE_formal), Swiss German (de_CH), and informal Swiss German (de_CH_informal) locales for Stripe emails.
-* Fix - Set failed order as pre order
+* Fix - Set failed order as pre order.
 * Tweak - Skip Apple Pay registration for accounts from India.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2683

## Changes proposed in this Pull Request:

- Pass the value of the `payment_request` setting to the checkout JS variables.
- Disable Apple and Google wallets from the Elements payment method when their PRBs are disabled.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Setting things up**
- Confirm you have access to Google Chrome and Safari, and a payment method set up in both Google and Apple wallets. Certain buttons show up for [certain browsers](https://stripe.com/docs/stripe-js/elements/payment-request-button). This will be easier to test if you have them set up
- Set up a page to have the classic (shortcode) checkout, and another one to have the block checkout
- Make your store publicly accessible with SSL. Jurassic tube works

**Confirm the wallets show up when enabled**
1. Enable UPE. `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` > Advanced settings > Enable the updated checkout experience
2. Enable Apple Pay / Google Pay Payment Request Buttons. `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` > Express checkouts > Apple Pay / Google Pay
3. Open the site in Google Chrome with a browser profile that has a payment method set in the wallet
5. Add a product to the cart
6. Visit both the classic and block checkout pages
7. For both pages, confirm that the Google Pay express button appears at the top of the checkout, and that a Google Pay option appears in the checkout cards section.
![8romVk.png](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/6a373bcd-47c5-4a45-ab19-6e6a81a06c7f)
8. Open the site in Safari from a device with a payment method in the wallet
9. Visit both the classic and block checkout pages
10. For both pages, confirm that the Apple Pay express button appears at the top of the checkout, and that a Apple Pay option appears in the checkout cards section
![OupvJK.png](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/a956b359-2c33-4018-afd6-601d5798133c)

**Confirm the wallets options don't show up when disabled**
1. Disable Apple Pay / Google Pay Payment Request Buttons
2. Go to the Google Chrome pages you opened in the previous tests, for both the classic and block checkout
3. Refresh both pages
4. Confirm that the Google Pay buttons don't show up in either the classic or block checkout pages
![OATIr8.png](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/f7ab1ec7-4d95-47c1-a056-5ab1ba5bf378)
5. Go to the Safari pages you opened in the previous tests, for both the classic and block checkout
6. Refresh both pages
7. Confirm that the Apple Pay buttons don't show up in either the classic or block checkout pages
![0K7xEm.png](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/72508397-ad6b-49ff-a455-758df7fd2dc4)


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)