### PR TITLE
Fix issue with saving plugin settings when existent bank descriptor is no longer valid

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 8.1.0 - xxxx-xx-xx =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
+* Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 
 = 8.0.0 - 2024-02-29 =
 * Add - Implement deferred payment intents for the Payment Element (or UPE), used on the updated checkout experience.

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 8.1.0 - xxxx-xx-xx =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
+* Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -158,58 +158,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$response = $this->rest_get_settings();
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'foobar', $response->get_data()[ $option_name ] );
-
-		// Test update works for values passing validation.
-		$this->get_gateway()->update_option( $option_name, 'foobar' );
-
-		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
-		if ( 'short_statement_descriptor' === $option_name ) {
-			$request->set_param( 'is_short_statement_descriptor_enabled', true );
-		}
-		$request->set_param( $option_name, 'quuxcorge' );
-		$response = rest_do_request( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'quuxcorge', $this->get_gateway()->get_option( $option_name ) );
-
-		// Do not update if rest key not present in update request.
-		$this->get_gateway()->update_option( $option_name, 'foobar' );
-
-		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
-		rest_do_request( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'foobar', $this->get_gateway()->get_option( $option_name ) );
-
-		// Test update fails and returns HTTP code 400 for non-string values.
-		$this->assert_statement_descriptor_update_request_fails_for_value(
-			$option_name,
-			[]
-		);
-
-		// Test update fails and returns HTTP code 400 for values that are too short.
-		$this->assert_statement_descriptor_update_request_fails_for_value(
-			$option_name,
-			'1234'
-		);
-
-		// Test update fails and returns HTTP code 400 for values that are too long.
-		$this->assert_statement_descriptor_update_request_fails_for_value(
-			$option_name,
-			str_pad( '', $max_allowed_length + 1, 'a' )
-		);
-
-		// Test update fails and returns HTTP code 400 for values that contain no letters.
-		$this->assert_statement_descriptor_update_request_fails_for_value(
-			$option_name,
-			'123456'
-		);
-
-		// Test update fails and returns HTTP code 400 for values that contain special characters.
-		$this->assert_statement_descriptor_update_request_fails_for_value(
-			$option_name,
-			'foobar\''
-		);
 	}
 
 	public function test_individual_payment_method_settings() {
@@ -252,24 +200,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'Giropay', $gateway_settings['title'] );
 		$this->assertEquals( 'Pay with Giropay', $gateway_settings['description'] );
-	}
-
-	public function test_short_statement_descriptor_is_not_updated() {
-		// It returns option value under expected key with HTTP code 200.
-		$this->get_gateway()->update_option( 'short_statement_descriptor', 'foobar' );
-		$response = $this->rest_get_settings();
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'foobar', $response->get_data()['short_statement_descriptor'] );
-
-		// test update does not fail since is_short_statement_descriptor_enabled is disabled
-		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
-		$request->set_param( 'is_short_statement_descriptor_enabled', false );
-		$request->set_param( 'short_statement_descriptor', '123' );
-		$response = rest_do_request( $request );
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( 'foobar', $this->get_gateway()->get_option( 'short_statement_descriptor' ) );
 	}
 
 	public function test_get_settings_returns_available_payment_method_ids() {
@@ -434,21 +364,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			'statement_descriptor'       => [ 'statement_descriptor', 22 ],
 			'short_statement_descriptor' => [ 'short_statement_descriptor', 10 ],
 		];
-	}
-
-	private function assert_statement_descriptor_update_request_fails_for_value( $option_name, $new_invalid_value ) {
-		$this->get_gateway()->update_option( $option_name, 'foobar' );
-
-		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
-		if ( 'short_statement_descriptor' === $option_name ) {
-			$request->set_param( 'is_short_statement_descriptor_enabled', true );
-		}
-		$request->set_param( $option_name, $new_invalid_value );
-
-		$response = rest_do_request( $request );
-
-		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'foobar', $this->get_gateway()->get_option( $option_name ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2971

## Changes proposed in this Pull Request:
- Removed the code that validates and saves the `satement_descriptor` and `short_satement_descriptor` (As these two fields are not editable for the frontend)

## Testing instructions
- Go to the Stripe settings page.
- Change different settings property and click save.
- Changes should be saved correctly every time without any errors. On page refresh, changes should persist.