### PR TITLE
[Split PE] Fixes error on block checkout when attempting to pay for failed renewal with a saved card

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1548,6 +1548,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param stdClass $intent Payment intent information.
 	 */
 	public function save_intent_to_order( $order, $intent ) {
+		// Don't save any intent information on a subscription.
+		if ( $this->is_subscription( $order ) ) {
+			return;
+		}
+
 		if ( 'payment_intent' === $intent->object ) {
 			WC_Stripe_Helper::add_payment_intent_to_order( $intent->id, $order );
 		} elseif ( 'setup_intent' === $intent->object ) {

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -115,4 +115,16 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 		return wcs_cart_contains_renewal();
 	}
 
+	/**
+	 * Checks if the given object is a WC_Subscription.
+	 *
+	 * Slightly more performant than has_subscription() which checks wcs_order_contains_subscription() first.
+	 *
+	 * @param  mixed $subscription
+	 *
+	 * @return boolean
+	 */
+	public function is_subscription( $subscription ) {
+		return function_exists( 'wcs_is_subscription' ) && wcs_is_subscription( $subscription );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2904 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This issue is fairly edge case, nevertheless, after changing a subscription's payment method via the **My Account > View Subscription** page, this incorrectly stores the `_stripe_setup_intent` metadata on the subscription which then gets copied to future renewal orders.

If a renewal order fails and has this setup_intent data, when a customer attempts to pay for the renewal order with a saved card on the checkout block, they will get an error on the checkout.
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/9f36a0fa-a323-4288-9f50-58edbbd308a3)


After digging into error there are actually two main issues at play:
1. Block checkout isn't always setting the `wc-stripe-is-deferred-intent` data, when using a standard Stripe saved card. This causes the `process_payment()` function to call `process_payment_with_saved_payment_method()` instead of the expected `process_payment_with_deferred_intent()`. Fixed by 7d32890aa51f9dca8820b9d2623a70183cc37fff
2. When changing a subscriptions payment method from the My Account > View Subscription page, we're saving the setup intent on the subscription which is then being copied to all future renewal orders. This setup intent is then being used to attempt payment which won't work. 8b08b230bafaf4e62dad1ea1b39e31d7a88788b9

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Enable UPE gateway and checkout `add/deferred-intent` branch
2. Set a block checkout as your default checkout.
3. Checkout `add/deferred-intent`
4. Purchase a subscription using a successful card (i.e. 4242)
5. From the **My Account > View subscription** page, change the payment method on your subscription to a card that will fail on the next renewal i.e. `4000000000000341`
6. Process a renewal order from the WP Admin Edit Subscription actions drop-down
7. From My Account click "Pay" next to the most recent failed order
8. Attempt to use the saved 4242 card to fix up the failed renewal order
9. Notice the checkout fails
10. Checkout this branch and attempt to use the saved card again to fix up the failed order. It should succeed.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
