### PR TITLE
Show the payment method terms on the checkout pages

### DIFF
--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -2,6 +2,7 @@ import jQuery from 'jquery';
 import WCStripeAPI from '../../api';
 import {
 	generateCheckoutEventNames,
+	generateCheckoutSavePaymentMethodInputId,
 	getSelectedUPEGatewayPaymentMethod,
 	getStripeServerData,
 	isUsingSavedPaymentMethod,
@@ -44,18 +45,11 @@ jQuery( function ( $ ) {
 		}
 	}
 
+	const savePaymentMethodInputIds = generateCheckoutSavePaymentMethodInputId();
 	$( document ).on( 'change', function ( event ) {
-		// TODO: get a static array with the IDs instead of retrieving the selected one.
-		const selectedPaymentMethod = getSelectedUPEGatewayPaymentMethod();
-		const newPaymentMethodInputId =
-			selectedPaymentMethod === 'card'
-				? ''
-				: `_${ selectedPaymentMethod }`;
-
 		if (
 			event.target &&
-			event.target.id ===
-				`wc-stripe${ newPaymentMethodInputId }-new-payment-method`
+			savePaymentMethodInputIds.includes( event.target.id )
 		) {
 			renderTerms( event );
 		}

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -11,6 +11,7 @@ import {
 	processPayment,
 	mountStripePaymentElement,
 	createAndConfirmSetupIntent,
+	renderTerms,
 	confirmVoucherPayment,
 } from './payment-processing';
 
@@ -42,6 +43,23 @@ jQuery( function ( $ ) {
 			return processPayment( api, $form, paymentMethodType );
 		}
 	}
+
+	$( document ).on( 'change', function ( event ) {
+		// TODO: get a static array with the IDs instead of retrieving the selected one.
+		const selectedPaymentMethod = getSelectedUPEGatewayPaymentMethod();
+		const newPaymentMethodInputId =
+			selectedPaymentMethod === 'card'
+				? ''
+				: `_${ selectedPaymentMethod }`;
+
+		if (
+			event.target &&
+			event.target.id ===
+				`wc-stripe${ newPaymentMethodInputId }-new-payment-method`
+		) {
+			renderTerms( event );
+		}
+	} );
 
 	// Mount the Stripe Payment Elements onto the Add Payment Method page and Pay for Order page.
 	if (

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -1,6 +1,6 @@
 import jQuery from 'jquery';
 import WCStripeAPI from '../../api';
-import { getStripeServerData, getUPETerms } from '../../stripe-utils';
+import { getStripeServerData } from '../../stripe-utils';
 import { legacyHashchangeHandler } from './legacy-support';
 import './style.scss';
 import './deferred-intent.js';
@@ -280,19 +280,6 @@ jQuery( function ( $ ) {
 				handleUPECheckout( $( this ) );
 				return false;
 			}
-		}
-	} );
-
-	// Add terms parameter to UPE if save payment information checkbox is checked.
-	// This shows required legal mandates when customer elects to save payment method during checkout.
-	$( document ).on( 'change', '#wc-stripe-new-payment-method', () => {
-		const value = $( '#wc-stripe-new-payment-method' ).is( ':checked' )
-			? 'always'
-			: 'never';
-		if ( isUPEEnabled && upeElement ) {
-			upeElement.update( {
-				terms: getUPETerms( value ),
-			} );
 		}
 	} );
 

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -4,8 +4,10 @@ import {
 	initializeUPEAppearance,
 	getStripeServerData,
 	getUpeSettings,
+	getTerms,
 	showErrorCheckout,
 	appendSetupIntentToForm,
+	getSelectedUPEGatewayPaymentMethod,
 } from '../../stripe-utils';
 import { getFontRulesFromPage } from '../../styles/upe';
 
@@ -77,7 +79,7 @@ function createStripePaymentElement( api, paymentMethodType = null ) {
 
 	const elements = api.getStripe().elements( options );
 	const createdStripePaymentElement = elements.create( 'payment', {
-		...getUpeSettings(),
+		...getUpeSettings( paymentMethodType ),
 		wallets: {
 			applePay: 'never',
 			googlePay: 'never',
@@ -275,6 +277,27 @@ export const createAndConfirmSetupIntent = (
 			return confirmedSetupIntent;
 		} );
 };
+
+/**
+ * Updates the terms parameter in the Payment Element based on the "save payment information" checkbox.
+ *
+ * @param {Event} event The change event that triggers the function.
+ */
+export function renderTerms( event ) {
+	const isChecked = event.target.checked;
+	const value = isChecked ? 'always' : 'never';
+	const paymentMethodType = getSelectedUPEGatewayPaymentMethod();
+	if ( ! paymentMethodType ) {
+		return;
+	}
+
+	const upeElement = gatewayUPEComponents[ paymentMethodType ].upeElement;
+	if ( upeElement ) {
+		upeElement.update( {
+			terms: getTerms( paymentMethodType, value ),
+		} );
+	}
+}
 
 /**
  * Handles displaying the Boleto or Oxxo voucher to the customer and then redirecting

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -287,6 +287,17 @@ export const generateCheckoutEventNames = () => {
 		.join( ' ' );
 };
 
+/**
+ * Returns an array with the ID of the inputs to save a new Payment Method.
+ *
+ * @return {Array} Array of input IDs.
+ */
+export const generateCheckoutSavePaymentMethodInputId = () => {
+	return Object.values( getPaymentMethodsConstants() ).map(
+		( method ) => `wc-${ method }-new-payment-method`
+	);
+};
+
 export const appendPaymentMethodIdToForm = ( form, paymentMethodId ) => {
 	form.append(
 		`<input type="hidden" id="wc-stripe-payment-method" name="wc-stripe-payment-method" value="${ paymentMethodId }" />`

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -162,7 +162,12 @@ function shouldIncludeTerms( paymentMethodType ) {
  * @return {Object} Terms parameter fit for UPE.
  */
 export const getTerms = ( paymentMethodType, value = 'always' ) => {
-	return { [ paymentMethodType ]: value };
+	// The key for SEPA debit is different from the slug we use in paymentMethodType.
+	// Ref: https://stripe.com/docs/js/elements_object/create_payment_element#payment_element_create-options-terms
+	const termKey =
+		paymentMethodType !== 'sepa_debit' ? paymentMethodType : 'sepaDebit';
+
+	return { [ termKey ]: value };
 };
 
 /**


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Pass the [terms property](https://stripe.com/docs/js/elements_object/create_payment_element#payment_element_create-options-terms) for reusable payment method types
- Update the terms property according to whether the user is saving a payment method

## Testing instructions

1. Change the store currency to EUR
2. Enable UPE, under the Stripe's settings tab
3. Enable Cards, Bancontact, SEPA, iDEAL, and Sofort
4. As a shopper, go to the classic checkout page
5. For each of these payment methods, confirm that:
  - When "Save payment information to my account for future purchases" is checked off, the terms must be displayed
  - When this input isn't checked, no terms must be displayed

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
