### PR TITLE
Fix Link payment issues

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -159,15 +159,18 @@ jQuery( function( $ ) {
 					const field = $( this ).find( ':input' );
 					const value = field.val();
 					const name = field.attr( 'name' );
-					if ( value && ! data[ name ] ) {
-						data[ name ] = value;
-					}
-					// if shipping same as billing is selected, copy the billing field to shipping field.
-					const shipToDiffAddress = $( '#ship-to-different-address' ).find( 'input' ).is( ':checked' );
-					if ( ! shipToDiffAddress ) {
-						var shippingFieldName = name.replace( 'billing_', 'shipping_' );
-						if ( ! data[ shippingFieldName ] && data[ name ] ) {
-							data[ shippingFieldName ] = data[ name ];
+					if ( value && name ) {
+						if ( ! data[ name ] ) {
+							data[ name ] = value;
+						}
+	
+						// if shipping same as billing is selected, copy the billing field to shipping field.
+						const shipToDiffAddress = $( '#ship-to-different-address' ).find( 'input' ).is( ':checked' );
+						if ( ! shipToDiffAddress ) {
+							var shippingFieldName = name.replace( 'billing_', 'shipping_' );
+							if ( ! data[ shippingFieldName ] && data[ name ] ) {
+								data[ shippingFieldName ] = data[ name ];
+							}
 						}
 					}
 				});

--- a/client/api/blocks.js
+++ b/client/api/blocks.js
@@ -79,6 +79,11 @@ export const createOrder = ( sourceEvent, paymentRequestType ) => {
 
 const getRequiredFieldDataFromCheckoutForm = ( data ) => {
 	const checkoutForm = document.querySelector( '.wc-block-checkout' );
+	// Return if cart page.
+	if ( ! checkoutForm ) {
+		return data;
+	}
+
 	const requiredFields = checkoutForm.querySelectorAll( '[required]' );
 
 	if ( requiredFields.length ) {


### PR DESCRIPTION
Fixes #2958 

## Changes proposed in this Pull Request:
Link payment is failing in 2 places. In the block cart page and shortcode checkout page. We added some required field checks for the PRBs in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2886 which is causing the issue.

- In block cart page, it was looking for the checkout fields. Added a early return there.
- In shortcode checkout page, Jquery was picking up some fields from the Link pop-up. Added check for name and value field there to avoid the Link fields.

## Testing instructions
- Go to Stripe settings page and enable UPE.
- Enabled Link.
- As a shopper purchase a product from all of the following pages
- [ ] Product
- [ ] Shortcode cart
- [ ] Shortcode checkout
- [ ] Block cart
- [ ] Block checkout
- Purchases with Link from all the above pages should be successful without any error.

## Additional testing
Test the steps from https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2886 to make sure the required field issue did not resurface with the changes in this PR.