### PR TITLE
Add filters to statement descriptors

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -429,8 +429,18 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function generate_payment_request( $order, $prepared_payment_method ) {
 		$settings                              = get_option( 'woocommerce_stripe_settings', [] );
-		$statement_descriptor                  = ! empty( $settings['statement_descriptor'] ) ? str_replace( "'", '', $settings['statement_descriptor'] ) : '';
-		$short_statement_descriptor            = ! empty( $settings['short_statement_descriptor'] ) ? str_replace( "'", '', $settings['short_statement_descriptor'] ) : '';
+		$statement_descriptor                  = apply_filters(
+			'wc_stripe_payment_statement_descriptor',
+			! empty( $settings['statement_descriptor'] ) ? str_replace( "'", '', $settings['statement_descriptor'] ) : '',
+			$order,
+			$prepared_payment_method
+		);
+		$short_statement_descriptor            = apply_filters(
+			'wc_stripe_payment_short_statement_descriptor',
+			! empty( $settings['short_statement_descriptor'] ) ? str_replace( "'", '', $settings['short_statement_descriptor'] ) : '',
+			$order,
+			$prepared_payment_method
+		);
 		$is_short_statement_descriptor_enabled = ! empty( $settings['is_short_statement_descriptor_enabled'] ) && 'yes' === $settings['is_short_statement_descriptor_enabled'];
 		$capture                               = ! empty( $settings['capture'] ) && 'yes' === $settings['capture'] ? true : false;
 		$post_data                             = [];


### PR DESCRIPTION
Add filters to statement descriptors, allowinf 3rd party developers to change the default bank statement defind on the settings.

Fixes #2841

## Changes proposed in this Pull Request:

As explained on the original issue, it creates the possibility to change the bank statement descriptor, for example if you're running a multi language store with different URL or comercial name per language.

The reason I think these filters are useful is that if we use the, more generic, `wc_stripe_generate_payment_request` filter, the variables won't go through the helper cleaner functions.

## Testing instructions

Add a filter on `wc_stripe_payment_statement_descriptor` or `wc_stripe_payment_short_statement_descriptor` and return a different string.
