### PR TITLE
Fix issue with rendering Sepa 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 8.1.0 - xxxx-xx-xx =
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
+* Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
 
 = 8.0.1 - 2024-03-13 =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1916,8 +1916,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		// If Stripe is not enabled bail.
-		if ( 'no' === $this->enabled ) {
+		// bail if no Stripe payment method is enabled.
+		if ( 'no' === $this->enabled && empty( WC_Stripe_Helper::get_legacy_enabled_payment_methods() ) ) {
 			return;
 		}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1916,7 +1916,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return;
 		}
 
-		// bail if no Stripe payment method is enabled.
+		// Bail if no Stripe payment method is enabled.
 		if ( 'no' === $this->enabled && empty( WC_Stripe_Helper::get_legacy_enabled_payment_methods() ) ) {
 			return;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 8.1.0 - xxxx-xx-xx =
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
+* Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #1404 

If the Stripe credit card payment method is disabled, but the SEPA payment method is enabled, then the SEPA checkout doesn't render due to the `woocommerce_stripe` script not being registered when the SEPA code tries to enqueue it.

## Changes proposed in this Pull Request:
- Registering the `woocommerce_stripe` script when the card or at least another Stripe payment method is enabled. 

## Testing instructions
- Use `develop` branch.
- Set Euro as store currency.
- Go to Stripe settings page. Disable the new checkout experience (UPE), disable the card method and enable the SEPA payment method.
- As a shopper go to the checkout page.
- You should find that the `IBAN` number field of the SEPA payment method fails to render.

<img src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/5967a03f-96c0-48cf-8252-86fed0d3f2ea" width="50%" height="50%" />

- Now use this branch.
- As a shopper go to the checkout page again. The `IBAN` number field of the SEPA payment method should be rendered perfectly.

<img src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/c1f2bebd-8e31-4210-af0e-6963b9208653" width="50%" height="50%" />
