### PR TITLE
Remove UGX from the zero decimal currency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.
 * Fix - Catch request failure errors.
+* Fix - Remove ugx from the zero decimal currency list as a special case in Stripe.
 
 = 7.6.0 - 2023-09-14 =
 * Fix - PHP fatal error when saving a non-UPE payment method and the Stripe request to retrieve it fails.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -239,7 +239,6 @@ class WC_Stripe_Helper {
 			'mga', // Malagasy Ariary
 			'pyg', // Paraguayan Guaraní
 			'rwf', // Rwandan Franc
-			'ugx', // Ugandan Shilling
 			'vnd', // Vietnamese Đồng
 			'vuv', // Vanuatu Vatu
 			'xaf', // Central African Cfa Franc

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -224,6 +224,7 @@ class WC_Stripe_Helper {
 	/**
 	 * List of currencies supported by Stripe that has no decimals
 	 * https://stripe.com/docs/currencies#zero-decimal from https://stripe.com/docs/currencies#presentment-currencies
+	 * ugx is an exception and not in this list for being a special cases in Stripe https://stripe.com/docs/currencies#special-cases
 	 *
 	 * @return array $currencies
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Use admin theme color in selectors.
 * Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.
 * Fix - Catch request failure errors.
+* Fix - Remove ugx from the zero decimal currency list as a special case in Stripe.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2674 

## Description
UGX is a zero decimal currency also recognized by Stripe https://stripe.com/docs/currencies#zero-decimal and it was included in the list returned by `no_decimal_currencies` function in #885. However, unlike the other zero decimal currencies, UGX is a special case in Stripe https://stripe.com/docs/currencies#special-cases and for backward compatibility on Stripe's end it is treated as a decimal-based (x100) as it used to be a decimal-based currency.

As explained in the Stripe doc, if you intend to create a charge for 5 UGX you need to pass 500 - not 5. For this reason, UGX should be excluded from the zero decimal currency list in the `no_decimal_currencies` function.

## Changes proposed in this Pull Request:
Removed `UGX` from the list in `no_decimal_currencies` function. 

## Testing instructions
#### In the `develop` branch
- Set the store currency to `UGX`.
- Create a product that is of 5 UGX price.
- Add this product to the cart as a shopper and go to the checkout page. 
- You should see an error notice on the page that says `Invalid amount. Currency UGX has become effectively zero-decimal and charged amounts must be evenly divisible by 100. See https://stripe.com/docs/currencies#zero-decimal for more information.`

<img height="50%" width="50%" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/a92cf3a2-5cdb-4099-944c-2fa380f6dd14" />

- Now edit the product and update the price to 5000 UGX.
- Refresh the checkout page and now you should see another error notice that says `Amount must convert to at least 50 cents. 50.00 USh converts to approximately $0.01.` (this is not expected because 5000 UGX is ~1.34 USD and so we should not see this notice. As Stripe is considering UGX as a decimal currency, it's taking the amount as 50 UGX (`5000/100=50`) which converts to ~0.013 USD)

<img height="50%" width="50%" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/3facba12-9024-4c8e-9679-f7148304fc64" />

#### In this branch
- Set the store currency to `UGX`.
- Create a product that is of 5 UGX price.
- Add this product to the cart as a shopper and go to the checkout page. 
- You should see an error notice on the page that says `Amount must convert to at least 50 cents. 5.00 USh converts to approximately $0.00.` (this is expected)
- Now edit the product and update the price to 5000 UGX.
- Refresh the checkout page and you should not see any error notice now.
- Complete the purchase and go to your Stripe dashboard's Payment page. (https://dashboard.stripe.com/test/payments).
- Find the recent payment and make sure that the correct amount has been changed.

<img height="50%" width="50%" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/397d9f20-32cc-45c9-ae8d-f137b2f17d15" />




