### PR TITLE
[Deferred intent] Update the payment method billing details during checkout

### DIFF
--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1,5 +1,4 @@
 import {
-	appendIsUsingDeferredIntentToForm,
 	appendPaymentMethodIdToForm,
 	getPaymentMethodTypes,
 	initializeUPEAppearance,
@@ -280,7 +279,6 @@ export const processPayment = (
 				jQueryForm,
 				paymentMethodType
 			);
-			appendIsUsingDeferredIntentToForm( jQueryForm );
 			appendPaymentMethodIdToForm(
 				jQueryForm,
 				paymentMethodObject.paymentMethod.id

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -267,13 +267,6 @@ export const generateCheckoutEventNames = () => {
 		.join( ' ' );
 };
 
-// To be removed when we fully switch to dPE.
-export const appendIsUsingDeferredIntentToForm = ( form ) => {
-	form.append(
-		'<input type="hidden" id="wc-stripe-is-deferred-intent" name="wc-stripe-is-deferred-intent" value="1" />'
-	);
-};
-
 export const appendPaymentMethodIdToForm = ( form, paymentMethodId ) => {
 	form.append(
 		`<input type="hidden" id="wc-stripe-payment-method" name="wc-stripe-payment-method" value="${ paymentMethodId }" />`

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -293,10 +293,8 @@ export const appendSetupIntentToForm = ( form, setupIntent ) => {
  */
 export const isUsingSavedPaymentMethod = () => {
 	return (
-		document.querySelector( '#wc-stripe-new-payment-method' )?.length &&
-		! document
-			.querySelector( '#wc-stripe-new-payment-method' )
-			.is( ':checked' )
+		document.querySelector( '#wc-stripe-payment-token-new' ) !== null &&
+		! document.querySelector( '#wc-stripe-payment-token-new' ).checked
 	);
 };
 

--- a/includes/class-wc-stripe-action-scheduler-service.php
+++ b/includes/class-wc-stripe-action-scheduler-service.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * WC_Stripe_Action_Scheduler_Service class
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class which handles setting up all ActionScheduler hooks.
+ */
+class WC_Stripe_Action_Scheduler_Service {
+
+	const GROUP_ID = 'woocommerce_stripe';
+
+	/**
+	 * Schedule an action scheduler job. Also unschedules (replaces) any previous instances of the same job.
+	 * This prevents duplicate jobs, for example when multiple events fire as part of the order update process.
+	 * The `as_unschedule_action` function will only replace a job which has the same $hook, $args AND $group.
+	 *
+	 * @param int    $timestamp - When the job will run.
+	 * @param string $hook      - The hook to trigger.
+	 * @param array  $args      - An array containing the arguments to be passed to the hook.
+	 * @param string $group     - The AS group the action will be created under.
+	 *
+	 * @return void
+	 */
+	public function schedule_job( int $timestamp, string $hook, array $args = [], string $group = self::GROUP_ID ) {
+		// Unschedule any previously scheduled instances of this particular job.
+		as_unschedule_action( $hook, $args, $group );
+
+		// Schedule the job.
+		as_schedule_single_action( $timestamp, $hook, $args, $group );
+	}
+}

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -292,6 +292,23 @@ class WC_Stripe_API {
 	}
 
 	/**
+	 * Update payment method data.
+	 *
+	 * @param string $payment_method_id   Payment method ID.
+	 * @param array  $payment_method_data Payment method updated data.
+	 *
+	 * @return array Payment method details.
+	 *
+	 * @throws WC_Stripe_Exception If payment method update fails.
+	 */
+	public static function update_payment_method( $payment_method_id, $payment_method_data = [] ) {
+		return self::request(
+			$payment_method_data,
+			'payment_methods/' . $payment_method_id
+		);
+	}
+
+	/**
 	 * Attaches a payment method to the given customer.
 	 *
 	 * @param string $customer_id        The ID of the customer the payment method should be attached to.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -687,7 +687,7 @@ class WC_Stripe_Intent_Controller {
 	 *
 	 * @throws WC_Stripe_Exception - If the create intent call returns with an error.
 	 *
-	 * @return array
+	 * @return stdClass
 	 */
 	public function create_and_confirm_payment_intent( $payment_information ) {
 		// Throws a WC_Stripe_Exception if required information is missing.
@@ -747,12 +747,6 @@ class WC_Stripe_Intent_Controller {
 		// Only update the payment_type if we have a reference to the payment type the customer selected.
 		if ( '' !== $selected_payment_type ) {
 			$order->update_meta_data( '_stripe_upe_payment_type', $selected_payment_type );
-		}
-
-		// Throw an exception when there's an error.
-		if ( ! empty( $payment_intent->error ) ) {
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			throw new WC_Stripe_Exception( print_r( $payment_intent->error, true ), $payment_intent->error->message );
 		}
 
 		return $payment_intent;

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -755,8 +755,6 @@ class WC_Stripe_Intent_Controller {
 			throw new WC_Stripe_Exception( print_r( $payment_intent->error, true ), $payment_intent->error->message );
 		}
 
-		WC_Stripe_Helper::add_payment_intent_to_order( $payment_intent->id, $order );
-
 		return $payment_intent;
 	}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -729,6 +729,14 @@ class WC_Stripe_Intent_Controller {
 			$request['setup_future_usage'] = 'off_session';
 		}
 
+		// Run the necessary filter to make sure mandate information is added when it's required.
+		$request = apply_filters(
+			'wc_stripe_generate_create_intent_request',
+			$request,
+			$order,
+			null // $prepared_source parameter is not necessary for adding mandate information.
+		);
+
 		$payment_intent = WC_Stripe_API::request_with_level3_data(
 			$request,
 			'payment_intents',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -698,6 +698,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 				$payment_intent = $this->intent_controller->create_and_confirm_payment_intent( $payment_information );
 
+				// Handle saving the payment method in the store.
+				// It's already attached to the Stripe customer at this point.
 				if ( $payment_information['save_payment_method_to_store'] ) {
 					$this->handle_saving_payment_method(
 						$order,
@@ -1708,7 +1710,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return true;
 		}
 
-		// TODO: should we check whether saving payment methods is enabled in Stripe settings?
+		// Unless it's paying for a subscription, don't save it when saving payment methods is disabled.
+		if ( ! $this->is_saved_cards_enabled() ) {
+			return false;
+		}
 
 		$save_payment_method_request_arg = 'wc-' . self::ID . '-new-payment-method';
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1515,8 +1515,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'payment_type'   => $payment_type,
 		];
 
-		// TODO: Either change the filter name or provide the payment method as the third argument to match its other implemention.
-		return apply_filters( 'wc_stripe_payment_metadata', $metadata, $order, null );
+		return apply_filters( 'wc_stripe_intent_metadata', $metadata, $order );
 	}
 
 	/**
@@ -1694,9 +1693,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		if ( $is_using_saved_payment_method ) {
 			// Use the saved payment method.
 			$token = WC_Stripe_Payment_Tokens::get_token_from_request( $_POST );
+
+			// A valid token couldn't be retrieved from the request.
 			if ( null === $token ) {
-				// TODO: add a better localized and loggable error messages.
-				throw new WC_Stripe_Exception( 'Invalid payment method.', 'wc_stripe_invalid_payment_method' );
+				throw new WC_Stripe_Exception(
+					'A valid payment method token could not be retrieved from the request.',
+					__( "The selected payment method isn't valid.", 'woocommerce-gateway-stripe' )
+				);
 			}
 
 			$payment_method_id = $token->get_token();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -699,7 +699,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_method_id     = $payment_information['payment_method'];
 			$selected_payment_type = $payment_information['selected_payment_type'];
 
-			// Update saved payment method async to include billing details, if missing.
+			// Update saved payment method async to include billing details.
 			if ( $payment_information['is_using_saved_payment_method'] ) {
 				$this->action_scheduler_service->schedule_job(
 					time(),

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -669,13 +669,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$order = wc_get_order( $order_id );
 
 		try {
-			if ( $this->is_using_saved_payment_method() ) {
-				return [ 'result' => 'failure' ];
-			}
-
-			$payment_needed = $this->is_payment_needed( $order->get_id() );
-
 			$payment_information = $this->prepare_payment_information_from_request( $order );
+			$payment_needed      = $this->is_payment_needed( $order->get_id() );
+
+			// Make sure that we attach the payment method and the customer ID to the order meta data.
+			$payment_method = $payment_information['payment_method'];
+			$order          = $payment_information['order'];
+
+			$this->set_payment_method_id_for_order( $order, $payment_method );
+			$this->set_customer_id_for_order( $order, $payment_information['customer'] );
 
 			if ( $payment_needed ) {
 				$this->validate_selected_payment_method_type( $payment_information, $order->get_billing_country() );
@@ -683,6 +685,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				// Throw an exception if the minimum order amount isn't met.
 				$this->validate_minimum_order_amount( $order );
 
+				// TODO: check if the order already has a related payment intent. $this->get_intent_from_order( $order );
 				// Throws an exception on error.
 				$payment_intent = $this->intent_controller->create_and_confirm_payment_intent( $payment_information );
 
@@ -713,6 +716,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			$redirect = $this->get_return_url( $order );
 
+			// TODO: should we check for the 'requires_confirmation' status?
 			// If the payment intent requires action, respond with the pi and client secret so it can confirmed on checkout.
 			if ( 'requires_action' === $payment_intent->status ) {
 				$redirect = sprintf(
@@ -1614,33 +1618,49 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return array An array containing the payment information for processing a payment intent.
 	 */
 	private function prepare_payment_information_from_request( WC_Order $order ) {
-		$payment_method_id     = sanitize_text_field( wp_unslash( $_POST['wc-stripe-payment-method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$selected_payment_type = sanitize_text_field( wp_unslash( $_POST['wc_stripe_selected_upe_payment_type'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$capture_method        = empty( $this->get_option( 'capture' ) ) || $this->get_option( 'capture' ) === 'yes' ? 'automatic' : 'manual'; // automatic | manual.
 		$currency              = strtolower( $order->get_currency() );
 		$amount                = $order->get_total();
 		$shipping_details      = null;
 
+		$is_using_saved_payment_method = $this->is_using_saved_payment_method();
+
 		// If order requires shipping, add the shipping address details to the payment intent request.
 		if ( method_exists( $order, 'get_shipping_postcode' ) && ! empty( $order->get_shipping_postcode() ) ) {
 			$shipping_details = $this->get_address_data_for_payment_request( $order );
 		}
 
+		$payment_method_id = '';
+		if ( $is_using_saved_payment_method ) {
+			// Use the saved payment method.
+			$token = WC_Stripe_Payment_Tokens::get_token_from_request( $_POST );
+			if ( null === $token ) {
+				// TODO: add a better localized and loggable error messages.
+				throw new WC_Stripe_Exception( 'Invalid payment method.', 'wc_stripe_invalid_payment_method' );
+			}
+
+			$payment_method_id = $token->get_token();
+		} else {
+			$payment_method_id = sanitize_text_field( wp_unslash( $_POST['wc-stripe-payment-method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		}
+
 		$payment_information = [
-			'amount'                       => WC_Stripe_Helper::get_stripe_amount( $amount, $currency ),
-			'currency'                     => $currency,
-			'customer'                     => $this->get_customer_id_for_order( $order ),
-			'capture_method'               => $capture_method,
-			'level3'                       => $this->get_level3_data_from_order( $order ),
-			'metadata'                     => $this->get_metadata_from_order( $order ),
-			'order'                        => $order,
-			'payment_initiated_by'         => 'initiated_by_customer', // initiated_by_merchant | initiated_by_customer.
-			'payment_method'               => $payment_method_id,
-			'payment_type'                 => 'single', // single | recurring.
-			'save_payment_method_to_store' => $this->should_save_payment_method_from_request( $order->get_id(), $selected_payment_type ),
-			'selected_payment_type'        => $selected_payment_type,
-			'shipping'                     => $shipping_details,
-			'statement_descriptor'         => $this->get_statement_descriptor( $order, $selected_payment_type ),
+			'amount'                        => WC_Stripe_Helper::get_stripe_amount( $amount, $currency ),
+			'currency'                      => $currency,
+			'customer'                      => $this->get_customer_id_for_order( $order ),
+			'is_using_saved_payment_method' => $is_using_saved_payment_method,
+			'capture_method'                => $capture_method,
+			'level3'                        => $this->get_level3_data_from_order( $order ),
+			'metadata'                      => $this->get_metadata_from_order( $order ),
+			'order'                         => $order,
+			'payment_initiated_by'          => 'initiated_by_customer', // initiated_by_merchant | initiated_by_customer.
+			'payment_method'                => $payment_method_id,
+			'payment_type'                  => 'single', // single | recurring.
+			'save_payment_method_to_store'  => $this->should_save_payment_method_from_request( $order->get_id(), $selected_payment_type ),
+			'selected_payment_type'         => $selected_payment_type,
+			'shipping'                      => $shipping_details,
+			'statement_descriptor'          => $this->get_statement_descriptor( $order, $selected_payment_type ),
 		];
 
 		return $payment_information;
@@ -1658,6 +1678,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return boolean
 	 */
 	private function should_save_payment_method_from_request( $order_id, $payment_method_type ) {
+		// TODO: check if we're using a saved payment method.
+
 		// Don't save it when the type is unknown or not reusable.
 		if (
 			! isset( $this->payment_methods[ $payment_method_type ] ) ||
@@ -1714,13 +1736,36 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Add the payment method information to the ordeer.
 		$prepared_payment_method_object = $this->prepare_payment_method( $payment_method_object );
-		$this->save_payment_method_to_order( $order, $prepared_payment_method_object );
+		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object );
 
 		// Create a payment token for the user in the store.
 		$payment_method_instance = $this->payment_methods[ $payment_method_type ];
 		$payment_method_instance->create_payment_token_for_user( $user->ID, $payment_method_object );
 
 		do_action( 'woocommerce_stripe_add_payment_method', $user->ID, $payment_method_object );
+	}
+
+	/**
+	 * Set the payment metadata for payment method id.
+	 *
+	 * @param WC_Order $order The order.
+	 * @param string   $payment_method_id The value to be set.
+	 */
+	private function set_payment_method_id_for_order( WC_Order $order, string $payment_method_id ) {
+		// Save the payment method id as `source_id`, because we use both `sources` and `payment_methods` APIs.
+		$order->update_meta_data( '_stripe_source_id', $payment_method_id );
+		$order->save_meta_data();
+	}
+
+	/**
+	 * Set the payment metadata for customer id.
+	 *
+	 * @param WC_Order $order The order.
+	 * @param string   $customer_id The value to be set.
+	 */
+	private function set_customer_id_for_order( WC_Order $order, string $customer_id ) {
+		$order->update_meta_data( '_stripe_customer_id', $customer_id );
+		$order->save_meta_data();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -488,6 +488,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				<div id="wc-stripe-upe-errors" role="alert"></div>
 				<input id="wc-stripe-payment-method-upe" type="hidden" name="wc-stripe-payment-method-upe" />
 				<input id="wc_stripe_selected_upe_payment_type" type="hidden" name="wc_stripe_selected_upe_payment_type" />
+				<input type="hidden" id="wc-stripe-is-deferred-intent" name="wc-stripe-is-deferred-intent" value="1" />
 			</fieldset>
 			<?php
 			$methods_enabled_for_saved_payments = array_filter( $this->get_upe_enabled_payment_method_ids(), [ $this, 'is_enabled_for_saved_payments' ] );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1772,7 +1772,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Save it when the checkout checkbox for saving a payment method was checked off.
 		$save_payment_method = wc_clean( wp_unslash( $_POST[ $save_payment_method_request_arg ] ) );
-		// wc-stripe-new-payment-method is 'true' for classic and '1' for block. TODO: unify this.
+
+		// Its value is 'true' for classic and '1' for block.
 		if ( in_array( $save_payment_method, [ 'true', '1' ], true ) ) {
 			return true;
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -42,6 +42,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	const SUCCESSFUL_INTENT_STATUS = [ 'succeeded', 'requires_capture', 'processing' ];
 
 	/**
+	 * ActionScheduler hook name for updating saved payment method.
+	 *
+	 * @type string
+	 */
+	const UPDATE_SAVED_PAYMENT_METHOD = 'wc_stripe_update_saved_payment_method';
+
+	/**
 	 * Notices (array)
 	 *
 	 * @var array
@@ -91,6 +98,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public $intent_controller;
 
 	/**
+	 * WC_Stripe_Action_Scheduler_Service instance for scheduling ActionScheduler jobs.
+	 *
+	 * @var WC_Stripe_Action_Scheduler_Service
+	 */
+	public $action_scheduler_service;
+
+	/**
 	 * Array mapping payment method string IDs to classes
 	 *
 	 * @var WC_Stripe_UPE_Payment_Method[]
@@ -119,7 +133,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$this->payment_methods[ $payment_method->get_id() ] = $payment_method;
 		}
 
-		$this->intent_controller = new WC_Stripe_Intent_Controller();
+		$this->intent_controller        = new WC_Stripe_Intent_Controller();
+		$this->action_scheduler_service = new WC_Stripe_Action_Scheduler_Service();
 
 		// Load the form fields.
 		$this->init_form_fields();
@@ -163,6 +178,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, [ $this, 'process_admin_options' ] );
+
+		// This is an ActionScheduler action.
+		add_action( self::UPDATE_SAVED_PAYMENT_METHOD, [ $this, 'update_saved_payment_method' ], 10, 2 );
+
 		add_action( 'wp_footer', [ $this, 'payment_scripts' ] );
 
 		// Needed for 3DS compatibility when checking out with PRBs..
@@ -679,6 +698,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_needed        = $this->is_payment_needed( $order->get_id() );
 			$payment_method_id     = $payment_information['payment_method'];
 			$selected_payment_type = $payment_information['selected_payment_type'];
+
+			// Update saved payment method async to include billing details, if missing.
+			if ( $payment_information['is_using_saved_payment_method'] ) {
+				$this->action_scheduler_service->schedule_job(
+					time(),
+					self::UPDATE_SAVED_PAYMENT_METHOD,
+					[
+						'payment_method' => $payment_method_id,
+						'order_id'       => $order->get_id(),
+					]
+				);
+			}
 
 			// Make sure that we attach the payment method and the customer ID to the order meta data.
 			$this->set_payment_method_id_for_order( $order, $payment_method_id );
@@ -1580,6 +1611,52 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return [
 				'result' => 'error',
 			];
+		}
+	}
+
+	/**
+	 * Update the saved payment method information with checkout values, in a CRON job.
+	 *
+	 * @param string $payment_method_id The payment method to update.
+	 * @param int    $order_id          WC order id.
+	 */
+	public function update_saved_payment_method( $payment_method_id, $order_id ) {
+		$order = wc_get_order( $order_id );
+
+		try {
+			// Get the billing details from the order.
+			$billing_details = [
+				'address' => [
+					'city'        => $order->get_billing_city(),
+					'country'     => $order->get_billing_country(),
+					'line1'       => $order->get_billing_address_1(),
+					'line2'       => $order->get_billing_address_2(),
+					'postal_code' => $order->get_billing_postcode(),
+					'state'       => $order->get_billing_state(),
+				],
+				'email'   => $order->get_billing_email(),
+				'name'    => trim( $order->get_formatted_billing_full_name() ),
+				'phone'   => $order->get_billing_phone(),
+			];
+
+			$billing_details['address'] = array_filter( $billing_details['address'] );
+			$billing_details            = array_filter( $billing_details );
+
+			if ( empty( $billing_details ) ) {
+				return;
+			}
+
+			// Update the billing details of the selected payment method in Stripe.
+			WC_Stripe_API::update_payment_method(
+				$payment_method_id,
+				[
+					'billing_details' => $billing_details,
+				]
+			);
+
+		} catch ( WC_Stripe_Exception $e ) {
+			// If updating the payment method fails, log the error message.
+			WC_Stripe_Logger::log( 'Error when updating saved payment method: ' . $e->getMessage() );
 		}
 	}
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -124,6 +124,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->setMethods( [ 'create_and_confirm_payment_intent' ] )
 			->getMock();
 
+		$this->mock_gateway->action_scheduler_service = $this->getMockBuilder( WC_Stripe_Action_Scheduler_Service::class )
+		->setMethods( [ 'schedule_job' ] )
+		->getMock();
+
 		$this->mock_stripe_customer = $this->getMockBuilder( WC_Stripe_Customer::class )
 			->disableOriginalConstructor()
 			->setMethods(
@@ -358,6 +362,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
 
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->never() )
+			->method( 'schedule_job' );
+
 		$response = $this->mock_gateway->process_payment( $order_id );
 
 		$this->assertEquals( 'success', $response['result'] );
@@ -413,6 +421,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_latest_charge_from_intent' )
 			->willReturn( (object) [] );
 
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->never() )
+			->method( 'schedule_job' );
+
 		$response = $this->mock_gateway->process_payment( $order_id );
 
 		$this->assertEquals( 'success', $response['result'] );
@@ -456,6 +468,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
 
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->never() )
+			->method( 'schedule_job' );
+
 		$response = $this->mock_gateway->process_payment( $order_id );
 
 		$this->assertEquals( 'failure', $response['result'] );
@@ -497,6 +513,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
 
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->never() )
+			->method( 'schedule_job' );
+
 		$response = $this->mock_gateway->process_payment( $order_id );
 
 		$this->assertEquals( 'failure', $response['result'] );
@@ -537,6 +557,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
+
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->never() )
+			->method( 'schedule_job' );
 
 		$response = $this->mock_gateway->process_payment( $order_id );
 
@@ -1044,6 +1068,18 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
 
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->greaterThanOrEqual( time() ),
+				'wc_stripe_update_saved_payment_method',
+				[
+					'payment_method' => $payment_method_id,
+					'order_id'       => $order_id,
+				]
+			);
+
 		$response    = $this->mock_gateway->process_payment( $order_id );
 		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
@@ -1108,6 +1144,18 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
 
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->greaterThanOrEqual( time() ),
+				'wc_stripe_update_saved_payment_method',
+				[
+					'payment_method' => $payment_method_id,
+					'order_id'       => $order_id,
+				]
+			);
+
 		$response      = $this->mock_gateway->process_payment( $order_id );
 		$final_order   = wc_get_order( $order_id );
 		$client_secret = $payment_intent_mock->client_secret;
@@ -1157,6 +1205,18 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
+
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->greaterThanOrEqual( time() ),
+				'wc_stripe_update_saved_payment_method',
+				[
+					'payment_method' => $payment_method_id,
+					'order_id'       => $order_id,
+				]
+			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
 		$final_order = wc_get_order( $order_id );
@@ -1228,6 +1288,18 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
+
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->greaterThanOrEqual( time() ),
+				'wc_stripe_update_saved_payment_method',
+				[
+					'payment_method' => $payment_method_id,
+					'order_id'       => $order_id,
+				]
+			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
 		$final_order = wc_get_order( $order_id );
@@ -1310,6 +1382,18 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->expects( $this->once() )
 			->method( 'get_stripe_customer_id' )
 			->willReturn( $customer_id );
+
+		$this->mock_gateway->action_scheduler_service
+			->expects( $this->once() )
+			->method( 'schedule_job' )
+			->with(
+				$this->greaterThanOrEqual( time() ),
+				'wc_stripe_update_saved_payment_method',
+				[
+					'payment_method' => $payment_method_id,
+					'order_id'       => $order_id,
+				]
+			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
 		$final_order = wc_get_order( $order_id );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -198,6 +198,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-woo-compat-utils.php';
 				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect.php';
 				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect-api.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-action-scheduler-service.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-order-handler.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-payment-tokens.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-customer.php';


### PR DESCRIPTION
Blocked by https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2816

Related to #2760 

## Changes proposed in this Pull Request:

- Introduce the WC_Stripe_Action_Scheduler_Service class, aimed to handle scheduling actions.
- When using a saved payment method in the checkout, update its billing details in Stripe async with the order billing details.

## Testing instructions

1. Ensure the new checkout experience is enabled
2. As a logged-in shopper, go to the My account > Payment methods > Add payment method
3. Add a new card, like 4242424242424242
4. Go to the Stripe dashboard > Customers > The customer associated with the shopper you used to add the card
5. Confirm the Payment method doesn't have any billing details associated with it
  <img width="700" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/75be7210-1951-4d58-8c73-92dea8a67bca">

7. As the shopper, add a product to the cart and go to the checkout page
8. Fill up the checkout form to include the billing details
9. Select the card you just added and place the order
10. As the store admin, go to the WordPress dashboard > Scheduled Actions page ( `siteurl/wp-admin/tools.php?page=action-scheduler` )
11. Search for `wc_stripe_update_saved_payment_method`
12. Confirm there's an action with:
  - Status: Either "Pending" or "Complete". It could have run already
  - Arguments: 'payment_method' => The ID of the payment method we're updating, 'order_id' => The ID of the WC order you just placed
  - Group: "woocommerce_stripe"
  - Recurrence: "Non-repeating"
  - Scheduled date: Now or sometime in the past.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
