### PR TITLE
Fix duplicated tokens and tokens type mismatch

### DIFF
--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -291,6 +291,9 @@ class WC_Stripe_Payment_Tokens {
 					'stripe_card' !== $payment_method_instance_id &&
 					$token_gateway_id !== $payment_method_instance_id
 				) {
+					// Prevent these from being displayed in the list.
+					// SEPA tokens created before 8.0.0 match this case.
+					unset( $tokens[ $token->get_id() ] );
 					continue;
 				}
 

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -336,7 +336,15 @@ class WC_Stripe_Payment_Tokens {
 
 				// Create a new token for the payment method and add it to the list.
 				if ( ! in_array( $stripe_payment_method->id, $locally_stored_payment_methods_ids, true ) ) {
-					$token = $payment_method_instance->create_payment_token_for_user( $user_id, $stripe_payment_method );
+					$payment_method_type = $stripe_payment_method->type;
+
+					// The payment method type doesn't match the ones we use. Nothing to do here.
+					if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
+						continue;
+					}
+
+					$payment_method_instance = $gateway->payment_methods[ $payment_method_type ];
+					$token                   = $payment_method_instance->create_payment_token_for_user( $user_id, $stripe_payment_method );
 
 					$tokens[ $token->get_id() ] = $token;
 				}

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -21,12 +21,12 @@ class WC_Stripe_Payment_Tokens {
 	 * The values are the related gateway ID we use for them in the extension.
 	 */
 	const UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD = [
-		'card'       => WC_Stripe_UPE_Payment_Gateway::ID,
-		'link'       => WC_Stripe_UPE_Payment_Gateway::ID,
-		'bancontact' => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
-		'ideal'      => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
-		'sepa_debit' => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
-		'sofort'     => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID         => WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID       => WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID      => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID       => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID     => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
 	];
 
 	/**
@@ -439,7 +439,7 @@ class WC_Stripe_Payment_Tokens {
 		$gateway_id          = self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ $payment_method_type ];
 
 		switch ( $payment_method_type ) {
-			case 'card':
+			case WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID:
 				$token = new WC_Payment_Token_CC();
 				$token->set_expiry_month( $payment_method->card->exp_month );
 				$token->set_expiry_year( $payment_method->card->exp_year );
@@ -447,7 +447,7 @@ class WC_Stripe_Payment_Tokens {
 				$token->set_last4( $payment_method->card->last4 );
 				break;
 
-			case 'link':
+			case WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID:
 				$token = new WC_Payment_Token_Link();
 				$token->set_email( $payment_method->link->email );
 				$token->set_payment_method_type( $payment_method_type );

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -12,13 +12,21 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Payment_Tokens {
 	private static $_this;
 
-	const UPE_REUSABLE_GATEWAYS = [
-		// Link payment methods are saved under the main Stripe gateway.
-		WC_Stripe_UPE_Payment_Gateway::ID,
-		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
+	/**
+	 * List of reusable payment gateways by payment method.
+	 *
+	 * The keys are the possible values for the type of the PaymentMethod object in Stripe.
+	 * https://docs.stripe.com/api/payment_methods/object#payment_method_object-type
+	 *
+	 * The values are the related gateway ID we use for them in the extension.
+	 */
+	const UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD = [
+		'card'       => WC_Stripe_UPE_Payment_Gateway::ID,
+		'link'       => WC_Stripe_UPE_Payment_Gateway::ID,
+		'bancontact' => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
+		'ideal'      => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
+		'sepa_debit' => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
+		'sofort'     => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
 	];
 
 	/**
@@ -239,8 +247,10 @@ class WC_Stripe_Payment_Tokens {
 	 * @return array
 	 */
 	public function woocommerce_get_customer_upe_payment_tokens( $tokens, $user_id, $gateway_id ) {
-
-		if ( ! is_user_logged_in() || ( ! empty( $gateway_id ) && ! in_array( $gateway_id, WC_Stripe_Helper::get_stripe_gateway_ids(), true ) ) ) {
+		if (
+			! is_user_logged_in() ||
+			( ! empty( $gateway_id ) && ! in_array( $gateway_id, self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) )
+		) {
 			return $tokens;
 		}
 
@@ -251,109 +261,61 @@ class WC_Stripe_Payment_Tokens {
 		}
 
 		try {
+			$stored_tokens = [];
+
+			foreach ( $tokens as $token ) {
+				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
+					$stored_tokens[ $token->get_token() ] = $token;
+				}
+			}
+
 			$gateway  = WC_Stripe::get_instance()->get_main_stripe_gateway();
 			$customer = new WC_Stripe_Customer( $user_id );
 
-			// Payment methods that exist in Stripe.
-			$stripe_payment_methods     = [];
-			$stripe_payment_methods_ids = [];
-
-			// List of the types already retrieved to avoid pulling redundant information.
-			$types_retrieved_from_stripe = [];
-
-			// IDs of the payment methods that exist locally.
-			$locally_stored_payment_methods_ids = [];
-
-			// 1. Check if there's any discrepancy between the locally saved payment methods and those saved on Stripe's side.
-			// 2. If local payment methods are not found on Stripe's side, delete them.
-			// 3. If payment methods are found on Stripe's side but not locally, create them.
-			foreach ( $tokens as $token ) {
-				$token_gateway_id = $token->get_gateway_id();
-
-				// The gateway ID of the token doesn't belong to our gateways.
-				if ( ! in_array( $token_gateway_id, self::UPE_REUSABLE_GATEWAYS, true ) ) {
-					continue;
-				}
-
-				$payment_method_type = $this->get_payment_method_type_from_token( $token );
+			// Retrieve the payment methods for the enabled reusable gateways.
+			$payment_methods = [];
+			foreach ( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD as $payment_method_type => $gateway_id ) {
 
 				// The payment method type doesn't match the ones we use. Nothing to do here.
 				if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
 					continue;
 				}
 
-				$payment_method_instance    = $gateway->payment_methods[ $payment_method_type ];
-				$payment_method_instance_id = $payment_method_instance->id;
-
-				// Card tokens are the only ones expected to have a mismatch between the token's gateway ID and the payment method instance ID.
-				if (
-					'stripe' === $token_gateway_id &&
-					'stripe_card' !== $payment_method_instance_id &&
-					$token_gateway_id !== $payment_method_instance_id
-				) {
-					// Prevent these from being displayed in the list.
-					// SEPA tokens created before 8.0.0 match this case.
-					unset( $tokens[ $token->get_id() ] );
-					continue;
-				}
-
-				// Don't display the payment method if the gateway isn't enabled.
-				if ( ! $payment_method_instance->is_enabled() ) {
-					unset( $tokens[ $token->get_id() ] );
-					continue;
-				}
-
-				// Get the slug for the payment method type expected by the Stripe API.
-				$payment_method_retrievable_type = $payment_method_instance->get_retrievable_type();
-
-				// Avoid redundancy by only processing the payment methods for each type once.
-				if ( ! in_array( $payment_method_retrievable_type, $types_retrieved_from_stripe, true ) ) {
-
-					$payment_methods_for_type   = $customer->get_payment_methods( $payment_method_retrievable_type );
-					$stripe_payment_methods     = array_merge( $stripe_payment_methods, $payment_methods_for_type );
-					$stripe_payment_methods_ids = array_merge( $stripe_payment_methods_ids, wp_list_pluck( $payment_methods_for_type, 'id' ) );
-
-					$types_retrieved_from_stripe[] = $payment_method_retrievable_type;
-				}
-
-				// Delete the local payment method if it doesn't exist in Stripe.
-				if ( ! in_array( $token->get_token(), $stripe_payment_methods_ids, true ) ) {
-					unset( $tokens[ $token->get_id() ] );
-
-					// Prevent unnecessary recursion when deleting tokens.
-					remove_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
-
-					$token->delete();
-
-					add_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
-				} else {
-					$locally_stored_payment_methods_ids[] = $token->get_token();
+				$payment_method_instance = $gateway->payment_methods[ $payment_method_type ];
+				if ( $payment_method_instance->is_enabled() ) {
+					$payment_methods[] = $customer->get_payment_methods( $payment_method_type );
 				}
 			}
+
+			$payment_methods = array_merge( ...$payment_methods );
 
 			// Prevent unnecessary recursion, WC_Payment_Token::save() ends up calling 'woocommerce_get_customer_payment_tokens' in some cases.
 			remove_action( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );
 
-			// Create a local payment method if it exists in Stripe but not locally.
-			foreach ( $stripe_payment_methods as $stripe_payment_method ) {
+			foreach ( $payment_methods as $payment_method ) {
+				if ( ! isset( $payment_method->type ) ) {
+					continue;
+				}
 
-				// Create a new token for the payment method and add it to the list.
-				if ( ! in_array( $stripe_payment_method->id, $locally_stored_payment_methods_ids, true ) ) {
-					$payment_method_type = $stripe_payment_method->type;
-
-					// The payment method type doesn't match the ones we use. Nothing to do here.
-					if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
-						continue;
-					}
-
-					$payment_method_instance = $gateway->payment_methods[ $payment_method_type ];
-					$token                   = $payment_method_instance->create_payment_token_for_user( $user_id, $stripe_payment_method );
-
+				if (
+					! isset( $stored_tokens[ $payment_method->id ] ) &&
+					( $this->is_valid_payment_method_type_for_gateway( $payment_method->type, $gateway_id ) || empty( $gateway_id ) )
+				) {
+					$token                      = $this->add_token_to_user( $payment_method, $customer );
 					$tokens[ $token->get_id() ] = $token;
+				} else {
+					unset( $stored_tokens[ $payment_method->id ] );
 				}
 			}
-
 			add_action( 'woocommerce_get_customer_payment_tokens', [ $this, 'woocommerce_get_customer_payment_tokens' ], 10, 3 );
+
+			// Remove the payment methods that no longer exist in Stripe's side.
+			remove_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
+			foreach ( $stored_tokens as $token ) {
+				unset( $tokens[ $token->get_id() ] );
+				$token->delete();
+			}
+			add_action( 'woocommerce_payment_token_deleted', [ $this, 'woocommerce_payment_token_deleted' ], 10, 2 );
 
 		} catch ( WC_Stripe_Exception $e ) {
 			wc_add_notice( $e->getLocalizedMessage(), 'error' );
@@ -409,7 +371,7 @@ class WC_Stripe_Payment_Tokens {
 		$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
 		try {
 			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS, true ) ) {
+				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
 					$stripe_customer->detach_payment_method( $token->get_token() );
 				}
 			} else {
@@ -445,6 +407,60 @@ class WC_Stripe_Payment_Tokens {
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 		}
+	}
+
+	/**
+	 * Returns boolean value if payment method type matches relevant payment gateway.
+	 *
+	 * @param string $payment_method_type Stripe payment method type ID.
+	 * @param string $gateway_id          WC Stripe gateway ID.
+	 * @return bool                       True, if payment method type matches gateway, false if otherwise.
+	 */
+	private function is_valid_payment_method_type_for_gateway( $payment_method_type, $gateway_id ) {
+		return self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ $payment_method_type ] === $gateway_id;
+	}
+
+	/**
+	 * Creates and add a token to an user, based on the PaymentMethod object.
+	 *
+	 * @param   array              $payment_method                              Payment method to be added.
+	 * @param   WC_Stripe_Customer $user                                        WC_Stripe_Customer we're processing the tokens for.
+	 * @return  WC_Payment_Token_CC|WC_Payment_Token_Link|WC_Payment_Token_SEPA The WC object for the payment token.
+	 */
+	private function add_token_to_user( $payment_method, WC_Stripe_Customer $customer ) {
+		// Clear cached payment methods.
+		$customer->clear_cache();
+
+		$gateway_id = self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ $payment_method->type ];
+
+		// TODO: add sofort, ideal, bancontact.
+		switch ( $payment_method->type ) {
+			case 'card':
+				$token = new WC_Payment_Token_CC();
+				$token->set_expiry_month( $payment_method->card->exp_month );
+				$token->set_expiry_year( $payment_method->card->exp_year );
+				$token->set_card_type( strtolower( $payment_method->card->brand ) );
+				$token->set_last4( $payment_method->card->last4 );
+				break;
+
+			case 'link':
+				$token = new WC_Payment_Token_Link();
+				$token->set_email( $payment_method->link->email );
+				$token->set_payment_method_type( $payment_method->type );
+				break;
+
+			default:
+				$token = new WC_Payment_Token_SEPA();
+				$token->set_last4( $payment_method->sepa_debit->last4 );
+				$token->set_payment_method_type( $payment_method->type );
+		}
+
+		$token->set_gateway_id( $gateway_id );
+		$token->set_token( $payment_method->id );
+		$token->set_user_id( $customer->get_user_id() );
+		$token->save();
+
+		return $token;
 	}
 }
 

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -287,8 +287,8 @@ class WC_Stripe_Payment_Tokens {
 
 				// Card tokens are the only ones expected to have a mismatch between the token's gateway ID and the payment method instance ID.
 				if (
-					'stripe_card' === $token_gateway_id &&
-					'card' !== $payment_method_instance_id &&
+					'stripe' === $token_gateway_id &&
+					'stripe_card' !== $payment_method_instance_id &&
 					$token_gateway_id !== $payment_method_instance_id
 				) {
 					continue;


### PR DESCRIPTION
Fixes #2894

## Changes proposed in this Pull Request:

- Update the check for a mismatch in the token's ID and the payment method instance ID. We were comparing them against the wrong strings before.
- When the token's ID and the payment method instance ID don't match, remove this token from the returned list. This mismatch happens for SEPA tokens created before Split PE (See #2894). We want to prevent them from being displayed while keeping them in the DB. (Or should we delete them from the DB?)
- When creating tokens, update the value of `$payment_method_instance` to match the type of the payment method we're processing.

## Testing instructions

**Creating the tokens in an older version**

1. Check out `develop`
2. Select EUR as the store currency
3. Under the Stripe settings, enable UPE and enable SEPA
4. As a shopper, go to the checkout page
5. Select "Use a new payment method"
6. Select SEPA
7. Enter `AT611904300234573201` and check off "Save payment information to my account for future purchases"
8. Place the order
9. Go to My Account > Payment methods
10. Notice there's a token for the SEPA payment method, all good

**Upgrading to 8.0.0**
1. Check out `add/deferred-intent`
2. Reload the My Account > Payment methods page
3. Confirm that there's a single token for SEPA, not two
4. Go to the shortcode checkout page
5. Confirm that the SEPA payment method only exists under the SEPA gateway, and not under Cards
6. Reload the My Account > Payment methods page
7. Confirm that no tokens got duplicated
8. Access the site database > wp_woocommerce_payment_tokens > search for the tokens for the shopper you're using
9. Confirm there's a single entry for the SEPA token. It must have a  "stripe_sepa_debit" value under the "payment_gateway_id" column

**Retrieving other APM tokens**
1. Buy a subscription using Bancontact, iDEAL, or Sofort
2. Reload the My Account > Payment methods page
3. Access the site database > wp_woocommerce_payment_tokens > search for the tokens for the shopper you're using
4. Confirm a token was created, and that it has "stripe_bancontact" under "payment_gateway_id"
5. Reload the My Account > Payment methods page
6. Confirm the Bancontact token doesn't get duplicated

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
