### PR TITLE
Refactor updated settings page

### DIFF
--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -45,6 +45,17 @@ export default {
 		currencies: [ 'EUR' ],
 		capability: 'sepa_debit_payments',
 	},
+	sepa: {
+		id: 'sepa',
+		label: __( 'Direct debit payment', 'woocommerce-gateway-stripe' ),
+		description: __(
+			'Reach 500 million customers and over 20 million businesses across the European Union.',
+			'woocommerce-gateway-stripe'
+		),
+		Icon: SepaIcon,
+		currencies: [ 'EUR' ],
+		capability: 'sepa_debit_payments',
+	},
 	sofort: {
 		id: 'sofort',
 		label: __( 'Sofort', 'woocommerce-gateway-stripe' ),

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -106,7 +106,9 @@ const GeneralSettingsSection = () => {
 	// Hide payment methods that are not part of the account capabilities.
 	const availablePaymentMethods = upePaymentMethods
 		.filter( ( method ) =>
-			capabilities.hasOwnProperty( `${ method }_payments` )
+			method === 'sepa'
+				? capabilities.hasOwnProperty( 'sepa_debit_payments' )
+				: capabilities.hasOwnProperty( `${ method }_payments` )
 		)
 		.filter( ( id ) => id !== 'link' );
 

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -614,7 +614,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	public function update_individual_payment_method_settings( WP_REST_Request $request ) {
 		$payment_method_id = $request->get_param( 'payment_method_id' );
 		// Map the ids used in the frontend to the legacy gateway class ids.
-		$mapped_legacy_method_id = 'sepa_debit' === $payment_method_id ? 'stripe_sepa' : ( 'stripe_' . $payment_method_id );
+		$mapped_legacy_method_id = ( 'stripe_' . $payment_method_id );
 		$is_enabled              = $request->get_param( 'is_enabled' );
 		$title                   = sanitize_text_field( $request->get_param( 'title' ) );
 		$description             = sanitize_text_field( $request->get_param( 'description' ) );

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -604,7 +604,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 */
 	public function update_individual_payment_method_settings( WP_REST_Request $request ) {
 		$payment_method_id = $request->get_param( 'payment_method_id' );
-		// test
+		// Map the ids used in the frontend to the legacy gateway class ids.
 		$mapped_legacy_method_id = 'sepa_debit' === $payment_method_id ? 'stripe_sepa' : ( 'stripe_' . $payment_method_id );
 		$is_enabled              = $request->get_param( 'is_enabled' );
 		$title                   = sanitize_text_field( $request->get_param( 'title' ) );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -113,7 +113,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		// Title shows the count of enabled payment methods in settings page only.
 		if ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
-			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_methods() );
+			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_method_ids() );
 			$this->title                   = $enabled_payment_methods_count ?
 				/* translators: $1. Count of enabled payment methods. */
 				sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count )
@@ -126,7 +126,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_fee' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_payout' ], 20 );
 		add_action( 'woocommerce_customer_save_address', [ $this, 'show_update_card_notice' ], 10, 2 );
-		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'get_available_payment_methods' ] );
+		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'get_available_payment_gateways' ] );
 		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'prepare_order_pay_page' ] );
 		add_action( 'woocommerce_account_view-order_endpoint', [ $this, 'check_intent_status_on_order_page' ], 1 );
 		add_filter( 'woocommerce_payment_successful_result', [ $this, 'modify_successful_payment_result' ], 99999, 2 );
@@ -651,7 +651,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @param WC_Payment_Gateway[] $gateways A list of all available gateways on the payments settings page.
 	 * @return WC_Payment_Gateway[]          The same list if UPE is disabled or a list including the available legacy payment methods.
 	 */
-	public function get_available_payment_methods( $gateways ) {
+	public function get_available_payment_gateways( $gateways ) {
 		// We need to include the payment methods when UPE is disabled, return the same list when UPE is enabled.
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return $gateways;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -18,6 +18,13 @@ class WC_Stripe_Helper {
 	const META_NAME_STRIPE_CURRENCY = '_stripe_currency';
 
 	/**
+	 * List of legacy Stripe gateways.
+	 *
+	 * @var array
+	 */
+	private static $stripe_legacy_gateways = [];
+
+	/**
 	 * Gets the Stripe currency for order.
 	 *
 	 * @since 4.1.0
@@ -366,39 +373,39 @@ class WC_Stripe_Helper {
 	}
 
 	/**
-	 * Get legacy payment method by id.
-	 *
-	 * @return object|null
-	 */
-	public static function get_legacy_payment_method( $id ) {
-		$payment_method_classes = self::get_legacy_payment_method_classes();
-
-		if ( ! isset( $payment_method_classes[ $id ] ) ) {
-			return null;
-		}
-
-		$payment_method_class = $payment_method_classes[ $id ];
-		$payment_method       = new $payment_method_class();
-
-		return $payment_method;
-	}
-
-	/**
 	 * List of legacy payment methods.
 	 *
 	 * @return array
 	 */
 	public static function get_legacy_payment_methods() {
-		$payment_method_classes = self::get_legacy_payment_method_classes();
-
-		$payment_methods = [];
-
-		foreach ( $payment_method_classes as $payment_method_class ) {
-			$payment_method                         = new $payment_method_class();
-			$payment_methods[ $payment_method->id ] = $payment_method;
+		if ( ! empty( self::$stripe_legacy_gateways ) ) {
+			return self::$stripe_legacy_gateways;
 		}
 
-		return $payment_methods;
+		$payment_method_classes = self::get_legacy_payment_method_classes();
+
+		foreach ( $payment_method_classes as $payment_method_class ) {
+			$payment_method = new $payment_method_class();
+
+			self::$stripe_legacy_gateways[ $payment_method->id ] = $payment_method;
+		}
+
+		return self::$stripe_legacy_gateways;
+	}
+
+	/**
+	 * Get legacy payment method by id.
+	 *
+	 * @return object|null
+	 */
+	public static function get_legacy_payment_method( $id ) {
+		$payment_methods = self::get_legacy_payment_methods();
+
+		if ( ! isset( $payment_methods[ $id ] ) ) {
+			return null;
+		}
+
+		return $payment_methods[ $id ];
 	}
 
 	/**

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -22,7 +22,7 @@ class WC_Stripe_Helper {
 	 *
 	 * @var array
 	 */
-	private static $stripe_legacy_gateways = [];
+	public static $stripe_legacy_gateways = [];
 
 	/**
 	 * Gets the Stripe currency for order.
@@ -484,8 +484,8 @@ class WC_Stripe_Helper {
 
 		$payment_method_settings = [
 			'card' => [
-				'name'        => $stripe_settings['title'],
-				'description' => $stripe_settings['description'],
+				'name'        => isset( $stripe_settings['title'] ) ? $stripe_settings['title'] : '',
+				'description' => isset( $stripe_settings['description'] ) ? $stripe_settings['description'] : '',
 			],
 		];
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -453,21 +453,24 @@ class WC_Stripe_Helper {
 	 * @return array
 	 */
 	public static function get_legacy_enabled_payment_method_ids() {
-		$stripe_settings   = get_option( 'woocommerce_stripe_settings', [] );
-		$is_stripe_enabled = isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
-
-		$enabled_payment_methods        = self::get_legacy_enabled_payment_methods();
-		$mapped_enabled_payment_methods = array_map(
-			function( $payment_method ) {
-				return 'stripe_sepa' === $payment_method ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method );
-			},
-			array_keys( $enabled_payment_methods )
-		);
+		$is_stripe_enabled = self::get_settings( null, 'enabled' );
 
 		// In legacy mode (when UPE is disabled), Stripe refers to card as payment method.
-		$enabled_payment_method_ids = $is_stripe_enabled ? [ 'card' ] : [];
+		$enabled_payment_method_ids = 'yes' === $is_stripe_enabled ? [ 'card' ] : [];
 
-		return array_merge( $enabled_payment_method_ids, $mapped_enabled_payment_methods );
+		$payment_methods                   = self::get_legacy_payment_methods();
+		$mapped_enabled_payment_method_ids = [];
+
+		foreach ( $payment_methods as $payment_method ) {
+			if ( ! $payment_method->is_enabled() ) {
+				continue;
+			}
+			$payment_method_id = 'stripe_sepa' === $payment_method->id ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method->id );
+
+			$mapped_enabled_payment_method_ids[] = $payment_method_id;
+		}
+
+		return array_merge( $enabled_payment_method_ids, $mapped_enabled_payment_method_ids );
 	}
 
 	/**

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -366,6 +366,24 @@ class WC_Stripe_Helper {
 	}
 
 	/**
+	 * Get legacy payment method by id.
+	 *
+	 * @return object|null
+	 */
+	public static function get_legacy_payment_method( $id ) {
+		$payment_method_classes = self::get_legacy_payment_method_classes();
+
+		if ( ! isset( $payment_method_classes[ $id ] ) ) {
+			return null;
+		}
+
+		$payment_method_class = $payment_method_classes[ $id ];
+		$payment_method       = new $payment_method_class();
+
+		return $payment_method;
+	}
+
+	/**
 	 * List of legacy payment methods.
 	 *
 	 * @return array

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -420,7 +420,7 @@ class WC_Stripe_Helper {
 		$available_payment_method_ids = [ 'card' ];
 
 		foreach ( $payment_method_classes as $payment_method_class ) {
-			$payment_method_id              = 'stripe_sepa' === $payment_method_class::ID ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method_class::ID );
+			$payment_method_id              = str_replace( 'stripe_', '', $payment_method_class::ID );
 			$available_payment_method_ids[] = $payment_method_id;
 		}
 
@@ -465,7 +465,7 @@ class WC_Stripe_Helper {
 			if ( ! $payment_method->is_enabled() ) {
 				continue;
 			}
-			$payment_method_id = 'stripe_sepa' === $payment_method->id ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method->id );
+			$payment_method_id = str_replace( 'stripe_', '', $payment_method->id );
 
 			$mapped_enabled_payment_method_ids[] = $payment_method_id;
 		}
@@ -500,7 +500,7 @@ class WC_Stripe_Helper {
 				$settings['expiration'] = $unique_settings[ $payment_method->id . '_expiration' ];
 			}
 
-			$payment_method_id = 'stripe_sepa' === $payment_method->id ? 'sepa_debit' : str_replace( 'stripe_', '', $payment_method->id );
+			$payment_method_id = str_replace( 'stripe_', '', $payment_method->id );
 
 			$payment_method_settings[ $payment_method_id ] = $settings;
 		}

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -223,13 +223,9 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 				WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => 'no',
 			]
 		);
-		update_option(
-			'woocommerce_stripe_eps_settings',
-			[
-				'title'       => 'EPS',
-				'description' => 'Pay with EPS',
-			]
-		);
+		$gateways = WC_Stripe_Helper::get_legacy_payment_methods();
+		$gateways['stripe_eps']->update_option( 'title', 'EPS' );
+		$gateways['stripe_eps']->update_option( 'description', 'Pay with EPS' );
 
 		$response                                = $this->rest_get_settings();
 		$individual_payment_method_settings_data = $response->get_data()['individual_payment_method_settings'];

--- a/tests/phpunit/helpers/class-upe-test-helper.php
+++ b/tests/phpunit/helpers/class-upe-test-helper.php
@@ -28,6 +28,7 @@ class UPE_Test_Helper {
 		$closure();
 		WC()->payment_gateways()->payment_gateways = [];
 		WC()->payment_gateways()->init();
+		WC_Stripe_Helper::$stripe_legacy_gateways = [];
 	}
 
 	public function enable_upe() {

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -153,7 +153,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 
 	public function test_get_legacy_available_payment_method_ids() {
 		$result = WC_Stripe_Helper::get_legacy_available_payment_method_ids();
-		$this->assertEquals( [ 'card', 'bancontact', 'eps', 'giropay', 'ideal', 'p24', 'sepa_debit', 'boleto', 'oxxo' ], $result );
+		$this->assertEquals( [ 'card', 'bancontact', 'eps', 'giropay', 'ideal', 'p24', 'sepa', 'boleto', 'oxxo' ], $result );
 	}
 
 	public function test_get_legacy_enabled_payment_methods() {

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -157,48 +157,31 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	}
 
 	public function test_get_legacy_enabled_payment_methods() {
-		// Enable Stripe, EPS, Giropay and P24 LPM gateways.
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled' => 'yes',
-				WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => 'no',
-			]
-		);
-		update_option( 'woocommerce_stripe_eps_settings', [ 'enabled' => 'yes' ] );
-		update_option( 'woocommerce_stripe_giropay_settings', [ 'enabled' => 'yes' ] );
-		update_option( 'woocommerce_stripe_p24_settings', [ 'enabled' => 'yes' ] );
+		// Enable EPS, Giropay and P24 LPM gateways.
+		$gateways = WC_Stripe_Helper::get_legacy_payment_methods();
+		$gateways['stripe_eps']->enable();
+		$gateways['stripe_giropay']->enable();
+		$gateways['stripe_p24']->enable();
 
 		$result = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
 		$this->assertEquals( [ 'stripe_eps', 'stripe_giropay', 'stripe_p24' ], array_keys( $result ) );
 	}
 
 	public function test_get_legacy_enabled_payment_method_ids() {
-		// Enable Stripe, EPS, Giropay and P24 LPM gateways.
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled' => 'yes',
-				WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => 'no',
-			]
-		);
-		update_option( 'woocommerce_stripe_eps_settings', [ 'enabled' => 'yes' ] );
-		update_option( 'woocommerce_stripe_giropay_settings', [ 'enabled' => 'yes' ] );
-		update_option( 'woocommerce_stripe_p24_settings', [ 'enabled' => 'yes' ] );
+		// Enable EPS, Giropay and P24 LPM gateways.
+		$gateways = WC_Stripe_Helper::get_legacy_payment_methods();
+		$gateways['stripe_eps']->enable();
+		$gateways['stripe_giropay']->enable();
+		$gateways['stripe_p24']->enable();
 
 		$result = WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
-		$this->assertEquals( [ 'card', 'eps', 'giropay', 'p24' ], $result );
+		$this->assertEquals( [ 'eps', 'giropay', 'p24' ], $result );
 	}
 
 	public function test_get_legacy_individual_payment_method_settings() {
-		update_option(
-			'woocommerce_stripe_eps_settings',
-			[
-				'enabled'     => 'yes',
-				'title'       => 'EPS',
-				'description' => 'Pay with EPS',
-			]
-		);
+		$gateways = WC_Stripe_Helper::get_legacy_payment_methods();
+		$gateways['stripe_eps']->update_option( 'title', 'EPS' );
+		$gateways['stripe_eps']->update_option( 'description', 'Pay with EPS' );
 
 		$result = WC_Stripe_Helper::get_legacy_individual_payment_method_settings();
 		$this->arrayHasKey( 'eps', $result );


### PR DESCRIPTION
Made some refactors over the changes of https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2792 and https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2750

## Changes proposed in this Pull Request:
- Refactored a few function names and variable names. 
- Reduced the number of looping in the helper methods.

## Testing instructions

#### Non UPE
- In `Advance settings` section of `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` page uncheck `New checkout experience` (disable UPE).
- In `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` page the methods should be listed with a checkbox. Enabling/disabling methods should work, save should work and changes should persist on page refresh.
- Clicking on the `Customize` button should show the `name` and `description` form fields. Change some values, then click `Save changes`. In the network tab there should be a successful POST request to `<your_site>/wp-json/wc/v3/wc_stripe/settings/payment_method` and the changes should be saved.
- On `WooCommerce > Settings > Payments` page the selected payment method count should be present similar to when UPE is enabled. The other legacy methods should not appear in the list here.
- On checkout page, the enabled payment methods should be preset.

#### UPE
- In `Advance settings` section of `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` page select `New checkout experience` (enable UPE).
- In `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` page the listed methods should work as before. Enabling/disabling methods should work, save should work and changes should persist on page refresh.
- There should be no `Customize` button beside the methods.

#### Additional tests
- With `New checkout experience` (UPE) enabled, enable/disable a few methods and save the changes.
- Now disable `New checkout experience` and make sure the previously selected methods are still selected after disabling UPE.
- With UPE disabled, enable/disable a few methods and save the changes.
- Check `New checkout experience` again and make sure the previously selected methods are still selected after enabling UPE.