### PR TITLE
Update E2E tests date to use 2029 for credit card expiration date

### DIFF
--- a/tests/e2e/test-data/default.json
+++ b/tests/e2e/test-data/default.json
@@ -75,7 +75,7 @@
 			"number": "4242424242424242",
 			"expires": {
 				"month": "02",
-				"year": "24"
+				"year": "28"
 			},
 			"cvc": "424",
 			"label": "Visa •••• 4242 (02/2024)"
@@ -84,7 +84,7 @@
 			"number": "4111111111111111",
 			"expires": {
 				"month": "11",
-				"year": "25"
+				"year": "28"
 			},
 			"cvc": "123",
 			"label": "Visa •••• 1111 (11/2025)"
@@ -102,7 +102,7 @@
 			"number": "4000002760003184",
 			"expires": {
 				"month": "03",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "525",
 			"label": "Visa •••• 3184 (03/2025)"
@@ -129,7 +129,7 @@
 			"number": "4000000000000259",
 			"expires": {
 				"month": "05",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "525",
 			"label": "Visa ending in 0259"
@@ -138,7 +138,7 @@
 			"number": "4000000000002685",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 2685"
@@ -147,7 +147,7 @@
 			"number": "4000000000000002",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 0002",
@@ -160,7 +160,7 @@
 			"number": "4000000000009995",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 9995",
@@ -173,7 +173,7 @@
 			"number": "4242424242424241",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 4241",
@@ -186,7 +186,7 @@
 			"number": "4000000000000069",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 0069",
@@ -196,7 +196,7 @@
 			"number": "4000000000000127",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 0127",
@@ -209,7 +209,7 @@
 			"number": "4000000000000119",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 0119",
@@ -222,7 +222,7 @@
 			"number": "4000008400001629",
 			"expires": {
 				"month": "06",
-				"year": "25"
+				"year": "29"
 			},
 			"cvc": "626",
 			"label": "Visa ending in 1629"
@@ -240,7 +240,7 @@
 			"number": "4242424242424242",
 			"expires": {
 				"month": "06",
-				"year": "24"
+				"year": "29"
 			},
 			"cvc": "11",
 			"label": "Visa ending in 4242"


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixes E2E tests failing due to expired credit cards used for testing

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
