### PR TITLE
Deferred intent - Display a detailed error message to customers on card declines

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1829,7 +1829,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				throw new WC_Stripe_Exception(
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					print_r( $payment_intent, true ),
-					__( 'Sorry, we are unable to process your payment at this time. Please retry later.', 'woocommerce-gateway-stripe' )
+					$payment_intent->error->message
 				);
 			}
 


### PR DESCRIPTION
Fixes #2920

## Changes proposed in this Pull Request:

This pull request makes sure we display a more detailed and specific error message when a card declines. 

| Before | After |
|--------|--------|
| <img width="580" alt="Screenshot 2024-02-21 at 10 21 05 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/fe13112b-ab77-483b-9518-2f90c048019a">| <img width="565" alt="Screenshot 2024-02-21 at 10 21 50 am" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/9090c740-8c52-494a-9193-0268831b7339">| 

## Testing instructions

1. Enable UPE checkout. 
2. Add a product to your cart
3. On checkout use one of the failing payment methods:
    - `4000000000009995` - Insufficient funds decline
    - `4000000000000069` - Expired card decline
    - `4000000000000127` - Incorrect CVC decline
4. On `add/deferred-intent` you will see a generic error message not indicative of the error that occurred. See before screenshot above. 
5. On this branch a more specific error will be displayed. 

 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
