### PR TITLE
Fix syncing of local tokens with remote payment methods

### DIFF
--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -251,7 +251,7 @@ class WC_Stripe_Payment_Tokens {
 		}
 
 		try {
-			$gateway  = new WC_Stripe_UPE_Payment_Gateway();
+			$gateway  = WC_Stripe::get_instance()->get_main_stripe_gateway();
 			$customer = new WC_Stripe_Customer( $user_id );
 
 			// Payment methods that exist in Stripe.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -268,6 +268,7 @@ class WC_Stripe_Payment_Tokens {
 			// 2. If local payment methods are not found on Stripe's side, delete them.
 			// 3. If payment methods are found on Stripe's side but not locally, create them.
 			foreach ( $tokens as $token ) {
+				$payment_method_type = $this->get_payment_method_type_from_token( $token );
 
 				// The payment method type doesn't belong to us. Nothing to do here.
 				if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
@@ -295,16 +296,16 @@ class WC_Stripe_Payment_Tokens {
 				}
 
 				// Get the slug for the payment method type expected by the Stripe API.
-				$payment_method_type = $payment_method_instance->get_retrievable_type();
+				$payment_method_retrievable_type = $payment_method_instance->get_retrievable_type();
 
 				// Avoid redundancy by only processing the payment methods for each type once.
-				if ( ! in_array( $payment_method_type, $types_retrieved_from_stripe, true ) ) {
+				if ( ! in_array( $payment_method_retrievable_type, $types_retrieved_from_stripe, true ) ) {
 
-					$payment_methods_for_type   = $customer->get_payment_methods( $payment_method_type );
+					$payment_methods_for_type   = $customer->get_payment_methods( $payment_method_retrievable_type );
 					$stripe_payment_methods     = array_merge( $stripe_payment_methods, $payment_methods_for_type );
 					$stripe_payment_methods_ids = array_merge( $stripe_payment_methods_ids, wp_list_pluck( $payment_methods_for_type, 'id' ) );
 
-					$types_retrieved_from_stripe[] = $payment_method_type;
+					$types_retrieved_from_stripe[] = $payment_method_retrievable_type;
 				}
 
 				// Delete the local payment method if it doesn't exist in Stripe.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -249,71 +249,65 @@ class WC_Stripe_Payment_Tokens {
 			// Having 10 saved credit cards is considered an unsupported edge case, new ones that have been stored in Stripe won't be added.
 			return $tokens;
 		}
+		$gateway  = new WC_Stripe_UPE_Payment_Gateway();
+		$customer = new WC_Stripe_Customer( $user_id );
 
-		$gateway     = WC_Stripe::get_instance()->get_main_stripe_gateway();
-		$upe_gateway = null;
+		// IDs of the payment methods that exist in Stripe.
+		$stripe_payment_methods_ids = [];
 
-		foreach ( $gateway->payment_methods as $payment_gateway ) {
-			if ( $payment_gateway->id === $gateway_id ) {
-				$upe_gateway = $payment_gateway;
-				break;
-			}
-		}
+		// List of the types already retrieved to avoid pulling redundant information.
+		$types_retrieved_from_stripe = [];
 
-		if ( ! $upe_gateway || ! $upe_gateway->is_reusable() ) {
-			return $tokens;
-		}
-
-		$customer       = new WC_Stripe_Customer( $user_id );
-		$current_tokens = [];
-
+		// 1. Check if there's any discrepancy between the locally saved payment methods and those saved on Stripe's side.
+		// 2. If local payment methods are not found on Stripe's side, delete them.
+		// 3. If payment methods are found on Stripe's side but not locally, create them.
 		foreach ( $tokens as $token ) {
-			// Store relevant existing tokens here.
-			// We will use this list to check whether these methods still exist on Stripe's side.
-			$current_tokens[ $token->get_token() ] = $token;
-		}
 
-		try {
-			// If this UPE method uses a different payment method type as a token, we don't want to retrieve tokens for it. ie Bancontact uses SEPA tokens.
-			$payment_methods = $customer->get_payment_methods( $upe_gateway->get_retrievable_type() );
-
-			// Prevent unnecessary recursion, WC_Payment_Token::save() ends up calling 'woocommerce_get_customer_payment_tokens' in some cases.
-			remove_action( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );
-
-			foreach ( $payment_methods as $payment_method ) {
-				if ( ! isset( $current_tokens[ $payment_method->id ] ) ) {
-					$payment_method_type = $this->get_original_payment_method_type( $payment_method );
-
-					if ( $payment_method_type !== $upe_gateway::STRIPE_ID ) {
-						continue;
-					}
-
-					// Create new token for new payment method and add to list.
-					$token                      = $upe_gateway->create_payment_token_for_user( $user_id, $payment_method );
-					$tokens[ $token->get_id() ] = $token;
-				} else {
-					// Count that existing token for payment method is still present on Stripe.
-					// Remaining IDs in $remaining_tokens no longer exist with Stripe and will be eliminated.
-					unset( $current_tokens[ $payment_method->id ] );
-				}
+			// The payment method type doesn't belong to us. Nothing to do here.
+			if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
+				continue;
 			}
 
-			add_action( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );
+			$payment_method_instance = $gateway->payment_methods[ $payment_method_type ];
 
-			// Eliminate remaining payment methods no longer known by Stripe.
-			// Prevent unnecessary recursion, when deleting tokens.
-			remove_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
+			$token_gateway_id           = $token->get_gateway_id();
+			$payment_method_instance_id = $payment_method_instance->id;
 
-			foreach ( $current_tokens as $token ) {
+			// The gateway ID of the token doesn't belong to our gateways.
+			if (
+				'stripe_card' === $token_gateway_id &&
+				'card' !== $payment_method_instance_id &&
+				$token_gateway_id !== $payment_method_instance_id
+			) {
+				continue;
+			}
+
+			// Don't display the payment method if the gateway isn't enabled.
+			if ( ! $payment_method_instance->is_enabled() ) {
+				unset( $tokens[ $token->get_id() ] );
+				continue;
+			}
+
+			// Get the slug for the payment method type expected by the Stripe API.
+			$payment_method_type = $payment_method_instance->get_retrievable_type();
+
+			// Avoid redundancy by only processing the payment methods for each type once.
+			if ( ! in_array( $payment_method_type, $types_retrieved_from_stripe, true ) ) {
+
+				$payment_methods_for_type   = $customer->get_payment_methods( $payment_method_type );
+				$stripe_payment_methods_ids = array_merge( $stripe_payment_methods_ids, wp_list_pluck( $payment_methods_for_type, 'id' ) );
+
+				$types_retrieved_from_stripe[] = $payment_method_type;
+			}
+
+			// Delete the local payment method if it doesn't exist in Stripe.
+			if ( ! in_array( $token->get_token(), $stripe_payment_methods_ids, true ) ) {
 				unset( $tokens[ $token->get_id() ] );
 				$token->delete();
 			}
-			add_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
-
-		} catch ( WC_Stripe_Exception $e ) {
-			wc_add_notice( $e->getLocalizedMessage(), 'error' );
-			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 		}
+
+		// TODO: Create a local payment method if it exists in Stripe but not locally.
 
 		return $tokens;
 	}

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -353,26 +353,6 @@ class WC_Stripe_Payment_Tokens {
 	}
 
 	/**
-	 * Returns original type of payment method from Stripe payment method response,
-	 * after checking whether payment method is SEPA method generated from another type.
-	 *
-	 * @param object $payment_method Stripe payment method JSON object.
-	 *
-	 * @return string Payment method type/ID
-	 */
-	private function get_original_payment_method_type( $payment_method ) {
-		if ( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID === $payment_method->type ) {
-			if ( ! is_null( $payment_method->sepa_debit->generated_from->charge ) ) {
-				return $payment_method->sepa_debit->generated_from->charge->payment_method_details->type;
-			}
-			if ( ! is_null( $payment_method->sepa_debit->generated_from->setup_attempt ) ) {
-				return $payment_method->sepa_debit->generated_from->setup_attempt->payment_method_details->type;
-			}
-		}
-		return $payment_method->type;
-	}
-
-	/**
 	 * Returns original Stripe payment method type from payment token
 	 *
 	 * @param WC_Payment_Token $payment_token WC Payment Token (CC or SEPA)


### PR DESCRIPTION
Fixes #2896 

## Changes proposed in this Pull Request:

- Reduce the amount of iteration when syncing local tokens with the payment methods in Stripe. We had four loops, two of them nested within each other. Now we're using two, not nested.
- (Hopefully) Simplify the logic behind the syncing process.

## Testing instructions

**Pulling remote payment methods**
1. Log in as a shopper
2. Go to My Account > Payment methods
3. Take note of the payment methods displayed
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/071a3d34-8acc-46e3-b40f-1ef2085545d3">

4. On the Stripe dashboard, go to the page for the customer associated with this shopper. It's in `https://dashboard.stripe.com/test/customers/cus_xxxx`
5. Under Payment Methods, click on Add > Add card
6. Enter a test card, like `4000056655665556`
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/9c5b04b2-6bc6-415c-9c8f-d056edc259fb">

7. Skip the stored transient. Either remove the transient in wp_options `LIKE '%stripe_payment_methods_%'`, or assign `false` to [this variable](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/tokens-syncing/includes/class-wc-stripe-customer.php#L451)
8. As the shopper, reload the My Account > Payment methods page
9. Confirm that the card you just added to Stripe is listed
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/af47ec9f-d897-4e04-8919-3d10f8d63323">

**Deleting local payment methods when removed remotely**
1. Log in as a shopper
2. Go to My Account > Payment methods
3. Take note of the payment methods displayed there
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/7384488e-07d4-4a00-b3ac-eba6dbea900c">

4. On the Stripe dashboard, go to the page for the customer associated with this shopper. It's in `https://dashboard.stripe.com/test/customers/cus_xxxx`
5. Under Payment Methods, delete one of the payment methods
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/dbd91cfc-003f-492b-a65e-4d9db0de7f1b">

6. Skip the stored transient. Either remove the transient in wp_options `LIKE '%stripe_payment_methods_%'`, or assign `false` to [this variable](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/tokens-syncing/includes/class-wc-stripe-customer.php#L451)
7. As the shopper, reload the My Account > Payment methods page
8. Confirm that the payment method you deleted in Stripe is no longer listed
<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/56d5cf11-639f-42cb-89aa-77926da21d9c">


**Regression tests**

Listing of payment methods from other extensions
1. Enable WooPayments
2. Save some card and SEPA payment methods
3. Visit the My Account > Payment methods page
4. Confirm all the tokens are listed as expected: The tokens are listed, and they don't get duplicated or deleted

Listing saved APMs
1. Purchase a subscription using iDEAL, SEPA, or Bancontact
2. Go to the My Account > Payment Methods page
3. Confirm all the tokens are listed as expected


Disabling specific payment method types with saved payment methods
1. As a shopper, save a card and a SEPA payment method
2. Go to the My Account > Payment Methods page and note the listed payment methods
3. As a merchant, go to the Stripe settings page in the WP dashboard > Payment methods tab
4. Disable SEPA
5. As a shopper, go to the My Account > Payment Methods page
6. Confirm no SEPA payment methods are listed

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
