### PR TITLE
Fix Undefined property $latest_charge PHP Warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,13 @@
 *** Changelog ***
 
+
 = 8.0.0 - 2024-xx-xx =
 * Fix - When toggling on the Stripe gateway from the payment methods list, don't incorrectly redirect the merchant to Stripe settings when test mode is enabled.
 * Fix - Hiding the expandable menu for UPE entirely when the feature is disabled.
 * Fix - Critical error when deactivating the extension after deactivating WooCommerce.
 * Fix - Add missing fee and payout information to the order details page in admin.
 * Fix - Hiding "Early Access" label and "Refresh payment methods" button when UPE is disabled.
+* Fix - Prevent undefined $latest_charge property warnings when signing up to subscriptions with no initial payment (eg free trials).
 * Tweak - Orders with `trash` status are not retrieving anymore when calling `get_order_by_intent_id` function.
 * Add   - Update the interface for customizing Stripe payment methods.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 *** Changelog ***
 
-
 = 8.0.0 - 2024-xx-xx =
 * Fix - When toggling on the Stripe gateway from the payment methods list, don't incorrectly redirect the merchant to Stripe settings when test mode is enabled.
 * Fix - Hiding the expandable menu for UPE entirely when the feature is disabled.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1538,15 +1538,15 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function save_intent_to_order( $order, $intent ) {
 		if ( 'payment_intent' === $intent->object ) {
 			WC_Stripe_Helper::add_payment_intent_to_order( $intent->id, $order );
+
+			// Add the mandate id necessary for renewal payments with Indian cards if it's present.
+			$charge = $this->get_latest_charge_from_intent( $intent );
+
+			if ( isset( $charge->payment_method_details->card->mandate ) ) {
+				$order->update_meta_data( '_stripe_mandate_id', $charge->payment_method_details->card->mandate );
+			}
 		} elseif ( 'setup_intent' === $intent->object ) {
 			$order->update_meta_data( '_stripe_setup_intent', $intent->id );
-		}
-
-		// Add the mandate id necessary for renewal payments with Indian cards if it's present.
-		$charge = $this->get_latest_charge_from_intent( $intent );
-
-		if ( isset( $charge->payment_method_details->card->mandate ) ) {
-			$order->update_meta_data( '_stripe_mandate_id', $charge->payment_method_details->card->mandate );
 		}
 
 		if ( is_callable( [ $order, 'save' ] ) ) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -710,11 +710,15 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return object
 	 */
 	public function get_latest_charge_from_intent( $intent ) {
+		$latest_charge = null;
+
 		if ( ! empty( $intent->charges->data ) ) {
-			return end( $intent->charges->data );
-		} else {
-			return $this->get_charge_object( $intent->latest_charge );
+			$latest_charge = end( $intent->charges->data );
+		} elseif ( ! empty( $intent->latest_charge ) ) {
+			$latest_charge = $this->get_charge_object( $intent->latest_charge );
 		}
+
+		return $latest_charge;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2901

## Changes proposed in this Pull Request:

When you sign up to a subscription product that is free, we create a set up intent and then save it to the order via `save_intent_to_order()`. Inside that function we attempt to get the latest charge from the intent to store mandate date.

However, the latest charge is a property of [payment intents](https://docs.stripe.com/api/payment_intents/object#payment_intent_object-latest_charge) not [set up intents](https://docs.stripe.com/api/setup_intents/object) and that leads to the following error:

```
PHP Warning:  Undefined property: stdClass::$latest_charge in /woocommerce-gateway-stripe/includes/abstracts/abstract-wc-stripe-payment-gateway.php on line 728
```

This PR fixes that by making sure we only attempt to fetch the latest charge on payment intents, and not setup intents as well as prevent the warning by checking that the latest charge property is set before attempting to access it. 

## Testing instructions

1. Install and activate Woo Subscriptions.
2. Create a subscription product with a free trial. 
3. Add the product to your cart and make sure the initial total is $0 (we need a set up intent).
4. Using a card, complete the purchase. 
   - On `develop` you will see the PHP warning I mentioned above.
   - On this branch there shouldn't be an error. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
