### PR TITLE
Update express button placement (hook) and remove "OR" separator on cart and product pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 7.8.0 - xxxx-xx-xx =
+* Tweak - Removed '- OR -' separator and updated placement of Express payment buttons (eg Apple Pay and Google Pay) to align with WooCommerce Express payment button standards.
+
 = 7.7.0 - 2023-11-09 =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
 * Fix - Display the Payment Request Buttons' error message in the classic checkout page.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -859,24 +859,24 @@ class WC_Stripe_Payment_Request {
 			</div>
 		</div>
 		<?php
+		$this->display_payment_request_button_separator_html();
 	}
 
 	/**
 	 * Display payment request button separator.
 	 *
-	 * @deprecated 7.8.0
 	 * @since   4.0.0
 	 * @version 5.2.0
 	 */
 	public function display_payment_request_button_separator_html() {
-		wc_deprecated_function( __FUNCTION__, '7.8.0' );
+
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! isset( $gateways['stripe'] ) ) {
 			return;
 		}
 
-		if ( ! is_cart() && ! is_checkout() && ! $this->is_product() && ! is_wc_endpoint_url( 'order-pay' ) ) {
+		if ( ! is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -869,7 +869,6 @@ class WC_Stripe_Payment_Request {
 	 * @version 5.2.0
 	 */
 	public function display_payment_request_button_separator_html() {
-
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! isset( $gateways['stripe'] ) ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -217,14 +217,9 @@ class WC_Stripe_Payment_Request {
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_after_add_to_cart_quantity', [ $this, 'display_payment_request_button_separator_html' ], 2 );
-
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_separator_html' ], 2 );
-
+		add_action( 'woocommerce_after_add_to_cart_form', [ $this, 'display_payment_request_button_html' ], 1 );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_payment_request_button_html' ], 25 );
 		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_html' ], 1 );
-		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_payment_request_button_separator_html' ], 2 );
 
 		add_action( 'wc_ajax_wc_stripe_get_cart_details', [ $this, 'ajax_get_cart_details' ] );
 		add_action( 'wc_ajax_wc_stripe_get_shipping_options', [ $this, 'ajax_get_shipping_options' ] );
@@ -853,7 +848,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		?>
-		<div id="wc-stripe-payment-request-wrapper" style="clear:both;padding-top:1.5em;display:none;">
+		<div id="wc-stripe-payment-request-wrapper" style="clear:both;display:none;">
 			<div id="wc-stripe-payment-request-button">
 				<?php
 				if ( $this->is_custom_button() ) {
@@ -869,10 +864,12 @@ class WC_Stripe_Payment_Request {
 	/**
 	 * Display payment request button separator.
 	 *
+	 * @deprecated 7.8.0
 	 * @since   4.0.0
 	 * @version 5.2.0
 	 */
 	public function display_payment_request_button_separator_html() {
+		wc_deprecated_function( __FUNCTION__, '7.8.0' );
 		$gateways = WC()->payment_gateways->get_available_payment_gateways();
 
 		if ( ! isset( $gateways['stripe'] ) ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -876,7 +876,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		?>
-		<div id="wc-stripe-payment-request-wrapper" style="clear:both;display:none;">
+		<div id="wc-stripe-payment-request-wrapper" style="margin-top: 1em;clear:both;display:none;">
 			<div id="wc-stripe-payment-request-button">
 				<?php
 				if ( $this->is_custom_button() ) {

--- a/readme.txt
+++ b/readme.txt
@@ -128,25 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.7.0 - 2023-11-09 =
-* Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.
-* Fix - Display the Payment Request Buttons' error message in the classic checkout page.
-* Fix - Prevent escaping the anchor tag under the Apple Pay domain registration failure notice.
-* Fix - Use the card's payer name for Payment Request Buttons when the billing name isn't available.
-* Fix - Display the Payment Request Buttons according to the selected settings.
-* Tweak - Record Track events during the onboarding process.
-* Tweak - Prevent Google Pay and Apple Pay from showing up in the UPE card Element.
-* Tweak - Use admin theme color in selectors.
-* Tweak - Refactor `is_valid_pay_for_order_endpoint` for better performance.
-* Fix - Catch request failure errors.
-* Tweak - Add test mode notice.
-* Fix - Remove ugx from the zero decimal currency list as a special case in Stripe.
-* Fix - Deleting customer on staging site detaches tokens from customer in Stripe.
-* Fix - Resolved an issue preventing changing a subscriptions payment method when UPE is enabled.
-* Fix - Send customer billing and address details to Stripe when changing a subscriptions payment method.
-* Add - Attach billing details to customers created in Stripe to support Indian merchants in processing international transactions.
-* Fix - Prevent "Invalid recurring shipping method" errors when attempting to purchase a synchronised subscription with payment request buttons.
-* Fix - When using Payment Request buttons on variable product pages, ensure shipping is properly calculated after the customer closes the window and changes variations.
-* Fix - Purchasing a virtual variable product using Apple Pay and Google Pay on the product page will no longer require shipping details.
+= 7.8.0 - xxxx-xx-xx =
+* Tweak - Removed '- OR -' separator and updated placement of Express payment buttons (eg Apple Pay and Google Pay) to align with WooCommerce Express payment button standards.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2758 

## Changes proposed in this Pull Request:

Inline with incoming Express payment button standards, this PR removes the **"- OR -"** separator and updates the hooks we use to render the buttons so they appear in the correct place. These changes update the Stripe plugin to follow similar changes made to WooPayments in https://github.com/Automattic/woocommerce-payments/pull/6985.

### Product

| Before | After |
|--------|--------|
| <img width="400" alt="Screenshot 2023-11-20 at 10 01 28 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/d1870fca-42ee-4fe9-a312-2284747d0ed3"> | <img width="400" alt="Screenshot 2023-11-20 at 10 00 11 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/61fc7e58-d899-40bb-9220-477feeae4c68"> | 

### Cart

| Before | After |
|--------|--------|
| <img width="593" alt="Screenshot 2023-11-20 at 10 05 34 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c2a9766d-2f41-45e6-8ed4-d4d7b680ba79"> | <img width="620" alt="Screenshot 2023-11-20 at 10 09 05 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/3ea3bdaa-fd67-42cd-bf73-7edde6bb434a"> | 

### Stripe vs WooPayments comparison

Given this PR is implementing the changes WooPayments have already made in https://github.com/Automattic/woocommerce-payments/pull/6985, I've included side by side comparisons.

<p align="center">
<img width="1562" alt="Screenshot 2023-11-20 at 10 26 51 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/17b7551f-6d8f-450f-a49b-52fb752b68a8">
</br>
<sup>Stripe (left). WooPayments (right)</sup>
</p>

<p align="center">
<img width="1485" alt="Screenshot 2023-11-20 at 10 33 45 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ed41b2a8-1309-4919-a97c-1d911a8dea5c">
</br>
<sup>Stripe (left). WooPayments (right)</sup>
</p>

<p align="center">
<img width="1485" alt="Screenshot 2023-11-20 at 10 33 45 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ed41b2a8-1309-4919-a97c-1d911a8dea5c">
</br>
<sup>Stripe (left). WooPayments (right)</sup>
</p>

## Testing instructions

- Checkout this branch.
- Make sure Google Pay and Apple pay are enabled in Stripe plugin settings (**WooCommerce > Settings > Payments > Stripe**). 
- In Google Chrome (Google Pay) or Safari (Apple Pay) open the product page. 
- Confirm button placement and changes as outlined above.
- Add product to the cart. 
- Go to cart page. 
- Confirm placement of button on cart page. 

> [!NOTE]
> Checkout **hasn't** been changed by this PR. It is already consistant with WooPayments. 

<p align="center">
<img width="1194" alt="Screenshot 2023-11-20 at 11 10 44 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ad5228a7-40d9-476b-a7ee-45d5ec25198a">

</br>
<sup>Stripe (left). WooPayments (right)</sup>
</p>



---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)