### PR TITLE
MultiBanco: Fix for HTML tags to print as expected on the Order Confirmation page, and "Thank you for your order" email.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Fix - Don't require shipping when purchasing a virtual variable subscription product using Google Pay and Apple Pay.
 * Fix - When using Payment Request buttons, fix $0 total for stores using a customized product page that adds the variation product ID directly into the cart.
+* Fix - MultiBanco: HTML tags to print as expected on the Order Confirmation page, and "Thank you for your order" email.
 * Tweak - Improve compatibility with PHP 8+.
 
 = 7.7.0 - 2023-11-09 =

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -194,7 +194,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '">';
 
 		if ( $description ) {
-			echo wpautop( esc_html( apply_filters( 'wc_stripe_description', esc_html( $description ), $this->id ) ) );
+			echo wpautop( esc_html( apply_filters( 'wc_stripe_description', $description, $this->id ) ) );
 		}
 
 		echo '</div>';

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -194,7 +194,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 			data-currency="' . esc_attr( strtolower( get_woocommerce_currency() ) ) . '">';
 
 		if ( $description ) {
-			echo wpautop( esc_html( apply_filters( 'wc_stripe_description', wp_kses_post( $description ), $this->id ) ) );
+			echo wpautop( esc_html( apply_filters( 'wc_stripe_description', esc_html( $description ), $this->id ) ) );
 		}
 
 		echo '</div>';
@@ -248,7 +248,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 			esc_html_e( 'MULTIBANCO INFORMAÇÕES DE ENCOMENDA:', 'woocommerce-gateway-stripe' ) . "\n\n";
 			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 			esc_html_e( 'Montante:', 'woocommerce-gateway-stripe' ) . "\n\n";
-			echo esc_html( $data['amount'] ) . "\n\n";
+			echo wp_kses_post( $data['amount'] ) . "\n\n";
 			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 			esc_html_e( 'Entidade:', 'woocommerce-gateway-stripe' ) . "\n\n";
 			echo esc_html( $data['entity'] ) . "\n\n";
@@ -261,7 +261,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 			<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
 			<li class="woocommerce-order-overview__order order">
 				<?php esc_html_e( 'Montante:', 'woocommerce-gateway-stripe' ); ?>
-				<strong><?php echo esc_html( $data['amount'] ); ?></strong>
+				<strong><?php echo wp_kses_post( $data['amount'] ); ?></strong>
 			</li>
 			<li class="woocommerce-order-overview__order order">
 				<?php esc_html_e( 'Entidade:', 'woocommerce-gateway-stripe' ); ?>

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Fix - Don't require shipping when purchasing a virtual variable subscription product using Google Pay and Apple Pay.
 * Fix - When using Payment Request buttons, fix $0 total for stores using a customized product page that adds the variation product ID directly into the cart.
+* Fix - MultiBanco: HTML tags to print as expected on the Order Confirmation page, and "Thank you for your order" email.
 * Tweak - Improve compatibility with PHP 8+.
 
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2651 #2641 


## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This change is necessary for when the MultiBanco option is selected upon checkout, the HTML tags are escaped accordingly, on the Order Confirmation page, and subsequent "Thank you for your order" email.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

Tested, with a test installation of mine, and nothing appears to be breaking. Kindly double-check, though. 🙂

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

### Before:

<img width="1128" alt="Screenshot 2023-10-21 at 18 41 14" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/73900974/6280ff5a-3a89-4734-a897-bb87bae69495">

<img width="630" alt="Screenshot 2023-10-21 at 18 56 47" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/73900974/fcb66ffa-636d-4fc8-84db-f5c390e54eb0">

### After:

<img width="1122" alt="Screenshot 2023-10-21 at 19 05 15" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/73900974/f8e72c32-e986-4e3c-b7d1-cd7191eda86b">

<img width="663" alt="Screenshot 2023-10-21 at 19 06 01" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/73900974/085e3e7a-2c39-4598-83ba-afa1b3861460">


## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
