### PR TITLE
Fix order amount for currencies with 3 decimal places

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.1.0 - xxxx-xx-xx =
+* Fix - The payment amount over Stripe when purchasing using currencies with 3 decimal places.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 
 = 8.0.1 - 2024-03-13 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 8.1.0 - xxxx-xx-xx =
-* Fix - The payment amount over Stripe when purchasing using currencies with 3 decimal places.
+* Fix - Incorrect payment amount sent to Stripe when using three-decimal currencies.
 * Tweak - Update the Stripe JS library to 1.36.0.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1306,9 +1306,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$payment_method_types = [ $prepared_source->source_object->type ];
 		}
 
+		$currency = strtolower( $order->get_currency() );
+
 		$request = [
-			'amount'               => WC_Stripe_Helper::get_stripe_amount( $order->get_total() ),
-			'currency'             => strtolower( $order->get_currency() ),
+			'amount'               => WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency ),
+			'currency'             => $currency,
 			'description'          => $full_request['description'],
 			'metadata'             => $full_request['metadata'],
 			'capture_method'       => ( 'true' === $full_request['capture'] ) ? 'automatic' : 'manual',
@@ -1453,7 +1455,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$request = WC_Stripe_Helper::add_payment_method_to_request_array( $prepared_source->source, $request );
 		}
 
-		$new_amount = WC_Stripe_Helper::get_stripe_amount( $order->get_total() );
+		$currency   = strtolower( $order->get_currency() );
+		$new_amount = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		if ( $intent->amount !== $new_amount ) {
 			$request['amount'] = $new_amount;
 		}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -186,7 +186,8 @@ class WC_Stripe_Helper {
 		if ( in_array( $currency, self::no_decimal_currencies(), true ) ) {
 			return absint( $total );
 		} elseif ( in_array( $currency, self::tree_decimal_currencies(), true ) ) {
-			return absint( wc_format_decimal( ( (float) $total * 1000 ), wc_get_price_decimals() ) ); // For tree decimal currencies.
+			$amount = absint( wc_format_decimal( ( (float) $total * 100 ), wc_get_price_decimals() ) ); // For tree decimal currencies.
+			return $amount - ( $amount % 10 ); // Round the last digit down. See https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal
 		} else {
 			return absint( wc_format_decimal( ( (float) $total * 100 ), wc_get_price_decimals() ) ); // In cents.
 		}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -186,7 +186,8 @@ class WC_Stripe_Helper {
 		if ( in_array( $currency, self::no_decimal_currencies(), true ) ) {
 			return absint( $total );
 		} elseif ( in_array( $currency, self::three_decimal_currencies(), true ) ) {
-			$amount = absint( wc_format_decimal( ( (float) $total * 100 ), wc_get_price_decimals() ) ); // For tree decimal currencies.
+			$cent_precision = pow( 10, wc_get_price_decimals() );
+			$amount         = absint( wc_format_decimal( ( (float) $total * $cent_precision ), wc_get_price_decimals() ) ); // For tree decimal currencies.
 			return $amount - ( $amount % 10 ); // Round the last digit down. See https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal
 		} else {
 			return absint( wc_format_decimal( ( (float) $total * 100 ), wc_get_price_decimals() ) ); // In cents.
@@ -708,7 +709,7 @@ class WC_Stripe_Helper {
 		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' ) && OrderUtil::custom_orders_table_usage_is_enabled() ) {
 			$orders   = wc_get_orders(
 				[
-					'limit'          => 1,
+					'limit'      => 1,
 					'meta_query' => [
 						[
 							'key'   => '_stripe_refund_id',

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -185,7 +185,7 @@ class WC_Stripe_Helper {
 
 		if ( in_array( $currency, self::no_decimal_currencies(), true ) ) {
 			return absint( $total );
-		} elseif ( in_array( $currency, self::tree_decimal_currencies(), true ) ) {
+		} elseif ( in_array( $currency, self::three_decimal_currencies(), true ) ) {
 			$amount = absint( wc_format_decimal( ( (float) $total * 100 ), wc_get_price_decimals() ) ); // For tree decimal currencies.
 			return $amount - ( $amount % 10 ); // Round the last digit down. See https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal
 		} else {

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -266,7 +266,7 @@ class WC_Stripe_Helper {
 	 *
 	 * @return array $currencies
 	 */
-	private static function tree_decimal_currencies() {
+	private static function three_decimal_currencies() {
 		return [
 			'bhd', // Bahraini Dinar
 			'jod', // Jordanian Dinar

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -181,8 +181,12 @@ class WC_Stripe_Helper {
 			$currency = get_woocommerce_currency();
 		}
 
-		if ( in_array( strtolower( $currency ), self::no_decimal_currencies() ) ) {
+		$currency = strtolower( $currency );
+
+		if ( in_array( $currency, self::no_decimal_currencies(), true ) ) {
 			return absint( $total );
+		} elseif ( in_array( $currency, self::tree_decimal_currencies(), true ) ) {
+			return absint( wc_format_decimal( ( (float) $total * 1000 ), wc_get_price_decimals() ) ); // For tree decimal currencies.
 		} else {
 			return absint( wc_format_decimal( ( (float) $total * 100 ), wc_get_price_decimals() ) ); // In cents.
 		}
@@ -252,6 +256,22 @@ class WC_Stripe_Helper {
 			'xaf', // Central African Cfa Franc
 			'xof', // West African Cfa Franc
 			'xpf', // Cfp Franc
+		];
+	}
+
+	/**
+	 * List of currencies supported by Stripe that has three decimals
+	 * https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal
+	 *
+	 * @return array $currencies
+	 */
+	private static function tree_decimal_currencies() {
+		return [
+			'bhd', // Bahraini Dinar
+			'jod', // Jordanian Dinar
+			'kwd', // Kuwaiti Dinar
+			'omr', // Omani Rial
+			'tnd', // Tunisian Dinar
 		];
 	}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -186,8 +186,8 @@ class WC_Stripe_Helper {
 		if ( in_array( $currency, self::no_decimal_currencies(), true ) ) {
 			return absint( $total );
 		} elseif ( in_array( $currency, self::three_decimal_currencies(), true ) ) {
-			$cent_precision = pow( 10, wc_get_price_decimals() );
-			$amount         = absint( wc_format_decimal( ( (float) $total * $cent_precision ), wc_get_price_decimals() ) ); // For tree decimal currencies.
+			$price_decimals = wc_get_price_decimals();
+			$amount         = absint( wc_format_decimal( ( (float) $total * 1000 ), $price_decimals ) ); // For tree decimal currencies.
 			return $amount - ( $amount % 10 ); // Round the last digit down. See https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal
 		} else {
 			return absint( wc_format_decimal( ( (float) $total * 100 ), wc_get_price_decimals() ) ); // In cents.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -3,8 +3,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
-
 /**
  * WC_Stripe_Intent_Controller class.
  *
@@ -718,14 +716,12 @@ class WC_Stripe_Intent_Controller {
 
 		$request = $this->build_base_payment_intent_request_params( $payment_information );
 
-		$currency = strtolower( $payment_information['currency'] );
-
 		$request = array_merge(
 			$request,
 			[
-				'amount'               => WC_Stripe_Helper::get_stripe_amount( $payment_information['amount'], $currency ),
+				'amount'               => $payment_information['amount'],
 				'confirm'              => 'true',
-				'currency'             => $currency,
+				'currency'             => $payment_information['currency'],
 				'customer'             => $payment_information['customer'],
 				/* translators: 1) blog name 2) order number */
 				'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+
 /**
  * WC_Stripe_Intent_Controller class.
  *
@@ -716,12 +718,14 @@ class WC_Stripe_Intent_Controller {
 
 		$request = $this->build_base_payment_intent_request_params( $payment_information );
 
+		$currency = strtolower( $payment_information['currency'] );
+
 		$request = array_merge(
 			$request,
 			[
-				'amount'               => $payment_information['amount'],
+				'amount'               => WC_Stripe_Helper::get_stripe_amount( $payment_information['amount'], $currency ),
 				'confirm'              => 'true',
-				'currency'             => $payment_information['currency'],
+				'currency'             => $currency,
 				'customer'             => $payment_information['customer'],
 				/* translators: 1) blog name 2) order number */
 				'description'          => sprintf( __( '%1$s - Order %2$s', 'woocommerce-gateway-stripe' ), wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES ), $order->get_order_number() ),

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.1.0 - xxxx-xx-xx =
-* Fix - The payment amount over Stripe when purchasing using currencies with 3 decimal places.
+* Fix - Incorrect payment amount sent to Stripe when using three-decimal currencies.
 * Tweak - Update the Stripe JS library to 1.36.0.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.1.0 - xxxx-xx-xx =
+* Fix - The payment amount over Stripe when purchasing using currencies with 3 decimal places.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -196,13 +196,13 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	* Test for `get_order_by_intent_id`
-	*
-	* @param string $status              The order status to return.
-	* @param bool   $success             Whether the order should be found.
-	* @return void
-	* @dataProvider provide_test_get_order_by_intent_id
-	*/
+	 * Test for `get_order_by_intent_id`
+	 *
+	 * @param string $status              The order status to return.
+	 * @param bool   $success             Whether the order should be found.
+	 * @return void
+	 * @dataProvider provide_test_get_order_by_intent_id
+	 */
 	public function test_get_order_by_intent_id( $status, $success ) {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -240,4 +240,57 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Test for `get_stripe_amount`
+	 *
+	 * @param int    $total    The total amount.
+	 * @param string $currency The currency.
+	 * @param int    $expected The expected amount.
+	 * @dataProvider provide_test_get_stripe_amount
+	 */
+	public function test_get_stripe_amount( int $total, string $currency, int $expected ): void {
+		$amount = WC_Stripe_Helper::get_stripe_amount( $total, $currency );
+		$this->assertEquals( $expected, $amount );
+	}
+
+	/**
+	 * Data provider for `test_get_stripe_amount`
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_stripe_amount(): array {
+		return [
+			'USD' => [
+				'total'    => 100,
+				'currency' => 'USD',
+				'expected' => 10000,
+			],
+			'JPY' => [
+				'total'    => 100,
+				'currency' => 'JPY',
+				'expected' => 100,
+			],
+			'EUR' => [
+				'total'    => 100,
+				'currency' => 'EUR',
+				'expected' => 10000,
+			],
+			'BHD' => [
+				'total'    => 100,
+				'currency' => 'BHD',
+				'expected' => 10000,
+			],
+			'JOD' => [
+				'total'    => 100,
+				'currency' => 'JOD',
+				'expected' => 10000,
+			],
+			'BIF' => [
+				'total'    => 100,
+				'currency' => 'BIF',
+				'expected' => 100,
+			],
+		];
+	}
 }

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -250,7 +250,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_get_stripe_amount
 	 */
 	public function test_get_stripe_amount( int $total, string $currency, int $expected, int $price_decimals_setting = 2 ): void {
-		if ( 2 !== price_decimals_setting ) {
+		if ( 2 !== $price_decimals_setting ) {
 			update_option( 'woocommerce_price_num_decimals', $price_decimals_setting );
 		}
 

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -222,10 +222,10 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	* Data provider for `test_get_order_by_intent_id`
-	*
-	* @return array
-	*/
+	 * Data provider for `test_get_order_by_intent_id`
+	 *
+	 * @return array
+	 */
 	public function provide_test_get_order_by_intent_id(): array {
 		return [
 			'regular table' => [

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -196,13 +196,13 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test for `get_order_by_intent_id`
-	 *
-	 * @param string $status              The order status to return.
-	 * @param bool   $success             Whether the order should be found.
-	 * @return void
-	 * @dataProvider provide_test_get_order_by_intent_id
-	 */
+	* Test for `get_order_by_intent_id`
+	*
+	* @param string $status              The order status to return.
+	* @param bool   $success             Whether the order should be found.
+	* @return void
+	* @dataProvider provide_test_get_order_by_intent_id
+	*/
 	public function test_get_order_by_intent_id( $status, $success ) {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
@@ -222,10 +222,10 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for `test_get_order_by_intent_id`
-	 *
-	 * @return array
-	 */
+	* Data provider for `test_get_order_by_intent_id`
+	*
+	* @return array
+	*/
 	public function provide_test_get_order_by_intent_id(): array {
 		return [
 			'regular table' => [
@@ -283,18 +283,18 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 			'BHD'              => [
 				'total'    => 100,
 				'currency' => 'BHD',
-				'expected' => 10000,
+				'expected' => 100000,
 			],
 			'BHD (3 decimals)' => [
 				'total'                  => 100,
 				'currency'               => 'BHD',
-				'expected'               => 10000,
+				'expected'               => 100000,
 				'price_decimals_setting' => 3,
 			],
 			'JOD'              => [
 				'total'    => 100,
 				'currency' => 'JOD',
-				'expected' => 10000,
+				'expected' => 100000,
 			],
 			'BIF'              => [
 				'total'    => 100,

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -249,7 +249,11 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	 * @param int    $expected The expected amount.
 	 * @dataProvider provide_test_get_stripe_amount
 	 */
-	public function test_get_stripe_amount( int $total, string $currency, int $expected ): void {
+	public function test_get_stripe_amount( int $total, string $currency, int $expected, int $price_decimals_setting = 2 ): void {
+		if ( 2 !== price_decimals_setting ) {
+			update_option( 'woocommerce_price_num_decimals', $price_decimals_setting );
+		}
+
 		$amount = WC_Stripe_Helper::get_stripe_amount( $total, $currency );
 		$this->assertEquals( $expected, $amount );
 	}
@@ -261,32 +265,38 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_get_stripe_amount(): array {
 		return [
-			'USD' => [
+			'USD'              => [
 				'total'    => 100,
 				'currency' => 'USD',
 				'expected' => 10000,
 			],
-			'JPY' => [
+			'JPY'              => [
 				'total'    => 100,
 				'currency' => 'JPY',
 				'expected' => 100,
 			],
-			'EUR' => [
+			'EUR'              => [
 				'total'    => 100,
 				'currency' => 'EUR',
 				'expected' => 10000,
 			],
-			'BHD' => [
+			'BHD'              => [
 				'total'    => 100,
 				'currency' => 'BHD',
 				'expected' => 10000,
 			],
-			'JOD' => [
+			'BHD (3 decimals)' => [
+				'total'                  => 100,
+				'currency'               => 'BHD',
+				'expected'               => 10000,
+				'price_decimals_setting' => 3,
+			],
+			'JOD'              => [
 				'total'    => 100,
 				'currency' => 'JOD',
 				'expected' => 10000,
 			],
-			'BIF' => [
+			'BIF'              => [
 				'total'    => 100,
 				'currency' => 'BIF',
 				'expected' => 100,


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2720 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR fixes the handling of currencies with [3 decimal places](https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal). We do this by using the existing `WC_Stripe_Helper::get_stripe_amount` method, always passing the currency, and improving it to identify those specific currencies. When any if found, we multiple the amount by 100 and round the last digit as mentioned [here](https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Change the country of your Stripe account to "United Arab Emirates"
- Checkout to this branch on your local environment
- Setup your Stripe keys
- Change your store currency to any of the [3-decimal places ones](https://docs.stripe.com/currencies?presentment-currency=AE#three-decimal)
- Start it with `npm run up`
- Place an order
- Verify that you can see the correct amount on Stripe (instead of 10% of it, as it happens in the `develop` branch)
- Confirm the same behavior with both UPE enabled or disabled

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
