### PR TITLE
Split PE - Fix errors when using OXXO or Boleto

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1511,8 +1511,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 		$payment_method       = $this->payment_methods[ $payment_method_type ];
 		$payment_method_title = $payment_method->get_label();
+		$payment_method_id    = $payment_method instanceof WC_Stripe_UPE_Payment_Method_CC ? $this->id : $payment_method->id;
 
-		$order->set_payment_method( $this->get_upe_gateway_id_for_order( $payment_method ) );
+		$order->set_payment_method( $payment_method_id );
 		$order->set_payment_method_title( $payment_method_title );
 		$order->save();
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2355,10 +2355,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	private function get_upe_gateway_id_for_order( $payment_method ) {
 		$token_gateway_type = $payment_method->get_retrievable_type();
 
-		if ( 'card' !== $token_gateway_type ) {
+		if ( 'card' === $token_gateway_type ) {
+			return $this->id;
+		} elseif ( isset( $this->payment_methods[ $token_gateway_type ] ) ) {
 			return $this->payment_methods[ $token_gateway_type ]->id;
+		} else {
+			return $payment_method->id;
 		}
-
-		return $this->id;
 	}
 }


### PR DESCRIPTION
Fixes #2942 

## Changes proposed in this Pull Request:

While testing our Split PE with deferred intent changes, Global Step found there are errors when processing payments via Boleto or Oxxo on the checkout. 

```
PHP Warning:  Undefined array key "" in /public/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php on line 2359
PHP Warning:  Attempt to read property "id" on null in /public/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php on line 2359
```

This error occurs because when we attempt to set the order's payment method ID, we fetch the UPE payment method's retrievable type. This aims to fetch the payment method to store on the order/subscription. Eg Bancontact > SEPA. Because Boleto and OXXO don't have a retrievable type and isn't reusable it returns null. In this case, we should return the payment the Boleto payment ID. 

This PR fixes this issue.

`get_upe_gateway_id_for_order()` now handles 3 cases:

- `card` → `stripe`
- If the gateway has a different retrievable type it will return the retreviable type ID. ie `bancontact` → `sepa_debit`, `ideal` → `sepa_debit` etc. 
- If none of the above, it will be the UPE's method ID. `boleto` → `boleto`

## Testing instructions



---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
