### PR TITLE
Fix required fields breaking Google Pay and Apple pay

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -6,7 +6,7 @@ jQuery( function( $ ) {
 		locale: wc_stripe_payment_request_params.stripe.locale
 	} ),
 		paymentRequestType,
-		showButtonsOnInit = wc_stripe_payment_request_params.product.validVariationSelected ?? true;
+		showButtonsOnInit = ( wc_stripe_payment_request_params.product.validVariationSelected ?? true ) && ! wc_stripe_payment_request_params.hide_button;
 
 	/**
 	 * Object to handle Stripe payment forms.
@@ -39,7 +39,8 @@ jQuery( function( $ ) {
 				data:    data,
 				url:     wc_stripe_payment_request.getAjaxURL( 'get_cart_details' ),
 				success: function( response ) {
-					wc_stripe_payment_request.startPaymentRequest( response );
+					const hideButtonOnCartPage = wc_stripe_payment_request_params.is_cart_page && wc_stripe_payment_request_params.hide_button
+					wc_stripe_payment_request.startPaymentRequest( response, ! hideButtonOnCartPage );
 				}
 			} );
 		},

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -139,6 +139,38 @@ jQuery( function( $ ) {
 				data.shipping_postcode   = shipping.postalCode;
 			}
 
+			data = wc_stripe_payment_request.getRequiredFieldDataFromCheckoutForm( data );
+
+			return data;
+		},
+
+		/**
+		 * Get required field values from the checkout form if they are filled and add to the order data.
+		 *
+		 * @param {Object} data Order data.
+		 *
+		 * @return {Object}
+		 */
+		getRequiredFieldDataFromCheckoutForm: function( data ) {
+			const requiredfields = $( 'form.checkout' ).find( '.validate-required' );
+
+			if ( requiredfields.length ) {
+				requiredfields.each( function() {
+					const field = $( this ).find( ':input' );
+					const value = field.val();
+					const name = field.attr( 'name' );
+					if ( value && ! data[ name ] ) {
+						data[ name ] = value;
+					}
+					// if shipping same as billing is selected, copy the billing field to shipping field.
+					const shipToDiffAddress = $( '#ship-to-different-address' ).find( 'input' ).is( ':checked' );
+					if ( value === '' && name.indexOf( 'shipping_', 0 ) !== -1 && ! shipToDiffAddress ) {
+						var billingFieldName = name.replace( 'shipping_', 'billing_' );
+						data[ name ] = data[ billingFieldName ];
+					}
+				});
+			}
+
 			return data;
 		},
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -164,9 +164,11 @@ jQuery( function( $ ) {
 					}
 					// if shipping same as billing is selected, copy the billing field to shipping field.
 					const shipToDiffAddress = $( '#ship-to-different-address' ).find( 'input' ).is( ':checked' );
-					if ( value === '' && name.indexOf( 'shipping_', 0 ) !== -1 && ! shipToDiffAddress ) {
-						var billingFieldName = name.replace( 'shipping_', 'billing_' );
-						data[ name ] = data[ billingFieldName ];
+					if ( ! shipToDiffAddress ) {
+						var shippingFieldName = name.replace( 'billing_', 'shipping_' );
+						if ( ! data[ shippingFieldName ] && data[ name ] ) {
+							data[ shippingFieldName ] = data[ name ];
+						}
 					}
 				});
 			}

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -6,7 +6,7 @@ jQuery( function( $ ) {
 		locale: wc_stripe_payment_request_params.stripe.locale
 	} ),
 		paymentRequestType,
-		showButtonsOnInit = ( wc_stripe_payment_request_params.product.validVariationSelected ?? true ) && ! wc_stripe_payment_request_params.hide_button;
+		showButtonsOnInit = wc_stripe_payment_request_params.product.validVariationSelected ?? true;
 
 	/**
 	 * Object to handle Stripe payment forms.
@@ -39,8 +39,7 @@ jQuery( function( $ ) {
 				data:    data,
 				url:     wc_stripe_payment_request.getAjaxURL( 'get_cart_details' ),
 				success: function( response ) {
-					const hideButtonOnCartPage = wc_stripe_payment_request_params.is_cart_page && wc_stripe_payment_request_params.hide_button
-					wc_stripe_payment_request.startPaymentRequest( response, ! hideButtonOnCartPage );
+					wc_stripe_payment_request.startPaymentRequest( response );
 				}
 			} );
 		},

--- a/client/api/blocks.js
+++ b/client/api/blocks.js
@@ -66,7 +66,8 @@ export const updateShippingDetails = ( shippingOption ) => {
 };
 
 export const createOrder = ( sourceEvent, paymentRequestType ) => {
-	const data = normalizeOrderData( sourceEvent, paymentRequestType );
+	let data = normalizeOrderData( sourceEvent, paymentRequestType );
+	data = getRequiredFieldDataFromCheckoutForm( data );
 
 	return $.ajax( {
 		type: 'POST',
@@ -74,4 +75,32 @@ export const createOrder = ( sourceEvent, paymentRequestType ) => {
 		dataType: 'json',
 		url: getAjaxUrl( 'create_order' ),
 	} );
+};
+
+const getRequiredFieldDataFromCheckoutForm = ( data ) => {
+	const checkoutForm = document.querySelector( '.wc-block-checkout' );
+	const requiredFields = checkoutForm.querySelectorAll( '[required]' );
+
+	if ( requiredFields.length ) {
+		requiredFields.forEach( ( field ) => {
+			const value = field.value;
+			const id = field.id?.replace( '-', '_' );
+			if ( value && ! data[ id ] ) {
+				data[ id ] = value;
+			}
+
+			// if billing same as shipping is selected, copy the shipping field to billing field.
+			const useSameBillingAddress = checkoutForm
+				.querySelector( '.wc-block-checkout__use-address-for-billing' )
+				?.querySelector( 'input' )?.checked;
+			if ( useSameBillingAddress ) {
+				const billingFieldName = id.replace( 'shipping_', 'billing_' );
+				if ( ! data[ billingFieldName ] && data[ id ] ) {
+					data[ billingFieldName ] = data[ id ];
+				}
+			}
+		} );
+	}
+
+	return data;
 };

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -763,9 +763,7 @@ class WC_Stripe_Payment_Request {
 	 * @return array  The settings used for the payment request button in JavaScript.
 	 */
 	public function javascript_params() {
-		$is_product_page = $this->is_product();
-		$is_cart_page    = is_cart();
-		$needs_shipping  = 'no';
+		$needs_shipping = 'no';
 		if ( ! is_null( WC()->cart ) && WC()->cart->needs_shipping() ) {
 			$needs_shipping = 'yes';
 		}
@@ -804,59 +802,9 @@ class WC_Stripe_Payment_Request {
 			],
 			'button'             => $this->get_button_settings(),
 			'login_confirmation' => $this->get_login_confirmation_settings(),
-			'is_product_page'    => $is_product_page,
-			'is_cart_page'       => $is_cart_page,
+			'is_product_page'    => $this->is_product(),
 			'product'            => $this->get_product_data(),
-			'hide_button'        => ( $is_cart_page || $is_product_page ) ? $this->has_required_checkout_fields() : false,
 		];
-	}
-
-	/**
-	 * Returns true if the checkout has any required fields other than the default ones, false otherwise.
-	 * to not be empty.
-	 *
-	 * @since 4.3.1
-	 *
-	 * @return boolean
-	 */
-	public function has_required_checkout_fields() {
-		// Default WooCommerce Core required fields for billing and shipping.
-		$default_required_fields = [
-			'billing_first_name',
-			'billing_last_name',
-			'billing_country',
-			'billing_address_1',
-			'billing_city',
-			'billing_state',
-			'billing_postcode',
-			'billing_phone',
-			'billing_email',
-			'shipping_first_name',
-			'shipping_last_name',
-			'shipping_country',
-			'shipping_address_1',
-			'shipping_city',
-			'shipping_state',
-			'shipping_postcode',
-		];
-
-		$fields = WC()->checkout()->get_checkout_fields();
-		$fields = array_merge(
-			$fields['billing'] ?? [],
-			$fields['shipping'] ?? [],
-			$fields['order'] ?? [],
-			$fields['account'] ?? []
-		);
-
-		foreach ( $fields as $field_key => $field_data ) {
-			if ( false === array_search( $field_key, $default_required_fields, true ) ) {
-				if ( isset( $field_data['required'] ) && true === $field_data['required'] ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -974,6 +974,11 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
+		// Don't show on cart if there are required checkout fields.
+		if ( is_cart() && $this->has_required_checkout_fields() ) {
+			return false;
+		}
+
 		// Don't show on checkout if disabled.
 		if ( is_checkout() && ! $this->should_show_prb_on_checkout_page() ) {
 			return false;
@@ -981,6 +986,11 @@ class WC_Stripe_Payment_Request {
 
 		// Don't show if product page PRB is disabled.
 		if ( $this->is_product() && ! $this->should_show_prb_on_product_pages() ) {
+			return false;
+		}
+
+		// Don't show on product if there are required checkout fields.
+		if ( $this->is_product() && $this->has_required_checkout_fields() ) {
 			return false;
 		}
 
@@ -1056,6 +1066,54 @@ class WC_Stripe_Payment_Request {
 			! $should_show_on_product_page,
 			$post
 		);
+	}
+
+	/**
+	 * Returns true if the checkout has any required fields other than the default ones, false otherwise.
+	 * to not be empty.
+	 *
+	 * @since 8.0.0
+	 *
+	 * @return boolean
+	 */
+	public function has_required_checkout_fields() {
+		// Default WooCommerce Core required fields for billing and shipping.
+		$default_required_fields = [
+			'billing_first_name',
+			'billing_last_name',
+			'billing_country',
+			'billing_address_1',
+			'billing_city',
+			'billing_state',
+			'billing_postcode',
+			'billing_phone',
+			'billing_email',
+			'shipping_first_name',
+			'shipping_last_name',
+			'shipping_country',
+			'shipping_address_1',
+			'shipping_city',
+			'shipping_state',
+			'shipping_postcode',
+		];
+
+		$fields = WC()->checkout()->get_checkout_fields();
+		$fields = array_merge(
+			$fields['billing'] ?? [],
+			$fields['shipping'] ?? [],
+			$fields['order'] ?? [],
+			$fields['account'] ?? []
+		);
+
+		foreach ( $fields as $field_key => $field_data ) {
+			if ( false === array_search( $field_key, $default_required_fields, true ) ) {
+				if ( isset( $field_data['required'] ) && true === $field_data['required'] ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2343 #2169 

If there is any required field on the checkout page, for example `Company` field, user can not purchase with Google/Apple pay. The reason of this issue is, when we create the order during payment, the validation fails due to the required field. Because we map the order data from the Google Pay response which does not include the required field (company).

## Changes proposed in this Pull Request:
- From the checkout page when paying with Google/Apple Pay, we are now checking if the outstanding required field has value on the checkout page form field. If yes, then we include that value in the order data.
- From shortcode cart we are hiding the payment request button if there are required fields (except for the default ones) present in the checkout page. We can get the form fields via `WC()->checkout()->get_checkout_fields()`. Similarly when the shop is using shortcode checkout (and has required field) we hide the button from product page as well.
- On the Block cart the button is not hidden for required checkout field as we don't have a `get_checkout_fields` function to utilize for the blocks. However, the js error mentioned in #2169 does not happen here and properly shows the error message on top of the page.
- The js error mentioned in #2169 was already fixed in PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2690

## Testing instructions
#### Shortcode
- If you already don't have, then create a shortcode checkout and shortcode cart page.
- Go to **Appearance -> Customize -> WooCommerce -> Checkout** and make the `Company` name field required.
- Go to **WooCommerce -> Settings -> Payments -> Stripe**. Customize Google/Apple Pay button locations and select Checkout, Cart, and Product.
- If you already don't have, then create a shortcode checkout and shortcode cart page.
- As a shopper, go to any product page. You should not see the Google/Apple Pay button.
- Add the product to the cart, then go to the cart page. You should not see the Google/Apple Pay button.
- Now proceed to the checkout page. Here the button should be present.
- Try to pay with Google/Apple Pay without filling up the `company` field. You should see an error message on the page.
- Add any value to the `company` field. Try again to pay with Google/Apple Pay. This time the purchase should be successful.
- Check the order data in your wp-admin and make sure the company name is there.
- Test with both `Ship to a different address` checked/unchecked and verify the order data.

#### Block
- If you already don't have, then create a Block checkout and Block cart page.
- Go to the edit Block checkout page, select the shipping address block and make the `Company` name field required from the right side panel. Similarly, make the `Company` field required for the billing address.
- Go to **WooCommerce -> Settings -> Payments -> Stripe**. Customize Google/Apple Pay button locations and select Checkout, Cart, and Product.
- As a shopper add a product to the cart, then go to the cart page. You should see the Google/Apple Pay button for the cart block but trying to purchase with Google//Apple pay should not create any fatal error. A proper error message should appear on the page.
- Now proceed to the checkout page. Try to pay with Google/Apple Pay without filling up the `company` field. You should see an error message on the page.
- Add any value to the `company` field. Try again to pay with Google/Apple Pay. This time the purchase should be successful.
- Check the order data in your wp-admin and make sure the company name is there.
- Test with both `Use same address for billing` checked/unchecked and verify the order data.