### PR TITLE
Remove PHP 7.3 from the compatibility matrix in the GH workflow

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         woocommerce: [ 'beta' ]
         wordpress:   [ 'latest' ]
-        php:         [ '7.3', '7.4', '8.0' ]
-          
-    
+        php:         [ '7.4', '8.0' ]
+
+
     name: Beta (PHP=${{ matrix.php }}, WP=${{ matrix.wordpress }}, WC=${{ matrix.woocommerce }})
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -34,7 +34,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage:    none
-          
+
       - name: If PHP >= 8.0, set up PHPUnit 9.5 for compatibility
         if: ${{ matrix.php >= '8.0' }}
         run: wget https://phar.phpunit.de/phpunit-9.5.13.phar && mv phpunit-9.5.13.phar phpunit.phar


### PR DESCRIPTION
WC's latest beta (8.2.0) sets the min PHP required version to 7.4. This workflow fails due to this incompatibility between WC and the PHP version.

[Here's](https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/6345787690/job/17238344421?pr=2715) a failing GH workflow for reference.

## Changes proposed in this Pull Request:

Remove PHP 7.3 from the compatibility matrix in the GH workflow.

## Testing instructions

Confirm no GH workflow fails.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
