### PR TITLE
Attach billing details to the new card when changing a subscriptions payment method & fix the change payment flow with UPE enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,8 @@
 * Tweak - Add test mode notice.
 * Fix - Remove ugx from the zero decimal currency list as a special case in Stripe.
 * Fix - Deleting customer on staging site detaches tokens from customer in Stripe.
+* Fix - Resolved an issue preventing changing a subscriptions payment method when UPE is enabled.
+* Fix - Send customer billing and address details to Stripe when changing a subscriptions payment method.
 
 = 7.6.1 - 2023-10-17 =
 * Fix - Add nonce check to OAuth flow.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1992,7 +1992,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		];
 
 		// If we're on the pay page we need to pass stripe.js the address of the order.
-		if ( $this->is_valid_pay_for_order_endpoint() ) {
+		if ( $this->is_valid_pay_for_order_endpoint() || isset( $_GET['change_payment_method'] ) ) {
 			$order_id = absint( get_query_var( 'order-pay' ) );
 			$order    = wc_get_order( $order_id );
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1992,7 +1992,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		];
 
 		// If we're on the pay page we need to pass stripe.js the address of the order.
-		if ( $this->is_valid_pay_for_order_endpoint() || isset( $_GET['change_payment_method'] ) ) {
+		if ( $this->is_valid_pay_for_order_endpoint() || $this->is_changing_payment_method_for_subscription() ) {
 			$order_id = absint( get_query_var( 'order-pay' ) );
 			$order    = wc_get_order( $order_id );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -288,7 +288,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public function javascript_params() {
 		global $wp;
 
-		$stripe_params = [
+		$is_change_payment_method = $this->is_changing_payment_method_for_subscription();
+		$stripe_params            = [
 			'title'        => $this->title,
 			'isUPEEnabled' => true,
 			'key'          => $this->publishable_key,
@@ -316,8 +317,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['addPaymentReturnURL']      = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']     = $enabled_billing_fields;
 
-		if ( parent::is_valid_pay_for_order_endpoint() || $this->is_changing_payment_method_for_subscription() ) {
-			if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {
+		if ( parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
+			if ( $this->is_subscriptions_enabled() && $is_change_payment_method ) {
 				$stripe_params['isChangingPayment']   = true;
 				$stripe_params['addPaymentReturnURL'] = wp_sanitize_redirect( esc_url_raw( home_url( add_query_arg( [] ) ) ) );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -316,7 +316,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['addPaymentReturnURL']      = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']     = $enabled_billing_fields;
 
-		if ( parent::is_valid_pay_for_order_endpoint() ) {
+		if ( parent::is_valid_pay_for_order_endpoint() || $this->is_changing_payment_method_for_subscription() ) {
 			if ( $this->is_subscriptions_enabled() && $this->is_changing_payment_method_for_subscription() ) {
 				$stripe_params['isChangingPayment']   = true;
 				$stripe_params['addPaymentReturnURL'] = wp_sanitize_redirect( esc_url_raw( home_url( add_query_arg( [] ) ) ) );
@@ -796,7 +796,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @version 5.6.0
 	 */
 	public function maybe_process_upe_redirect() {
-		if ( $this->is_payment_methods_page() ) {
+		if ( $this->is_payment_methods_page() || $this->is_changing_payment_method_for_subscription() ) {
 			if ( $this->is_setup_intent_success_creation_redirection() ) {
 				if ( isset( $_GET['redirect_status'] ) && 'succeeded' === $_GET['redirect_status'] ) {
 					$user_id  = wp_get_current_user()->ID;

--- a/readme.txt
+++ b/readme.txt
@@ -142,5 +142,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Add test mode notice.
 * Fix - Remove ugx from the zero decimal currency list as a special case in Stripe.
 * Fix - Deleting customer on staging site detaches tokens from customer in Stripe.
+* Fix - Resolved an issue preventing changing a subscriptions payment method when UPE is enabled.
+* Fix - Attach customer billing and address details to the new payment method in Stripe when changing a subscriptions payment method.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes 4565-gh-woocommerce/woocommerce-subscriptions

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR is fixing two issues:
1. When customers update their subscriptions payment method, the new card doesn't have any address or billing details added to it.

| On `develop`|On this branch|
|:-----------:|:------------:|
|![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/097237da-f90e-444c-a683-c6eb214eb8bd)|![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/94f376eb-ecda-4fb2-91b4-dc60b2da1d9e)|

2. With UPE enabled, customers get hit with an error (see screenshot below) when attempting to change their payment method on a subscription

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/971acde3-af95-460e-bc0c-9a79d30e6313)

After poking around at different areas of the code, I discovered the reason for this issue is that we basically need to treat the subscriptions change payment flow similar to how we treat the My Account > Add Payment Method flow:
- For UPE, inside the `maybe_process_upe_redirect()` make sure we're manually adding the customer's billing details (from `map_customer_data()`) to the setup intent request args
- For non-UPE, we need to manually add the customers billing details in the JavaScript params so that we use these inside our [`stripe.js`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/assets/js/stripe.js#L516-L521) since there are no checkout fields being submitted.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

1. Make sure you have the latest Woo Subscriptions activated along with a subscription product to purchase
2. Checkout `develop`
3. Enable the New Checkout Experience found under **WC > Settings > Payment Methods > Stripe > Advanced**
4. Purchase a subscription product
5. Visit **My Account > Subscriptions** and click on "Change Payment"
6. On `develop` you will see an error notice preventing you from changing payment method
7. Check out this branch and refresh the change payment method page.
8. Add a new card and click "Change payment method"
9. Visit https://dashboard.stripe.com/test/customers/cus_XXXXX and view the most recent card added to your customer
10. Verify the customer's name, phone and other billing details including address is on the new card.
11. Go into Stripe settings and disable the New Checkout Experience and repeat these testing instructions.
    1. The only difference will be while on `develop` you won't see the error notice on the change payment method page.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
