### PR TITLE
Order pay: get the last payment error pm or src

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -671,14 +671,15 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		if ( 'requires_payment_method' === $intent->status && isset( $intent->last_payment_error )
 			&& 'authentication_required' === $intent->last_payment_error->code ) {
-			$level3_data = $this->get_level3_data_from_order( $order );
-			$intent      = WC_Stripe_API::request_with_level3_data(
-				[
-					'payment_method' => $intent->last_payment_error->source->id,
-				],
-				'payment_intents/' . $intent->id . '/confirm',
-				$level3_data,
-				$order
+			$level3_data    = $this->get_level3_data_from_order( $order );
+			$payment_method = WC_Stripe_Helper::get_payment_method_from_intent( $intent );
+			$intent         = WC_Stripe_API::request_with_level3_data(
+					[
+							'payment_method' => is_string( $payment_method ) ? $payment_method : $payment_method->id,
+					],
+					'payment_intents/' . $intent->id . '/confirm',
+					$level3_data,
+					$order
 			);
 
 			if ( isset( $intent->error ) ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -672,7 +672,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		if ( 'requires_payment_method' === $intent->status && isset( $intent->last_payment_error )
 			&& 'authentication_required' === $intent->last_payment_error->code ) {
 			$level3_data    = $this->get_level3_data_from_order( $order );
-			$payment_method = WC_Stripe_Helper::get_payment_method_from_intent( $intent );
+			$payment_method = WC_Stripe_Helper::get_payment_method_from_intent( $intent->last_payment_error );
 			$intent         = WC_Stripe_API::request_with_level3_data(
 					[
 							'payment_method' => is_string( $payment_method ) ? $payment_method : $payment_method->id,


### PR DESCRIPTION
The order pay page, after a payment failed for `authentication_required` reason, doesn't get the payment source.

There is a PHP notice:
```
PHP Notice:  Undefined property: stdClass::$source in /app/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-gateway-stripe.php on line 685
```

## Changes proposed in this Pull Request:
Since the intent from last_payment_error only checks the source `$intent->last_payment_error->source`, the PR tries to get if it is a payment method or a source using the helper `WC_Stripe_Helper::get_payment_method_from_intent`.

## Testing instructions
Using WooCommerce Subscriptions, make a first payment with a method having 3DS always required.
The renewal should ask for an authentication.
The link to order pay page won't display the Stripe authentication modal, and instead will show the regular checkout form.
With the PR, the checkout form is not displayed, the authentication starts just after loading the page.

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
