### PR TITLE
[Split PE] Fix purchasing with Alipay with our deferred intent changes

### DIFF
--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -8,6 +8,7 @@ export const PAYMENT_METHOD_NAME_SOFORT = 'stripe_sofort';
 export const PAYMENT_METHOD_NAME_BOLETO = 'stripe_boleto';
 export const PAYMENT_METHOD_NAME_OXXO = 'stripe_oxxo';
 export const PAYMENT_METHOD_NAME_BANCONTACT = 'stripe_bancontact';
+export const PAYMENT_METHOD_NAME_ALIPAY = 'stripe_alipay';
 
 export function getPaymentMethodsConstants() {
 	return {
@@ -21,6 +22,7 @@ export function getPaymentMethodsConstants() {
 		boleto: PAYMENT_METHOD_NAME_BOLETO,
 		oxxo: PAYMENT_METHOD_NAME_OXXO,
 		bancontact: PAYMENT_METHOD_NAME_BANCONTACT,
+		alipay: PAYMENT_METHOD_NAME_ALIPAY,
 	};
 }
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -781,7 +781,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			 * Depending on the payment method used to process the payment, we may need to redirect the user to a URL for further processing.
 			 *
 			 * - Voucher payments (Boleto or Oxxo) respond with a hash URL so the client JS code can recognize the response, pull out the necessary args and handle the displaying of the voucher.
-			 * - Other payment methods like Giropay, iDEAL etc require a redirect to a URL provided by Stripe.
+			 * - Other payment methods like Giropay, iDEAL, Alipay etc require a redirect to a URL provided by Stripe.
 			 * - 3DS Card payments return a hash URL so the client JS code can recognize the response, pull out the necessary PI args and display the 3DS confirmation modal.
 			 */
 			if ( in_array( $payment_intent->status, [ 'requires_confirmation', 'requires_action' ], true ) ) {
@@ -794,8 +794,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 						$payment_intent->client_secret,
 						rawurlencode( $redirect )
 					);
-				} elseif ( isset( $payment_intent->next_action->type ) && 'redirect_to_url' === $payment_intent->next_action->type && ! empty( $payment_intent->next_action->redirect_to_url->url ) ) {
-					$redirect = $payment_intent->next_action->redirect_to_url->url;
+				} elseif ( isset( $payment_intent->next_action->type ) && in_array( $payment_intent->next_action->type, [ 'redirect_to_url', 'alipay_handle_redirect' ], true ) && ! empty( $payment_intent->next_action->{$payment_intent->next_action->type}->url ) ) {
+					$redirect = $payment_intent->next_action->{$payment_intent->next_action->type}->url;
 				} else {
 					$redirect = sprintf(
 						'#wc-stripe-confirm-%s:%s:%s:%s',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-alipay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-alipay.php
@@ -18,7 +18,7 @@ class WC_Stripe_UPE_Payment_Method_Alipay extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = __( 'Pay with Alipay', 'woocommerce-gateway-stripe' );
+		$this->title                = __( 'Alipay', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = false;
 		$this->supported_currencies = [
 			'EUR',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -294,7 +294,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 * to query to retrieve saved payment methods from Stripe.
 	 */
 	public function get_retrievable_type() {
-		return $this->is_reusable() ? WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID : null;
+		return $this->is_reusable() ? WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID : static::STRIPE_ID;
 	}
 
 	/**

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -240,14 +240,14 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Alipay', $alipay_method->get_title() );
 		$this->assertEquals( 'Alipay', $alipay_method->get_title( $mock_alipay_details ) );
 		$this->assertFalse( $alipay_method->is_reusable() );
-		$this->assertEquals( null, $alipay_method->get_retrievable_type() );
+		$this->assertEquals( 'alipay', $alipay_method->get_retrievable_type() );
 
 		$this->assertEquals( 'giropay', $giropay_method->get_id() );
 		$this->assertEquals( 'giropay', $giropay_method->get_label() );
 		$this->assertEquals( 'giropay', $giropay_method->get_title() );
 		$this->assertEquals( 'giropay', $giropay_method->get_title( $mock_giropay_details ) );
 		$this->assertFalse( $giropay_method->is_reusable() );
-		$this->assertEquals( null, $giropay_method->get_retrievable_type() );
+		$this->assertEquals( 'giropay', $giropay_method->get_retrievable_type() );
 		$this->assertEquals( '', $giropay_method->get_testing_instructions() );
 
 		$this->assertEquals( 'p24', $p24_method->get_id() );
@@ -255,7 +255,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Przelewy24', $p24_method->get_title() );
 		$this->assertEquals( 'Przelewy24', $p24_method->get_title( $mock_p24_details ) );
 		$this->assertFalse( $p24_method->is_reusable() );
-		$this->assertEquals( null, $p24_method->get_retrievable_type() );
+		$this->assertEquals( 'p24', $p24_method->get_retrievable_type() );
 		$this->assertEquals( '', $p24_method->get_testing_instructions() );
 
 		$this->assertEquals( 'eps', $eps_method->get_id() );
@@ -263,7 +263,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'EPS', $eps_method->get_title() );
 		$this->assertEquals( 'EPS', $eps_method->get_title( $mock_eps_details ) );
 		$this->assertFalse( $eps_method->is_reusable() );
-		$this->assertEquals( null, $eps_method->get_retrievable_type() );
+		$this->assertEquals( 'eps', $eps_method->get_retrievable_type() );
 		$this->assertEquals( '', $eps_method->get_testing_instructions() );
 
 		$this->assertEquals( 'sepa_debit', $sepa_method->get_id() );

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -237,8 +237,8 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'alipay', $alipay_method->get_id() );
 		$this->assertEquals( 'Alipay', $alipay_method->get_label() );
-		$this->assertEquals( 'Pay with Alipay', $alipay_method->get_title() );
-		$this->assertEquals( 'Pay with Alipay', $alipay_method->get_title( $mock_alipay_details ) );
+		$this->assertEquals( 'Alipay', $alipay_method->get_title() );
+		$this->assertEquals( 'Alipay', $alipay_method->get_title( $mock_alipay_details ) );
 		$this->assertFalse( $alipay_method->is_reusable() );
 		$this->assertEquals( null, $alipay_method->get_retrievable_type() );
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -306,7 +306,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'Boleto', $boleto_method->get_title() );
 		$this->assertEquals( 'Boleto', $boleto_method->get_title( $mock_boleto_details ) );
 		$this->assertFalse( $boleto_method->is_reusable() );
-		$this->assertEquals( null, $boleto_method->get_retrievable_type() );
+		$this->assertEquals( 'boleto', $boleto_method->get_retrievable_type() );
 		$this->assertEquals( '', $boleto_method->get_testing_instructions() );
 
 		$this->assertEquals( 'oxxo', $oxxo_method->get_id() );
@@ -314,7 +314,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'OXXO', $oxxo_method->get_title() );
 		$this->assertEquals( 'OXXO', $oxxo_method->get_title( $mock_oxxo_details ) );
 		$this->assertFalse( $oxxo_method->is_reusable() );
-		$this->assertEquals( null, $oxxo_method->get_retrievable_type() );
+		$this->assertEquals( 'oxxo', $oxxo_method->get_retrievable_type() );
 		$this->assertEquals( '', $oxxo_method->get_testing_instructions() );
 	}
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2939

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

With the latest Split dPE changes, purchasing a product with Alipay resulted in the following checkout notice:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/fa7a361a-502c-4c6d-a3af-18081acf69ec)

Stripe logs had the following error:
```
2024-02-27T03:30:55+00:00 DEBUG 
====Stripe Version: 8.0.0====
====Start Log====
Error: The information for creating and confirming the intent is missing the following data: payment_method.
====End Log====
```

This issue was caused by the `stripe_alipay` payment method not being handled in JS by our processPayments function. Fixed by 63922cf1fa488d45424465d95855c7abcfe0bea3.

After fixing this, attempting to checkout with Alipay resulted in:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/d31fe921-bbeb-4d80-8b62-146ad92d2914)

The issue here is caused by our `process_payment_with_deferred_intent()` returning a `#wc-stripe-confirm-%s:%s:%s:%s` redirect URL. 3f4aa0e9b64020dd4e4f80f36cd040712fd7ee3e fixes the issue by handling properly fetching the redirect URL to alipay from the intent object.

> [!IMPORTANT]
> There are a few smaller changes I added in this PR:
> 1. 56b56c9d792efd06ce6af9afb4430f170d1afe74 change the name/label used for Alipay on the checkout to just "Alipay" to be inline with our other UPE methods
> 2. 0980e72b95c6910d25f2476795355f7f318ef9d7 fixes `Undefined array key ""` and `Attempt to read property "id" on null` PHP warnings coming from the `get_upe_gateway_id_for_order()` function


## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Set your store to one of Alipay-supported currencies (i.e. 'EUR', 'AUD', 'CAD', 'USD')
2. Make sure the connected Stripe account matches the supported currency as well
3. Enable UPE and enable Alipay payment method
4. Checkout the `add/deferred-intent` branch
5. Add a simple product to your cart and visit the shortcode checkout
6. Attempt to purchase with Alipay and notice the error on checkout
7. Checkout this branch and attempt to pay with Alipay
8. Confirm you're redirected off-site to the Alipay <> Stripe payment page
9. Authorize/confirm the payment and confirm you are redirected to the order received page
10. Test Alipay on the block checkout

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
