### PR TITLE
Enable UPE by default for new account with latest install

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
+* Add - Enable the updated checkout experience (UPE) by default for new accounts.
 
 = 8.0.1 - 2024-03-13 =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -129,14 +129,15 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return new WP_Error( 'Invalid credentials received from WooCommerce Connect server' );
 			}
 
-			$is_test                                = false !== strpos( $result->publishableKey, '_test_' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			$prefix                                 = $is_test ? 'test_' : '';
-			$default_options                        = $this->get_default_stripe_config();
-			$options                                = array_merge( $default_options, get_option( self::SETTINGS_OPTION, [] ) );
-			$options['enabled']                     = 'yes';
-			$options['testmode']                    = $is_test ? 'yes' : 'no';
-			$options[ $prefix . 'publishable_key' ] = $result->publishableKey; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			$options[ $prefix . 'secret_key' ]      = $result->secretKey; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$is_test                                    = false !== strpos( $result->publishableKey, '_test_' ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$prefix                                     = $is_test ? 'test_' : '';
+			$default_options                            = $this->get_default_stripe_config();
+			$options                                    = array_merge( $default_options, get_option( self::SETTINGS_OPTION, [] ) );
+			$options['enabled']                         = 'yes';
+			$options['testmode']                        = $is_test ? 'yes' : 'no';
+			$options['upe_checkout_experience_enabled'] = $this->get_upe_checkout_experience_enabled();
+			$options[ $prefix . 'publishable_key' ]     = $result->publishableKey; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$options[ $prefix . 'secret_key' ]          = $result->secretKey; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			// While we are at it, let's also clear the account_id and
 			// test_account_id if present.
@@ -146,6 +147,20 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( self::SETTINGS_OPTION, $options );
 
 			return $result;
+		}
+
+		/**
+		 * If user is reconnecting and there are existing settings data, return the value from the settings.
+		 * Otherwise for new connections return 'yes' for `upe_checkout_experience_enabled` field.
+		 */
+		private function get_upe_checkout_experience_enabled() {
+			$existing_stripe_settings = get_option( self::SETTINGS_OPTION, [] );
+
+			if ( isset( $existing_stripe_settings['upe_checkout_experience_enabled'] ) ) {
+				return $existing_stripe_settings['upe_checkout_experience_enabled'];
+			}
+
+			return 'yes';
 		}
 
 		/**
@@ -183,6 +198,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 					$result[ $key ] = $value['default'];
 				}
 			}
+
+			$result['upe_checkout_experience_enabled'] = 'yes';
 
 			return $result;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -133,5 +133,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.
 * Add - Include Stripe API version in logs.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
+* Add - Enable the updated checkout experience (UPE) by default for new accounts.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2995

#### Acceptance criteria
- When activating Stripe on a new store, the updated checkout experience must be enabled. Currently, it's disabled by default.
- When merchants upgrade to the current version, the checkout experience must be the same as before upgrading. It must not change.

## Changes proposed in this Pull Request:
- Setting the value of `upe_checkout_experience_enabled`  during the OAuth connect.
- For all new accounts and new installs we set `upe_checkout_experience_enabled => 'yes'`.
- For existing merchants, if they try to reconnect, we check the flag in `woocommerce_stripe_settings` and set it accordingly.

## Testing instructions
- Create a JN site. Install the latest Stripe plugin.
- Connect to your Stripe account. Notice that `New checkout experience` checkbox is disabled (UPE disabled) after connecting.
- Build the Stripe plugin from this branch. Install this build in your JN account.
- Disconnect your Stripe account from the `Account details` section's dropdown menu (Settings tab).
- Now connect to your Stripe account again. Ensure that the `New checkout experience` checkbox is still disabled. 
- Create a JN site. Install the build of this branch.
- Connect to your Stripe account. Notice that `New checkout experience` is enabled  (UPE enabled) by default now after connecting.