### PR TITLE
Split UPE with deferred intents - Fix Block Checkout error

### DIFF
--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -7,7 +7,6 @@ import { SavedTokenHandler } from './saved-token-handler';
 import paymentRequestPaymentMethod from 'wcstripe/blocks/payment-request';
 import WCStripeAPI from 'wcstripe/api';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
-import { getStripeServerData } from 'wcstripe/stripe-utils';
 import './styles.scss';
 
 // Register Stripe UPE.
@@ -26,7 +25,7 @@ const upeMethods = {
 };
 
 const api = new WCStripeAPI(
-	getStripeServerData(),
+	getBlocksConfiguration(),
 	// A promise-based interface to jQuery.post.
 	( url, args ) => {
 		return new Promise( ( resolve, reject ) => {


### PR DESCRIPTION
## Changes proposed in this Pull Request:

In #https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2784, I added support for UPE with deferred intents on the blocks checkout. In that PR I created the WC Stripe API object using the `getStripeServerData()`. That server data object though is intended for the classic checkout, not the block checkout, as indicated by this comment. 

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/72f276b66b632ad3538f6bdf34d400ce94b4d8d4/client/stripe-utils/utils.js#L19-L20

This PR updates the code to make sure we use the `getBlocksConfiguration()` in the blocks checkout. This is also inline with how the Stripe API object is instantiated on `trunk`. 

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/f1412a0a1f63691f6757666245368246bc926731/client/blocks/upe/payment-method.js#L9 

I came across this as a potential issue when creating a fresh JN site. I couldn't replicate this error locally, but I could on a JN site some reason, however, this PR fixes this error:

<p align="center">
<img width="500" alt="Screenshot 2023-12-05 at 5 53 17 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/e3d5d5c7-7000-4257-803c-dfe103704acc">
</p>

## Testing instructions

1. Build an fresh zip of the `add/deferred-intent` branch or use the provided one below. 

**`add/deferred-intent` branch**
[woocommerce-gateway-stripe.zip](https://github.com/woocommerce/woocommerce-gateway-stripe/files/13556754/woocommerce-gateway-stripe.zip)

2. Create a fresh JN site with WooCommerce and upload that zip.
3. Onboard/enter Stripe API credentials.
4. Enable UPE in the Stripe advanced settings.
5. Create a standard product. 
6. Add the product to your cart and go to the checkout (it should be by default a block checkout). 
7. Check the browser console and you should see the error I mentioned above.
8. Upload a zip of this branch and that error should be resolved. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
