### PR TITLE
Handling saving of co-branded credit cards

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.1.0 - xxxx-xx-xx =
+* Add - Additional information is displayed on the "Payment methods" page when listing co-branded credit cards.
 * Tweak - Update the Stripe JS library to 1.36.0.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.

--- a/includes/class-wc-stripe-cc-co-branded-payment-token.php
+++ b/includes/class-wc-stripe-cc-co-branded-payment-token.php
@@ -1,0 +1,36 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+// phpcs:disable WordPress.Files.FileName
+
+/**
+ * WooCommerce Stripe Co-Branded Credit Card Payment Token.
+ *
+ * Representation of a payment token for co-branded credit cards.
+ *
+ * @class    WC_Payment_Token_CC_Co_Branded
+ */
+class WC_Payment_Token_CC_Co_Branded extends WC_Payment_Token_CC {
+	/**
+	 * Sets the list of available networks (brands) for the card.
+	 *
+	 * @param array $available_networks List of available networks (brands) for the card.
+	 * @return void
+	 */
+	public function set_available_networks( $available_networks ) {
+		$this->set_prop( 'available_networks', $available_networks );
+	}
+
+	/**
+	 * Sets the preferred network (brand) for the card.
+	 *
+	 * @param string|null $preferred_network Preferred network (brand) for the card.
+	 * @return void
+	 */
+	public function set_preferred_network( $preferred_network ) {
+		$this->set_prop( 'preferred_network', $preferred_network );
+	}
+}

--- a/includes/class-wc-stripe-cc-payment-token.php
+++ b/includes/class-wc-stripe-cc-payment-token.php
@@ -42,7 +42,7 @@ class WC_Payment_Token_CC_Stripe extends WC_Payment_Token_CC {
 	 * @return bool
 	 */
 	public function is_co_branded() {
-		return null !== $this->get_available_networks() && count( $this->get_available_networks() ) > 1;
+		return ! empty( $this->get_available_networks() ) && count( $this->get_available_networks() ) > 1;
 	}
 
 	/**

--- a/includes/class-wc-stripe-cc-payment-token.php
+++ b/includes/class-wc-stripe-cc-payment-token.php
@@ -14,13 +14,35 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class    WC_Payment_Token_CC_Stripe
  */
 class WC_Payment_Token_CC_Stripe extends WC_Payment_Token_CC {
+
+	/**
+	 * Token Type String.
+	 *
+	 * @var string
+	 */
+	protected $type = 'CC_stripe';
+
+	/**
+	 * Stores Credit Card payment token data.
+	 *
+	 * @var array
+	 */
+	protected $extra_data = [
+		'last4'              => '',
+		'expiry_year'        => '',
+		'expiry_month'       => '',
+		'card_type'          => '',
+		'available_networks' => null,
+		'preferred_network'  => null,
+	];
+
 	/**
 	 * Returns true if the card is co-branded.
 	 *
 	 * @return bool
 	 */
 	public function is_co_branded() {
-		return count( $this->get_available_networks() ) > 1;
+		return null !== $this->get_available_networks() && count( $this->get_available_networks() ) > 1;
 	}
 
 	/**
@@ -41,6 +63,16 @@ class WC_Payment_Token_CC_Stripe extends WC_Payment_Token_CC {
 	 */
 	public function set_available_networks( $available_networks ) {
 		$this->set_prop( 'available_networks', $available_networks );
+	}
+
+	/**
+	 * Returns the preferred network (brand) for the card.
+	 *
+	 * @param string $context What the value is for. Valid values are view and edit.
+	 * @return string|null Preferred network (brand) for the card.
+	 */
+	public function get_preferred_network( $context = 'view' ) {
+		return $this->get_prop( 'preferred_network', $context );
 	}
 
 	/**

--- a/includes/class-wc-stripe-cc-payment-token.php
+++ b/includes/class-wc-stripe-cc-payment-token.php
@@ -7,13 +7,32 @@ if ( ! defined( 'ABSPATH' ) ) {
 // phpcs:disable WordPress.Files.FileName
 
 /**
- * WooCommerce Stripe Co-Branded Credit Card Payment Token.
+ * WooCommerce Stripe Credit Card Payment Token (with co-branded cards support).
  *
  * Representation of a payment token for co-branded credit cards.
  *
- * @class    WC_Payment_Token_CC_Co_Branded
+ * @class    WC_Payment_Token_CC_Stripe
  */
-class WC_Payment_Token_CC_Co_Branded extends WC_Payment_Token_CC {
+class WC_Payment_Token_CC_Stripe extends WC_Payment_Token_CC {
+	/**
+	 * Returns true if the card is co-branded.
+	 *
+	 * @return bool
+	 */
+	public function is_co_branded() {
+		return count( $this->get_available_networks() ) > 1;
+	}
+
+	/**
+	 * Returns the list of available networks (brands) for the card.
+	 *
+	 * @param string $context What the value is for. Valid values are view and edit.
+	 * @return array|null List of available networks (brands) for the card.
+	 */
+	public function get_available_networks( $context = 'view' ) {
+		return $this->get_prop( 'available_networks', $context );
+	}
+
 	/**
 	 * Sets the list of available networks (brands) for the card.
 	 *

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1796,7 +1796,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function display_co_branded_credit_card_label( $method ) {
 		if ( $method['method']['is_co_branded'] && count( $method['method']['networks'] ) > 1 ) {
-			$brands_label  = implode(
+			$brands_label = implode(
 				' / ',
 				array_map(
 					function ( $network ) {
@@ -1805,7 +1805,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					$method['method']['networks']
 				)
 			);
-			$brands_label .= ' (' . esc_html( wc_get_credit_card_type_label( $method['method']['preferred_network'] ) ) . ' preferred)';
+			/* translators: %s: a credit card brand. */
+			$brands_label .= ' (' . sprintf( esc_html__( '%s preferred', 'woocommerce-gateway-stripe' ), esc_html( wc_get_credit_card_type_label( $method['method']['preferred_network'] ) ) ) . ')';
 		} else {
 			$brands_label = esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) );
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1795,27 +1795,24 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return void
 	 */
 	public function display_co_branded_credit_card_label( $method ) {
-		if ( $method['method']['is_co_branded'] ) {
-			if ( count( $method['method']['networks'] ) > 1 ) {
-				$brands_label = implode(
-					' / ',
-					array_map(
-						function ( $network ) {
-							return esc_html( wc_get_credit_card_type_label( $network ) );
-						},
-						$method['method']['networks']
-					)
-				);
-			} else {
-				$brands_label = esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) );
-			}
+		if ( $method['method']['is_co_branded'] && count( $method['method']['networks'] ) > 1 ) {
+			$brands_label = implode(
+				' / ',
+				array_map(
+					function ( $network ) {
+						return esc_html( wc_get_credit_card_type_label( $network ) );
+					},
+					$method['method']['networks']
+				)
+			);
+		} else {
+			$brands_label = esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) );
+		}
+		if ( ! empty( $method['method']['last4'] ) ) {
 			/* translators: 1: credit card type 2: last 4 digits */
 			echo sprintf( esc_html__( '%1$s ending in %2$s', 'woocommerce-gateway-stripe' ), $brands_label, esc_html( $method['method']['last4'] ) );
-		} elseif ( ! empty( $method['method']['last4'] ) ) {
-			/* translators: 1: credit card type 2: last 4 digits */
-			echo sprintf( esc_html__( '%1$s ending in %2$s', 'woocommerce-gateway-stripe' ), esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) ), esc_html( $method['method']['last4'] ) );
 		} else {
-			echo esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) );
+			echo $brands_label;
 		}
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1796,7 +1796,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function display_co_branded_credit_card_label( $method ) {
 		if ( $method['method']['is_co_branded'] && count( $method['method']['networks'] ) > 1 ) {
-			$brands_label = implode(
+			$brands_label  = implode(
 				' / ',
 				array_map(
 					function ( $network ) {
@@ -1805,6 +1805,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					$method['method']['networks']
 				)
 			);
+			$brands_label .= ' (' . esc_html( wc_get_credit_card_type_label( $method['method']['preferred_network'] ) ) . ' preferred)';
 		} else {
 			$brands_label = esc_html( wc_get_credit_card_type_label( $method['method']['brand'] ) );
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -81,13 +81,7 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 	 * @return WC_Payment_Token_CC
 	 */
 	public function create_payment_token_for_user( $user_id, $payment_method ) {
-		if ( count( $payment_method->card->networks->available ) > 1 ) {
-			$token = new WC_Payment_Token_CC_Co_Branded();
-			$token->set_available_networks( $payment_method->card->networks->available );
-			$token->set_preferred_network( $payment_method->card->networks->preferred );
-		} else {
-			$token = new WC_Payment_Token_CC();
-		}
+		$token = new WC_Payment_Token_CC_Stripe();
 		$token->set_expiry_month( $payment_method->card->exp_month );
 		$token->set_expiry_year( $payment_method->card->exp_year );
 		$token->set_card_type( strtolower( $payment_method->card->brand ) );
@@ -95,6 +89,11 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 		$token->set_gateway_id( WC_Stripe_UPE_Payment_Gateway::ID );
 		$token->set_token( $payment_method->id );
 		$token->set_user_id( $user_id );
+		// This is a co-branded card. We need to store some additional information.
+		if ( count( $payment_method->card->networks->available ) > 1 ) {
+			$token->set_available_networks( $payment_method->card->networks->available );
+			$token->set_preferred_network( $payment_method->card->networks->preferred );
+		}
 		$token->save();
 		return $token;
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -81,7 +81,13 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 	 * @return WC_Payment_Token_CC
 	 */
 	public function create_payment_token_for_user( $user_id, $payment_method ) {
-		$token = new WC_Payment_Token_CC();
+		if ( count( $payment_method->card->networks->available ) > 1 ) {
+			$token = new WC_Payment_Token_CC_Co_Branded();
+			$token->set_available_networks( $payment_method->card->networks->available );
+			$token->set_preferred_network( $payment_method->card->networks->preferred );
+		} else {
+			$token = new WC_Payment_Token_CC();
+		}
 		$token->set_expiry_month( $payment_method->card->exp_month );
 		$token->set_expiry_year( $payment_method->card->exp_year );
 		$token->set_card_type( strtolower( $payment_method->card->brand ) );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -93,6 +93,8 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 		if ( count( $payment_method->card->networks->available ) > 1 ) {
 			$token->set_available_networks( $payment_method->card->networks->available );
 			$token->set_preferred_network( $payment_method->card->networks->preferred );
+		} else {
+			$token->set_available_networks( [ $payment_method->card->brand ] );
 		}
 		$token->save();
 		return $token;

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.1.0 - xxxx-xx-xx =
+* Add - Additional information is displayed on the "Payment methods" page when listing co-branded credit cards.
 * Tweak - Update the Stripe JS library to 1.36.0.
 * Fix - PHP 8.2 deprecation warnings within the WC_Stripe_UPE_Payment_Method class.
 * Fix - Resolved an issue with saving plugin settings when bank descriptor value is invalid.

--- a/tests/phpunit/helpers/class-wc-helper-token.php
+++ b/tests/phpunit/helpers/class-wc-helper-token.php
@@ -45,4 +45,27 @@ class WC_Helper_Token {
 
 		return WC_Payment_Tokens::get( $token->get_id() );
 	}
+
+	/**
+	 * Create a CC token (with co-branded cards support).
+	 *
+	 * @param string $payment_method Token payment method.
+	 * @param int    $user_id        ID of the token's user, defaults to get_current_user_id().
+	 * @param string $gateway        Token's Gateway ID, default to WC_Gateway_Stripe::ID
+	 */
+	public static function create_cc_stripe_token( $payment_method, $user_id = null, $gateway = WC_Gateway_Stripe::ID ) {
+		$token = new WC_Payment_Token_CC_Stripe();
+		$token->set_token( $payment_method );
+		$token->set_gateway_id( $gateway );
+		$token->set_user_id( is_null( $user_id ) ? get_current_user_id() : $user_id );
+		$token->set_card_type( 'visa' );
+		$token->set_last4( '4242' );
+		$token->set_expiry_month( 7 );
+		$token->set_expiry_year( intval( gmdate( 'Y' ) ) + 1 );
+		$token->set_available_networks( [ 'visa', 'cartes_bancaires' ] );
+		$token->set_preferred_network( 'visa' );
+		$token->save();
+
+		return WC_Payment_Tokens::get( $token->get_id() );
+	}
 }

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1919,9 +1919,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$method = [
 			'method' => [
-				'brand' => 'visa',
+				'brand'         => 'visa',
+				'is_co_branded' => false,
 			],
 		];
+
+		$this->mock_gateway = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
+			->setMethods( [ 'display_co_branded_credit_card_info', 'display_co_branded_credit_card_label' ] )
+			->getMock();
 
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'display_co_branded_credit_card_info' )
@@ -1932,7 +1937,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->with( $method );
 
 		apply_filters( 'woocommerce_payment_methods_list_item', $item, $payment_token );
+
+		ob_start();
 		do_action( 'woocommerce_account_payment_methods_column_method', $method );
+		ob_get_clean();
 	}
 
 	/**

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -115,8 +115,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					'get_intent_from_order',
 					'has_pre_order_charged_upon_release',
 					'has_pre_order',
-					'display_co_branded_credit_card_info',
-					'display_co_branded_credit_card_label',
 				]
 			)
 			->getMock();
@@ -1846,7 +1844,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		do_action( 'woocommerce_admin_order_totals_after_total', $order->get_id() );
 	}
-
 	/**
 	 * Test for `process_payment` when the order has an existing payment intent attached.
 	 *
@@ -1936,6 +1933,115 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		apply_filters( 'woocommerce_payment_methods_list_item', $item, $payment_token );
 		do_action( 'woocommerce_account_payment_methods_column_method', $method );
+	}
+
+	/**
+	 * Test for `display_co_branded_credit_card_info`
+	 *
+	 * @param string $type    The type of payment method.
+	 * @param string $expected The expected result.
+	 * @return void
+	 * @dataProvider provide_display_co_branded_card_info
+	 */
+	public function test_display_co_branded_credit_card_info( $type, $expected ) {
+		$item = [];
+
+		/** @var WC_Payment_Token_CC_Stripe $payment_token */
+		if ( 'cc_stripe' === $type ) {
+			$payment_token = WC_Helper_Token::create_cc_stripe_token( 'pm_mock' );
+		} else {
+			$payment_token = WC_Helper_Token::create_token( 'pm_mock' );
+		}
+
+		$result = $this->mock_gateway->display_co_branded_credit_card_info( $item, $payment_token );
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Data provider for `test_display_co_branded_credit_card_info`
+	 *
+	 * @return array
+	 */
+	public function provide_display_co_branded_card_info() {
+		return [
+			'not CC Stripe' => [
+				'type'     => 'sepa',
+				'expected' => [],
+			],
+			'CC Stripe'     => [
+				'type'     => 'cc_stripe',
+				'expected' => [
+					'method'  => [
+						'last4'             => '4242',
+						'brand'             => 'Visa',
+						'is_co_branded'     => true,
+						'networks'          => [
+							'visa',
+							'cartes_bancaires',
+						],
+						'preferred_network' => 'visa',
+					],
+					'expires' => '07/25',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test for `display_co_branded_credit_card_label`
+	 *
+	 * @param bool  $is_co_branded   Whether the card is co-branded.
+	 * @param string|null $last4 The last 4 digits of the card.
+	 * @param string|null $expected The expected result.
+	 * @return void
+	 * @dataProvider provide_test_display_co_branded_credit_card_label
+	 */
+	public function test_display_co_branded_credit_card_label( $is_co_branded, $last4 = null, $expected = null ) {
+		$method = [
+			'method' => [
+				'brand'             => 'visa',
+				'is_co_branded'     => $is_co_branded,
+				'last4'             => $last4,
+				'networks'          => $is_co_branded ? [ 'visa', 'cartes_bancaires' ] : [ 'visa' ],
+				'preferred_network' => $is_co_branded ? 'visa' : null,
+			],
+		];
+
+		ob_start();
+		$this->mock_gateway->display_co_branded_credit_card_label( $method );
+		$output = ob_get_clean();
+		$this->assertStringMatchesFormat( $expected, $output );
+	}
+
+	/**
+	 * Data provider for `test_display_co_branded_credit_card_label`
+	 *
+	 * @return array
+	 */
+	public function provide_test_display_co_branded_credit_card_label() {
+		return [
+			'co-branded card with last 4'        => [
+				'is co branded' => true,
+				'last 4'        => '4242',
+				'expected'      => 'Visa / Cartes bancaires (Visa preferred) ending in 4242',
+			],
+			'co-branded card without last 4'     => [
+				'is co branded' => true,
+				'last 4'        => null,
+				'expected'      => 'Visa / Cartes bancaires (Visa preferred)',
+			],
+			'non co-branded card with last 4'    => [
+				'is co branded' => false,
+				'last 4'        => '4242',
+				'expected'      => 'Visa ending in 4242',
+			],
+			'non co-branded card without last 4' => [
+				'is co branded' => false,
+				'last 4'        => null,
+				'expected'      => 'Visa',
+			],
+		];
 	}
 
 	/**

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -115,6 +115,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					'get_intent_from_order',
 					'has_pre_order_charged_upon_release',
 					'has_pre_order',
+					'display_co_branded_credit_card_info',
+					'display_co_branded_credit_card_label',
 				]
 			)
 			->getMock();
@@ -289,11 +291,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 
 		$expected_request = [
-			'amount'               => $amount,
-			'currency'             => $currency,
-			'description'          => $description,
-			'customer'             => $customer_id,
-			'metadata'             => $metadata,
+			'amount'      => $amount,
+			'currency'    => $currency,
+			'description' => $description,
+			'customer'    => $customer_id,
+			'metadata'    => $metadata,
 		];
 
 		$_POST = [ 'wc_payment_intent_id' => $payment_intent_id ];
@@ -396,7 +398,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					],
 				],
 				'payment_method' => 'pm_mock',
-				'charges' => (object) [
+				'charges'        => (object) [
 					'total_count' => 0, // Intents requiring SCA verification respond with no charges.
 					'data'        => [],
 				],
@@ -1439,12 +1441,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 
 		$expected_request = [
-			'amount'               => $amount,
-			'currency'             => $currency,
-			'description'          => $description,
-			'customer'             => $customer_id,
-			'metadata'             => $metadata,
-			'setup_future_usage'   => 'off_session',
+			'amount'             => $amount,
+			'currency'           => $currency,
+			'description'        => $description,
+			'customer'           => $customer_id,
+			'metadata'           => $metadata,
+			'setup_future_usage' => 'off_session',
 		];
 
 		$_POST = [ 'wc_payment_intent_id' => $payment_intent_id ];
@@ -1844,6 +1846,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		do_action( 'woocommerce_admin_order_totals_after_total', $order->get_id() );
 	}
+
 	/**
 	 * Test for `process_payment` when the order has an existing payment intent attached.
 	 *
@@ -1900,6 +1903,39 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertMatchesRegularExpression( "/#wc-stripe-confirm-pi:{$order_id}:{$mock_intent->client_secret}/", $response['redirect'] );
+	}
+
+	/**
+	 * Test if `display_co_branded_credit_card_info` and `display_co_branded_credit_card_label` are called when displaying a credit card
+	 *
+	 * @return void
+	 */
+	public function test_co_branded_card_action_and_filter_called() {
+		$item          = [
+			'method'  => [
+				'last4' => '4242',
+				'brand' => 'Visa',
+			],
+			'expires' => '07/25',
+		];
+		$payment_token = WC_Helper_Token::create_token( 'pm_mock' );
+
+		$method = [
+			'method' => [
+				'brand' => 'visa',
+			],
+		];
+
+		$this->mock_gateway->expects( $this->once() )
+			->method( 'display_co_branded_credit_card_info' )
+			->with( $item, $payment_token );
+
+		$this->mock_gateway->expects( $this->once() )
+			->method( 'display_co_branded_credit_card_label' )
+			->with( $method );
+
+		apply_filters( 'woocommerce_payment_methods_list_item', $item, $payment_token );
+		do_action( 'woocommerce_account_payment_methods_column_method', $method );
 	}
 
 	/**

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -184,7 +184,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 				]
 			),
 		];
-		$mock_alipay_details    = [
+		$mock_alipay_details     = [
 			'type' => 'alipay',
 		];
 		$mock_giropay_details    = [
@@ -402,8 +402,8 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	 * Payment method is only enabled when its supported currency is present or method supports all currencies.
 	 */
 	public function test_payment_methods_are_only_enabled_when_currency_is_supported() {
-		$stripe_settings             = get_option( 'woocommerce_stripe_settings' );
-		$stripe_settings['capture']  = 'yes';
+		$stripe_settings            = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['capture'] = 'yes';
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 		WC_Stripe::get_instance()->get_main_stripe_gateway()->init_settings();
 		$payment_method_ids = array_map( [ $this, 'get_id' ], $this->mock_payment_methods );
@@ -466,10 +466,14 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 			switch ( $payment_method_id ) {
 				case WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID:
 					$card_payment_method_mock = $this->array_to_object( self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE );
-					$token                    = $payment_method->create_payment_token_for_user( $user_id, $card_payment_method_mock );
+					/** @var WC_Payment_Token_CC_Stripe $token */
+					$token = $payment_method->create_payment_token_for_user( $user_id, $card_payment_method_mock );
 					$this->assertTrue( 'WC_Payment_Token_CC_Stripe' === get_class( $token ) );
 					$this->assertSame( $token->get_last4(), $card_payment_method_mock->card->last4 );
 					$this->assertSame( $token->get_token(), $card_payment_method_mock->id );
+					$this->assertTrue( $token->is_co_branded() );
+					$this->assertSame( $token->get_available_networks(), $card_payment_method_mock->card->networks->available );
+					$this->assertSame( $token->get_preferred_network(), $card_payment_method_mock->card->networks->preferred );
 					break;
 				case WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID:
 					$link_payment_method_mock = $this->array_to_object( self::MOCK_LINK_PAYMENT_METHOD_TEMPLATE );
@@ -493,7 +497,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	 */
 	public function test_upe_method_enabled() {
 		// Enable Stripe and reset the accepted payment methods.
-		$stripe_settings = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings            = get_option( 'woocommerce_stripe_settings' );
 		$stripe_settings['enabled'] = 'yes';
 		$stripe_settings['upe_checkout_experience_accepted_payments'] = [];
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -23,6 +23,10 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 			'exp_year'  => '2099',
 			'funding'   => 'credit',
 			'last4'     => '4242',
+			'networks'  => [
+				'available' => [ 'visa', 'cartes_bancaires' ],
+				'preferred' => 'visa',
+			],
 		],
 	];
 
@@ -463,7 +467,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 				case WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID:
 					$card_payment_method_mock = $this->array_to_object( self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE );
 					$token                    = $payment_method->create_payment_token_for_user( $user_id, $card_payment_method_mock );
-					$this->assertTrue( 'WC_Payment_Token_CC' === get_class( $token ) );
+					$this->assertTrue( 'WC_Payment_Token_CC_Stripe' === get_class( $token ) );
 					$this->assertSame( $token->get_last4(), $card_payment_method_mock->card->last4 );
 					$this->assertSame( $token->get_token(), $card_payment_method_mock->id );
 					break;

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -168,6 +168,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-handler.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-sepa-payment-token.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-link-payment-token.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-cc-payment-token.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-apple-pay-registration.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-stripe.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php';


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3011

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR adds support to the display of [co-branded credit cards](https://docs.stripe.com/co-badged-cards-compliance?type=checkout-payment-links#testing) in the payment methods screen (under "my account").

Users can choose their preferred brand when saving cards and see that information when listing them.

Before:
![Screenshot 2024-03-21 at 13 13 31](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/2e4b60ec-c5af-4e5f-98ea-bddb8779365b)

After:
![Screenshot 2024-03-21 at 13 13 35](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/5ac5dc3b-2421-4057-ae15-9d85a50e962a)

This change does not cover the possibility of paying with the preferred brand of the saved card.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch on your local environment. (`add/handling-co-branded-cards-persistence`)
- Run `npm install` and `npm run build:webpack`
- Start it with `npm run up`
- Configure your keys (you must use a French Stripe account)
- Set your store currency to EUR
- Access the "payment methods" page (http://localhost:8082/my-account/payment-methods/) and insert some [regular testing cards](https://stripe.com/docs/testing#use-test-cards)
- Confirm they work just like before
- Add the co-branded test cards from [here](https://docs.stripe.com/co-badged-cards-compliance?type=checkout-payment-links#testing)
- Confirm that the new information is displayed like above

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
