### PR TITLE
Add background color and a grab pointer to the draggable payment methods

### DIFF
--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -60,6 +60,8 @@ const DraggableList = styled( Reorder.Group )`
 	> li {
 		margin: 0;
 		padding: 16px 24px 14px 24px;
+		background-color: #fff;
+		cursor: grab;
 
 		@media ( min-width: 660px ) {
 			padding: 24px 24px 24px 24px;


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Add a background color to the draggable list items, so the content of the ones in the background isn't visible while dragging
- Add a "grab" cursor when hovering over the draggable list items, so it "feels" they are interactive

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

| Before | After |
|--------|--------|
|![iW2dG4.gif](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/455e70ed-91fe-4266-af98-ce3393d01bd1) | ![84MrbP.gif](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/1547d2b1-6dff-4dc0-bf20-f2c5e50383e1) | 

## Testing instructions

1. Disable UPE. Under Stripe > Settings tab (`siteurl/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`) > Advanced settings > Enable the updated checkout experience
2. Go to the Payment methods tab (`siteurl/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`)
3. Click on "Change display order"
4. Hover over the payment method types 
5. Confirm the cursor is of a "grab" type, and not the regular style
6. Drag one of the items in the list
7. Confirm that the content of the items in the background is covered by the item being dragged


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)