### PR TITLE
Prevent displaying wallets in the UPE card element

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 
 = 7.6.0 - 2023-09-14 =
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.

--- a/client/blocks/upe/fields.js
+++ b/client/blocks/upe/fields.js
@@ -337,6 +337,10 @@ const UPEField = ( {
 				},
 			},
 		},
+		wallets: {
+			applePay: 'never',
+			googlePay: 'never',
+		},
 	};
 
 	return (

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -244,6 +244,10 @@ jQuery( function ( $ ) {
 				const businessName = getStripeServerData()?.accountDescriptor;
 				const upeSettings = {
 					business: { name: businessName },
+					wallets: {
+						applePay: 'never',
+						googlePay: 'never',
+					},
 				};
 				if ( isCheckout && ! isOrderPay ) {
 					upeSettings.fields = {

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2683

The PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2689 was the original fix, but we decided to hide the wallets due to the blocker found in this other issue https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2573#issuecomment-1726464506

## Changes proposed in this Pull Request:

- Pass the wallet property to the card UPE Element with `never` as the value of the `google_pay` and `apple_pay` properties. [Doc reference](https://stripe.com/docs/js/elements_object/create_payment_element#payment_element_create-options-wallets)

## Testing instructions

**Setting things up**

- Confirm you have access to Google Chrome and Safari, and a payment method set up in both Google and Apple wallets. Certain buttons show up for [certain browsers](https://stripe.com/docs/stripe-js/elements/payment-request-button). This will be easier to test if you have them set up
- Set up a page to have the classic (shortcode) checkout, and another one to have the block checkout
- Make your store publicly accessible with SSL. Jurassic tube works

**Confirm the wallets show up when enabled**
1. Enable UPE. `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` > Advanced settings > Enable the updated checkout experience
2. Enable Apple Pay / Google Pay Payment Request Buttons. `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` > Express checkouts > Apple Pay / Google Pay
3. Open the site in Google Chrome with a browser profile that has a payment method set in the wallet
5. Add a product to the cart
6. Visit both the classic and block checkout pages
7. For both pages, confirm that the Google Pay express button appears at the top of the checkout, and that a Google Pay option doesn't appear in the checkout cards section.
<img width="1554" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/acfd15ee-e705-444e-8000-dff833e3b730">

8. Open the site in Safari from a device with a payment method in the wallet
9. Visit both the classic and block checkout pages
10. For both pages, confirm that the Apple Pay express button appears at the top of the checkout, and that an Apple Pay option doesn't appear in the checkout cards section

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
