### PR TITLE
Checking for trashed orders in webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 7.8.2 - 2024-xx-xx =
+* Tweak - Orders with `trash` status are not retrieving anymore when calling `get_order_by_intent_id` function. 
+
 = 7.8.1 - 2023-12-28 =
 * Fix - Check if a valid order of tye WC_Order is returned before calling `get_meta` function.
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -496,7 +496,7 @@ class WC_Stripe_Helper {
 			$order = wc_get_order( $order_id );
 		}
 
-		if ( ! empty( $order ) && $order->get_status() !== \WCPay\Constants\Order_Status::TRASH ) {
+		if ( ! empty( $order ) && $order->get_status() !== 'trash' ) {
 			return $order;
 		}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -493,7 +493,11 @@ class WC_Stripe_Helper {
 		}
 
 		if ( ! empty( $order_id ) ) {
-			return wc_get_order( $order_id );
+			$order = wc_get_order( $order_id );
+		}
+
+		if ( ! empty( $order ) && $order->get_status() !== \WCPay\Constants\Order_Status::TRASH ) {
+			return $order;
 		}
 
 		return false;

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 7.8.2 - 2024-xx-xx =
+* Tweak - Orders with `trash` status are not retrieving anymore when calling `get_order_by_intent_id` function.
+
 = 7.8.1 - 2023-12-28 =
 * Fix - Check if a valid order of tye WC_Order is returned before calling `get_meta` function.
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1025

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR changes the `get_order_by_intent_id` to check for the order status before returning it. If the status is `trash` it will not be retrieved. That's to avoid updating orders that are already deleted from a store (through webhook calls).

This should cover edge cases in which an order is trashed before a webhook call is processed.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Code review. Check if the tests are still passing. This should not affect the default webhook behavior.

OR

- Set up a store
- Test and confirm that [a regular purchase works](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#checkout-with-normal-credit-card) (webhook is correctly triggered and it updates an order)
- Test and confirm that a quickly trashed order is ignored

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
