### PR TITLE
Adds deferred intent support for our APMs (iDEAL, EPS, giropay, etc) that redirect customers off-site to complete payment

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -708,7 +708,6 @@ class WC_Stripe_Intent_Controller {
 			'payment_method_types' => $payment_method_types,
 			'shipping'             => $payment_information['shipping'],
 			'statement_descriptor' => $payment_information['statement_descriptor'],
-			'return_url'           => $payment_information['return_url'],
 		];
 
 		// For Stripe Link & SEPA with deferred intent UPE, we must create mandate to acknowledge that terms have been shown to customer.
@@ -722,6 +721,10 @@ class WC_Stripe_Intent_Controller {
 					],
 				],
 			];
+		}
+
+		if ( $this->request_needs_redirection( $payment_method_types ) ) {
+			$request['return_url'] = $payment_information['return_url'];
 		}
 
 		if ( $payment_information['save_payment_method_to_store'] ) {
@@ -856,5 +859,17 @@ class WC_Stripe_Intent_Controller {
 		$is_sepa_debit_payment  = 'sepa_debit' === $selected_payment_type;
 
 		return $is_stripe_link_enabled || $is_sepa_debit_payment;
+	}
+
+	/**
+	 * Determines whether the request needs to redirect customer off-site to authorize payment.
+	 * This is needed for the non-card UPE payment method (i.e. iDeal, giropay, etc.)
+	 *
+	 * @param array $payment_methods The list of payment methods used for the processing the payment.
+	 *
+	 * @return boolean True if the arrray consist of only one payment method which is not a card. False otherwise.
+	 */
+	private function request_needs_redirection( $payment_methods ) {
+		return 1 === count( $payment_methods ) && 'card' !== $payment_methods[0];
 	}
 }

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -708,6 +708,7 @@ class WC_Stripe_Intent_Controller {
 			'payment_method_types' => $payment_method_types,
 			'shipping'             => $payment_information['shipping'],
 			'statement_descriptor' => $payment_information['statement_descriptor'],
+			'return_url'           => $payment_information['return_url'],
 		];
 
 		// For Stripe Link & SEPA with deferred intent UPE, we must create mandate to acknowledge that terms have been shown to customer.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1629,6 +1629,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'selected_payment_type'        => $selected_payment_type,
 			'shipping'                     => $shipping_details,
 			'statement_descriptor'         => $this->get_statement_descriptor( $selected_payment_type ),
+			'return_url'                   => $this->get_stripe_return_url( $order ),
 		];
 
 		return $payment_information;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -702,13 +702,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			// If the payment intent requires action, respond with the pi and client secret so it can confirmed on checkout.
 			if ( 'requires_action' === $payment_intent->status ) {
-				$redirect = sprintf(
-					'#wc-stripe-confirm-%s:%s:%s:%s',
-					$payment_needed ? 'pi' : 'si',
-					$order_id,
-					$payment_intent->client_secret,
-					wp_create_nonce( 'wc_stripe_update_order_status_nonce' )
-				);
+				if ( isset( $payment_intent->next_action->type ) && 'redirect_to_url' === $payment_intent->next_action->type && ! empty( $payment_intent->next_action->redirect_to_url->url ) ) {
+					$redirect = $payment_intent->next_action->redirect_to_url->url;
+				} else {
+					$redirect = sprintf(
+						'#wc-stripe-confirm-%s:%s:%s:%s',
+						$payment_needed ? 'pi' : 'si',
+						$order_id,
+						$payment_intent->client_secret,
+						wp_create_nonce( 'wc_stripe_update_order_status_nonce' )
+					);
+				}
 			}
 
 			return [

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1633,7 +1633,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'selected_payment_type'        => $selected_payment_type,
 			'shipping'                     => $shipping_details,
 			'statement_descriptor'         => $this->get_statement_descriptor( $selected_payment_type ),
-			'return_url'                   => $this->get_stripe_return_url( $order ),
+			'return_url'                   => $this->get_return_url_for_redirect( $order, $save_payment_method_to_store ),
 		];
 
 		return $payment_information;
@@ -1725,5 +1725,29 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				__( 'This payment method type is not available in the selected country.', 'woocommerce-gateway-stripe' )
 			);
 		}
+	}
+
+	/**
+	 * Returns a URL to process UPE redirect payments.
+	 *
+	 * @param WC_Order $order               The WC Order to be paid for.
+	 * @param bool     $save_payment_method Whether to save the payment method for future use.
+	 *
+	 * @return string
+	 */
+	private function get_return_url_for_redirect( $order, $save_payment_method ) {
+		return wp_sanitize_redirect(
+			esc_url_raw(
+				add_query_arg(
+					[
+						'order_id'            => $order->get_id(),
+						'wc_payment_method'   => self::ID,
+						'_wpnonce'            => wp_create_nonce( 'wc_stripe_process_redirect_order_nonce' ),
+						'save_payment_method' => $save_payment_method ? 'yes' : 'no',
+					],
+					$this->get_return_url( $order )
+				)
+			)
+		);
 	}
 }


### PR DESCRIPTION
Fixes #2768
Fixes #2767 
Fixes #2769
Fixes #2770  
Fixes #2771
Fixes #2774

> [!NOTE]
> It's unknown if this PR also fixes Boleto, OXXO, Sofort & Multibanco payment methods as I haven't been able to set these up. I will need to test and confirm. 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When customers use one of Stripe's non-card UPE payment methods (giropay, EPS, iDEAL, etc), they're redirected off-site to authorize/complete the payment, for example, with test mode enabled, purchasing with giropay sends you to this page:

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/64f41ad8-0a40-44a7-bd49-0e7280f9bda8)

Once the customer confirms/processes the payment they're redirected back to the order received page.
With our changes to support deferred intents, attempting to purchase with a non-card UPE payment method results in the following error on checkout:

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/0263e74b-fcd2-46cd-9a88-d2d95a1cb90c)

In this PR, we are fixing these issues and adding deferred intent support to most of our APMs by making the following changes:
1. 992b93197782ccd43c98d43d9d13d07f539b48b4 and 2fa08474024197ba0676df58e181f75150bb57ce - send the [`return_url`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-return_url) to the payment_intents request
2. 838a22d0f536ec6cedca65eae75a1e82c1ec683f - adds additional logic to `process_payment_with_deferred_intent()` to support payment intents with the status "requires_action" that have the the action type of "redirect_to_url".

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Alternative Payment Methods to test:
- Go to **WC > Settings > General** and change your stores currency to EUR
  - Giropay
  - EPS
  - Przelewy24
  - iDEAL
  - Bancontact
- Change your stores currency to USD
  - Alipay

**General instructions for testing redirecting APMs**
 
1. Go to https://dashboard.stripe.com/test/settings/payment_methods and make sure to turn on all of the payment methods![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/5e70ff73-9b29-4d49-bac0-657c40111383)
2. Ensure **New checkout experience** is enabled (this setting is found: WC > Settings > Payments > Stripe > Settings > Advanced)
3. Add a product to your cart
4. On the checkout page, select a non-card payment method (i.e. giropay)
5. While on `develop` you will see an error on the checkout
6. On this branch you will be redirected to a Stripe test page
7. In WC > Orders, confirm the new is processing.
8. Purchase a new product and when redirected off-site, click "Fail test payment"
9. Confirm you land back on the checkout page
10. Confirm a failed order is created.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
