### PR TITLE
Avoid initializing WC_Stripe_UPE_Payment_Gateway for retrieving the enabled UPE payment methods

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -39,10 +39,9 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 			return false;
 		}
 
-		$upe_gateway            = new WC_Stripe_UPE_Payment_Gateway();
-		$upe_enabled_method_ids = $upe_gateway->get_upe_enabled_payment_method_ids();
+		$upe_enabled_method_ids = WC_Stripe_Helper::get_settings( null, 'upe_checkout_experience_accepted_payments' );
 
-		return in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );
+		return is_array( $upe_enabled_method_ids ) && in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );
 	}
 
 	/**


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Retrieve the enabled UPE payment methods from wp_options instead of initializing WC_Stripe_UPE_Payment_Gateway for this.

This change is needed because renewal payments are double charged on Stripe's end.

Pasting @mattallan 's explanation for context:
> This PR is initiating a new instance of new WC_Stripe_UPE_Payment_Gateway(); which is calling maybe_init_subscriptions() when subscriptions has already been inited.
maybe_init_subscriptions() attaches subscriptions action hooks to process renewals so when we initiate two instances of this class we attach these hooks twice which then charges the customer twice.

I’d rather see this is_link_enabled method as a non-static one, and we could access the `enabled` property within the Link payment gateway class instead of looking into wp_options. But that’d require a more significant set of changes, and it may be better to handle it after the Split UPE + deferred intent implementation. This should do for now.

## Testing instructions

**Confirm Link continues to be displayed as expected**

1. Make your store publicly accessible. Jurassic tube does the trick
2. Create a page with the classic checkout and another with the block checkout, if you don't have them already
3. Open both the classic checkout and block checkout in private navigation, where Link would appear.
4. Enable UPE: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` > Advanced settings > Enable the updated checkout experience
5. Enable Link: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` > Express checkouts > Link
6. As a shopper, confirm that:
- The Link express button appears at the top of the checkout page, both in the shortcode and block checkout pages.
- On the shortcode checkout page, the email address field is the first field in the checkout form.
7. Disable Link: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` > Express checkouts > Link
8. As a shopper, confirm that:
- The Link express button doesn't appear at the top of the checkout pages.
- On the shortcode checkout page, the email address field isn't the first field in the checkout form.

**Confirm renewal payments are double charged on Stripe's end**
1. Activate WooCommerce Subscriptions
2. Create a subscription product
3. As a shopper, purchase this subscription product
4. Go to Stripe's dashboard
5. Confirm there's a single payment for this purchase
6. In the WC store, renew this subscription
7. Confirm there's a single payment for the renewal
---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

Not adding a changelog entry because this problem didn't get on a release.

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
