### PR TITLE
[Split PE] Fix errors on checkout caused by attempting to reuse intents that require action or require manual confirmation

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2273,11 +2273,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		);
 	}
 
-	/* Retrieves the (possible) existing payment intent for an order and payment method types.
+	/**
+	 * Retrieves the (possible) existing payment intent for an order and payment method types.
 	 *
 	 * @param WC_Order $order The order.
-	 * @param array $payment_method_types The payment method types.
+	 * @param array    $payment_method_types The payment method types.
+	 *
 	 * @return object|null
+	 *
 	 * @throws WC_Stripe_Exception
 	 */
 	private function get_existing_compatible_payment_intent( $order, $payment_method_types ) {
@@ -2295,6 +2298,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Check if the status of the intent still allows update.
 		if ( in_array( $intent->status, [ 'canceled', 'succeeded' ], true ) ) {
+			return null;
+		}
+
+		// If the intent requires confirmation to show voucher on checkout (i.e. Boleto or oxxo ) or requires action (i.e. need to show a 3DS confirmation card or handle the UPE redirect), don't reuse the intent
+		if ( in_array( $intent->status, [ 'requires_confirmation', 'requires_action' ], true ) ) {
 			return null;
 		}
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1883,7 +1883,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
-			->method( 'update_and_confirm_payment_intent' )
+			->method( 'create_and_confirm_payment_intent' )
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2950 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2845 we implemented reusing payment intents that have been stored on the order, however, this throws the following error for payment intents with `requires_action` and `requires_confirmation` statuses:

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/82ee81c0-ec15-4929-a887-e7c5ea65466e)

1. Payment intents with `requires_action` status are used for 3DS cards and UPE payment methods that redirect the customer off-site have this status
2. Intents with `requires_confirmation` status are from purchases with Boleto and OXXO vouchers as we manually confirm the intent on checkout to show the voucher to the customer

This PR fixes this issue by making sure we create a new intent when the one stored on the order requires action, instead of trying to update and confirm the intent.

Ideally, we could still reuse these payment intents that require action/confirmation and just don't attempt to confirm them via the Stripe API (only update the intent data), but when I tried to implement this I ran into further errors from Stripe. I think one of them had something to do with not being able to send a `return_url` to the `/payments_intents/{id}` endpoint. For the sake of fixing this issue I opted for the more simple approach at this time.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

### With a 3DS card

1. Add a product to your cart and navigate to the checkout page
5. Purchase using a 3DS card: `4000000000003220`
6. When the 3ds pop-up appears, refresh your checkout page
7. Attempt to checkout again using the same card `4000000000003220`
8. There should not be any errors and checkout should process successfully

### With a UPE redirecting payment method

1. Set your currency to EUR and enable the EPS payment method
2. Add a product to your cart and navigate to the checkout page
3. Select EPS on the checkout and click "Place order"
4. Once you've been redirected off-site to the EPS payment page, don't click on any buttons and manually navigate back to your dev store's checkout page (i.e. `https://woo.local/checkout`)
9. Attempt to checkout again using EPS
10. There should not be any errors. Completing the payment off-site should redirect to the order received page.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
