### PR TITLE
Send 'mandate_options' only for supported currencies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
 * Tweak - Removed the "Early Access" pill and "Disable" option from the Stripe payment methods dropdown menu.
 * Tweak - Remove unused UPE title field.
+* Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 
 = 8.0.1 - 2024-03-13 =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -612,7 +612,7 @@ trait WC_Stripe_Subscriptions_Trait {
 		}
 
 		// Add mandate options to request to create new mandate if mandate id does not already exist in a previous renewal or parent order.
-		$mandate_options = $this->create_mandate_options_for_order( $order, $subscriptions_for_renewal_order, $request['currency'] );
+		$mandate_options = $this->create_mandate_options_for_order( $order, $subscriptions_for_renewal_order );
 		if ( ! empty( $mandate_options ) ) {
 			$request['payment_method_options']['card']['mandate_options'] = $mandate_options;
 		}
@@ -654,11 +654,11 @@ trait WC_Stripe_Subscriptions_Trait {
 	 *
 	 * @param WC_Order $order The renewal order.
 	 * @param WC_Order $subscriptions Subscriptions for the renewal order.
-	 * @param string   $currency The currency of the order.
 	 * @return array the mandate_options for the subscription order.
 	 */
-	private function create_mandate_options_for_order( $order, $subscriptions, $currency ) {
+	private function create_mandate_options_for_order( $order, $subscriptions ) {
 		$mandate_options = [];
+		$currency        = strtolower( $order->get_currency() );
 
 		// India recurring payment mandates can only be requested for the following currencies.
 		if ( ! in_array( $currency, [ 'inr', 'usd', 'eur', 'gbp', 'sgd', 'cad', 'chf', 'sek', 'aed', 'jpy', 'nok', 'myr', 'hkd' ], true ) ) {

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -612,7 +612,7 @@ trait WC_Stripe_Subscriptions_Trait {
 		}
 
 		// Add mandate options to request to create new mandate if mandate id does not already exist in a previous renewal or parent order.
-		$mandate_options = $this->create_mandate_options_for_order( $order, $subscriptions_for_renewal_order );
+		$mandate_options = $this->create_mandate_options_for_order( $order, $subscriptions_for_renewal_order, $request['currency'] );
 		if ( ! empty( $mandate_options ) ) {
 			$request['payment_method_options']['card']['mandate_options'] = $mandate_options;
 		}
@@ -653,10 +653,17 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * Create mandate options for a subscription order to be added to the payment intent request.
 	 *
 	 * @param WC_Order $order The renewal order.
+	 * @param WC_Order $subscriptions Subscriptions for the renewal order.
+	 * @param string   $currency The currency of the order.
 	 * @return array the mandate_options for the subscription order.
 	 */
-	private function create_mandate_options_for_order( $order, $subscriptions ) {
+	private function create_mandate_options_for_order( $order, $subscriptions, $currency ) {
 		$mandate_options = [];
+
+		// India recurring payment mandates can only be requested for the following currencies.
+		if ( ! in_array( $currency, [ 'inr', 'usd', 'eur', 'gbp', 'sgd', 'cad', 'chf', 'sek', 'aed', 'jpy', 'nok', 'myr', 'hkd' ], true ) ) {
+			return [];
+		}
 
 		// If this is the first order, not a renewal, then get the subscriptions for the parent order.
 		if ( empty( $subscriptions ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
 * Tweak - Removed the "Early Access" pill and "Disable" option from the Stripe payment methods dropdown menu.
 * Tweak - Remove unused UPE title field.
+* Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2988 

Mandate data are required to process subscription payments with India issued cards. According to Stripe [docs](https://docs.stripe.com/india-recurring-payments?integration=paymentIntents-setupIntents#create-mandate) we can send the mandate data for all types of cards.

> You can pass the payment_method_options[card][mandate_options] parameter for all requests. Stripe ignores these parameters if your customer is using a non-India issued card because the regulation doesn’t apply to them.

However, there is a restriction with the currency and only the following list of currencies is supported by the INR mandate for international business.

> [ 'inr', 'usd', 'eur', 'gbp', 'sgd', 'cad', 'chf', 'sek', 'aed', 'jpy', 'nok', 'myr', 'hkd' ]

## Changes proposed in this Pull Request:
- Sending the `mandate_option` only when the order currency is supported.

## Testing instructions
- Use the `develop` branch.
- Set your store currency to an in-eligible currency. eg MXN.
- Install Woo Subscriptions.
- Create a subscription product if you don't have one.
- Purchase the subscription using a card issued in India.
    - Stripe provide these test cards: https://docs.stripe.com/india-recurring-payments?integration=paymentIntents-setupIntents#testing
    - 4000003560000008 is another generic India card you can use for testing.
- The payment will fail and you will see an error notice regarding the supported currencies.

![error notice](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/bb6b0a56-f8b0-43bd-b323-4c853e5a1b5e)

- Now checkout this branch and follow the above steps again.
- This time you should be able to complete the purchase without any error.
- Check the logs in your admin dashboard. Find the payment intent request, it should not contain any `mandate_option` field.

### Additional tests
**Regular card**
- Set your store currency to a supported currency.
- Purchase subscriptions with a regular card card. (`4242424242424242`).
- The purchase should be successful.
- Check the logs in your admin dashboard. Find the payment intent request in logs, it should have the `mandate_option` field.
- Find the response in logs. The `mandate` field should be empty.

**Regular card**
- Set your store currency to a supported currency.
- Purchase subscriptions with an India issued card. (`4000003560000008`).
- The purchase should be successful.
- Check the logs in your admin dashboard. Find the payment intent request in logs, it should have the `mandate_option` field.
- Find the response in logs. The `mandate` field should have a mandate id.
- Find the `_stripe_mandate_id` order meta for this order in your database. The value should match the returned mandate id.