### PR TITLE
Split PE - Fixes Woo Subscriptions support when using card payments with dPE

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -166,16 +166,17 @@ export default class WCStripeAPI {
 	/**
 	 * Creates and confirms a setup intent.
 	 *
-	 * @param {string} paymentMethodId The id of the payment method.
+	 * @param {Object} paymentMethod The id of the payment method.
 	 *
 	 * @return {Promise} Promise containing the setup intent.
 	 */
-	setupIntent( paymentMethodId ) {
+	setupIntent( paymentMethod ) {
 		return this.request(
 			this.getAjaxUrl( 'create_and_confirm_setup_intent' ),
 			{
 				action: 'create_and_confirm_setup_intent',
-				'wc-stripe-payment-method': paymentMethodId,
+				'wc-stripe-payment-method': paymentMethod.id,
+				'wc-stripe-payment-type': paymentMethod.type,
 				_ajax_nonce: this.options?.createAndConfirmSetupIntentNonce,
 			}
 		).then( ( response ) => {

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -166,7 +166,9 @@ export default class WCStripeAPI {
 	/**
 	 * Creates and confirms a setup intent.
 	 *
-	 * @param {Object} paymentMethod The id of the payment method.
+	 * @param {Object} paymentMethod      Payment method data.
+	 * @param {string} paymentMethod.id   The ID of the payment method.
+	 * @param {string} paymentMethod.type The type of the payment method.
 	 *
 	 * @return {Promise} Promise containing the setup intent.
 	 */

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -63,11 +63,14 @@ jQuery( function ( $ ) {
 
 	// Pay for Order page submit.
 	$( '#order_review' ).on( 'submit', () => {
-		return processPayment(
-			api,
-			$( '#order_review' ),
-			getSelectedUPEGatewayPaymentMethod()
-		);
+		const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
+		if ( ! isUsingSavedPaymentMethod( paymentMethodType ) ) {
+			return processPayment(
+				api,
+				$( '#order_review' ),
+				paymentMethodType
+			);
+		}
 	} );
 
 	// If the card element selector doesn't exist, then do nothing.

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -269,7 +269,7 @@ export const createAndConfirmSetupIntent = (
 	api
 ) => {
 	return api
-		.setupIntent( paymentMethod.id )
+		.setupIntent( paymentMethod )
 		.then( function ( confirmedSetupIntent ) {
 			appendSetupIntentToForm( jQueryForm, confirmedSetupIntent );
 			return confirmedSetupIntent;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -880,4 +880,21 @@ class WC_Stripe_Helper {
 
 		return null;
 	}
+
+	/**
+	 * Returns the payment intent or setup intent id method ID from a given intent object.
+	 *
+	 * @param WC_Order $order The order to fetch the Stripe intent from.
+	 *
+	 * @return string|bool  The intent ID if found, false otherwise.
+	 */
+	public static function get_intent_id_from_order( $order ) {
+		$intent_id = $order->get_meta( '_stripe_intent_id' );
+
+		if ( ! $intent_id ) {
+			$intent_id = $order->get_meta( '_stripe_setup_intent' );
+		}
+
+		return $intent_id ?? false;
+	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -882,7 +882,7 @@ class WC_Stripe_Helper {
 	}
 
 	/**
-	 * Returns the payment intent or setup intent id method ID from a given intent object.
+	 * Returns the payment intent or setup intent ID from a given order object.
 	 *
 	 * @param WC_Order $order The order to fetch the Stripe intent from.
 	 *

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -713,7 +713,7 @@ class WC_Stripe_Intent_Controller {
 		];
 
 		// For Stripe Link & SEPA with deferred intent UPE, we must create mandate to acknowledge that terms have been shown to customer.
-		if ( ! $this->is_mandate_data_required( $selected_payment_type ) ) {
+		if ( $this->is_mandate_data_required( $selected_payment_type ) ) {
 			$request = $this->add_mandate_data( $request );
 		}
 
@@ -919,7 +919,7 @@ class WC_Stripe_Intent_Controller {
 		];
 
 		// SEPA setup intents require mandate data.
-		if ( ! $this->is_mandate_data_required( $payment_information['selected_payment_type'] ) ) {
+		if ( $this->is_mandate_data_required( $payment_information['selected_payment_type'] ) ) {
 			$request = $this->add_mandate_data( $request );
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -888,7 +888,7 @@ class WC_Stripe_Intent_Controller {
 	 * This applies to SEPA and Link payment methods.
 	 * https://stripe.com/docs/payments/finalize-payments-on-the-server
 	 *
-	 * @param $selected_payment_type The name of the selected UPE payment type.
+	 * @param string $selected_payment_type The name of the selected UPE payment type.
 	 *
 	 * @return bool True if a mandate must be shown and acknowledged by customer before deferred intent UPE payment can be processed, false otherwise.
 	 */

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -562,7 +562,7 @@ class WC_Stripe_Intent_Controller {
 				throw new WC_Stripe_Exception( 'order_not_found', __( "We're not able to process this payment. Please try again later.", 'woocommerce-gateway-stripe' ) );
 			}
 
-			$intent_id          = $order->get_meta( '_stripe_intent_id' );
+			$intent_id          = WC_Stripe_Helper::get_intent_id_from_order( $order );
 			$intent_id_received = isset( $_POST['intent_id'] ) ? wc_clean( wp_unslash( $_POST['intent_id'] ) ) : null;
 			if ( empty( $intent_id_received ) || $intent_id_received !== $intent_id ) {
 				$note = sprintf(

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -923,6 +923,13 @@ class WC_Stripe_Intent_Controller {
 			$request = $this->add_mandate_data( $request );
 		}
 
+		/**
+		 * When the setup intent is being created from a checkout request, i.e. purchasing a subscription product
+		 * with a free trial, send the setup_intents request with level3 and order data.
+		 *
+		 * If the given $payment_information doesn't have the level3 or order data i.e. creating a setup intent from the Add Payment Method
+		 * page, send off a generic Stripe request.
+		 */
 		if ( isset( $payment_information['level3'], $payment_information['order'] ) ) {
 			$setup_intent = WC_Stripe_API::request_with_level3_data(
 				$request,

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -919,7 +919,7 @@ class WC_Stripe_Intent_Controller {
 		];
 
 		// SEPA setup intents require mandate data.
-		if ( ! $this->is_mandate_data_required( $selected_payment_type ) ) {
+		if ( ! $this->is_mandate_data_required( $payment_information['selected_payment_type'] ) ) {
 			$request = $this->add_mandate_data( $request );
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -923,23 +923,7 @@ class WC_Stripe_Intent_Controller {
 			$request = $this->add_mandate_data( $request );
 		}
 
-		/**
-		 * When the setup intent is being created from a checkout request, i.e. purchasing a subscription product
-		 * with a free trial, send the setup_intents request with level3 and order data.
-		 *
-		 * If the given $payment_information doesn't have the level3 or order data i.e. creating a setup intent from the Add Payment Method
-		 * page, send off a generic Stripe request.
-		 */
-		if ( isset( $payment_information['level3'], $payment_information['order'] ) ) {
-			$setup_intent = WC_Stripe_API::request_with_level3_data(
-				$request,
-				'setup_intents',
-				$payment_information['level3'],
-				$payment_information['order']
-			);
-		} else {
-			$setup_intent = WC_Stripe_API::request( $request, 'setup_intents' );
-		}
+		$setup_intent = WC_Stripe_API::request( $request, 'setup_intents' );
 
 		if ( ! empty( $setup_intent->error ) ) {
 			throw new WC_Stripe_Exception( print_r( $setup_intent->error, true ), $setup_intent->error->message );

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -42,7 +42,7 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	 * @return bool
 	 */
 	public function is_changing_payment_method_for_subscription() {
-		if ( isset( $_GET['change_payment_method'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_GET['change_payment_method'] ) && function_exists( 'wcs_is_subscription' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			return wcs_is_subscription( wc_clean( wp_unslash( $_GET['change_payment_method'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification
 		}
 		return false;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -715,7 +715,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					$payment_information['payment_method'],
 					$selected_payment_type
 				);
-			} else if ( $payment_information['is_using_saved_payment_method'] ) {
+			} elseif ( $payment_information['is_using_saved_payment_method'] ) {
 				$this->maybe_update_source_on_subscription_order(
 					$order,
 					(object) [

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -781,7 +781,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 						'payment_method' => $payment_information['payment_method'],
 					]
 				);
-			} else {
+			} elseif ( in_array( $payment_intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
 				$order->payment_complete();
 			}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -712,6 +712,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 						$payment_information['payment_method'],
 						$selected_payment_type
 					);
+				} else if ( $payment_information['is_using_saved_payment_method'] ) {
+					$this->maybe_update_source_on_subscription_order(
+						$order,
+						(object) [
+							'payment_method' => $payment_information['payment_method'],
+							'customer'       => $payment_information['customer'],
+						]
+					);
 				}
 
 				// Use the last charge within the intent to proceed.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

For #2777 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes compatibility issues with Woo Subscriptions and our new Split PE with deferred intent changes. In my testing there were three main issues I found:
1. Subscriptions purchased with an existing saved card remain on-hold after processing a renewal.
2. Attempting to purchase a subscription that had a free trial or was synced, resulted in a generic error on the checkout.
3. Error when attempting to change a subscription's payment method to an existing card.

I have addressed the above issues in the following commits:
- e2fa15d1524a36d92bae8af797a62d64c590791b - fixes the first issue by making sure we call [`maybe_update_source_on_subscription_order()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/2ff2d6815f34dac261d8ead11b11e1af8efea310/includes/compat/trait-wc-stripe-subscriptions.php#L390) whenever we're using an existing saved payment method so that the `pm_` and `cus_` tokens are saved on the subscription. This function was already being handled when a new card was being saved (see inside [`handle_saving_payment_method()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/2ff2d6815f34dac261d8ead11b11e1af8efea310/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L1848)), but not when an existing card was used.
- 9bc5fc67d5abf7e7848c06d89bc286ba4dc5567b - fixes the second issue by adding support for creating setup intents inside  `process_payment_with_deferred_intent()` for purchases that don't have an upfront payment but still require the card to be taken for future payments i.e. a subscription with a free trial. This single commit ended up being a bit larger than I typically like however, it can be broken down into the following changes:
  - Refactor the `intent_controller->create_and_confirm_setup_intent()` function so that it can handle requests from the front-end (My Account > Payment methods > Add new) and our `process_payment_with_deferred_intent()` function.
  - Update the `process_payment_with_deferred_intent()` to add functionality when `$payment_needed` is false. When no payment needed and we're inside the process_payment flow, it's expected for a setup intent to be created.
  - I moved the code that saves the stripe meta to the order and the handling of saving a new card outside of the needs_payment condition so that it's run when we're using payment intents and setup intents.
  - When payment is not needed, don't process the charge and instead mark the order as complete.
- 86d3d62ead7f3a28970b7c323a786f122da318d9 - fixes the final issue by not calling `processPayment` when a customer is changing payment method to an existing saved card.


## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Before testing, make sure you have:
- the latest Woo Subscriptions installed and activated,
- a simple subscription product and another with a free trial period

There are a lot of subscription flows to cover and rather than go through them all here, I'll link to our testing instructions for the critical subscription flows:
- [Shopper subscription flows](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#shopper-subscriptions-1)
- [Merchant subscription flows](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Testing-instructions-for-critical-flows-using-the-classic-checkout-experience#merchant-subscriptions-1)

#### Purchasing and renewing subscriptions

1. Add the simple subscription product to your cart
2. Navigate to the checkout page and confirm only reusable payment methods are visible
3. Complete the checkout using a new card
4. Visit WP Admin > WooCommerce > Subscriptions and view the newly purchased subscription
5. On the Edit Subscription admin page, click on the pencil icon in the Billing Details section and confirm the Stripe customer ID and source ID (`pm_1234`) are correctly saved on the subscription ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/d2eadda1-6c9b-44de-afcf-e9043b20297a)
6. Use the Order Actions to process an automatic renewal for the subscription: ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/083b342f-998a-408a-ac77-82d11166cedf)
7. Confirm the renewal order is created and is processing, and confirm the subscription is active.
8. Confirm the payment in Stripe

#### Purchasing and renewing subscriptions with setup intents

1. Follow the above steps except this time add a subscription product with a trial period
2. Confirm the new card you added above, is now in your list of saved cards (to confirm new cards used to purchase subscriptions are always saved)
3. Use a saved card this time instead of adding a new one
4. Confirm there's no payment for the initial purchase.
5. After processing a renewal order, confirm the charge in Stripe.

#### Changing subscriptions payment method

> [!NOTE]
> Before running this test, make sure you have at least 2 active subscriptions to test updating all payment methods.

1. From the frontend of your store, go to My Account > Subscriptions and click to view one of your active subscriptions
2. Click on the Change payment button![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/e128e594-f5ca-4ee7-a846-9a02448f3b96)
3. Choose a new card number that differs from your existing card i.e. if your subscription has the visa `4242424242424242`, change the payment to mastercard `5555555555554444` so it's easier to notice the difference
6. Check the "Update the payment method used for all of my current subscriptions (optional)" box and submit the form
7. Go back to My Account > Subscriptions to confirm all of your active subscriptions now have the updated payment method ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/84f9db84-9328-4d1b-9ca5-8cdaa29724a9)
8. Process a subscription renewal using the Edit Subscription actions shown in the previous tests and confirm the new/changed card is used to process the subscription.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
