### PR TITLE
Prevent escaping the anchor tag under the Apple Pay domain registration failure notice

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -397,13 +397,6 @@ class WC_Stripe_Apple_Pay_Registration {
 		];
 		$verification_failed_without_error = __( 'Apple Pay domain verification failed.', 'woocommerce-gateway-stripe' );
 		$verification_failed_with_error    = __( 'Apple Pay domain verification failed with the following error:', 'woocommerce-gateway-stripe' );
-		$check_log_text                    = sprintf(
-			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			esc_html__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
-			'<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
-			'</a>'
-		);
-
 		?>
 		<div class="error stripe-apple-pay-message">
 			<?php if ( $empty_notice ) : ?>
@@ -412,7 +405,16 @@ class WC_Stripe_Apple_Pay_Registration {
 				<p><?php echo esc_html( $verification_failed_with_error ); ?></p>
 				<p><i><?php echo wp_kses( make_clickable( esc_html( $this->apple_pay_verify_notice ) ), $allowed_html ); ?></i></p>
 			<?php endif; ?>
-			<p><?php echo esc_html( $check_log_text ); ?></p>
+			<p>
+				<?php
+					printf(
+						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
+						esc_html__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
+						'<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
+						'</a>'
+					);
+				?>
+			</p>
 		</div>
 		<?php
 	}

--- a/includes/class-wc-stripe-apple-pay-registration.php
+++ b/includes/class-wc-stripe-apple-pay-registration.php
@@ -410,7 +410,7 @@ class WC_Stripe_Apple_Pay_Registration {
 					printf(
 						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 						esc_html__( 'Please check the %1$slogs%2$s for more details on this issue. Logging must be enabled to see recorded logs.', 'woocommerce-gateway-stripe' ),
-						'<a href="' . admin_url( 'admin.php?page=wc-status&tab=logs' ) . '">',
+						'<a href="' . esc_url( admin_url( 'admin.php?page=wc-status&tab=logs' ) ) . '">',
 						'</a>'
 					);
 				?>

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 7.7.0 - xxxx-xx-xx =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
+* Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Print the escaped notice directly into the page, instead of escaping the entire string again.
- Use esc_url for escaping the admin_url() in the notice.

## Testing instructions

- Enable Apple Pay/Google Pay in the WordPress' Stripe settings. WP's Stripe settings page (/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods) -> Express checkouts -> Apple Pay/Google Pay
- Force displaying the notice by commenting out [this check](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/class-wc-stripe-apple-pay-registration.php#L383-L385)
- Reload the Stripe settings page in the WP dashboard
- Find the WP notice that begins with "Apple Pay domain verification failed."
- Confirm the word "logs" is a link, instead of it being surrounded by an escaped anchor tag

<img width="1679" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/82a005b3-fa7d-4fd3-b1e3-4ecf83b2749d">

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
