### PR TITLE
Use `statement_descriptor_suffix` for card payments and fallback to Stripe account statement descriptions for all payments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Changelog ***
 
+= 7.9.2 - 2024-xx-xx =
+* Fix - Resolved an issue that could cause card payments to fail when providing a Bank statement description with the `statement_descriptor` parameter.
+* Tweak - The Bank statement description settings in the Stripe plugin settings are no longer editable. The description is now automatically pulled from the Stripe account settings.
+
 = 7.9.1 - 2024-01-16 =
 * Fix - PHP fatal error when updating a user with saved tokens from the WP Dashboard.
 

--- a/client/settings/payments-and-transactions-section/__tests__/index.test.js
+++ b/client/settings/payments-and-transactions-section/__tests__/index.test.js
@@ -103,7 +103,7 @@ describe( 'PaymentsAndTransactionsSection', () => {
 			document.querySelector(
 				'.shortened-bank-statement .transaction-detail.description'
 			)
-		).toHaveTextContent( 'WOOTEST* #123456' );
+		).toHaveTextContent( 'WOOTEST* W #123456' );
 	} );
 
 	it( 'should not show the shortened customer bank statement preview when useIsShortAccountStatementEnabled is false', () => {

--- a/client/settings/payments-and-transactions-section/__tests__/index.test.js
+++ b/client/settings/payments-and-transactions-section/__tests__/index.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import PaymentsAndTransactionsSection from '..';
 import { useAccount } from 'wcstripe/data/account';
 import {
@@ -34,35 +34,27 @@ describe( 'PaymentsAndTransactionsSection', () => {
 			jest.fn(),
 		] );
 		useSeparateCardForm.mockReturnValue( [ true, jest.fn() ] );
-		useAccountStatementDescriptor.mockReturnValue( [
-			'WOOTESTING, LTD',
-			jest.fn(),
-		] );
-		useShortAccountStatementDescriptor.mockReturnValue( [
-			'WOOTESTING',
-			jest.fn(),
-		] );
+		useAccount.mockReturnValue( {
+			data: {
+				account: {
+					settings: {
+						payments: { statement_descriptor: 'WOOTESTING, LTD' },
+						card_payments: {
+							statement_descriptor_prefix: 'WOOTEST',
+						},
+					},
+				},
+			},
+		} );
 		useGetSavingError.mockReturnValue( null );
 		useAccount.mockReturnValue( { data: {} } );
 	} );
 
 	it( 'displays the length of the bank statement input', () => {
-		const updateAccountStatementDescriptor = jest.fn();
-		useAccountStatementDescriptor.mockReturnValue( [
-			'WOOTESTING, LTD',
-			updateAccountStatementDescriptor,
-		] );
 		render( <PaymentsAndTransactionsSection /> );
 
+		// The default bank statement ("WOOTESTING, LTD") is 15 characters long.
 		expect( screen.getByText( '15 / 22' ) ).toBeInTheDocument();
-
-		fireEvent.change( screen.getByLabelText( 'Full bank statement' ), {
-			target: { value: 'New Statement Name' },
-		} );
-
-		expect( updateAccountStatementDescriptor ).toHaveBeenCalledWith(
-			'New Statement Name'
-		);
 	} );
 
 	it( 'shows the shortened bank statement input', () => {
@@ -70,41 +62,21 @@ describe( 'PaymentsAndTransactionsSection', () => {
 			true,
 			jest.fn(),
 		] );
-		const updateShortAccountStatementDescriptor = jest.fn();
-		useShortAccountStatementDescriptor.mockReturnValue( [
-			'WOOTEST',
-			updateShortAccountStatementDescriptor,
-		] );
+
 		render( <PaymentsAndTransactionsSection /> );
 
+		// The default short bank statement ("WOOTEST") is 7 characters long.
 		expect( screen.getByText( '7 / 10' ) ).toBeInTheDocument();
-
-		fireEvent.change(
-			screen.getByLabelText( 'Shortened customer bank statement' ),
-			{
-				target: { value: 'WOOTESTING' },
-			}
-		);
-
-		expect( updateShortAccountStatementDescriptor ).toHaveBeenCalledWith(
-			'WOOTESTING'
-		);
 	} );
 
 	it( 'shows the full bank statement preview', () => {
-		const updateAccountStatementDescriptor = jest.fn();
-		const mockValue = 'WOOTESTING, LTD';
-		useAccountStatementDescriptor.mockReturnValue( [
-			mockValue,
-			updateAccountStatementDescriptor,
-		] );
 		render( <PaymentsAndTransactionsSection /> );
 
 		expect(
 			document.querySelector(
 				'.full-bank-statement .transaction-detail.description'
 			)
-		).toHaveTextContent( mockValue );
+		).toHaveTextContent( 'WOOTESTING, LTD' );
 	} );
 
 	it( 'shows the shortened customer bank statement preview when useIsShortAccountStatementEnabled is true', () => {
@@ -112,19 +84,14 @@ describe( 'PaymentsAndTransactionsSection', () => {
 			true,
 			jest.fn(),
 		] );
-		const updateShortAccountStatementDescriptor = jest.fn();
-		const mockValue = 'WOOTEST';
-		useShortAccountStatementDescriptor.mockReturnValue( [
-			mockValue,
-			updateShortAccountStatementDescriptor,
-		] );
+
 		render( <PaymentsAndTransactionsSection /> );
 
 		expect(
 			document.querySelector(
 				'.shortened-bank-statement .transaction-detail.description'
 			)
-		).toHaveTextContent( `${ mockValue }* #123456` );
+		).toHaveTextContent( 'WOOTEST* #123456' );
 	} );
 
 	it( 'should not show the shortened customer bank statement preview when useIsShortAccountStatementEnabled is false', () => {
@@ -132,12 +99,7 @@ describe( 'PaymentsAndTransactionsSection', () => {
 			false,
 			jest.fn(),
 		] );
-		const updateShortAccountStatementDescriptor = jest.fn();
-		const mockValue = 'WOOTEST';
-		useShortAccountStatementDescriptor.mockReturnValue( [
-			mockValue,
-			updateShortAccountStatementDescriptor,
-		] );
+
 		render( <PaymentsAndTransactionsSection /> );
 
 		expect(
@@ -214,26 +176,5 @@ describe( 'PaymentsAndTransactionsSection', () => {
 				`Customer bank statement is invalid. No special characters: ' " * < >`
 			)
 		).toBeInTheDocument();
-	} );
-
-	it( "shows the account's statement descriptor placeholder", () => {
-		const mockValue = 'WOOTESTING, LTD';
-
-		useAccount.mockReturnValue( {
-			data: {
-				account: {
-					settings: { payments: { statement_descriptor: mockValue } },
-				},
-			},
-		} );
-		useIsShortAccountStatementEnabled.mockReturnValue( [
-			true,
-			jest.fn(),
-		] );
-		render( <PaymentsAndTransactionsSection /> );
-
-		expect(
-			screen.queryByText( 'Full bank statement' ).nextElementSibling
-		).toHaveAttribute( 'placeholder', mockValue );
 	} );
 } );

--- a/client/settings/payments-and-transactions-section/__tests__/index.test.js
+++ b/client/settings/payments-and-transactions-section/__tests__/index.test.js
@@ -46,8 +46,8 @@ describe( 'PaymentsAndTransactionsSection', () => {
 				},
 			},
 		} );
+
 		useGetSavingError.mockReturnValue( null );
-		useAccount.mockReturnValue( { data: {} } );
 	} );
 
 	it( 'displays the length of the bank statement input', () => {
@@ -62,6 +62,18 @@ describe( 'PaymentsAndTransactionsSection', () => {
 			true,
 			jest.fn(),
 		] );
+
+		useAccount.mockReturnValue( {
+			data: {
+				account: {
+					settings: {
+						card_payments: {
+							statement_descriptor_prefix: 'WOOTEST',
+						},
+					},
+				},
+			},
+		} );
 
 		render( <PaymentsAndTransactionsSection /> );
 

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -183,7 +183,7 @@ const PaymentsAndTransactionsSection = () => {
 							<TextControl
 								help={ interpolateComponents( {
 									mixedString: __(
-										"We'll use the shortened descriptor in combination with the customer order number. You can change the shortened description your {{settingsLink}}Stripe account settings{{/settingsLink}}.",
+										"We'll use the shortened descriptor in combination with the customer order number. You can change the shortened description in your {{settingsLink}}Stripe account settings{{/settingsLink}}.",
 										'woocommerce-gateway-stripe'
 									),
 									components: {

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -67,6 +67,12 @@ const PaymentsAndTransactionsSection = () => {
 		data?.account?.settings?.card_payments?.statement_descriptor_prefix ||
 		'';
 
+	// Stripe requires the short statement descriptor suffix to have at least 1 latin character.
+	// To meet this requirement, we use the first character of the full statement descriptor.
+	const shortStatementDescriptorSuffix = stripeAccountShortStatementDescriptor.charAt(
+		0
+	);
+
 	return (
 		<Card className="transactions-and-payouts">
 			<CardBody>
@@ -211,7 +217,7 @@ const PaymentsAndTransactionsSection = () => {
 								'Cards & Express Checkouts',
 								'woocommerce-gateway-stripe'
 							) }
-							text={ `${ stripeAccountShortStatementDescriptor }* #123456` }
+							text={ `${ stripeAccountShortStatementDescriptor }* ${ shortStatementDescriptorSuffix } #123456` }
 							className="shortened-bank-statement"
 						/>
 					) }

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -429,13 +429,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function generate_payment_request( $order, $prepared_payment_method ) {
 		$settings                              = get_option( 'woocommerce_stripe_settings', [] );
-		$statement_descriptor                  = ! empty( $settings['statement_descriptor'] ) ? str_replace( "'", '', $settings['statement_descriptor'] ) : '';
-		$short_statement_descriptor            = ! empty( $settings['short_statement_descriptor'] ) ? str_replace( "'", '', $settings['short_statement_descriptor'] ) : '';
 		$is_short_statement_descriptor_enabled = ! empty( $settings['is_short_statement_descriptor_enabled'] ) && 'yes' === $settings['is_short_statement_descriptor_enabled'];
 		$capture                               = ! empty( $settings['capture'] ) && 'yes' === $settings['capture'] ? true : false;
 		$post_data                             = [];
 		$post_data['currency']                 = strtolower( $order->get_currency() );
 		$post_data['amount']                   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $post_data['currency'] );
+
 		/* translators: 1) blog name 2) order number */
 		$post_data['description'] = sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() );
 		$billing_email            = $order->get_billing_email();
@@ -446,21 +445,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$post_data['receipt_email'] = $billing_email;
 		}
 
-		switch ( $order->get_payment_method() ) {
-			case 'stripe':
-				if ( $is_short_statement_descriptor_enabled && ! ( empty( $short_statement_descriptor ) && empty( $statement_descriptor ) ) ) {
-					$post_data['statement_descriptor'] = WC_Stripe_Helper::get_dynamic_statement_descriptor( $short_statement_descriptor, $order, $statement_descriptor );
-				} elseif ( ! empty( $statement_descriptor ) ) {
-					$post_data['statement_descriptor'] = WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor );
-				}
-
-				$post_data['capture'] = $capture ? 'true' : 'false';
-				break;
-			case 'stripe_sepa':
-				if ( ! empty( $statement_descriptor ) ) {
-					$post_data['statement_descriptor'] = WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor );
-				}
-				// other payment methods error if we try to add a statement descriptor in the request
+		if ( 'stripe' === $order->get_payment_method() ) {
+			$post_data['capture'] = $capture ? 'true' : 'false';
+			if ( $is_short_statement_descriptor_enabled ) {
+				$post_data['statement_descriptor_suffix'] = WC_Stripe_Helper::get_dynamic_statement_descriptor_suffix( $order );
+			}
 		}
 
 		if ( method_exists( $order, 'get_shipping_postcode' ) && ! empty( $order->get_shipping_postcode() ) ) {
@@ -1324,8 +1313,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$request['customer'] = $prepared_source->customer;
 		}
 
-		if ( isset( $full_request['statement_descriptor'] ) ) {
-			$request['statement_descriptor'] = $full_request['statement_descriptor'];
+		if ( isset( $full_request['statement_descriptor_suffix'] ) ) {
+			$request['statement_descriptor_suffix'] = $full_request['statement_descriptor_suffix'];
 		}
 
 		if ( isset( $full_request['shipping'] ) ) {

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -200,4 +200,16 @@ class WC_Stripe_Account {
 		$currencies = array_filter( array_column( $account['external_accounts']['data'], 'currency' ) );
 		return array_values( array_unique( $currencies ) );
 	}
+
+	/**
+	 * Returns the Stripe account's card payment bank statement prefix.
+	 *
+	 * Merchants can set this in their Stripe settings at: https://dashboard.stripe.com/settings/public.
+	 *
+	 * @return string The Stripe Accounts card statement prefix.
+	 */
+	public function get_card_statement_prefix() {
+		$account = $this->get_cached_account_data();
+		return $account['settings']['card_payments']['statement_descriptor_prefix'] ?? '';
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.9.1 - 2024-01-16 =
-* Fix - PHP fatal error when updating a user with saved tokens from the WP Dashboard.
+= 7.9.2 - 2024-xx-xx =
+* Fix - Resolved an issue that could cause card payments to fail when providing a Bank statement description with the `statement_descriptor` parameter.
+* Tweak - The Bank statement description settings in the Stripe plugin settings are no longer editable. The description is now automatically pulled from the Stripe account settings.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -279,7 +279,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			'description'          => $description,
 			'customer'             => $customer_id,
 			'metadata'             => $metadata,
-			'statement_descriptor' => null,
 		];
 
 		$_POST = [ 'wc_payment_intent_id' => $payment_intent_id ];
@@ -1105,7 +1104,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			'customer'             => $customer_id,
 			'metadata'             => $metadata,
 			'setup_future_usage'   => 'off_session',
-			'statement_descriptor' => null,
 		];
 
 		$_POST = [ 'wc_payment_intent_id' => $payment_intent_id ];

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -75,7 +75,6 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 		$currency             = strtolower( $initial_order->get_currency() );
 		$customer             = 'cus_123abc';
 		$source               = 'src_123abc';
-		$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $this->statement_descriptor );
 		$intents_api_endpoint = 'https://api.stripe.com/v1/payment_intents';
 		$urls_used            = [];
 
@@ -112,7 +111,6 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 			$customer,
 			$source,
 			$intents_api_endpoint,
-			$statement_descriptor,
 			$order_id,
 			&$urls_used
 		) {
@@ -154,7 +152,6 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 				'source'               => $source,
 				'amount'               => $stripe_amount,
 				'currency'             => $currency,
-				'statement_descriptor' => $statement_descriptor,
 				'customer'             => $customer,
 				'setup_future_usage'   => 'off_session',
 				'payment_method_types' => [ 'card' ],

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -84,7 +84,6 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$currency                      = strtolower( $renewal_order->get_currency() );
 		$customer                      = 'cus_123abc';
 		$source                        = 'src_123abc';
-		$statement_descriptor          = WC_Stripe_Helper::clean_statement_descriptor( $this->statement_descriptor );
 		$should_retry                  = false;
 		$previous_error                = false;
 		$payments_intents_api_endpoint = 'https://api.stripe.com/v1/payment_intents';
@@ -118,7 +117,6 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 			$currency,
 			$customer,
 			$source,
-			$statement_descriptor,
 			$payments_intents_api_endpoint,
 			&$urls_used
 		) {
@@ -147,7 +145,6 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 				'off_session'          => 'true',
 				'confirm'              => 'true',
 				'confirmation_method'  => 'automatic',
-				'statement_descriptor' => $statement_descriptor,
 			];
 			foreach ( $expected_request_body_values as $key => $value ) {
 				$this->assertArrayHasKey( $key, $request_args['body'] );


### PR DESCRIPTION
Fixes #2830 

## Changes proposed in this Pull Request:

According to [Stripe's docs](https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges), using the `statement_descriptor` parameter for card payments is deprecated since January 2nd 2024. We're suppose to be using `statement_descriptor_suffix` instead. 

No one internally has been able to replicate this issue, however many merchants have already reported this and experiencing this error. 

This PR does a number of things to fix this:

1. Customisable Statement descriptors from within the plugin settings are essentially removed.
   - The Stripe plugin settings screen now pulls the statement descriptions from the Stripe Account. 
   - These fields are no longer editable. 

<p align="center">
<img width="700" alt="Screenshot 2024-01-16 at 5 35 41 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/28d3fa30-4b27-4aa4-8f57-f78b5cc4a728">
</p>

2. To make sure changes that users make to their Stripe Account are instantly reflected in the WC Settings. I've made sure that the account cache is cleared on loading the Stripe settings page. 
3. All transactions now don't pass the `statement_descriptor` arg. 
   - Stripe already sets the transaction statement description to the one set on the account anyway. 
4. If the store has enabled dynamic statement descriptions (the "Add customer order number to the bank statement" setting), Card transactions now provide that via the `statement_descriptor_suffix`.

## Testing instructions

**Base tests**

1. Go to the Stripe plugin settings. 
   - On `develop` you'll notice the bank statement description settings are customisable. 
   - On this branch those text fields are now read only and cannot be changed. I've also added some information about how merchants can update those bank statement descriptors. 

| Before | After |
|--------|--------|
| <img width="714" alt="Screenshot 2024-01-16 at 5 47 11 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/0c5ffc7e-ac3b-4c03-8f43-4d2d535a908c"> | <img width="717" alt="Screenshot 2024-01-17 at 3 57 20 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/52a6147d-372b-4a4b-83ab-9ceaa6ba349f"> | 

2. On this branch switching between checking the "Add customer order number to the bank statement" setting should still toggle the example statement descriptions.
3. Change the statement descriptions in your Stripe settings (https://dashboard.stripe.com/settings/public). Refresh the Stripe plugin settings page and notice the changes are reflected in the settings immediately. 

**Repeat the following steps with both UPE enabled and disabled.**

1. Turn **off** the "Add customer order number to the bank statement" setting.
3. Make a purchase using the Card payment method. 
4. View the transaction in your Stripe dashboard. 
    - It should include a statement descriptor which matches the setting in the Stripe settings and Stripe plugin settings
   
<p align="center">
<img width="300" alt="Screenshot 2024-01-16 at 5 53 51 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/dc26fc67-bc04-4a8a-8181-90b1bee1ddeb">
</p>

5. Place an order and use another PM like **Giropay**. 
   - Note: other APMs don't include bank statement descriptions.
6. Place an order and use **Google** or **Apple pay**.  
7. View the transaction in your Stripe dashboard. 
    - It should include a statement descriptor which matches the setting in the Stripe settings and Stripe plugin settings.
2. Turn **on** the "Add customer order number to the bank statement" setting.
3. Repeat all the example purchases I mentioned above. 
    - APM (Giropay) - Still no statement description.
    - Card payments and express payment methods (Google or Apple Pay) - you should see the statement description now includes the order number.

<p align="center">
<img width="300" alt="Screenshot 2024-01-16 at 6 02 09 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/0b76ad97-fbf8-45f5-8f8f-30f32da10079">
</p>


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
