### PR TITLE
Validate $response->error->code exists

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1637,7 +1637,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return boolean Whether or not it's a 'authentication_required' error
 	 */
 	public function is_authentication_required_for_payment( $response ) {
-		return ( ! empty( $response->error ) && 'authentication_required' === $response->error->code )
+		return ( ! empty( $response->error ) && ! empty( $response->error->code ) && 'authentication_required' === $response->error->code )
 			|| ( ! empty( $response->last_payment_error ) && 'authentication_required' === $response->last_payment_error->code );
 	}
 


### PR DESCRIPTION
Fixes #2678

## Changes proposed in this Pull Request:

Introduce a validation of `$response->error->code` to prevent `PHP Warning:  Undefined property: stdClass::$code`
