### PR TITLE
Remove APM payment methods in Stripe when their tokens are deleted locally

### DIFF
--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -12,6 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Payment_Tokens {
 	private static $_this;
 
+	const UPE_REUSABLE_GATEWAYS = [
+		WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
+		// TODO: Also add other UPE payment methods here.
+	];
+
 	/**
 	 * Constructor.
 	 *
@@ -374,7 +380,7 @@ class WC_Stripe_Payment_Tokens {
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
 		$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			if ( WC_Stripe_UPE_Payment_Gateway::ID === $token->get_gateway_id() ) {
+			if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS, true ) ) {
 				try {
 					$stripe_customer->detach_payment_method( $token->get_token() );
 				} catch ( WC_Stripe_Exception $e ) {

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -13,9 +13,12 @@ class WC_Stripe_Payment_Tokens {
 	private static $_this;
 
 	const UPE_REUSABLE_GATEWAYS = [
+		// Link payment methods are saved under the main Stripe gateway.
 		WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
 		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
-		// TODO: Also add other UPE payment methods here.
+		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
 	];
 
 	/**

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -379,22 +379,18 @@ class WC_Stripe_Payment_Tokens {
 	 */
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
 		$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS, true ) ) {
-				try {
+		try {
+			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS, true ) ) {
 					$stripe_customer->detach_payment_method( $token->get_token() );
-				} catch ( WC_Stripe_Exception $e ) {
-					WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 				}
-			}
-		} else {
-			if ( 'stripe' === $token->get_gateway_id() || 'stripe_sepa' === $token->get_gateway_id() ) {
-				try {
+			} else {
+				if ( 'stripe' === $token->get_gateway_id() || 'stripe_sepa' === $token->get_gateway_id() ) {
 					$stripe_customer->delete_source( $token->get_token() );
-				} catch ( WC_Stripe_Exception $e ) {
-					WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 				}
 			}
+		} catch ( WC_Stripe_Exception $e ) {
+			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 		}
 	}
 


### PR DESCRIPTION
Fixes #2898

## Changes proposed in this Pull Request:

- Keep a static array with the names of our reusable gateways.
- When UPE is enabled, check whether the token belongs to our reusable gateways, instead of only checking whether it belongs to the main gateway.

## Testing instructions

1. Enable Woo Subscriptions
2. Enable an the iDeal APM
3. Purchase a subscription product using iDeal
4. Confirm the new iDeal token is saved in your wc_woocommerce_payment_tokens table
5. Navigate to the Stripe dashboard (https://dashboard.stripe.com/test/customers/cus_XXXXXXX) and confirm the new iDeal/SEPA payment method in the list of the customers payment methods
6. Navigate to My Account > Payment methods 
7. Delete the iDeal token (listed as SEPA IBAN)
<img width="500" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/2116c07d-7388-40f2-b5a6-0670f0827930" >

8. Navigate to the Stripe dashboard (https://dashboard.stripe.com/test/customers/cus_XXXXXXX)
9. Confirm the iDeal/SEPA payment method was deleted

Test again using Bancontact and SEPA (and Sofort, once it's included in the base branch).

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
