### PR TITLE
Hide payment method currency requirement notice from the Stripe settings page

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -76,6 +76,7 @@ class WC_Stripe_Admin_Notices {
 						'target' => [],
 					],
 					'strong' => [],
+					'br'     => [],
 				]
 			);
 			echo '</p></div>';
@@ -314,12 +315,12 @@ class WC_Stripe_Admin_Notices {
 
 		// phpcs:ignore
 		$is_stripe_settings_page = isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 0 === strpos( $_GET['section'], 'stripe' );
+		$currency_messages       = '';
 
 		foreach ( $payment_methods as $method => $class ) {
-			$show_notice = get_option( 'wc_stripe_show_' . $method . '_notice' );
-			$gateway     = new $class();
+			$gateway = new $class();
 
-			if ( 'yes' !== $gateway->enabled || 'no' === $show_notice ) {
+			if ( 'yes' !== $gateway->enabled ) {
 				continue;
 			}
 
@@ -334,8 +335,13 @@ class WC_Stripe_Admin_Notices {
 				$this->add_admin_notice( 'sofort', 'notice notice-warning', $message, false );
 			} elseif ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $gateway->get_supported_currency(), true ) ) {
 				/* translators: 1) Payment method, 2) List of supported currencies */
-				$this->add_admin_notice( $method, 'notice notice-error', sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s', 'woocommerce-gateway-stripe' ), $gateway->get_method_title(), implode( ', ', $gateway->get_supported_currency() ) ), true );
+				$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $gateway->get_method_title(), implode( ', ', $gateway->get_supported_currency() ) );
 			}
+		}
+
+		$show_notice = get_option( 'wc_stripe_show_payment_methods_notice' );
+		if ( ! empty( $currency_messages && 'no' !== $show_notice ) ) {
+			$this->add_admin_notice( 'payment_methods', 'notice notice-error', $currency_messages, true );
 		}
 
 		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() || ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
@@ -346,10 +352,9 @@ class WC_Stripe_Admin_Notices {
 			if ( WC_Stripe_UPE_Payment_Method_CC::class === $method_class ) {
 				continue;
 			}
-			$method      = $method_class::STRIPE_ID;
-			$show_notice = get_option( 'wc_stripe_show_' . $method . '_upe_notice' );
-			$upe_method  = new $method_class();
-			if ( ! $upe_method->is_enabled() || 'no' === $show_notice ) {
+			$method     = $method_class::STRIPE_ID;
+			$upe_method = new $method_class();
+			if ( ! $upe_method->is_enabled() ) {
 				continue;
 			}
 
@@ -364,8 +369,13 @@ class WC_Stripe_Admin_Notices {
 				$this->add_admin_notice( 'sofort', 'notice notice-warning', $message, false );
 			} elseif ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $upe_method->get_supported_currencies(), true ) ) {
 				/* translators: %1$s Payment method, %2$s List of supported currencies */
-				$this->add_admin_notice( $method . '_upe', 'notice notice-error', sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $upe_method->get_supported_currencies() ) ), true );
+				$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $upe_method->get_supported_currencies() ) );
 			}
+		}
+
+		$show_notice = get_option( 'wc_stripe_show_upe_payment_methods_notice' );
+		if ( ! empty( $currency_messages ) && 'no' !== $show_notice ) {
+			$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true );
 		}
 	}
 
@@ -409,32 +419,11 @@ class WC_Stripe_Admin_Notices {
 				case '3ds':
 					update_option( 'wc_stripe_show_3ds_notice', 'no' );
 					break;
-				case 'alipay':
-					update_option( 'wc_stripe_show_alipay_notice', 'no' );
-					break;
-				case 'bancontact':
-					update_option( 'wc_stripe_show_bancontact_notice', 'no' );
-					break;
-				case 'eps':
-					update_option( 'wc_stripe_show_eps_notice', 'no' );
-					break;
-				case 'giropay':
-					update_option( 'wc_stripe_show_giropay_notice', 'no' );
-					break;
-				case 'ideal':
-					update_option( 'wc_stripe_show_ideal_notice', 'no' );
-					break;
-				case 'multibanco':
-					update_option( 'wc_stripe_show_multibanco_notice', 'no' );
-					break;
-				case 'p24':
-					update_option( 'wc_stripe_show_p24_notice', 'no' );
-					break;
-				case 'sepa':
-					update_option( 'wc_stripe_show_sepa_notice', 'no' );
-					break;
 				case 'sofort':
 					update_option( 'wc_stripe_show_sofort_notice', 'no' );
+					break;
+				case 'sofort':
+					update_option( 'wc_stripe_show_sofort_upe_notice', 'no' );
 					break;
 				case 'sca':
 					update_option( 'wc_stripe_show_sca_notice', 'no' );
@@ -442,10 +431,11 @@ class WC_Stripe_Admin_Notices {
 				case 'changed_keys':
 					update_option( 'wc_stripe_show_changed_keys_notice', 'no' );
 					break;
-				default:
-					if ( false !== strpos( $notice, '_upe' ) ) {
-						update_option( 'wc_stripe_show_' . $notice . '_notice', 'no' );
-					}
+				case 'payment_methods':
+					update_option( 'wc_stripe_show_payment_methods_notice', 'no' );
+					break;
+				case 'upe_payment_methods':
+					update_option( 'wc_stripe_show_upe_payment_methods_notice', 'no' );
 					break;
 			}
 		}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -312,6 +312,9 @@ class WC_Stripe_Admin_Notices {
 	public function payment_methods_check_environment() {
 		$payment_methods = $this->get_payment_methods();
 
+		// phpcs:ignore
+		$is_stripe_settings_page = isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 0 === strpos( $_GET['section'], 'stripe' );
+
 		foreach ( $payment_methods as $method => $class ) {
 			$show_notice = get_option( 'wc_stripe_show_' . $method . '_notice' );
 			$gateway     = new $class();
@@ -329,7 +332,7 @@ class WC_Stripe_Admin_Notices {
 				);
 
 				$this->add_admin_notice( 'sofort', 'notice notice-warning', $message, false );
-			} elseif ( ! in_array( get_woocommerce_currency(), $gateway->get_supported_currency(), true ) ) {
+			} elseif ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $gateway->get_supported_currency(), true ) ) {
 				/* translators: 1) Payment method, 2) List of supported currencies */
 				$this->add_admin_notice( $method, 'notice notice-error', sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s', 'woocommerce-gateway-stripe' ), $gateway->get_method_title(), implode( ', ', $gateway->get_supported_currency() ) ), true );
 			}
@@ -359,7 +362,7 @@ class WC_Stripe_Admin_Notices {
 				);
 
 				$this->add_admin_notice( 'sofort', 'notice notice-warning', $message, false );
-			} elseif ( ! in_array( get_woocommerce_currency(), $upe_method->get_supported_currencies(), true ) ) {
+			} elseif ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $upe_method->get_supported_currencies(), true ) ) {
 				/* translators: %1$s Payment method, %2$s List of supported currencies */
 				$this->add_admin_notice( $method . '_upe', 'notice notice-error', sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $upe_method->get_supported_currencies() ) ), true );
 			}

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -113,14 +113,12 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		$notices->admin_notices();
 		ob_end_clean();
 		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
-			$this->assertCount( 4, $notices->notices );
+			$this->assertCount( 2, $notices->notices );
 			$this->assertArrayHasKey( 'wcver', $notices->notices );
 		} else {
-			$this->assertCount( 3, $notices->notices );
+			$this->assertCount( 1, $notices->notices );
 		}
-		$this->assertArrayHasKey( 'giropay_upe', $notices->notices );
-		$this->assertArrayHasKey( 'bancontact_upe', $notices->notices );
-		$this->assertArrayHasKey( 'eps_upe', $notices->notices );
+		$this->assertArrayHasKey( 'upe_payment_methods', $notices->notices );
 	}
 
 	public function test_invalid_keys_notice_is_shown_when_account_data_is_not_valid() {
@@ -507,7 +505,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 					],
 				],
 				[
-					'giropay',
+					'payment_methods',
 				],
 			],
 		];


### PR DESCRIPTION
## Changes proposed in this Pull Request:
In the design of the new setting, we are marking the currency requirement on the Stripe settings page by blurring the payment method row and showing a yellow alert icon with tooltip. All the individual currency notices are not required on this page as they convey the same message. In this PR, we are hiding the notices from the Stripe settings page as discussed with @elizaan36.

## Testing instructions
- While in `develop` branch, set store currency as Euro. 
- Go to the Stripe settings page and enable all the payment methods that require Euro as currency (like EPS, giropay, Bancontact etc)
- Now set store currency as USD.
- Go to the Stripe settings page and refresh the page. You will see a stack of notices on the page.

![notice_and_icon](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/65d50ed7-cd32-4781-b9f3-e81ee1172c23)

- Now checkout this branch and reload the Stripe settings page. The stack of notices should not be there anymore.

![no notice](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/c5ff37e3-08a9-43b0-ad83-e2f263320bc6)

- Go to another page like the general settings page, payments settings page, etc. and you should see all the notices on those page.

![merged messages](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/0201a240-4676-42d4-9566-bcda19047c03)

