### PR TITLE
Add notice on the Payment Methods tab to disable the Legacy experience

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Tweak - Remove unused UPE title field.
 * Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 * Add - Enable the updated checkout experience (UPE) by default for new accounts.
+* Add - Banner encouraging the transition to the updated checkout experience.
 
 = 8.0.1 - 2024-03-13 =
 * Fix - Resolved failing card payments when `statement_descriptor` parameter is used.

--- a/client/settings/general-settings-section/index.js
+++ b/client/settings/general-settings-section/index.js
@@ -39,7 +39,7 @@ const GeneralSettingsSection = ( { onSaveChanges } ) => {
 	const [ isChangingDisplayOrder, setIsChangingDisplayOrder ] = useState(
 		false
 	);
-	const { isUpeEnabled } = useContext( UpeToggleContext );
+	const { isUpeEnabled, setIsUpeEnabled } = useContext( UpeToggleContext );
 	const { isRefreshing } = useAccount();
 
 	const onChangeDisplayOrder = ( isChanging, data = null ) => {
@@ -52,7 +52,10 @@ const GeneralSettingsSection = ( { onSaveChanges } ) => {
 
 	return (
 		<>
-			<LegacyExperienceTransitionNotice />
+			<LegacyExperienceTransitionNotice
+				isUpeEnabled={ isUpeEnabled }
+				setIsUpeEnabled={ setIsUpeEnabled }
+			/>
 			<AccountActivationNotice />
 			<StyledCard>
 				<LoadableSettingsSection numLines={ 30 }>

--- a/client/settings/general-settings-section/index.js
+++ b/client/settings/general-settings-section/index.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import { Card, VisuallyHidden } from '@wordpress/components';
 import LoadableSettingsSection from '../loadable-settings-section';
 import AccountActivationNotice from '../account-activation-notice';
+import LegacyExperienceTransitionNotice from '../notices/legacy-experience-transition';
 import SectionHeading from './section-heading';
 import SectionFooter from './section-footer';
 import PaymentMethodsList from './payment-methods-list';
@@ -51,6 +52,7 @@ const GeneralSettingsSection = ( { onSaveChanges } ) => {
 
 	return (
 		<>
+			<LegacyExperienceTransitionNotice />
 			<AccountActivationNotice />
 			<StyledCard>
 				<LoadableSettingsSection numLines={ 30 }>

--- a/client/settings/notices/legacy-experience-transition/__tests__/legacy-experience-transition.test.js
+++ b/client/settings/notices/legacy-experience-transition/__tests__/legacy-experience-transition.test.js
@@ -97,7 +97,7 @@ describe( 'LegacyExperienceTransitionNotice', () => {
 		expect( recordEvent ).toHaveBeenCalledWith(
 			'wcstripe_legacy_experience_disabled',
 			{
-				source: 'payament-methods-tab-notice',
+				source: 'payment-methods-tab-notice',
 			}
 		);
 	} );

--- a/client/settings/notices/legacy-experience-transition/__tests__/legacy-experience-transition.test.js
+++ b/client/settings/notices/legacy-experience-transition/__tests__/legacy-experience-transition.test.js
@@ -1,0 +1,104 @@
+import { useDispatch } from '@wordpress/data';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import LegacyExperienceTransitionNotice from '..';
+import { recordEvent } from 'wcstripe/tracking';
+
+jest.mock( '@wordpress/data' );
+
+const noticesDispatch = {
+	createErrorNotice: jest.fn(),
+	createSuccessNotice: jest.fn(),
+};
+
+jest.mock( 'wcstripe/tracking', () => ( {
+	recordEvent: jest.fn(),
+} ) );
+
+useDispatch.mockImplementation( ( storeName ) => {
+	if ( storeName === 'core/notices' ) {
+		return noticesDispatch;
+	}
+
+	return {};
+} );
+
+describe( 'LegacyExperienceTransitionNotice', () => {
+	it( 'should render notice if the updated experience is not enabled', () => {
+		render(
+			<LegacyExperienceTransitionNotice
+				isUpeEnabled={ false }
+				setIsUpeEnabled={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.queryByText(
+				'Ensure payments continue to work on your store'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render notice if the updated experience is enabled', () => {
+		render(
+			<LegacyExperienceTransitionNotice
+				isUpeEnabled={ true }
+				setIsUpeEnabled={ jest.fn() }
+			/>
+		);
+
+		expect(
+			screen.queryByText(
+				'Ensure payments continue to work on your store'
+			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should enable UPE when clicking on the CTA button', () => {
+		const setIsUpeEnabledMock = jest.fn().mockResolvedValue( true );
+
+		render(
+			<LegacyExperienceTransitionNotice
+				isUpeEnabled={ false }
+				setIsUpeEnabled={ setIsUpeEnabledMock }
+			/>
+		);
+
+		userEvent.click( screen.getByText( 'Enable the new checkout' ) );
+		expect( setIsUpeEnabledMock ).toHaveBeenCalled();
+	} );
+
+	it( 'should display a success message when clicking on the CTA button', () => {
+		render(
+			<LegacyExperienceTransitionNotice
+				isUpeEnabled={ false }
+				setIsUpeEnabled={ jest.fn() }
+			/>
+		);
+
+		userEvent.click( screen.getByText( 'Enable the new checkout' ) );
+
+		expect( noticesDispatch.createSuccessNotice ).toHaveBeenCalledWith(
+			'New checkout experience enabled'
+		);
+	} );
+
+	it( 'should record a Track event when clicking on the CTA button', () => {
+		render(
+			<LegacyExperienceTransitionNotice
+				isUpeEnabled={ false }
+				setIsUpeEnabled={ jest.fn() }
+			/>
+		);
+
+		userEvent.click( screen.getByText( 'Enable the new checkout' ) );
+
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_legacy_experience_disabled',
+			{
+				source: 'payament-methods-tab-notice',
+			}
+		);
+	} );
+} );

--- a/client/settings/notices/legacy-experience-transition/index.js
+++ b/client/settings/notices/legacy-experience-transition/index.js
@@ -1,3 +1,4 @@
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
 import React, { useContext } from 'react';
@@ -31,6 +32,10 @@ const LearnMoreAnchor = styled.a`
 const LegacyExperienceTransitionNotice = () => {
 	const { isUpeEnabled, setIsUpeEnabled } = useContext( UpeToggleContext );
 
+	const { createErrorNotice, createSuccessNotice } = useDispatch(
+		'core/notices'
+	);
+
 	// The merchant already disabled the legacy experience. Nothing to do here.
 	if ( isUpeEnabled ) {
 		return null;
@@ -40,7 +45,21 @@ const LegacyExperienceTransitionNotice = () => {
 		const callback = async () => {
 			try {
 				await setIsUpeEnabled( true );
-			} catch ( err ) {}
+
+				createSuccessNotice(
+					__(
+						'New checkout experience enabled',
+						'woocommerce-gateway-stripe'
+					)
+				);
+			} catch ( err ) {
+				createErrorNotice(
+					__(
+						'There was an error. Please reload the page and try again.',
+						'woocommerce-gateway-stripe'
+					)
+				);
+			}
 		};
 
 		// creating a separate callback so that the UI isn't blocked by the async call.

--- a/client/settings/notices/legacy-experience-transition/index.js
+++ b/client/settings/notices/legacy-experience-transition/index.js
@@ -1,10 +1,9 @@
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
-import React, { useContext } from 'react';
+import React from 'react';
 import { Button } from '@wordpress/components';
 import { recordEvent } from 'wcstripe/tracking';
-import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 const NoticeWrapper = styled.div`
 	display: flex;
@@ -30,9 +29,10 @@ const LearnMoreAnchor = styled.a`
 	color: #bd8600 !important;
 `;
 
-const LegacyExperienceTransitionNotice = () => {
-	const { isUpeEnabled, setIsUpeEnabled } = useContext( UpeToggleContext );
-
+const LegacyExperienceTransitionNotice = ( {
+	isUpeEnabled,
+	setIsUpeEnabled,
+} ) => {
 	const { createErrorNotice, createSuccessNotice } = useDispatch(
 		'core/notices'
 	);

--- a/client/settings/notices/legacy-experience-transition/index.js
+++ b/client/settings/notices/legacy-experience-transition/index.js
@@ -48,7 +48,7 @@ const LegacyExperienceTransitionNotice = ( {
 				await setIsUpeEnabled( true );
 
 				recordEvent( 'wcstripe_legacy_experience_disabled', {
-					source: 'payament-methods-tab-notice',
+					source: 'payment-methods-tab-notice',
 				} );
 
 				createSuccessNotice(

--- a/client/settings/notices/legacy-experience-transition/index.js
+++ b/client/settings/notices/legacy-experience-transition/index.js
@@ -1,0 +1,81 @@
+import { __ } from '@wordpress/i18n';
+import styled from '@emotion/styled';
+import React, { useContext } from 'react';
+import { Button } from '@wordpress/components';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
+
+const NoticeWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
+	padding: 12px 16px;
+	align-items: flex-start;
+	gap: 12px;
+	margin: 0 0 24px 0;
+	background: #fcf9e8;
+`;
+
+const Message = styled.div`
+	color: #1e1e1e;
+	font-size: 13px;
+`;
+
+const DisableLegacyButton = styled( Button )`
+	box-shadow: inset 0 0 0 1px #bd8600 !important;
+	color: #bd8600 !important;
+`;
+
+const LearnMoreAnchor = styled.a`
+	color: #bd8600 !important;
+`;
+
+const LegacyExperienceTransitionNotice = () => {
+	const { isUpeEnabled, setIsUpeEnabled } = useContext( UpeToggleContext );
+
+	// The merchant already disabled the legacy experience. Nothing to do here.
+	if ( isUpeEnabled ) {
+		return null;
+	}
+
+	const handleDisableButtonClick = () => {
+		const callback = async () => {
+			try {
+				await setIsUpeEnabled( true );
+			} catch ( err ) {}
+		};
+
+		// creating a separate callback so that the UI isn't blocked by the async call.
+		callback();
+	};
+
+	return (
+		<NoticeWrapper>
+			<Message>
+				{ __(
+					'Your checkout will soon be deprecated. To ensure continuing high performance of your store, transition to the updated checkout experience.',
+					'woocommerce-gateway-stripe'
+				) }{ ' ' }
+			</Message>
+			<div>
+				<DisableLegacyButton
+					variant="secondary"
+					onClick={ handleDisableButtonClick }
+				>
+					{ __(
+						'Enable the new checkout',
+						'woocommerce-gateway-stripe'
+					) }
+				</DisableLegacyButton>
+				<LearnMoreAnchor
+					href="https://woo.com/document/stripe/admin-experience/new-checkout-experience/"
+					className="components-button is-tertiary"
+					target="_blank"
+					rel="noreferrer"
+				>
+					{ __( 'Learn more', 'woocommerce-gateway-stripe' ) }
+				</LearnMoreAnchor>
+			</div>
+		</NoticeWrapper>
+	);
+};
+
+export default LegacyExperienceTransitionNotice;

--- a/client/settings/notices/legacy-experience-transition/index.js
+++ b/client/settings/notices/legacy-experience-transition/index.js
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
 import React, { useContext } from 'react';
 import { Button } from '@wordpress/components';
+import { recordEvent } from 'wcstripe/tracking';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 const NoticeWrapper = styled.div`
@@ -45,6 +46,10 @@ const LegacyExperienceTransitionNotice = () => {
 		const callback = async () => {
 			try {
 				await setIsUpeEnabled( true );
+
+				recordEvent( 'wcstripe_legacy_experience_disabled', {
+					source: 'payament-methods-tab-notice',
+				} );
 
 				createSuccessNotice(
 					__(

--- a/client/settings/notices/legacy-experience-transition/index.js
+++ b/client/settings/notices/legacy-experience-transition/index.js
@@ -69,10 +69,16 @@ const LegacyExperienceTransitionNotice = () => {
 	return (
 		<NoticeWrapper>
 			<Message>
+				<h3>
+					{ __(
+						'Ensure payments continue to work on your store',
+						'woocommerce-gateway-stripe'
+					) }
+				</h3>
 				{ __(
-					'Your checkout will soon be deprecated. To ensure continuing high performance of your store, transition to the updated checkout experience.',
+					"You're using the legacy experience of the Stripe Payment Gateway extension. Soon, this experience will be deprecated by Stripe and replaced with the new checkout.",
 					'woocommerce-gateway-stripe'
-				) }{ ' ' }
+				) }
 			</Message>
 			<div>
 				<DisableLegacyButton

--- a/client/settings/settings-manager/__tests__/index.test.js
+++ b/client/settings/settings-manager/__tests__/index.test.js
@@ -8,6 +8,10 @@ jest.mock( '@woocommerce/navigation', () => ( {
 
 jest.mock( 'wcstripe/settings/customization-options-notice', () => () => null );
 
+jest.mock( 'wcstripe/settings/notices/legacy-experience-transition', () => () =>
+	null
+);
+
 describe( 'SettingsManager', () => {
 	beforeEach( () => {
 		global.wc_stripe_settings_params = {

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Remove unused UPE title field.
 * Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 * Add - Enable the updated checkout experience (UPE) by default for new accounts.
+* Add - Banner encouraging the transition to the updated checkout experience.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2998

## Changes proposed in this Pull Request:

- When the updated checkout experience is disabled, display a banner under the Payment Methods tab requesting the merchant to disable the Legacy checkout experience
- When the banner CTA is clicked, enable the updated checkout experience
- Introduce a new `wcstripe_legacy_experience_disabled` Track event to record when the merchant disables the legacy experience

## Testing instructions

For testing Track events, ensure that tracking is enabled in WooCommerce's settings, at `siteurl/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` > Allow usage of WooCommerce to be tracked

1. Go to Stripe's Settings tab, at `siteurl/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
2. Disable UPE
3. Go to the Payment Methods tab, at `siteurl/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
4. Confirm there's a banner titled "Ensure payments continue to work on your store"
<img width="700" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/2f8c7640-b1a1-4941-9ba7-6631a604b407">

5. Confirm that the Learn more button goes to `https://woo.com/document/stripe/admin-experience/new-checkout-experience/`
6. Click on "Enable the new checkout"
7. Confirm that
   - A notification is displayed saying "New checkout experience enabled"
   - UPE is now enabled
   - The banner is no longer displayed
8. Go to Tracks > Live view
9. Search for `%wcstripe_legacy_experience_disabled`
10. Confirm there's an event recorded from when you clicked on the CTA button. It may take ~10 mins to be displayed on the list

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
