### PR TITLE
Updating StripeJS library to support card brand choice

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.1.0 - xxxx-xx-xx =
+* Tweak - Update the Stripe JS library to 1.36.0.
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "woocommerce-gateway-stripe",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
         "@stripe/react-stripe-js": "1.4.1",
-        "@stripe/stripe-js": "1.15.1",
+        "@stripe/stripe-js": "^1.36.0",
         "@testing-library/react-hooks": "^7.0.2",
         "framer-motion": "^7.6.1",
         "gridicons": "^3.4.0",
@@ -4598,9 +4598,9 @@
       }
     },
     "node_modules/@stripe/stripe-js": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.15.1.tgz",
-      "integrity": "sha512-yJiDGutlwu25iajCy51VRJeoH3UMs+s5qVIDGfmPUuFpZ+F6AJ9g9EFrsBNvHxAGBahQFMLlBdzlCVydhGp6tg=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.36.0.tgz",
+      "integrity": "sha512-m45BD9JxOfIBT0Tz4MupiKzM8M58NX/We8wKlf+54TCZpW1RVAyFpJ58CbtyU/LxAM+opT6cewHRVfs7bTUtBA=="
     },
     "node_modules/@stylelint/postcss-css-in-js": {
       "version": "0.37.2",
@@ -39068,9 +39068,9 @@
       }
     },
     "@stripe/stripe-js": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.15.1.tgz",
-      "integrity": "sha512-yJiDGutlwu25iajCy51VRJeoH3UMs+s5qVIDGfmPUuFpZ+F6AJ9g9EFrsBNvHxAGBahQFMLlBdzlCVydhGp6tg=="
+      "version": "1.36.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.36.0.tgz",
+      "integrity": "sha512-m45BD9JxOfIBT0Tz4MupiKzM8M58NX/We8wKlf+54TCZpW1RVAyFpJ58CbtyU/LxAM+opT6cewHRVfs7bTUtBA=="
     },
     "@stylelint/postcss-css-in-js": {
       "version": "0.37.2",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@stripe/react-stripe-js": "1.4.1",
-    "@stripe/stripe-js": "1.15.1",
+    "@stripe/stripe-js": "^1.36.0",
     "@testing-library/react-hooks": "^7.0.2",
     "framer-motion": "^7.6.1",
     "gridicons": "^3.4.0",

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.1.0 - xxxx-xx-xx =
+* Tweak - Update the Stripe JS library to 1.36.0.
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #133

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR just updates our StripeJS package to the version [1.36.0](https://github.com/stripe/stripe-js/releases/tag/v1.36.0) in order to support the [Card Brand Choice feature](https://docs.stripe.com/co-badged-cards-compliance). This package version is the first to support card brand event listeners.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch and run `npm install`
- Build the frontend scripts by running `npm run build:webpack`
- Enable UPE
- Add the Stripe keys from a French account
- Confirm that you are able to purchase anything normally with credit cards
- Try to purchase using [any Cartes Bancaires test card](https://docs.stripe.com/co-badged-cards-compliance) *
- Confirm that you can select the card brand next to the card number field

\* This is currently not working due to an issue on the Stripe side.

We will add e2e tests for this new feature once it is fixed on Stripe's side.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
