### PR TITLE
Non-UPE - Fix payment methods being shown that shouldn't be unavailable

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -126,7 +126,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_fee' ] );
 		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'display_order_payout' ], 20 );
 		add_action( 'woocommerce_customer_save_address', [ $this, 'show_update_card_notice' ], 10, 2 );
-		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'get_available_payment_gateways' ] );
+		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'reorder_available_payment_gateways' ] );
 		add_filter( 'woocommerce_available_payment_gateways', [ $this, 'prepare_order_pay_page' ] );
 		add_action( 'woocommerce_account_view-order_endpoint', [ $this, 'check_intent_status_on_order_page' ], 1 );
 		add_filter( 'woocommerce_payment_successful_result', [ $this, 'modify_successful_payment_result' ], 99999, 2 );
@@ -649,58 +649,36 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Include the available legacy payment methods in the list of payment methods.
-	 * As we are not registering the other Stripe payment methods to show in the settings page,
-	 * we need to include them here so that they are available in the checkout, pay for order, add payment method etc. pages.
+	 * Reorders the list of available payment gateways to include the Stripe methods in the order merchants have chosen in the settings.
 	 *
-	 * @param WC_Payment_Gateway[] $gateways A list of all available gateways on the payments settings page.
-	 * @return WC_Payment_Gateway[]          The same list if UPE is disabled or a list including the available legacy payment methods.
+	 * @param WC_Payment_Gateway[] $gateways A list of all available gateways.
+	 * @return WC_Payment_Gateway[] The same list of gateways, but with the Stripe methods in the right order.
 	 */
-	public function get_available_payment_gateways( $gateways ) {
-		// Unset the stripe methods from the array first, then place it in the correct position below
-		// as set in `stripe_ordered_payment_method_ids`.
-		foreach ( $gateways as $key => $gateway ) {
-			if ( 0 === strpos( $key, 'stripe_' ) ) {
-				unset( $gateways[ $key ] );
+	public function reorder_available_payment_gateways( $gateways ) {
+		$ordered_available_stripe_methods = [];
+
+		// Keep a record of where Stripe was found in the $gateways array so we can insert the Stripe methods in the right place.
+		$stripe_index = array_search( 'stripe', array_keys( $gateways ), true );
+
+		// Generate a list of all available Stripe payment methods in the order they should be displayed.
+		foreach ( WC_Stripe_Helper::get_legacy_available_payment_method_ids() as $payment_method ) {
+			$gateway_id = 'card' === $payment_method ? 'stripe' : 'stripe_' . $payment_method;
+
+			if ( isset( $gateways[ $gateway_id ] ) ) {
+				$ordered_available_stripe_methods[ $gateway_id ] = $gateways[ $gateway_id ];
+				unset( $gateways[ $gateway_id ] ); // Remove it from the list of available gateways. We'll add all Stripe methods back in the right order.
 			}
 		}
 
-		$legacy_enabled_gateways           = WC_Stripe_Helper::get_legacy_enabled_payment_methods();
-		$stripe_ordered_payment_method_ids = WC_Stripe_Helper::get_legacy_available_payment_method_ids();
-
-		// Map the IDs of the Stripe payment methods to match the ones expected in the $gateways array.
-		$stripe_ordered_payment_method_ids = array_map(
-			function( $id ) {
-				return 'card' === $id ? 'stripe' : 'stripe_' . $id;
-			},
-			$stripe_ordered_payment_method_ids
-		);
-
-		// If Stripe is not found in the $gateways array, but other legacy methods are enabled,
-		// they will be placed on the top in their saved order, followed by other gateways.
-		$stripe_index           = array_search( 'stripe', array_keys( $gateways ), true );
-		$gateways_before_stripe = array_slice( $gateways, 0, $stripe_index );
-		$gateways_after_stripe  = array_slice( $gateways, $stripe_index + 1 );
-		$stripe_gateways        = [];
-
-		foreach ( $stripe_ordered_payment_method_ids as $id ) {
-			$gateway = null;
-			if ( 'stripe' === $id ) {
-				$gateway = $this;
-			} elseif ( isset( $legacy_enabled_gateways[ $id ] ) ) {
-				$gateway = $legacy_enabled_gateways[ $id ];
-			}
-
-			if ( $gateway && $gateway->is_available() ) {
-				if ( ! is_add_payment_method_page() ) {
-					$stripe_gateways[ $id ] = $gateway;
-				} elseif ( $gateway->supports( 'add_payment_method' ) || $gateway->supports( 'tokenization' ) ) {
-					$stripe_gateways[ $id ] = $gateway;
-				}
-			}
+		// Add the ordered list of available Stripe payment methods back into the list of available gateways.
+		if ( $stripe_index ) {
+			$gateways = array_slice( $gateways, 0, $stripe_index, true ) + $ordered_available_stripe_methods + array_slice( $gateways, $stripe_index, null, true );
+		} else {
+			// In cases where Stripe is not found in the list of available gateways but there were other legacy methods available, add the Stripe methods to the front of the list.
+			$gateways = array_merge( $ordered_available_stripe_methods, $gateways );
 		}
 
-		return array_merge( $gateways_before_stripe, $stripe_gateways, $gateways_after_stripe );
+		return $gateways;
 	}
 
 	/**


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes an issue on stores not using the new UPE experience. If a customer had a subscription product in the cart, all APMs were being shown on the classic checkout even if they didn't support subscriptions. 

This PR fixes that.

> [!important]
> **Background:** Tracking down the history of this is a little complicated. You're best to compare the expected behaviour on 7.9.3 because `develop` is also impacted by this issue since the original issue was introduced in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2934 which was merged into `develop`, however there have be subsequent fixes in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2934 and https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2937 which were merged into `add/deferred-intent`. Because of this, this PR is based off `add/deferred-intent`. 

This issue is caused by the `WC_Gateway_Stripe::get_available_payment_gateways()` function which, prior to this PR, would insert payment gateways that had been deteremined to be unavailable by third-party plugins like Woo Subscriptions. Eg Subscriptions hooks on at 10 too and would unset any gateways that don't support subscriptions purchases, but the Stripe plugin would hook in at 10 too and reinsert all the methods it believes to be available. 

This PR fixes that by removing the old `get_available_payment_gateways()` and replace it with a function that just reorders the methods without inserting any gateways that weren't already passed in via the filter. Since https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2934 and https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2937, I don't believe inserting methods is required anymore. 

## Testing instructions

### Subscriptions

1. Enter Stripe credentials for an account capable of processing EU APMS (Bancontact, iDEAL, SEPA etc). 
2. Disable the UPE if you have it enabled.
3. Change the store currency to Euros.
4. Enable all available APMS.
5. Enable the Woo Subscription plugin.
6. Create a subscription product if you don't have one.
7. Place the subscription product in your cart. 
8. Go to the classic/shortcode checkout
    - On `add/deferred-intent` notice that all APMs are displayed.
    - On this branch only Card and SEPA should be available. 

| `add/deferred-intent` | This branch |
|--------|--------|
| <img width="416" alt="Screenshot 2024-02-28 at 4 57 01 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/7cb6b4a3-0aca-4970-a01b-b66ba81c68cc">| <img width="433" alt="Screenshot 2024-02-28 at 4 56 35 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/87a7d53c-c772-4cf9-8c7f-91f7735242a6"> | 

### Display order

1. Enable other payment gateways like Bank transfer, check etc. This is just to make sure ordering relative to other gateways is still working_.
1. Go to the Stripe payment methods settings and click the **"Change display order"** button.
<p align="center">
<img width="696" alt="Screenshot 2024-02-28 at 5 02 14 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c95101cc-428a-403a-8492-ba46579117e5">
</p>

5. Jumble up the payment methods and make a note of the order. 
7. Place the standard, simple product in the cart.
9. Go to the classic/shortcode checkout. 
10. On this branch the payment methods should still match the order you chose. 

eg 

| Checkout | Settings |
|--------|--------|
|<img width="419" alt="Screenshot 2024-02-28 at 5 05 13 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/43e29e4a-457f-4169-86f0-f3eb77aa0199"> | <img width="1411" alt="Screenshot 2024-02-28 at 5 10 46 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c04db7c7-447d-4ae3-b4c5-7ce41dd4c618"><p align="center"><sup>Stripe methods are sandwiched between Bank transfer and Check</sup></p> |

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
