### PR TITLE
Fix PHP 8.2 deprecation warnings

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -75,6 +75,13 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	public $enabled;
 
 	/**
+	 * Is test mode active?
+	 *
+	 * @var bool
+	 */
+	public $testmode;
+
+	/**
 	 * List of supported countries
 	 *
 	 * @var array


### PR DESCRIPTION
Fixes #2975 

## Changes proposed in this Pull Request:
- Added `testmode` variable as a class property to avoid PHP 8.2 `Dynamic Properties are deprecated` warning.

## Testing instructions

### Reproduce the bug
- Switch to PHP 8.2
- Enable UPE
- Load any admin page or checkout page and see the deprecation warning.

### Test the fix
- Switch to PHP 8.2
- Enable UPE
- Load any admin page or checkout page and ensure that there are no deprecation warnings.
- On the checkout page, select `card` as the payment method. The test mode instructions should be displayed.
- Switch back to the default PHP version (`7.4`)
- Load any admin page or checkout page and ensure that there are no deprecation warnings.
- On the checkout page, select `card` as the payment method. The test mode instructions should be displayed.