### PR TITLE
Fix form validation error when using Google Pay test cards

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -88,12 +88,12 @@ jQuery( function( $ ) {
 			var email    = source.owner.email;
 			var phone    = source.owner.phone;
 			var billing  = source.owner.address;
-			var name     = source.owner.name;
+			var name     = source.owner.name ?? evt.payerName;
 			var shipping = evt.shippingAddress;
 			var data     = {
 				_wpnonce:                  wc_stripe_payment_request_params.nonce.checkout,
-				billing_first_name:        null !== name ? name.split( ' ' ).slice( 0, 1 ).join( ' ' ) : '',
-				billing_last_name:         null !== name ? name.split( ' ' ).slice( 1 ).join( ' ' ) : '',
+				billing_first_name:        name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
+				billing_last_name:         name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',
 				billing_company:           '',
 				billing_email:             null !== email   ? email : evt.payerEmail,
 				billing_phone:             null !== phone   ? phone : evt.payerPhone && evt.payerPhone.replace( '/[() -]/g', '' ),

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
+* Fix - Use the card's payer name for Payment Request Buttons when the billing name isn't available.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.

--- a/client/blocks/normalize.js
+++ b/client/blocks/normalize.js
@@ -22,7 +22,7 @@ const normalizeOrderData = ( sourceEvent, paymentRequestType ) => {
 	const email = source?.owner?.email;
 	const phone = source?.owner?.phone;
 	const billing = source?.owner?.address;
-	const name = source?.owner?.name;
+	const name = source?.owner?.name ?? sourceEvent.payerName;
 	const shipping = sourceEvent?.shippingAddress;
 
 	const data = {

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
+* Fix - Use the card's payer name for Payment Request Buttons when the billing name isn't available.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.


### PR DESCRIPTION
Fixes #2516

## Changes proposed in this Pull Request:

- Use the event's payerName property when the source's name property is `null`.

## Testing instructions

Steps to reproduce the behavior:
1. Enable Express checkout via Google Pay and Apple Pay in your Stripe settings. wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods
2. Join the [Google Pay API Test Cards Allowlist group](https://groups.google.com/g/googlepay-test-mode-stub-data)
3. Navigate to a single product page or the cart page and attempt to check out using Google Pay
4. Confirm that:
  - The payment is processed correctly. Previously, an error with the following message appeared `Billing First name is a required field. Billing Last name is a required field.`
  - The order's first name is set to "Card", and the last name is set to "Holder Name"

**Other scenarios**
Confirm the order gets placed when checking out from:
- The classic checkout page
- A checkout page using the block checkout
- The cart

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
