### PR TITLE
Add support for Oxxo & Boleto payments via the Block checkout

### DIFF
--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -47,7 +47,7 @@ Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
 				// Use `false` as fallback values in case server provided configuration is missing.
 				showSavedCards:
 					getBlocksConfiguration()?.showSavedCards ?? false,
-				showSaveOption: upeConfig.isReusable ?? false,
+				showSaveOption: upeConfig.showSaveOption ?? false,
 				features: getBlocksConfiguration()?.supports ?? [],
 			},
 		} );

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -2,27 +2,13 @@ import {
 	registerPaymentMethod,
 	registerExpressPaymentMethod,
 } from '@woocommerce/blocks-registry';
+import { getPaymentMethodsConstants } from '../../stripe-utils/constants';
 import { getDeferredIntentCreationUPEFields } from './upe-deferred-intent-creation/payment-elements.js';
 import { SavedTokenHandler } from './saved-token-handler';
 import paymentRequestPaymentMethod from 'wcstripe/blocks/payment-request';
 import WCStripeAPI from 'wcstripe/api';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
 import './styles.scss';
-
-// Register Stripe UPE.
-const upeMethods = {
-	card: 'stripe',
-	bancontact: 'stripe_bancontact',
-	au_becs_debit: 'stripe_au_becs_debit',
-	eps: 'stripe_eps',
-	giropay: 'stripe_giropay',
-	ideal: 'stripe_ideal',
-	p24: 'stripe_p24',
-	sepa_debit: 'stripe_sepa_debit',
-	sofort: 'stripe_sofort',
-	affirm: 'stripe_affirm',
-	afterpay_clearpay: 'stripe_afterpay_clearpay',
-};
 
 const api = new WCStripeAPI(
 	getBlocksConfiguration(),
@@ -34,6 +20,7 @@ const api = new WCStripeAPI(
 	}
 );
 
+const upeMethods = getPaymentMethodsConstants();
 Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
 	.filter( ( [ upeName ] ) => upeName !== 'link' )
 	.forEach( ( [ upeName, upeConfig ] ) => {

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -47,8 +47,7 @@ Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
 				// Use `false` as fallback values in case server provided configuration is missing.
 				showSavedCards:
 					getBlocksConfiguration()?.showSavedCards ?? false,
-				showSaveOption:
-					getBlocksConfiguration()?.showSaveOption ?? false,
+				showSaveOption: upeConfig.isReusable ?? false,
 				features: getBlocksConfiguration()?.supports ?? [],
 			},
 		} );

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -5,10 +5,10 @@ import { Elements } from '@stripe/react-stripe-js';
 import PaymentProcessor from './payment-processor';
 import WCStripeAPI from 'wcstripe/api';
 import {
-	getStripeServerData,
 	getPaymentMethodTypes,
 	initializeUPEAppearance,
 } from 'wcstripe/stripe-utils';
+import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
 
 /**
  * Renders a Stripe Payment elements component.
@@ -21,8 +21,8 @@ import {
  */
 const PaymentElements = ( { api, ...props } ) => {
 	const stripe = api.getStripe();
-	const amount = Number( getStripeServerData()?.cartTotal );
-	const currency = getStripeServerData()?.currency.toLowerCase();
+	const amount = Number( getBlocksConfiguration()?.cartTotal );
+	const currency = getBlocksConfiguration()?.currency.toLowerCase();
 	const appearance = initializeUPEAppearance();
 
 	return (

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -170,6 +170,14 @@ const PaymentProcessor = ( {
 								},
 							},
 						} );
+
+					if ( paymentMethodObject.error ) {
+						return {
+							type: 'error',
+							message: paymentMethodObject.error.message,
+						};
+					}
+
 					return {
 						type: 'success',
 						meta: {

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -689,7 +689,16 @@ class WC_Stripe_Helper {
 	 * @return boolean
 	 */
 	public static function has_cart_or_checkout_on_current_page() {
-		return is_cart() || is_checkout() || has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
+		return is_cart() || is_checkout() || self::has_cart_or_checkout_block_on_current_page();
+	}
+
+	/**
+	 * Checks if this page has a cart or checkout block.
+	 *
+	 * @return bool
+	 */
+	public static function has_cart_or_checkout_block_on_current_page() {
+		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
 	}
 
 	/**

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -689,16 +689,7 @@ class WC_Stripe_Helper {
 	 * @return boolean
 	 */
 	public static function has_cart_or_checkout_on_current_page() {
-		return is_cart() || is_checkout() || self::has_cart_or_checkout_block_on_current_page();
-	}
-
-	/**
-	 * Checks if this page has a cart or checkout block.
-	 *
-	 * @return bool
-	 */
-	public static function has_cart_or_checkout_block_on_current_page() {
-		return has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
+		return is_cart() || is_checkout() || has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -759,7 +759,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				sprintf( __( 'Payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getLocalizedMessage() )
 			);
 
-			throw new Exception( $shopper_error_message );
+			return [
+				'result' => 'failure',
+				'redirect' => '',
+			];
 		}
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -759,7 +759,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				sprintf( __( 'Payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getLocalizedMessage() )
 			);
 
-			return [ 'result' => 'failure' ];
+			throw new Exception( $shopper_error_message );
 		}
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -313,7 +313,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 		}
 
-		$stripe_params['isCheckout']                       = is_checkout() && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
+		$stripe_params['isCheckout']                       = ( is_checkout() || has_block( 'woocommerce/checkout' ) ) && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
 		$stripe_params['return_url']                       = $this->get_stripe_return_url();
 		$stripe_params['ajax_url']                         = WC_AJAX::get_endpoint( '%%endpoint%%' );
 		$stripe_params['theme_name']                       = get_option( 'stylesheet' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -257,6 +257,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			true
 		);
 
+		wp_register_style( 'stripelink_styles', plugins_url( 'assets/css/stripe-link.css', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION );
+		wp_enqueue_style( 'stripelink_styles' );
+
+		// The rest of this function is specific to classic pages so bail if we're not on one.
+		if ( WC_Stripe_Helper::has_cart_or_checkout_block_on_current_page() ) {
+			return;
+		}
+
 		wp_register_script(
 			'wc-stripe-upe-classic',
 			WC_STRIPE_PLUGIN_URL . '/build/upe_classic.js',
@@ -284,9 +292,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		wp_enqueue_script( 'wc-stripe-upe-classic' );
 		wp_enqueue_style( 'wc-stripe-upe-classic' );
-
-		wp_register_style( 'stripelink_styles', plugins_url( 'assets/css/stripe-link.css', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION );
-		wp_enqueue_style( 'stripelink_styles' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -387,9 +387,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		foreach ( $enabled_payment_methods as $payment_method ) {
 			$settings[ $payment_method ] = [
-				'isReusable' => $this->payment_methods[ $payment_method ]->is_reusable(),
-				'title' => $this->payment_methods[ $payment_method ]->get_title(),
+				'isReusable'          => $this->payment_methods[ $payment_method ]->is_reusable(),
+				'title'               => $this->payment_methods[ $payment_method ]->get_title(),
 				'testingInstructions' => $this->payment_methods[ $payment_method ]->get_testing_instructions(),
+				'showSaveOption'      => $this->payment_methods[ $payment_method ]->should_show_save_option(),
 			];
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -257,14 +257,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			true
 		);
 
-		wp_register_style( 'stripelink_styles', plugins_url( 'assets/css/stripe-link.css', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION );
-		wp_enqueue_style( 'stripelink_styles' );
-
-		// The rest of this function is specific to classic pages so bail if we're not on one.
-		if ( WC_Stripe_Helper::has_cart_or_checkout_block_on_current_page() ) {
-			return;
-		}
-
 		wp_register_script(
 			'wc-stripe-upe-classic',
 			WC_STRIPE_PLUGIN_URL . '/build/upe_classic.js',
@@ -292,6 +284,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		wp_enqueue_script( 'wc-stripe-upe-classic' );
 		wp_enqueue_style( 'wc-stripe-upe-classic' );
+
+		wp_register_style( 'stripelink_styles', plugins_url( 'assets/css/stripe-link.css', WC_STRIPE_MAIN_FILE ), [], WC_STRIPE_VERSION );
+		wp_enqueue_style( 'stripelink_styles' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -400,7 +400,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 				<div id="wc-<?php echo esc_attr( $this->id ); ?>-upe-errors" role="alert"></div>
 			</fieldset>
 			<?php
-			if ( $this->is_saved_cards_enabled() && $this->is_reusable() ) {
+			if ( $this->should_show_save_option() ) {
 				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
 				if ( is_user_logged_in() ) {
 					$this->save_payment_method_checkbox( $force_save_payment );
@@ -424,6 +424,15 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 */
 	public function is_saved_cards_enabled() {
 		return 'yes' === $this->get_option( 'saved_cards' );
+	}
+
+	/**
+	 * Determines if this payment method should show the save to account checkbox.
+	 *
+	 * @return bool
+	 */
+	public function should_show_save_option() {
+		return $this->is_reusable() && $this->is_saved_cards_enabled();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2790

## Changes proposed in this Pull Request:

The changes in this PR are pretty small. @mattallan added most of the changes necessary to get Boleto and Oxxo to work on the block checkout page in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2823 

## Testing instructions

_These testing instructions are largely copied from Matt's PR._

**Pre-requisites**

- Separate Stripe merchant accounts located in Brazil and Mexico
- Ability to receive webhooks from Stripe (I use ngrok)

#### Testing Boleto

1. Go to **WooCommerce > Settings > General** and set your store's currency to Brazilian real (R$)
2. Go to **WooCommerce > Settings > Payments > Stripe > Settings** (panel) (/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings)
4. Click on edit keys and update the private, secret and webhook keys to your Stripe Brazil store
> [!WARNING]
> If this is not a fresh store and you are connecting a different Stripe account, you will need to go into the `usermeta` and delete the row with `meta_key` `wp__stripe_customer_id` as the existing customer ID won't exist in the Brazil store.
4. From the shop page, add a product to the cart and proceed to the block checkout
6. Enter a [valid Brazilian address](https://www.fakeaddressgenerator.com/World/Brazil_address_generator) with an email that fits the `{any_prefix}@{any_domain}` format (i.e. test@example.com)
7. Select Boleto on the block checkout and enter `00.000.000/0000-00` into the text box.
8. Click on "Place Order" and you should see a pop-up window for the voucher.
9. Closing the voucher should redirect you to the order received page.
10. If you have webhooks setup properly, the order should be on-hold almost immediately.
11. Wait 3mins for the success webhook to come through and confirm the order is updated to processing

**Boleto error testing**

Stripe docs on testing Boleto: https://stripe.com/docs/payments/boleto/accept-a-payment?platform=checkout#test-integration

1. **Testing with an expired voucher**
   1. Add the product to the cart and go to the block checkout
   2. While on the block checkout set your email to `expire_immediately@example.com`
   3. Select Boleto and fill in the tax ID field with `00.000.000/0000-00`
   4. Placing the order should show a popup with a voucher that has expired
   5. Closing the window should send you to the order received page with a Pay link
   6. Navigate to the WooCommerce > Orders and confirm the order is set to failed status
2. **Testing invalid checkout errors**
   1. Add product to the cart and navigate to the block checkout
   2. Set your country to something other than Brazil (i.e. Australia)
   3. Select Boleto and fill in the tax ID field with `00.000.000/0000-00`
   4. Placing the order should show an error on the block checkout.

#### Testing Oxxo

Testing Oxxo is the same as Boleto above, except you'll need to connect a Stripe account set in Mexico and set your store's currency to **Mexican Peso**. A few things to note:

- Make sure you reset your billing email back to test@example.com or something other than `expire_immediately@example` so that the vouchers don't expire immediately.

#### Testing APM errors

This PR also fixes error processing when using APMS on the block checkout. 

These are some sketchy steps to replicate but the easiest way to see this with APMs is to following these steps: 

1. In your database go to the `usermeta` table. 
2. Search for `wp__stripe_customer_id` 
3. Alter your customer ID so it's invalid. 
4. On `add/deferred-intent` branch (base branch) attempt to make a purchase with any payment method other than a card. 
   - You should get a generic `Something went wrong. Please contact us to get assistance.` error and the follow warning in your error logs. `PHP Warning:  Undefined array key "redirect" in /plugins/woocommerce/src/StoreApi/Legacy.php on line 68
`
5. Checkout this branch and repeat. 
 - you should see a localised message to the payment method section and it should indicate what actually went wrong. You should also no longer get the redirect PHP error. 

<img width="1090" alt="Screenshot 2024-01-19 at 3 48 09 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/16354d88-2fa7-456b-9511-df5bb7874761">


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
