### PR TITLE
Remove WC Blocks version check during JN set-up

### DIFF
--- a/tests/e2e/config/global-setup.js
+++ b/tests/e2e/config/global-setup.js
@@ -125,13 +125,11 @@ module.exports = async ( config ) => {
 	} )
 		.then( async () => {
 			const apiTokensPage = await adminContext.newPage();
-			const wooBlocksVersionPage = await adminContext.newPage();
 			const updatePluginPage = await adminContext.newPage();
 			const wooSubscriptionsInstallPage = await adminContext.newPage();
 
 			// create consumer token and update plugin in parallel.
 			let restApiKeysFinished = false;
-			let wooBlocksVersionFinished = false;
 			let pluginUpdateFinished = false;
 			let wooSubscriptionsInstallFinished = false;
 			let stripeSetupFinished = false;
@@ -143,17 +141,6 @@ module.exports = async ( config ) => {
 				.catch( () => {
 					console.error(
 						'Cannot proceed e2e test, as we could not create a WC REST API key. Please check if the test site has been setup correctly.'
-					);
-					process.exit( 1 );
-				} );
-
-			checkWooGutenbergProductsBlockVersion( wooBlocksVersionPage )
-				.then( () => {
-					wooBlocksVersionFinished = true;
-				} )
-				.catch( () => {
-					console.error(
-						'Cannot proceed e2e test, as we could not find the WC Blocks plugin version. Please check if the test site has been setup correctly.'
 					);
 					process.exit( 1 );
 				} );
@@ -222,7 +209,6 @@ module.exports = async ( config ) => {
 			while (
 				! pluginUpdateFinished ||
 				! restApiKeysFinished ||
-				! wooBlocksVersionFinished ||
 				! stripeSetupFinished ||
 				! wooSubscriptionsInstallFinished
 			) {

--- a/tests/e2e/utils/playwright-setup.js
+++ b/tests/e2e/utils/playwright-setup.js
@@ -137,60 +137,6 @@ export const createApiTokens = ( page ) =>
 	} );
 
 /**
- * Helper function to check the version of WC Blocks
- * and save it to the WC_BLOCKS_VERSION env variable.
- * This function is used when the admin user is already logged in.
- * @param {Page} page Playwright page object.
- * @return {Promise} Promise object represents the state of the operation.
- */
-export const checkWooGutenbergProductsBlockVersion = ( page ) =>
-	new Promise( ( resolve, reject ) => {
-		( async () => {
-			const nRetries = 5;
-			for ( let i = 0; i < nRetries; i++ ) {
-				try {
-					console.log( '- Trying to check WC Blocks version...' );
-					await page.goto( `/wp-admin/admin.php?page=wc-status` );
-
-					await page.waitForSelector(
-						'td[data-export-label="WC Blocks Version"]'
-					);
-
-					// Use $eval to find the table cell with data-export-label="WC Blocks Version" and extract the text.
-					const versionElement = await page.$eval(
-						'td[data-export-label="WC Blocks Version"] + td + td',
-						( el ) => el.innerText
-					);
-
-					// Split and get the version number. Assuming the version text is formatted like: "9.8.2 /some/path/to/version"
-					const versionNumber = versionElement
-						.trim()
-						.split( ' ' )[ 0 ];
-
-					if ( isNaN( parseFloat( versionNumber ) ) ) {
-						throw new Error(
-							`Failed to parse WC Blocks version number. Got: ${ versionElement }`
-						);
-					}
-
-					process.env.WC_BLOCKS_VERSION = versionNumber;
-					console.log(
-						`\u2714 Checked WC Blocks version successfully. The version is ${ versionNumber }.`
-					);
-					resolve();
-					return;
-				} catch ( e ) {
-					console.log(
-						`Failed to check WC Blocks version. Retrying... ${ i }/${ nRetries }`
-					);
-					console.log( e );
-				}
-			}
-			reject();
-		} )();
-	} );
-
-/**
  * Helper function to download the Stripe plugin from the repository and install it on the site.
  * This is useful when we want to test a specific version of the plugin.
  * If the plugin is already installed, it will be updated to the specified version.


### PR DESCRIPTION
Fixes #3018

## Changes proposed in this Pull Request:

The WC Blocks version is no longer present on the System status page (/wp-admin/admin.php?page=wc-status); this PR updates the E2E suite remote setup to remove the check.

## Testing instructions
1. Create a new Jurassic Ninja site.
2. Update the variables in your `./tests/e2e/config/local.env` file with the new site info.
     - Check the file `./tests/e2e/config/local.env.example` for default values (ADMIN_USER, SSH_HOST and SSH_PATH)
4. Run the E2E setup
    - `npm run test:e2e-setup -- --base_url=<JN_SITE_URL>`
5. Check that all tests pass:
    ![Screenshot 2024-02-14 at 17 19 10](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/4401de57-146a-495d-86d4-2ec1a04b49e8)
