### PR TITLE
Don't load payment request buttons for synced subscriptions that don't have payment due today and also require shipping

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Deleting customer on staging site detaches tokens from customer in Stripe.
 * Fix - Resolved an issue preventing changing a subscriptions payment method when UPE is enabled.
 * Fix - Send customer billing and address details to Stripe when changing a subscriptions payment method.
+* Fix - Prevent "Invalid recurring shipping method" errors when attempting to purchase a synchronised subscription with payment request buttons.
 
 = 7.6.1 - 2023-10-17 =
 * Fix - Add nonce check to OAuth flow.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -592,8 +592,8 @@ class WC_Stripe_Payment_Request {
 				return false;
 			}
 
-			// Trial subscriptions with shipping are not supported.
-			if ( class_exists( 'WC_Subscriptions_Product' ) && WC_Subscriptions_Product::is_subscription( $_product ) && $_product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $_product ) > 0 ) {
+			// Subscriptions with a trial period that need shipping are not supported.
+			if ( $this->product_has_trial_and_needs_shipping( $_product ) ) {
 				return false;
 			}
 		}
@@ -606,6 +606,47 @@ class WC_Stripe_Payment_Request {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks if subscription or variable subscription is a product that has a free trial period and requires shipping.
+	 * This could be a subscription product with a trial period or a synchronised subscription with a delayed payment.
+	 *
+	 * Supports being passed a simple, variation or variable subscription product.
+	 * If any product/variation has a trial period and needs shipping, the whole product is considered to have a trial period and needs shipping.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @param WC_Product|null $product Product object.
+	 *
+	 * @return boolean
+	 */
+	public function product_has_trial_and_needs_shipping( $product ) {
+		if ( ! class_exists( 'WC_Subscriptions_Product' ) || ! class_exists( 'WC_Subscriptions_Synchroniser' ) || ! WC_Subscriptions_Product::is_subscription( $product ) ) {
+			return false;
+		}
+
+		if ( $product->get_type() === 'variable-subscription' ) {
+			$products = $product->get_available_variations( 'object' );
+		} else {
+			$products = [ $product ];
+		}
+
+		foreach ( $products as $product ) {
+			// Skip any products that are virtual as we only care about products that require shipping
+			if ( ! $product->needs_shipping() ) {
+				continue;
+			}
+
+			// If the product has a trial period or is synchronised and the first payment is not today.
+			if ( WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+				return true;
+			} else if ( WC_Subscriptions_Synchroniser::is_product_synced( $product ) && ! WC_Subscriptions_Synchroniser::is_payment_upfront( $product ) && ! WC_Subscriptions_Synchroniser::is_today( WC_Subscriptions_Synchroniser::calculate_first_payment_date( $product, 'timestamp' ) ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -1006,7 +1047,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Trial subscriptions with shipping are not supported.
-		if ( class_exists( 'WC_Subscriptions_Product' ) && $product->needs_shipping() && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+		if ( $this->product_has_trial_and_needs_shipping( $product ) ) {
 			return false;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -144,5 +144,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Deleting customer on staging site detaches tokens from customer in Stripe.
 * Fix - Resolved an issue preventing changing a subscriptions payment method when UPE is enabled.
 * Fix - Attach customer billing and address details to the new payment method in Stripe when changing a subscriptions payment method.
+* Fix - Prevent "Invalid recurring shipping method" errors when attempting to purchase a synchronised subscription with payment request buttons.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2395

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When customers attempt to use Apple Pay or Google Pay to purchase a synchronised subscription product that has no upfront costs (i.e. not prorated and not synced to today) and also requires shipping, they're met with an error on the page:

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/890d706b-82ca-426e-a935-c54eb9a04a26)

Inside our Stripe payment request class, we have code that prevents physical products with free trials to be purchased with our payment request methods, but there isn't any code to handle pseudo-free-trials in the form synchronised subscription purchases that are being purchased outside of the synced date.

In this PR, I've introduced a new function that checks if the product is a subscription product and has a free trial (either trial period or is synced with no upfront costs and not purchased on synced date, and requires shipping, and if so, don't load our payment request buttons on the page.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Enable Apple Pay and Google Pay payment methods
2. Install and active Woo Subscriptions
3. Enable synchronised subscriptions in **WooCommerce > Settings > Subscriptions > Synchronise renewals**
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/336e0a3d-c6c9-4978-a66a-9eb0d1d28628)
4. Create a synced product that is not virtual and is not synced to today:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/72e7c87d-3e96-4b8a-8913-8f0a663a9cfd)
5. While on the `develop` branch, view the product page and note the Payment Request buttons (PRB) are loaded. If you attempt to purchase this product with PRB, you will see the above error.
6. Check out this branch and confirm the PRB are no longer loaded on product pages for physical synced subscription products that

Other test cases to run:
 - Physical (non-virtual) variable synced subscriptions. The PRB shouldn't show on the product page if any variation isn't supported.
 - Virtual synced subscriptions. The PRB should show.
 - Physical synced products with a sync date set to today. The PRB should show
 - Physical synced subscription that is synced to another day but proration is enabled in **WC > Settings > Subscriptions**


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
