### PR TITLE
Incorrect totals in Google Pay/Apple Pay on variable product pages when you close the window and choose another variation

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -12,6 +12,11 @@ jQuery( function( $ ) {
 	 */
 	var wc_stripe_payment_request = {
 		/**
+		 * Whether the payment request window was canceled/dismissed by the customer.
+		 */
+		paymentCanceled: false,
+
+		/**
 		 * Get WC AJAX endpoint URL.
 		 *
 		 * @param  {String} endpoint Endpoint.
@@ -440,11 +445,13 @@ jQuery( function( $ ) {
 				} );
 
 				paymentRequest.on( 'cancel', function() {
-					// If the customer closes the Payment Request window on the product page, chooses another variation and then attempts to pay with the payment request buttons again,
-					// we need to make sure we re-init the payment request so that the 'shippingaddresschange' event is fired again, otherwise shipping options won't be calculated.
-					if ( wc_stripe_payment_request_params.is_product_page ) {
-						wc_stripe_payment_request.init();
-					}
+					/**
+					 * If the customer closes the Payment Request window set paymentCanceled to true.
+					 *
+					 * This helps us determine whether we need to rebuild the payment request UI after it's been closed. This is to fix issues like the
+					 * 'shippingaddresschange' event not triggering when the customer closes the Google Pay/Apple Pay window and chooses a different variation product.
+					 */
+					wc_stripe_payment_request.paymentCanceled = true;
 				} );
 			} catch( e ) {
 				// Leave for troubleshooting
@@ -667,14 +674,34 @@ jQuery( function( $ ) {
 				$( document.body ).trigger( 'wc_stripe_block_payment_request_button' );
 
 				$.when( wc_stripe_payment_request.getSelectedProductData() ).then( function ( response ) {
-					$.when(
-						paymentRequest.update( {
-							total: response.total,
-							displayItems: response.displayItems,
-						} )
-					).then( function () {
+					/**
+					 * If the customer canceled the payment request, we need to re-init the payment request buttons to ensure the shipping
+					 * options are fetched again. If the customer didn't close the payment request, and the product's shipping status is
+					 * consistent, we can simply update the payment request button with the new total and display items.
+					 */
+					if ( ! wc_stripe_payment_request.paymentCanceled && wc_stripe_payment_request_params.product.requestShipping === response.requestShipping ) {
+						$.when(
+							paymentRequest.update( {
+								total: response.total,
+								displayItems: response.displayItems,
+							} )
+						).then( function () {
+							$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
+						} );
+					} else {
+						/**
+						 * Re init the payment request button.
+						 *
+						 * This ensures that when the customer clicks on the payment button, the available shipping options are
+						 * refetched based on the selected variable product's data and the chosen address.
+						 */
+						wc_stripe_payment_request_params.product.requestShipping = response.requestShipping;
+						wc_stripe_payment_request_params.product.total           = response.total;
+						wc_stripe_payment_request_params.product.displayItems    = response.displayItems;
+
+						wc_stripe_payment_request.init();
 						$( document.body ).trigger( 'wc_stripe_unblock_payment_request_button' );
-					} );
+					}
 				});
 			});
 
@@ -804,6 +831,7 @@ jQuery( function( $ ) {
 				wc_stripe_payment_request.getCartDetails();
 			}
 
+			wc_stripe_payment_request.paymentCanceled = false;
 		},
 	};
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -438,6 +438,14 @@ jQuery( function( $ ) {
 						} );
 					}
 				} );
+
+				paymentRequest.on( 'cancel', function() {
+					// If the customer closes the Payment Request window on the product page, chooses another variation and then attempts to pay with the payment request buttons again,
+					// we need to make sure we re-init the payment request so that the 'shippingaddresschange' event is fired again, otherwise shipping options won't be calculated.
+					if ( wc_stripe_payment_request_params.is_product_page ) {
+						wc_stripe_payment_request.init();
+					}
+				} );
 			} catch( e ) {
 				// Leave for troubleshooting
 				console.error( e );

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Fix - Send customer billing and address details to Stripe when changing a subscriptions payment method.
 * Add - Attach billing details to customers created in Stripe to support Indian merchants in processing international transactions.
 * Fix - Prevent "Invalid recurring shipping method" errors when attempting to purchase a synchronised subscription with payment request buttons.
+* Fix - When using Payment Request buttons on variable product pages, ensure shipping is properly calculated after the customer closes the window and changes variations.
 
 = 7.6.2 - 2023-10-31 =
 * Deprecate - Remove Sofort support for new accounts.

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Add - Attach billing details to customers created in Stripe to support Indian merchants in processing international transactions.
 * Fix - Prevent "Invalid recurring shipping method" errors when attempting to purchase a synchronised subscription with payment request buttons.
 * Fix - When using Payment Request buttons on variable product pages, ensure shipping is properly calculated after the customer closes the window and changes variations.
+* Fix - Purchasing a virtual variable product using Apple Pay and Google Pay on the product page will no longer require shipping details.
 
 = 7.6.2 - 2023-10-31 =
 * Deprecate - Remove Sofort support for new accounts.

--- a/readme.txt
+++ b/readme.txt
@@ -146,5 +146,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Send customer billing and address details to Stripe when changing a subscriptions payment method.
 * Add - Attach billing details to customers created in Stripe to support Indian merchants in processing international transactions.
 * Fix - Prevent "Invalid recurring shipping method" errors when attempting to purchase a synchronised subscription with payment request buttons.
+* Fix - When using Payment Request buttons on variable product pages, ensure shipping is properly calculated after the customer closes the window and changes variations.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -147,5 +147,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Attach billing details to customers created in Stripe to support Indian merchants in processing international transactions.
 * Fix - Prevent "Invalid recurring shipping method" errors when attempting to purchase a synchronised subscription with payment request buttons.
 * Fix - When using Payment Request buttons on variable product pages, ensure shipping is properly calculated after the customer closes the window and changes variations.
+* Fix - Purchasing a virtual variable product using Apple Pay and Google Pay on the product page will no longer require shipping details.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

While working on https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2741 and testing Payment Request buttons on variable products I noticed some funky behavior happens when you close the Google Pay window, choose another variation and then try to purchase with Google Pay. What I found is the total checkout amount wasn't being calculated with any shipping totals:

https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/2dde3ed8-a705-42c0-814f-d27970bec792



What I found is this is being caused by Stripe only triggering the `'shippingaddresschange'` event ([Stripe docs](https://stripe.com/docs/js/payment_request/events/on_shipping_address_change)) when the Payment Request window is first opened and then only if the shipping address has changed. This means, when a customer chooses a variation, clicks Google Pay/Apple Pay, we calculate the shipping options and totals which shows the correct total with shipping included. If the customer closes the window, chooses a different variation and clicks Google Pay/Apple Pay, we won't calculate shipping options/totals again because the `shippingaddresschange` event is not triggered which then leads to the totals in Google Pay/Apple Pay not including shipping amounts.

To fix this issue I've made a small change to the JS to hook onto Stripe's Payment Request [`cancel`](https://stripe.com/docs/js/payment_request/events/on_cancel) event and if we're on the product page, re-init our Payment Request Buttons.



## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Create a non-virtual variable product with at least 2 variations
2. Enable the Express checkout methods in **WC > Settings > Payments > Stripe**
3. Enable shipping and create a non-free shipping option
4. Visit the variable product page, select a variation
5. Click on Google Pay and notice the total is correct in the pop-up window
6. Close the window, select another variation and click on Google Pay again
7. On `develop` you will notice the total doesn't include shipping
8. On this branch the totals should include shipping

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
