### PR TITLE
Check if failed order email exist before triggering it

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 7.8.0 - xxxx-xx-xx =
-*
+* Fix: Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
 
 = 7.7.0 - 2023-11-09 =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -607,7 +607,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function send_failed_order_email( $order_id ) {
 		$emails = WC()->mailer()->get_emails();
-		if ( ! empty( $emails ) && ! empty( $order_id ) ) {
+		if ( ! empty( $emails ) && ! empty( $order_id ) && isset( $emails['WC_Email_Failed_Order'] ) ) {
 			$emails['WC_Email_Failed_Order']->trigger( $order_id );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.8.0 - xxxx-xx-xx =
-*
+* Fix: Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
+
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
We can disable some WooCommerce emails with the `woocommerce_email_classes` filter. 
This PR is a check for for `WC_Email_Failed_Order` email to avoid a PHP fatal error.

## Changes proposed in this Pull Request:

This PR just avoids the error `PHP Fatal error:  Uncaught Error: Call to a member function trigger() on null` in `/wp-content/plugins/woocommerce-gateway-stripe/includes/abstracts/abstract-wc-stripe-payment.php`

## Testing instructions

1. Disable the `WC_Email_Failed_Order` email with the `woocommerce_email_classes` filter.
2. Make an payment fail.
3. Check the error log with the error above

With the PR, the error disappears.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
