### PR TITLE
[POC] Update PaymentRequestExpressComponent to inherit payment guidelines

### DIFF
--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -44,6 +44,7 @@ const PaymentRequestExpressComponent = ( {
 	onClick,
 	onClose,
 	setExpressPaymentError,
+	buttonAttributes,
 } ) => {
 	const stripe = useStripe();
 	const { needsShipping } = shippingData;
@@ -69,19 +70,11 @@ const PaymentRequestExpressComponent = ( {
 	);
 	useCancelHandler( paymentRequest, onClose );
 
-	// locale is not a valid value for the paymentRequestButton style.
-	// Make sure `theme` defaults to 'dark' if it's not found in the server provided configuration.
-	const {
-		type = 'default',
-		theme = 'dark',
-		height = '48',
-	} = getBlocksConfiguration()?.button;
-
 	const paymentRequestButtonStyle = {
 		paymentRequestButton: {
-			type,
-			theme,
-			height: `${ height }px`,
+			type: buttonAttributes.label ? 'buy' : 'default',
+			theme: buttonAttributes.theme,
+			height: `${ buttonAttributes.height }`,
 		},
 	};
 
@@ -138,7 +131,6 @@ const PaymentRequestExpressComponent = ( {
 		paymentRequestButtonStyle.paymentRequestButton.type =
 			brandedType === 'long' ? 'buy' : 'default';
 	}
-
 	return (
 		<LoadingMask
 			isLoading={ isUpdatingPaymentRequest }

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -72,7 +72,7 @@ const PaymentRequestExpressComponent = ( {
 
 	const paymentRequestButtonStyle = {
 		paymentRequestButton: {
-			type: buttonAttributes.label ? 'buy' : 'default',
+			type: buttonAttributes.label,
 			theme: buttonAttributes.theme,
 			height: `${ buttonAttributes.height }`,
 		},


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

P2 Post: pdFofs-1O1-p2


## Changes proposed in this Pull Request:

This is POC PR to demonstrate how an extension can follow the express payment button guidelines. 


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1.  Set a local environment for PR: https://github.com/woocommerce/woocommerce/pull/44542
2. Activate the payment methods and express payment button. 
3. Go to Checkout block page with https
4. Confirm the below express payment button is displayed for stripe:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/11503784/fcea0dcc-5346-4091-81e8-bcfd1a24045a)

 


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)