### PR TITLE
Show banner when capabilities list is empty

### DIFF
--- a/client/settings/account-activation-notice/__tests__/account-activation-notice.test.js
+++ b/client/settings/account-activation-notice/__tests__/account-activation-notice.test.js
@@ -52,6 +52,17 @@ describe( 'AccountActivationNotice', () => {
 		).toBeInTheDocument();
 	} );
 
+	it( 'should render notice if capability object is empty', () => {
+		useGetCapabilities.mockReturnValue( {} );
+		render( <AccountActivationNotice /> );
+
+		expect(
+			screen.queryByText(
+				'Payment methods require activation in your Stripe dashboard.'
+			)
+		).toBeInTheDocument();
+	} );
+
 	it( 'should not render notice if no method has "inactive" or "pending status', () => {
 		useGetCapabilities.mockReturnValue( {
 			giropay_payments: 'active',

--- a/client/settings/account-activation-notice/index.js
+++ b/client/settings/account-activation-notice/index.js
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
 import React from 'react';
 import { Button } from '@wordpress/components';
+import { isEmpty } from 'lodash';
 import { useGetCapabilities } from 'wcstripe/data/account';
 import { useGetAvailablePaymentMethodIds } from 'wcstripe/data';
 
@@ -29,12 +30,15 @@ const AccountActivationNotice = () => {
 	const capabilities = useGetCapabilities();
 	const upePaymentMethods = useGetAvailablePaymentMethodIds();
 
-	const requiresActivation = upePaymentMethods.some( ( method ) => {
-		const capabilityStatus = capabilities[ `${ method }_payments` ];
-		return (
-			capabilityStatus === 'pending' || capabilityStatus === 'inactive'
-		);
-	} );
+	const requiresActivation =
+		isEmpty( capabilities ) ||
+		upePaymentMethods.some( ( method ) => {
+			const capabilityStatus = capabilities[ `${ method }_payments` ];
+			return (
+				capabilityStatus === 'pending' ||
+				capabilityStatus === 'inactive'
+			);
+		} );
 
 	if ( ! requiresActivation ) {
 		return null;


### PR DESCRIPTION
Fixes #2941

The Stripe account used in the [GS testing](https://different-garden-fan.jurassic.ninja) is returning `capabilities` object as empty. As an empty list is not considered for the activation banner's display logic, it is not rendered for this account.

## Changes proposed in this Pull Request:
- Displaying the account activation banner when the `capabilities` of an account is empty along with when one or more payment methods have `inactive` or `pending` status in capability.

## Testing instructions
- Connect a test Stripe account that returns an empty list as `capabilities` (as a workaround mock the `useGetCapabilities` function to return an empty object)
- In the `develop` branch, the account activation banner should not be there.
- In this branch, the account activation banner should be displayed on top of the payment methods list.

![act banner](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/468ba3a1-7022-4241-a187-85e56f8355ca)
