### PR TITLE
Remove the option under the Settings tab > General > Display settings > Name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
+* Tweak - Remove unused UPE title field.
 
 = 8.0.1 - 2024-03-13 =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -157,7 +157,6 @@ export const usePaymentRequestLocations = makeSettingsHook(
 	EMPTY_ARR
 );
 export const useIsStripeEnabled = makeSettingsHook( 'is_stripe_enabled' );
-export const useUpeTitle = makeSettingsHook( 'title_upe', '' );
 export const useTestMode = makeSettingsHook( 'is_test_mode_enabled' );
 export const useSavedCards = makeSettingsHook( 'is_saved_cards_enabled' );
 export const useManualCapture = makeSettingsHook( 'is_manual_capture_enabled' );

--- a/client/settings/payment-settings/__tests__/general-settings-section.test.js
+++ b/client/settings/payment-settings/__tests__/general-settings-section.test.js
@@ -6,10 +6,8 @@ import {
 	useIsStripeEnabled,
 	useEnabledPaymentMethodIds,
 	useTestMode,
-	useUpeTitle,
 } from 'wcstripe/data';
 import { useAccountKeys } from 'wcstripe/data/account-keys/hooks';
-import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useIsStripeEnabled: jest.fn(),
@@ -65,17 +63,5 @@ describe( 'GeneralSettingsSection', () => {
 		userEvent.click( testModeCheckbox );
 
 		expect( setTestModeMock ).toHaveBeenCalledWith( true );
-	} );
-
-	it( 'should render UPE title field when UPE is enabled', () => {
-		useUpeTitle.mockReturnValue( [ 'UPE title', jest.fn() ] );
-
-		render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<GeneralSettingsSection />
-			</UpeToggleContext.Provider>
-		);
-
-		expect( screen.getByDisplayValue( 'UPE title' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/payment-settings/general-settings-section.js
+++ b/client/settings/payment-settings/general-settings-section.js
@@ -1,29 +1,19 @@
 import { __ } from '@wordpress/i18n';
 import { React, useState, useContext } from 'react';
-import { Card, CheckboxControl, TextControl } from '@wordpress/components';
+import { Card, CheckboxControl } from '@wordpress/components';
 import styled from '@emotion/styled';
 import CardBody from '../card-body';
 import { AccountKeysModal } from './account-keys-modal';
 import TestModeCheckbox from './test-mode-checkbox';
-import {
-	useIsStripeEnabled,
-	useUpeTitle,
-	useEnabledPaymentMethodIds,
-} from 'wcstripe/data';
+import { useIsStripeEnabled, useEnabledPaymentMethodIds } from 'wcstripe/data';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 const StyledCard = styled( Card )`
 	margin-bottom: 12px;
 `;
 
-const Description = styled.div`
-	color: #757575;
-	font-size: 12px;
-`;
-
 const GeneralSettingsSection = ( { setKeepModalContent } ) => {
 	const [ isStripeEnabled, setIsStripeEnabled ] = useIsStripeEnabled();
-	const [ upeTitle, setUpeTitle ] = useUpeTitle();
 	const [
 		enabledPaymentMethods,
 		setEnabledPaymentMethods,
@@ -83,29 +73,6 @@ const GeneralSettingsSection = ( { setKeepModalContent } ) => {
 							'woocommerce-gateway-stripe'
 						) }
 					/>
-					{ isUpeEnabled && (
-						<>
-							<h4>
-								{ __(
-									'Display settings',
-									'woocommerce-gateway-stripe'
-								) }
-							</h4>
-							<Description>
-								{ __(
-									'Enter the payment method name that will be displayed at checkout when there are multiple available payment methods.',
-									'woocommerce-gateway-stripe'
-								) }
-							</Description>
-						</>
-					) }
-					{ isUpeEnabled && (
-						<TextControl
-							label={ __( 'Name', 'woocommerce-gateway-stripe' ) }
-							value={ upeTitle }
-							onChange={ setUpeTitle }
-						/>
-					) }
 					<TestModeCheckbox />
 				</CardBody>
 			</StyledCard>

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -66,11 +66,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'title_upe'                        => [
-						'description'       => __( 'New checkout experience title.', 'woocommerce-gateway-stripe' ),
-						'type'              => 'string',
-						'validate_callback' => 'rest_validate_request_arg',
-					],
 					'enabled_payment_method_ids'       => [
 						'description'       => __( 'Payment method IDs that should be enabled. Other methods will be disabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'array',
@@ -226,7 +221,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > General */
 				'is_stripe_enabled'                     => $this->gateway->is_enabled(),
 				'is_test_mode_enabled'                  => $this->gateway->is_in_test_mode(),
-				'title_upe'                             => $this->gateway->get_validated_option( 'title_upe' ),
 
 				/* Settings > Payments accepted on checkout */
 				'enabled_payment_method_ids'            => $is_upe_enabled ? WC_Stripe_Helper::get_upe_settings_enabled_payment_method_ids( $this->gateway ) : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids(),
@@ -264,7 +258,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	public function update_settings( WP_REST_Request $request ) {
 		/* Settings > General */
 		$this->update_is_stripe_enabled( $request );
-		$this->update_title_upe( $request );
 		$this->update_is_test_mode_enabled( $request );
 
 		/* Settings > Payments accepted on checkout */
@@ -334,21 +327,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		} else {
 			$this->gateway->disable();
 		}
-	}
-
-	/**
-	 * Updates UPE title.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 */
-	private function update_title_upe( WP_REST_Request $request ) {
-		$title_upe = $request->get_param( 'title_upe' );
-
-		if ( null === $title_upe ) {
-			return;
-		}
-
-		$this->gateway->update_validated_option( 'title_upe', $title_upe );
 	}
 
 	/**

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -22,13 +22,6 @@ $stripe_settings = apply_filters(
 			'default'     => __( 'Credit Card (Stripe)', 'woocommerce-gateway-stripe' ),
 			'desc_tip'    => true,
 		],
-		'title_upe'                           => [
-			'title'       => __( 'Title', 'woocommerce-gateway-stripe' ),
-			'type'        => $is_gte_wc6_6 ? 'safe_text' : 'text',
-			'description' => __( 'This controls the title which the user sees during checkout when multiple payment methods are enabled.', 'woocommerce-gateway-stripe' ),
-			'default'     => __( 'Popular payment methods', 'woocommerce-gateway-stripe' ),
-			'desc_tip'    => true,
-		],
 		'description'                         => [
 			'title'       => __( 'Description', 'woocommerce-gateway-stripe' ),
 			'type'        => 'text',

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -189,7 +189,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function init_form_fields() {
 		$this->form_fields = require dirname( __FILE__ ) . '/admin/stripe-settings.php';
-		unset( $this->form_fields['title_upe'] );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -133,5 +133,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
+* Tweak - Remove unused UPE title field.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2990

With UPE enebled, the option Settings > General > Display settings, called "Name" is no longer used.

Before Split PE was implemented in 8.0.0, this string was used as a name for all of the payment methods that were displayed together as tabs under the Stripe gateway. As the description reads:

> Enter the payment method name that will be displayed at checkout when there are multiple available payment methods.

Since `8.0.0`, every payment method type has its own gateway, and this string is no longer used on the checkout page. It was used by `WC_Stripe_UPE_Payment_Gateway` previously.

## Changes proposed in this Pull Request:
- Removed the `Name` field from the settings page.

## Testing instructions
- Check out `develop` branch.
- Enable UPE.
- Go to Stripe settings > Settings tab > General > Display settings.
- Notice that there is a text field labeled `Name` (This is an unused field now)

![before name](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/091763fc-ccad-4af2-8f9f-b569ff10f635)

- Check out this branch. 
- Ensure the `Name` field no longer exists on the settings page.

![after title](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/b576b3aa-906a-477f-94fa-8184324105e8)
