### PR TITLE
Add deferred intent support for Boleto & Oxxo (Voucher payment method types)

### DIFF
--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -108,7 +108,7 @@ jQuery( function ( $ ) {
 	// On every page load and on hash change, check to see whether we should display the Boleto or Oxxo modal.
 	// Every page load is needed for the Pay for Order page which doesn't trigger the hash change.
 	maybeConfirmVoucherPayment();
-	window.addEventListener( 'hashchange', () => {
+	$( window ).on( 'hashchange', () => {
 		maybeConfirmVoucherPayment();
 	} );
 } );

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -11,6 +11,7 @@ import {
 	processPayment,
 	mountStripePaymentElement,
 	createAndConfirmSetupIntent,
+	confirmVoucherPayment,
 } from './payment-processing';
 
 jQuery( function ( $ ) {
@@ -84,4 +85,30 @@ jQuery( function ( $ ) {
 			}
 		}
 	}
+
+	/**
+	 * Checks if the URL hash starts with #wc-stripe-voucher- and whether we
+	 * should display the Boleto or Oxxo confirmation modal.
+	 */
+	function maybeConfirmVoucherPayment() {
+		if (
+			window.location.hash.startsWith( '#wc-stripe-voucher-' ) &&
+			( getStripeServerData()?.isOrderPay ||
+				getStripeServerData()?.isCheckout )
+		) {
+			confirmVoucherPayment(
+				api,
+				getStripeServerData()?.isOrderPay
+					? $( '#order_review' )
+					: $( 'form.checkout' )
+			);
+		}
+	}
+
+	// On every page load and on hash change, check to see whether we should display the Boleto or Oxxo modal.
+	// Every page load is needed for the Pay for Order page which doesn't trigger the hash change.
+	maybeConfirmVoucherPayment();
+	window.addEventListener( 'hashchange', () => {
+		maybeConfirmVoucherPayment();
+	} );
 } );

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -104,16 +104,9 @@ function createStripePaymentElement( api, paymentMethodType = null ) {
 /**
  * Submits the provided jQuery form and removes the 'processing' class from it.
  *
- * @param {Object} jQueryForm    The jQuery object for the form being submitted.
- * @param {Object} api           The API object used to create the Stripe payment method.
- * @param {Object} paymentMethod The Stripe payment method object.
+ * @param {Object} jQueryForm The jQuery object for the form being submitted.
  */
-function submitForm( jQueryForm, api, paymentMethod ) {
-	if ( paymentMethod.type === 'boleto' || paymentMethod.type === 'oxxo' ) {
-		handleVoucherCheckout( paymentMethod, jQueryForm, api );
-		return;
-	}
-
+function submitForm( jQueryForm ) {
 	jQueryForm.removeClass( 'processing' ).trigger( 'submit' );
 }
 
@@ -298,7 +291,7 @@ export const processPayment = (
 				api
 			);
 			hasCheckoutCompleted = true;
-			submitForm( jQueryForm, api, paymentMethodObject.paymentMethod );
+			submitForm( jQueryForm );
 		} catch ( err ) {
 			hasCheckoutCompleted = false;
 			jQueryForm.removeClass( 'processing' ).unblock();
@@ -335,59 +328,77 @@ export const createAndConfirmSetupIntent = (
 };
 
 /**
- * Handles the checkout for Voucher payment methods (Boleto & Oxxo).
+ * Handles displaying the Boleto or Oxxo voucher to the customer and then redirecting
+ * them to the order received page once they close the voucher window.
  *
- * This function manually processes the checkout and displays the voucher
- * to the customer, before then redirecting to the order received page.
+ * When processing a payment for one of our voucher payment methods on the checkout or order pay page,
+ * the process_payment_with_deferred_intent() function redirects the customer to a URL
+ * formatted with: #wc-stripe-voucher-<order_id>:<payment_method_type>:<client_secret>:<redirect_url>.
  *
- * @param {Object} paymentMethod The payment method object.
- * @param {Object} jQueryForm    The jQuery object for the form being submitted.
+ * This function, which is hooked onto the hashchanged event, checks if the URL contains the data we need to process the voucher payment.
+ *
  * @param {Object} api           The API object used to create the Stripe payment method.
+ * @param {Object} jQueryForm    The jQuery object for the form being submitted.
  */
-const handleVoucherCheckout = ( paymentMethod, jQueryForm, api ) => {
-	const formFields = jQueryForm.serializeArray().reduce( ( obj, field ) => {
-		obj[ field.name ] = field.value;
-		return obj;
-	}, {} );
+export const confirmVoucherPayment = async ( api, jQueryForm ) => {
+	const isOrderPay = getStripeServerData()?.isOrderPay;
 
-	/**
-	 * Manually process the checkout form rather than submitting the form so that we can display
-	 * the Boleto/Oxxo voucher on checkout page, before redirecting to the order received page.
-	 */
-	api.processCheckout( paymentMethod.id, formFields )
-		.then( async ( response ) => {
-			if (
-				response.result !== 'success' ||
-				! response.client_secret ||
-				! response.redirect
-			) {
-				hasCheckoutCompleted = false;
-				jQueryForm.removeClass( 'processing' ).unblock();
-				return;
-			}
+	// The Order Pay page does a hard refresh when the hash changes, so we need to block the UI again.
+	if ( isOrderPay ) {
+		blockUI( jQueryForm );
+	}
 
-			// Confirm the payment to tell Stripe to display the voucher to the customer.
-			let confirmPayment;
-			if ( paymentMethod.type === 'boleto' ) {
-				confirmPayment = await api
-					.getStripe()
-					.confirmBoletoPayment( response.client_secret, {} );
-			} else {
-				confirmPayment = await api
-					.getStripe()
-					.confirmOxxoPayment( response.client_secret, {} );
-			}
+	const partials = window.location.href.match(
+		/#wc-stripe-voucher-(.+):(.+):(.+):(.+)$/
+	);
 
-			if ( confirmPayment.error ) {
-				throw confirmPayment.error;
-			}
+	if ( ! partials ) {
+		jQueryForm.removeClass( 'processing' ).unblock();
+		return;
+	}
 
-			// Once the customer closes the voucher and there are no errors, redirect them to the order received page.
-			window.location.href = response.redirect;
-		} )
-		.catch( ( error ) => {
-			hasCheckoutCompleted = false;
-			jQueryForm.removeClass( 'processing' ).unblock();
-			showErrorCheckout( error.message );
-		} );
+	// Remove the hash from the URL.
+	history.replaceState(
+		'',
+		document.title,
+		window.location.pathname + window.location.search
+	);
+
+	const orderId = partials[ 1 ];
+	const clientSecret = partials[ 3 ];
+
+	// Verify the request using the data added to the URL.
+	if (
+		! clientSecret ||
+		( isOrderPay && orderId !== getStripeServerData()?.orderId )
+	) {
+		jQueryForm.removeClass( 'processing' ).unblock();
+		return;
+	}
+
+	const paymentMethodType = partials[ 2 ];
+
+	try {
+		// Confirm the payment to tell Stripe to display the voucher to the customer.
+		let confirmPayment;
+		if ( paymentMethodType === 'boleto' ) {
+			confirmPayment = await api
+				.getStripe()
+				.confirmBoletoPayment( clientSecret, {} );
+		} else {
+			confirmPayment = await api
+				.getStripe()
+				.confirmOxxoPayment( clientSecret, {} );
+		}
+
+		if ( confirmPayment.error ) {
+			throw confirmPayment.error;
+		}
+
+		// Once the customer closes the voucher and there are no errors, redirect them to the order received page.
+		window.location.href = decodeURIComponent( partials[ 4 ] );
+	} catch ( error ) {
+		jQueryForm.removeClass( 'processing' ).unblock();
+		showErrorCheckout( error.message );
+	}
 };

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -159,7 +159,13 @@ function createStripePaymentMethod(
 
 	return api
 		.getStripe( paymentMethodType )
-		.createPaymentMethod( { elements, params } );
+		.createPaymentMethod( { elements, params } )
+		.then( ( paymentMethod ) => {
+			if ( paymentMethod.error ) {
+				throw paymentMethod.error;
+			}
+			return paymentMethod;
+		} );
 }
 
 /**

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -952,6 +952,6 @@ class WC_Stripe_Intent_Controller {
 	 * @return boolean True if the arrray consist of only one payment method which is not a card. False otherwise.
 	 */
 	private function request_needs_redirection( $payment_methods ) {
-		return 1 === count( $payment_methods ) && 'card' !== $payment_methods[0];
+		return 1 === count( $payment_methods ) && ! in_array( $payment_methods[0], [ 'card', 'boleto', 'oxxo' ] );
 	}
 }

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -730,7 +730,7 @@ class WC_Stripe_Intent_Controller {
 		}
 
 		// For voucher payment methods type like Boleto & Oxxo, we shouldn't confirm the intent immediately as this is done on the front-end when displaying the voucher to the customer.
-		// When the intent is confirmed, Stripes sends a webhook to the store which puts the order on-hold, which we only want to happen after successfully displaying the voucher.
+		// When the intent is confirmed, Stripe sends a webhook to the store which puts the order on-hold, which we only want to happen after successfully displaying the voucher.
 		if ( $this->is_delayed_confirmation_required( $payment_method_types ) ) {
 			$request['confirm'] = 'false';
 		}

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -729,6 +729,12 @@ class WC_Stripe_Intent_Controller {
 			$request['return_url'] = $payment_information['return_url'];
 		}
 
+		// For voucher payment methods type like Boleto & Oxxo, we shouldn't confirm the intent immediately as this is done on the front-end when displaying the voucher to the customer.
+		// When the intent is confirmed, Stripes sends a webhook to the store which puts the order on-hold, which we only want to happen after successfully displaying the voucher.
+		if ( $this->is_delayed_confirmation_required( $payment_method_types ) ) {
+			$request['confirm'] = 'false';
+		}
+
 		if ( $payment_information['save_payment_method_to_store'] ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
@@ -949,9 +955,23 @@ class WC_Stripe_Intent_Controller {
 	 *
 	 * @param array $payment_methods The list of payment methods used for the processing the payment.
 	 *
-	 * @return boolean True if the arrray consist of only one payment method which is not a card. False otherwise.
+	 * @return boolean True if the array consist of only one payment method which is not a card. False otherwise.
 	 */
 	private function request_needs_redirection( $payment_methods ) {
 		return 1 === count( $payment_methods ) && ! in_array( $payment_methods[0], [ 'card', 'boleto', 'oxxo' ] );
+	}
+
+	/**
+	 * Determines whether the intent needs to be confirmed later.
+	 *
+	 * Some payment methods such as Boleto and Oxxo require the payment to be confirmed later when
+	 * displaying the voucher to the customer on the checkout or pay for order page.
+	 *
+	 * @param array $payment_methods The list of payment methods used for the processing the payment.
+	 *
+	 * @return boolean
+	 */
+	private function is_delayed_confirmation_required( $payment_methods ) {
+		return in_array( 'boleto', $payment_methods, true ) || in_array( 'oxxo', $payment_methods, true );
 	}
 }

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -955,7 +955,7 @@ class WC_Stripe_Intent_Controller {
 	 *
 	 * @param array $payment_methods The list of payment methods used for the processing the payment.
 	 *
-	 * @return boolean True if the array consist of only one payment method which is not a card. False otherwise.
+	 * @return boolean True if the array consist of only one payment method and it isn't card, Boleto or Oxxo. False otherwise.
 	 */
 	private function request_needs_redirection( $payment_methods ) {
 		return 1 === count( $payment_methods ) && ! in_array( $payment_methods[0], [ 'card', 'boleto', 'oxxo' ] );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -719,7 +719,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				}
 			}
 
-			// For Voucher payment method types (Boleto/Oxxo), redirect the customer to a URL hash formated #wc-stripe-voucher-{order_id}:{payment_method_type}:{client_secret}:{redirect_url} to confirm the intent which also displays the voucher.
+			// For Voucher payment method types (Boleto/Oxxo), redirect the customer to a URL hash formatted #wc-stripe-voucher-{order_id}:{payment_method_type}:{client_secret}:{redirect_url} to confirm the intent which also displays the voucher.
 			if ( in_array( $payment_intent->status, [ 'requires_confirmation', 'requires_action' ], true ) && isset( $payment_intent->payment_method_types ) && count( array_intersect( [ 'boleto', 'oxxo' ], $payment_intent->payment_method_types ) ) !== 0 ) {
 				$redirect = sprintf(
 					'#wc-stripe-voucher-%s:%s:%s:%s',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2775
Fixes #2776 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR adds deferred intent support for Boleto and Oxxo which are voucher payment method types available to stores in Brazil and Mexico.

| Boleto | Oxxo |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/bba9f1e3-308a-4883-b1b6-81a4ceb61d6e) | ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/1e35be8b-7756-4c49-b8a6-60b32f99ce0d) | 


These payment methods are a little different from our other payment methods and require displaying a voucher to the customer on checkout submission, and then redirecting them to the order received page once they've closed the voucher window.

The order remains on-hold until Stripe then sends a webhook confirming the payment has been received.

Supporting voucher payment methods in this PR required the following changes:

1. ~~cd2605dfba895d104cfa173e81d3d5f059bcb1a5 Inside `process_payment_with_deferred_intent()` after successfully creating and confirming the payment intent, attach the `client_secret` to the response array when the intent has a `requires_action` type set to either `'oxxo_display_details'` or `'boleto_display_details'`. This is so it can be used on the front-end to display the voucher window to the customer.~~
2. ~~830fb094c0702e1a34c2e3a1384d2c39bf9a0a74 Instead of submitting for checkout form, this commit introduces `handleVoucherCheckout()` which processes the checkout manually when using Boleto or Oxxo and displays the voucher to the customer before then redirecting them to the order received page.~~
   1. ~~The reason for not submitting the form is because we need to first get the response from server to display the voucher on the checkout.~~
   2. In order to display the Boleto or Oxxo vouchers on checkout, I'm using `confirmBoletoPayment` and `confirmOxxoPayment` which just takes the `client_secret` ([stripe docs](https://stripe.com/docs/js/payment_intents/confirm_boleto_payment#stripe_confirm_boleto_payment-attached))

> [!NOTE]
> As of the latest commits, the above approach is no longer accurate and to support the Pay for Order page, I needed to refactor the entire handling of these voucher payment method types.

1. [30abdd0](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2823/commits/30abdd03e188c394330f495a794f5a9fac46af7e) Inside `process_payment_with_deferred_intent()` after successfully creating the confirming the payment intent, attach the redirect URL, client secret, payment type and order ID inside the URL hash. This is so we can hook onto the hashchanged event and display the Boleto or Oxxo voucher to the customer before redirecting them to the order received page.

All existing webhook handling didn't need to be updated.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

**Pre-requisites**

- Separate Stripe merchant accounts located in Brazil and Mexico
- Ability to receive webhooks from Stripe (I use ngrok)

#### Testing Boleto

1. Go to WooCommerce > Settings > General and set your store's currency to Brazilian real (R$)
2. Go to WooCommerce > Settings > Payments > Stripe > Settings (panel) (/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings)
4. Click on edit keys and update the private, secret and webhook keys to your Stripe Brazil store
> [!WARNING]
> If this is not a fresh store and you are connecting a different Stripe account, you will need to go into the `usermeta` and delete the row with `meta_key` `wp__stripe_customer_id` as the existing customer ID won't exist in the Brazil store.
5. From the shop page, add a product to the cart and proceed to checkout
6. Enter a [valid Brazilian address](https://www.fakeaddressgenerator.com/World/Brazil_address_generator) with an email that fits the `{any_prefix}@{any_domain}` format (i.e. test@example.com)
7. Select Boleto on the checkout and enter `00.000.000/0000-00` into the text box.
8. Click on "Place Order" and you should see a pop-up window for the voucher.
9. Closing the voucher should redirect you to the order received page.
10. If you have webhooks setup properly, the order should be on-hold almost immediately.
11. Wait 3mins for the success webhook to come through and confirm the order is updated to processing

> [!NOTE]
> Refunds are not supported by both Boleto and Oxxo so no need to test refunding these payments.

**Boleto error testing**

Stripe docs on testing Boleto: https://stripe.com/docs/payments/boleto/accept-a-payment?platform=checkout#test-integration

1. **Testing with an expired voucher**
   1. Add the product to the cart and go to the checkout
   2. While on the checkout set your email to `expire_immediately@example.com`
   3. Select Boleto and fill in the tax ID field with `00.000.000/0000-00`
   4. Placing the order should show a popup with a voucher that has expired
   5. Closing the window should send you to the order received page with a Pay link
   6. Navigate to the WooCommerce > Orders and confirm the order is set to failed status
2. **Testing invalid checkout errors**
   1. Add product to the cart and navigate to the checkout
   2. Set your country to something other than Brazil (i.e. Australia)
   3. Select Boleto and fill in the tax ID field with `00.000.000/0000-00`
   4. Placing the order should show an error on the checkout.

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/fb48fa5d-d1bb-4175-85c0-37f9202d730e)

#### Testing Oxxo

Testing Oxxo is the same as Boleto above, except you'll need to connect a Stripe account set in Mexico and set your store's currency to **Mexican Peso**. A few things to note:

- Make sure you reset your billing email back to test@example.com or something other than `expire_immediately@example` so that the vouchers don't expire immediately.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
