### PR TITLE
Add Requires plugins header

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Tweak - Remove unused UPE title field.
 * Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 * Add - Enable the updated checkout experience (UPE) by default for new accounts.
+* Tweak - Add WooCommerce as a plugin dependency
 
 = 8.0.1 - 2024-03-13 =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,6 @@
 === WooCommerce Stripe Payment Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
-Requires Plugins: woocommerce
 Requires at least: 6.1
 Tested up to: 6.4.2
 Requires PHP: 7.4

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,7 @@
 === WooCommerce Stripe Payment Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
+Requires Plugins: woocommerce
 Requires at least: 6.1
 Tested up to: 6.4.2
 Requires PHP: 7.4

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -52,7 +52,7 @@ function woocommerce_stripe_missing_wc_notice() {
 
 	$admin_notice_content = sprintf(
 		// translators: 1$-2$: opening and closing <strong> tags, 3$-4$: link tags, takes to woocommerce plugin on wp.org, 5$-6$: opening and closing link tags, leads to plugins.php in admin
-		esc_html__( '%1$sWooCommerce Stripe Gateway is inactive.%2$s The %3$sWooCommerce plugin%4$s must be active for the Stripe Gateway to work. Please %5$sinstall & activate Woo &raquo;%6$s', 'woocommerce-gateway-stripe' ),
+		esc_html__( '%1$sWooCommerce Stripe Gateway is inactive.%2$s The %3$sWooCommerce plugin%4$s must be active for the Stripe Gateway to work. Please %5$sinstall & activate WooCommerce &raquo;%6$s', 'woocommerce-gateway-stripe' ),
 		'<strong>',
 		'</strong>',
 		'<a href="http://wordpress.org/extend/plugins/woocommerce/">',

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -6,6 +6,7 @@
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Version: 8.1.0
+ * Requires Plugins: woocommerce
  * Requires at least: 6.1
  * Tested up to: 6.4.3
  * WC requires at least: 8.2

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -38,8 +38,31 @@ define( 'WC_STRIPE_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) 
  * @since 4.1.2
  */
 function woocommerce_stripe_missing_wc_notice() {
-	/* translators: 1. URL link. */
-	echo '<div class="error"><p><strong>' . sprintf( esc_html__( 'Stripe requires WooCommerce to be installed and active. You can download %s here.', 'woocommerce-gateway-stripe' ), '<a href="https://woocommerce.com/" target="_blank">WooCommerce</a>' ) . '</strong></p></div>';
+	$install_url = wp_nonce_url(
+		add_query_arg(
+			[
+				'action' => 'install-plugin',
+				'plugin' => 'woocommerce',
+			],
+			admin_url( 'update.php' )
+		),
+		'install-plugin_woocommerce'
+	);
+
+	$admin_notice_content = sprintf(
+		// translators: 1$-2$: opening and closing <strong> tags, 3$-4$: link tags, takes to woocommerce plugin on wp.org, 5$-6$: opening and closing link tags, leads to plugins.php in admin
+		esc_html__( '%1$sWooCommerce Stripe Gateway is inactive.%2$s The %3$sWooCommerce plugin%4$s must be active for the Stripe Gateway to work. Please %5$sinstall & activate Woo &raquo;%6$s', 'woocommerce-gateway-stripe' ),
+		'<strong>',
+		'</strong>',
+		'<a href="http://wordpress.org/extend/plugins/woocommerce/">',
+		'</a>',
+		'<a href="' . esc_url( $install_url ) . '">',
+		'</a>'
+	);
+
+	echo '<div class="error">';
+	echo '<p>' . wp_kses_post( $admin_notice_content ) . '</p>';
+	echo '</div>';
 }
 
 /**


### PR DESCRIPTION
Fixes #2962, #3018

## Changes proposed in this Pull Request:

This PR adds `WooCommerce` as a plugin requirement, using the new `Requires Plugins` header ([more info](https://make.wordpress.org/core/2024/02/15/merge-announcement-plugin-dependencies/))

Also, this PR updates the message shown when WooCommerce is not installed and activated to include a link to install Woo (like the notice Woo Subscriptions use)

> Old notice:
![Screenshot 2024-03-21 at 2 37 06 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/0b0473c4-da48-4b94-9622-21605b467b2b)
New notice:
![Screenshot 2024-03-21 at 2 35 39 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/cadbb52b-c49a-478e-8d85-e27d6e8882bc)

## Testing instructions
- Updated notice:
1. Go to the Plugins page: `/wp-admin/plugins.php`
2. Make sure `WooCommerce` is `deactivated`
3. Make sure `WooCommerce Stripe Gateway` is `active`
4. Check that the notice that WooCommerce is required is present and it has a link to install Woo.


- Requires Plugins header
1. Update to WordPress 6.5 (current version is  6.5-RC3)
    - [You can test WordPress 6.5 RC3 in four ways](https://wordpress.org/news/2024/03/wordpress-6-5-release-candidate-3/)
2. Go to the Plugins page: `/wp-admin/plugins.php`
3. Check that plugin description now includes a "Requires: [WooCommerce](https://stripe.local/wp-admin/plugin-install.php?tab=plugin-information&plugin=woocommerce&TB_iframe=true&width=600&height=550)" section.
    ![Screenshot 2024-03-21 at 2 53 06 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/2b739965-d6a5-40e1-af0d-33564f2f26ee)