### PR TITLE
Implement PE with deferred intent for the card payment method in the classic checkout

### DIFF
--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -1,8 +1,16 @@
 import jQuery from 'jquery';
 import WCStripeAPI from '../../api';
-import { getStripeServerData } from '../../stripe-utils';
+import {
+	generateCheckoutEventNames,
+	getSelectedUPEGatewayPaymentMethod,
+	getStripeServerData,
+	isUsingSavedPaymentMethod,
+} from '../../stripe-utils';
 import './style.scss';
-import { mountStripePaymentElement } from './payment-processing';
+import {
+	processPayment,
+	mountStripePaymentElement,
+} from './payment-processing';
 
 jQuery( function ( $ ) {
 	// Create an API object, which will be used throughout the checkout.
@@ -21,6 +29,17 @@ jQuery( function ( $ ) {
 	$( document.body ).on( 'updated_checkout', () => {
 		maybeMountStripePaymentElement();
 	} );
+
+	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {
+		return processPaymentIfNotUsingSavedMethod( $( this ) );
+	} );
+
+	function processPaymentIfNotUsingSavedMethod( $form ) {
+		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
+		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
+			return processPayment( api, $form, paymentMethodType );
+		}
+	}
 
 	// If the card element selector doesn't exist, then do nothing.
 	// For example, when a 100% discount coupon is applied).

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -1,0 +1,40 @@
+import jQuery from 'jquery';
+import WCStripeAPI from '../../api';
+import { getStripeServerData } from '../../stripe-utils';
+import './style.scss';
+import { mountStripePaymentElement } from './payment-processing';
+
+jQuery( function ( $ ) {
+	// Create an API object, which will be used throughout the checkout.
+	const api = new WCStripeAPI(
+		getStripeServerData(),
+		// A promise-based interface to jQuery.post.
+		( url, args ) => {
+			return new Promise( ( resolve, reject ) => {
+				jQuery.post( url, args ).then( resolve ).fail( reject );
+			} );
+		}
+	);
+
+	// Only attempt to mount the card element once that section of the page has loaded.
+	// We can use the updated_checkout event for this.
+	$( document.body ).on( 'updated_checkout', () => {
+		maybeMountStripePaymentElement();
+	} );
+
+	// If the card element selector doesn't exist, then do nothing.
+	// For example, when a 100% discount coupon is applied).
+	// We also don't re-mount if already mounted in DOM.
+	async function maybeMountStripePaymentElement() {
+		if (
+			$( '.wc-stripe-upe-element' ).length &&
+			! $( '.wc-stripe-upe-element' ).children().length
+		) {
+			for ( const upeElement of $(
+				'.wc-stripe-upe-element'
+			).toArray() ) {
+				await mountStripePaymentElement( api, upeElement );
+			}
+		}
+	}
+} );

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -200,7 +200,7 @@ jQuery( function ( $ ) {
 		// Do not recreate UPE element unnecessarily.
 		if ( upeElement ) {
 			upeElement.unmount();
-			upeElement.mount( '#wc-stripe-upe-element' );
+			upeElement.mount( '.wc-stripe-upe-element' );
 			return;
 		}
 
@@ -221,7 +221,7 @@ jQuery( function ( $ ) {
 				// I repeat, do NOT recreate UPE element unnecessarily.
 				if ( upeElement || paymentIntentId ) {
 					upeElement.unmount();
-					upeElement.mount( '#wc-stripe-upe-element' );
+					upeElement.mount( '.wc-stripe-upe-element' );
 					return;
 				}
 
@@ -302,7 +302,7 @@ jQuery( function ( $ ) {
 				}
 
 				upeElement = elements.create( 'payment', upeSettings );
-				upeElement.mount( '#wc-stripe-upe-element' );
+				upeElement.mount( '.wc-stripe-upe-element' );
 
 				upeElement.on( 'ready', () => {
 					unblockUI( $( upeLoadingSelector ) );
@@ -346,8 +346,8 @@ jQuery( function ( $ ) {
 		// If the card element selector doesn't exist, then do nothing (for example, when a 100% discount coupon is applied).
 		// We also don't re-mount if already mounted in DOM.
 		if (
-			$( '#wc-stripe-upe-element' ).length &&
-			! $( '#wc-stripe-upe-element' ).children().length &&
+			$( '.wc-stripe-upe-element' ).length &&
+			! $( '.wc-stripe-upe-element' ).children().length &&
 			isUPEEnabled
 		) {
 			const isSetupIntent = ! (
@@ -362,8 +362,8 @@ jQuery( function ( $ ) {
 		$( 'form#order_review' ).length
 	) {
 		if (
-			$( '#wc-stripe-upe-element' ).length &&
-			! $( '#wc-stripe-upe-element' ).children().length &&
+			$( '.wc-stripe-upe-element' ).length &&
+			! $( '.wc-stripe-upe-element' ).children().length &&
 			isUPEEnabled &&
 			! upeElement
 		) {

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -11,6 +11,7 @@ import { getFontRulesFromPage, getAppearance } from '../../styles/upe';
 import enableStripeLinkPaymentMethod from '../../stripe-link';
 import { legacyHashchangeHandler } from './legacy-support';
 import './style.scss';
+import './deferred-intent.js';
 
 jQuery( function ( $ ) {
 	const key = getStripeServerData()?.key;
@@ -338,24 +339,6 @@ jQuery( function ( $ ) {
 				);
 			} );
 	};
-
-	// Only attempt to mount the card element once that section of the page has loaded. We can use the updated_checkout
-	// event for this. This part of the page can also reload based on changes to checkout details, so we call unmount
-	// first to ensure the card element is re-mounted correctly.
-	$( document.body ).on( 'updated_checkout', () => {
-		// If the card element selector doesn't exist, then do nothing (for example, when a 100% discount coupon is applied).
-		// We also don't re-mount if already mounted in DOM.
-		if (
-			$( '.wc-stripe-upe-element' ).length &&
-			! $( '.wc-stripe-upe-element' ).children().length &&
-			isUPEEnabled
-		) {
-			const isSetupIntent = ! (
-				getStripeServerData()?.isPaymentNeeded ?? true
-			);
-			mountUPEElement( isSetupIntent );
-		}
-	} );
 
 	if (
 		$( 'form#add_payment_method' ).length ||

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -243,20 +243,21 @@ function setSelectedUPEPaymentType( paymentType ) {
 
 // Show or hide save payment information checkbox
 function showNewPaymentMethodCheckbox( show = true ) {
-	if ( show ) {
-		document.querySelector(
-			'.woocommerce-SavedPaymentMethods-saveNew'
-		).style.visibility = 'visible';
-	} else {
-		document.querySelector(
-			'.woocommerce-SavedPaymentMethods-saveNew'
-		).style.visibility = 'hidden';
-		document
-			.querySelector( 'input#wc-stripe-new-payment-method' )
-			.setAttribute( 'checked', false );
-		document
-			.querySelector( 'input#wc-stripe-new-payment-method' )
-			.dispatchEvent( new Event( 'change' ) );
+	const saveCardElement = document.querySelector(
+		'.woocommerce-SavedPaymentMethods-saveNew'
+	);
+
+	if ( saveCardElement ) {
+		saveCardElement.style.visibility = show ? 'visible' : 'hidden';
+	}
+
+	const stripeSaveCardCheckbox = document.querySelector(
+		'input#wc-stripe-new-payment-method'
+	);
+
+	if ( ! show && stripeSaveCardCheckbox ) {
+		stripeSaveCardCheckbox.setAttribute( 'checked', false );
+		stripeSaveCardCheckbox.dispatchEvent( new Event( 'change' ) );
 	}
 }
 

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -171,7 +171,7 @@ function createStripePaymentMethod(
 
 /**
  * Mounts the existing Stripe Payment Element to the DOM element.
- * Creates the Stipe Payment Element instance if it doesn't exist and mounts it to the DOM element.
+ * Creates the Stripe Payment Element instance if it doesn't exist and mounts it to the DOM element.
  *
  * @todo Make it only Split when implemented.
  *

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1,0 +1,163 @@
+import {
+	getPaymentMethodTypes,
+	getStripeServerData,
+	getUpeSettings,
+} from '../../stripe-utils';
+
+const gatewayUPEComponents = {};
+
+const paymentMethodsConfig = getStripeServerData()?.paymentMethodsConfig;
+
+for ( const paymentMethodType in paymentMethodsConfig ) {
+	gatewayUPEComponents[ paymentMethodType ] = {
+		elements: null,
+		upeElement: null,
+	};
+}
+
+/**
+ * Initializes the appearance of the payment element by retrieving the UPE configuration
+ * from the API and saving the appearance if it doesn't exist. If the appearance already exists,
+ * it is simply returned.
+ *
+ * @return {Object} The appearance object for the UPE.
+ */
+function initializeAppearance() {
+	return {};
+}
+
+/**
+ * Validates the Stripe elements by submitting them and handling any errors that occur during submission.
+ * If an error occurs, the function removes loading effect from the provided jQuery form and thus unblocks it,
+ * and shows an error message in the checkout.
+ *
+ * @param {Object} elements The Stripe elements object to be validated.
+ * @return {Promise} Promise for the checkout submission.
+ */
+export function validateElements( elements ) {
+	return elements.submit().then( ( result ) => {
+		if ( result.error ) {
+			throw new Error( result.error.message );
+		}
+	} );
+}
+
+/**
+ * Creates a Stripe payment element with the specified payment method type and options. The function
+ * retrieves the necessary data from the UPE configuration and initializes the appearance. It then creates the
+ * Stripe elements and the Stripe payment element, which is attached to the gatewayUPEComponents object afterward.
+ *
+ * @todo Make paymentMethodType required when Split is implemented.
+ *
+ * @param {Object} api The API object used to create the Stripe payment element.
+ * @param {string} paymentMethodType The type of Stripe payment method to create.
+ * @return {Object} A promise that resolves with the created Stripe payment element.
+ */
+function createStripePaymentElement( api, paymentMethodType = null ) {
+	const amount = Number( getStripeServerData()?.cartTotal );
+	const paymentMethodTypes = getPaymentMethodTypes( paymentMethodType );
+	const options = {
+		mode: amount < 1 ? 'setup' : 'payment',
+		currency: getStripeServerData()?.currency.toLowerCase(),
+		amount,
+		paymentMethodCreation: 'manual',
+		paymentMethodTypes,
+		appearance: initializeAppearance(),
+	};
+
+	const elements = api.getStripe().elements( options );
+	const createdStripePaymentElement = elements.create( 'payment', {
+		...getUpeSettings(),
+		wallets: {
+			applePay: 'never',
+			googlePay: 'never',
+		},
+	} );
+
+	// To be removed with Split PE.
+	if ( paymentMethodType === null ) {
+		return createdStripePaymentElement;
+	}
+
+	gatewayUPEComponents[ paymentMethodType ].elements = elements;
+	gatewayUPEComponents[
+		paymentMethodType
+	].upeElement = createdStripePaymentElement;
+	return createdStripePaymentElement;
+}
+
+/**
+ * Mounts the existing Stripe Payment Element to the DOM element.
+ * Creates the Stipe Payment Element instance if it doesn't exist and mounts it to the DOM element.
+ *
+ * @todo Make it only Split when implemented.
+ *
+ * @param {Object} api The API object.
+ * @param {string} domElement The selector of the DOM element of particular payment method to mount the UPE element to.
+ **/
+export async function mountStripePaymentElement( api, domElement ) {
+	/*
+	 * Trigger this event to ensure the tokenization-form.js init
+	 * is executed.
+	 *
+	 * This script handles the radio input interaction when toggling
+	 * between the user's saved card / entering new card details.
+	 *
+	 * Ref: https://github.com/woocommerce/woocommerce/blob/2429498/assets/js/frontend/tokenization-form.js#L109
+	 */
+	const event = new Event( 'wc-credit-card-form-init' );
+	document.body.dispatchEvent( event );
+
+	const paymentMethodType = domElement.dataset.paymentMethodType;
+	let upeElement;
+
+	// Non-split PE. To be removed.
+	if ( typeof paymentMethodType === 'undefined' ) {
+		upeElement = await createStripePaymentElement( api );
+
+		upeElement.on( 'change', ( e ) => {
+			const selectedUPEPaymentType = e.value.type;
+			const isPaymentMethodReusable =
+				paymentMethodsConfig[ selectedUPEPaymentType ].isReusable;
+			showNewPaymentMethodCheckbox( isPaymentMethodReusable );
+			setSelectedUPEPaymentType( selectedUPEPaymentType );
+		} );
+	} else {
+		// Split PE.
+		if ( ! gatewayUPEComponents[ paymentMethodType ] ) {
+			return;
+		}
+
+		upeElement =
+			gatewayUPEComponents[ paymentMethodType ].upeElement ||
+			( await createStripePaymentElement( api, paymentMethodType ) );
+	}
+
+	upeElement.mount( domElement );
+}
+
+// Set the selected UPE payment type field
+function setSelectedUPEPaymentType( paymentType ) {
+	document.querySelector(
+		'#wc_stripe_selected_upe_payment_type'
+	).value = paymentType;
+}
+
+// Show or hide save payment information checkbox
+function showNewPaymentMethodCheckbox( show = true ) {
+	if ( show ) {
+		document.querySelector(
+			'.woocommerce-SavedPaymentMethods-saveNew'
+		).style.visibility = 'visible';
+	} else {
+		document.querySelector(
+			'.woocommerce-SavedPaymentMethods-saveNew'
+		).style.visibility = 'hidden';
+		document
+			.querySelector( 'input#wc-stripe-new-payment-method' )
+			.setAttribute( 'checked', false );
+		document
+			.querySelector( 'input#wc-stripe-new-payment-method' )
+			.dispatchEvent( new Event( 'change' ) );
+	}
+}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -2,10 +2,14 @@ import {
 	appendIsUsingDeferredIntentToForm,
 	appendPaymentMethodIdToForm,
 	getPaymentMethodTypes,
+	getStorageWithExpiration,
 	getStripeServerData,
 	getUpeSettings,
+	setStorageWithExpiration,
 	showErrorCheckout,
+	storageKeys,
 } from '../../stripe-utils';
+import { getFontRulesFromPage, getAppearance } from '../../styles/upe';
 
 const gatewayUPEComponents = {};
 
@@ -26,7 +30,17 @@ for ( const paymentMethodType in paymentMethodsConfig ) {
  * @return {Object} The appearance object for the UPE.
  */
 function initializeAppearance() {
-	return {};
+	const themeName = getStripeServerData()?.theme_name;
+	const storageKey = `${ storageKeys.UPE_APPEARANCE }_${ themeName }`;
+	let appearance = getStorageWithExpiration( storageKey );
+
+	if ( ! appearance ) {
+		appearance = getAppearance();
+		const oneDayDuration = 24 * 60 * 60 * 1000;
+		setStorageWithExpiration( storageKey, appearance, oneDayDuration );
+	}
+
+	return appearance;
 }
 
 /**
@@ -81,6 +95,7 @@ function createStripePaymentElement( api, paymentMethodType = null ) {
 		paymentMethodCreation: 'manual',
 		paymentMethodTypes,
 		appearance: initializeAppearance(),
+		fonts: getFontRulesFromPage(),
 	};
 
 	const elements = api.getStripe().elements( options );

--- a/client/classic/upe/style.scss
+++ b/client/classic/upe/style.scss
@@ -1,3 +1,3 @@
-#wc-stripe-upe-element {
+.wc-stripe-upe-element {
 	margin-bottom: 4px;
 }

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -281,7 +281,7 @@ export const appendPaymentMethodIdToForm = ( form, paymentMethodId ) => {
  */
 export const isUsingSavedPaymentMethod = () => {
 	return (
-		document.querySelector( '#wc-stripe-new-payment-method' ).length &&
+		document.querySelector( '#wc-stripe-new-payment-method' )?.length &&
 		! document
 			.querySelector( '#wc-stripe-new-payment-method' )
 			.is( ':checked' )

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -728,8 +728,10 @@ class WC_Stripe_Intent_Controller {
 		$order->update_status( 'pending', __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
 		$order->save();
 
+		// Throw an exception when there's an error.
 		if ( ! empty( $payment_intent->error ) ) {
-			throw new WC_Stripe_Exception( $payment_intent->error->message );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			throw new WC_Stripe_Exception( print_r( $payment_intent->error, true ), $payment_intent->error->message );
 		}
 
 		WC_Stripe_Helper::add_payment_intent_to_order( $payment_intent->id, $order );

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -725,9 +725,6 @@ class WC_Stripe_Intent_Controller {
 			$order->update_meta_data( '_stripe_upe_payment_type', $selected_payment_type );
 		}
 
-		$order->update_status( 'pending', __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
-		$order->save();
-
 		// Throw an exception when there's an error.
 		if ( ! empty( $payment_intent->error ) ) {
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -18,11 +18,11 @@ class WC_Stripe_Intent_Controller {
 	protected $gateway;
 
 	/**
-	 * Class constructor, adds the necessary hooks.
+	 * Adds the necessary hooks.
 	 *
 	 * @since 4.2.0
 	 */
-	public function __construct() {
+	public function init_hooks() {
 		add_action( 'wc_ajax_wc_stripe_verify_intent', [ $this, 'verify_intent' ] );
 		add_action( 'wc_ajax_wc_stripe_create_setup_intent', [ $this, 'create_setup_intent' ] );
 
@@ -677,5 +677,3 @@ class WC_Stripe_Intent_Controller {
 		}
 	}
 }
-
-new WC_Stripe_Intent_Controller();

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -678,46 +678,45 @@ class WC_Stripe_Intent_Controller {
 	}
 
 	/**
-	 * Creates payment intent using current cart or order and store details.
+	 * Creates and confirm a payment intent with the given payment information.
 	 * Used for dPE.
 	 *
-	 * @param int $order_id The id of the order if intent created from Order.
-	 * @throws Exception - If the create intent call returns with an error.
+	 * @param object $payment_information The payment information needed for creating and confirming the intent.
+	 *
+	 * @throws WC_Stripe_Exception - If the create intent call returns with an error.
+	 *
 	 * @return array
 	 */
 	public function create_and_confirm_payment_intent( $payment_information ) {
-		$gateway = $this->get_upe_gateway();
-		$order   = $payment_information->order;
+		// Throws a WC_Stripe_Exception if required information is missing.
+		$this->validate_create_and_confirm_intent_payment_information( $payment_information );
 
-		$selected_payment_type = $payment_information->selected_payment_type;
+		$order                 = $payment_information['order'];
+		$selected_payment_type = $payment_information['selected_payment_type'];
 		$payment_method_types  = $this->get_payment_method_types_for_intent_creation( $selected_payment_type, $order->get_id() );
 
 		$request = [
-			'amount'               => $payment_information->amount,
+			'amount'               => $payment_information['amount'],
+			'capture_method'       => $payment_information['capture_method'],
 			'confirm'              => 'true',
-			'currency'             => $payment_information->currency,
-			'capture_method'       => $payment_information->capture_method,
+			'currency'             => $payment_information['currency'],
+			'customer'             => $payment_information['customer'],
 			/* translators: 1) blog name 2) order number */
 			'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
-			'metadata'             => $gateway->get_metadata_from_order( $order ),
-			'payment_method'       => $payment_information->payment_method,
+			'metadata'             => $payment_information['metadata'],
+			'payment_method'       => $payment_information['payment_method'],
 			'payment_method_types' => $payment_method_types,
-			'statement_descriptor' => $payment_information->statement_descriptor,
+			'statement_descriptor' => $payment_information['statement_descriptor'],
 		];
 
-		$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
-		if ( ! empty( $customer ) && $customer->get_id() ) {
-			$request['customer'] = $customer->get_id();
-		}
-
-		if ( $payment_information->save_payment_method_to_store ) {
+		if ( $payment_information['save_payment_method_to_store'] ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 
 		$payment_intent = WC_Stripe_API::request_with_level3_data(
 			$request,
 			'payment_intents',
-			$gateway->get_level3_data_from_order( $order ),
+			$payment_information['level3'],
 			$order
 		);
 
@@ -736,6 +735,57 @@ class WC_Stripe_Intent_Controller {
 		WC_Stripe_Helper::add_payment_intent_to_order( $payment_intent->id, $order );
 
 		return $payment_intent;
+	}
+
+	/**
+	 * Validate the provided information for creating and confirming a payment intent.
+	 *
+	 * @param array $payment_information The payment information to be validated.
+	 *
+	 * @throws WC_Stripe_Exception If the required data is missing.
+	 */
+	private function validate_create_and_confirm_intent_payment_information( array $payment_information ) {
+		$required_params = [
+			'amount',
+			'capture_method',
+			'currency',
+			'customer',
+			'level3',
+			'metadata',
+			'payment_method',
+			'order',
+			'save_payment_method_to_store',
+			'statement_descriptor',
+		];
+
+		$missing_params = [];
+		foreach ( $required_params as $param ) {
+			// Check if they're set. Some can be null.
+			if ( ! array_key_exists( $param, $payment_information ) ) {
+				$missing_params[] = $param;
+			}
+		}
+
+		$shopper_error_message = __( 'There was a problem processing the payment.', 'woocommerce-gateway-stripe' );
+
+		// Bail out if we're missing required information.
+		if ( ! empty( $missing_params ) ) {
+			throw new WC_Stripe_Exception(
+				sprintf(
+					'The information for creating and confirming the intent is missing the following data: %s.',
+					implode( ', ', $missing_params )
+				),
+				$shopper_error_message
+			);
+		}
+
+		// Bail out if the "order" parameter isn't a WC_Order.
+		if ( ! is_a( $payment_information['order'], 'WC_Order' ) ) {
+			throw new WC_Stripe_Exception(
+				'The provided value for the "order" parameter is not a WC_Order',
+				$shopper_error_message
+			);
+		}
 	}
 
 	/**

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -706,6 +706,7 @@ class WC_Stripe_Intent_Controller {
 			'metadata'             => $payment_information['metadata'],
 			'payment_method'       => $payment_information['payment_method'],
 			'payment_method_types' => $payment_method_types,
+			'shipping'             => $payment_information['shipping'],
 			'statement_descriptor' => $payment_information['statement_descriptor'],
 		];
 
@@ -751,9 +752,10 @@ class WC_Stripe_Intent_Controller {
 			'customer',
 			'level3',
 			'metadata',
-			'payment_method',
 			'order',
+			'payment_method',
 			'save_payment_method_to_store',
+			'shipping',
 			'statement_descriptor',
 		];
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -663,8 +663,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	private function process_payment_with_deferred_intent( int $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		// TODO: check we're processing a payment for an order with a pending status.
-
 		try {
 			if ( $this->is_using_saved_payment_method() ) {
 				return [ 'result' => 'failure' ];

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -661,7 +661,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 *
 	 * @return array An array with the result of the payment processing, and a redirect URL on success.
 	 */
-	private function process_payment_with_deferred_intent( $order_id ) {
+	private function process_payment_with_deferred_intent( int $order_id ) {
 		$order = wc_get_order( $order_id );
 
 		// TODO: check we're processing a payment for an order with a pending status.
@@ -1574,7 +1574,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * Collects the payment information needed for processing a payment intent.
 	 *
 	 * @param WC_Order $order The WC Order to be paid for.
-	 * @return object An object containing the payment information for processing a payment intent.
+	 * @return array An array containing the payment information for processing a payment intent.
 	 */
 	private function prepare_payment_information_from_request( WC_Order $order ) {
 		// TODO: throw exception if any required information is missing.
@@ -1591,6 +1591,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'currency'                     => $currency,
 			'customer'                     => $this->get_customer_id_for_order( $order ),
 			'capture_method'               => $capture_method,
+			'level3'                       => $this->get_level3_data_from_order( $order ),
+			'metadata'                     => $this->get_metadata_from_order( $order ),
 			'order'                        => $order,
 			'payment_initiated_by'         => 'initiated_by_customer', // initiated_by_merchant | initiated_by_customer.
 			'payment_method'               => $payment_method,
@@ -1600,7 +1602,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'statement_descriptor'         => $this->get_statement_descriptor( $selected_payment_type ),
 		];
 
-		return (object) $payment_information;
+		return $payment_information;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -682,6 +682,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				// Use the last charge within the intent to proceed.
 				$this->process_response( end( $payment_intent->charges->data ), $order );
 
+				// Set the selected UPE payment method type title in the WC order.
+				$this->set_payment_method_title_for_order( $order, $payment_information['selected_payment_type'] );
 			} else {
 				return [ 'result' => 'failure' ];
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1583,8 +1583,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$selected_payment_type        = sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$capture_method               = empty( $this->get_option( 'capture' ) ) || $this->get_option( 'capture' ) === 'yes' ? 'automatic' : 'manual'; // automatic | manual.
 		$save_payment_method_to_store = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
+		$currency                     = strtolower( get_woocommerce_currency() );
+		$amount                       = $order->get_total();
 
 		$payment_information = [
+			'amount'                       => WC_Stripe_Helper::get_stripe_amount( $amount, $currency ),
+			'currency'                     => $currency,
 			'customer'                     => $this->get_customer_id_for_order( $order ),
 			'capture_method'               => $capture_method,
 			'order'                        => $order,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1588,7 +1588,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$selected_payment_type        = sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$capture_method               = empty( $this->get_option( 'capture' ) ) || $this->get_option( 'capture' ) === 'yes' ? 'automatic' : 'manual'; // automatic | manual.
 		$save_payment_method_to_store = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
-		$currency                     = strtolower( get_woocommerce_currency() );
+		$currency                     = strtolower( $order->get_currency() );
 		$amount                       = $order->get_total();
 
 		$payment_information = [

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -465,7 +465,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			?>
 
 			<fieldset id="wc-stripe-upe-form" class="wc-upe-form wc-payment-form">
-				<div id="wc-stripe-upe-element"></div>
+				<div class="wc-stripe-upe-element"></div>
 				<div id="wc-stripe-upe-errors" role="alert"></div>
 				<input id="wc-stripe-payment-method-upe" type="hidden" name="wc-stripe-payment-method-upe" />
 				<input id="wc_stripe_selected_upe_payment_type" type="hidden" name="wc_stripe_selected_upe_payment_type" />

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -317,6 +317,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['addPaymentReturnURL']      = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']     = $enabled_billing_fields;
 
+		$cart_total = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
+		$currency   = get_woocommerce_currency();
+
+		$stripe_params['cartTotal'] = WC_Stripe_Helper::get_stripe_amount( $cart_total, strtolower( $currency ) );
+		$stripe_params['currency']  = $currency;
+
 		if ( parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
 			if ( $this->is_subscriptions_enabled() && $is_change_payment_method ) {
 				$stripe_params['isChangingPayment']   = true;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -119,7 +119,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$this->payment_methods[ $payment_method->get_id() ] = $payment_method;
 		}
 
-		// TODO: Maybe pass this as a class dependency.
 		$this->intent_controller = new WC_Stripe_Intent_Controller();
 
 		// Load the form fields.
@@ -668,20 +667,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		try {
 			if ( $this->is_using_saved_payment_method() ) {
-				// TODO: if using a saved payment method.
 				return [ 'result' => 'failure' ];
 			}
 
 			$payment_needed = $this->is_payment_needed( $order->get_id() );
 
 			$payment_information = $this->prepare_payment_information_from_request( $order );
-			// TODO: if 0-amount and not saving a payment method.
 
 			if ( $payment_needed ) {
 				// Throw an exception if the minimum order amount isn't met.
 				$this->validate_minimum_order_amount( $order );
-
-				// TODO: Update the payment intent if one is already associated with the order. Order meta '_stripe_intent_id'.
 
 				// Throws an exception on error.
 				$payment_intent = $this->intent_controller->create_and_confirm_payment_intent( $payment_information );
@@ -690,7 +685,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$this->process_response( end( $payment_intent->charges->data ), $order );
 
 			} else {
-				// TODO: no payment is needed.
 				return [ 'result' => 'failure' ];
 			}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1584,8 +1584,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return array An array containing the payment information for processing a payment intent.
 	 */
 	private function prepare_payment_information_from_request( WC_Order $order ) {
-		// TODO: throw exception if any required information is missing.
-
 		$payment_method               = sanitize_text_field( wp_unslash( $_POST['wc-stripe-payment-method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$selected_payment_type        = sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$capture_method               = empty( $this->get_option( 'capture' ) ) || $this->get_option( 'capture' ) === 'yes' ? 'automatic' : 'manual'; // automatic | manual.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1584,6 +1584,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$save_payment_method_to_store = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
 		$currency                     = strtolower( $order->get_currency() );
 		$amount                       = $order->get_total();
+		$shipping_details             = null;
+
+		// If order requires shipping, add the shipping address details to the payment intent request.
+		if ( method_exists( $order, 'get_shipping_postcode' ) && ! empty( $order->get_shipping_postcode() ) ) {
+			$shipping_details = $this->get_address_data_for_payment_request( $order );
+		}
 
 		$payment_information = [
 			'amount'                       => WC_Stripe_Helper::get_stripe_amount( $amount, $currency ),
@@ -1598,6 +1604,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'payment_type'                 => 'single', // single | recurring.
 			'save_payment_method_to_store' => $save_payment_method_to_store,
 			'selected_payment_type'        => $selected_payment_type,
+			'shipping'                     => $shipping_details,
 			'statement_descriptor'         => $this->get_statement_descriptor( $selected_payment_type ),
 		];
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -253,7 +253,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	public function test_payment_fields_outputs_fields() {
 		$this->mock_gateway->payment_fields();
-		$this->expectOutputRegex( '/<div id="wc-stripe-upe-element"><\/div>/' );
+		$this->expectOutputRegex( '/<div class="wc-stripe-upe-element"><\/div>/' );
 	}
 
 	/**

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -312,6 +312,50 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test basic checkout process_payment flow.
+	 */
+	public function test_process_payment_deferred_returns_valid_response() {
+		$payment_intent_id = 'pi_mock';
+		$customer_id       = 'cus_mock';
+		$order             = WC_Helper_Order::create_order();
+		$currency          = $order->get_currency();
+		$order_id          = $order->get_id();
+
+		$mock_intent = (object) [
+			'charges' => (object) [
+				'data' => [
+					(object) [
+						'id'       => $order_id,
+						'captured' => 'yes',
+						'status'   => 'succeeded',
+					],
+				],
+			],
+		];
+
+		$_POST = [ 'wc-stripe-is-deferred-intent' => '1' ];
+
+		$this->mock_gateway->intent_controller = $this->getMockBuilder( WC_Stripe_Intent_Controller::class )
+			->setMethods( [ 'create_and_confirm_payment_intent' ] )
+			->getMock();
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( $customer_id );
+
+		$response = $this->mock_gateway->process_payment( $order_id );
+
+		$this->assertEquals( 'success', $response['result'] );
+		$this->assertEquals( self::MOCK_RETURN_URL, $response['redirect'] );
+	}
+
+	/**
 	 * Test basic redirect payment processed correctly.
 	 */
 	public function test_process_redirect_payment_returns_valid_response() {

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -398,42 +398,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Exception handling of the process_payment flow with deferred intent.
-	 */
-	public function test_process_payment_deferred_intent_handles_failed_intent_creation() {
-		$payment_intent_id = 'pi_mock';
-		$customer_id       = 'cus_mock';
-		$order             = WC_Helper_Order::create_order();
-		$currency          = $order->get_currency();
-		$order_id          = $order->get_id();
-
-		$mock_intent = (object) [
-			'last_payment_error' => (object) [
-				'message' => 'Still a trap',
-			],
-		];
-
-		$_POST = [ 'wc-stripe-is-deferred-intent' => '1' ];
-
-		$this->mock_gateway->intent_controller
-			->expects( $this->once() )
-			->method( 'create_and_confirm_payment_intent' )
-			->willReturn( $mock_intent );
-
-		$this->mock_gateway
-			->expects( $this->once() )
-			->method( 'get_stripe_customer_id' )
-			->willReturn( $customer_id );
-
-		$response = $this->mock_gateway->process_payment( $order_id );
-
-		$this->assertEquals( 'failure', $response['result'] );
-
-		$processed_order = wc_get_order( $order_id );
-		$this->assertEquals( 'failed', $processed_order->get_status() );
-	}
-
-	/**
 	 * Test basic redirect payment processed correctly.
 	 */
 	public function test_process_redirect_payment_returns_valid_response() {

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -118,6 +118,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				$this->returnValue( self::MOCK_RETURN_URL )
 			);
 
+		$this->mock_gateway->intent_controller = $this->getMockBuilder( WC_Stripe_Intent_Controller::class )
+			->setMethods( [ 'create_and_confirm_payment_intent' ] )
+			->getMock();
+
 		$this->mock_stripe_customer = $this->getMockBuilder( WC_Stripe_Customer::class )
 			->disableOriginalConstructor()
 			->setMethods(
@@ -312,9 +316,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test basic checkout process_payment flow.
+	 * Test basic checkout process_payment flow with deferred intent.
 	 */
-	public function test_process_payment_deferred_returns_valid_response() {
+	public function test_process_payment_deferred_intent_returns_valid_response() {
 		$payment_intent_id = 'pi_mock';
 		$customer_id       = 'cus_mock';
 		$order             = WC_Helper_Order::create_order();
@@ -335,10 +339,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$_POST = [ 'wc-stripe-is-deferred-intent' => '1' ];
 
-		$this->mock_gateway->intent_controller = $this->getMockBuilder( WC_Stripe_Intent_Controller::class )
-			->setMethods( [ 'create_and_confirm_payment_intent' ] )
-			->getMock();
-
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
 			->method( 'create_and_confirm_payment_intent' )
@@ -353,6 +353,84 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( self::MOCK_RETURN_URL, $response['redirect'] );
+	}
+
+	/**
+	 * Exception handling of the process_payment flow with deferred intent.
+	 */
+	public function test_process_payment_deferred_intent_handles_exception() {
+		$payment_intent_id = 'pi_mock';
+		$customer_id       = 'cus_mock';
+		$order             = WC_Helper_Order::create_order();
+		$currency          = $order->get_currency();
+		$order_id          = $order->get_id();
+
+		$mock_intent = (object) [
+			'charges' => (object) [
+				'data' => [
+					(object) [
+						'id'       => $order_id,
+						'captured' => 'yes',
+						'status'   => 'succeeded',
+					],
+				],
+			],
+		];
+
+		$_POST = [ 'wc-stripe-is-deferred-intent' => '1' ];
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willThrowException( new WC_Stripe_Exception( "It's a trap!" ) );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( $customer_id );
+
+		$response = $this->mock_gateway->process_payment( $order_id );
+
+		$this->assertEquals( 'failure', $response['result'] );
+
+		$processed_order = wc_get_order( $order_id );
+		$this->assertEquals( 'failed', $processed_order->get_status() );
+	}
+
+	/**
+	 * Exception handling of the process_payment flow with deferred intent.
+	 */
+	public function test_process_payment_deferred_intent_handles_failed_intent_creation() {
+		$payment_intent_id = 'pi_mock';
+		$customer_id       = 'cus_mock';
+		$order             = WC_Helper_Order::create_order();
+		$currency          = $order->get_currency();
+		$order_id          = $order->get_id();
+
+		$mock_intent = (object) [
+			'last_payment_error' => (object) [
+				'message' => 'Still a trap',
+			],
+		];
+
+		$_POST = [ 'wc-stripe-is-deferred-intent' => '1' ];
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( $customer_id );
+
+		$response = $this->mock_gateway->process_payment( $order_id );
+
+		$this->assertEquals( 'failure', $response['result'] );
+
+		$processed_order = wc_get_order( $order_id );
+		$this->assertEquals( 'failed', $processed_order->get_status() );
 	}
 
 	/**

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -213,6 +213,9 @@ function woocommerce_gateway_stripe() {
 				$this->payment_request_configuration = new WC_Stripe_Payment_Request();
 				$this->account                       = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
 
+				$intent_controller = new WC_Stripe_Intent_Controller();
+				$intent_controller->init_hooks();
+
 				if ( is_admin() ) {
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';
 					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-settings-controller.php';


### PR DESCRIPTION
Fixes #2747

This PR doesn't point to `develop` as we'll require further work before these changes get shipped.

## Changes proposed in this Pull Request:

- Collect the payment details before creating the payment intent (aka, use [deferred intents](https://stripe.com/docs/payments/accept-a-payment-deferred)). Previously, a payment intent was created when the checkout page was loaded.
- When processing the payment, the payment intent gets created already with the payment details and confirmed.
- Processing UPE payments after the redirection to the "Order confirmation" page isn't needed anymore.
- When the payment processing fails, the failed response gets added to the debug log

This PR only covers:
  - Processing payments from the classic checkout page. The block checkout, Pay for order page, and adding a new payment method from my account aren't covered.
  - Automatic captures. Authorizing the transaction and capturing later will be handled separately.
  - Using new cards regular. Other payment methods, 3DS cards, saving a card, or reusing an already saved card will be handled separately.

## Testing instructions

- Enable UPE
- As a shopper, process payments under the classic checkout page for all tests

**Happy path**
- Check out `develop` 
- Pay for an order using a new regular card, not saving it. Flow: [Shopper > Checkout with normal credit card](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#checkout-with-normal-credit-card)
- Check out this branch and pay for another order
- Open both WC orders in the database
- Confirm these meta exist and match between both orders:
  -  _stripe_charge_captured
  - _stripe_currency
  - _stripe_fee
  - _stripe_intent_id
  - _stripe_net
  - _stripe_upe_payment_type
- Confirm that the meta _stripe_upe_redirect_processed, isn't set in the order processed using this branch
- Open the payment intents in Stripe for both orders
- Confirm that the information for the payment intents created for each order is consistent with each other:
  - Customer data. You could try checking out as:
    - A guest -> A new Stripe customer should be created
    - A customer with no associated Stripe user -> A new Stripe customer should be created. It'll be reused
    - A customer with an associated Stripe user -> No new Stripe customer should be created. The associated one should be reused
  - Payment details
    - For the statement descriptor, it must reflect the short or long version depending on the options in the plugin dashboard
  - Payment method data 
  - Metadata:
    - customer_email
    - customer_name
    - order_id
    - order_key
    - payment_type
    - site_url

**Confirm the intent creation flow is deferred**
- Add a product to the cart and go to the checkout page. Don't continue
- In the Stripe dashboard, confirm no payment intent was created
- Proceed with the checkout
- Confirm that the payment intent was created and confirmed

**Card failures**
  - Confirm the following flow behaves as expected [Shopper > Checkout failures (with various cards)](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#checkout-failures-with-various-cards)

**Note:** With the card failures, a new payment intent will be created for each retry. In the future, the same intent will be reused as possible. This will be fixed by https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2761.


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
