### PR TITLE
Fix pre-orders status when UPE is enabled (with a new payment method)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.0.0 - 2024-xx-xx =
+* Fix - Wrong status when purchasing a pre-order product with a new payment method.
 * Fix - When toggling on the Stripe gateway from the payment methods list, don't incorrectly redirect the merchant to Stripe settings when test mode is enabled.
 * Fix - Hiding the expandable menu for UPE entirely when the feature is disabled.
 * Fix - Critical error when deactivating the extension after deactivating WooCommerce.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -707,14 +707,15 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @since 7.0.2
 	 * @param object $intent Stripe API Payment Intent object response.
 	 *
-	 * @return object
+	 * @return string|object
 	 */
 	public function get_latest_charge_from_intent( $intent ) {
 		if ( ! empty( $intent->charges->data ) ) {
 			return end( $intent->charges->data );
-		} else {
+		} elseif ( ! empty( $intent->latest_charge ) ) {
 			return $this->get_charge_object( $intent->latest_charge );
 		}
+		return '';
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -712,10 +712,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function get_latest_charge_from_intent( $intent ) {
 		if ( ! empty( $intent->charges->data ) ) {
 			return end( $intent->charges->data );
-		} elseif ( ! empty( $intent->latest_charge ) ) {
+		} else {
 			return $this->get_charge_object( $intent->latest_charge );
 		}
-		return '';
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -944,7 +944,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
-		// @todo status is not one of these yet
 		if ( $order->has_status( [ 'processing', 'completed', 'on-hold' ] ) ) {
 			return;
 		}
@@ -1000,13 +999,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 		$payment_method = $this->payment_methods[ $payment_method_type ];
 
-		$is_pre_order = false;
 		if ( $this->maybe_process_pre_orders( $order->get_id() ) ) {
 			// If this is a pre-order, simply mark the order as pre-ordered and allow
 			// the subsequent logic to save the payment method and proceed to complete the order.
 			$this->mark_order_as_pre_ordered( $order->get_id() );
 			$save_payment_method = true;
-			$is_pre_order        = true;
 		} else {
 			if ( $payment_needed ) {
 				// Use the last charge within the intent to proceed.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -530,10 +530,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$converted_amount = WC_Stripe_Helper::get_stripe_amount( $amount, $currency );
 
 				$request = [
-					'amount'               => $converted_amount,
-					'currency'             => $currency,
+					'amount'      => $converted_amount,
+					'currency'    => $currency,
 					/* translators: 1) blog name 2) order number */
-					'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+					'description' => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
 				];
 
 				// Use the dynamic + short statement descriptor if enabled and it's a card payment.
@@ -944,6 +944,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
+		// @todo status is not one of these yet
 		if ( $order->has_status( [ 'processing', 'completed', 'on-hold' ] ) ) {
 			return;
 		}
@@ -999,11 +1000,20 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 		$payment_method = $this->payment_methods[ $payment_method_type ];
 
+		$is_pre_order = false;
 		if ( $this->maybe_process_pre_orders( $order->get_id() ) ) {
 			// If this is a pre-order, simply mark the order as pre-ordered and allow
 			// the subsequent logic to save the payment method and proceed to complete the order.
 			$this->mark_order_as_pre_ordered( $order->get_id() );
 			$save_payment_method = true;
+			$is_pre_order        = true;
+		} else {
+			if ( $payment_needed ) {
+				// Use the last charge within the intent to proceed.
+				$this->process_response( end( $intent->charges->data ), $order );
+			} else {
+				$order->payment_complete();
+			}
 		}
 
 		if ( $save_payment_method && $payment_method->is_reusable() ) {
@@ -1023,12 +1033,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			do_action( 'woocommerce_stripe_add_payment_method', $customer->get_user_id(), $payment_method_object );
 		}
 
-		if ( $payment_needed ) {
-			// Use the last charge within the intent to proceed.
-			$this->process_response( end( $intent->charges->data ), $order );
-		} else {
-			$order->payment_complete();
-		}
 		$this->save_intent_to_order( $order, $intent );
 		$this->set_payment_method_title_for_order( $order, $payment_method_type );
 		$order->update_meta_data( '_stripe_upe_redirect_processed', true );

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.0.0 - 2024-xx-xx =
+* Fix - Wrong status when purchasing a pre-order product with a new payment method.
 * Fix - When toggling on the Stripe gateway from the payment methods list, don't incorrectly redirect the merchant to Stripe settings when test mode is enabled.
 * Fix - Hiding the expandable menu for UPE entirely when the feature is disabled.
 * Fix - Critical error when deactivating the extension after deactivating WooCommerce.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2572

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR fixes an issue when checking out pre-order products with a new payment method. Currently, there's a bug that puts pre-orders into the `processing` status on this case (the status should remain as `pre-ordered`).

The fix consists in replicating part of the non-UPE purchase flow and not calling the `process_response` or `payment_complete` for pre-orders.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch on your local environment
- Run `npm install`, `npm build:webpack` and `npm run up`
- Access your admin and install [pre-orders plugin](https://github.com/woocommerce/woocommerce-pre-orders/releases)
- Create a pre-order product
- Purchase it using a new payment method
- Confirm that the order status will be `pre-ordered` as expected

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
