### PR TITLE
Fix updated settings page bug

### DIFF
--- a/client/settings/general-settings-section/customize-payment-method.js
+++ b/client/settings/general-settings-section/customize-payment-method.js
@@ -1,11 +1,13 @@
 import { __ } from '@wordpress/i18n';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from '@emotion/styled';
 import { Button, TextControl } from '@wordpress/components';
+import { isEqual } from 'lodash';
 import {
 	useCustomizePaymentMethodSettings,
 	useEnabledPaymentMethodIds,
 } from 'wcstripe/data';
+import useConfirmNavigation from 'utils/use-confirm-navigation';
 
 const ButtonWrapper = styled.div`
 	display: flex;
@@ -26,6 +28,20 @@ const CustomizePaymentMethod = ( { method, onClose } ) => {
 	const [ methodName, setMethodName ] = useState( name );
 	const [ methodDescription, setMethodDescription ] = useState( description );
 	const [ methodExpiration, setMethodExpiration ] = useState( expiration );
+
+	const isPristine =
+		isEqual( name, methodName ) &&
+		isEqual( description, methodDescription ) &&
+		isEqual( expiration, methodExpiration );
+	const displayPrompt = ! isPristine;
+	const confirmationNavigationCallback = useConfirmNavigation(
+		displayPrompt
+	);
+
+	useEffect( confirmationNavigationCallback, [
+		displayPrompt,
+		confirmationNavigationCallback,
+	] );
 
 	const onSave = async () => {
 		const data = {

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -307,7 +307,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > Payments accepted on checkout */
 				'enabled_payment_method_ids'            => $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids(),
 				'available_payment_method_ids'          => $available_payment_method_ids,
-				'ordered_payment_method_ids'            => $available_payment_method_ids,
+				'ordered_payment_method_ids'            => array_diff( $available_payment_method_ids, [ 'link' ] ),
 				'individual_payment_method_settings'    => $is_upe_enabled ? [] : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),
 
 				/* Settings > Express checkouts */

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -307,7 +307,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > Payments accepted on checkout */
 				'enabled_payment_method_ids'            => $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids(),
 				'available_payment_method_ids'          => $available_payment_method_ids,
-				'ordered_payment_method_ids'            => array_diff( $available_payment_method_ids, [ 'link' ] ),
+				'ordered_payment_method_ids'            => array_diff( $available_payment_method_ids, [ 'link' ] ), // exclude Link from this list as it is a express methods.
 				'individual_payment_method_settings'    => $is_upe_enabled ? [] : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),
 
 				/* Settings > Express checkouts */


### PR DESCRIPTION
This PR fixes two bugs in the updated settings page.
1. The payment method list crashes when UPE is enabled.
2. Reload confirmation prompt not triggered when a payment method is customized but not saved.

### How to reproduce 1
- Go to the Stripe settings page and enable UPE from the settings tab.
- Go to the payment methods tab. 
- You will see the payment method list is not rendered and there is an error in the console. 

The reason behind this error is, that the `ordered_payment_mthod_ids` object sent from the backend on page load contains `Link`. In the frontend `Link` is not expected in this section as it is not part of the regular methods and does not have mapping for icon, description, etc.

**Expected behavior**
Page should load with the payment method list properly.

### How to reproduce 2
-  Go to the Stripe settings page and disable UPE from the settings tab.
- Go to the payment methods tab and click the `Customize` button beside any method.
- Change name/description and without saving them, try to refresh the page.
- The page will refresh without any warning about unsaved changes.

**Expected behavior**
If you try to refresh the page before saving the customized data, you should see a prompt with a message about unsaved changes.

## Testing instructions
- Go to the Stripe settings page and enable UPE from the settings tab.
- Go to the payment methods tab. 
- The payment method list should render and you should not see any related error in the console.
- Now disable UPE from the settings tab.
- Go to the payment methods tab and click the `Customize` button beside any method.
- Change name/description and without saving them, try to refresh the page.
- A confirmation prompt should appear informing about the unsaved changes.
- Now customize a payment method again and save the changes. 
- Refresh the page. This time you should not see any prompt.