### PR TITLE
Fix statement descriptor issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Fix - Wrong status when purchasing a pre-order product with a new payment method.
 * Tweak - Orders with `trash` status are not retrieving anymore when calling `get_order_by_intent_id` function.
 * Tweak - Hide Stripe secret keys in the UI.
+* Fix - Resolved failing payments when statement descriptor prefix starts with a number.
 
 = 7.9.3 - 2024-02-12 =
 * Fix - Resolved failing payments when statement descriptor only contains the order number.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -822,9 +822,9 @@ class WC_Stripe_Helper {
 		if ( method_exists( $order, 'get_order_number' ) && ! empty( $order->get_order_number() ) ) {
 			$suffix = '#' . $order->get_order_number();
 
-			// Stripe requires at least 1 latin (alphabet) character in the suffix so we add the first character of the prefix before the order number.
+			// Stripe requires at least 1 latin (alphabet) character in the suffix so we add an extra `O` before the order number.
 			if ( 0 === preg_match( '/[a-zA-Z]/', $suffix ) ) {
-				$suffix = ! empty( $prefix ) ? substr( $prefix, 0, 1 ) . ' ' . $suffix : 'O ' . $suffix;
+				$suffix = 'O ' . $suffix;
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,5 +140,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Wrong status when purchasing a pre-order product with a new payment method.
 * Tweak - Orders with `trash` status are not retrieving anymore when calling `get_order_by_intent_id` function.
 * Tweak - Hide Stripe secret keys in the UI.
+* Fix - Resolved failing payments when statement descriptor prefix starts with a number.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2885 

When `Add customer order number to the bank statement` is checked in the Stripe settings page, we send the `statement_descriptor_suffix` field in our request body. As Stripe requires at least 1 Latin character in the suffix, we were [adding the first character of the prefix before the order number](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8cdd33aad9a9e9a9349714daa5c5c1fdd10566f3/includes/class-wc-stripe-helper.php#L578-L581). 

If the `Shortened Descriptor` is not set in the Stripe Dashboard, the prefix would be empty resulting in the `statement_descriptor_suffix` containing only the order id (without any Latin characters) and finally the request will fail. This issue was fixed in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2890 by adding an extra `O` before the order id when prefix is empty.

However, in `7.9.2` also a few merchants are facing the payment failures. The reason is if the prefix itself starts with a digit then our function will add a digit before the order id. For example, if the prefix is `44 Test` and order id is `1234` the `statement_descriptor_suffix` becomes `4 #1234`.

## Changes proposed in this Pull Request:
- To address both the empty prefix scenario and prefix starting with a digit scenario, I am adding `O` before the order if always instead of considering the prefix.


## Testing instructions
- In your [Stripe dashboard](https://dashboard.stripe.com/settings/public) add a Shortened Descriptor (`STEST`)
- In wp-admin, go to the Stripe settings page. Scroll to the `Payments and transactions` section and check `Add customer order number to the bank statement`.
- Add a product to the cart and checkout using Stripe (credit/debit card) as a shopper.
- The purchase should be successful.
- Go to Stripe dashboard and find the corresponding payment on the Payments page.
- In the Payment details section the Statement Descriptor should appear like `STEST* O #1234`