### PR TITLE
[Split PE] Don't render the Stripe Link payment method option on classic checkouts

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -96,7 +96,7 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	/**
 	 * Returns whether the payment method requires automatic capture.
 	 * By default all the UPE payment methods require automatic capture, except for "card" and "link".
-	  *
+	 *
 	 * @return bool
 	 */
 	public function requires_automatic_capture() {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -87,6 +87,11 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	/**
 	 * Returns true if the UPE method is available.
 	 *
+	 * Link isn't like a traditional UPE payment method as it is not shown as a standard payment method at checkout.
+	 * Customers use the Stripe Link button and the existing credit card fields to enter their payment details. The payment is then treated as a card.
+	 *
+	 * We return false here so the payment method isn't considered available by WooCommerce and rendered as a payment method at checkout.
+	 *
 	 * @return bool
 	 */
 	public function is_available() {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -92,4 +92,19 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	public function is_available() {
 		return $this->is_available_for_account_country() && parent::is_available();
 	}
+
+	/**
+	 * Returns whether the payment method is enabled at checkout.
+	 *
+	 * Link isn't like a traditional UPE payment method as it is not shown as a standard payment method at checkout.
+	 * Customers use the Stripe Link button and the existing credit card fields to enter their payment details. The payment is then treated as a card.
+	 *
+	 * We return false here so the payment method isn't rendered as a payment method at checkout.
+	 *
+	 * @param int|null $order_id
+	 * @return bool
+	 */
+	public function is_enabled_at_checkout( $order_id = null ) {
+		return false;
+	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -90,7 +90,7 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	 * @return bool
 	 */
 	public function is_available() {
-		return $this->is_available_for_account_country() && parent::is_available();
+		return false;
 	}
 
 	/**
@@ -100,21 +100,6 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	 * @return bool
 	 */
 	public function requires_automatic_capture() {
-		return false;
-	}
-
-	/**
-	 * Returns whether the payment method is enabled at checkout.
-	 *
-	 * Link isn't like a traditional UPE payment method as it is not shown as a standard payment method at checkout.
-	 * Customers use the Stripe Link button and the existing credit card fields to enter their payment details. The payment is then treated as a card.
-	 *
-	 * We return false here so the payment method isn't rendered as a payment method at checkout.
-	 *
-	 * @param int|null $order_id
-	 * @return bool
-	 */
-	public function is_enabled_at_checkout( $order_id = null ) {
 		return false;
 	}
 }


### PR DESCRIPTION
Fixes #2925 

## Changes proposed in this Pull Request:

On the **`add/deferred-intent`** branch, Stripe Link is currently being rendered on the classic  checkout with no payment element fields. 

<p align="center">
<img width="300" alt="Screenshot 2024-02-21 at 3 17 04 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/4aa28fb3-35f1-4145-bae8-d442bc8d2cff">
</p> 

This PR fixes that by making sure Link isn't enabled on Checkout. Link isn't a traditional payment method. A Link Express Payment button is rendered and once authenticated, the existing credit card fields are populated with that accounts card on file. _see example below_.

<p align="center">
<img width="600" alt="Screenshot 2024-02-21 at 3 19 49 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/0b3a2017-c1b0-4deb-a3c0-808e772fc8d3">
</p> 

With that in mind, there's no need for the a separate Link payment element to be shown on the checkout. 

> [!note]
> This only impacts the classic checkout. Block checkout isn't effected by this bug. 


## Testing instructions

1. Checkout the latest `add/deferred-intent` branch
2. Enter Stripe API credentials for a US based account. 
   - Note: the Stripe account needs to have a US address, simply setting your WC store to the US won't work. 
3. Set the store currency to USD.
3. On the Stripe Payment methods settings enable **Link**

<p align="center">
<img width="500" alt="Screenshot 2024-02-20 at 5 39 56 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/134be6ae-05a7-4f91-973e-33dd89c922b8">
</p>

4. Add an item to the cart. 
   - Go to the checkout page and note that the Stripe Link express elements have been displayed, but there's also an empty payment gateway option with Link. 
   - On this branch no Link option is shown. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
