### PR TITLE
Reusing payment intents when possible

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1096,7 +1096,7 @@ class WC_Stripe_Intent_Controller {
 		$payment_method_types = $this->get_payment_method_types_for_intent_creation( $selected_payment_type, $order->get_id() );
 
 		// If the payment method types match, we can reuse the payment intent.
-		if ( ! count( array_intersect( $intent->payment_method_types, $payment_method_types ) ) === count( $payment_method_types ) ) {
+		if ( count( array_intersect( $intent->payment_method_types, $payment_method_types ) ) !== count( $payment_method_types ) ) {
 			return null;
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1021,6 +1021,9 @@ class WC_Stripe_Intent_Controller {
 	public function get_existing_compatible_payment_intent( $order, $selected_payment_type ) {
 		$gateway = $this->get_gateway();
 		$intent  = $gateway->get_intent_from_order( $order );
+		if ( ! $intent ) {
+			return null;
+		}
 
 		$payment_method_types = $this->get_payment_method_types_for_intent_creation( $selected_payment_type, $order->get_id() );
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -971,12 +971,8 @@ class WC_Stripe_Intent_Controller {
 	 * @throws WC_Stripe_Exception
 	 */
 	private function query_for_compatible_payment_intent( $customer, $order_id, $payment_method_types ) {
-		$search_data    = [
-			'customer'             => $customer,
-			'status'               => 'requires_payment_method',
-			'metadata["order_id"]' => $order_id,
-		];
-		$search_results = WC_Stripe_API::request( $search_data, 'payment_intents/search', 'GET' );
+		$query_string   = sprintf( "customer:'%s' AND status:'requires_payment_method' AND metadata['order_id']:'%s'", $customer, $order_id );
+		$search_results = WC_Stripe_API::request( [ 'query' => $query_string ], 'payment_intents/search', 'GET' );
 		foreach ( $search_results->data as $result ) {
 			// If the payment method types match, we can reuse the payment intent.
 			if ( count( array_intersect( $result, $payment_method_types ) ) === count( $payment_method_types ) ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -686,7 +686,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$this->validate_minimum_order_amount( $order );
 
 				// Throws an exception on error.
-				$payment_intent = $this->intent_controller->create_and_confirm_payment_intent( $payment_information );
+				$payment_intent = $this->intent_controller->get_or_create_and_confirm_payment_intent( $payment_information );
 
 				// Use the last charge within the intent to proceed.
 				$charge = end( $payment_intent->charges->data );

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -119,7 +119,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			);
 
 		$this->mock_gateway->intent_controller = $this->getMockBuilder( WC_Stripe_Intent_Controller::class )
-			->setMethods( [ 'get_or_create_and_confirm_payment_intent' ] )
+			->setMethods( [ 'create_and_confirm_payment_intent' ] )
 			->getMock();
 
 		$this->mock_stripe_customer = $this->getMockBuilder( WC_Stripe_Customer::class )
@@ -319,15 +319,13 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	 * Test basic checkout process_payment flow with deferred intent.
 	 */
 	public function test_process_payment_deferred_intent_returns_valid_response() {
-		$payment_intent_id = 'pi_mock';
-		$customer_id       = 'cus_mock';
-		$order             = WC_Helper_Order::create_order();
-		$currency          = $order->get_currency();
-		$order_id          = $order->get_id();
+		$customer_id = 'cus_mock';
+		$order       = WC_Helper_Order::create_order();
+		$order_id    = $order->get_id();
 
 		$mock_intent = (object) wp_parse_args(
 			[
-				'charges' => (object) [
+				'charges'        => (object) [
 					'data' => [
 						(object) [
 							'id'       => $order_id,
@@ -349,7 +347,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
-			->method( 'get_or_create_and_confirm_payment_intent' )
+			->method( 'create_and_confirm_payment_intent' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -367,14 +365,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	 * Test SCA/3DS checkout process_payment flow with deferred intent.
 	 */
 	public function test_process_payment_deferred_intent_with_required_action_returns_valid_response() {
-		$customer_id       = 'cus_mock';
-		$order             = WC_Helper_Order::create_order();
-		$order_id          = $order->get_id();
+		$customer_id = 'cus_mock';
+		$order       = WC_Helper_Order::create_order();
+		$order_id    = $order->get_id();
 
 		$mock_intent = (object) wp_parse_args(
 			[
-				'status' => 'requires_action',
-				'data' => [
+				'status'         => 'requires_action',
+				'data'           => [
 					(object) [
 						'id'       => $order_id,
 						'captured' => 'yes',
@@ -382,7 +380,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					],
 				],
 				'payment_method' => 'pm_mock',
-				'charges' => (object) [
+				'charges'        => (object) [
 					'total_count' => 0, // Intents requiring SCA verification respond with no charges.
 					'data'        => [],
 				],
@@ -398,7 +396,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
-			->method( 'get_or_create_and_confirm_payment_intent' )
+			->method( 'create_and_confirm_payment_intent' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -441,7 +439,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
-			->method( 'get_or_create_and_confirm_payment_intent' )
+			->method( 'create_and_confirm_payment_intent' )
 			->willThrowException( new WC_Stripe_Exception( "It's a trap!" ) );
 
 		$this->mock_gateway
@@ -483,7 +481,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->never() )
-			->method( 'get_or_create_and_confirm_payment_intent' );
+			->method( 'create_and_confirm_payment_intent' );
 
 		$this->mock_gateway
 			->expects( $this->once() )
@@ -524,7 +522,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->never() )
-			->method( 'get_or_create_and_confirm_payment_intent' );
+			->method( 'create_and_confirm_payment_intent' );
 
 		$this->mock_gateway
 			->expects( $this->once() )

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -119,7 +119,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			);
 
 		$this->mock_gateway->intent_controller = $this->getMockBuilder( WC_Stripe_Intent_Controller::class )
-			->setMethods( [ 'create_and_confirm_payment_intent' ] )
+			->setMethods( [ 'get_or_create_and_confirm_payment_intent' ] )
 			->getMock();
 
 		$this->mock_stripe_customer = $this->getMockBuilder( WC_Stripe_Customer::class )
@@ -349,7 +349,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
-			->method( 'create_and_confirm_payment_intent' )
+			->method( 'get_or_create_and_confirm_payment_intent' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -398,7 +398,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
-			->method( 'create_and_confirm_payment_intent' )
+			->method( 'get_or_create_and_confirm_payment_intent' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
@@ -441,7 +441,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
-			->method( 'create_and_confirm_payment_intent' )
+			->method( 'get_or_create_and_confirm_payment_intent' )
 			->willThrowException( new WC_Stripe_Exception( "It's a trap!" ) );
 
 		$this->mock_gateway
@@ -483,7 +483,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->never() )
-			->method( 'create_and_confirm_payment_intent' );
+			->method( 'get_or_create_and_confirm_payment_intent' );
 
 		$this->mock_gateway
 			->expects( $this->once() )
@@ -524,7 +524,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->never() )
-			->method( 'create_and_confirm_payment_intent' );
+			->method( 'get_or_create_and_confirm_payment_intent' );
 
 		$this->mock_gateway
 			->expects( $this->once() )

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -347,6 +347,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
+			->method( 'get_existing_compatible_payment_intent' )
+			->willReturn( null );
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
 			->method( 'create_and_confirm_payment_intent' )
 			->willReturn( $mock_intent );
 
@@ -396,6 +401,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
+			->method( 'get_existing_compatible_payment_intent' )
+			->willReturn( null );
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
 			->method( 'create_and_confirm_payment_intent' )
 			->willReturn( $mock_intent );
 
@@ -436,6 +446,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			'wc_stripe_selected_upe_payment_type' => 'card',
 			'wc-stripe-is-deferred-intent'        => '1',
 		];
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'get_existing_compatible_payment_intent' )
+			->willReturn( null );
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
@@ -480,6 +495,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		];
 
 		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'get_existing_compatible_payment_intent' )
+			->willReturn( null );
+
+		$this->mock_gateway->intent_controller
 			->expects( $this->never() )
 			->method( 'create_and_confirm_payment_intent' );
 
@@ -519,6 +539,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			'wc_stripe_selected_upe_payment_type' => 'some_invalid_type',
 			'wc-stripe-is-deferred-intent'        => '1',
 		];
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'get_existing_compatible_payment_intent' )
+			->willReturn( null );
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->never() )

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -36,7 +36,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		$this->order           = WC_Helper_Order::create_order();
 		$this->gateway         = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'maybe_process_upe_redirect', 'get_intent_from_order', 'get_upe_enabled_at_checkout_payment_method_ids' ] )
+			->setMethods( [ 'maybe_process_upe_redirect', 'get_intent_from_order', 'get_upe_enabled_at_checkout_payment_method_ids', 'get_upe_enabled_payment_method_ids' ] )
 			->getMock();
 		$this->mock_controller = $this->getMockBuilder( 'WC_Stripe_Intent_Controller' )
 			->disableOriginalConstructor()
@@ -174,6 +174,109 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 			'no compatible intent found'      => [
 				'associated intent' => $not_compatible_intent,
 				'expected'          => null,
+			],
+		];
+	}
+
+	/**
+	 * Test for `update_and_confirm_payment_intent` method.
+	 *
+	 * @param array $payment_information Payment information.
+	 * @param object $payment_intent Payment intent.
+	 * @param string|null $expected Expected result.
+	 * @param string|null $expected_exception Expected exception.
+	 * @return void
+	 * @dataProvider provide_test_update_and_confirm_payment_intent
+	 * @throws WC_Stripe_Exception If invalid payment method type is passed.
+	 */
+	public function test_update_and_confirm_payment_intent( $payment_information, $payment_intent, $expected = null, $expected_exception = null ) {
+		$payment_information = array_merge( $payment_information, [ 'order' => $this->order ] );
+
+		if ( $expected_exception ) {
+			$this->expectException( $expected_exception );
+		}
+
+		$test_request = function () use ( $payment_intent ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( $payment_intent ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$mocked_ids = [
+			WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+			WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
+		];
+
+		$this->gateway
+			->expects( $this->any() )
+			->method( 'get_upe_enabled_at_checkout_payment_method_ids' )
+			->willReturn( $mocked_ids );
+
+		$this->gateway
+			->expects( $this->any() )
+			->method( 'get_upe_enabled_payment_method_ids' )
+			->willReturn( $mocked_ids );
+
+		$actual = $this->mock_controller->update_and_confirm_payment_intent( $payment_intent, $payment_information );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Provider for `test_update_and_confirm_payment_intent` method.
+	 *
+	 * @return array
+	 */
+	public function provide_test_update_and_confirm_payment_intent() {
+		$payment_information = [
+			'amount'                       => 100,
+			'capture_method'               => 'automatic',
+			'currency'                     => 'usd',
+			'customer'                     => 'cus_123',
+			'level3'                       => [ 'test' => 'test' ],
+			'metadata'                     => [],
+			'payment_method'               => 'pm_123',
+			'save_payment_method_to_store' => false,
+			'shipping'                     => [],
+			'statement_descriptor'         => '',
+			'selected_payment_type'        => '',
+		];
+
+		$payment_information_with_selected_method = array_merge(
+			$payment_information,
+			[
+				'selected_payment_type' => WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+			]
+		);
+
+		$payment_intent_regular = [ 'id' => 'pi_123' ];
+		$payment_intent_error   = (object) array_merge(
+			$payment_intent_regular,
+			[
+				'error' => (object) [
+					'message' => 'error',
+				],
+			]
+		);
+		return [
+			'payment method not selected' => [
+				'payment information' => $payment_information,
+				'payment intent'      => (object) $payment_intent_regular,
+				'expected'            => (object) $payment_intent_regular,
+			],
+			'payment intent error'        => [
+				'payment information' => $payment_information_with_selected_method,
+				'payment intent'      => $payment_intent_error,
+				'expected'            => null,
+				'expected exception'  => WC_Stripe_Exception::class,
+			],
+			'success'                     => [
+				'payment information' => $payment_information_with_selected_method,
+				'payment intent'      => (object) $payment_intent_regular,
+				'expected'            => (object) $payment_intent_regular,
 			],
 		];
 	}

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -156,10 +156,15 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 				WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
 				WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 			],
+			'status'               => 'requires_payment_method',
 		];
 		$not_compatible_intent = (object) [
 			'id'                   => 'pi_456',
 			'payment_method_types' => [ 'boleto' ],
+		];
+		$invalid_status_intent = (object) [
+			'id'     => 'pi_789',
+			'status' => 'canceled',
 		];
 
 		return [
@@ -173,6 +178,10 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 			],
 			'no compatible intent found'      => [
 				'associated intent' => $not_compatible_intent,
+				'expected'          => null,
+			],
+			'invalid status'                  => [
+				'associated intent' => $invalid_status_intent,
 				'expected'          => null,
 			],
 		];

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -161,10 +161,15 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		$not_compatible_intent = (object) [
 			'id'                   => 'pi_456',
 			'payment_method_types' => [ 'boleto' ],
+			'status'               => 'requires_payment_method',
 		];
 		$invalid_status_intent = (object) [
-			'id'     => 'pi_789',
-			'status' => 'canceled',
+			'id'                   => 'pi_789',
+			'payment_method_types' => [
+				WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+				WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
+			],
+			'status'               => 'canceled',
 		];
 
 		return [

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -36,7 +36,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		$this->order           = WC_Helper_Order::create_order();
 		$this->gateway         = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'maybe_process_upe_redirect' ] )
+			->setMethods( [ 'maybe_process_upe_redirect', 'get_intent_from_order', 'get_upe_enabled_at_checkout_payment_method_ids' ] )
 			->getMock();
 		$this->mock_controller = $this->getMockBuilder( 'WC_Stripe_Intent_Controller' )
 			->disableOriginalConstructor()
@@ -113,5 +113,68 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', $test_request, 10, 3 );
 
 		$this->mock_controller->create_payment_intent( $this->order->get_id() );
+	}
+
+	/**
+	 * Test for `get_existing_compatible_payment_intent` method.
+	 *
+	 * @param string|null $associated_intent Associated intent.
+	 * @param string|null $expected Expected result.
+	 * @return void
+	 * @dataProvider provide_test_get_existing_compatible_payment_intent
+	 * @throws WC_Stripe_Exception If invalid payment method type is passed.
+	 */
+	public function test_get_existing_compatible_payment_intent( $associated_intent, $expected ) {
+		$this->gateway
+			->expects( $this->once() )
+			->method( 'get_intent_from_order' )
+			->willReturn( $associated_intent );
+
+		$this->gateway
+			->expects( $this->any() )
+			->method( 'get_upe_enabled_at_checkout_payment_method_ids' )
+			->willReturn(
+				[
+					WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
+				]
+			);
+
+		$actual = $this->mock_controller->get_existing_compatible_payment_intent( $this->order, '' );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Provider for `test_get_existing_compatible_payment_intent` method.
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_existing_compatible_payment_intent() {
+		$compatible_intent     = (object) [
+			'id'                   => 'pi_123',
+			'payment_method_types' => [
+				WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+				WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
+			],
+		];
+		$not_compatible_intent = (object) [
+			'id'                   => 'pi_456',
+			'payment_method_types' => [ 'boleto' ],
+		];
+
+		return [
+			'no intent associated with order' => [
+				'associated intent' => null,
+				'expected'          => null,
+			],
+			'compatible intent found'         => [
+				'associated intent' => $compatible_intent,
+				'expected'          => $compatible_intent,
+			],
+			'no compatible intent found'      => [
+				'associated intent' => $not_compatible_intent,
+				'expected'          => null,
+			],
+		];
 	}
 }

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -212,12 +212,12 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		];
 
 		$this->gateway
-			->expects( $this->any() )
+			->expects( '' === $payment_information['selected_payment_type'] ? $this->once() : $this->never() )
 			->method( 'get_upe_enabled_at_checkout_payment_method_ids' )
 			->willReturn( $mocked_ids );
 
 		$this->gateway
-			->expects( $this->any() )
+			->expects( '' === $payment_information['selected_payment_type'] ? $this->never() : $this->exactly( 2 ) )
 			->method( 'get_upe_enabled_payment_method_ids' )
 			->willReturn( $mocked_ids );
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2761

This PR doesn't point to `develop`, since more work will be needed before these changes get shipped.

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

With the changes from this PR, we can reuse existing payment intents for the same order ID. This way, when a checkout process fails, we will no longer create a new intent for the next try. For this to happen, the payment method types must match.

This should work with all payment methods using [deferred intents](https://stripe.com/docs/payments/accept-a-payment-deferred).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch (`add/reusing-payment-intents`)
- Try to pay for an order by forcing a failure with any payment method ([cards](https://stripe.com/docs/testing#invalid-data), for example)
- Open the Stripe dashboard and confirm that you see a failed payment intent
- Try the purchase again using a working method now ([example](https://stripe.com/docs/testing))
- Reaccess the Stripe dashboard and confirm that the previous payment intent now succeeded

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
