### PR TITLE
Pass the PM back to the JS to ensure it can be confirmed on the checkout if it requires 3DS confirmation

### DIFF
--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -108,7 +108,9 @@ const PaymentProcessor = ( {
 	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;
 	const gatewayConfig = getPaymentMethods()[ upeMethods[ paymentMethodId ] ];
 
-	// Set shouldSavePayment to true if the cart contains a subscription or the payment method supports saving.
+	// Make sure shouldSavePayment is set to true if the cart contains a subscription.
+	// shouldSavePayment might be set to false because the cart contains a subscription and so the save checkbox isn't shown.
+	// If thats the case, we need to force it to true.
 	shouldSavePayment =
 		shouldSavePayment || getBlocksConfiguration()?.cartContainsSubscription;
 

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -108,6 +108,10 @@ const PaymentProcessor = ( {
 	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;
 	const gatewayConfig = getPaymentMethods()[ upeMethods[ paymentMethodId ] ];
 
+	// Set shouldSavePayment to true if the cart contains a subscription or the payment method supports saving.
+	shouldSavePayment =
+		shouldSavePayment || getBlocksConfiguration()?.cartContainsSubscription;
+
 	useEffect(
 		() =>
 			onPaymentSetup( () => {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -716,6 +716,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_method_id     = $payment_information['payment_method'];
 			$selected_payment_type = $payment_information['selected_payment_type'];
 			$upe_payment_method    = $this->payment_methods[ $selected_payment_type ] ?? null;
+			$response_args         = [];
 
 			// Update saved payment method async to include billing details.
 			if ( $payment_information['is_using_saved_payment_method'] ) {
@@ -805,6 +806,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 						$payment_intent->client_secret,
 						wp_create_nonce( 'wc_stripe_update_order_status_nonce' )
 					);
+
+					// Return the payment method used to process the payment so the block checkout can save the payment method.
+					$response_args['payment_method'] = $payment_information['payment_method'];
 				}
 			}
 
@@ -833,10 +837,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$order->payment_complete();
 			}
 
-			return [
-				'result'   => 'success',
-				'redirect' => $redirect,
-			];
+			return array_merge(
+				[
+					'result'   => 'success',
+					'redirect' => $redirect,
+				],
+				$response_args
+			);
 		} catch ( WC_Stripe_Exception $e ) {
 			$shopper_error_message = sprintf(
 				/* translators: localized exception message */


### PR DESCRIPTION
Fixes #2905

## Changes proposed in this Pull Request:

If you signed up to a subscription on the Block checkout, using a 3DS card, the subscription would eventually get created without a complete set of payment meta.

| <img width="631" alt="Screenshot 2024-02-15 at 1 18 00 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/13e2fc48-ea5e-475b-b906-d8be95a3d4d8"> | <img width="306" alt="Screenshot 2024-02-15 at 1 22 15 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ef3ddcd5-5255-42aa-ac00-72f5fa14a380"> |
|--------|--------|

This PR fixes that. 

For some background, this change puts the block checkout inline with classic checkout.

The classic checkout handles this by passing the `confirmIntent()` function the payment method ID ([code ref](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/2905-set-payment-method-on-3ds-confirmation/client/classic/upe/index.js#L217-L221)) that then leads the to the `confirmIntent()` function to pass the payment method ID to the `update_order_status` AJAX request (https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/2905-set-payment-method-on-3ds-confirmation/client/api/index.js#L318) which then leads to the payment method being saved [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/2905-set-payment-method-on-3ds-confirmation/includes/class-wc-stripe-intent-controller.php#L576-L580). 

Blocks is a little different. 

Classic checkouts store the `PM_` in a hidden element that can be pulled from. Block checkouts don't have that so I need to return it via the payment response ([this is inline with how WooPayments does it](https://github.com/Automattic/woocommerce-payments/blob/7.2.0/includes/class-wc-payment-gateway-wcpay.php#L1696)). 

On the classic checkout, the save payment method checkbox is also automatically checked if we require it to be saved (eg if the cart contains a subscription). That's not how it works on the Block checkout either. Because we don't show the checkbox, the `shouldSavePayment` is `false`. This PR makes sure it is set to true if the cart contains a subscription (ie we are required to save the payment method). 

## Testing instructions

1. Enable the Woo Subscriptions plugin.
2. Create a subscription product if you don't already have one. 
3. Place the subscription product in your cart and proceed to the block checkout page. 
4. Use a 3DS card `4000 0025 0000 3155`. 
5. Complete and authorize the payment. 
   - On `add/deferred-intent` if you view the subscription it will be missing the customer ID. 
   - On this branch it should be all good. 

| `add/deferred-intent` | This branch |
|--------|--------|
| <img width="631" alt="Screenshot 2024-02-15 at 1 18 00 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/13e2fc48-ea5e-475b-b906-d8be95a3d4d8"><img width="306" alt="Screenshot 2024-02-15 at 1 22 15 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ef3ddcd5-5255-42aa-ac00-72f5fa14a380"> | <img width="601" alt="Screenshot 2024-02-16 at 2 04 20 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/81ad5ba9-0dc1-42d9-abe5-f9ab075ade02"> <img width="702" alt="Screenshot 2024-02-16 at 2 07 15 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/d312ff24-2061-426b-8e95-8c35a111d545">|




---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
