### PR TITLE
Add statement_descriptor_suffix to request when creating intent with UPE enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 8.1.0 - xxxx-xx-xx =
-*
+* Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
 
 = 8.0.0 - 2024-02-29 =
 * Add - Implement deferred payment intents for the Payment Element (or UPE), used on the updated checkout experience.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -702,7 +702,6 @@ class WC_Stripe_Intent_Controller {
 			'payment_method',
 			'save_payment_method_to_store',
 			'shipping',
-			'statement_descriptor',
 		];
 
 		$non_empty_params = [ 'payment_method' ];
@@ -720,15 +719,15 @@ class WC_Stripe_Intent_Controller {
 		$request = array_merge(
 			$request,
 			[
-				'amount'               => $payment_information['amount'],
-				'confirm'              => 'true',
-				'currency'             => $payment_information['currency'],
-				'customer'             => $payment_information['customer'],
+				'amount'                      => $payment_information['amount'],
+				'confirm'                     => 'true',
+				'currency'                    => $payment_information['currency'],
+				'customer'                    => $payment_information['customer'],
 				/* translators: 1) blog name 2) order number */
-				'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
-				'metadata'             => $payment_information['metadata'],
-				'payment_method_types' => $payment_method_types,
-				'statement_descriptor' => $payment_information['statement_descriptor'],
+				'description'                 => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+				'metadata'                    => $payment_information['metadata'],
+				'payment_method_types'        => $payment_method_types,
+				'statement_descriptor_suffix' => $payment_information['statement_descriptor_suffix'],
 			]
 		);
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -719,17 +719,20 @@ class WC_Stripe_Intent_Controller {
 		$request = array_merge(
 			$request,
 			[
-				'amount'                      => $payment_information['amount'],
-				'confirm'                     => 'true',
-				'currency'                    => $payment_information['currency'],
-				'customer'                    => $payment_information['customer'],
+				'amount'               => $payment_information['amount'],
+				'confirm'              => 'true',
+				'currency'             => $payment_information['currency'],
+				'customer'             => $payment_information['customer'],
 				/* translators: 1) blog name 2) order number */
-				'description'                 => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
-				'metadata'                    => $payment_information['metadata'],
-				'payment_method_types'        => $payment_method_types,
-				'statement_descriptor_suffix' => $payment_information['statement_descriptor_suffix'],
+				'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+				'metadata'             => $payment_information['metadata'],
+				'payment_method_types' => $payment_method_types,
 			]
 		);
+
+		if ( isset( $payment_information['statement_descriptor_suffix'] ) ) {
+			$request['statement_descriptor_suffix'] = $payment_information['statement_descriptor_suffix'];
+		}
 
 		if ( $this->request_needs_redirection( $payment_method_types ) ) {
 			$request['return_url'] = $payment_information['return_url'];

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1947,7 +1947,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		$payment_method_types = $this->get_payment_method_types_for_intent_creation( $selected_payment_type, $order->get_id() );
 
-		return [
+		$payment_information = [
 			'amount'                        => $amount,
 			'currency'                      => $currency,
 			'customer'                      => $this->get_customer_id_for_order( $order ),
@@ -1963,10 +1963,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'selected_payment_type'         => $selected_payment_type,
 			'payment_method_types'          => $payment_method_types,
 			'shipping'                      => $shipping_details,
-			'statement_descriptor'          => $this->get_statement_descriptor( $order, $selected_payment_type ),
 			'token'                         => $token,
 			'return_url'                    => $this->get_return_url_for_redirect( $order, $save_payment_method_to_store ),
 		];
+
+		// Use the dynamic + short statement descriptor if enabled and it's a card payment.
+		$is_short_statement_descriptor_enabled = ! empty( $this->get_option( 'is_short_statement_descriptor_enabled' ) ) && 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
+		if ( 'card' === $selected_payment_type && $is_short_statement_descriptor_enabled ) {
+			$payment_information['statement_descriptor_suffix'] = WC_Stripe_Helper::get_dynamic_statement_descriptor_suffix( $order );
+		}
+
+		return $payment_information;
 	}
 
 	/**
@@ -2127,35 +2134,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$customer = new WC_Stripe_Customer( $user->ID );
 
 		return $customer->update_or_create_customer();
-	}
-
-	/**
-	 * Returns the statement descriptor given the selected payment type.
-	 *
-	 * @param WC_Order $order The WC order for which we're getting the statement descriptor.
-	 * @param string $selected_payment_type The selected payment type.
-	 *
-	 * @return string|null
-	 */
-	private function get_statement_descriptor( WC_Order $order, string $selected_payment_type ) {
-		$statement_descriptor                  = ! empty( $this->get_option( 'statement_descriptor' ) ) ? str_replace( "'", '', $this->get_option( 'statement_descriptor' ) ) : '';
-		$short_statement_descriptor            = ! empty( $this->get_option( 'short_statement_descriptor' ) ) ? str_replace( "'", '', $this->get_option( 'short_statement_descriptor' ) ) : '';
-		$is_short_statement_descriptor_enabled = ! empty( $this->get_option( 'is_short_statement_descriptor_enabled' ) ) && 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
-
-		// Use the shortened statement descriptor for card transactions only.
-		if (
-			'card' === $selected_payment_type &&
-			$is_short_statement_descriptor_enabled &&
-			! ( empty( $short_statement_descriptor ) && empty( $statement_descriptor ) )
-		) {
-			return WC_Stripe_Helper::get_dynamic_statement_descriptor( $short_statement_descriptor, $order, $statement_descriptor );
-		}
-
-		if ( ! empty( $statement_descriptor ) ) {
-			return WC_Stripe_Helper::clean_statement_descriptor( $statement_descriptor );
-		}
-
-		return null;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1968,7 +1968,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		];
 
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.
-		$is_short_statement_descriptor_enabled = ! empty( $this->get_option( 'is_short_statement_descriptor_enabled' ) ) && 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled' );
+		$is_short_statement_descriptor_enabled = 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled', 'no' );
 		if ( 'card' === $selected_payment_type && $is_short_statement_descriptor_enabled ) {
 			$payment_information['statement_descriptor_suffix'] = WC_Stripe_Helper::get_dynamic_statement_descriptor_suffix( $order );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.1.0 - xxxx-xx-xx =
-*
+* Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2830

In `8.0.0` when UPE was enabled, we are adding `statement_descriptor` to the create intent request which leads to an API error. (because for card payments `statement_descriptor` parameter is [not supported](https://support.stripe.com/questions/use-of-the-statement-descriptor-parameter-on-paymentintents-for-card-charges) anymore)  For card payments, the expected key is `statement_descriptor_suffix`.

## Changes proposed in this Pull Request:
- Sending `statement_descriptor_suffix` parameter with the create intent request.

## Testing instructions
- Use `develop` branch.
- From Stripe settings page enable UPE and enable `Add customer order number to the bank statement`.
- As a shopper make a purchase and check logs for the create intent request. Notice that in the request body the `payment_method_types` is `card` and `statement_descriptor` parameter is present.
- Now use this branch.
- As a shopper make another purchase and check logs for the create intent request. Notice that in the request body the `payment_method_types` is `card` and `statement_descriptor` is not sent anymore. Instead, we have the `statement_descriptor_suffix` is sent.