### PR TITLE
Non-UPE - Introduce a new gateway option to record if cards are enabled or not

### DIFF
--- a/client/settings/general-settings-section/payment-method-checkbox.js
+++ b/client/settings/general-settings-section/payment-method-checkbox.js
@@ -1,16 +1,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 import interpolateComponents from 'interpolate-components';
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import { CheckboxControl, VisuallyHidden } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
-import UpeToggleContext from '../upe-toggle/context';
 import RemoveMethodConfirmationModal from './remove-method-confirmation-modal';
-import {
-	useEnabledPaymentMethodIds,
-	useManualCapture,
-	useIsStripeEnabled,
-} from 'wcstripe/data';
+import { useEnabledPaymentMethodIds, useManualCapture } from 'wcstripe/data';
 import Tooltip from 'wcstripe/components/tooltip';
 
 const StyledCheckbox = styled( CheckboxControl )`
@@ -51,19 +46,11 @@ const PaymentMethodCheckbox = ( {
 		enabledPaymentMethods,
 		setEnabledPaymentMethods,
 	] = useEnabledPaymentMethodIds();
-	const [ , setIsStripeEnabled ] = useIsStripeEnabled();
-	const { isUpeEnabled } = useContext( UpeToggleContext );
 
 	const handleCheckboxChange = ( hasBeenChecked ) => {
 		if ( ! hasBeenChecked ) {
 			setIsConfirmationModalOpen( true );
 			return;
-		}
-
-		// In legacy mode (UPE disabled), Stripe refers to the card payment method.
-		// So if the card payment method is enabled, Stripe should be enabled.
-		if ( id === 'card' && ! isUpeEnabled ) {
-			setIsStripeEnabled( true );
 		}
 
 		setEnabledPaymentMethods( [ ...enabledPaymentMethods, id ] );
@@ -74,12 +61,6 @@ const PaymentMethodCheckbox = ( {
 		setEnabledPaymentMethods(
 			enabledPaymentMethods.filter( ( m ) => m !== id )
 		);
-
-		// In legacy mode (UPE disabled), Stripe refers to the card payment method.
-		// So if the card payment method is disabled, Stripe should be disabled.
-		if ( id === 'card' && ! isUpeEnabled ) {
-			setIsStripeEnabled( false );
-		}
 	};
 
 	if ( ! isCurrencySupported ) {

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -646,6 +646,13 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				}
 			}
 
+			// Cards are handled by the main gateway so we store a separate option rather than updating the global gateway's enabled setting directly.
+			if ( in_array( 'card', $payment_method_ids_to_enable, true ) ) {
+				$this->gateway->update_option( 'cards_enabled', 'yes' );
+			} else {
+				$this->gateway->update_option( 'cards_enabled', 'no' );
+			}
+
 			return;
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -142,9 +142,16 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Checks if gateway should be available to use.
 	 *
+	 * Note: This method checks if the "card" method is available because the main gateway is responsible for cards specifically.
+	 *
 	 * @since 4.0.2
 	 */
 	public function is_available() {
+
+		if ( 'no' === $this->get_option( 'cards_enabled' ) ) {
+			return false;
+		}
+
 		if ( is_add_payment_method_page() && ! $this->saved_cards ) {
 			return false;
 		}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
