### PR TITLE
Split PE - Set the order's payment method ID to the processing payment method

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1517,8 +1517,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 		$payment_method       = $this->payment_methods[ $payment_method_type ];
 		$payment_method_title = $payment_method->get_label();
+		$payment_method_id    = $payment_method instanceof WC_Stripe_UPE_Payment_Method_CC ? $this->id : $payment_method->id;
 
-		$order->set_payment_method( $this->get_upe_gateway_id_for_order( $payment_method ) );
+		$order->set_payment_method( $payment_method_id );
 		$order->set_payment_method_title( $payment_method_title );
 		$order->save();
 	}


### PR DESCRIPTION
Fixes #2949

## Changes proposed in this Pull Request:

This PR makes sure we set the order's payment method ID to the UPE payment method used to process the payment. Prior to our changes in `add/deferred-intent` this code use to set to `stripe` all the time ([code link](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7.9.0/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L1265)). In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2883, I changed it to set the orders payment ID to the retrievable payment method ID (ie SEPA for bancontact, iDEAL, Sofort). That PR was about subscription support so I suspect I was under the impression thats how it should work for orders, however that's not true.  

## Testing instructions

1. Enter Stripe credentials capable of processing iDEAL and Bancontact payments
3. In the Stripe advanced plugin settings, enable UPE.
4. Enable Bancontact, SEPA, Sofort (optional) and iDEAL payment methods. 
6. Complete a purchase using Bancontact, iDEAL or Sofort. 
7. View the order in WooCommerce > Orders. 
   - On `add/deferred-intent` note the order's payment method is set to SEPA.
   - On this branch it should be set to the payment method you chose on checkout. 

| Before | After |
|--------|--------|
| <img width="790" alt="Screenshot 2024-02-27 at 3 24 59 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/b29d4f6f-c89e-41bb-9a23-0cc9e7b7f691">|<img width="725" alt="Screenshot 2024-02-27 at 3 26 34 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/1acc1616-f045-4829-9850-2101986a94ee"> | 

I've tested subscription purchases and this still correctly sets the subscription's payment method SEPA and the parent order to Bancontact. 

| Order | Subscription |
|--------|--------|
| <img width="738" alt="Screenshot 2024-02-27 at 3 45 32 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/70f85d35-59dd-497e-bb00-543eaf5a19de"></br><sup>Order Payment Method is iDEAL</sup> | <img width="861" alt="Screenshot 2024-02-27 at 3 41 54 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/03571089-9fcb-4954-925f-bd87086178e8"></br><sup>Subscription Payment Method is SEPA debit</sup> | 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
