### PR TITLE
Fix statement descriptor issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 7.9.3 - xxxx-xx-xx =
+* Fix - Resolved failing payments when statement descriptor only contains the order number.
+
 = 7.9.2 - 2024-02-07 =
 * Fix - Resolved an issue that could cause card payments to fail when providing a Bank statement description with the `statement_descriptor` parameter.
 * Tweak - The Bank statement description settings in the Stripe plugin settings are no longer editable. The description is now automatically pulled from the Stripe account settings.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -577,7 +577,7 @@ class WC_Stripe_Helper {
 
 			// Stripe requires at least 1 latin (alphabet) character in the suffix so we add the first character of the prefix before the order number.
 			if ( 0 === preg_match( '/[a-zA-Z]/', $suffix ) ) {
-				$suffix = substr( $prefix, 0, 1 ) . ' ' . $suffix;
+				$suffix = ! empty( $prefix ) ? substr( $prefix, 0, 1 ) . ' ' . $suffix : 'O ' . $suffix;
 			}
 		}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -577,7 +577,7 @@ class WC_Stripe_Helper {
 
 			// Stripe requires at least 1 latin (alphabet) character in the suffix so we add the first character of the prefix before the order number.
 			if ( 0 === preg_match( '/[a-zA-Z]/', $suffix ) ) {
-				$suffix = ! empty( $prefix ) ? substr( $prefix, 0, 1 ) . ' ' . $suffix : 'O ' . $suffix;
+				$suffix = ! empty( $prefix ) ? substr( $prefix, 0, 1 ) . ' ' . $suffix : 'ID ' . $suffix;
 			}
 		}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -577,7 +577,7 @@ class WC_Stripe_Helper {
 
 			// Stripe requires at least 1 latin (alphabet) character in the suffix so we add the first character of the prefix before the order number.
 			if ( 0 === preg_match( '/[a-zA-Z]/', $suffix ) ) {
-				$suffix = ! empty( $prefix ) ? substr( $prefix, 0, 1 ) . ' ' . $suffix : 'ID ' . $suffix;
+				$suffix = ! empty( $prefix ) ? substr( $prefix, 0, 1 ) . ' ' . $suffix : 'O ' . $suffix;
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,8 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 7.9.2 - 2024-02-07 =
-* Fix - Resolved an issue that could cause card payments to fail when providing a Bank statement description with the `statement_descriptor` parameter.
-* Tweak - The Bank statement description settings in the Stripe plugin settings are no longer editable. The description is now automatically pulled from the Stripe account settings.
+= 7.9.3 - xxxx-xx-xx =
+* Fix - Resolved failing payments when statement descriptor only contains the order number.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2885

When `Add customer order number to the bank statement` is checked in the Stripe settings page, we send the `statement_descriptor_suffix` field in our request body. As Stripe requires at least 1 Latin character in the suffix, we were [adding the first character of the prefix before the order number](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8cdd33aad9a9e9a9349714daa5c5c1fdd10566f3/includes/class-wc-stripe-helper.php#L578-L581). However, if the `Shortened Descriptor` is not set in the Stripe Dashboard, the prefix would be empty resulting in the `statement_descriptor_suffix` containing only the order id (without any Latin characters) and finally the request will fail.

## Changes proposed in this Pull Request:
- Added an additional character `O` before the order Id when `statement_descriptor_prefix` is empty in the Stripe account.

## Testing instructions
#### Steps to reproduce the bug
- Use branch `trunk`.
- In your [Stripe dashboard](https://dashboard.stripe.com/settings/public) make your that the `Shortened Descriptor` is empty.
- In `wp-admin`, go to the Stripe settings page. Scroll to the `Payments and transactions` section and check `Add customer order number to the bank statement`.
- Add a product to the cart and checkout using Stripe (credit/debit card) as a shopper.
- There should be an error while processing the payment.
(Check #2885 for more details)

#### Steps to test the fix
- Use this branch.
- In your [Stripe dashboard](https://dashboard.stripe.com/settings/public) make your that the `Shortened Descriptor` is empty.
- In `wp-admin`, go to the Stripe settings page. Scroll to the `Payments and transactions` section and check `Add customer order number to the bank statement`.
- Add a product to the cart and checkout using Stripe (credit/debit card) as a shopper.
- The purchase should be successful.
- Go to Stripe dashboard and find the corresponding payment on the `Payments` page.
- In the `Payment details` section the `Statement Descriptor` should appear like `O #1234`.
- In your [Stripe dashboard](https://dashboard.stripe.com/settings/public) add a `Shortened Descriptor` (`STEST`)
- Add a product to the cart and checkout using Stripe (credit/debit card) as a shopper.
- The purchase should be successful.
- Go to Stripe dashboard and find the corresponding payment on the `Payments` page.
- In the `Payment details` section the `Statement Descriptor` should appear like `STEST* S #1234`.
