### PR TITLE
Fixes deprecation warnings on PHP 8.2 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 8.1.0 - xxxx-xx-xx =
-*
+* Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 
 = 8.0.0 - 2024-02-29 =
 * Add - Implement deferred payment intents for the Payment Element (or UPE), used on the updated checkout experience.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -82,6 +82,13 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	protected $supported_countries;
 
 	/**
+	 * Wether this UPE method is in testmode.
+	 *
+	 * @var bool
+	 */
+	public $testmode;
+
+	/**
 	 * Create instance of payment method
 	 */
 	public function __construct() {

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.1.0 - xxxx-xx-xx =
-*
+* Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2975 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

After switching over to PHP 8.2 I'm seeing the following PHP warnings coming from Stripe:

```
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_CC::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Alipay::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Giropay::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Eps::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Bancontact::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Boleto::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Ideal::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Oxxo::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Sepa::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_P24::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
[07-Mar-2024 22:50:34 UTC] PHP Deprecated:  Creation of dynamic property WC_Stripe_UPE_Payment_Method_Link::$testmode is deprecated in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method.php on line 93
```

This looks to have been introduced recently in v8.0 with https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2827/commits/f879a1652c2269d74cf32e4df4b759e0a2565977

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Switch to PHP 8.2 or above
2. Enable UPE
3. Check the error logs to see deprecation warnings

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
