### PR TITLE
Refactor `is_valid_pay_for_order_endpoint` function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Twaek - Refactor `is_valid_pay_for_order_endpoint` for better performance.
 
 = 7.6.0 - 2023-09-14 =
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1782,14 +1782,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
-		$order_id = wc_get_order_id_by_order_key( wc_clean( wp_unslash( $_GET['key'] ) ) );
+		$order_id = absint( get_query_var( 'order-pay' ) );
+		$order    = wc_get_order( $order_id );
 
-		// If the order ID is not found or the order ID does not match the order ID in the URL, return false.
-		if ( ! $order_id || ( absint( get_query_var( 'order-pay' ) ) !== absint( $order_id ) ) ) {
+		// If the order is not found or the param `key` is not set or the order key does not match the order key in the URL param, return false.
+		if ( ! $order || ! isset( $_GET['key'] ) || wc_clean( wp_unslash( $_GET['key'] ) ) !== $order->get_order_key() ) {
 			return false;
 		}
-
-		$order = wc_get_order( $order_id );
 
 		// If the order doesn't need payment, we don't need to prepare the payment page.
 		if ( ! $order->needs_payment() ) {

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Twaek - Refactor `is_valid_pay_for_order_endpoint` for better performance.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2647 

## Changes proposed in this Pull Request:
It is reported in #2647 that the `wc_get_order_id_by_order_key` function used inside the `is_valid_pay_for_order_endpoint` function is causing performance issues in stores having more than 200.000 orders. With the refactor made in this PR, we find the order by ID and then compare the order's key with the `order_key` URL param.  

## Testing instructions
- Create an order with `pending payment` status.
- Go to the order edit page and click the `Customer payment page` link.
- Open the `Pay for order` page for an order.
- Add card details and click the `Pay for order` button.
- The payment should be completed without any errors.
