### PR TITLE
[Split PE] Create the token on returning to the store with Bancontact, iDEAL, Sofort

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1249,6 +1249,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			if ( $payment_method->get_id() !== $payment_method->get_retrievable_type() ) {
 				$generated_payment_method_id = $payment_method_details[ $payment_method_type ]->generated_sepa_debit;
 				$payment_method_object       = $this->stripe_request( "payment_methods/$generated_payment_method_id", [], null, 'GET' );
+
+				// This is our first opportunity to save the payment method for payment methods that have a different retrievable type. Save it now.
+				$payment_method->create_payment_token_for_user( $order->get_customer_id(), $payment_method_object );
 			} else {
 				$payment_method_object = $intent->payment_method;
 			}


### PR DESCRIPTION
Fixes #2928

## Changes proposed in this Pull Request:

When you opt to save a payment method and you use a payment method like Bancontact, iDEAL or Sofort, when you return to the store after authenticating the payment, the payment method isn't saved. 

This PR fixes that. 

## Testing instructions

1. Delete all payment tokens prior to testing so it's easier to track token changes. 
1. Check out **add/deferred-intent**
1. Select EUR as the store currency
2. Under the Stripe settings, enable UPE and enable Bancontact, iDEAL, Sofort
3. As a shopper, go to the checkout page
4. Select Bancontact, iDEAL or Sofort
5. Check the box to save the payment method
6. Place the order
7. Once redirected to Stripe test authorization page, authorize the payment
8. When you are returned to the store, open the database `wp_woocommerce_payment_tokens` table and notice that no `stripe_` token was created for that saved payment method.
9. Checkout this branch and repeat the steps above. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
