### PR TITLE
Update our `filter_gateway_title()` function to work in HPOS but also fix it from overriding the stripe payment method title

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -459,14 +459,18 @@ class WC_Stripe_Payment_Request {
 	 * Filters the gateway title to reflect Payment Request type
 	 */
 	public function filter_gateway_title( $title, $id ) {
-		global $post;
+		global $theorder;
 
-		if ( ! is_object( $post ) ) {
+		// If $theorder is empty (i.e. non-HPOS), fallback to using the global post object.
+		if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
+			$theorder = wc_get_order( $GLOBALS['post']->ID );
+		}
+
+		if ( ! is_object( $theorder ) ) {
 			return $title;
 		}
 
-		$order        = wc_get_order( $post->ID );
-		$method_title = is_object( $order ) ? $order->get_payment_method_title() : '';
+		$method_title = $theorder->get_payment_method_title();
 
 		if ( 'stripe' === $id && ! empty( $method_title ) ) {
 			if ( 'Apple Pay (Stripe)' === $method_title

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -483,8 +483,6 @@ class WC_Stripe_Payment_Request {
 			if ( 'Chrome Payment Request (Stripe)' === $method_title ) {
 				return 'Payment Request (Stripe)';
 			}
-
-			return $method_title;
 		}
 
 		return $title;


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2899 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR is fixing two issues present in our `WC_Stripe_Payment_Request::filter_gateway_title()` function:

1. When HPOS is disabled, purchasing a subscription with SEPA causes the payment methods drop-down list on the Edit Subscription page to have two SEPA options:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/e04d35e3-1e61-443c-84f2-4cea6e135e0a)
2. When HPOS is enabled and viewing the Edit Order page for an order purchased with Apple Pay and/or Google Pay will show the payment was via Credit Card instead of the expected Google Pay (Stripe):![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/fe024e79-3dd5-413f-8ce3-b56ad5437129)


These two issues are caused by the `WC_Stripe_Payment_Request::filter_gateway_title()` not supporting HPOS environments, and incorrect logic which overrides the payment method title for payment method "Stripe" to whatever is set on the order/subscription.

These two issues are fixed by this PR.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Have Woo Subscriptions enabled and a subscription product to purchase
2. Have HPOS with compatibility mode/syncing enabled (so that you can easily switch between HPOS and non-HPOS environments)
3. Enable the New checkout experience in Woo > Stripe settings
4. Switch your store currency to EUR and have SEPA and Google Pay enabled and available to test
5. Checkout the `add/deferred-intent` branch
6. Start with HPOS turned off by selecting **WordPress posts storage** (`wp-admin/admin.php?page=wc-settings&tab=advanced&section=features`)
7. Purchase a subscription product with SEPA
8. Visit the WP Admin > Edit Subscription page for this new subscription and edit the billing details to view/change the payment method.
9. Click on the payment method drop-down and notice there are two SEPA options:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/49abd26b-c9d3-428d-abca-07e8c689eb63)
10. Checkout this branch and refresh the Edit Subscription page
11. Notice there are now two payment method titles displayed instead of duplicates: SEPA + Credit Card![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/1a2b9d4c-f9cc-4413-9c5c-2e087f28eb79)
12. Turn on HPOS
13. Confirm the payment method titles listed in the payment methods dropdown on the Edit Subscription page is still correct.
14. Purchase any product with Google Pay
15. Checkout `add/deferred-intent` branch
16. View the Edit Order page and observe the line under the **Order #1235 details says:** Payment via Credit / Debit Card
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/47972301-0ec5-4826-b903-02aa7132355e)
17. Checkout this branch and refresh the page to confirm the correct Payment Method title is being used for orders purchased with our PRB:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/607a2007-394a-4bbd-9127-474d8dc3d774)


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
