### PR TITLE
Display the wallets in the PRBs according to the plugin settings

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -365,6 +365,20 @@ jQuery( function( $ ) {
 				options.disableWallets = [ 'link' ];
 			}
 
+			const disableWallets = [];
+
+			// Prevent displaying Link in the PRBs if disabled in the plugin settings.
+			if ( ! wc_stripe_payment_request_params?.stripe?.is_link_enabled ) {
+				disableWallets.push( 'link' );
+			}
+
+			// Prevent displaying Apple Pay and Google Pay in the PRBs if disabled in the plugin settings.
+			if ( ! wc_stripe_payment_request_params?.stripe?.is_payment_request_enabled ) {
+				disableWallets.push( 'applePay', 'googlePay' );
+			}
+
+			options.disableWallets = disableWallets;
+
 			// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.
 			// Since it's considered a US state by Stripe, we need to do some special mapping.
 			if ( 'PR' === options.country ) {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -360,6 +360,11 @@ jQuery( function( $ ) {
 				paymentDetails = cart.order_data;
 			}
 
+			// Prevent displaying Link in the PRBs if disabled in the plugin settings.
+			if ( ! wc_stripe_payment_request_params?.stripe?.allow_link ) {
+				options.disableWallets = [ 'link' ];
+			}
+
 			// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.
 			// Since it's considered a US state by Stripe, we need to do some special mapping.
 			if ( 'PR' === options.country ) {
@@ -376,12 +381,6 @@ jQuery( function( $ ) {
 				// Check the availability of the Payment Request API first.
 				paymentRequest.canMakePayment().then( function( result ) {
 					if ( ! result ) {
-						return;
-					}
-
-					const availablePaymentRequestTypes = Object.keys( result ).filter( type => result[type] );
-
-					if ( availablePaymentRequestTypes.length === 1 && result.link && ! wc_stripe_payment_request_params.stripe.allow_link ) {
 						return;
 					}
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -360,11 +360,6 @@ jQuery( function( $ ) {
 				paymentDetails = cart.order_data;
 			}
 
-			// Prevent displaying Link in the PRBs if disabled in the plugin settings.
-			if ( ! wc_stripe_payment_request_params?.stripe?.is_link_enabled ) {
-				options.disableWallets = [ 'link' ];
-			}
-
 			const disableWallets = [];
 
 			// Prevent displaying Link in the PRBs if disabled in the plugin settings.

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -361,7 +361,7 @@ jQuery( function( $ ) {
 			}
 
 			// Prevent displaying Link in the PRBs if disabled in the plugin settings.
-			if ( ! wc_stripe_payment_request_params?.stripe?.allow_link ) {
+			if ( ! wc_stripe_payment_request_params?.stripe?.is_link_enabled ) {
 				options.disableWallets = [ 'link' ];
 			}
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
+* Fix - Display the Payment Request Buttons according to the selected settings.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -32,7 +32,7 @@ export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 	};
 
 	// Prevent displaying Link in the PRBs if disabled in the plugin settings.
-	if ( ! getBlocksConfiguration()?.stripe?.allow_link ) {
+	if ( ! getBlocksConfiguration()?.stripe?.is_link_enabled ) {
 		options.disableWallets = [ 'link' ];
 	}
 

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -31,6 +31,11 @@ export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 		displayItems: cart.order_data.displayItems,
 	};
 
+	// Prevent displaying Link in the PRBs if disabled in the plugin settings.
+	if ( ! getBlocksConfiguration()?.stripe?.allow_link ) {
+		options.disableWallets = [ 'link' ];
+	}
+
 	// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.
 	// Since it's considered a US state by Stripe, we need to do some special mapping.
 	if ( options.country === 'PR' ) {

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -19,6 +19,18 @@ export const getBlocksConfiguration = () => {
  * @return {Object} A Stripe payment request.
  */
 export const createPaymentRequestUsingCart = ( stripe, cart ) => {
+	const disableWallets = [];
+
+	// Prevent displaying Link in the PRBs if disabled in the plugin settings.
+	if ( ! getBlocksConfiguration()?.stripe?.is_link_enabled ) {
+		disableWallets.push( 'link' );
+	}
+
+	// Prevent displaying Apple Pay and Google Pay in the PRBs if disabled in the plugin settings.
+	if ( ! getBlocksConfiguration()?.stripe?.is_payment_request_enabled ) {
+		disableWallets.push( 'applePay', 'googlePay' );
+	}
+
 	const options = {
 		total: cart.order_data.total,
 		currency: cart.order_data.currency,
@@ -29,12 +41,8 @@ export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 			?.needs_payer_phone,
 		requestShipping: cart.shipping_required ? true : false,
 		displayItems: cart.order_data.displayItems,
+		disableWallets,
 	};
-
-	// Prevent displaying Link in the PRBs if disabled in the plugin settings.
-	if ( ! getBlocksConfiguration()?.stripe?.is_link_enabled ) {
-		options.disableWallets = [ 'link' ];
-	}
 
 	// Puerto Rico (PR) is the only US territory/possession that's supported by Stripe.
 	// Since it's considered a US state by Stripe, we need to do some special mapping.

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -186,7 +186,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		//       to version 5.0.
 		if ( function_exists( 'has_block' ) ) {
 			// Don't show if PRBs are turned off entirely.
-			if ( ! isset( $this->settings['payment_request'] ) || 'yes' !== $this->settings['payment_request'] ) {
+			if ( ! $this->payment_request_configuration->is_at_least_one_payment_request_button_enabled() ) {
 				return false;
 			}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -87,8 +87,12 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		// Checks if Payment Request is enabled.
-		if ( ! isset( $this->stripe_settings['payment_request'] ) || 'yes' !== $this->stripe_settings['payment_request'] ) {
+		// Don't initiate this class if both Link and
+		// the Payment Request Buttons (Apple Pay/Google Pay) are disabled.
+		if (
+			! WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() &&
+			( ! isset( $this->stripe_settings['payment_request'] ) || 'yes' !== $this->stripe_settings['payment_request'] )
+		) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -705,10 +705,11 @@ class WC_Stripe_Payment_Request {
 		return [
 			'ajax_url'           => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'             => [
-				'key'                => $this->publishable_key,
-				'allow_prepaid_card' => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
-				'locale'             => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
-				'allow_link'         => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
+				'key'                        => $this->publishable_key,
+				'allow_prepaid_card'         => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
+				'locale'                     => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+				'allow_link'                 => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
+				'is_payment_request_enabled' => $this->is_payment_request_enabled(),
 			],
 			'nonce'              => [
 				'payment'                   => wp_create_nonce( 'wc-stripe-payment-request' ),
@@ -859,7 +860,7 @@ class WC_Stripe_Payment_Request {
 	 */
 	public function is_at_least_one_payment_request_button_enabled() {
 		// Apple Pay / Google Pay is enabled.
-		if ( isset( $this->stripe_settings['payment_request'] ) && 'yes' === $this->stripe_settings['payment_request'] ) {
+		if ( $this->is_payment_request_enabled() ) {
 			return true;
 		}
 
@@ -1898,5 +1899,16 @@ class WC_Stripe_Payment_Request {
 		}
 
 		return $this->stripe_settings['payment_request_button_locations'];
+	}
+
+	/**
+	 * Returns whether Payment Request is enabled.
+	 *
+	 * This option defines whether Apple Pay and Google Pay's payment request buttons are enabled.
+	 *
+	 * @return boolean
+	 */
+	private function is_payment_request_enabled() {
+		return isset( $this->stripe_settings['payment_request'] ) && 'yes' === $this->stripe_settings['payment_request'];
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -708,7 +708,7 @@ class WC_Stripe_Payment_Request {
 				'key'                        => $this->publishable_key,
 				'allow_prepaid_card'         => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
 				'locale'                     => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
-				'allow_link'                 => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
+				'is_link_enabled'            => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
 				'is_payment_request_enabled' => $this->is_payment_request_enabled(),
 			],
 			'nonce'              => [

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -87,12 +87,8 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		// Don't initiate this class if both Link and
-		// the Payment Request Buttons (Apple Pay/Google Pay) are disabled.
-		if (
-			! WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() &&
-			( ! isset( $this->stripe_settings['payment_request'] ) || 'yes' !== $this->stripe_settings['payment_request'] )
-		) {
+		// Don't initiate this class if none of the PRBs are enabled.
+		if ( ! $this->is_at_least_one_payment_request_button_enabled() ) {
 			return;
 		}
 
@@ -851,6 +847,28 @@ class WC_Stripe_Payment_Request {
 		?>
 		<p id="wc-stripe-payment-request-button-separator" style="margin-top:1.5em;text-align:center;display:none;">&mdash; <?php esc_html_e( 'OR', 'woocommerce-gateway-stripe' ); ?> &mdash;</p>
 		<?php
+	}
+
+	/**
+	 * Returns whether at least one of the Express checkouts is enabled.
+	 *
+	 * We have one setting for the Apple Pay / Google Pay wallet and another for Link.
+	 * This method returns true if at least one of those two options is enabled.
+	 *
+	 * @return boolean
+	 */
+	public function is_at_least_one_payment_request_button_enabled() {
+		// Apple Pay / Google Pay is enabled.
+		if ( isset( $this->stripe_settings['payment_request'] ) && 'yes' === $this->stripe_settings['payment_request'] ) {
+			return true;
+		}
+
+		// Link is enabled.
+		if ( WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -39,11 +39,10 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 			return false;
 		}
 
-		return in_array(
-			self::STRIPE_ID,
-			woocommerce_gateway_stripe()->get_main_stripe_gateway()->get_upe_enabled_payment_method_ids(),
-			true
-		);
+		$upe_gateway            = new WC_Stripe_UPE_Payment_Gateway();
+		$upe_enabled_method_ids = $upe_gateway->get_upe_enabled_payment_method_ids();
+
+		return in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
+* Fix - Display the Payment Request Buttons according to the selected settings.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -53,10 +53,17 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	private $local_pickup_id;
 
 	/**
+	 * @var UPE_Test_Helper
+	 */
+	private $upe_helper;
+
+	/**
 	 * Sets up things all tests need.
 	 */
 	public function set_up() {
 		parent::set_up();
+
+		$this->upe_helper = new UPE_Test_Helper();
 
 		$this->pr = new WC_Stripe_Payment_Request();
 
@@ -177,5 +184,35 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $data['result'] );
 		$this->assertEquals( $expected_shipping_options, $data['shipping_options'], 'Shipping options mismatch' );
+	}
+
+	public function test_is_at_least_one_payment_request_button_enabled_link_enabled() {
+		$this->pr->stripe_settings = [ 'payment_request' => false ];
+
+		$this->upe_helper->enable_upe();
+
+		update_option(
+			'woocommerce_stripe_settings',
+			array_merge(
+				get_option( 'woocommerce_stripe_settings', [] ),
+				[
+					'upe_checkout_experience_accepted_payments' => [ 'link' ],
+				]
+			)
+		);
+
+		$this->assertTrue( $this->pr->is_at_least_one_payment_request_button_enabled() );
+	}
+
+	public function test_is_at_least_one_payment_request_button_enabled_pr_enabled() {
+		$this->pr->stripe_settings = [ 'payment_request' => 'yes' ];
+
+		$this->assertTrue( $this->pr->is_at_least_one_payment_request_button_enabled() );
+	}
+
+	public function test_is_at_least_one_payment_request_button_enabled_none_enabled() {
+		$this->pr->stripe_settings = [ 'payment_request' => false ];
+
+		$this->assertFalse( $this->pr->is_at_least_one_payment_request_button_enabled() );
 	}
 }


### PR DESCRIPTION
Fixes #2713
Fixes #2634

## Changes proposed in this Pull Request:

- Replace the call to woocommerce_gateway_stripe() in WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() to avoid redefining the WC_Stripe class.
- Check whether Link and Google Pay / Apple Pay are enabled in the plugin settings when deciding whether to initiate the WC_Stripe_Payment_Request class.
- Use disableWallets for conditionally disabling Link and Google Pay / Apple Pay from the displayed wallets.

## Testing instructions

To test Apple Pay, you'll need to verify your domain and have access to a device with MacOS or iOS.

**Setting things up**
1. Make your store publicly accessible. Jurassic tube does the trick
2. Create a page with the classic checkout and another with the block checkout, if you don't have them already
3. Open both the classic checkout and block checkout in different browsers where the three wallets can show up. [Reference](https://stripe.com/docs/stripe-js/elements/payment-request-button). For example:
- Any browser in private navigation, where Link would appear
- Google Chrome with a profile that has a registered payment method, where Google Pay would appear
- Safari, where Apple Pay would appear

**Testing**
1. Go to the Stripe plugin settings page (/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods) -> Express checkouts
2. Disable both Link and Apple Pay / Google Pay
3. Confirm that no Express checkout appears in any browsers, in either the block or classic checkout pages
4. Enable Link
5. Confirm that Link shows up at the top of both the block and classic checkout pages, for all of the browsers.
6. Confirm that the email address field shows up as the first form field in the classic checkout page
7. Enable both Link and Apple Pay / Google Pay
8. Confirm that:
  - Private navigation displays Link
  - Chrome displays Google Pay
  - Safari displays Apple Pay
 9. Disable Link, leaving only Apple Pay/Google Pay enabled
   - Private navigation displays no Express button
  - Chrome displays Google Pay
  - Safari displays Apple Pay

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
