### PR TITLE
Fix PHP fatal error in WC 8.5.0 when updating a user with saved tokens from the WP dashboard

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 7.9.1 - xxxx-xx-xx =
+* Fix - PHP fatal error when updating a user with saved tokens from the WP Dashboard.
+
 = 7.9.0 - 2024-01-11 =
 * Tweak - Updated supported/tested versions of WordPress and WooCommerce.
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -150,7 +150,12 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @param string $load_address The address to load.
 	 */
 	public function show_update_card_notice( $user_id, $load_address ) {
-		if ( ! $this->saved_cards || ! WC_Stripe_Payment_Tokens::customer_has_saved_methods( $user_id ) || 'billing' !== $load_address ) {
+		if (
+			is_admin() ||
+			! $this->saved_cards ||
+			! WC_Stripe_Payment_Tokens::customer_has_saved_methods( $user_id ) ||
+			'billing' !== $load_address
+		) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.9.0 - 2024-01-11 =
-* Tweak - Updated supported/tested versions of WordPress and WooCommerce.
+= 7.9.1 - xxxx-xx-xx =
+* Fix - PHP fatal error when updating a user with saved tokens from the WP Dashboard.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2834 

## Changes proposed in this Pull Request:

- Bail out early in `WC_Gateway_Stripe::show_update_card_notice()` when the action `woocommerce_customer_save_address` is called from the WP dashboard.

## Testing instructions

**Testing the error isn't triggered anymore**
1. Ensure you have WC 8.5.0 or newer installed
2. Log in as a customer in the WC store
3. Go to My account > Payment methods > Add payment method `siteurl/my-account/add-payment-method/`
4. Add a card, like 4242424242424242
5. As the store admin, go to the edit page for this user `siteurl/wp-admin/users.php`
6. Click on "Update user"
7. Confirm no error is triggered

### Regression tests

**Testing the WC notice continues to be displayed in the frontend**
1. Log in as the customer with the saved cards
2. Go to My account > Addresses > Edit billing address `siteurl/my-account/edit-address/billing/`
3. Click on "Save address"
4. Confirm a WC notice is added at the top of the page saying "If your billing address has been changed for saved payment methods, be sure to remove any [saved payment methods](http://localhost:8082/my-account/payment-methods/) on file and re-add them."
  <img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/8daed5a3-5d9b-4edd-ab32-4288627726f9">

**Testing the WC notice isn't displayed when updating the billing address**

1. Log in as the customer with the saved cards
2. Go to My account > Addresses > Edit shipping address `siteurl/my-account/edit-address/shipping/`
3. Click on "Save address"
4. Confirm the WC notice saying "If your billing address has been changed for saved payment methods..." isn't displayed

**Testing the WC notice isn't displayed when the user doesn't have saved tokens**
1. Log in as a customer with no saved cards (or delete the card for the user you used previously)
2. Go to My account > Addresses > Edit billing address `siteurl/my-account/edit-address/billing/`
3. Click on "Save address"
4. Confirm the WC notice saying "If your billing address has been changed for saved payment methods..." isn't displayed

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
