### PR TITLE
Fix PRB's error message not showing up in classic checkout

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -159,7 +159,7 @@ jQuery( function( $ ) {
 
 			const $prependErrorMessageTo = wc_stripe_payment_request_params.is_product_page ?
 				$( '.product' ).first() :
-				$( '.shop_table.cart' ).closest( 'form' );
+				$( '.shop_table' ).closest( 'form' );
 
 			// Couldn't found the element to which prepend the error. This shouldn't happen.
 			if ( ! $prependErrorMessageTo.length ) {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -157,20 +157,22 @@ jQuery( function( $ ) {
 		displayErrorMessage: function( message ) {
 			$( '.woocommerce-error' ).remove();
 
-			if ( wc_stripe_payment_request_params.is_product_page ) {
-				var element = $( '.product' ).first();
-				element.before( message );
+			const $prependErrorMessageTo = wc_stripe_payment_request_params.is_product_page ?
+				$( '.product' ).first() :
+				$( '.shop_table.cart' ).closest( 'form' );
 
-				$( 'html, body' ).animate({
-					scrollTop: element.prev( '.woocommerce-error' ).offset().top
-				}, 600 );
-			} else {
-				var $form = $( '.shop_table.cart' ).closest( 'form' );
-				$form.before( message );
-				$( 'html, body' ).animate({
-					scrollTop: $form.prev( '.woocommerce-error' ).offset().top
-				}, 600 );
+			// Couldn't found the element to which prepend the error. This shouldn't happen.
+			if ( ! $prependErrorMessageTo.length ) {
+				// But log the error so there's at least some indication of what's going on.
+				console.error( 'Could not prepend the error message element:', message );
+				return;
 			}
+
+			$prependErrorMessageTo.before( message );
+
+			$( 'html, body' ).animate({
+				scrollTop: $prependErrorMessageTo.prev( '.woocommerce-error' ).offset().top
+			}, 600 );
 		},
 
 		/**
@@ -659,7 +661,7 @@ jQuery( function( $ ) {
 					} );
 				});
 			});
-			
+
 			const blockPaymentRequestButton = function () {
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 			}
@@ -689,7 +691,7 @@ jQuery( function( $ ) {
 			// when the customer clicks on the button before the debounced event is processed.
 			$( '.quantity' ).on( 'input', '.qty', blockPaymentRequestButton );
 			$( '.quantity' ).on('input', '.qty', wc_stripe_payment_request.debounce(250, cartChangedHandler));
-			
+
 			// Update payment request buttons if product add-ons are modified.
 			$( '.cart:not(.cart_group)' ).on( 'updated_addons', blockPaymentRequestButton );
 			$( '.cart:not(.cart_group)' ).on( 'updated_addons', wc_stripe_payment_request.debounce( 250, cartChangedHandler ));

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.
 * Fix - Missing mapping for formal German (de_DE_formal), Swiss German (de_CH), and informal Swiss German (de_CH_informal) locales for Stripe emails.
 * Fix - Set failed order as pre order
+* Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Tweak - Skip Apple Pay registration for accounts from India.
 
 = 7.5.0 - 2023-08-10 =

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.
 * Fix - Missing mapping for formal German (de_DE_formal), Swiss German (de_CH), and informal Swiss German (de_CH_informal) locales for Stripe emails.
 * Fix - Set failed order as pre order
+* Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Tweak - Skip Apple Pay registration for accounts from India.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- When the current page isn't a product page, change the selector of the element to which the error is prepended from `.shop_table.cart` to `.shop_table`
- When the element to which the error is prepended isn't found, log the error in the browser console. I don't see a case where this would happen, but adding it as a fallback

## Testing instructions

1. Enable UPE. `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` > Advanced settings > Enable the updated checkout experience
2. Enable Apple Pay / Google Pay Payment Request Buttons. `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` > Express checkouts > Apple Pay / Google Pay
3. Open the site in Google Chrome with a browser profile that has a payment method set in the wallet
4. As a guest, add a product to the cart
5.  Go to a checkout page using the classic (shortcode) checkout
6. Ensure the name and last name fields aren't filled
7. Click on the Google Pay express button at the top of the page and try to place an order
8. Confirm that an error message shows up at the top of the checkout page
Previously, an error showed up in the console and no error was shown on the page
<img width="979" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/4305c34d-f3ec-48cb-b821-30304d6a7e7e">


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
