### PR TITLE
Add placeholder in the account card when no email address is available

### DIFF
--- a/client/settings/payment-settings/account-details-section.js
+++ b/client/settings/payment-settings/account-details-section.js
@@ -77,9 +77,15 @@ const AccountDetailsSection = ( { setModalType, setKeepModalContent } ) => {
 		<Card className="account-details">
 			<CardHeader>
 				<HeaderDetails>
-					{ data.account?.email && (
-						<h4>( { data.account.email } )</h4>
-					) }
+					<h4>
+						{ data.account?.email
+							? data.account.email
+							: __(
+									'Account status',
+									'woocommerce-gateway-stripe'
+							  ) }
+					</h4>
+
 					{ isTestModeEnabled && (
 						<Pill>
 							{ __( 'Test Mode', 'woocommerce-gateway-stripe' ) }


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Add "Account status" as a placeholder to the "Account details" card when Stripe returns no email for the account object.

[According to the docs](https://stripe.com/docs/api/accounts/object#account_object-email), the "email" property under the "account" object is nullable. This PR handles the interface when this property is null.

Smallest PR ever 🙂 From the comments in this other PR https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2740. Instead of just "Account", I used "Account status" because it's what we used before. Glad to update it.

## Testing instructions

- Go to the Stripe > Setting tab > Account details section, in `siteurl/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
- In [this line](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/client/settings/payment-settings/account-details-section.js#L75), set `data.account.email` to `null` 
- Confirm that "Account status" shows up as the card header
- Set `data.account.email` to `merchant@email.com` in the same line before
- Confirm that this email address continues to show up as the card header


| Before | After |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/d7089c27-1cbe-45db-ad84-12acd829c54e) | ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/627b41f5-ddcf-4bb9-ba81-ddd7ef8394e0) |

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)