### PR TITLE
Add onboarding track events

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
+* Tweak - Record Track events during the onboarding process.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.

--- a/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
+++ b/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
@@ -9,6 +9,7 @@ import {
 	useAccountKeysWebhookSecret,
 } from 'wcstripe/data/account-keys/hooks';
 import { useAccount } from 'wcstripe/data/account';
+import { recordEvent } from 'wcstripe/tracking';
 
 jest.mock( 'wcstripe/data/account-keys/hooks', () => ( {
 	useAccountKeys: jest.fn(),
@@ -19,6 +20,10 @@ jest.mock( 'wcstripe/data/account-keys/hooks', () => ( {
 
 jest.mock( 'wcstripe/data/account', () => ( {
 	useAccount: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/tracking', () => ( {
+	recordEvent: jest.fn(),
 } ) );
 
 describe( 'ConnectStripeAccount', () => {
@@ -35,21 +40,62 @@ describe( 'ConnectStripeAccount', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should have a Stripe OAuth link for "Create or connect an account" button', () => {
+	it( 'should render both the Connect Account and Enter keys buttons when the Stripe OAuth link is provided', () => {
 		render(
 			<ConnectStripeAccount oauthUrl="https://connect.stripe.com/oauth/v2/authorize?response_type=code&client_id=ca_1234&scope=read_write&state=1234" />
 		);
 
 		expect( screen.queryByText( 'Terms of service.' ) ).toBeInTheDocument();
+
 		expect(
 			screen.getByText( 'Create or connect an account' )
-		).toHaveAttribute(
-			'href',
-			'https://connect.stripe.com/oauth/v2/authorize?response_type=code&client_id=ca_1234&scope=read_write&state=1234'
-		);
+		).toBeInTheDocument();
+
 		expect(
 			screen.queryByText( 'Enter account keys (advanced)' )
 		).toBeInTheDocument();
+	} );
+
+	it( 'should redirect to the Stripe OAuth link when clicking on the "Create or connect an account" button', () => {
+		// Keep the original function at hand.
+		const assign = window.location.assign;
+
+		Object.defineProperty( window, 'location', {
+			value: { assign: jest.fn() },
+		} );
+
+		const oauthUrl =
+			'https://connect.stripe.com/oauth/v2/authorize?response_type=code&client_id=ca_1234&scope=read_write&state=1234';
+
+		render( <ConnectStripeAccount oauthUrl={ oauthUrl } /> );
+
+		const connectAccountButton = screen.getByText(
+			'Create or connect an account'
+		);
+		userEvent.click( connectAccountButton );
+
+		expect( window.location.assign ).toHaveBeenCalledWith( oauthUrl );
+
+		// Set the original function back to keep further tests working as expected.
+		Object.defineProperty( window, 'location', {
+			value: { assign },
+		} );
+	} );
+
+	it( 'should record a "wcstripe_create_or_connect_account_click" Track event when clicking on the Connect account button', () => {
+		render(
+			<ConnectStripeAccount oauthUrl="https://connect.stripe.com/oauth/v2/authorize?response_type=code&client_id=ca_1234&scope=read_write&state=1234" />
+		);
+
+		const connectAccountButton = screen.getByText(
+			'Create or connect an account'
+		);
+		userEvent.click( connectAccountButton );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_create_or_connect_account_click',
+			{}
+		);
 	} );
 
 	it( 'should only have the "Enter account keys" button if OAuth URL is blank', () => {

--- a/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
+++ b/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
@@ -138,4 +138,16 @@ describe( 'ConnectStripeAccount', () => {
 			screen.queryByText( /edit live account keys & webhooks/i )
 		).toBeInTheDocument();
 	} );
+
+	it( 'should record a "wcstripe_enter_account_keys_click" Track event when clicking on the Enter account keys button', () => {
+		render( <ConnectStripeAccount oauthUrl="" /> );
+
+		const accountKeysButton = screen.queryByText( /enter account keys/i );
+		userEvent.click( accountKeysButton );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_enter_account_keys_click',
+			{}
+		);
+	} );
 } );

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -59,6 +59,11 @@ const ConnectStripeAccount = ( { oauthUrl } ) => {
 		window.location.href = oauthUrl;
 	};
 
+	const handleEnterAccountKeys = () => {
+		recordEvent( 'wcstripe_enter_account_keys_click', {} );
+		setModalType( 'live' );
+	};
+
 	return (
 		<>
 			{ modalType && (
@@ -120,7 +125,7 @@ const ConnectStripeAccount = ( { oauthUrl } ) => {
 							isPrimary={ ! oauthUrl }
 							isSecondary={ !! oauthUrl }
 							// eslint-disable-next-line no-alert, no-undef
-							onClick={ () => setModalType( 'live' ) }
+							onClick={ handleEnterAccountKeys }
 						>
 							{ oauthUrl
 								? __(

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -56,7 +56,7 @@ const ConnectStripeAccount = ( { oauthUrl } ) => {
 
 	const handleCreateOrConnectAccount = () => {
 		recordEvent( 'wcstripe_create_or_connect_account_click', {} );
-		window.location.href = oauthUrl;
+		window.location.assign( oauthUrl );
 	};
 
 	const handleEnterAccountKeys = () => {

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -6,6 +6,7 @@ import { Button, Card } from '@wordpress/components';
 import CardBody from '../card-body';
 import { AccountKeysModal } from '../payment-settings/account-keys-modal';
 import StripeBanner from 'wcstripe/components/stripe-banner';
+import { recordEvent } from 'wcstripe/tracking';
 
 const CardWrapper = styled( Card )`
 	max-width: 560px;
@@ -51,6 +52,11 @@ const ConnectStripeAccount = ( { oauthUrl } ) => {
 	const [ modalType, setModalType ] = useState( '' );
 	const handleModalDismiss = () => {
 		setModalType( '' );
+	};
+
+	const handleCreateOrConnectAccount = () => {
+		recordEvent( 'wcstripe_create_or_connect_account_click', {} );
+		window.location.href = oauthUrl;
 	};
 
 	return (
@@ -100,7 +106,10 @@ const ConnectStripeAccount = ( { oauthUrl } ) => {
 					) }
 					<ButtonWrapper>
 						{ oauthUrl && (
-							<Button isPrimary href={ oauthUrl }>
+							<Button
+								isPrimary
+								onClick={ handleCreateOrConnectAccount }
+							>
 								{ __(
 									'Create or connect an account',
 									'woocommerce-gateway-stripe'

--- a/client/tracking/index.js
+++ b/client/tracking/index.js
@@ -49,6 +49,7 @@ export function recordEvent( eventName, eventProperties ) {
 			return;
 		}
 
+		// TODO: add is_test_mode to eventProperties.
 		getLibrary().recordEvent( eventName, eventProperties );
 	} );
 }

--- a/client/tracking/index.js
+++ b/client/tracking/index.js
@@ -49,7 +49,6 @@ export function recordEvent( eventName, eventProperties ) {
 			return;
 		}
 
-		// TODO: add is_test_mode to eventProperties.
 		getLibrary().recordEvent( eventName, eventProperties );
 	} );
 }

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -217,6 +217,8 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 			} elseif ( trim( $settings['test_publishable_key'] ) && trim( $settings['test_secret_key'] ) ) {
 				$settings['testmode'] = 'yes';
 			}
+
+			$this->record_manual_account_connect_track_event( 'yes' === $settings['testmode'] );
 		} elseif ( $is_deleting_account ) {
 			$settings['enabled'] = 'no';
 		}
@@ -228,5 +230,20 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		$account = $this->account->get_cached_account_data();
 
 		return new WP_REST_Response( $account, 200 );
+	}
+
+	/**
+	 * Records a track event when the keys of an account are manually added and no keys were previously stored.
+	 *
+	 * @param bool $is_test_mode Whether the keys are test ones.
+	 */
+	private function record_manual_account_connect_track_event( bool $is_test_mode ) {
+		if ( ! class_exists( 'WC_Tracks' ) ) {
+			return;
+		}
+
+		// We're recording this directly instead of queueing it because
+		// a queue wouldn't be processed due to the redirect that comes after.
+		WC_Tracks::record_event( 'wcstripe_stripe_connected', [ 'is_test_mode' => $is_test_mode ] );
 	}
 }

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -238,12 +238,10 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 	 * @param bool $is_test_mode Whether the keys are test ones.
 	 */
 	private function record_manual_account_connect_track_event( bool $is_test_mode ) {
-		if ( ! class_exists( 'WC_Tracks' ) ) {
+		if ( ! function_exists( 'wc_admin_record_tracks_event' ) ) {
 			return;
 		}
 
-		// We're recording this directly instead of queueing it because
-		// a queue wouldn't be processed due to the redirect that comes after.
-		WC_Tracks::record_event( 'wcstripe_stripe_connected', [ 'is_test_mode' => $is_test_mode ] );
+		wc_admin_record_tracks_event( 'wcstripe_stripe_connected', [ 'is_test_mode' => $is_test_mode ] );
 	}
 }

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -92,7 +92,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 				$response = $this->connect_oauth( wc_clean( wp_unslash( $_GET['wcs_stripe_state'] ) ), wc_clean( wp_unslash( $_GET['wcs_stripe_code'] ) ) );
 
-				$this->maybe_record_oboarding_track_event( is_wp_error( $response ) );
+				$this->record_account_connect_track_event( is_wp_error( $response ) );
 
 				wp_safe_redirect( esc_url_raw( remove_query_arg( [ 'wcs_stripe_state', 'wcs_stripe_code' ] ) ) );
 				exit;
@@ -182,22 +182,21 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		}
 
 		/**
-		 * Records the onboarding flow track event if WC_Tracks exists.
+		 * Records a track event after the user is redirected back to the store from the Stripe UX.
 		 *
 		 * @param bool $had_error Whether the Stripe connection had an error.
-		 * @return void
 		 */
-		private function maybe_record_oboarding_track_event( $had_error ) {
+		private function record_account_connect_track_event( bool $had_error ) {
 			if ( ! class_exists( 'WC_Tracks' ) ) {
 				return;
 			}
 
 			$options    = get_option( self::SETTINGS_OPTION, [] );
 			$is_test    = isset( $options['testmode'] ) && 'yes' === $options['testmode'];
-			$event_name = ! $had_error ? 'wcstripe_onboarding_flow_redirected' : 'wcstripe_onboarding_flow_redirected_error';
+			$event_name = ! $had_error ? 'wcstripe_stripe_connected' : 'wcstripe_stripe_connect_error';
 
 			// We're recording this directly instead of queueing it because
-			// a queue wouldn't be processed due to the redirect below.
+			// a queue wouldn't be processed due to the redirect that comes after.
 			WC_Tracks::record_event( $event_name, [ 'is_test_mode' => $is_test ] );
 		}
 	}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -91,6 +91,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			if ( isset( $_GET['wcs_stripe_code'], $_GET['wcs_stripe_state'] ) ) {
 
 				$response = $this->connect_oauth( wc_clean( wp_unslash( $_GET['wcs_stripe_state'] ) ), wc_clean( wp_unslash( $_GET['wcs_stripe_code'] ) ) );
+
+				$this->maybe_record_oboarding_track_event( is_wp_error( $response ) );
+
 				wp_safe_redirect( esc_url_raw( remove_query_arg( [ 'wcs_stripe_state', 'wcs_stripe_code' ] ) ) );
 				exit;
 			}
@@ -176,6 +179,26 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			} else {
 				return isset( $options['publishable_key'], $options['secret_key'] ) && trim( $options['publishable_key'] ) && trim( $options['secret_key'] );
 			}
+		}
+
+		/**
+		 * Records the onboarding flow track event if WC_Tracks exists.
+		 *
+		 * @param bool $had_error Whether the Stripe connection had an error.
+		 * @return void
+		 */
+		private function maybe_record_oboarding_track_event( $had_error ) {
+			if ( ! class_exists( 'WC_Tracks' ) ) {
+				return;
+			}
+
+			$options    = get_option( self::SETTINGS_OPTION, [] );
+			$is_test    = isset( $options['testmode'] ) && 'yes' === $options['testmode'];
+			$event_name = ! $had_error ? 'wcstripe_onboarding_flow_redirected' : 'wcstripe_onboarding_flow_redirected_error';
+
+			// We're recording this directly instead of queueing it because
+			// a queue wouldn't be processed due to the redirect below.
+			WC_Tracks::record_event( $event_name, [ 'is_test_mode' => $is_test ] );
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.
 * Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
+* Tweak - Record Track events during the onboarding process.
 * Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Record Tracks events when:
- Clicking on the Connect Account button, `wcstripe_create_or_connect_account_click`
- Successfully connecting the account when coming from the oAuth flow, `wcstripe_stripe_connected`
- Failure on connecting the account when coming from the oAuth flow, `wcstripe_stripe_connect_error`
- Clicking on the Enter Account Keys button, `wcstripe_enter_account_keys_click`
- Manually saving the account keys when none was stored before, `wcstripe_stripe_connected`

## Testing instructions

**Setting things up**
Make sure you have opted into tracking under the WC settings > Advanced > WooCommerce.com (`/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`).

The events may take ~10 minutes to show up in Tracks.

**Testing a successful oAuth flow**
1. In `includes/connect/class-wc-stripe-connect-api.php`, set the `WOOCOMMERCE_CONNECT_SERVER_URL` constant to `https://api-staging.woocommerce.com/`
2. Make the store accessible through SSL. Jurassic tube does the trick
3. Go to the Stripe plugin settings page (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`)
4. Disconnect any Stripe account you have connected to the store
5. Click on "Create or connect an account"
6. In Tracks, confirm that an event called `wcadmin_wcstripe_create_or_connect_account_click` was recorded
7. Complete the onboarding flow until you're redirected back to the store
8. In Tracks, confirm that an event called `wcadmin_wcstripe_stripe_connected` was recorded
9. Confirm that this event has a property called `is_test_mode` and its value is `1`

**Testing a failing oAuth flow**
1. In `includes/connect/class-wc-stripe-connect-api.php`, set the `WOOCOMMERCE_CONNECT_SERVER_URL` constant to `https://api-staging.woocommerce.com/`
2. Go to the Stripe plugin settings page (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`)
3. Disconnect any Stripe account you have connected to the store
4. Make the method WC_Stripe_Connect::connect_oauth() return a WP_Error, mocking the WP_Error that it'd return on failure
5. In Tracks, confirm that an event called `wcadmin_wcstripe_stripe_connect_error` was recorded

**Testing manually adding the keys**
1. Go to the Stripe plugin settings page (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`)
2. Disconnect any Stripe account you have connected to the store
6. Click on "Enter account keys"
7. In Tracks, confirm that an event called `wcadmin_wcstripe_enter_account_keys_click` was recorded
8. Enter the keys from your account and save
9. In Tracks, confirm that an event called `wcadmin_wcstripe_stripe_connected` was recorded
10. Confirm that this event has a property called `is_test_mode` and its value is `1`


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
