### PR TITLE
Add APM support for Subscriptions and tokens with split UPE with deferred intent

### DIFF
--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -32,13 +32,15 @@ Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
 				upeName,
 				upeMethods,
 				api,
-				upeConfig.testingInstructions
+				upeConfig.testingInstructions,
+				upeConfig.showSaveOption ?? false
 			),
 			edit: getDeferredIntentCreationUPEFields(
 				upeName,
 				upeMethods,
 				api,
-				upeConfig.testingInstructions
+				upeConfig.testingInstructions,
+				upeConfig.showSaveOption ?? false
 			),
 			savedTokenComponent: <SavedTokenHandler api={ api } />,
 			canMakePayment: () => !! api.getStripe(),

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -24,21 +24,25 @@ const PaymentElements = ( { api, ...props } ) => {
 	const amount = Number( getBlocksConfiguration()?.cartTotal );
 	const currency = getBlocksConfiguration()?.currency.toLowerCase();
 	const appearance = initializeUPEAppearance();
+	const options = {
+		mode: amount < 1 ? 'setup' : 'payment',
+		amount,
+		currency,
+		paymentMethodCreation: 'manual',
+		paymentMethodTypes: getPaymentMethodTypes( props.paymentMethodId ),
+		appearance,
+	};
+
+	// If the cart contains a subscription or the payment method supports saving, we need to use off_session setup so Stripe can display appropriate terms and conditions.
+	if (
+		getBlocksConfiguration()?.cartContainsSubscription ||
+		props.showSaveOption
+	) {
+		options.setupFutureUsage = 'off_session';
+	}
 
 	return (
-		<Elements
-			stripe={ stripe }
-			options={ {
-				mode: amount < 1 ? 'setup' : 'payment',
-				amount,
-				currency,
-				paymentMethodCreation: 'manual',
-				paymentMethodTypes: getPaymentMethodTypes(
-					props.paymentMethodId
-				),
-				appearance,
-			} }
-		>
+		<Elements stripe={ stripe } options={ options }>
 			<PaymentProcessor api={ api } { ...props } />
 		</Elements>
 	);
@@ -51,6 +55,7 @@ const PaymentElements = ( { api, ...props } ) => {
  * @param {Array}       upeMethods
  * @param {WCStripeAPI} api
  * @param {string}      testingInstructions
+ * @param {boolean}     showSaveOption
  *
  * @return {JSX.Element} Rendered Payment elements.
  */
@@ -58,7 +63,8 @@ export const getDeferredIntentCreationUPEFields = (
 	paymentMethodId,
 	upeMethods,
 	api,
-	testingInstructions
+	testingInstructions,
+	showSaveOption
 ) => {
 	return (
 		<PaymentElements
@@ -66,6 +72,7 @@ export const getDeferredIntentCreationUPEFields = (
 			upeMethods={ upeMethods }
 			api={ api }
 			testingInstructions={ testingInstructions }
+			showSaveOption={ showSaveOption }
 		/>
 	);
 };

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1709,9 +1709,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$full_request = $this->generate_payment_request( $order, $prepared_source );
 
 		$payment_method_types = [ 'card' ];
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			$payment_method_types = $this->get_upe_enabled_at_checkout_payment_method_ids();
-		} elseif ( isset( $prepared_source->source_object->type ) ) {
+
+		if ( isset( $prepared_source->source_object->type ) ) {
 			$payment_method_types = [ $prepared_source->source_object->type ];
 		}
 

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -364,6 +364,14 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				// Strip "Stripe_" from the payment method name to get the payment method type.
 				$payment_method_type      = substr( $context->payment_method, strlen( $this->name ) + 1 );
 				$is_stripe_payment_method = isset( $main_gateway->payment_methods[ $payment_method_type ] );
+
+				/**
+				 * When using the block checkout and a saved token is being used, we need to set a flag
+				 * to indicate that deferred intent should be used.
+				 */
+				if ( $is_stripe_payment_method && isset( $data['issavedtoken'] ) && $data['issavedtoken'] ) {
+					$context->set_payment_data( array_merge( $data, [ 'wc-stripe-is-deferred-intent' => true ] ) );
+				}
 			}
 		}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1105,4 +1105,22 @@ class WC_Stripe_Helper {
 
 		return $intent_id ?? false;
 	}
+
+	/**
+	 * Fetches a list of all Stripe gateway IDs.
+	 *
+	 * @return array An array of all Stripe gateway IDs.
+	 */
+	public static function get_stripe_gateway_ids() {
+		$main_gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+		$gateway_ids  = [ 'stripe' => $main_gateway->id ];
+
+		if ( is_a( $main_gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
+			$gateways = $main_gateway->payment_methods;
+		} else {
+			$gateways = self::get_legacy_payment_methods();
+		}
+
+		return array_merge( $gateway_ids, wp_list_pluck( $gateways, 'id', 'id' ) );
+	}
 }

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -934,7 +934,7 @@ class WC_Stripe_Intent_Controller {
 	 */
 	public function is_mandate_data_required( $selected_payment_type ) {
 
-		if ( in_array( $selected_payment_type, [ 'sepa_debit', 'bancontact', 'ideal' ], true ) ) {
+		if ( in_array( $selected_payment_type, [ 'sepa_debit', 'bancontact', 'ideal', 'sofort' ], true ) ) {
 			return true;
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -893,12 +893,12 @@ class WC_Stripe_Intent_Controller {
 	 * @return bool True if a mandate must be shown and acknowledged by customer before deferred intent UPE payment can be processed, false otherwise.
 	 */
 	public function is_mandate_data_required( $selected_payment_type ) {
-		$gateway = $this->get_upe_gateway();
 
-		$is_stripe_link_enabled = 'card' === $selected_payment_type && in_array( 'link', $gateway->get_upe_enabled_payment_method_ids(), true );
-		$is_sepa_debit_payment  = 'sepa_debit' === $selected_payment_type;
+		if ( in_array( $selected_payment_type, [ 'sepa_debit', 'bancontact', 'ideal' ], true ) ) {
+			return true;
+		}
 
-		return $is_stripe_link_enabled || $is_sepa_debit_payment;
+		return 'card' === $selected_payment_type && in_array( 'link', $this->get_upe_gateway()->get_upe_enabled_payment_method_ids(), true );
 	}
 
 	/**
@@ -911,11 +911,12 @@ class WC_Stripe_Intent_Controller {
 	 * @return array
 	 */
 	public function create_and_confirm_setup_intent( $payment_information ) {
-		$request  = [
+		$request = [
 			'payment_method'       => $payment_information['payment_method'],
 			'payment_method_types' => [ $payment_information['selected_payment_type'] ],
 			'customer'             => $payment_information['customer'],
 			'confirm'              => 'true',
+			'return_url'           => $payment_information['return_url'],
 		];
 
 		// SEPA setup intents require mandate data.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -12,6 +12,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Payment_Tokens {
 	private static $_this;
 
+	const UPE_REUSABLE_GATEWAYS = [
+		// Link payment methods are saved under the main Stripe gateway.
+		WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
+	];
+
 	/**
 	 * Constructor.
 	 *
@@ -373,22 +382,18 @@ class WC_Stripe_Payment_Tokens {
 	 */
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
 		$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			if ( WC_Stripe_UPE_Payment_Gateway::ID === $token->get_gateway_id() ) {
-				try {
+		try {
+			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS, true ) ) {
 					$stripe_customer->detach_payment_method( $token->get_token() );
-				} catch ( WC_Stripe_Exception $e ) {
-					WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 				}
-			}
-		} else {
-			if ( 'stripe' === $token->get_gateway_id() || 'stripe_sepa' === $token->get_gateway_id() ) {
-				try {
+			} else {
+				if ( 'stripe' === $token->get_gateway_id() || 'stripe_sepa' === $token->get_gateway_id() ) {
 					$stripe_customer->delete_source( $token->get_token() );
-				} catch ( WC_Stripe_Exception $e ) {
-					WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 				}
 			}
+		} catch ( WC_Stripe_Exception $e ) {
+			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 		}
 	}
 

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -386,8 +386,12 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * Updates other subscription sources.
 	 *
 	 * @since 5.6.0
+	 *
+	 * @param WC_Order $order              The order object.
+	 * @param string   $source_id          The source ID.
+	 * @param string   $payment_gateway_id The payment method ID. eg 'stripe.
 	 */
-	public function maybe_update_source_on_subscription_order( $order, $source ) {
+	public function maybe_update_source_on_subscription_order( $order, $source, $payment_gateway_id = '' ) {
 		if ( ! $this->is_subscriptions_enabled() ) {
 			return;
 		}
@@ -404,13 +408,17 @@ trait WC_Stripe_Subscriptions_Trait {
 		}
 
 		foreach ( $subscriptions as $subscription ) {
-			$subscription_id = $subscription->get_id();
 			$subscription->update_meta_data( '_stripe_customer_id', $source->customer );
 
 			if ( ! empty( $source->payment_method ) ) {
 				$subscription->update_meta_data( '_stripe_source_id', $source->payment_method );
 			} else {
 				$subscription->update_meta_data( '_stripe_source_id', $source->source );
+			}
+
+			// Update the payment method.
+			if ( ! empty( $payment_gateway_id ) ) {
+				$subscription->set_payment_method( $payment_gateway_id );
 			}
 
 			$subscription->save();

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -11,6 +11,15 @@ trait WC_Stripe_Subscriptions_Trait {
 	use WC_Stripe_Subscriptions_Utilities_Trait;
 
 	/**
+	 * Stores a flag to indicate if the subscription integration hooks have been attached.
+	 *
+	 * The callbacks attached as part of maybe_init_subscriptions() only need to be attached once to avoid duplication.
+	 *
+	 * @var bool False by default, true once the callbacks have been attached.
+	 */
+	private static $has_attached_integration_hooks = false;
+
+	/**
 	 * Initialize subscription support and hooks.
 	 *
 	 * @since 5.6.0
@@ -38,18 +47,33 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		add_action( 'woocommerce_scheduled_subscription_payment_' . $this->id, [ $this, 'scheduled_subscription_payment' ], 10, 2 );
 		add_action( 'woocommerce_subscription_failing_payment_method_updated_' . $this->id, [ $this, 'update_failing_payment_method' ], 10, 2 );
-		add_action( 'wcs_resubscribe_order_created', [ $this, 'delete_resubscribe_meta' ], 10 );
-		add_action( 'wcs_renewal_order_created', [ $this, 'delete_renewal_meta' ], 10 );
+
 		add_action( 'wc_stripe_payment_fields_' . $this->id, [ $this, 'display_update_subs_payment_checkout' ] );
 		add_action( 'wc_stripe_add_payment_method_' . $this->id . '_success', [ $this, 'handle_add_payment_method_success' ], 10, 2 );
-		add_action( 'woocommerce_subscriptions_change_payment_before_submit', [ $this, 'differentiate_change_payment_method_form' ] );
 
 		// Display the payment method used for a subscription in the "My Subscriptions" table.
 		add_filter( 'woocommerce_my_subscriptions_payment_method', [ $this, 'maybe_render_subscription_payment_method' ], 10, 2 );
 
 		// Allow store managers to manually set Stripe as the payment method on a subscription.
 		add_filter( 'woocommerce_subscription_payment_meta', [ $this, 'add_subscription_payment_meta' ], 10, 2 );
+
+		// Validate the payment method meta data set on a subscription.
 		add_filter( 'woocommerce_subscription_validate_payment_meta', [ $this, 'validate_subscription_payment_meta' ], 10, 2 );
+
+		/**
+		 * The callbacks attached below only need to be attached once. We don't need each gateway instance to have its own callback.
+		 * Therefore we only attach them once on the main `stripe` gateway and store a flag to indicate that they have been attached.
+		 */
+		if ( self::$has_attached_integration_hooks || WC_Gateway_Stripe::ID !== $this->id ) {
+			return;
+		}
+
+		self::$has_attached_integration_hooks = true;
+
+		add_action( 'woocommerce_subscriptions_change_payment_before_submit', [ $this, 'differentiate_change_payment_method_form' ] );
+		add_action( 'wcs_resubscribe_order_created', [ $this, 'delete_resubscribe_meta' ], 10 );
+		add_action( 'wcs_renewal_order_created', [ $this, 'delete_renewal_meta' ], 10 );
+
 		add_filter( 'wc_stripe_display_save_payment_method_checkbox', [ $this, 'display_save_payment_method_checkbox' ] );
 
 		// Add the necessary information to create a mandate to the payment intent.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1932,7 +1932,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Add the payment method information to the order.
 		$prepared_payment_method_object = $this->prepare_payment_method( $payment_method_object );
-		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object );
+		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object, $this->id );
 
 		// Create a payment token for the user in the store.
 		$payment_method_instance = $this->payment_methods[ $payment_method_type ];

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -727,7 +727,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 						'payment_method' => $payment_information['payment_method'],
 						'customer'       => $payment_information['customer'],
 					],
-					$this->get_upe_gateway_id_for_subscription_order( $upe_payment_method )
+					$this->get_upe_gateway_id_for_order( $upe_payment_method )
 				);
 			}
 
@@ -1453,10 +1453,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		if ( ! isset( $this->payment_methods[ $payment_method_type ] ) ) {
 			return;
 		}
+		$payment_method       = $this->payment_methods[ $payment_method_type ];
+		$payment_method_title = $payment_method->get_label();
 
-		$payment_method_title = $this->payment_methods[ $payment_method_type ]->get_label();
-
-		$order->set_payment_method( self::ID );
+		$order->set_payment_method( $this->get_upe_gateway_id_for_order( $payment_method ) );
 		$order->set_payment_method_title( $payment_method_title );
 		$order->save();
 	}
@@ -1941,7 +1941,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Add the payment method information to the order.
 		$prepared_payment_method_object = $this->prepare_payment_method( $payment_method_object );
-		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object, $this->get_upe_gateway_id_for_subscription_order( $payment_method_instance ) );
+		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object, $this->get_upe_gateway_id_for_order( $payment_method_instance ) );
 
 		do_action( 'woocommerce_stripe_add_payment_method', $user->ID, $payment_method_object );
 	}
@@ -2169,7 +2169,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @param WC_Stripe_UPE_Payment_Method $payment_method The UPE payment method instance.
 	 * @return string The gateway ID to set on the subscription/order.
 	 */
-	private function get_upe_gateway_id_for_subscription_order( $payment_method ) {
+	private function get_upe_gateway_id_for_order( $payment_method ) {
 		$token_gateway_type = $payment_method->get_retrievable_type();
 
 		if ( 'card' !== $token_gateway_type ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -712,7 +712,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			// Handle saving the payment method in the store.
 			// It's already attached to the Stripe customer at this point.
-			if ( $payment_information['save_payment_method_to_store'] ) {
+			if ( $payment_information['save_payment_method_to_store'] && $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type() ) {
 				$this->handle_saving_payment_method(
 					$order,
 					$payment_information['payment_method'],
@@ -1803,6 +1803,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 
 			$payment_method_id = $token->get_token();
+
+			if ( is_a( $token, 'WC_Payment_Token_SEPA' ) ) {
+				$selected_payment_type = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
+			}
 		} else {
 			$payment_method_id = sanitize_text_field( wp_unslash( $_POST['wc-stripe-payment-method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -330,6 +330,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['accountDescriptor']                = $this->statement_descriptor;
 		$stripe_params['addPaymentReturnURL']              = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']             = $enabled_billing_fields;
+		$stripe_params['cartContainsSubscription']         = $this->is_subscription_item_in_cart();
 
 		$cart_total = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
 		$currency   = get_woocommerce_currency();
@@ -392,7 +393,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				'isReusable'          => $this->payment_methods[ $payment_method ]->is_reusable(),
 				'title'               => $this->payment_methods[ $payment_method ]->get_title(),
 				'testingInstructions' => $this->payment_methods[ $payment_method ]->get_testing_instructions(),
-				'showSaveOption'      => $this->payment_methods[ $payment_method ]->should_show_save_option(),
+				'showSaveOption'      => $this->should_upe_payment_method_show_save_option( $this->payment_methods[ $payment_method ] ),
 			];
 		}
 
@@ -2137,5 +2138,20 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Checks if the save option for a payment method should be displayed or not.
+	 *
+	 * @param WC_Stripe_UPE_Payment_Method $payment_method UPE Payment Method instance.
+	 * @return bool - True if the payment method is reusable and the saved cards feature is enabled for the gateway and there is no subscription item in the cart, false otherwise.
+	 */
+	private function should_upe_payment_method_show_save_option( $payment_method ) {
+		if ( $payment_method->is_reusable() ) {
+			// If a subscription in the cart, it will be saved by default so no need to show the option.
+			return $this->is_saved_cards_enabled() && ! $this->is_subscription_item_in_cart();
+		}
+
+		return false;
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -727,7 +727,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 						'payment_method' => $payment_information['payment_method'],
 						'customer'       => $payment_information['customer'],
 					],
-					$this->id
+					$this->payment_methods[ $upe_payment_method->get_retrievable_type() ]->id
 				);
 			}
 
@@ -1266,7 +1266,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$order->save();
 		}
 
-		$this->maybe_update_source_on_subscription_order( $order, $payment_method, $this->id );
+		// Fetch the payment method ID from the payment method object.
+		if ( isset( $this->payment_methods[ $payment_method->payment_method_object->type ] ) ) {
+			$payment_method_id = $this->payment_methods[ $payment_method->payment_method_object->type ]->id;
+		}
+
+		$this->maybe_update_source_on_subscription_order( $order, $payment_method, $payment_method_id ?? $this->id );
 	}
 
 	/**
@@ -1930,13 +1935,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$customer = new WC_Stripe_Customer( $user->ID );
 		$customer->clear_cache();
 
-		// Add the payment method information to the order.
-		$prepared_payment_method_object = $this->prepare_payment_method( $payment_method_object );
-		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object, $this->id );
-
 		// Create a payment token for the user in the store.
 		$payment_method_instance = $this->payment_methods[ $payment_method_type ];
 		$payment_method_instance->create_payment_token_for_user( $user->ID, $payment_method_object );
+
+		// Add the payment method information to the order.
+		$prepared_payment_method_object = $this->prepare_payment_method( $payment_method_object );
+		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object, $this->payment_methods[ $payment_method_instance->get_retrievable_type() ]->id );
 
 		do_action( 'woocommerce_stripe_add_payment_method', $user->ID, $payment_method_object );
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1310,7 +1310,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Fetch the payment method ID from the payment method object.
 		if ( isset( $this->payment_methods[ $payment_method->payment_method_object->type ] ) ) {
-			$payment_method_id = $this->payment_methods[ $payment_method->payment_method_object->type ]->id;
+			$payment_method_id = $this->get_upe_gateway_id_for_order( $this->payment_methods[ $payment_method->payment_method_object->type ] );
 		}
 
 		$this->maybe_update_source_on_subscription_order( $order, $payment_method, $payment_method_id ?? $this->id );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -724,7 +724,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					(object) [
 						'payment_method' => $payment_information['payment_method'],
 						'customer'       => $payment_information['customer'],
-					]
+					],
+					$this->id
 				);
 			}
 
@@ -1263,7 +1264,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$order->save();
 		}
 
-		$this->maybe_update_source_on_subscription_order( $order, $payment_method );
+		$this->maybe_update_source_on_subscription_order( $order, $payment_method, $this->id );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -684,6 +684,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_needed        = $this->is_payment_needed( $order->get_id() );
 			$payment_method_id     = $payment_information['payment_method'];
 			$selected_payment_type = $payment_information['selected_payment_type'];
+			$upe_payment_method    = $this->payment_methods[ $selected_payment_type ] ?? null;
 
 			// Make sure that we attach the payment method and the customer ID to the order meta data.
 			$this->set_payment_method_id_for_order( $order, $payment_method_id );
@@ -1928,7 +1929,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$customer = new WC_Stripe_Customer( $user->ID );
 		$customer->clear_cache();
 
-		// Add the payment method information to the ordeer.
+		// Add the payment method information to the order.
 		$prepared_payment_method_object = $this->prepare_payment_method( $payment_method_object );
 		$this->maybe_update_source_on_subscription_order( $order, $prepared_payment_method_object );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
@@ -24,6 +24,7 @@ class WC_Stripe_UPE_Payment_Method_Bancontact extends WC_Stripe_UPE_Payment_Meth
 		$this->label                = __( 'Bancontact', 'woocommerce-gateway-stripe' );
 		$this->supports[]           = 'subscriptions';
 		$this->supports[]           = 'tokenization';
+		$this->supports[]           = 'multiple_subscriptions';
 		$this->description          = __(
 			'Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
@@ -22,6 +22,8 @@ class WC_Stripe_UPE_Payment_Method_Bancontact extends WC_Stripe_UPE_Payment_Meth
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'Bancontact', 'woocommerce-gateway-stripe' );
+		$this->supports[]           = 'subscriptions';
+		$this->supports[]           = 'tokenization';
 		$this->description          = __(
 			'Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php
@@ -25,6 +25,7 @@ class WC_Stripe_UPE_Payment_Method_Boleto extends WC_Stripe_UPE_Payment_Method {
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'BRL' ];
 		$this->supported_countries  = [ 'BR' ];
+		$this->supports             = [ 'products' ];
 		$this->label                = __( 'Boleto', 'woocommerce-gateway-stripe' );
 		$this->description          = __(
 			'Boleto is an official payment method in Brazil. Customers receive a voucher that can be paid at authorized agencies or banks, ATMs, or online bank portals.',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -25,6 +25,8 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 		$this->title       = __( 'Credit / Debit Card', 'woocommerce-gateway-stripe' );
 		$this->is_reusable = true;
 		$this->label       = __( 'Credit / Debit Card', 'woocommerce-gateway-stripe' );
+		$this->supports[]  = 'subscriptions';
+		$this->supports[]  = 'tokenization';
 		$this->description = __(
 			'Let your customers pay with major credit and debit cards without leaving your store.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
@@ -23,6 +23,7 @@ class WC_Stripe_UPE_Payment_Method_Ideal extends WC_Stripe_UPE_Payment_Method {
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'iDEAL', 'woocommerce-gateway-stripe' );
 		$this->supports[]           = 'subscriptions';
+		$this->supports[]           = 'multiple_subscriptions';
 		$this->supports[]           = 'tokenization';
 		$this->description          = __(
 			'iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
@@ -22,6 +22,8 @@ class WC_Stripe_UPE_Payment_Method_Ideal extends WC_Stripe_UPE_Payment_Method {
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'iDEAL', 'woocommerce-gateway-stripe' );
+		$this->supports[]           = 'subscriptions';
+		$this->supports[]           = 'tokenization';
 		$this->description          = __(
 			'iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php
@@ -25,6 +25,7 @@ class WC_Stripe_UPE_Payment_Method_Oxxo extends WC_Stripe_UPE_Payment_Method {
 		$this->is_reusable          = false;
 		$this->supported_currencies = [ 'MXN' ];
 		$this->supported_countries  = [ 'MX' ];
+		$this->supports             = [ 'products' ];
 		$this->label                = __( 'OXXO', 'woocommerce-gateway-stripe' );
 		$this->description          = __(
 			'OXXO is a Mexican chain of convenience stores that allows customers to pay bills and online purchases in-store with cash.',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * SEPA Payment Method class extending UPE base class
  */
 class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
+	use WC_Stripe_Subscriptions_Trait;
 
 	const STRIPE_ID = 'sepa_debit';
 
@@ -30,6 +31,9 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 			'Reach 500 million customers and over 20 million businesses across the European Union.',
 			'woocommerce-gateway-stripe'
 		);
+
+		// SEPA Direct Debit is the tokenization method for this method as well as Bancontact and iDEAL. Init subscription so it can process subscription payments.
+		$this->maybe_init_subscriptions();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -24,6 +24,8 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'SEPA Direct Debit', 'woocommerce-gateway-stripe' );
+		$this->supports[]           = 'subscriptions';
+		$this->supports[]           = 'tokenization';
 		$this->description          = __(
 			'Reach 500 million customers and over 20 million businesses across the European Union.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -25,8 +25,6 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'SEPA Direct Debit', 'woocommerce-gateway-stripe' );
-		$this->supports[]           = 'subscriptions';
-		$this->supports[]           = 'tokenization';
 		$this->description          = __(
 			'Reach 500 million customers and over 20 million businesses across the European Union.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -22,6 +22,8 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 		$this->is_reusable          = true;
 		$this->supported_currencies = [ 'EUR' ];
 		$this->label                = __( 'Sofort', 'woocommerce-gateway-stripe' );
+		$this->supports[]           = 'subscriptions';
+		$this->supports[]           = 'tokenization';
 		$this->description          = __(
 			'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -24,6 +24,7 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 		$this->label                = __( 'Sofort', 'woocommerce-gateway-stripe' );
 		$this->supports[]           = 'subscriptions';
 		$this->supports[]           = 'tokenization';
+		$this->supports[]           = 'multiple_subscriptions';
 		$this->description          = __(
 			'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
 			'woocommerce-gateway-stripe'

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -111,7 +111,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	public function __call( $method, $arguments ) {
 		$upe_gateway_instance = WC_Stripe::get_instance()->get_main_stripe_gateway();
 
-		if ( in_array( $name, get_class_methods( $upe_gateway_instance ) ) ) {
+		if ( in_array( $method, get_class_methods( $upe_gateway_instance ) ) ) {
 			return call_user_func_array( [ $upe_gateway_instance, $method ], $arguments );
 		} else {
 			$message = method_exists( $upe_gateway_instance, $method ) ? 'Call to private method ' : 'Call to undefined method ';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -278,7 +278,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	public function create_payment_token_for_user( $user_id, $payment_method ) {
 		$token = new WC_Payment_Token_SEPA();
 		$token->set_last4( $payment_method->sepa_debit->last4 );
-		$token->set_gateway_id( WC_Stripe_UPE_Payment_Gateway::ID );
+		$token->set_gateway_id( $this->id );
 		$token->set_token( $payment_method->id );
 		$token->set_payment_method_type( $this->get_id() );
 		$token->set_user_id( $user_id );
@@ -418,6 +418,10 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 				if ( is_user_logged_in() ) {
 					$this->save_payment_method_checkbox( $force_save_payment );
 				}
+			}
+			if ( $display_tokenization ) {
+				$this->tokenization_script();
+				$this->saved_payment_methods();
 			}
 		} catch ( Exception $e ) {
 			// Output the error message.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -391,6 +391,18 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Processes an order payment.
+	 *
+	 * UPE Payment methods use the WC_Stripe_UPE_Payment_Gateway::process_payment() function.
+	 *
+	 * @param int $order_id The order ID to process.
+	 * @return array The payment result.
+	 */
+	public function process_payment( $order_id ) {
+		return WC_Stripe::get_instance()->get_main_stripe_gateway()->process_payment( $order_id );
+	}
+
+	/**
 	 * Determines if the Stripe Account country supports this UPE method.
 	 *
 	 * @return bool

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -91,6 +91,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		$this->enabled  = $is_stripe_enabled && in_array( static::STRIPE_ID, $this->get_option( 'upe_checkout_experience_accepted_payments', [ 'card' ] ), true ) ? 'yes' : 'no';
 		$this->id       = WC_Gateway_Stripe::ID . '_' . static::STRIPE_ID;
 		$this->testmode = ! empty( $main_settings['testmode'] ) && 'yes' === $main_settings['testmode'];
+		$this->supports = [ 'products', 'refunds' ];
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -403,6 +403,25 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Process a refund.
+	 *
+	 * UPE Payment methods use the WC_Stripe_UPE_Payment_Gateway::process_payment() function.
+	 *
+	 * @param int        $order_id Order ID.
+	 * @param float|null $amount Refund amount.
+	 * @param string     $reason Refund reason.
+	 *
+	 * @return bool|\WP_Error True or false based on success, or a WP_Error object.
+	 */
+	public function process_refund( $order_id, $amount = null, $reason = '' ) {
+		if ( ! $this->can_refund_via_stripe() ) {
+			return false;
+		}
+
+		return WC_Stripe::get_instance()->get_main_stripe_gateway()->process_refund( $order_id, $amount, $reason );
+	}
+
+	/**
 	 * Determines if the Stripe Account country supports this UPE method.
 	 *
 	 * @return bool


### PR DESCRIPTION
Fixes #2872 

## Changes proposed in this Pull Request:

This PR adds/fixes the following:

1. Subscriptions via iDEAL, Bancontact and SEPA Debit.
2. Saved tokens via iDEAL, Bancontact and SEPA. 
   - Using saved tokens via block checkout.
3. Passing off-session args to the Stripe Payment Elements so the terms are shown to customers on the block checkout.
3. Refunds via payment methods that support it. 

## Testing instructions

### Subscriptions

1. Enable the iDEAL, SEPA, Bancontact payment methods.
2. Enable the Woo Subscriptions plugin. 
3. Create a subscription product if you don't have one. 
4. Add a subscription product to the cart. 
5. Go to the block and/or block checkout. 
   - On `add/deferred-intent` only the card payment element will be shown.
   - On this branch, SEPA, Bancontact and iDEAL should all be shown.

| `add/deferred-intent` | This branch |
|--------|--------|
| <img width="515" alt="Screenshot 2024-02-07 at 5 35 39 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/eb1fe8f9-2035-4d30-8436-8762877a1b20"> | <img width="518" alt="Screenshot 2024-02-07 at 5 36 05 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/eef7dc68-43ad-4e7e-bb6f-72a37ac28f29"> |

6. Test all these additional payment methods with subscriptions in your cart.
7. View the subscription and you should see that it has a payment method via SEPA. 

<p align="center">
<img width="460" alt="Screenshot 2024-02-07 at 5 38 18 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c6c3bac5-53b3-42ab-9c95-896235b820b2">
</p>

> [!important]
> Keep in mind that no matter which payment method you use (SEPA, Bancontact or iDEAL) they all resolve to SEPA payment tokens as described in Stripe docs [here](https://stripe.com/docs/payments/bancontact), under "**Recurring payments**".

8. Test automatic, and early renewals. 
   - Note that because it's a SEPA token, final payment is processed via the webhook.

### Tokens

After you've purchased a subscription using any of the APMs mentioned above, you should now have a SEPA token. These steps will walk through the process of using a SEPA token and saving a new one. 

1. Add a simple product to your cart and on the checkout select Bancontact, SEPA, or iDEAL.
2. Choose to save the payment method. 
3. Complete checkout. 
4. Add another product to the cart and process the payment using the saved token. 
   - Again, note that because it's a SEPA token, final payment is processed via the webhook.


#### Deleting tokens 

1. Go into your database and the `wp_woocommerce_payment_tokens` table. 
2. Delete all your Stripe related tokens.  
3. Refresh the checkout page and notice that all the tokens you deleted that still exist in your Stripe account have been recreated. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
