### PR TITLE
Fix failing E2E tests in WC 8.6 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "7.9.3",
+  "version": "8.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-gateway-stripe",
-      "version": "7.9.1",
+      "version": "8.0.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/tests/e2e/tests/checkout/card-failures.spec.js
+++ b/tests/e2e/tests/checkout/card-failures.spec.js
@@ -45,11 +45,11 @@ test.describe.configure( { mode: 'parallel' } );
 test.describe( 'customer cannot checkout with invalid cards', () => {
 	test( `a declined card shows the correct error message @smoke`, async ( {
 		page,
-	} ) => testCardBlocks( page, 'cards.declined' ) );
+	} ) => testCard( page, 'cards.declined' ) );
 
 	test( `a card with insufficient funds shows the correct error message`, async ( {
 		page,
-	} ) => testCardBlocks( page, 'cards.declined-funds' ) );
+	} ) => testCard( page, 'cards.declined-funds' ) );
 
 	test( `a card with invalid number shows the correct error message`, async ( {
 		page,
@@ -57,13 +57,13 @@ test.describe( 'customer cannot checkout with invalid cards', () => {
 
 	test( `an expired card shows the correct error message`, async ( {
 		page,
-	} ) => testCardBlocks( page, 'cards.declined-expired' ) );
+	} ) => testCard( page, 'cards.declined-expired' ) );
 
 	test( `a card with incorrect CVC shows the correct error message @smoke`, async ( {
 		page,
-	} ) => testCardBlocks( page, 'cards.declined-cvc' ) );
+	} ) => testCard( page, 'cards.declined-cvc' ) );
 
 	test( `an error processing the card shows the correct error message`, async ( {
 		page,
-	} ) => testCardBlocks( page, 'cards.declined-processing' ) );
+	} ) => testCard( page, 'cards.declined-processing' ) );
 } );

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -25,7 +25,7 @@ export async function emptyCart( page ) {
 	}
 
 	await expect(
-		page.locator( '.wc-block-components-notice-banner__content' )
+		page.locator( '.wc-empty-cart-message .cart-empty' )
 	).toHaveText( 'Your cart is currently empty.' );
 }
 


### PR DESCRIPTION
Fixes #2913

## Changes proposed in this Pull Request:

This PR updates the selectors for the Empty Cart message in the shortcode cart, and for the Error messages in the shortcode checkout page.

## Testing instructions

1. Create a JN site
2. Run the E2E suite with the latest release (`7.9.3`):
    `npm run test:e2e-setup -- --base_url=<JN_URL>`
3. Verify that the setup and all 22 e2e tests succeed.
     <img width="1711" alt="Screenshot 2024-02-18 at 04 19 17" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/2bc49780-437e-4455-87a6-136d0dc1e615">

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
