### PR TITLE
Split upe w' deferred intent - don't display APMs on classic checkout while auth and capture is enabled

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -92,4 +92,14 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	public function is_available() {
 		return $this->is_available_for_account_country() && parent::is_available();
 	}
+
+	/**
+	 * Returns whether the payment method requires automatic capture.
+	 * By default all the UPE payment methods require automatic capture, except for "card" and "link".
+	 *
+	 * @return bool
+	 */
+	public function requires_automatic_capture() {
+		return false;
+	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -218,6 +218,11 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return $this->is_reusable();
 		}
 
+		// Note: this $this->is_automatic_capture_enabled() call will fall through to the UPE gateway class.
+		if ( $this->requires_automatic_capture() && ! $this->is_automatic_capture_enabled() ) {
+			return false;
+		}
+
 		return true;
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -218,7 +218,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return $this->is_reusable();
 		}
 
-		// Note: this $this->is_automatic_capture_enabled() call will fall through to the UPE gateway class.
+		// Note: this $this->is_automatic_capture_enabled() call will be handled by $this->__call() and fall through to the UPE gateway class.
 		if ( $this->requires_automatic_capture() && ! $this->is_automatic_capture_enabled() ) {
 			return false;
 		}

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -363,6 +363,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 			$this->set_mock_payment_method_return_value( 'get_capabilities_response', $mock_capabilities_response, true );
 			$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', $currency );
 			$this->set_mock_payment_method_return_value( 'is_subscription_item_in_cart', false );
+			$this->set_mock_payment_method_return_value( 'is_automatic_capture_enabled', true );
 
 			$payment_method = $this->mock_payment_methods[ $id ];
 			$this->assertFalse( $payment_method->is_enabled_at_checkout() );
@@ -388,6 +389,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 			$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', 'CASHMONEY', true );
 			$this->set_mock_payment_method_return_value( 'get_capabilities_response', self::MOCK_ACTIVE_CAPABILITIES_RESPONSE );
 			$this->set_mock_payment_method_return_value( 'is_subscription_item_in_cart', false );
+			$this->set_mock_payment_method_return_value( 'is_automatic_capture_enabled', true );
 
 			$payment_method       = $this->mock_payment_methods[ $id ];
 			$supported_currencies = $payment_method->get_supported_currencies();

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -349,6 +349,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		// Disable testmode.
 		$stripe_settings             = get_option( 'woocommerce_stripe_settings' );
 		$stripe_settings['testmode'] = 'no';
+		$stripe_settings['capture']  = 'yes';
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
@@ -363,7 +364,6 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 			$this->set_mock_payment_method_return_value( 'get_capabilities_response', $mock_capabilities_response, true );
 			$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', $currency );
 			$this->set_mock_payment_method_return_value( 'is_subscription_item_in_cart', false );
-			$this->set_mock_payment_method_return_value( 'is_automatic_capture_enabled', true );
 
 			$payment_method = $this->mock_payment_methods[ $id ];
 			$this->assertFalse( $payment_method->is_enabled_at_checkout() );
@@ -384,12 +384,14 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	 * Payment method is only enabled when its supported currency is present or method supports all currencies.
 	 */
 	public function test_payment_methods_are_only_enabled_when_currency_is_supported() {
+		$stripe_settings             = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['capture']  = 'yes';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
 		foreach ( $payment_method_ids as $id ) {
 			$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', 'CASHMONEY', true );
 			$this->set_mock_payment_method_return_value( 'get_capabilities_response', self::MOCK_ACTIVE_CAPABILITIES_RESPONSE );
 			$this->set_mock_payment_method_return_value( 'is_subscription_item_in_cart', false );
-			$this->set_mock_payment_method_return_value( 'is_automatic_capture_enabled', true );
 
 			$payment_method       = $this->mock_payment_methods[ $id ];
 			$supported_currencies = $payment_method->get_supported_currencies();

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -351,6 +351,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$stripe_settings['testmode'] = 'no';
 		$stripe_settings['capture']  = 'yes';
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+		WC_Stripe::get_instance()->get_main_stripe_gateway()->init_settings();
 
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
 		foreach ( $payment_method_ids as $id ) {
@@ -387,6 +388,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$stripe_settings             = get_option( 'woocommerce_stripe_settings' );
 		$stripe_settings['capture']  = 'yes';
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+		WC_Stripe::get_instance()->get_main_stripe_gateway()->init_settings();
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
 		foreach ( $payment_method_ids as $id ) {
 			$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', 'CASHMONEY', true );


### PR DESCRIPTION
Fixes #2923 

## Changes proposed in this Pull Request:

When you enable authorize and capture in the Stripe plugin settings, a modal pops up to explain that only card payments will be available while using auth and capture. 

This works as expected on the block checkout, however it doesn't on the classic checkout. All APMS were being shown even though auth and capture were enabled.

| <img width="272" alt="Screenshot 2024-02-20 at 11 35 12 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c2209917-45ce-4f4d-a428-3a19692ccbda"> | <img width="300" alt="Screenshot 2024-02-20 at 11 42 21 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/155afbce-cc24-42a9-8408-31cf66fa36f8"> |
|--------|--------|

This PR fixes that. 

## Testing instructions

1. Under **WooCommerce > Settings > General**, set the store currency to EUR
2. Under the Stripe Payment methods tab, enable all available APMs. 
3. Under the Stripe Settings tab, enable the Updated Checkout Experience and the _'authorization on checkout, and capture later'_ setting.
6. As a shopper, add a product to your cart and go to the classic checkout. 
   - On the `add/deferred-intent` branch notice all APMs are displayed.
   - On the this branch only cards are shown. 
7. Turn off authorize and capture and all payment methods should be now shown again. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
