### PR TITLE
Split PE - Add WooCommerce Pre-Order support for SEPA, iDEAL, Bancontact, Sofort purchases

### DIFF
--- a/includes/compat/trait-wc-stripe-pre-orders.php
+++ b/includes/compat/trait-wc-stripe-pre-orders.php
@@ -15,7 +15,7 @@ trait WC_Stripe_Pre_Orders_Trait {
 	 *
 	 * @var bool False by default, true once the callbacks have been attached.
 	 */
-	private static $has_attached_integration_hooks = false;
+	private static $has_attached_pre_order_integration_hooks = false;
 
 	/**
 	 * Initialize pre-orders hook.
@@ -35,11 +35,11 @@ trait WC_Stripe_Pre_Orders_Trait {
 		 * The callbacks attached below only need to be attached once. We don't need each gateway instance to have its own callback.
 		 * Therefore we only attach them once on the main `stripe` gateway and store a flag to indicate that they have been attached.
 		 */
-		if ( self::$has_attached_integration_hooks || WC_Gateway_Stripe::ID !== $this->id ) {
+		if ( self::$has_attached_pre_order_integration_hooks || WC_Gateway_Stripe::ID !== $this->id ) {
 			return;
 		}
 
-		self::$has_attached_integration_hooks = true;
+		self::$has_attached_pre_order_integration_hooks = true;
 
 		add_filter( 'wc_stripe_display_save_payment_method_checkbox', [ $this, 'hide_save_payment_for_pre_orders_charged_upon_release' ] );
 	}

--- a/includes/compat/trait-wc-stripe-pre-orders.php
+++ b/includes/compat/trait-wc-stripe-pre-orders.php
@@ -9,6 +9,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 trait WC_Stripe_Pre_Orders_Trait {
 
 	/**
+	 * Stores a flag to indicate if the Pre-order integration hooks have been attached.
+	 *
+	 * The callbacks attached as part of maybe_init_pre_orders() only need to be attached once to avoid duplication.
+	 *
+	 * @var bool False by default, true once the callbacks have been attached.
+	 */
+	private static $has_attached_integration_hooks = false;
+
+	/**
 	 * Initialize pre-orders hook.
 	 *
 	 * @since 5.8.0
@@ -21,6 +30,18 @@ trait WC_Stripe_Pre_Orders_Trait {
 		$this->supports[] = 'pre-orders';
 
 		add_action( 'wc_pre_orders_process_pre_order_completion_payment_' . $this->id, [ $this, 'process_pre_order_release_payment' ] );
+
+		/**
+		 * The callbacks attached below only need to be attached once. We don't need each gateway instance to have its own callback.
+		 * Therefore we only attach them once on the main `stripe` gateway and store a flag to indicate that they have been attached.
+		 */
+		if ( self::$has_attached_integration_hooks || WC_Gateway_Stripe::ID !== $this->id ) {
+			return;
+		}
+
+		self::$has_attached_integration_hooks = true;
+
+		add_filter( 'wc_stripe_display_save_payment_method_checkbox', [ $this, 'hide_save_payment_for_pre_orders_charged_upon_release' ] );
 	}
 
 	/**
@@ -263,5 +284,36 @@ trait WC_Stripe_Pre_Orders_Trait {
 				$order->add_order_note( $order_note );
 			}
 		}
+	}
+
+	/**
+	 * Determines if there is a pre-order in the cart and if it is charged upon release.
+	 *
+	 * @return bool
+	 */
+	public function is_pre_order_charged_upon_release_in_cart() {
+		$pre_order_product = $this->get_pre_order_product_from_cart();
+		return $pre_order_product && $this->is_pre_order_product_charged_upon_release( $pre_order_product );
+	}
+
+	/**
+	 * Hides the save payment method checkbox when the cart contains a pre-order that is charged upon release.
+	 *
+	 * @param bool $display_save_option The default value of whether the save payment method checkbox should be displayed.
+	 * @return bool Whether the save payment method checkbox should be displayed.
+	 */
+	public function hide_save_payment_for_pre_orders_charged_upon_release( $display_save_option ) {
+
+		// This function only sets the display param to false, so if it's already hidden or the cart doesn't contain a pre-order, we don't need to do anything.
+		if ( ! $display_save_option || ! $this->is_pre_order_item_in_cart() ) {
+			return $display_save_option;
+		}
+
+		// If the cart contains a pre-order that is charged upon release, we hide the save payment method checkbox because the payment method is force saved.
+		if ( $this->is_pre_order_charged_upon_release_in_cart() ) {
+			return false;
+		}
+
+		return $display_save_option;
 	}
 }

--- a/includes/compat/trait-wc-stripe-pre-orders.php
+++ b/includes/compat/trait-wc-stripe-pre-orders.php
@@ -297,6 +297,16 @@ trait WC_Stripe_Pre_Orders_Trait {
 	}
 
 	/**
+	 * Determines if an order contains a pre-order and if it is charged upon release.
+	 *
+	 * @return bool
+	 */
+	public function has_pre_order_charged_upon_release( $order ) {
+		$pre_order_product = $this->get_pre_order_product_from_order( $order );
+		return $pre_order_product && $this->is_pre_order_product_charged_upon_release( $pre_order_product );
+	}
+
+	/**
 	 * Hides the save payment method checkbox when the cart contains a pre-order that is charged upon release.
 	 *
 	 * @param bool $display_save_option The default value of whether the save payment method checkbox should be displayed.

--- a/includes/compat/trait-wc-stripe-pre-orders.php
+++ b/includes/compat/trait-wc-stripe-pre-orders.php
@@ -39,9 +39,9 @@ trait WC_Stripe_Pre_Orders_Trait {
 			return;
 		}
 
-		self::$has_attached_pre_order_integration_hooks = true;
-
 		add_filter( 'wc_stripe_display_save_payment_method_checkbox', [ $this, 'hide_save_payment_for_pre_orders_charged_upon_release' ] );
+
+		self::$has_attached_pre_order_integration_hooks = true;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1236,10 +1236,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$payment_method = $this->payment_methods[ $payment_method_type ];
 
 		$is_pre_order = false;
-		if ( $this->maybe_process_pre_orders( $order->get_id() ) ) {
+		if ( $this->has_pre_order( $order->get_id() ) ) {
 			// If this is a pre-order, simply mark the order as pre-ordered and allow
 			// the subsequent logic to save the payment method and proceed to complete the order.
-			$this->mark_order_as_pre_ordered( $order->get_id() );
+			if ( $this->maybe_process_pre_orders( $order->get_id() ) ) {
+				$this->mark_order_as_pre_ordered( $order->get_id() );
+			}
 			$save_payment_method = true;
 			$is_pre_order        = true;
 		}
@@ -2336,7 +2338,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	private function should_upe_payment_method_show_save_option( $payment_method ) {
 		if ( $payment_method->is_reusable() ) {
 			// If a subscription in the cart, it will be saved by default so no need to show the option.
-			return $this->is_saved_cards_enabled() && ! $this->is_subscription_item_in_cart();
+			return $this->is_saved_cards_enabled() && ! $this->is_subscription_item_in_cart() && ! $this->is_pre_order_charged_upon_release_in_cart();
 		}
 
 		return false;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -831,7 +831,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					]
 				);
 			} elseif ( in_array( $payment_intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
-				$order->payment_complete();
+				if ( ! $this->has_pre_order( $order ) ) {
+					$order->payment_complete();
+				} elseif ( $this->maybe_process_pre_orders( $order ) ) {
+					$this->mark_order_as_pre_ordered( $order );
+				}
 			}
 
 			return array_merge(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1243,10 +1243,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		if ( $this->has_pre_order( $order->get_id() ) ) {
 			// If this is a pre-order, simply mark the order as pre-ordered and allow
 			// the subsequent logic to save the payment method and proceed to complete the order.
-			if ( $this->maybe_process_pre_orders( $order->get_id() ) ) {
-				$this->mark_order_as_pre_ordered( $order->get_id() );
-			}
-			$save_payment_method = true;
+			$this->mark_order_as_pre_ordered( $order->get_id() );
+
+			// We require to save the payment method if the pre-order is charged upon release.
+			$save_payment_method = $save_payment_method || $this->has_pre_order_charged_upon_release( $order );
 			$is_pre_order        = true;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
@@ -29,5 +29,8 @@ class WC_Stripe_UPE_Payment_Method_Bancontact extends WC_Stripe_UPE_Payment_Meth
 			'Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.',
 			'woocommerce-gateway-stripe'
 		);
+
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
@@ -29,5 +29,8 @@ class WC_Stripe_UPE_Payment_Method_Ideal extends WC_Stripe_UPE_Payment_Method {
 			'iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.',
 			'woocommerce-gateway-stripe'
 		);
+
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -33,6 +33,9 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 
 		// SEPA Direct Debit is the tokenization method for this method as well as Bancontact and iDEAL. Init subscription so it can process subscription payments.
 		$this->maybe_init_subscriptions();
+
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -29,5 +29,8 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 			'Accept secure bank transfers from Austria, Belgium, Germany, Italy, Netherlands, and Spain.',
 			'woocommerce-gateway-stripe'
 		);
+
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
 	}
 }

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1713,7 +1713,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		// Mock order has pre-order product.
 		$this->mock_gateway->expects( $this->once() )
-			->method( 'maybe_process_pre_orders' )
+			->method( 'has_pre_order' )
 			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1714,7 +1714,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// Mock order has pre-order product.
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'has_pre_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( $order_id )
 			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )
@@ -1740,7 +1740,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'mark_order_as_pre_ordered' );
 
-		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, true );
+		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
 		$final_order = wc_get_order( $order_id );
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -113,6 +113,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					'display_order_fee',
 					'display_order_payout',
 					'get_intent_from_order',
+					'has_pre_order_charged_upon_release',
+					'has_pre_order',
 				]
 			)
 			->getMock();
@@ -1781,7 +1783,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		// Mock order has pre-order product.
 		$this->mock_gateway->expects( $this->once() )
-			->method( 'maybe_process_pre_orders' )
+			->method( 'has_pre_order' )
 			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1712,9 +1712,17 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$payment_intent_mock['charges']['data'][0]['payment_method_details'] = $payment_method_mock;
 
 		// Mock order has pre-order product.
-		$this->mock_gateway->expects( $this->once() )
+		$this->mock_gateway->expects( $this->any() )
 			->method( 'has_pre_order' )
 			->with( $order_id )
+			->will( $this->returnValue( true ) );
+
+		$this->mock_gateway->expects( $this->once() )
+			->method( 'is_pre_order_item_in_cart' )
+			->will( $this->returnValue( true ) );
+
+		$this->mock_gateway->expects( $this->once() )
+			->method( 'is_pre_order_product_charged_upfront' )
 			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1714,6 +1714,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// Mock order has pre-order product.
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'has_pre_order' )
+			->with( wc_get_order( $order_id ) )
 			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1729,10 +1729,15 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				$this->returnValue( $this->mock_stripe_customer )
 			);
 
+		$this->mock_gateway->expects( $this->any() )
+			->method( 'has_pre_order_charged_upon_release' )
+			->with( wc_get_order( $order_id ) )
+			->will( true );
+
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'mark_order_as_pre_ordered' );
 
-		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
+		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, true );
 
 		$final_order = wc_get_order( $order_id );
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1734,7 +1734,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'has_pre_order_charged_upon_release' )
 			->with( wc_get_order( $order_id ) )
-			->will( true );
+			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'mark_order_as_pre_ordered' );


### PR DESCRIPTION
Closes #2780

## Changes proposed in this Pull Request:

This PR fixes a number of issues I encountered when adding APM support for pre-orders. 

1. APMs that support pre orders, iDEAL, Sofort, Bancontact, and SEPA weren't being displayed as options on the checkout. 
2. Using those APMs, I noticed 2 follow up issues:
   1. The save payment method option was being shown, despite it being required when purhcasing pre-order products that are charged "upon release" (at a later time).
   2. The order was automatically transitioning to processing rather than 'pre-ordered'. *

This PR fixes all those issues. 

> [!note]
> \* This was partly fixed in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2911, however I was still experiencing that issue because `is_pre_order` wasn't being set to true [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/add/deferred-intent/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L1244). I suspect it was because the original logic (`maybe_process_pre_orders()`) checks if the order already has a saved payment method on it, I suspect it might have had a token saved earlier and that was leading the order to be processed. 
 
## Testing instructions

### Prerequisites  

- Install WooCommerce Pre-orders - you can get the lates from your woo.com downloads page (https://woo.com/my-account/downloads/). 
- UPE enabled in the **Advanced** Stripe plugin settings.
- A Stripe account with access to Bancontact, SEPA, iDEAL and Sofort and enabled in the Stripe plugin settings.

⚠️ **Sofort** cannot be enabled via the UI anymore so you can enable it running the following code snippet. 

```php
$settings = get_option( 'woocommerce_stripe_settings' );
if ( ! in_array( 'sofort', $settings['upe_checkout_experience_accepted_payments'] ) ) {
    $settings['upe_checkout_experience_accepted_payments'][] = 'sofort';
}
update_option( 'woocommerce_stripe_settings', $settings );
```

### Pre Order charged upon release

1. Create a new product with any price (not free).
2. In the product settings, enter a pre-order release date in the **"Pre orders"** tab.
3. Set the product to charge **"upon release"**.

<p align="center">
<img width="800" alt="Screenshot 2024-02-23 at 4 24 50 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/12957059-10c7-4934-b1d7-9d900df233ac">

4. Add that preorder product to your cart. 
5. Go to the checkout page and on `add/deferred-intent` note 2 things:
   1. All the APMs (Bancontact, SEPA, iDEAL, Sofort) aren't shown.  
   2. If you select the card payment method, you should see the option to Save the payment method. 

| <img width="439" alt="Screenshot 2024-02-23 at 4 34 08 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/133447ef-e67b-40f1-8fc7-fd5fffa4d914"> | <img width="1056" alt="Screenshot 2024-02-23 at 4 33 41 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ce27713f-589e-4173-b336-1ab87b10e9c5"> |
|--------|--------|

6. Checkout this branch (`issue/2780`) and all available APMs should be listed.
7. All APMs shouldn't show the option to save, it's being forced on.

| <img width="1031" alt="Screenshot 2024-02-23 at 4 55 20 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/12d69bfb-8a23-45d7-b53c-27e88b8d8891"> | <img width="422" alt="Screenshot 2024-02-23 at 4 54 47 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/5ce30719-0ba0-443b-89f7-a2fd5bbea934"> |
|--------|--------|

8. Purchase the product using any or all APMs
9. Go to the Admin orders list table and you should have orders with pre-ordered statuses. 

<p align="center">
<img width="1200" alt="Screenshot 2024-02-23 at 5 24 01 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/d3cc45c4-d88f-4780-938d-6a8fe23f0b23">
</p>

10. Go to the **WooCommerce > Pre-orders** table.
11. Go to the **Actions tab** _(at the top)_ **> Complete. 
12. Choose your product and complete the pre-orders.

<p align="center">
<img width="1371" alt="Screenshot 2024-02-23 at 5 26 07 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/be05598d-f870-4e15-873c-482488852960">
</p>

13. Once that has finished return to the Orders table and those pre-orders should now be on-hold. 
14. Wait a minute for Stripe to process those SEPA payments and for the webhooks to be processed and all orders should eventually go to processing or completed. 
15. Check your Stripe payments in the dashboard and confirm that the payments are processed. 

<p align="center">
<img width="511" alt="Screenshot 2024-02-23 at 5 29 45 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/689eec8b-9967-4d70-a05d-fad55f6ea482">
</p>

### Pre Order charged upfront

1. Create a new product with any price (not free).
2. In the product settings, enter a pre-order release date in the **"Pre orders"** tab.
3. Set the product to charge **"upon release"**.

<p align="center">
<img width="1373" alt="Screenshot 2024-02-23 at 5 40 23 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/b53d3904-ed89-45bb-83fa-e2706f967f3b">
</p>

4. Add that preorder product to your cart. 
5. Go to the checkout page and note 3 things:
   1. All the APMs (Bancontact, SEPA, iDEAL, Sofort) are shown.  
   2. If you select a payment method, you should see the option to Save the payment method. Charging upfront means we don't require a saved token so it's optional just like standard purchases.
8. Purchase the product using any or all APMs
9. Go to the Admin orders list table and you should have orders with pre-ordered statuses.

<p align="center"> 
<img width="1103" alt="Screenshot 2024-02-23 at 6 12 09 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/7e6ae827-fd65-4cd6-ae00-a55995cbac7e">
</p>

10. Check your Stripe payments dashboard and confirm that the payments have been processed. Remember these are charged upfront so will be paid before the pre-order is complete.  

<p align="center">
<img width="522" alt="Screenshot 2024-02-23 at 6 13 13 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ce932e10-78bc-4b72-a49d-e754c24fe3bc">
</p>

10. Once again, go to the **WooCommerce > Pre-orders** table.
11. Go to the **Actions tab** _(at the top)_ **> Complete. 
12. Choose your upfront product and complete the pre-orders.
13. Review the order list table and payments in Stripe and confirm all orders are now processing and there was no duplicate charge. 

| <img width="1085" alt="Screenshot 2024-02-23 at 6 15 06 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/e2b48a13-0e3b-4825-867f-bf265ee7b451"> |
|--------|
|<img width="520" alt="Screenshot 2024-02-23 at 6 16 29 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/59ed943a-6d8b-424b-a4a2-96fbf482254a"> | 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
