### PR TITLE
PHP8 static analysis compatibility fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 7.8.0 - xxxx-xx-xx =
-*
+* Tweak - Improve compatibility with PHP 8+.
 
 = 7.7.0 - 2023-11-09 =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1085,7 +1085,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		$request['charge'] = $charge_id;
 		WC_Stripe_Logger::log( "Info: Beginning refund for order {$charge_id} for the amount of {$amount}" );
-
+		$response = new stdClass();
 		try {
 			$request = apply_filters( 'wc_stripe_refund_request', $request, $order );
 

--- a/includes/admin/class-wc-stripe-payment-gateways-controller.php
+++ b/includes/admin/class-wc-stripe-payment-gateways-controller.php
@@ -21,7 +21,7 @@ class WC_Stripe_Payment_Gateways_Controller {
 		$enabled_upe_payment_methods  = isset( $stripe_settings['upe_checkout_experience_accepted_payments'] ) ? $stripe_settings['upe_checkout_experience_accepted_payments'] : [];
 		$upe_payment_requests_enabled = 'yes' === $stripe_settings['payment_request'];
 
-		if ( count( $enabled_upe_payment_methods ) > 0 || $upe_payment_requests_enabled ) {
+		if ( ( is_array( $enabled_upe_payment_methods ) && count( $enabled_upe_payment_methods ) > 0 ) || $upe_payment_requests_enabled ) {
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ] );
 			add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'wc_stripe_gateway_container' ] );
 		}

--- a/includes/admin/class-wc-stripe-upe-compatibility-controller.php
+++ b/includes/admin/class-wc-stripe-upe-compatibility-controller.php
@@ -70,7 +70,7 @@ class WC_Stripe_UPE_Compatibility_Controller {
 	}
 
 	private function get_installed_versions_message( $unsatisfied_requirements ) {
-		return join(
+		return implode(
 			__( ' and ', 'woocommerce-gateway-stripe' ),
 			array_map(
 				function ( $requirement ) {
@@ -82,7 +82,7 @@ class WC_Stripe_UPE_Compatibility_Controller {
 	}
 
 	private function get_unsatisfied_requirements_message( $unsatisfied_requirements ) {
-		return join(
+		return implode(
 			__( ' and ', 'woocommerce-gateway-stripe' ),
 			array_map(
 				function ( $requirement ) {
@@ -93,7 +93,7 @@ class WC_Stripe_UPE_Compatibility_Controller {
 		);
 	}
 
-	private function show_current_compatibility_notice( $unsatisfied_requirements ) {
+	private function show_current_compatibility_notice( array $unsatisfied_requirements ) {
 		/*
 		 * The following might be hard to read, but here's what I'm trying to do:
 		 * - If WP and WC are both supported -> nothing to do

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1244,7 +1244,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		if ( empty( $this->form_fields ) ) {
 			$this->init_form_fields();
 		}
-		if ( key_exists( $field_key, $this->form_fields ) ) {
+		if ( array_key_exists( $field_key, $this->form_fields ) ) {
 			$field_type = $this->form_fields[ $field_key ]['type'];
 
 			if ( is_callable( [ $this, 'validate_' . $field_type . '_field' ] ) ) {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -103,6 +103,7 @@ class WC_Stripe_Intent_Controller {
 	public function verify_intent() {
 		global $woocommerce;
 
+		$order = false;
 		$gateway = $this->get_gateway();
 
 		try {
@@ -545,6 +546,7 @@ class WC_Stripe_Intent_Controller {
 	 * @throws WC_Stripe_Exception
 	 */
 	public function update_order_status_ajax() {
+		$order = false;
 		try {
 			$is_nonce_valid = check_ajax_referer( 'wc_stripe_update_order_status_nonce', false, false );
 			if ( ! $is_nonce_valid ) {
@@ -605,6 +607,7 @@ class WC_Stripe_Intent_Controller {
 	 * @throws WC_Stripe_Exception
 	 */
 	public function update_failed_order_ajax() {
+		$order = false;
 		try {
 			$is_nonce_valid = check_ajax_referer( 'wc_stripe_update_failed_order_nonce', false, false );
 			if ( ! $is_nonce_valid ) {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -656,8 +656,9 @@ class WC_Stripe_Intent_Controller {
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
 
-			/* translators: error message */
-			$order->update_status( 'failed' );
+			if ( $order ) {
+				$order->update_status( 'failed' );
+			}
 		}
 
 		wp_send_json_success();

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -215,6 +215,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return stdClass|void Result of payment capture.
 	 */
 	public function capture_payment( $order_id ) {
+		$result = new stdClass();
 		$order = wc_get_order( $order_id );
 
 		if ( 'stripe' === $order->get_payment_method() ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -332,7 +332,7 @@ abstract class WC_Stripe_UPE_Payment_Method {
 			$messages[] = $text . '<span class="tips" data-tip="' . $tooltip_content . '"><span class="woocommerce-help-tip" style="margin-top: 0;"></span></span>';
 		}
 
-		return count( $messages ) > 0 ? join( '&nbsp;–&nbsp;', $messages ) : '';
+		return count( $messages ) > 0 ? implode( '&nbsp;–&nbsp;', $messages ) : '';
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 7.8.0 - xxxx-xx-xx =
 * Fix: Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
+* Tweak - Improve compatibility with PHP 8+.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes a few instances where complex conditionals make it unclear whether a variable is declared via static analysis. Replaces calls to aliased functions with their preferred variant, i.e. join() => implode(), key_exists() => array_key_exists() Ensures counted variables are countable within scope.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
