### PR TITLE
Split UPE - Prevent loading JS scripts when all payment methods are disabled

### DIFF
--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -51,20 +51,20 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return boolean
 	 */
 	public function is_active() {
-		// If Stripe isn't enabled, then we don't need to check anything else.
+		// If Stripe isn't enabled, then we don't need to check anything else - it isn't active.
 		if ( empty( $this->settings['enabled'] ) || 'yes' !== $this->settings['enabled'] ) {
 			return false;
 		}
 
-		// If UPE is disabled, then we don't need to check anything else.
+		// If UPE is disabled, then we don't need to go further - we know the gateway is enabled.
 		$stripe_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
 
 		if ( ! is_a( $stripe_gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
 			return true;
 		}
 
+		// This payment method is active if there is at least 1 UPE method available.
 		foreach ( $stripe_gateway->payment_methods as $upe_method ) {
-			// Exit once we've found one of our UPE methods.
 			if ( $upe_method->is_enabled() && $upe_method->is_available() ) {
 				return true;
 			}


### PR DESCRIPTION
Fixes #2865 

## Changes proposed in this Pull Request:

This PR fixes the following JS error if you disable all payment methods, including cards. 

```
index.js:24 Uncaught TypeError: Cannot convert undefined or null to object
    at entries (<anonymous>)
    at ./client/blocks/upe/index.js (index.js:24:1)
    at __webpack_require__ (upe_blocks.js?ver=b65b5b1030ced18a6fe92b14ac363333:20:30)
    at upe_blocks.js?ver=b65b5b1030ced18a6fe92b14ac363333:84:18
    at upe_blocks.js?ver=b65b5b1030ced18a6fe92b14ac363333:87:10
```

## Testing instructions

1. Go to **WooCommerce → Settings → Payments → Stripe (Settings)**
2. Enable UPE in the advanced section.
3. Go to the Payment methods tab and disable all payment methods (including cards).

<p align="center">
<img width="300" alt="Screenshot 2024-01-29 at 4 25 11 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c5aaf2f4-a4c4-449f-9acd-ecc57a0a2bd1">
</p>

5. Add a product to the cart and go to the block checkout page and view the browser console.
   - On `add/deferred-intent` branch you should see the error message above.
   - On this branch no error is observered.
6. Disable UPE in Stripe _advanced_ settings, make sure that the the block checkout still works with and without Stripe enabled.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
