### PR TITLE
Stripe common settings page

### DIFF
--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -107,6 +107,11 @@ export const useShortAccountStatementDescriptor = makeSettingsHook(
 export const useDebugLog = makeSettingsHook( 'is_debug_log_enabled' );
 export const useIsUpeEnabled = makeSettingsHook( 'is_upe_enabled' );
 
+export const useIndividualPaymentMethodSettings = makeSettingsHook(
+	'individual_payment_method_settings',
+	EMPTY_ARR
+);
+
 export const useGetAvailablePaymentMethodIds = makeReadOnlySettingsHook(
 	'available_payment_method_ids',
 	EMPTY_ARR

--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -143,7 +143,41 @@ describe( 'GeneralSettingsSection', () => {
 		] );
 	} );
 
-	it( 'should show modal to disable a payment method when UPE is enabled', () => {
+	it( 'should allow to enable a payment method when UPE is disabled', () => {
+		useGetAvailablePaymentMethodIds.mockReturnValue( [
+			'card',
+			'giropay',
+			'sofort',
+			'sepa_debit',
+		] );
+		const updateEnabledMethodsMock = jest.fn();
+		useEnabledPaymentMethodIds.mockReturnValue( [
+			[ 'card' ],
+			updateEnabledMethodsMock,
+		] );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
+		const giropayCheckbox = screen.getByRole( 'checkbox', {
+			name: /giropay/,
+		} );
+
+		expect( updateEnabledMethodsMock ).not.toHaveBeenCalled();
+		expect( giropayCheckbox ).not.toBeChecked();
+
+		userEvent.click( giropayCheckbox );
+
+		expect( updateEnabledMethodsMock ).toHaveBeenCalledWith( [
+			'card',
+			'giropay',
+		] );
+	} );
+
+	it( 'should show modal to disable a payment method', () => {
 		useGetAvailablePaymentMethodIds.mockReturnValue( [
 			'card',
 			'giropay',
@@ -367,6 +401,26 @@ describe( 'GeneralSettingsSection', () => {
 		);
 
 		expect( setIndividualPaymentMethodSettingsMock ).toHaveBeenCalled();
+	} );
+
+	it( 'should not display customization section in the payment method when UPE is enabled', () => {
+		useGetAvailablePaymentMethodIds.mockReturnValue( [ 'giropay' ] );
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<GeneralSettingsSection />
+			</UpeToggleContext.Provider>
+		);
+
+		expect(
+			screen.queryByRole( 'checkbox', {
+				name: 'giropay',
+			} )
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', {
+				name: 'Customize',
+			} )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'displays the payment method checkbox when manual capture is disabled', () => {

--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import GeneralSettingsSection from '..';
 import UpeToggleContext from '../../upe-toggle/context';
 import {
+	useIsStripeEnabled,
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,
 	useManualCapture,
@@ -12,6 +13,7 @@ import {
 import { useAccount, useGetCapabilities } from 'wcstripe/data/account';
 
 jest.mock( 'wcstripe/data', () => ( {
+	useIsStripeEnabled: jest.fn(),
 	useGetAvailablePaymentMethodIds: jest.fn(),
 	useEnabledPaymentMethodIds: jest.fn(),
 	useManualCapture: jest.fn(),
@@ -48,6 +50,7 @@ describe( 'GeneralSettingsSection', () => {
 			jest.fn(),
 		] );
 		useAccount.mockReturnValue( { isRefreshing: false } );
+		useIsStripeEnabled.mockReturnValue( [ false, jest.fn() ] );
 	} );
 
 	it( 'should show information to screen readers about the payment methods being updated', () => {

--- a/client/settings/general-settings-section/customize-payment-method.js
+++ b/client/settings/general-settings-section/customize-payment-method.js
@@ -1,7 +1,8 @@
 import { __ } from '@wordpress/i18n';
-import React from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { Button, TextControl } from '@wordpress/components';
+import { useIndividualPaymentMethodSettings } from 'wcstripe/data';
 
 const ButtonWrapper = styled.div`
 	display: flex;
@@ -9,23 +10,32 @@ const ButtonWrapper = styled.div`
 	gap: 8px;
 `;
 
-const CustomizePaymentMethod = ( { method, onCancel } ) => {
-	// eslint-disable-next-line @wordpress/i18n-no-variables
-	const description = __(
-		`You will be redirected to ${ method }.`,
-		'woocommerce-gateway-stripe'
-	);
+const CustomizePaymentMethod = ( { method, onClose } ) => {
+	const [
+		individualPaymentMethodSettings,
+		setIndividualPaymentMethodSettings,
+	] = useIndividualPaymentMethodSettings();
+	const { name, description } = individualPaymentMethodSettings[ method ];
+	const [ methodName, setMethodName ] = useState( name );
+	const [ methodDescription, setMethodDescription ] = useState( description );
 
 	const onSave = () => {
-		// todo: save method
+		setIndividualPaymentMethodSettings( {
+			...individualPaymentMethodSettings,
+			[ method ]: {
+				name: methodName,
+				description: methodDescription,
+			},
+		} );
+		onClose();
 	};
 
 	return (
 		<div>
 			<TextControl
 				label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
-				value={ method }
-				onChange={ () => {} }
+				value={ methodName }
+				onChange={ setMethodName }
 				help={ __(
 					'Enter a name which customers will see during checkout.',
 					'woocommerce-gateway-stripe'
@@ -33,15 +43,15 @@ const CustomizePaymentMethod = ( { method, onCancel } ) => {
 			/>
 			<TextControl
 				label={ __( 'Description', 'woocommerce-gateway-stripe' ) }
-				value={ description }
-				onChange={ () => {} }
+				value={ methodDescription }
+				onChange={ setMethodDescription }
 				help={ __(
 					'Describe how customers should use this payment method during checkout.',
 					'woocommerce-gateway-stripe'
 				) }
 			/>
 			<ButtonWrapper>
-				<Button variant="tertiary" onClick={ onCancel }>
+				<Button variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel', 'woocommerce-gateway-stripe' ) }
 				</Button>
 				<Button variant="secondary" onClick={ onSave }>

--- a/client/settings/general-settings-section/customize-payment-method.js
+++ b/client/settings/general-settings-section/customize-payment-method.js
@@ -1,0 +1,55 @@
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+import styled from '@emotion/styled';
+import { Button, TextControl } from '@wordpress/components';
+
+const ButtonWrapper = styled.div`
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+`;
+
+const CustomizePaymentMethod = ( { method, onCancel } ) => {
+	// eslint-disable-next-line @wordpress/i18n-no-variables
+	const description = __(
+		`You will be redirected to ${ method }.`,
+		'woocommerce-gateway-stripe'
+	);
+
+	const onSave = () => {
+		// todo: save method
+	};
+
+	return (
+		<div>
+			<TextControl
+				label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
+				value={ method }
+				onChange={ () => {} }
+				help={ __(
+					'Enter a name which customers will see during checkout.',
+					'woocommerce-gateway-stripe'
+				) }
+			/>
+			<TextControl
+				label={ __( 'Description', 'woocommerce-gateway-stripe' ) }
+				value={ description }
+				onChange={ () => {} }
+				help={ __(
+					'Describe how customers should use this payment method during checkout.',
+					'woocommerce-gateway-stripe'
+				) }
+			/>
+			<ButtonWrapper>
+				<Button variant="tertiary" onClick={ onCancel }>
+					{ __( 'Cancel', 'woocommerce-gateway-stripe' ) }
+				</Button>
+				<Button variant="secondary" onClick={ onSave }>
+					{ __( 'Save changes', 'woocommerce-gateway-stripe' ) }
+				</Button>
+			</ButtonWrapper>
+		</div>
+	);
+};
+
+export default CustomizePaymentMethod;

--- a/client/settings/general-settings-section/payment-method-checkbox.js
+++ b/client/settings/general-settings-section/payment-method-checkbox.js
@@ -1,9 +1,8 @@
 import { __, sprintf } from '@wordpress/i18n';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
-import UpeToggleContext from '../upe-toggle/context';
 import RemoveMethodConfirmationModal from './remove-method-confirmation-modal';
 import { useEnabledPaymentMethodIds, useManualCapture } from 'wcstripe/data';
 import Tooltip from 'wcstripe/components/tooltip';
@@ -24,7 +23,6 @@ const IconWrapper = styled.span`
 `;
 
 const PaymentMethodCheckbox = ( { id, label, isAllowingManualCapture } ) => {
-	const { isUpeEnabled } = useContext( UpeToggleContext );
 	const [ isManualCaptureEnabled ] = useManualCapture();
 	const [ isConfirmationModalOpen, setIsConfirmationModalOpen ] = useState(
 		false
@@ -49,10 +47,6 @@ const PaymentMethodCheckbox = ( { id, label, isAllowingManualCapture } ) => {
 			enabledPaymentMethods.filter( ( m ) => m !== id )
 		);
 	};
-
-	if ( ! isUpeEnabled ) {
-		return null;
-	}
 
 	return (
 		<>

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import styled from '@emotion/styled';
 import classnames from 'classnames';
 import { Button } from '@wordpress/components';
+import UpeToggleContext from '../upe-toggle/context';
 import PaymentMethodsMap from '../../payment-methods-map';
 import PaymentMethodDescription from './payment-method-description';
 import CustomizePaymentMethod from './customize-payment-method';
@@ -95,6 +96,7 @@ const StyledFees = styled( PaymentMethodFeesPill )`
 `;
 
 const GeneralSettingsSection = () => {
+	const { isUpeEnabled } = useContext( UpeToggleContext );
 	const [ customizationStatus, setCustomizationStatus ] = useState( {} );
 	const upePaymentMethods = useGetAvailablePaymentMethodIds();
 	const capabilities = useGetCapabilities();
@@ -156,27 +158,29 @@ const GeneralSettingsSection = () => {
 								/>
 								<StyledFees id={ method } />
 							</PaymentMethodWrapper>
-							{ ! customizationStatus[ method ] && (
-								<Button
-									variant="secondary"
-									onClick={ () =>
-										setCustomizationStatus( {
-											...customizationStatus,
-											[ method ]: true,
-										} )
-									}
-								>
-									{ __(
-										'Customize',
-										'woocommerce-gateway-stripe'
-									) }
-								</Button>
-							) }
+							{ ! isUpeEnabled &&
+								method !== 'card' &&
+								! customizationStatus[ method ] && (
+									<Button
+										variant="secondary"
+										onClick={ () =>
+											setCustomizationStatus( {
+												...customizationStatus,
+												[ method ]: true,
+											} )
+										}
+									>
+										{ __(
+											'Customize',
+											'woocommerce-gateway-stripe'
+										) }
+									</Button>
+								) }
 						</ListElement>
-						{ customizationStatus[ method ] && (
+						{ ! isUpeEnabled && customizationStatus[ method ] && (
 							<CustomizePaymentMethod
 								method={ method }
-								onCancel={ () =>
+								onClose={ () =>
 									setCustomizationStatus( {
 										...customizationStatus,
 										[ method ]: false,

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -1,7 +1,6 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
 import classnames from 'classnames';
-import UpeToggleContext from '../upe-toggle/context';
 import PaymentMethodsMap from '../../payment-methods-map';
 import PaymentMethodDescription from './payment-method-description';
 import PaymentMethodCheckbox from './payment-method-checkbox';
@@ -74,7 +73,6 @@ const StyledFees = styled( PaymentMethodFeesPill )`
 `;
 
 const GeneralSettingsSection = () => {
-	const { isUpeEnabled } = useContext( UpeToggleContext );
 	const upePaymentMethods = useGetAvailablePaymentMethodIds();
 	const capabilities = useGetCapabilities();
 	const [ isManualCaptureEnabled ] = useManualCapture();
@@ -129,7 +127,7 @@ const GeneralSettingsSection = () => {
 								description={ description }
 								label={ label }
 							/>
-							{ isUpeEnabled && <StyledFees id={ method } /> }
+							<StyledFees id={ method } />
 						</PaymentMethodWrapper>
 					</ListElement>
 				);

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -132,9 +132,8 @@ const GeneralSettingsSection = () => {
 				} = PaymentMethodsMap[ method ];
 
 				return (
-					<>
+					<div key={ method }>
 						<ListElement
-							key={ method }
 							className={ classnames( {
 								'has-overlay':
 									! isAllowingManualCapture &&
@@ -188,7 +187,7 @@ const GeneralSettingsSection = () => {
 								}
 							/>
 						) }
-					</>
+					</div>
 				);
 			} ) }
 		</List>

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import { __ } from '@wordpress/i18n';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import classnames from 'classnames';
+import { Button } from '@wordpress/components';
 import PaymentMethodsMap from '../../payment-methods-map';
 import PaymentMethodDescription from './payment-method-description';
+import CustomizePaymentMethod from './customize-payment-method';
 import PaymentMethodCheckbox from './payment-method-checkbox';
 import {
 	useEnabledPaymentMethodIds,
@@ -26,12 +29,31 @@ const List = styled.ul`
 		&:not( :last-child ) {
 			box-shadow: inset 0 -1px 0 #e8eaeb;
 		}
+
+		&.expanded {
+			box-shadow: none;
+			padding-bottom: 0;
+		}
+	}
+
+	> div {
+		margin: 0;
+		padding: 16px 24px 14px 24px;
+
+		@media ( min-width: 660px ) {
+			padding: 16px 24px 24px 24px;
+		}
+
+		&:not( :last-child ) {
+			box-shadow: inset 0 -1px 0 #e8eaeb;
+		}
 	}
 `;
 
 const ListElement = styled.li`
 	display: flex;
 	flex-wrap: nowrap;
+	gap: 16px;
 
 	@media ( min-width: 660px ) {
 		align-items: center;
@@ -73,6 +95,7 @@ const StyledFees = styled( PaymentMethodFeesPill )`
 `;
 
 const GeneralSettingsSection = () => {
+	const [ customizationStatus, setCustomizationStatus ] = useState( {} );
 	const upePaymentMethods = useGetAvailablePaymentMethodIds();
 	const capabilities = useGetCapabilities();
 	const [ isManualCaptureEnabled ] = useManualCapture();
@@ -107,29 +130,61 @@ const GeneralSettingsSection = () => {
 				} = PaymentMethodsMap[ method ];
 
 				return (
-					<ListElement
-						key={ method }
-						className={ classnames( {
-							'has-overlay':
-								! isAllowingManualCapture &&
-								isManualCaptureEnabled,
-						} ) }
-					>
-						<PaymentMethodCheckbox
-							id={ method }
-							label={ label }
-							isAllowingManualCapture={ isAllowingManualCapture }
-						/>
-						<PaymentMethodWrapper>
-							<PaymentMethodDescription
+					<>
+						<ListElement
+							key={ method }
+							className={ classnames( {
+								'has-overlay':
+									! isAllowingManualCapture &&
+									isManualCaptureEnabled,
+								expanded: customizationStatus[ method ],
+							} ) }
+						>
+							<PaymentMethodCheckbox
 								id={ method }
-								Icon={ Icon }
-								description={ description }
 								label={ label }
+								isAllowingManualCapture={
+									isAllowingManualCapture
+								}
 							/>
-							<StyledFees id={ method } />
-						</PaymentMethodWrapper>
-					</ListElement>
+							<PaymentMethodWrapper>
+								<PaymentMethodDescription
+									id={ method }
+									Icon={ Icon }
+									description={ description }
+									label={ label }
+								/>
+								<StyledFees id={ method } />
+							</PaymentMethodWrapper>
+							{ ! customizationStatus[ method ] && (
+								<Button
+									variant="secondary"
+									onClick={ () =>
+										setCustomizationStatus( {
+											...customizationStatus,
+											[ method ]: true,
+										} )
+									}
+								>
+									{ __(
+										'Customize',
+										'woocommerce-gateway-stripe'
+									) }
+								</Button>
+							) }
+						</ListElement>
+						{ customizationStatus[ method ] && (
+							<CustomizePaymentMethod
+								method={ method }
+								onCancel={ () =>
+									setCustomizationStatus( {
+										...customizationStatus,
+										[ method ]: false,
+									} )
+								}
+							/>
+						) }
+					</>
 				);
 			} ) }
 		</List>

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -1,16 +1,13 @@
 import { __ } from '@wordpress/i18n';
-import React, { useContext } from 'react';
+import React from 'react';
 import { ExternalLink } from '@wordpress/components';
 import SettingsSection from '../settings-section';
 import PaymentRequestSection from '../payment-request-section';
 import GeneralSettingsSection from '../general-settings-section';
 import LoadableSettingsSection from '../loadable-settings-section';
-import UpeToggleContext from '../upe-toggle/context';
 import CustomizationOptionsNotice from '../customization-options-notice';
 
 const PaymentMethodsDescription = () => {
-	const { isUpeEnabled } = useContext( UpeToggleContext );
-
 	return (
 		<>
 			<h2>
@@ -20,16 +17,14 @@ const PaymentMethodsDescription = () => {
 				) }
 			</h2>
 
-			{ isUpeEnabled && (
-				<p>
-					{ __(
-						'Select payments available to customers at checkout. ' +
-							'Based on their device type, location, and purchase history, ' +
-							'your customers will only see the most relevant payment methods.',
-						'woocommerce-gateway-stripe'
-					) }
-				</p>
-			) }
+			<p>
+				{ __(
+					'Select payments available to customers at checkout. ' +
+						'Based on their device type, location, and purchase history, ' +
+						'your customers will only see the most relevant payment methods.',
+					'woocommerce-gateway-stripe'
+				) }
+			</p>
 		</>
 	);
 };

--- a/client/settings/payment-settings/__tests__/general-settings-section.test.js
+++ b/client/settings/payment-settings/__tests__/general-settings-section.test.js
@@ -7,6 +7,7 @@ import GeneralSettingsSection from '../general-settings-section';
 import { AccountKeysModal } from 'wcstripe/settings/payment-settings/account-keys-modal';
 import {
 	useIsStripeEnabled,
+	useEnabledPaymentMethodIds,
 	useTestMode,
 	useTitle,
 	useUpeTitle,
@@ -26,6 +27,7 @@ import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useIsStripeEnabled: jest.fn(),
+	useEnabledPaymentMethodIds: jest.fn(),
 	useTestMode: jest.fn(),
 	useTitle: jest.fn().mockReturnValue( [] ),
 	useUpeTitle: jest.fn().mockReturnValue( [] ),
@@ -69,6 +71,10 @@ describe( 'GeneralSettingsSection', () => {
 				test_webhook_secret: 'test_whs',
 			},
 		} );
+		useEnabledPaymentMethodIds.mockReturnValue( [
+			[ 'card', 'giropay' ],
+			jest.fn(),
+		] );
 
 		render( <GeneralSettingsSection /> );
 

--- a/client/settings/payment-settings/general-settings-section.js
+++ b/client/settings/payment-settings/general-settings-section.js
@@ -17,6 +17,7 @@ import {
 	useTitle,
 	useUpeTitle,
 	useDescription,
+	useEnabledPaymentMethodIds,
 } from 'wcstripe/data';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
@@ -35,11 +36,40 @@ const GeneralSettingsSection = ( { setKeepModalContent } ) => {
 	const [ title, setTitle ] = useTitle();
 	const [ upeTitle, setUpeTitle ] = useUpeTitle();
 	const [ description, setDescription ] = useDescription();
+	const [
+		enabledPaymentMethods,
+		setEnabledPaymentMethods,
+	] = useEnabledPaymentMethodIds();
 	const [ modalType, setModalType ] = useState( '' );
 	const { isUpeEnabled } = useContext( UpeToggleContext );
 
 	const handleModalDismiss = () => {
 		setModalType( '' );
+	};
+
+	const handleCheckboxChange = ( hasBeenChecked ) => {
+		setIsStripeEnabled( hasBeenChecked );
+
+		// In legacy mode (UPE disabled), Stripe refers to the card payment method.
+		// So if Stripe is disabled, card should be excluded from the enabled methods list and vice versa.
+		if ( ! isUpeEnabled ) {
+			if (
+				! hasBeenChecked &&
+				enabledPaymentMethods.includes( 'card' )
+			) {
+				setEnabledPaymentMethods(
+					enabledPaymentMethods.filter( ( m ) => m !== 'card' )
+				);
+			} else if (
+				hasBeenChecked &&
+				! enabledPaymentMethods.includes( 'card' )
+			) {
+				setEnabledPaymentMethods( [
+					...enabledPaymentMethods,
+					'card',
+				] );
+			}
+		}
 	};
 
 	return (
@@ -55,7 +85,7 @@ const GeneralSettingsSection = ( { setKeepModalContent } ) => {
 				<CardBody>
 					<CheckboxControl
 						checked={ isStripeEnabled }
-						onChange={ setIsStripeEnabled }
+						onChange={ handleCheckboxChange }
 						label={ __(
 							'Enable Stripe',
 							'woocommerce-gateway-stripe'

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -86,6 +86,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'array',
 						'items'             => [
 							'type' => 'string',
+							'enum' => array_merge( $this->gateway->get_upe_available_payment_methods(), WC_Stripe_Helper::get_legacy_available_payment_method_ids() ),
 						],
 						'validate_callback' => 'rest_validate_request_arg',
 					],
@@ -578,8 +579,13 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 */
 	private function update_enabled_payment_methods( WP_REST_Request $request ) {
 		$payment_method_ids_to_enable = $request->get_param( 'enabled_payment_method_ids' );
+		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
 
-		if ( ! $request->get_param( 'is_upe_enabled' ) ) {
+		if ( null === $is_upe_enabled ) {
+			return;
+		}
+
+		if ( ! $is_upe_enabled ) {
 			$currently_enabled_payment_method_ids = WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
 			$payment_gateways                     = WC_Stripe_Helper::get_legacy_payment_methods();
 

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -235,6 +235,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return WP_REST_Response
 	 */
 	public function get_settings() {
+		$is_upe_enabled = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
+
 		return new WP_REST_Response(
 			[
 				/* Settings > General */
@@ -245,8 +247,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'description'                           => $this->gateway->get_validated_option( 'description' ),
 
 				/* Settings > Payments accepted on checkout */
-				'enabled_payment_method_ids'            => $this->gateway->get_upe_enabled_payment_method_ids(),
-				'available_payment_method_ids'          => $this->gateway->get_upe_available_payment_methods(),
+				'enabled_payment_method_ids'            => $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids(),
+				'available_payment_method_ids'          => $is_upe_enabled ? $this->gateway->get_upe_available_payment_methods() : WC_Stripe_Helper::get_legacy_available_payment_method_ids(),
 
 				/* Settings > Express checkouts */
 				'is_payment_request_enabled'            => 'yes' === $this->gateway->get_option( 'payment_request' ),

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -255,7 +255,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'description'                           => $this->gateway->get_validated_option( 'description' ),
 
 				/* Settings > Payments accepted on checkout */
-				'enabled_payment_method_ids'            => $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' ),
+				'enabled_payment_method_ids'            => $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids(),
 				'available_payment_method_ids'          => $is_upe_enabled ? $this->gateway->get_upe_available_payment_methods() : WC_Stripe_Helper::get_legacy_available_payment_method_ids(),
 				'individual_payment_method_settings'    => $is_upe_enabled ? [] : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),
 
@@ -586,7 +586,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		if ( ! $is_upe_enabled ) {
-			$currently_enabled_payment_method_ids = WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' );
+			$currently_enabled_payment_method_ids = WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
 			$payment_gateways                     = WC_Stripe_Helper::get_legacy_payment_methods();
 
 			foreach ( $payment_gateways as $gateway ) {

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -56,32 +56,32 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'callback'            => [ $this, 'update_settings' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
-					'is_stripe_enabled'                => [
+					'is_stripe_enabled'                  => [
 						'description'       => __( 'If Stripe should be enabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_test_mode_enabled'             => [
+					'is_test_mode_enabled'               => [
 						'description'       => __( 'Stripe test mode setting.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'title'                            => [
+					'title'                              => [
 						'description'       => __( 'Stripe display title.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'title_upe'                        => [
+					'title_upe'                          => [
 						'description'       => __( 'New checkout experience title.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'description'                      => [
+					'description'                        => [
 						'description'       => __( 'Stripe display description.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'enabled_payment_method_ids'       => [
+					'enabled_payment_method_ids'         => [
 						'description'       => __( 'Payment method IDs that should be enabled. Other methods will be disabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'array',
 						'items'             => [
@@ -97,31 +97,31 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						],
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_payment_request_enabled'       => [
+					'is_payment_request_enabled'         => [
 						'description'       => __( 'If Stripe express checkouts should be enabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'payment_request_button_type'      => [
+					'payment_request_button_type'        => [
 						'description'       => __( 'Express checkout button types.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'enum'              => array_keys( $form_fields['payment_request_button_type']['options'] ),
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'payment_request_button_theme'     => [
+					'payment_request_button_theme'       => [
 						'description'       => __( 'Express checkout button themes.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'enum'              => array_keys( $form_fields['payment_request_button_theme']['options'] ),
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'payment_request_button_size'      => [
+					'payment_request_button_size'        => [
 						'description'       => __( 'Express checkout button sizes.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						// it can happen that `$form_fields['payment_request_button_size']` is empty (in tests) - fixing temporarily.
 						'enum'              => array_keys( isset( $form_fields['payment_request_button_size']['options'] ) ? $form_fields['payment_request_button_size']['options'] : [] ),
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'payment_request_button_locations' => [
+					'payment_request_button_locations'   => [
 						'description'       => __( 'Express checkout locations that should be enabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'array',
 						'items'             => [
@@ -130,22 +130,22 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						],
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_manual_capture_enabled'        => [
+					'is_manual_capture_enabled'          => [
 						'description'       => __( 'If manual capture of charges should be enabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_saved_cards_enabled'           => [
+					'is_saved_cards_enabled'             => [
 						'description'       => __( 'If "Saved cards" should be enabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_separate_card_form_enabled'    => [
+					'is_separate_card_form_enabled'      => [
 						'description'       => __( 'If credit card number field, expiry date field, and CVC field should be separate.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'statement_descriptor'             => [
+					'statement_descriptor'               => [
 						'description'       => __( 'Bank account descriptor to be displayed in customers\' bank accounts.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'validate_callback' => [ $this, 'validate_regular_statement_descriptor' ],
@@ -155,12 +155,12 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'short_statement_descriptor'       => [
+					'short_statement_descriptor'         => [
 						'description'       => __( 'We\'ll use the short version in combination with the customer order number.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'validate_callback' => [ $this, 'validate_short_statement_descriptor' ],
 					],
-					'is_debug_log_enabled'             => [
+					'is_debug_log_enabled'               => [
 						'description'       => __( 'When enabled, payment error logs will be saved to WooCommerce > Status > Logs.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -255,7 +255,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'description'                           => $this->gateway->get_validated_option( 'description' ),
 
 				/* Settings > Payments accepted on checkout */
-				'enabled_payment_method_ids'            => $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids(),
+				'enabled_payment_method_ids'            => $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' ),
 				'available_payment_method_ids'          => $is_upe_enabled ? $this->gateway->get_upe_available_payment_methods() : WC_Stripe_Helper::get_legacy_available_payment_method_ids(),
 				'individual_payment_method_settings'    => $is_upe_enabled ? [] : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),
 
@@ -586,7 +586,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		if ( ! $is_upe_enabled ) {
-			$currently_enabled_payment_method_ids = WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
+			$currently_enabled_payment_method_ids = WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' );
 			$payment_gateways                     = WC_Stripe_Helper::get_legacy_payment_methods();
 
 			foreach ( $payment_gateways as $gateway ) {

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -632,12 +632,12 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$payment_gateways = WC_Stripe_Helper::get_legacy_payment_methods();
 
 		foreach ( $payment_gateways as $gateway ) {
-			$gateway_id       = str_replace( 'stripe_', '', $gateway->id );
-			$gateway_settings = $individual_payment_method_settings[ $gateway_id ];
-
-			if ( ! isset( $gateway_settings ) ) {
+			$gateway_id = str_replace( 'stripe_', '', $gateway->id );
+			if ( ! isset( $individual_payment_method_settings[ $gateway_id ] ) ) {
 				continue;
 			}
+
+			$gateway_settings = $individual_payment_method_settings[ $gateway_id ];
 
 			$name = sanitize_text_field( $gateway_settings['name'] );
 			$gateway->update_option( 'title', $name );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -113,7 +113,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		// Title shows the count of enabled payment methods in settings page only.
 		if ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
-			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_method_ids() );
+			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' ) );
 			$this->title                   = $enabled_payment_methods_count ?
 				/* translators: $1. Count of enabled payment methods. */
 				sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count )
@@ -126,6 +126,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_fee' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_payout' ], 20 );
 		add_action( 'woocommerce_customer_save_address', [ $this, 'show_update_card_notice' ], 10, 2 );
+		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'get_payment_methods_on_checkout' ] );
 		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'prepare_order_pay_page' ] );
 		add_action( 'woocommerce_account_view-order_endpoint', [ $this, 'check_intent_status_on_order_page' ], 1 );
 		add_filter( 'woocommerce_payment_successful_result', [ $this, 'modify_successful_payment_result' ], 99999, 2 );
@@ -640,6 +641,33 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_pay_order_after_submit', [ $this, 'render_payment_intent_inputs' ] );
 
 		return [];
+	}
+
+	/**
+	 * Include the available legacy payment methods in the list of payment methods on checkout page.
+	 *
+	 * @param WC_Payment_Gateway[] $gateways A list of all available gateways.
+	 * @return WC_Payment_Gateway[]          The same list if not checkout page or a list including the available legacy payment methods.
+	 */
+	public function get_payment_methods_on_checkout( $gateways ) {
+		if ( ! is_checkout() ) {
+			return $gateways;
+		}
+
+		$available_gateways      = $gateways;
+		$ordering                = (array) get_option( 'woocommerce_gateway_order' );
+		$legacy_enabled_gateways = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
+
+		foreach ( $legacy_enabled_gateways as $legacy_enabled_gateway ) {
+			if ( $legacy_enabled_gateway->is_available() ) {
+				if ( isset( $ordering[ $legacy_enabled_gateway->id ] ) && is_numeric( $ordering[ $legacy_enabled_gateway->id ] ) ) {
+					$available_gateways[ $ordering[ $legacy_enabled_gateway->id ] ] = $legacy_enabled_gateway;
+				}
+				$available_gateways[] = $legacy_enabled_gateway;
+			}
+		}
+
+		return $available_gateways;
 	}
 
 	/**

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -126,7 +126,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_fee' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_payout' ], 20 );
 		add_action( 'woocommerce_customer_save_address', [ $this, 'show_update_card_notice' ], 10, 2 );
-		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'get_payment_methods_on_checkout' ] );
+		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'get_available_payment_methods' ] );
 		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'prepare_order_pay_page' ] );
 		add_action( 'woocommerce_account_view-order_endpoint', [ $this, 'check_intent_status_on_order_page' ], 1 );
 		add_filter( 'woocommerce_payment_successful_result', [ $this, 'modify_successful_payment_result' ], 99999, 2 );
@@ -644,28 +644,34 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Include the available legacy payment methods in the list of payment methods on checkout page.
+	 * Include the available legacy payment methods in the list of payment methods.
+	 * As we are not registering the other Stripe payment methods to show in the settings page,
+	 * we need to include them here so that they are available in the checkout page, account page, pay for order etc. customer facing pages.
 	 *
-	 * @param WC_Payment_Gateway[] $gateways A list of all available gateways.
-	 * @return WC_Payment_Gateway[]          The same list if not checkout page or a list including the available legacy payment methods.
+	 * @param WC_Payment_Gateway[] $gateways A list of all available gateways on the payments settings page.
+	 * @return WC_Payment_Gateway[]          The same list if UPE is disabled or a list including the available legacy payment methods.
 	 */
-	public function get_payment_methods_on_checkout( $gateways ) {
-		if ( ! is_checkout() ) {
+	public function get_available_payment_methods( $gateways ) {
+		// We need to include the payment methods when UPE is disabled, return the same list when UPE is enabled.
+		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return $gateways;
 		}
 
-		$available_gateways      = $gateways;
-		$ordering                = (array) get_option( 'woocommerce_gateway_order' );
+		$available_gateways      = [];
+		$gateway_orders          = (array) get_option( 'woocommerce_gateway_order' );
 		$legacy_enabled_gateways = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
 
-		foreach ( $legacy_enabled_gateways as $legacy_enabled_gateway ) {
-			if ( $legacy_enabled_gateway->is_available() ) {
-				if ( isset( $ordering[ $legacy_enabled_gateway->id ] ) && is_numeric( $ordering[ $legacy_enabled_gateway->id ] ) ) {
-					$available_gateways[ $ordering[ $legacy_enabled_gateway->id ] ] = $legacy_enabled_gateway;
-				}
-				$available_gateways[] = $legacy_enabled_gateway;
+		foreach ( $gateway_orders as $name => $order ) {
+			if ( in_array( $name, array_keys( $gateways ), true ) ) {
+				$available_gateways[ $name ] = $gateways[ $name ];
+			} elseif ( in_array( $name, array_keys( $legacy_enabled_gateways ), true ) ) {
+				$available_gateways[ $name ] = $legacy_enabled_gateways[ $name ];
+				unset( $legacy_enabled_gateways[ $name ] );
 			}
 		}
+
+		// Add any remaining enabled gateways in case they were not present in `woocommerce_gateway_order` option.
+		$available_gateways = array_merge( $available_gateways, $legacy_enabled_gateways );
 
 		return $available_gateways;
 	}

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -659,7 +659,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		$available_gateways      = [];
 		$gateway_orders          = (array) get_option( 'woocommerce_gateway_order' );
-		$legacy_enabled_gateways = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
+		$legacy_enabled_gateways = WC_Stripe_Helper::get_legacy_payment_methods();
 
 		foreach ( $gateway_orders as $name => $order ) {
 			if ( in_array( $name, array_keys( $gateways ), true ) ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -658,7 +658,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		// Return if not checkout or pay for order page.
-		if ( ! is_wc_endpoint_url( 'order-pay' ) || ! is_checkout() ) {
+		$is_checkout_page      = is_checkout() || has_block( 'woocommerce/checkout' );
+		$is_pay_for_order_page = is_wc_endpoint_url( 'order-pay' );
+		if ( ! $is_checkout_page && ! $is_pay_for_order_page ) {
 			return $gateways;
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -646,7 +646,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Include the available legacy payment methods in the list of payment methods.
 	 * As we are not registering the other Stripe payment methods to show in the settings page,
-	 * we need to include them here so that they are available in the checkout page, account page, pay for order etc. customer facing pages.
+	 * we need to include them here so that they are available in the checkout page and pay for order page.
 	 *
 	 * @param WC_Payment_Gateway[] $gateways A list of all available gateways on the payments settings page.
 	 * @return WC_Payment_Gateway[]          The same list if UPE is disabled or a list including the available legacy payment methods.
@@ -654,6 +654,11 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function get_available_payment_methods( $gateways ) {
 		// We need to include the payment methods when UPE is disabled, return the same list when UPE is enabled.
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			return $gateways;
+		}
+
+		// Return if not checkout or pay for order page.
+		if ( ! is_wc_endpoint_url( 'order-pay' ) || ! is_checkout() ) {
 			return $gateways;
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -111,6 +111,15 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		WC_Stripe_API::set_secret_key( $this->secret_key );
 
+		// Title shows the count of enabled payment methods in settings page only.
+		if ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
+			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_method_ids() );
+			$this->title                   = $enabled_payment_methods_count ?
+				/* translators: $1. Count of enabled payment methods. */
+				sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count )
+				: $this->method_title;
+		}
+
 		// Hooks.
 		add_action( 'wp_enqueue_scripts', [ $this, 'payment_scripts' ] );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -659,11 +659,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		$available_gateways      = [];
 		$gateway_orders          = (array) get_option( 'woocommerce_gateway_order' );
-		$legacy_enabled_gateways = WC_Stripe_Helper::get_legacy_payment_methods();
+		$legacy_enabled_gateways = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
 
 		foreach ( $gateway_orders as $name => $order ) {
 			if ( in_array( $name, array_keys( $gateways ), true ) ) {
 				$available_gateways[ $name ] = $gateways[ $name ];
+				unset( $gateways[ $name ] );
 			} elseif ( in_array( $name, array_keys( $legacy_enabled_gateways ), true ) ) {
 				$gateway = $legacy_enabled_gateways[ $name ];
 				// This follows the same logic as `get_available_payment_gateways()` function in `woocommerce/includes/class-wc-payment-gateways.php`.
@@ -679,6 +680,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		}
 
 		// Add any remaining enabled gateways in case they were not present in `woocommerce_gateway_order` option.
+		$available_gateways = array_merge( $available_gateways, $gateways );
+
+		// Add any remaining legacy enabled gateways in case they were not present in `woocommerce_gateway_order` option.
 		foreach ( $legacy_enabled_gateways as $name => $gateway ) {
 			// This follows the same logic as `get_available_payment_gateways()` function in `woocommerce/includes/class-wc-payment-gateways.php`.
 			if ( $gateway->is_available() ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -113,7 +113,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		// Title shows the count of enabled payment methods in settings page only.
 		if ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
-			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' ) );
+			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_methods() );
 			$this->title                   = $enabled_payment_methods_count ?
 				/* translators: $1. Count of enabled payment methods. */
 				sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count )

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -338,6 +338,78 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * List of legacy payment methods.
+	 *
+	 * @return array
+	 */
+	public static function get_legacy_payment_methods() {
+		$payment_method_classes = [
+			WC_Gateway_Stripe_Bancontact::class,
+			WC_Gateway_Stripe_EPS::class,
+			WC_Gateway_Stripe_Giropay::class,
+			WC_Gateway_Stripe_Ideal::class,
+			WC_Gateway_Stripe_p24::class,
+			WC_Gateway_Stripe_Sepa::class,
+			WC_Gateway_Stripe_Boleto::class,
+			WC_Gateway_Stripe_Oxxo::class,
+		];
+
+		/** Show Sofort if it's already enabled. Hide from the new merchants and keep it for the old ones who are already using this gateway, until we remove it completely.
+		 * Stripe is deprecating Sofort https://support.stripe.com/questions/sofort-is-being-deprecated-as-a-standalone-payment-method.
+		 */
+		$sofort_settings = get_option( 'woocommerce_stripe_sofort_settings', [] );
+		if ( isset( $sofort_settings['enabled'] ) && 'yes' === $sofort_settings['enabled'] ) {
+			$payment_method_classes[] = WC_Gateway_Stripe_Sofort::class;
+		}
+
+		$payment_methods = [];
+
+		foreach ( $payment_method_classes as $payment_method_class ) {
+			$payment_method                         = new $payment_method_class();
+			$payment_methods[ $payment_method::ID ] = $payment_method;
+		}
+
+		return $payment_methods;
+	}
+
+	/**
+	 * List of available legacy payment methods.
+	 *
+	 * @return array
+	 */
+	public static function get_legacy_available_payment_method_ids() {
+		$payment_methods = self::get_legacy_payment_methods();
+
+		$available_payment_methods = [ 'card' ];
+
+		foreach ( $payment_methods as $payment_method ) {
+			$available_payment_methods[] = str_replace( 'stripe_', '', $payment_method::ID );
+		}
+
+		return $available_payment_methods;
+	}
+
+	/**
+	 * List of enabled legacy payment methods.
+	 *
+	 * @return array
+	 */
+	public static function get_legacy_enabled_payment_method_ids() {
+		$payment_methods = self::get_legacy_payment_methods();
+
+		$enabled_payment_methods = [ 'card' ];
+
+		foreach ( $payment_methods as $payment_method ) {
+			if ( ! $payment_method->is_enabled() ) {
+				continue;
+			}
+			$enabled_payment_methods[] = str_replace( 'stripe_', '', $payment_method::ID );
+		}
+
+		return $enabled_payment_methods;
+	}
+
+	/**
 	 * Checks if WC version is less than passed in version.
 	 *
 	 * @since 4.1.11

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -338,11 +338,11 @@ class WC_Stripe_Helper {
 	}
 
 	/**
-	 * List of legacy payment methods.
+	 * List of legacy payment method classes.
 	 *
 	 * @return array
 	 */
-	public static function get_legacy_payment_methods() {
+	public static function get_legacy_payment_method_classes() {
 		$payment_method_classes = [
 			WC_Gateway_Stripe_Bancontact::class,
 			WC_Gateway_Stripe_EPS::class,
@@ -362,6 +362,17 @@ class WC_Stripe_Helper {
 			$payment_method_classes[] = WC_Gateway_Stripe_Sofort::class;
 		}
 
+		return $payment_method_classes;
+	}
+
+	/**
+	 * List of legacy payment methods.
+	 *
+	 * @return array
+	 */
+	public static function get_legacy_payment_methods() {
+		$payment_method_classes = self::get_legacy_payment_method_classes();
+
 		$payment_methods = [];
 
 		foreach ( $payment_method_classes as $payment_method_class ) {
@@ -378,13 +389,13 @@ class WC_Stripe_Helper {
 	 * @return array
 	 */
 	public static function get_legacy_available_payment_method_ids() {
-		$payment_methods = self::get_legacy_payment_methods();
+		$payment_method_classes = self::get_legacy_payment_method_classes();
 
 		// In legacy mode (when UPE is disabled), Stripe refers to card as payment method.
 		$available_payment_method_ids = [ 'card' ];
 
-		foreach ( $payment_methods as $payment_method ) {
-			$payment_method_id              = 'stripe_sepa' === $payment_method->id ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method->id );
+		foreach ( $payment_method_classes as $payment_method_class ) {
+			$payment_method_id              = 'stripe_sepa' === $payment_method_class::ID ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method_class::ID );
 			$available_payment_method_ids[] = $payment_method_id;
 		}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -380,13 +380,13 @@ class WC_Stripe_Helper {
 	public static function get_legacy_available_payment_method_ids() {
 		$payment_methods = self::get_legacy_payment_methods();
 
-		$available_payment_methods = [ 'card' ];
+		$available_payment_method_ids = [ 'card' ];
 
 		foreach ( $payment_methods as $payment_method ) {
-			$available_payment_methods[] = str_replace( 'stripe_', '', $payment_method::ID );
+			$available_payment_method_ids[] = str_replace( 'stripe_', '', $payment_method::ID );
 		}
 
-		return $available_payment_methods;
+		return $available_payment_method_ids;
 	}
 
 	/**
@@ -394,16 +394,22 @@ class WC_Stripe_Helper {
 	 *
 	 * @return array
 	 */
-	public static function get_legacy_enabled_payment_method_ids() {
+	public static function get_legacy_enabled_payment_methods( $field = null ) {
 		$payment_methods = self::get_legacy_payment_methods();
 
-		$enabled_payment_methods = [ 'card' ];
+		$enabled_payment_method_ids = [ 'card' ];
+		$enabled_payment_methods    = [];
 
 		foreach ( $payment_methods as $payment_method ) {
 			if ( ! $payment_method->is_enabled() ) {
 				continue;
 			}
-			$enabled_payment_methods[] = str_replace( 'stripe_', '', $payment_method::ID );
+			$enabled_payment_methods[]    = $payment_method;
+			$enabled_payment_method_ids[] = str_replace( 'stripe_', '', $payment_method::ID );
+		}
+
+		if ( 'id' === $field ) {
+			return $enabled_payment_method_ids;
 		}
 
 		return $enabled_payment_methods;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -380,6 +380,7 @@ class WC_Stripe_Helper {
 	public static function get_legacy_available_payment_method_ids() {
 		$payment_methods = self::get_legacy_payment_methods();
 
+		// In legacy mode (when UPE is disabled), Stripe refers to card as payment method.
 		$available_payment_method_ids = [ 'card' ];
 
 		foreach ( $payment_methods as $payment_method ) {
@@ -395,9 +396,12 @@ class WC_Stripe_Helper {
 	 * @return array
 	 */
 	public static function get_legacy_enabled_payment_methods( $field = null ) {
-		$payment_methods = self::get_legacy_payment_methods();
+		$stripe_settings   = get_option( 'woocommerce_stripe_settings', [] );
+		$is_stripe_enabled = isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
+		$payment_methods   = self::get_legacy_payment_methods();
 
-		$enabled_payment_method_ids = [ 'card' ];
+		// In legacy mode (when UPE is disabled), Stripe refers to card as payment method.
+		$enabled_payment_method_ids = $is_stripe_enabled ? [ 'card' ] : [];
 		$enabled_payment_methods    = [];
 
 		foreach ( $payment_methods as $payment_method ) {

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -384,7 +384,8 @@ class WC_Stripe_Helper {
 		$available_payment_method_ids = [ 'card' ];
 
 		foreach ( $payment_methods as $payment_method ) {
-			$available_payment_method_ids[] = str_replace( 'stripe_', '', $payment_method->id );
+			$payment_method_id              = 'stripe_sepa' === $payment_method->id ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method->id );
+			$available_payment_method_ids[] = $payment_method_id;
 		}
 
 		return $available_payment_method_ids;
@@ -409,7 +410,9 @@ class WC_Stripe_Helper {
 				continue;
 			}
 			$enabled_payment_methods[ $payment_method->id ] = $payment_method;
-			$enabled_payment_method_ids[]                   = str_replace( 'stripe_', '', $payment_method->id );
+
+			$payment_method_id            = 'stripe_sepa' === $payment_method->id ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method->id );
+			$enabled_payment_method_ids[] = $payment_method_id;
 		}
 
 		if ( 'id' === $field ) {

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -396,30 +396,42 @@ class WC_Stripe_Helper {
 	 *
 	 * @return array
 	 */
-	public static function get_legacy_enabled_payment_methods( $field = null ) {
-		$stripe_settings   = get_option( 'woocommerce_stripe_settings', [] );
-		$is_stripe_enabled = isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
-		$payment_methods   = self::get_legacy_payment_methods();
+	public static function get_legacy_enabled_payment_methods() {
+		$payment_methods = self::get_legacy_payment_methods();
 
-		// In legacy mode (when UPE is disabled), Stripe refers to card as payment method.
-		$enabled_payment_method_ids = $is_stripe_enabled ? [ 'card' ] : [];
-		$enabled_payment_methods    = [];
+		$enabled_payment_methods = [];
 
 		foreach ( $payment_methods as $payment_method ) {
 			if ( ! $payment_method->is_enabled() ) {
 				continue;
 			}
 			$enabled_payment_methods[ $payment_method->id ] = $payment_method;
-
-			$payment_method_id            = 'stripe_sepa' === $payment_method->id ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method->id );
-			$enabled_payment_method_ids[] = $payment_method_id;
-		}
-
-		if ( 'id' === $field ) {
-			return $enabled_payment_method_ids;
 		}
 
 		return $enabled_payment_methods;
+	}
+
+	/**
+	 * List of enabled legacy payment method ids.
+	 *
+	 * @return array
+	 */
+	public static function get_legacy_enabled_payment_method_ids() {
+		$stripe_settings   = get_option( 'woocommerce_stripe_settings', [] );
+		$is_stripe_enabled = isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
+
+		$enabled_payment_methods        = self::get_legacy_enabled_payment_methods();
+		$mapped_enabled_payment_methods = array_map(
+			function( $payment_method ) {
+				return 'stripe_sepa' === $payment_method ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method );
+			},
+			array_keys( $enabled_payment_methods )
+		);
+
+		// In legacy mode (when UPE is disabled), Stripe refers to card as payment method.
+		$enabled_payment_method_ids = $is_stripe_enabled ? [ 'card' ] : [];
+
+		return array_merge( $enabled_payment_method_ids, $mapped_enabled_payment_methods );
 	}
 
 	/**

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -410,6 +410,32 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Get settings of individual payment methods.
+	 *
+	 * @return array
+	 */
+	public static function get_legacy_individual_payment_method_settings() {
+		$payment_methods = self::get_legacy_payment_methods();
+
+		$payment_method_settings = [];
+
+		foreach ( $payment_methods as $payment_method ) {
+			$settings = [
+				'name'        => $payment_method->get_option( 'title' ),
+				'description' => $payment_method->get_option( 'description' ),
+			];
+
+			if ( method_exists( $payment_method, 'get_unique_settings' ) ) {
+				$settings = $payment_method->get_unique_settings( $settings );
+			}
+
+			$payment_method_settings[ str_replace( 'stripe_', '', $payment_method::ID ) ] = $settings;
+		}
+
+		return $payment_method_settings;
+	}
+
+	/**
 	 * Checks if WC version is less than passed in version.
 	 *
 	 * @since 4.1.11

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -404,8 +404,8 @@ class WC_Stripe_Helper {
 			if ( ! $payment_method->is_enabled() ) {
 				continue;
 			}
-			$enabled_payment_methods[]    = $payment_method;
-			$enabled_payment_method_ids[] = str_replace( 'stripe_', '', $payment_method::ID );
+			$enabled_payment_methods[ $payment_method::ID ] = $payment_method;
+			$enabled_payment_method_ids[]                   = str_replace( 'stripe_', '', $payment_method::ID );
 		}
 
 		if ( 'id' === $field ) {

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -366,7 +366,7 @@ class WC_Stripe_Helper {
 
 		foreach ( $payment_method_classes as $payment_method_class ) {
 			$payment_method                         = new $payment_method_class();
-			$payment_methods[ $payment_method::ID ] = $payment_method;
+			$payment_methods[ $payment_method->id ] = $payment_method;
 		}
 
 		return $payment_methods;
@@ -384,7 +384,7 @@ class WC_Stripe_Helper {
 		$available_payment_method_ids = [ 'card' ];
 
 		foreach ( $payment_methods as $payment_method ) {
-			$available_payment_method_ids[] = str_replace( 'stripe_', '', $payment_method::ID );
+			$available_payment_method_ids[] = str_replace( 'stripe_', '', $payment_method->id );
 		}
 
 		return $available_payment_method_ids;
@@ -408,8 +408,8 @@ class WC_Stripe_Helper {
 			if ( ! $payment_method->is_enabled() ) {
 				continue;
 			}
-			$enabled_payment_methods[ $payment_method::ID ] = $payment_method;
-			$enabled_payment_method_ids[]                   = str_replace( 'stripe_', '', $payment_method::ID );
+			$enabled_payment_methods[ $payment_method->id ] = $payment_method;
+			$enabled_payment_method_ids[]                   = str_replace( 'stripe_', '', $payment_method->id );
 		}
 
 		if ( 'id' === $field ) {
@@ -439,7 +439,7 @@ class WC_Stripe_Helper {
 				$settings = $payment_method->get_unique_settings( $settings );
 			}
 
-			$payment_method_settings[ str_replace( 'stripe_', '', $payment_method::ID ) ] = $settings;
+			$payment_method_settings[ str_replace( 'stripe_', '', $payment_method->id ) ] = $settings;
 		}
 
 		return $payment_method_settings;

--- a/includes/payment-methods/class-wc-gateway-stripe-oxxo.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-oxxo.php
@@ -17,7 +17,7 @@ class WC_Gateway_Stripe_Oxxo extends WC_Stripe_Payment_Gateway_Voucher {
 	 *
 	 * @var string
 	 */
-	const ID = 'stripe_boleto';
+	const ID = 'stripe_oxxo';
 
 	/**
 	 * ID used by WooCommerce to identify the payment method

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -107,7 +107,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider enum_field_provider
 	 */
-	public function test_enum_fields( $rest_key, $option_name, $original_valid_value, $new_valid_value, $new_invalid_value ) {
+	public function test_enum_fields( $rest_key, $option_name, $original_valid_value, $new_valid_value, $new_invalid_value, $is_upe_enabled = true ) {
 		// It returns option value under expected key with HTTP code 200.
 		$this->get_gateway()->update_option( $option_name, $original_valid_value );
 		$response = $this->rest_get_settings();
@@ -118,6 +118,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->get_gateway()->update_option( $option_name, $original_valid_value );
 
 		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param( 'is_upe_enabled', $is_upe_enabled );
 		$request->set_param( $rest_key, $new_valid_value );
 		$response = rest_do_request( $request );
 
@@ -128,7 +129,8 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->get_gateway()->update_option( $option_name, $original_valid_value );
 
 		$status_before_request = $this->get_gateway()->get_option( $option_name );
-		$request               = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param( 'is_upe_enabled', $is_upe_enabled );
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
 		rest_do_request( $request );
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -138,6 +140,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->get_gateway()->update_option( $option_name, $original_valid_value );
 
 		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param( 'is_upe_enabled', $is_upe_enabled );
 		$request->set_param( $rest_key, $new_invalid_value );
 
 		$response = rest_do_request( $request );
@@ -313,6 +316,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 				[ 'card' ],
 				[ 'card', 'giropay' ],
 				[ 'foo' ],
+				true,
 			],
 			'payment_request_button_theme'     => [
 				'payment_request_button_theme',

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -212,6 +212,54 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_individual_payment_method_settings() {
+		// Disable UPE and set up EPS gateway.
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled' => 'yes',
+				WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => 'no',
+			]
+		);
+		update_option(
+			'woocommerce_stripe_eps_settings',
+			[
+				'title'       => 'EPS',
+				'description' => 'Pay with EPS',
+			]
+		);
+
+		$response                                = $this->rest_get_settings();
+		$individual_payment_method_settings_data = $response->get_data()['individual_payment_method_settings'];
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->arrayHasKey( 'eps', $individual_payment_method_settings_data );
+		$this->assertEquals(
+			[
+				'name'       => 'EPS',
+				'description' => 'Pay with EPS',
+			],
+			$individual_payment_method_settings_data['eps'],
+		);
+
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		$request->set_param(
+			'individual_payment_method_settings',
+			[
+				'giropay' => [
+					'name'        => 'Giropay',
+					'description' => 'Pay with Giropay',
+				],
+			]
+		);
+		$response         = rest_do_request( $request );
+		$gateway_settings = get_option( 'woocommerce_stripe_giropay_settings' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'Giropay', $gateway_settings['title'] );
+		$this->assertEquals( 'Pay with Giropay', $gateway_settings['description'] );
+	}
+
 	public function test_short_statement_descriptor_is_not_updated() {
 		// It returns option value under expected key with HTTP code 200.
 		$this->get_gateway()->update_option( 'short_statement_descriptor', 'foobar' );
@@ -230,67 +278,67 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'foobar', $this->get_gateway()->get_option( 'short_statement_descriptor' ) );
 	}
 
-	public function test_get_settings_returns_available_payment_method_ids() {
-		//link is available only in US
-		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
-													->disableOriginalConstructor()
-													->setMethods(
-														[
-															'get_cached_account_data',
-														]
-													)
-													->getMock();
+	// public function test_get_settings_returns_available_payment_method_ids() {
+	// 	//link is available only in US
+	// 	WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
+	// 												->disableOriginalConstructor()
+	// 												->setMethods(
+	// 													[
+	// 														'get_cached_account_data',
+	// 													]
+	// 												)
+	// 												->getMock();
 
-		WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn(
-			[
-				'country' => 'US',
-			]
-		);
-		$response = $this->rest_get_settings();
+	// 	WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn(
+	// 		[
+	// 			'country' => 'US',
+	// 		]
+	// 	);
+	// 	$response = $this->rest_get_settings();
 
-		$expected_method_ids = WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS;
-		$expected_method_ids = array_map(
-			function ( $method_class ) {
-				return $method_class::STRIPE_ID;
-			},
-			$expected_method_ids
-		);
+	// 	$expected_method_ids = WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS;
+	// 	$expected_method_ids = array_map(
+	// 		function ( $method_class ) {
+	// 			return $method_class::STRIPE_ID;
+	// 		},
+	// 		$expected_method_ids
+	// 	);
 
-		$available_method_ids = $response->get_data()['available_payment_method_ids'];
+	// 	$available_method_ids = $response->get_data()['available_payment_method_ids'];
 
-		$this->assertEquals(
-			$expected_method_ids,
-			$available_method_ids
-		);
-	}
+	// 	$this->assertEquals(
+	// 		$expected_method_ids,
+	// 		$available_method_ids
+	// 	);
+	// }
 
-	public function test_get_settings_fails_if_user_cannot_manage_woocommerce() {
-		$cb = $this->create_can_manage_woocommerce_cap_override( false );
-		add_filter( 'user_has_cap', $cb );
-		$response = $this->rest_get_settings();
-		$this->assertEquals( 403, $response->get_status() );
-		remove_filter( 'user_has_cap', $cb );
+	// public function test_get_settings_fails_if_user_cannot_manage_woocommerce() {
+	// 	$cb = $this->create_can_manage_woocommerce_cap_override( false );
+	// 	add_filter( 'user_has_cap', $cb );
+	// 	$response = $this->rest_get_settings();
+	// 	$this->assertEquals( 403, $response->get_status() );
+	// 	remove_filter( 'user_has_cap', $cb );
 
-		$cb = $this->create_can_manage_woocommerce_cap_override( true );
-		add_filter( 'user_has_cap', $cb );
-		$response = $this->rest_get_settings();
-		$this->assertEquals( 200, $response->get_status() );
-		remove_filter( 'user_has_cap', $cb );
-	}
+	// 	$cb = $this->create_can_manage_woocommerce_cap_override( true );
+	// 	add_filter( 'user_has_cap', $cb );
+	// 	$response = $this->rest_get_settings();
+	// 	$this->assertEquals( 200, $response->get_status() );
+	// 	remove_filter( 'user_has_cap', $cb );
+	// }
 
-	public function test_update_settings_fails_if_user_cannot_manage_woocommerce() {
-		$cb = $this->create_can_manage_woocommerce_cap_override( false );
-		add_filter( 'user_has_cap', $cb );
-		$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
-		$this->assertEquals( 403, $response->get_status() );
-		remove_filter( 'user_has_cap', $cb );
+	// public function test_update_settings_fails_if_user_cannot_manage_woocommerce() {
+	// 	$cb = $this->create_can_manage_woocommerce_cap_override( false );
+	// 	add_filter( 'user_has_cap', $cb );
+	// 	$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
+	// 	$this->assertEquals( 403, $response->get_status() );
+	// 	remove_filter( 'user_has_cap', $cb );
 
-		$cb = $this->create_can_manage_woocommerce_cap_override( true );
-		add_filter( 'user_has_cap', $cb );
-		$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
-		$this->assertEquals( 200, $response->get_status() );
-		remove_filter( 'user_has_cap', $cb );
-	}
+	// 	$cb = $this->create_can_manage_woocommerce_cap_override( true );
+	// 	add_filter( 'user_has_cap', $cb );
+	// 	$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
+	// 	$this->assertEquals( 200, $response->get_status() );
+	// 	remove_filter( 'user_has_cap', $cb );
+	// }
 
 	public function boolean_field_provider() {
 		return [

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -278,67 +278,67 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'foobar', $this->get_gateway()->get_option( 'short_statement_descriptor' ) );
 	}
 
-	// public function test_get_settings_returns_available_payment_method_ids() {
-	// 	//link is available only in US
-	// 	WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
-	// 												->disableOriginalConstructor()
-	// 												->setMethods(
-	// 													[
-	// 														'get_cached_account_data',
-	// 													]
-	// 												)
-	// 												->getMock();
+	public function test_get_settings_returns_available_payment_method_ids() {
+		//link is available only in US
+		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
+													->disableOriginalConstructor()
+													->setMethods(
+														[
+															'get_cached_account_data',
+														]
+													)
+													->getMock();
 
-	// 	WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn(
-	// 		[
-	// 			'country' => 'US',
-	// 		]
-	// 	);
-	// 	$response = $this->rest_get_settings();
+		WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn(
+			[
+				'country' => 'US',
+			]
+		);
+		$response = $this->rest_get_settings();
 
-	// 	$expected_method_ids = WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS;
-	// 	$expected_method_ids = array_map(
-	// 		function ( $method_class ) {
-	// 			return $method_class::STRIPE_ID;
-	// 		},
-	// 		$expected_method_ids
-	// 	);
+		$expected_method_ids = WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS;
+		$expected_method_ids = array_map(
+			function ( $method_class ) {
+				return $method_class::STRIPE_ID;
+			},
+			$expected_method_ids
+		);
 
-	// 	$available_method_ids = $response->get_data()['available_payment_method_ids'];
+		$available_method_ids = $response->get_data()['available_payment_method_ids'];
 
-	// 	$this->assertEquals(
-	// 		$expected_method_ids,
-	// 		$available_method_ids
-	// 	);
-	// }
+		$this->assertEquals(
+			$expected_method_ids,
+			$available_method_ids
+		);
+	}
 
-	// public function test_get_settings_fails_if_user_cannot_manage_woocommerce() {
-	// 	$cb = $this->create_can_manage_woocommerce_cap_override( false );
-	// 	add_filter( 'user_has_cap', $cb );
-	// 	$response = $this->rest_get_settings();
-	// 	$this->assertEquals( 403, $response->get_status() );
-	// 	remove_filter( 'user_has_cap', $cb );
+	public function test_get_settings_fails_if_user_cannot_manage_woocommerce() {
+		$cb = $this->create_can_manage_woocommerce_cap_override( false );
+		add_filter( 'user_has_cap', $cb );
+		$response = $this->rest_get_settings();
+		$this->assertEquals( 403, $response->get_status() );
+		remove_filter( 'user_has_cap', $cb );
 
-	// 	$cb = $this->create_can_manage_woocommerce_cap_override( true );
-	// 	add_filter( 'user_has_cap', $cb );
-	// 	$response = $this->rest_get_settings();
-	// 	$this->assertEquals( 200, $response->get_status() );
-	// 	remove_filter( 'user_has_cap', $cb );
-	// }
+		$cb = $this->create_can_manage_woocommerce_cap_override( true );
+		add_filter( 'user_has_cap', $cb );
+		$response = $this->rest_get_settings();
+		$this->assertEquals( 200, $response->get_status() );
+		remove_filter( 'user_has_cap', $cb );
+	}
 
-	// public function test_update_settings_fails_if_user_cannot_manage_woocommerce() {
-	// 	$cb = $this->create_can_manage_woocommerce_cap_override( false );
-	// 	add_filter( 'user_has_cap', $cb );
-	// 	$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
-	// 	$this->assertEquals( 403, $response->get_status() );
-	// 	remove_filter( 'user_has_cap', $cb );
+	public function test_update_settings_fails_if_user_cannot_manage_woocommerce() {
+		$cb = $this->create_can_manage_woocommerce_cap_override( false );
+		add_filter( 'user_has_cap', $cb );
+		$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
+		$this->assertEquals( 403, $response->get_status() );
+		remove_filter( 'user_has_cap', $cb );
 
-	// 	$cb = $this->create_can_manage_woocommerce_cap_override( true );
-	// 	add_filter( 'user_has_cap', $cb );
-	// 	$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
-	// 	$this->assertEquals( 200, $response->get_status() );
-	// 	remove_filter( 'user_has_cap', $cb );
-	// }
+		$cb = $this->create_can_manage_woocommerce_cap_override( true );
+		add_filter( 'user_has_cap', $cb );
+		$response = rest_do_request( new WP_REST_Request( 'POST', self::SETTINGS_ROUTE ) );
+		$this->assertEquals( 200, $response->get_status() );
+		remove_filter( 'user_has_cap', $cb );
+	}
 
 	public function boolean_field_provider() {
 		return [

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -145,4 +145,55 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		$intent_with_neither_source_nor_payment_method = new stdClass();
 		$this->assertNull( WC_Stripe_Helper::get_payment_method_from_intent( $intent_with_neither_source_nor_payment_method ) );
 	}
+
+	public function test_get_legacy_payment_methods() {
+		$result = WC_Stripe_Helper::get_legacy_payment_methods();
+		$this->assertEquals( [ 'stripe_bancontact', 'stripe_eps', 'stripe_giropay', 'stripe_ideal', 'stripe_p24', 'stripe_sepa', 'stripe_boleto', 'stripe_oxxo' ], array_keys( $result ) );
+	}
+
+	public function test_get_legacy_available_payment_method_ids() {
+		$result = WC_Stripe_Helper::get_legacy_available_payment_method_ids();
+		$this->assertEquals( [ 'card', 'bancontact', 'eps', 'giropay', 'ideal', 'p24', 'sepa', 'boleto', 'oxxo' ], $result );
+	}
+
+	public function test_get_legacy_enabled_payment_methods() {
+		// Enable Stripe, EPS, Giropay and P24 LPM gateways.
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled' => 'yes',
+				WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => 'no',
+			]
+		);
+		update_option( 'woocommerce_stripe_eps_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_giropay_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_p24_settings', [ 'enabled' => 'yes' ] );
+
+		$result = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
+		$this->assertEquals( [ 'stripe_eps', 'stripe_giropay', 'stripe_p24' ], array_keys( $result ) );
+
+		$result = WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' );
+		$this->assertEquals( [ 'card', 'eps', 'giropay', 'p24' ], $result );
+	}
+
+	public function test_get_legacy_individual_payment_method_settings() {
+		update_option(
+			'woocommerce_stripe_eps_settings',
+			[
+				'enabled'     => 'yes',
+				'title'       => 'EPS',
+				'description' => 'Pay with EPS',
+			]
+		);
+
+		$result = WC_Stripe_Helper::get_legacy_individual_payment_method_settings();
+		$this->arrayHasKey( 'eps', $result );
+		$this->assertEquals(
+			[
+				'name'       => 'EPS',
+				'description' => 'Pay with EPS',
+			],
+			$result['eps'],
+		);
+	}
 }

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -171,8 +171,22 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 
 		$result = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
 		$this->assertEquals( [ 'stripe_eps', 'stripe_giropay', 'stripe_p24' ], array_keys( $result ) );
+	}
 
-		$result = WC_Stripe_Helper::get_legacy_enabled_payment_methods( 'id' );
+	public function test_get_legacy_enabled_payment_method_ids() {
+		// Enable Stripe, EPS, Giropay and P24 LPM gateways.
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled' => 'yes',
+				WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => 'no',
+			]
+		);
+		update_option( 'woocommerce_stripe_eps_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_giropay_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_p24_settings', [ 'enabled' => 'yes' ] );
+
+		$result = WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
 		$this->assertEquals( [ 'card', 'eps', 'giropay', 'p24' ], $result );
 	}
 

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -153,7 +153,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 
 	public function test_get_legacy_available_payment_method_ids() {
 		$result = WC_Stripe_Helper::get_legacy_available_payment_method_ids();
-		$this->assertEquals( [ 'card', 'bancontact', 'eps', 'giropay', 'ideal', 'p24', 'sepa', 'boleto', 'oxxo' ], $result );
+		$this->assertEquals( [ 'card', 'bancontact', 'eps', 'giropay', 'ideal', 'p24', 'sepa_debit', 'boleto', 'oxxo' ], $result );
 	}
 
 	public function test_get_legacy_enabled_payment_methods() {
@@ -190,7 +190,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		$this->arrayHasKey( 'eps', $result );
 		$this->assertEquals(
 			[
-				'name'       => 'EPS',
+				'name'        => 'EPS',
 				'description' => 'Pay with EPS',
 			],
 			$result['eps'],

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -487,24 +487,26 @@ function woocommerce_gateway_stripe() {
 					$lpm_gateway_id = constant( $method_class::LPM_GATEWAY_CLASS . '::ID' );
 					if ( isset( $payment_gateways[ $lpm_gateway_id ] ) && $payment_gateways[ $lpm_gateway_id ]->is_enabled() ) {
 						// DISABLE LPM
-						if ( 'stripe' !== $lpm_gateway_id ) {
-							/**
-							 * TODO: This can be replaced with:
-							 *
-							 *   $payment_gateways[ $lpm_gateway_id ]->update_option( 'enabled', 'no' );
-							 *   $payment_gateways[ $lpm_gateway_id ]->enabled = 'no';
-							 *
-							 * ...once the minimum WC version is 3.4.0.
-							 */
-							$payment_gateways[ $lpm_gateway_id ]->settings['enabled'] = 'no';
-							update_option(
-								$payment_gateways[ $lpm_gateway_id ]->get_option_key(),
-								apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $payment_gateways[ $lpm_gateway_id ]::ID, $payment_gateways[ $lpm_gateway_id ]->settings ),
-								'yes'
-							);
-						}
+						/**
+						 * TODO: This can be replaced with:
+						 *
+						 *   $payment_gateways[ $lpm_gateway_id ]->update_option( 'enabled', 'no' );
+						 *   $payment_gateways[ $lpm_gateway_id ]->enabled = 'no';
+						 *
+						 * ...once the minimum WC version is 3.4.0.
+						 */
+						$payment_gateways[ $lpm_gateway_id ]->settings['enabled'] = 'no';
+						update_option(
+							$payment_gateways[ $lpm_gateway_id ]->get_option_key(),
+							apply_filters( 'woocommerce_settings_api_sanitized_fields_' . $payment_gateways[ $lpm_gateway_id ]::ID, $payment_gateways[ $lpm_gateway_id ]->settings ),
+							'yes'
+						);
 						// ENABLE UPE METHOD
 						$settings['upe_checkout_experience_accepted_payments'][] = $method_class::STRIPE_ID;
+					}
+
+					if ( 'stripe' === $lpm_gateway_id && $this->stripe_gateway->is_enabled() ) {
+						$settings['upe_checkout_experience_accepted_payments'][] = 'card';
 					}
 				}
 				if ( empty( $settings['upe_checkout_experience_accepted_payments'] ) ) {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -379,26 +379,6 @@ function woocommerce_gateway_stripe() {
 			public function add_gateways( $methods ) {
 				$methods[] = $this->get_main_stripe_gateway();
 
-				if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() || ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-					// These payment gateways will be hidden when UPE is enabled:
-					$methods[] = WC_Gateway_Stripe_Sepa::class;
-					$methods[] = WC_Gateway_Stripe_Giropay::class;
-					$methods[] = WC_Gateway_Stripe_Ideal::class;
-					$methods[] = WC_Gateway_Stripe_Bancontact::class;
-					$methods[] = WC_Gateway_Stripe_Eps::class;
-					$methods[] = WC_Gateway_Stripe_P24::class;
-					$methods[] = WC_Gateway_Stripe_Boleto::class;
-					$methods[] = WC_Gateway_Stripe_Oxxo::class;
-
-					/** Show Sofort if it's already enabled. Hide from the new merchants and keep it for the old ones who are already using this gateway, until we remove it completely.
-					 * Stripe is deprecating Sofort https://support.stripe.com/questions/sofort-is-being-deprecated-as-a-standalone-payment-method.
-					 */
-					$sofort_settings = get_option( 'woocommerce_stripe_sofort_settings', [] );
-					if ( isset( $sofort_settings['enabled'] ) && 'yes' === $sofort_settings['enabled'] ) {
-						$methods[] = WC_Gateway_Stripe_Sofort::class;
-					}
-				}
-
 				// These payment gateways will always be visible, regardless if UPE is enabled or disabled:
 				$methods[] = WC_Gateway_Stripe_Alipay::class;
 				$methods[] = WC_Gateway_Stripe_Multibanco::class;

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -505,7 +505,7 @@ function woocommerce_gateway_stripe() {
 						$settings['upe_checkout_experience_accepted_payments'][] = $method_class::STRIPE_ID;
 					}
 
-					if ( 'stripe' === $lpm_gateway_id && $this->stripe_gateway->is_enabled() ) {
+					if ( 'stripe' === $lpm_gateway_id && isset( $this->stripe_gateway ) && $this->stripe_gateway->is_enabled() ) {
 						$settings['upe_checkout_experience_accepted_payments'][] = 'card';
 					}
 				}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -477,14 +477,15 @@ function woocommerce_gateway_stripe() {
 
 			protected function enable_upe( $settings ) {
 				$settings['upe_checkout_experience_accepted_payments'] = [];
-				$payment_gateways                                      = WC()->payment_gateways->payment_gateways();
+
+				$payment_gateways = WC_Stripe_Helper::get_legacy_payment_methods();
 				foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $method_class ) {
 					if ( ! defined( "$method_class::LPM_GATEWAY_CLASS" ) ) {
 						continue;
 					}
 
 					$lpm_gateway_id = constant( $method_class::LPM_GATEWAY_CLASS . '::ID' );
-					if ( isset( $payment_gateways[ $lpm_gateway_id ] ) && 'yes' === $payment_gateways[ $lpm_gateway_id ]->enabled ) {
+					if ( isset( $payment_gateways[ $lpm_gateway_id ] ) && $payment_gateways[ $lpm_gateway_id ]->is_enabled() ) {
 						// DISABLE LPM
 						if ( 'stripe' !== $lpm_gateway_id ) {
 							/**


### PR DESCRIPTION
Fixes #2734 

## Changes proposed in this Pull Request:
This PR implements the same Settings screen for both non-UPE and UPE integrations. 
- For UPE enabled/disabled both scenarios, all the Stripe payment methods are listed in `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` page.
- For UPE enabled/disabled both scenarios, the list includes a checkbox to enable/disable the methods. The selection persists on save.
- When UPE is disabled, each method has a `Customize` button. You can add a name and a description for individual methods there except `card`.  Data persists on save.

## Testing instructions

#### Non UPE
- In `Advance settings` section of `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` page uncheck `New checkout experience` (disable UPE).
- In `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` page the methods should be listed with a checkbox. Enabling/disabling methods should work, save should work and changes should persist on page refresh.

<img width="50%" height="50%" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/0876d60f-88cd-49f1-9942-509a08500bb6" />

- Clicking on the `Customize` button should show the name and description form fields. Change some values, then click `Save changes`. This will close the section. Data gets saved when the `Save` button is clicked. 

<img width="50%" height="50%" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/0834a3f6-30b6-49ad-8de1-702cdbbdac87" />

- On `WooCommerce > Settings > Payments` page the selected payment method count should be present similar to when UPE is enabled.

![main list](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/4001333a-8267-4799-9c99-89ee32ecc89b)


#### UPE
- In `Advance settings` section of `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` page select `New checkout experience` (enable UPE).
- In `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` page the listed methods should work as before. Enabling/disabling methods should work, save should work and changes should persist on page refresh.

<img width="50%" height="50%" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/3d068bd7-57fa-4648-9e19-48ab2d29ee05" />

- Check `New checkout experience` and make sure the previously selected methods are still selected after enabling UPE.


### Note
- ToDo: add tests
- This PR does not remove the methods from `WooCommerce > Settings > Payments` page. This will be handled separately. Simply removing the classes removes them from checkout page also, so it needs further work.
- The design has the customize option for `card` too but it does not align with the current behavior and is unnecessary as the name/description has no usage for the card method).