### PR TITLE
Hide Sofort from the settings page when it's disabled and UPE is enabled

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -113,8 +113,19 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'add_payment_method',
 		];
 
+		$enabled_payment_methods = $this->get_upe_enabled_payment_method_ids();
+		$is_sofort_enabled       = in_array( 'sofort', $enabled_payment_methods, true );
+
 		$this->payment_methods = [];
 		foreach ( self::UPE_AVAILABLE_METHODS as $payment_method_class ) {
+
+			/** Show Sofort if it's already enabled. Hide from the new merchants and keep it for the old ones who are already using this gateway, until we remove it completely.
+			 * Stripe is deprecating Sofort https://support.stripe.com/questions/sofort-is-being-deprecated-as-a-standalone-payment-method.
+			 */
+			if ( WC_Stripe_UPE_Payment_Method_Sofort::class === $payment_method_class && ! $is_sofort_enabled ) {
+				continue;
+			}
+
 			$payment_method                                     = new $payment_method_class();
 			$this->payment_methods[ $payment_method->get_id() ] = $payment_method;
 		}
@@ -145,7 +156,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] ) {
-			$enabled_payment_methods_count = count( $this->get_upe_enabled_payment_method_ids() );
+			$enabled_payment_methods_count = count( $enabled_payment_methods );
 			$this->title                   = $enabled_payment_methods_count ?
 				/* translators: $1. Count of enabled payment methods. */
 				sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count )

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -290,13 +290,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		);
 		$response = $this->rest_get_settings();
 
-		$expected_method_ids = WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS;
-		$expected_method_ids = array_map(
-			function ( $method_class ) {
-				return $method_class::STRIPE_ID;
-			},
-			$expected_method_ids
-		);
+		$expected_method_ids = array_keys( $this->get_gateway()->payment_methods );
 
 		$available_method_ids = $response->get_data()['available_payment_method_ids'];
 
@@ -323,19 +317,11 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		);
 		$response = $this->rest_get_settings();
 
-		$expected_method_ids = WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS;
-		$expected_method_ids = array_map(
-			function ( $method_class ) {
-				return $method_class::STRIPE_ID;
-			},
-			$expected_method_ids
-		);
-		$expected_method_ids = array_filter(
-			$expected_method_ids,
-			function ( $method_id ) {
-				return 'link' !== $method_id;
-			}
-		);
+		$expected_methods = $this->get_gateway()->payment_methods;
+
+		unset( $expected_methods['link'] );
+
+		$expected_method_ids = array_keys( $expected_methods );
 
 		$ordered_method_ids = $response->get_data()['ordered_payment_method_ids'];
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -230,7 +230,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					WC_Stripe_UPE_Payment_Method_Oxxo::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_P24::STRIPE_ID,
-					WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 				],
 			],
@@ -246,7 +245,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					WC_Stripe_UPE_Payment_Method_Oxxo::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_P24::STRIPE_ID,
-					WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
 				],
 			],
 		];


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- When Sofort is disabled, hide it from the list of UPE payment methods.

Sofort showing up in the Payment methods list is a regression. Things work as expected in `develop`.
For some background, Sofort is being deprecated as a standalone payment method [Ref](https://support.stripe.com/questions/sofort-is-being-deprecated-as-a-standalone-payment-method). We're already hiding this payment gateway in the non-UPE experience.

| Before | After |
|--------|--------|
| <img width="400" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/bb399b77-6c99-476b-b41e-26b5dd3f3bb6"> | <img width="400" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/7cd4236e-3207-457a-85d3-a27433a0e239"> | 

## Testing instructions

1. Check out the `add/deferred-intent` branch.
2. Enable UPE, under the Stripe's settings tab (wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings) > Advanced settings > Enable the updated checkout experience
3.  Enable Sofort, under the Stripe's payment methods tab (wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods)
4. Check out this branch and reload the Payment methods tab
5. Confirm that Sofort continues to appear on the list
6. Disable Sofort, save, and reload the page
7. Confirm that Sofort is no longer on the list

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
