### PR TITLE
Remove early access pill and disable option from dropdown

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
-* Tweak - Removed "Early Access" pill and "Disable" button from dropdown menu.
+* Tweak - Removed the "Early Access" pill and "Disable" option from the Stripe payment methods dropdown menu.
 * Tweak - Remove unused UPE title field.
 
 = 8.0.1 - 2024-03-13 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
+* Tweak - Removed "Early Access" pill and "Disable" button from dropdown menu.
 
 = 8.0.1 - 2024-03-13 =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.

--- a/client/settings/general-settings-section/__tests__/general-settings-section.test.js
+++ b/client/settings/general-settings-section/__tests__/general-settings-section.test.js
@@ -325,33 +325,6 @@ describe( 'GeneralSettingsSection', () => {
 		expect( updateEnabledMethodsMock ).toHaveBeenCalled();
 	} );
 
-	it( 'should display a modal to allow to disable UPE', () => {
-		render(
-			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
-				<GeneralSettingsSection />
-			</UpeToggleContext.Provider>
-		);
-
-		expect(
-			screen.queryByText( /Without the new payments experience/ )
-		).not.toBeInTheDocument();
-
-		userEvent.click(
-			screen.getByRole( 'button', {
-				name: 'Payment methods menu',
-			} )
-		);
-		userEvent.click(
-			screen.getByRole( 'menuitem', {
-				name: 'Disable',
-			} )
-		);
-
-		expect(
-			screen.queryByText( /Without the new payments experience/ )
-		).toBeInTheDocument();
-	} );
-
 	it( 'does not display the payment method checkbox when currency is not supprted', () => {
 		global.wcSettings = { currency: { code: 'USD' } };
 		useGetAvailablePaymentMethodIds.mockReturnValue( [

--- a/client/settings/general-settings-section/section-heading.js
+++ b/client/settings/general-settings-section/section-heading.js
@@ -3,14 +3,11 @@ import React, { useContext } from 'react';
 import styled from '@emotion/styled';
 import { Button, CardHeader, DropdownMenu } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
-import DisableUpeConfirmationModal from './disable-upe-confirmation-modal';
-import Pill from 'wcstripe/components/pill';
 import { useAccount } from 'wcstripe/data/account';
 import {
 	useGetAvailablePaymentMethodIds,
 	useGetOrderedPaymentMethodIds,
 } from 'wcstripe/data';
-import useToggle from 'wcstripe/hooks/use-toggle';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 const StyledHeader = styled( CardHeader )`
@@ -63,10 +60,6 @@ const SectionHeading = ( { isChangingDisplayOrder, onChangeDisplayOrder } ) => {
 		saveOrderedPaymentMethodIds,
 	} = useGetOrderedPaymentMethodIds();
 
-	const [ isConfirmationModalOpen, toggleConfirmationModal ] = useToggle(
-		false
-	);
-
 	const { refreshAccount } = useAccount();
 
 	const onChangeDisplayOrderCancel = () => {
@@ -85,17 +78,7 @@ const SectionHeading = ( { isChangingDisplayOrder, onChangeDisplayOrder } ) => {
 				<span>
 					{ __( 'Payment methods', 'woocommerce-gateway-stripe' ) }
 				</span>{ ' ' }
-				{ isUpeEnabled && (
-					<Pill data-testid="upe-early-access-pill">
-						{ __( 'Early access', 'woocommerce-gateway-stripe' ) }
-					</Pill>
-				) }
 			</Title>
-			{ isConfirmationModalOpen && (
-				<DisableUpeConfirmationModal
-					onClose={ toggleConfirmationModal }
-				/>
-			) }
 			<ActionItems>
 				{ ! isChangingDisplayOrder ? (
 					<>
@@ -119,13 +102,6 @@ const SectionHeading = ( { isChangingDisplayOrder, onChangeDisplayOrder } ) => {
 									'woocommerce-gateway-stripe'
 								) }
 								controls={ [
-									{
-										title: __(
-											'Disable',
-											'woocommerce-gateway-stripe'
-										),
-										onClick: toggleConfirmationModal,
-									},
 									{
 										title: __(
 											'Refresh payment methods',

--- a/readme.txt
+++ b/readme.txt
@@ -134,7 +134,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
-* Tweak - Removed "Early Access" pill and "Disable" button from dropdown menu.
+* Tweak - Removed the "Early Access" pill and "Disable" option from the Stripe payment methods dropdown menu.
 * Tweak - Remove unused UPE title field.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -133,5 +133,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
+* Tweak - Removed "Early Access" pill and "Disable" button from dropdown menu.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3005

## Changes proposed in this Pull Request:
- Removed the `Early access` pill.
- Removed the `Disable` option from the dropdown menu.

**Before**

<img width="3134" alt="before pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/e4f16186-10e6-49c6-b4cd-2648775b7e21">


**After**
![pm after](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/abe0b48b-467a-470c-96fe-5c928f7a602d)

