### PR TITLE
Improvements to Apple Pay\Google Pay when handling subscription variations

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -678,36 +678,36 @@ jQuery( function( $ ) {
 						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
 						wc_stripe_payment_request.hidePaymentRequestButton();
 					} else {
-            /**
-             * If the customer canceled the payment request, we need to re-init the payment request buttons to ensure the shipping
-             * options are fetched again. If the customer didn't close the payment request, and the product's shipping status is
-             * consistent, we can simply update the payment request button with the new total and display items.
-             */
-            if ( ! wc_stripe_payment_request.paymentCanceled && wc_stripe_payment_request_params.product.requestShipping === response.requestShipping ) {
-              $.when(
-                paymentRequest.update( {
-                  total: response.total,
-                  displayItems: response.displayItems,
-                } )
-              ).then( function () {
-                $( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
-                wc_stripe_payment_request.showPaymentRequestButton();
-              } );
-            } else {
-              /**
-               * Re init the payment request button.
-               *
-               * This ensures that when the customer clicks on the payment button, the available shipping options are
-               * refetched based on the selected variable product's data and the chosen address.
-               */
-              wc_stripe_payment_request_params.product.requestShipping = response.requestShipping;
-              wc_stripe_payment_request_params.product.total           = response.total;
-              wc_stripe_payment_request_params.product.displayItems    = response.displayItems;
+						/**
+						 * If the customer canceled the payment request, we need to re-init the payment request buttons to ensure the shipping
+						 * options are fetched again. If the customer didn't close the payment request, and the product's shipping status is
+						 * consistent, we can simply update the payment request button with the new total and display items.
+						 */
+						if ( ! wc_stripe_payment_request.paymentCanceled && wc_stripe_payment_request_params.product.requestShipping === response.requestShipping ) {
+							$.when(
+								paymentRequest.update( {
+									total: response.total,
+									displayItems: response.displayItems,
+								} )
+							).then( function () {
+								$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+								wc_stripe_payment_request.showPaymentRequestButton();
+							} );
+						} else {
+							/**
+							 * Re init the payment request button.
+							 *
+							 * This ensures that when the customer clicks on the payment button, the available shipping options are
+							 * refetched based on the selected variable product's data and the chosen address.
+							 */
+							wc_stripe_payment_request_params.product.requestShipping = response.requestShipping;
+							wc_stripe_payment_request_params.product.total           = response.total;
+							wc_stripe_payment_request_params.product.displayItems    = response.displayItems;
 
-              wc_stripe_payment_request.init();
-              $( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
-            }
-          }
+							wc_stripe_payment_request.init();
+							$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+						}
+					}
 				});
 			});
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -5,7 +5,8 @@ jQuery( function( $ ) {
 	var stripe = Stripe( wc_stripe_payment_request_params.stripe.key, {
 		locale: wc_stripe_payment_request_params.stripe.locale
 	} ),
-		paymentRequestType;
+		paymentRequestType,
+		showButtonsOnInit = wc_stripe_payment_request_params.product.validVariationSelected ?? true;
 
 	/**
 	 * Object to handle Stripe payment forms.
@@ -342,9 +343,12 @@ jQuery( function( $ ) {
 		 * @since 4.0.0
 		 * @version 4.8.0
 		 */
-		startPaymentRequest: function( cart ) {
+		startPaymentRequest: function( cart, showButtonsOnInit ) {
 			var paymentDetails,
 				options;
+
+			// Whether to show the payment request buttons on init. Set to true by default.
+			showButtonsOnInit = showButtonsOnInit ?? true;
 
 			if ( wc_stripe_payment_request_params.is_product_page ) {
 				options = wc_stripe_payment_request.getRequestOptionsFromLocal();
@@ -407,7 +411,10 @@ jQuery( function( $ ) {
 					}
 
 					wc_stripe_payment_request.attachPaymentRequestButtonEventListeners( prButton, paymentRequest );
-					wc_stripe_payment_request.showPaymentRequestButton( prButton );
+
+					if ( showButtonsOnInit ) {
+						wc_stripe_payment_request.showPaymentRequestButton( prButton );
+					}
 				} );
 
 				// Possible statuses success, fail, invalid_payer_name, invalid_payer_email, invalid_payer_phone, invalid_shipping_address.
@@ -829,10 +836,11 @@ jQuery( function( $ ) {
 		 *
 		 * @since 4.0.0
 		 * @version 4.0.0
+		 * @param {boolean} showButtonsOnInit Whether to show the payment request buttons on init.
 		 */
-		init: function() {
+		init: function( showButtonsOnInit ) {
 			if ( wc_stripe_payment_request_params.is_product_page ) {
-				wc_stripe_payment_request.startPaymentRequest( '' );
+				wc_stripe_payment_request.startPaymentRequest( '', showButtonsOnInit );
 			} else {
 				wc_stripe_payment_request.getCartDetails();
 			}
@@ -841,7 +849,7 @@ jQuery( function( $ ) {
 		},
 	};
 
-	wc_stripe_payment_request.init();
+	wc_stripe_payment_request.init( showButtonsOnInit );
 
 	// We need to refresh payment request data when total is updated.
 	$( document.body ).on( 'updated_cart_totals', function() {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -659,14 +659,20 @@ jQuery( function( $ ) {
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
-					$.when(
-						paymentRequest.update( {
-							total: response.total,
-							displayItems: response.displayItems,
-						} )
-					).then( function () {
+					if ( response.error ) {
 						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
-					} );
+						wc_stripe_payment_request.hidePaymentRequestButton();
+					} else {
+						$.when(
+							paymentRequest.update( {
+								total: response.total,
+								displayItems: response.displayItems,
+							} )
+						).then( function () {
+							$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+							wc_stripe_payment_request.showPaymentRequestButton();
+						} );
+					}
 				});
 			});
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
 * Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
+* Fix - Don't require shipping when purchasing a virtual variable subscription product using Google Pay and Apple Pay.
 * Tweak - Improve compatibility with PHP 8+.
 
 = 7.7.0 - 2023-11-09 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,9 @@
 *** Changelog ***
 
 = 7.8.0 - xxxx-xx-xx =
-* Fix: Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
-* Fix: Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
-* Fix: Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
+* Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
+* Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
+* Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Tweak - Improve compatibility with PHP 8+.
 
 = 7.7.0 - 2023-11-09 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Fix - Don't require shipping when purchasing a virtual variable subscription product using Google Pay and Apple Pay.
+* Fix - When using Payment Request buttons, fix $0 total for stores using a customized product page that adds the variation product ID directly into the cart.
 * Tweak - Improve compatibility with PHP 8+.
 
 = 7.7.0 - 2023-11-09 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,8 @@
 
 = 7.8.0 - xxxx-xx-xx =
 * Fix: Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
+* Fix: Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
+* Fix: Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Tweak - Improve compatibility with PHP 8+.
 
 = 7.7.0 - 2023-11-09 =

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -385,7 +385,7 @@ class WC_Stripe_Payment_Request {
 
 		$product = $this->get_product();
 
-		if ( 'variable' === $product->get_type() ) {
+		if ( in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
 			$variation_attributes = $product->get_variation_attributes();
 			$attributes           = [];
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -617,18 +617,18 @@ class WC_Stripe_Payment_Request {
 	 *
 	 * If the product is a variable subscription, this function will return true if all of its variations have a trial and require shipping.
 	 *
-	 * @since 7.7.0
+	 * @since 7.8.0
 	 *
-	 * @param WC_Product|null $product Product object.
+	 * @param WC_Product|null $product                 Product object.
+	 * @param boolean         $is_product_page_request Whether this is a request from the product page.
 	 *
 	 * @return boolean
 	 */
-	public function is_invalid_subscription_product( $product ) {
+	public function is_invalid_subscription_product( $product, $is_product_page_request = false ) {
 		if ( ! class_exists( 'WC_Subscriptions_Product' ) || ! class_exists( 'WC_Subscriptions_Synchroniser' ) || ! WC_Subscriptions_Product::is_subscription( $product ) ) {
 			return false;
 		}
 
-		$is_product_page = $this->is_product();
 		$is_invalid      = true;
 
 		if ( $product->get_type() === 'variable-subscription' ) {
@@ -643,7 +643,7 @@ class WC_Stripe_Payment_Request {
 			$is_payment_upfront = WC_Subscriptions_Synchroniser::is_payment_upfront( $product );
 			$has_trial_period   = WC_Subscriptions_Product::get_trial_length( $product ) > 0;
 
-			if ( $is_product_page && $is_synced && ! $is_payment_upfront && ! $needs_shipping ) {
+			if ( $is_product_page_request && $is_synced && ! $is_payment_upfront && ! $needs_shipping ) {
 				/**
 				 * This condition prevents the purchase of virtual synced subscription products with no upfront costs via Payment Request Buttons from the product page.
 				 *
@@ -1067,7 +1067,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// Trial subscriptions with shipping are not supported.
-		if ( $this->is_invalid_subscription_product( $product ) ) {
+		if ( $this->is_invalid_subscription_product( $product, true ) ) {
 			return false;
 		}
 
@@ -1336,7 +1336,7 @@ class WC_Stripe_Payment_Request {
 				}
 			}
 
-			if ( $this->is_invalid_subscription_product( $product ) ) {
+			if ( $this->is_invalid_subscription_product( $product, true ) ) {
 				throw new Exception( __( 'The chosen subscription product is not supported.', 'woocommerce-gateway-stripe' ) );
 			}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -364,7 +364,7 @@ class WC_Stripe_Payment_Request {
 	public function get_product_price( $product ) {
 		$product_price = $product->get_price();
 		// Add subscription sign-up fees to product price.
-		if ( 'subscription' === $product->get_type() && class_exists( 'WC_Subscriptions_Product' ) ) {
+		if ( in_array( $product->get_type(), [ 'subscription', 'subscription_variation' ] ) && class_exists( 'WC_Subscriptions_Product' ) ) {
 			$product_price = $product->get_price() + WC_Subscriptions_Product::get_sign_up_fee( $product );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1317,6 +1317,10 @@ class WC_Stripe_Payment_Request {
 				}
 			}
 
+			if ( $this->product_has_trial_and_needs_shipping( $product ) ) {
+				throw new Exception( __( 'Subscription products with a trial period and require shipping are not supported.', 'woocommerce-gateway-stripe' ) );
+			}
+
 			// Force quantity to 1 if sold individually and check for existing item in cart.
 			if ( $product->is_sold_individually() ) {
 				$qty = apply_filters( 'wc_stripe_payment_request_add_to_cart_sold_individually_quantity', 1, $qty, $product_id, $variation_id );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1442,7 +1442,7 @@ class WC_Stripe_Payment_Request {
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
 		}
 
-		if ( 'simple' === $product_type || 'subscription' === $product_type ) {
+		if ( in_array( $product_type, [ 'simple', 'variation', 'subscription', 'subscription_variation' ], true ) ) {
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -639,7 +639,7 @@ class WC_Stripe_Payment_Request {
 
 			// If product is synced, check if the first payment is upfront or today (i.e. no trial period). If product is not synced, check if it has a trial period.
 			if ( WC_Subscriptions_Synchroniser::is_product_synced( $product ) ) {
-				if ( WC_Subscriptions_Synchroniser::is_payment_upfront( $product ) || WC_Subscriptions_Synchroniser::is_today( WC_Subscriptions_Synchroniser::calculate_first_payment_date( $product, 'timestamp' ) ) ) {
+				if ( WC_Subscriptions_Synchroniser::is_payment_upfront( $product ) ) {
 					return false;
 				}
 			} elseif ( WC_Subscriptions_Product::get_trial_length( $product ) <= 0 ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1306,7 +1306,7 @@ class WC_Stripe_Payment_Request {
 				throw new Exception( sprintf( __( 'Product with the ID (%1$s) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
 			}
 
-			if ( 'variable' === $product->get_type() && isset( $_POST['attributes'] ) ) {
+			if ( in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true ) && isset( $_POST['attributes'] ) ) {
 				$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
 
 				$data_store   = WC_Data_Store::load( 'product' );

--- a/readme.txt
+++ b/readme.txt
@@ -129,9 +129,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 7.8.0 - xxxx-xx-xx =
-* Fix: Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
-* Fix: Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
-* Fix: Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
+* Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
+* Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
+* Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Tweak - Improve compatibility with PHP 8+.
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 7.8.0 - xxxx-xx-xx =
 * Fix: Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
+* Fix: Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
+* Fix: Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Tweak - Improve compatibility with PHP 8+.
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
 * Fix - Don't require shipping when purchasing a virtual variable subscription product using Google Pay and Apple Pay.
+* Fix - When using Payment Request buttons, fix $0 total for stores using a customized product page that adds the variation product ID directly into the cart.
 * Tweak - Improve compatibility with PHP 8+.
 
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
 * Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
 * Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
+* Fix - Don't require shipping when purchasing a virtual variable subscription product using Google Pay and Apple Pay.
 * Tweak - Improve compatibility with PHP 8+.
 
 


### PR DESCRIPTION
Fixes #2755 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->


Recently we merged https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2736 which fixed an issue with synced subscriptions that required shipping not being supported by the Payment Request Buttons (PRB). We patched this by simply not loading the PRB's for synced subscriptions that didn't have an initial payment and required shipping.

While reviewing the same changes made to WooPayments (https://github.com/Automattic/woocommerce-payments/pull/7582) we discovered we can make improvements to how this function handles variable subscriptions. Previously we would completely hide the PRB's if **any** of the variations didn't support PRB, but turns out we can tweak the new `product_has_trial_and_needs_shipping()` function so that we only hide the PRB is _all_ variations, then when a variation is selected, check whether that specific variation supports PRB and hide/show the buttons accordingly:

![Screen Capture on 2023-11-03 at 12-48-54](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/3ddad22d-d0cb-43da-a45a-5f3259d4cfab)

While bringing over the same changes I made to WooPayments, I found a couple more issues with Stripe's payment request button implementation. These are all getting fixed by this PR:
1. `ajax_get_selected_product_data()` wasn't building the correct product data for subscription variations. This was because we were only looking for `'variable' === $product->get_type()` and not checking for `'variable-subscription'`
2. Exceptions thrown by the `ajax_get_selected_product_data()` function weren't hiding the PRB on the front end.
3. Virtual synced subscription products display the wrong total when purchased from the product page. This is because the `get_product_price()` function cannot accurately calculate the prorated sync price or incorporate mock trials. This only happens during `cart->calculate_totals()`
4. If you have selected a variation that is not supported by PRB and you click the add to cart button, the Apple Pay and Google Pay buttons were displayed on the page after adding the product to the cart.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

#### Testing Synced Variations

1. Enable Apple Pay and Google Pay payment methods
2. Install and active Woo Subscriptions
5. Enable synchronised subscriptions in **WooCommerce > Settings > Subscriptions > Synchronise renewals**
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/336e0a3d-c6c9-4978-a66a-9eb0d1d28628)
6. Create a variable subscription product where one is synced and virtual and the other is synced and not virtual and is not synced to today.
7. While on the `develop` branch, view the product page and note the Payment Request buttons (PRB) aren't loaded.
8. Check out this branch and confirm the PRB are loaded on product pages and only hidden after selecting the variation that is synced and requires shipping.

#### Incorrect ajax_get_selected_product_data()

1. Create a variable subscription with at least 2 variations that cost different amounts
2. While on `develop`, view the product page and select one variation and click on the GPay button
3. Close the GPay window and choose the other variation and click on the GPay button again
4. Notice the price doesn't change?

https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/c19229e7-acaa-416b-bb02-1d104740549d

When you run the same test on this branch, the correct prices are sent to the Payment Request Buttons.

> [!NOTE]
> I'm noticing the shipping values aren't being added correctly to the total but this isn't new to this PR. I'll keep exploring this issue to see if there's a simple solution.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
