### PR TITLE
Add check for order before calling get_meta function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 7.8.1 - xxxx-xx-xx =
+* Fix - Check if a valid order of tye WC_Order is returned before calling `get_meta` function.
+
 = 7.8.0 - 2023-12-21 =
 * Fix - Resolved an issue with Stripe errors not being displayed on the checkout page for stores using custom payment method elements.
 * Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -600,7 +600,11 @@ trait WC_Stripe_Subscriptions_Trait {
 		$renewal_order_ids = $order->get_related_orders( 'ids' );
 
 		foreach ( $renewal_order_ids as $renewal_order_id ) {
-			$renewal_order                = wc_get_order( $renewal_order_id );
+			$renewal_order = wc_get_order( $renewal_order_id );
+			if ( ! $renewal_order instanceof WC_Order ) {
+				continue;
+			}
+
 			$mandate                      = $renewal_order->get_meta( '_stripe_mandate_id', true );
 			$renewal_order_payment_method = $renewal_order->get_meta( '_stripe_source_id', true );
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,16 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.8.0 - 2023-12-21 =
-* Fix - Resolved an issue with Stripe errors not being displayed on the checkout page for stores using custom payment method elements.
-* Fix - Resolved a PHP fatal error occurring on stores that removed `WC_Email_Failed_Order` from the list of WC email classes while attempting to send the failed order email.
-* Fix - Prevent incorrect totals displayed in Google Pay and Apple Pay when purchasing a virtual sychronised subscription from the product page.
-* Fix - Hide the Google Pay and Apple Pay buttons on variable product pages, if the selected variation is not supported by Payment Request buttons.
-* Fix - Don't require shipping when purchasing a virtual variable subscription product using Google Pay and Apple Pay.
-* Fix - When using Payment Request buttons, fix $0 total for stores using a customized product page that adds the variation product ID directly into the cart.
-* Fix - MultiBanco: HTML tags to print as expected on the Order Confirmation page, and "Thank you for your order" email.
-* Tweak - Improve compatibility with PHP 8+.
-* Tweak - Adjusted default height of express payment button from 40px to 48px. Existing stores retain their current button height settings.
-* Tweak - Removed '- OR -' separator and updated placement of Express payment buttons (eg Apple Pay and Google Pay) on cart and product pages to align with WooCommerce Express payment button standards.
+= 7.8.1 - xxxx-xx-xx =
+* Fix - Check if a valid order of tye WC_Order is returned before calling `get_meta` function.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes issue reported in zen-7493554, zen-7498735
This issue was introduced in PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2633

The steps to reproduce the issue are not intuitive. I and the HEs could not reproduce the issue. However, this fix should handle the error as the error happens when `wc_get_order` returns a `boolean` and a check is added to prevent the scenario.

## Changes proposed in this Pull Request:
In `get_mandate_for_subscription` function we call the `wc_get_order` function with the renewal order ID. This `wc_get_order` may return a `WC_Order` object or a `boolean`  (false if there is any exception or missing resources). When it returns a boolean, not an order object, the `get_meta` call runs into an error. 

```
 Uncaught Error: Call to a member function get_meta() on bool in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/compat/trait-wc-stripe-subscriptions.php:604
```
In this PR, I have added a check for confirming whether `wc_get_order` has returned an object `WC_Order` before moving to the `get_meta` function.

## Testing instructions
- Set store currency to `USD`.
- Purchase a subscription as a shopper.
- Manually renew the subscription as a shopper.
- From `wp-admin` renew the subscription from the subscription edit page.
- Set store currency to `INR`.
- Purchase a subscription as a shopper with 3DS card `4000003560000123`
- Manually renew the subscription as a shopper.
- From `wp-admin` renew the subscription from the subscription edit page.
- Check logs in `WooCommerce -> Status -> Logs` and make sure there is no errors.
