### PR TITLE
Add Stripe Fee and Stripe Payout to new checkout experience

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -155,6 +155,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'payment_scripts' ] );
+		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_fee' ] );
+		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_payout' ], 20 );
 
 		// Needed for 3DS compatibility when checking out with PRBs..
 		// Copied from WC_Gateway_Stripe::__construct().


### PR DESCRIPTION
Fixes #2549

This change enables the display of Stripe Fee and Stripe Payout information in the order details when the "New checkout experience" option is enabled.

## Changes proposed in this Pull Request:

- Add information about **Stripe Fee** and **Stripe Payout** when the **New checkout experience** is enabled.

## Testing instructions

1. **Navigate to:** WP Admin → WooCommerce → Click on an order.
   - Verify that the **Stripe Fee** and **Stripe Payout** values appear in the order details.
2. **Navigate to:** WP Admin → WooCommerce → Settings → Payments → Stripe → Settings → Advanced Settings.
   - Enable "New checkout experience."
3. **Go back to:** WP Admin → WooCommerce → Click on an order.
   - Confirm that the **Stripe Fee** and **Stripe Payout** values are still visible in the order details.
   
![expected behaviour](https://user-images.githubusercontent.com/81605775/217478181-ee1e810a-182c-4537-9c84-ef4874e39e0c.png)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)