### PR TITLE
Fix failing e2e tests

### DIFF
--- a/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
+++ b/tests/e2e/tests/woocommerce-blocks/card-failures.spec.js
@@ -50,7 +50,7 @@ const testCard = async ( page, cardKey ) => {
 		) {
 			// If the version is smaller than 10.0.0, change the selector.
 			errorSelector =
-				'.wc-block-checkout__payment-method .woocommerce-error';
+				'.wc-block-checkout__payment-method .wc-block-components-notice-banner.is-error';
 		}
 
 		expected = await page.innerText(

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -24,8 +24,8 @@ export async function emptyCart( page ) {
 		await page.click( '.woocommerce-remove-coupon' );
 	}
 
-	await page.waitForSelector( '.cart-empty.woocommerce-info' );
-	await expect( page.locator( '.cart-empty.woocommerce-info' ) ).toHaveText(
+	await page.waitForSelector( '.wc-empty-cart-message' );
+	await expect( page.locator( '.wc-empty-cart-message' ) ).toHaveText(
 		'Your cart is currently empty.'
 	);
 }


### PR DESCRIPTION
Fixes #2892

## Changes proposed in this Pull Request:

1. Create a page that uses the shortcode checkout
2. Create a page that uses the shortcode cart
3. Expect that the default checkout and cart pages use their block versions
4. Adjust dom selectors to match the actual interface

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
