### PR TITLE
Deferred intent UPE - Fix errors when attempting to add payment methods via My Account > Payment methods

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -197,6 +197,8 @@ export default class WCStripeAPI {
 			) {
 				window.location.href =
 					response.data.next_action.redirect_to_url.url;
+
+				return response.data.next_action.type;
 			}
 
 			return this.getStripe()

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -191,6 +191,14 @@ export default class WCStripeAPI {
 				return response.data;
 			}
 
+			if (
+				response.data.status === 'requires_action' &&
+				response.data.next_action.type === 'redirect_to_url'
+			) {
+				window.location.href =
+					response.data.next_action.redirect_to_url.url;
+			}
+
 			return this.getStripe()
 				.confirmCardSetup( response.data.client_secret )
 				.then( ( confirmedSetupIntent ) => {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -224,6 +224,8 @@ export const processPayment = (
 	( async () => {
 		try {
 			await validateElements( elements );
+			let customerRedirected = false;
+
 			const paymentMethodObject = await createStripePaymentMethod(
 				api,
 				elements,
@@ -237,9 +239,19 @@ export const processPayment = (
 			await additionalActionsHandler(
 				paymentMethodObject.paymentMethod,
 				jQueryForm,
-				api
+				api,
+				() => {
+					// Provide a callback to flag that a redirect has occurred.
+					customerRedirected = true;
+				}
 			);
+
+			if ( customerRedirected ) {
+				return;
+			}
+
 			hasCheckoutCompleted = true;
+
 			submitForm( jQueryForm );
 		} catch ( err ) {
 			hasCheckoutCompleted = false;
@@ -260,17 +272,24 @@ export const processPayment = (
  * @param {string} paymentMethod The payment method ID (i.e. pm_1234567890).
  * @param {Object} jQueryForm The jQuery object for the form being submitted.
  * @param {Object} api The API object used to create the Stripe payment method.
+ * @param {Function} setCustomerRedirected The callback function to execute when a redirect is needed.
  *
  * @return {Promise<Object>} A promise that resolves with the confirmed setup intent.
  */
 export const createAndConfirmSetupIntent = (
 	paymentMethod,
 	jQueryForm,
-	api
+	api,
+	setCustomerRedirected
 ) => {
 	return api
 		.setupIntent( paymentMethod )
 		.then( function ( confirmedSetupIntent ) {
+			if ( confirmedSetupIntent === 'redirect_to_url' ) {
+				setCustomerRedirected();
+				return;
+			}
+
 			appendSetupIntentToForm( jQueryForm, confirmedSetupIntent );
 			return confirmedSetupIntent;
 		} );

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -251,7 +251,6 @@ export const processPayment = (
 			}
 
 			hasCheckoutCompleted = true;
-
 			submitForm( jQueryForm );
 		} catch ( err ) {
 			hasCheckoutCompleted = false;

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -957,8 +957,11 @@ class WC_Stripe_Intent_Controller {
 			'customer'             => $payment_information['customer'],
 			'confirm'              => 'true',
 			'return_url'           => $payment_information['return_url'],
-			'use_stripe_sdk'       => 'true',
 		];
+
+		if ( isset( $payment_information['use_stripe_sdk'] ) ) {
+			$request['use_stripe_sdk'] = $payment_information['use_stripe_sdk'];
+		}
 
 		// SEPA setup intents require mandate data.
 		if ( $this->is_mandate_data_required( $payment_information['selected_payment_type'] ) ) {
@@ -1006,6 +1009,7 @@ class WC_Stripe_Intent_Controller {
 				'customer'              => $customer->update_or_create_customer(),
 				'selected_payment_type' => $payment_type,
 				'return_url'            => wc_get_account_endpoint_url( 'payment-methods' ),
+				'use_stripe_sdk'        => 'true',
 			];
 
 			$setup_intent = $this->create_and_confirm_setup_intent( $payment_information );

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -957,6 +957,7 @@ class WC_Stripe_Intent_Controller {
 			'customer'             => $payment_information['customer'],
 			'confirm'              => 'true',
 			'return_url'           => $payment_information['return_url'],
+			'use_stripe_sdk'       => 'true',
 		];
 
 		// SEPA setup intents require mandate data.
@@ -1004,6 +1005,7 @@ class WC_Stripe_Intent_Controller {
 				'payment_method'        => $payment_method,
 				'customer'              => $customer->update_or_create_customer(),
 				'selected_payment_type' => $payment_type,
+				'return_url'            => wc_get_account_endpoint_url( 'payment-methods' ),
 			];
 
 			$setup_intent = $this->create_and_confirm_setup_intent( $payment_information );
@@ -1017,6 +1019,7 @@ class WC_Stripe_Intent_Controller {
 					'status'        => $setup_intent->status,
 					'id'            => $setup_intent->id,
 					'client_secret' => $setup_intent->client_secret,
+					'next_action'   => $setup_intent->next_action,
 				],
 				200
 			);

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -957,6 +957,7 @@ class WC_Stripe_Intent_Controller {
 			'customer'             => $payment_information['customer'],
 			'confirm'              => 'true',
 			'return_url'           => $payment_information['return_url'],
+			'use_stripe_sdk'       => 'true',
 		];
 
 		// SEPA setup intents require mandate data.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -957,7 +957,6 @@ class WC_Stripe_Intent_Controller {
 			'customer'             => $payment_information['customer'],
 			'confirm'              => 'true',
 			'return_url'           => $payment_information['return_url'],
-			'use_stripe_sdk'       => 'true',
 		];
 
 		// SEPA setup intents require mandate data.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1009,7 +1009,7 @@ class WC_Stripe_Intent_Controller {
 				'customer'              => $customer->update_or_create_customer(),
 				'selected_payment_type' => $payment_type,
 				'return_url'            => wc_get_account_endpoint_url( 'payment-methods' ),
-				'use_stripe_sdk'        => 'true',
+				'use_stripe_sdk'        => 'true', // We want the user to complete the next steps via the JS elements. ref https://docs.stripe.com/api/setup_intents/create#create_setup_intent-use_stripe_sdk
 			];
 
 			$setup_intent = $this->create_and_confirm_setup_intent( $payment_information );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -401,6 +401,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					)
 				);
 			}
+		} elseif ( is_wc_endpoint_url( 'add-payment-method' ) ) {
+			$stripe_params['cartTotal'] = 0;
 		}
 
 		// Pre-orders and free trial subscriptions don't require payments.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -29,6 +29,7 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 			'Reach 500 million customers and over 20 million businesses across the European Union.',
 			'woocommerce-gateway-stripe'
 		);
+		$this->supports[] = 'tokenization';
 
 		// SEPA Direct Debit is the tokenization method for this method as well as Bancontact and iDEAL. Init subscription so it can process subscription payments.
 		$this->maybe_init_subscriptions();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -422,6 +422,18 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Process the add payment method request.
+	 *
+	 * UPE Payment methods use the WC_Stripe_UPE_Payment_Gateway::process_payment() function.
+	 *
+	 * @return array The add payment method result.
+	 */
+	public function add_payment_method() {
+		$upe_gateway_instance = WC_Stripe::get_instance()->get_main_stripe_gateway();
+		return $upe_gateway_instance->add_payment_method();
+	}
+
+	/**
 	 * Determines if the Stripe Account country supports this UPE method.
 	 *
 	 * @return bool


### PR DESCRIPTION
Fixes #2907
Fixes #2798

## Changes proposed in this Pull Request:

This PR fixes a couple of issues encountered when trying to add payment methods via the My Account > Payment methods screen. 

Namely: 

1. Undefined `return_url` errors. As reported in #2907.
2. APMs that require a redirect like Bancontact and iDEAL are not correctly redirected and tokens created on returning to the store. 
3. Adding a SEPA payment method now properly calls the UPE gateway instance of `add_payment_method()`, rather than falling through to the base class. 

## Testing instructions

Setup: 

1. Use a Stripe account with access to all European APMS (iDEAL, Bancontact, SEPA, Sofort).
2. Enable UPE in the Stripe gateway advanced settings. 
3. Set your store to Euro currency. 
4. Enable all available payment methods in the Stripe plugin Settings.  
1. Go to My Account > Payment methods and delete all payment methods (this will just make it easier to track new tokens as they are being created).

### Cards

#### Standard Card
1. **My Account > Payment methods > _Add payment Method_**
2. Enter a default card ID `4242424242424242`
3. Fill all required fields and submit the form. 
4. On the following page, make sure the new payment method you just added is now listed.
5. Check the `wp_woocommerce_payment_tokens` database and confirm the the token was created with the `stripe` payment gateway ID. 

#### 3DS Card
1. **My Account > Payment methods > _Add payment Method_**
2. Enter a default card ID `4000002500003155`
3. Fill all required fields and submit the form. 
4. You should be shown a VISA auth popup modal. Hit **'Complete'**. 
6. On the following page, make sure the new payment method you just added is now listed.
5. Check the `wp_woocommerce_payment_tokens` database and confirm the the token was created with the `stripe` payment gateway.

### iDEAL/Bancontact/Sofort
1. **My Account > Payment methods > _Add payment Method_**
2. Select **iDEAL** or **Bancontact** or **Sofort**. 
3. Fill all required fields and submit the form. 
4. You should be redirected Stripe test page where you can confirm/deny authorization.
5. Hit Authorize
6. On the following page, make sure the new payment method you just added is now listed.
   - iDEAL payment methods end with  `5264`. 
   - Bancontact payment methods end with `7061`.
   - Sofort payment methods end with `3000 `
6. Check the `wp_woocommerce_payment_tokens` database and confirm the the token was created with the `stripe_ideal` payment gateway.

<img width="662" alt="Screenshot 2024-02-19 at 5 52 30 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/925e92f0-ed09-4f49-a12f-dbf1012b2387">

> [!note]
> If you're fail the authorization after the redirect, you will return to the store with an appropriate failure notice. 

### SEPA
1. **My Account > Payment methods > _Add payment Method_**
2. Select **SEPA**
3. Fill all required fields and submit the form and enter the test IBAN `AT61 1904 3002 3457 3201`
6. On the following page, make sure the new payment method you just added is now listed.
   - SEPA PMs end with `3201 `. 
6. Check the `wp_woocommerce_payment_tokens` database and confirm the the token was created with the `stripe_sepa_debit` payment gateway.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
