### PR TITLE
New settings dismissible banner

### DIFF
--- a/client/settings/display-ordercustomization-notice/__tests__/display-order-customization-notice.js
+++ b/client/settings/display-ordercustomization-notice/__tests__/display-order-customization-notice.js
@@ -1,0 +1,86 @@
+import apiFetch from '@wordpress/api-fetch';
+import React from 'react';
+import { screen, render, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DisplayOrderCustomizationNotice from '..';
+import UpeToggleContext from '../../upe-toggle/context';
+
+jest.mock( '@wordpress/api-fetch' );
+
+describe( 'DisplayOrderCustomizationNotice', () => {
+	const globalValues = global.wc_stripe_settings_params;
+	beforeEach( () => {
+		apiFetch.mockImplementation(
+			jest.fn( () => Promise.resolve( { data: {} } ) )
+		);
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			show_customization_notice: true,
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		global.wc_stripe_settings_params = globalValues;
+	} );
+
+	it( 'should render the notice when UPE is disabled and `show_customization_notice` is true', () => {
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<DisplayOrderCustomizationNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		const noticeText = screen.queryAllByText(
+			"Customize the display order of Stripe payment methods for customers at checkout. This customization occurs within the plugin and won't affect the order in relation to other installed payment providers."
+		)?.[ 0 ];
+		expect( noticeText ).toBeInTheDocument();
+	} );
+
+	it( 'should make an API call to dismiss the banner on button click', () => {
+		const dismissNoticeMock = jest.fn( () =>
+			Promise.resolve( { data: {} } )
+		);
+		apiFetch.mockImplementation( dismissNoticeMock );
+
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: false } }>
+				<DisplayOrderCustomizationNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		const dismissButton = screen.queryByRole( 'button', {
+			'aria-label': 'Dismiss the notice',
+		} );
+		expect( dismissButton ).toBeInTheDocument();
+		act( () => {
+			userEvent.click( dismissButton );
+		} );
+		expect( dismissNoticeMock ).toHaveBeenCalled();
+	} );
+
+	it( 'should not render the notice when UPE is enabled', () => {
+		const { container } = render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<DisplayOrderCustomizationNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should not render the notice when `show_customization_notice` is false', () => {
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			show_customization_notice: false,
+		};
+
+		const { container } = render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<DisplayOrderCustomizationNotice />
+			</UpeToggleContext.Provider>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+} );

--- a/client/settings/display-ordercustomization-notice/index.js
+++ b/client/settings/display-ordercustomization-notice/index.js
@@ -1,15 +1,16 @@
 /* global wc_stripe_settings_params */
 import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { Icon, Notice } from '@wordpress/components';
 import { info } from '@wordpress/icons';
+import apiFetch from '@wordpress/api-fetch';
 import UpeToggleContext from '../upe-toggle/context';
 
 const NoticeWrapper = styled( Notice )`
 	border-left: none;
 	margin: 0 0 24px 0;
-	background: var( --WP-Blue-Blue-0, #f0f6fc );
+	background: #f0f6fc;
 `;
 
 const NoticeContent = styled.div`
@@ -24,13 +25,21 @@ const NoticeContent = styled.div`
 
 const DisplayOrderCustomizationNotice = () => {
 	const { isUpeEnabled } = useContext( UpeToggleContext );
+	const [ showNotice, setShowNotice ] = useState(
+		wc_stripe_settings_params.show_customization_notice
+	);
 
-	const isCustomizationNoticeVisible =
-		wc_stripe_settings_params.show_customization_notice;
+	const handleDismissNotice = () => {
+		apiFetch( {
+			path: '/wc/v3/wc_stripe/settings/notice',
+			method: 'POST',
+			data: { wc_stripe_show_customization_notice: 'no' },
+		} ).finally( () => {
+			setShowNotice( false );
+		} );
+	};
 
-	const handleDismissNotice = () => {};
-
-	if ( isUpeEnabled || ! isCustomizationNoticeVisible ) {
+	if ( isUpeEnabled || ! showNotice ) {
 		return null;
 	}
 

--- a/client/settings/display-ordercustomization-notice/index.js
+++ b/client/settings/display-ordercustomization-notice/index.js
@@ -1,0 +1,50 @@
+/* global wc_stripe_settings_params */
+import { __ } from '@wordpress/i18n';
+import styled from '@emotion/styled';
+import React, { useContext } from 'react';
+import { Icon, Notice } from '@wordpress/components';
+import { info } from '@wordpress/icons';
+import UpeToggleContext from '../upe-toggle/context';
+
+const NoticeWrapper = styled( Notice )`
+	border-left: none;
+	margin: 0 0 24px 0;
+	background: var( --WP-Blue-Blue-0, #f0f6fc );
+`;
+
+const NoticeContent = styled.div`
+	display: inline-grid;
+	grid-template-columns: auto auto auto;
+	gap: 12px;
+
+	> svg {
+		fill: var( --wp-admin-theme-color );
+	}
+`;
+
+const DisplayOrderCustomizationNotice = () => {
+	const { isUpeEnabled } = useContext( UpeToggleContext );
+
+	const isCustomizationNoticeVisible =
+		wc_stripe_settings_params.show_customization_notice;
+
+	const handleDismissNotice = () => {};
+
+	if ( isUpeEnabled || ! isCustomizationNoticeVisible ) {
+		return null;
+	}
+
+	return (
+		<NoticeWrapper isDismissible={ true } onRemove={ handleDismissNotice }>
+			<NoticeContent>
+				<Icon icon={ info } size={ 24 } />
+				{ __(
+					"Customize the display order of Stripe payment methods for customers at checkout. This customization occurs within the plugin and won't affect the order in relation to other installed payment providers.",
+					'woocommerce-gateway-stripe'
+				) }
+			</NoticeContent>
+		</NoticeWrapper>
+	);
+};
+
+export default DisplayOrderCustomizationNotice;

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -6,6 +6,7 @@ import PaymentRequestSection from '../payment-request-section';
 import GeneralSettingsSection from '../general-settings-section';
 import LoadableSettingsSection from '../loadable-settings-section';
 import CustomizationOptionsNotice from '../customization-options-notice';
+import DisplayOrderCustomizationNotice from '../display-ordercustomization-notice';
 
 const PaymentMethodsDescription = () => {
 	return (
@@ -48,6 +49,7 @@ const PaymentMethodsPanel = () => {
 	return (
 		<>
 			<SettingsSection Description={ PaymentMethodsDescription }>
+				<DisplayOrderCustomizationNotice />
 				<GeneralSettingsSection />
 				<CustomizationOptionsNotice />
 			</SettingsSection>

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -182,6 +182,15 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				],
 			]
 		);
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/notice',
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'dismiss_customization_notice' ],
+				'permission_callback' => [ $this, 'check_permission' ],
+			]
+		);
 	}
 
 	/**
@@ -630,5 +639,21 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		return new WP_REST_Response( [], 200 );
+	}
+
+	/**
+	 * Set `wc_stripe_show_customization_notice` as `no` to dismiss notice.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function dismiss_customization_notice( WP_REST_Request $request ) {
+		if ( null === $request->get_param( 'wc_stripe_show_customization_notice' ) ) {
+			return new WP_REST_Response( [], 200 );
+		}
+
+		update_option( 'wc_stripe_show_customization_notice', 'no' );
+		return new WP_REST_Response( [ 'result' => 'notice dismissed' ], 200 );
 	}
 }

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -110,10 +110,11 @@ class WC_Stripe_Settings_Controller {
 		);
 
 		$params = [
-			'time'                    => time(),
-			'i18n_out_of_sync'        => $message,
-			'is_upe_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
-			'stripe_oauth_url'        => $oauth_url,
+			'time'                      => time(),
+			'i18n_out_of_sync'          => $message,
+			'is_upe_checkout_enabled'   => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+			'stripe_oauth_url'          => $oauth_url,
+			'show_customization_notice' => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -338,6 +338,17 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		remove_filter( 'user_has_cap', $cb );
 	}
 
+	public function test_dismiss_customization_notice() {
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE . '/notice' );
+		$request->set_param( 'wc_stripe_show_customization_notice', 'no' );
+
+		$response      = rest_do_request( $request );
+		$notice_option = get_option( 'wc_stripe_show_customization_notice' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'no', $notice_option );
+	}
+
 	public function boolean_field_provider() {
 		return [
 			'is_stripe_enabled'                     => [ 'is_stripe_enabled', 'enabled' ],


### PR DESCRIPTION
Implemented the dismissible banner as part of #2735

## Changes proposed in this Pull Request:
Considering a new option `` for the visibility of the notice. When the notice is dismissed the option's value is set as `no`

## Testing instructions
- Go to the Stripe settings page
- Disable UPE from the `Settings` tab.
- Go to the `Payment methods` tab. The notice should be visible on top of the payment method list.
![banner](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/c6c82cac-1354-419e-b9b9-a9dfe03a6803)

