### PR TITLE
Disabling automatic_payment_methods param when creating payment intents

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 8.1.0 - xxxx-xx-xx =
-*
+* Fix - Forcing `automatic_payment_methods.enabled` to `false` as a temporary fix for "return_url" errors
 
 = 8.0.0 - 2024-02-29 =
 * Add - Implement deferred payment intents for the Payment Element (or UPE), used on the updated checkout experience.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -346,6 +346,8 @@ class WC_Stripe_Intent_Controller {
 			'payment_intents'
 		);
 
+		WC_Stripe_Logger::log( 'Creating payment intent: ' . print_r( $payment_intent, true ) );
+
 		if ( ! empty( $payment_intent->error ) ) {
 			throw new Exception( $payment_intent->error->message );
 		}

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -346,8 +346,6 @@ class WC_Stripe_Intent_Controller {
 			'payment_intents'
 		);
 
-		WC_Stripe_Logger::log( 'Creating payment intent: ' . print_r( $payment_intent, true ) );
-
 		if ( ! empty( $payment_intent->error ) ) {
 			throw new Exception( $payment_intent->error->message );
 		}

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -337,11 +337,10 @@ class WC_Stripe_Intent_Controller {
 		$capture        = empty( $gateway->get_option( 'capture' ) ) || $gateway->get_option( 'capture' ) === 'yes';
 		$payment_intent = WC_Stripe_API::request(
 			[
-				'amount'                    => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
-				'currency'                  => strtolower( $currency ),
-				'payment_method_types'      => $enabled_payment_methods,
-				'capture_method'            => $capture ? 'automatic' : 'manual',
-				'automatic_payment_methods' => [ 'enabled' => false ],
+				'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
+				'currency'             => strtolower( $currency ),
+				'payment_method_types' => $enabled_payment_methods,
+				'capture_method'       => $capture ? 'automatic' : 'manual',
 			],
 			'payment_intents'
 		);
@@ -721,15 +720,15 @@ class WC_Stripe_Intent_Controller {
 		$request = array_merge(
 			$request,
 			[
-				'amount'               => $payment_information['amount'],
-				'confirm'              => 'true',
-				'currency'             => $payment_information['currency'],
-				'customer'             => $payment_information['customer'],
+				'amount'                    => $payment_information['amount'],
+				'confirm'                   => 'true',
+				'currency'                  => $payment_information['currency'],
+				'customer'                  => $payment_information['customer'],
 				/* translators: 1) blog name 2) order number */
-				'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
-				'metadata'             => $payment_information['metadata'],
-				'payment_method_types' => $payment_method_types,
-				'statement_descriptor' => $payment_information['statement_descriptor'],
+				'description'               => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),
+				'metadata'                  => $payment_information['metadata'],
+				'statement_descriptor'      => $payment_information['statement_descriptor'],
+				'automatic_payment_methods' => [ 'enabled' => 'false' ],
 			]
 		);
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -337,10 +337,11 @@ class WC_Stripe_Intent_Controller {
 		$capture        = empty( $gateway->get_option( 'capture' ) ) || $gateway->get_option( 'capture' ) === 'yes';
 		$payment_intent = WC_Stripe_API::request(
 			[
-				'amount'               => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
-				'currency'             => strtolower( $currency ),
-				'payment_method_types' => $enabled_payment_methods,
-				'capture_method'       => $capture ? 'automatic' : 'manual',
+				'amount'                    => WC_Stripe_Helper::get_stripe_amount( $amount, strtolower( $currency ) ),
+				'currency'                  => strtolower( $currency ),
+				'payment_method_types'      => $enabled_payment_methods,
+				'capture_method'            => $capture ? 'automatic' : 'manual',
+				'automatic_payment_methods' => [ 'enabled' => false ],
 			],
 			'payment_intents'
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.1.0 - xxxx-xx-xx =
-*
+* Fix - Forcing `automatic_payment_methods.enabled` to `false` as a temporary fix for "return_url" errors.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2982

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Some merchants are having issues when trying to process payments using UPE. Stripe is returning the error message:
```
A return_url must be specified because this Payment Intent is configured to automatically accept the payment methods enabled in the Dashboard, some of which may require a full page redirect to succeed. If you do not want to accept redirect-based payment methods, set automatic_payment_methods[enabled] to true and automatic_payment_methods[allow_redirects] to never when creating Setup Intents and Payment Intents.
```

This PR sends a temporary param to Stripe when creating payment intents to solve this until we figure out a better way to handle this requirement. With the introduction of this param, `payment_method_types` got to be removed (cannot be used together).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch
- Start your local environment with "New checkout experience" and "Log error messages"
- Add any product to your cart
- Checkout using Credit Card
- Confirm that you can see the new param included in the payment intent request logs (http://localhost:8082/wp-admin/admin.php?page=wc-status&tab=logs / [woocommerce-gateway-stripe](http://localhost:8082/wp-admin/admin.php?page=wc-status&tab=logs&view=single_file&file_id=woocommerce-gateway-stripe-2024-03-07) ) like:
```
====Start Log====
payment_intents request: Array
...
[automatic_payment_methods] => Array
        (
            [enabled] => false
        )
```

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
