### PR TITLE
Update default payment request button size to 48px

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - When using Payment Request buttons, fix $0 total for stores using a customized product page that adds the variation product ID directly into the cart.
 * Fix - MultiBanco: HTML tags to print as expected on the Order Confirmation page, and "Thank you for your order" email.
 * Tweak - Improve compatibility with PHP 8+.
+* Tweak - Adjusted default height of express payment button from 40px to 48px. Existing stores retain their current button height settings.
 
 = 7.7.0 - 2023-11-09 =
 * Add - Prevent saving the bank statement descriptor if it contains non-Latin characters.

--- a/client/entrypoints/payment-request-settings/__tests__/payment-request-settings.test.js
+++ b/client/entrypoints/payment-request-settings/__tests__/payment-request-settings.test.js
@@ -89,7 +89,7 @@ describe( 'PaymentRequestsSettingsSection', () => {
 
 		// confirm default values.
 		expect( screen.getByLabelText( 'Buy' ) ).toBeChecked();
-		expect( screen.getByLabelText( 'Default (40 px)' ) ).toBeChecked();
+		expect( screen.getByLabelText( 'Default (48 px)' ) ).toBeChecked();
 		expect( screen.getByLabelText( /Dark/ ) ).toBeChecked();
 	} );
 

--- a/client/entrypoints/payment-request-settings/payment-request-button-preview.js
+++ b/client/entrypoints/payment-request-settings/payment-request-button-preview.js
@@ -44,8 +44,8 @@ const BrowserHelpText = () => {
 };
 
 const buttonSizeToPxMap = {
-	default: 40,
-	medium: 48,
+	small: 40,
+	default: 48,
 	large: 56,
 };
 

--- a/client/entrypoints/payment-request-settings/payment-request-settings-section.js
+++ b/client/entrypoints/payment-request-settings/payment-request-settings-section.js
@@ -33,20 +33,20 @@ const buttonSizeOptions = [
 	{
 		label: makeButtonSizeText(
 			__(
-				'Default {{helpText}}(40 px){{/helpText}}',
+				'Small {{helpText}}(40 px){{/helpText}}',
 				'woocommerce-gateway-stripe'
 			)
 		),
-		value: 'default',
+		value: 'small',
 	},
 	{
 		label: makeButtonSizeText(
 			__(
-				'Medium {{helpText}}(48 px){{/helpText}}',
+				'Default {{helpText}}(48 px){{/helpText}}',
 				'woocommerce-gateway-stripe'
 			)
 		),
-		value: 'medium',
+		value: 'default',
 	},
 	{
 		label: makeButtonSizeText(

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -219,8 +219,8 @@ $stripe_settings = apply_filters(
 			'default'     => 'default',
 			'desc_tip'    => true,
 			'options'     => [
-				'default' => __( 'Default (40px)', 'woocommerce-gateway-stripe' ),
-				'medium'  => __( 'Medium (48px)', 'woocommerce-gateway-stripe' ),
+				'small' => __( 'Small (40px)', 'woocommerce-gateway-stripe' ),
+				'default'  => __( 'Default (48px)', 'woocommerce-gateway-stripe' ),
 				'large'   => __( 'Large (56px)', 'woocommerce-gateway-stripe' ),
 			],
 		],

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -276,8 +276,8 @@ class WC_Stripe_Payment_Request {
 		}
 
 		$height = isset( $this->stripe_settings['payment_request_button_size'] ) ? $this->stripe_settings['payment_request_button_size'] : 'default';
-		if ( 'medium' === $height ) {
-			return '48';
+		if ( 'small' === $height ) {
+			return '40';
 		}
 
 		if ( 'large' === $height ) {
@@ -285,7 +285,7 @@ class WC_Stripe_Payment_Request {
 		}
 
 		// for the "default" and "catch-all" scenarios.
-		return '40';
+		return '48';
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -239,6 +239,8 @@ class WC_Stripe_Payment_Request {
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'add_order_meta' ], 10, 2 );
 		add_filter( 'woocommerce_login_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
 		add_filter( 'woocommerce_registration_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
+
+		add_action( 'woocommerce_stripe_updated', [ $this, 'migrate_button_size' ] );
 	}
 
 	/**
@@ -1983,5 +1985,43 @@ class WC_Stripe_Payment_Request {
 	 */
 	private function is_payment_request_enabled() {
 		return isset( $this->stripe_settings['payment_request'] ) && 'yes' === $this->stripe_settings['payment_request'];
+	}
+
+	/**
+	 * Migrates the button size setting to the new default.
+	 *
+	 * Prior to v7.8.0 the default button size was 40px (small). In 7.8, the default size was changed to 48px (medium). This method
+	 * migrates the settings to maintain the previously selected size for existing users. default => small, medium => default.
+	 *
+	 * @since 7.8.0
+	 */
+	public function migrate_button_size() {
+		$previous_version = get_option( 'wc_stripe_version' );
+
+		// Exit if it's a new install or the previous version is already 7.8.0 or greater.
+		if ( ! $previous_version || version_compare( $previous_version, '7.8.0', '>=' ) ) {
+			return;
+		}
+
+		if ( ! isset( $this->stripe_settings['payment_request_button_size'] ) ) {
+			return;
+		}
+
+		$gateway = woocommerce_gateway_stripe()->get_main_stripe_gateway();
+
+		if ( ! $gateway ) {
+			return;
+		}
+
+		$button_size = $this->stripe_settings['payment_request_button_size'];
+
+		// If the button was set to the default, it is now the small size (40px). If it was set to medium, it is now the default size (48px).
+		if ( 'default' === $button_size ) {
+			$this->stripe_settings['payment_request_button_size'] = 'small';
+			$gateway->update_option( 'payment_request_button_size', 'small' );
+		} elseif ( 'medium' === $button_size ) {
+			$this->stripe_settings['payment_request_button_size'] = 'default';
+			$gateway->update_option( 'payment_request_button_size', 'default' );
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -136,6 +136,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - When using Payment Request buttons, fix $0 total for stores using a customized product page that adds the variation product ID directly into the cart.
 * Fix - MultiBanco: HTML tags to print as expected on the Order Confirmation page, and "Thank you for your order" email.
 * Tweak - Improve compatibility with PHP 8+.
+* Tweak - Adjusted default height of express payment button from 40px to 48px. Existing stores retain their current button height settings.
 
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -269,22 +269,22 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	public function test_get_button_height() {
 		// Small => 40px.
 		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'small' ];
-		$this->assertEquals( '40', $this->pr->migrate_button_size() );
+		$this->assertEquals( '40', $this->pr->get_button_height() );
 
 		// Default => 48px.
 		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'default' ];
-		$this->assertEquals( '48', $this->pr->migrate_button_size() );
+		$this->assertEquals( '48', $this->pr->get_button_height() );
 
 		// Large => 56px.
 		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'large' ];
-		$this->assertEquals( '56', $this->pr->migrate_button_size() );
+		$this->assertEquals( '56', $this->pr->get_button_height() );
 
 		// Empty => default.
 		$this->pr->stripe_settings = [];
-		$this->assertEquals( '48', $this->pr->migrate_button_size() );
+		$this->assertEquals( '48', $this->pr->get_button_height() );
 
 		// Invalid => default.
 		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'invalid-data' ];
-		$this->assertEquals( '48', $this->pr->migrate_button_size() );
+		$this->assertEquals( '48', $this->pr->get_button_height() );
 	}
 }

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -265,4 +265,26 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'payment_request_button_size', $this->pr->stripe_settings );
 		$this->assertEmpty( $this->pr->stripe_settings );
 	}
+
+	public function test_get_button_height() {
+		// Small => 40px.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'small' ];
+		$this->assertEquals( '40', $this->pr->migrate_button_size() );
+
+		// Default => 48px.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'default' ];
+		$this->assertEquals( '48', $this->pr->migrate_button_size() );
+
+		// Large => 56px.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'large' ];
+		$this->assertEquals( '56', $this->pr->migrate_button_size() );
+
+		// Empty => default.
+		$this->pr->stripe_settings = [];
+		$this->assertEquals( '48', $this->pr->migrate_button_size() );
+
+		// Invalid => default.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'invalid-data' ];
+		$this->assertEquals( '48', $this->pr->migrate_button_size() );
+	}
 }

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -215,4 +215,54 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $this->pr->is_at_least_one_payment_request_button_enabled() );
 	}
+
+	public function test_migrate_button_size() {
+		/**
+		 * Migration tests.
+		 *
+		 * Migrating the button size only happens when the plugin is updated from a version pre 7.8.0.
+		 */
+		update_option( 'wc_stripe_version', '7.6.0' );
+
+		// Default => small.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'default' ];
+		$this->pr->migrate_button_size();
+		$this->assertEquals( 'small', $this->pr->stripe_settings['payment_request_button_size'] );
+
+		// Large => large.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'large' ];
+		$this->pr->migrate_button_size();
+		$this->assertEquals( 'large', $this->pr->stripe_settings['payment_request_button_size'] );
+
+		// Medium => default.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'medium' ];
+		$this->pr->migrate_button_size();
+		$this->assertEquals( 'default', $this->pr->stripe_settings['payment_request_button_size'] );
+
+		/**
+		 * Non-migration tests.
+		 */
+		update_option( 'wc_stripe_version', '7.8.0' );
+
+		// Default => default.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'default' ];
+		$this->pr->migrate_button_size();
+		$this->assertEquals( 'default', $this->pr->stripe_settings['payment_request_button_size'] );
+
+		// Large => large.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'large' ];
+		$this->pr->migrate_button_size();
+		$this->assertEquals( 'large', $this->pr->stripe_settings['payment_request_button_size'] );
+
+		// Medium => Medium.
+		$this->pr->stripe_settings = [ 'payment_request_button_size' => 'medium' ];
+		$this->pr->migrate_button_size();
+		$this->assertEquals( 'medium', $this->pr->stripe_settings['payment_request_button_size'] );
+
+		// Button size not set.
+		$this->pr->stripe_settings = [];
+		$this->pr->migrate_button_size();
+		$this->assertArrayNotHasKey( 'payment_request_button_size', $this->pr->stripe_settings );
+		$this->assertEmpty( $this->pr->stripe_settings );
+	}
 }


### PR DESCRIPTION
Fixes #2781

## Changes proposed in this Pull Request:

This PR updates the default Express payment button height from 40px to 48px. Stores will have their pre-existing settings maintained. For instance, if the store had the default (40px) set, it will be changed to `small`. If they they had `medium` (48px) it will be changed to default. 

| Before | After |
|--------|--------|
| <img width="450" alt="Screenshot 2023-11-20 at 2 45 33 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/33af2bd5-a33f-46e3-8cec-edd515f29c7a"> | <img width="450" alt="Screenshot 2023-11-20 at 2 41 49 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/fdabcdeb-b7e8-44eb-b50b-4a3a97b4f16c"> |

## Testing instructions

Zip of this branch for testing: [woocommerce-gateway-stripe.zip](https://github.com/woocommerce/woocommerce-gateway-stripe/files/13406647/woocommerce-gateway-stripe.zip)

> [!NOTE]
> I've bumped the **`WC_STRIPE_VERSION`** in that zip to make sure the migrate flow is triggered when you upload it. 

### Fresh site

- Create a new Jurassic Ninja site with WooCommerce installed.
- Upload the zip of the Stripe plugin (provided above).
- Go to the Stripe settings and connect or enter API keys. 
- Go to the _Payment Methods_ Stripe tab. 
- **Customize** the Apple Pay / Google Pay settings. 
- Note the button size is set to the middle option - **Default (48px)**. 

</p>
<img width="250" alt="Screenshot 2023-11-20 at 3 09 21 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/07db4edb-f1a8-4d8b-a71e-936b104488be">
</p>


### Existing site

- Create a new Jurassic Ninja site with WooCommerce.
- Install the live version of Stripe from the WP plugin WordPress.org installer.
- Go to the Stripe settings and connect or enter API keys.
- Go to the _Payment Methods_ Stripe tab. 
- **Customize** the Apple Pay / Google Pay settings. 
- Note the button size is set to 40px (previous default). 
- Upload the zip of the Stripe plugin (provided above).
- Go back to the Payment button settings page. 
- Note that the button size has remained 40px but it is labeled **"Small"**.
- Repeat for **"Medium"** or **"Large"**.
    - Medium (48px) will be changed to Default (48px).
    - Large will be unchanged. 

### General tests

- Changing the button size and saving, saves the button size.
- Create a simple product.
- Confirm the selected button size is reflected when viewing the product, cart or checkout page. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
