### PR TITLE
Update Woo Subscriptions selector Id in the plugin listing during E2E setup step

### DIFF
--- a/tests/e2e/utils/playwright-setup.js
+++ b/tests/e2e/utils/playwright-setup.js
@@ -324,7 +324,7 @@ export const installWooSubscriptionsFromRepo = ( page ) =>
 
 			// Assert that the plugin is listed and active
 			await expect(
-				page.locator( `#deactivate-${ pluginSlug }` )
+				page.locator( '#deactivate-woo-subscriptions' )
 			).toBeVisible();
 
 			console.log(


### PR DESCRIPTION
After the rename of the Woo Subscriptions extension (previously WooCommerce Subscriptions) the e2e setup fails with the following error:

![Screenshot 2023-11-03 at 12 15 53](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/c5627010-bd60-43df-9f3e-ba085a5f8885)

The `id` in the plugins list changed from `#deactivate-woocommerce-subscriptions` to `#deactivate-woo-subscriptions`.

## Changes proposed in this Pull Request:

This PR directly updates the selector `#deactivate-${ pluginSlug }` as the method `installWooSubscriptionsFromRepo(...)` only installs Woo Subscriptions (as the name suggests).

## Testing instructions

1. Create a JurassicNinja site with PHP 8.0, the latest WordPress and the latest WooCommerce [clicking here](https://href.li/?https://jurassic.ninja/create?nojetpack&woocommerce).
2. If you don’t have the E2E environment configured, follow the [instructions here](https://href.li/?https://github.com/woocommerce/woocommerce-gateway-stripe/tree/develop/tests/e2e).
3. Edit your `/tests/e2e/config/local.env` file with the details of the newly created Jurassic Ninja site:
    - ADMIN_PASSWORD
    - SSH_HOST
    - SSH_USER
    - SSH_PASSWORD
    - SSH_PATH
4. Run the E2E tests: `npm run test:e2e-setup -- --base_url=<jurassic-ninja-site-url>`
5. All tests should now pass successfully.
