### PR TITLE
Include Stripe API version in logs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 8.1.0 - xxxx-xx-xx =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
+* Add - Include Stripe API version in logs.
 
 = 8.0.0 - 2024-02-29 =
 * Add - Implement deferred payment intents for the Payment Element (or UPE), used on the updated checkout experience.

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -135,6 +135,9 @@ class WC_Stripe_API {
 			]
 		);
 
+		$response_headers = wp_remote_retrieve_headers( $response );
+		WC_Stripe_Logger::log( "{$api} response with stripe-version: " . $response_headers['stripe-version'] );
+
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
 			WC_Stripe_Logger::log(
 				'Error Response: ' . print_r( $response, true ) . PHP_EOL . PHP_EOL . 'Failed request: ' . print_r(
@@ -152,7 +155,7 @@ class WC_Stripe_API {
 
 		if ( $with_headers ) {
 			return [
-				'headers' => wp_remote_retrieve_headers( $response ),
+				'headers' => $response_headers,
 				'body'    => json_decode( $response['body'] ),
 			];
 		}

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -136,7 +136,10 @@ class WC_Stripe_API {
 		);
 
 		$response_headers = wp_remote_retrieve_headers( $response );
-		WC_Stripe_Logger::log( "{$api} response with stripe-version: " . $response_headers['stripe-version'] );
+		// Log the stripe version in the response headers, if present.
+		if ( isset( $response_headers['stripe-version'] ) ) {
+			WC_Stripe_Logger::log( "{$api} response with stripe-version: " . $response_headers['stripe-version'] );
+		}
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
 			WC_Stripe_Logger::log(

--- a/includes/class-wc-stripe-logger.php
+++ b/includes/class-wc-stripe-logger.php
@@ -44,11 +44,13 @@ class WC_Stripe_Logger {
 				$elapsed_time         = round( abs( $end_time - $start_time ) / 60, 2 );
 
 				$log_entry  = "\n" . '====Stripe Version: ' . WC_STRIPE_VERSION . '====' . "\n";
+				$log_entry .= '====Stripe Plugin API Version: ' . WC_Stripe_API::STRIPE_API_VERSION . '====' . "\n";
 				$log_entry .= '====Start Log ' . $formatted_start_time . '====' . "\n" . $message . "\n";
 				$log_entry .= '====End Log ' . $formatted_end_time . ' (' . $elapsed_time . ')====' . "\n\n";
 
 			} else {
 				$log_entry  = "\n" . '====Stripe Version: ' . WC_STRIPE_VERSION . '====' . "\n";
+				$log_entry .= '====Stripe Plugin API Version: ' . WC_Stripe_API::STRIPE_API_VERSION . '====' . "\n";
 				$log_entry .= '====Start Log====' . "\n" . $message . "\n" . '====End Log====' . "\n\n";
 
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 8.1.0 - xxxx-xx-xx =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
+* Add - Include Stripe API version in logs.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
We've discovered that while working on Statement descriptor and return_url errors (https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2973), after investigating the errors it appears that it could be caused by newer Stripe API versions.

In this PR, include the Stripe API version in the Stripe request log so we can verify which version is being used.

Fixes #2977 

## Changes proposed in this Pull Request:
- Included Stripe plugin's API version and Stripe accounts API version (from response header) in logs.

## Testing instructions
- Go to Stripe payment gateway settings and enable logging.
- Complete a purchase using Stripe
- Go to the _WooCommerce > Status > Logs_.
- View the latest Stripe log.
- Note that the Stripe plugin's API version and Stripe accounts API version are added to the logs.

![log](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/f35afaf6-325b-4015-a229-46e02aa413b2)
