### PR TITLE
Turn Link on by default in the email field

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -1,5 +1,6 @@
 /* global Stripe */
 import { __ } from '@wordpress/i18n';
+import { isLinkEnabled } from 'wcstripe/stripe-utils';
 
 /**
  * Handles generic connections to the server and Stripe.
@@ -64,11 +65,8 @@ export default class WCStripeAPI {
 			isUPEEnabled,
 			paymentMethodsConfig,
 		} = this.options;
-		const isStripeLinkEnabled =
-			undefined !== paymentMethodsConfig.card &&
-			undefined !== paymentMethodsConfig.link;
 		if ( ! this.stripe ) {
-			if ( isUPEEnabled && isStripeLinkEnabled ) {
+			if ( isUPEEnabled && isLinkEnabled( paymentMethodsConfig ) ) {
 				this.stripe = this.createStripe( key, locale, [
 					'link_autofill_modal_beta_1',
 				] );

--- a/client/blocks/upe/hooks.js
+++ b/client/blocks/upe/hooks.js
@@ -3,6 +3,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import confirmCardPayment from './confirm-card-payment.js';
 import enableStripeLinkPaymentMethod from 'wcstripe/stripe-link';
 import { WC_STORE_CART } from 'wcstripe/blocks/credit-card/constants';
+import { isLinkEnabled } from 'wcstripe/stripe-utils';
 
 /**
  * Handles the Block Checkout onCheckoutSuccess event.
@@ -89,10 +90,7 @@ export const usePaymentFailHandler = (
 export const useStripeLink = ( api, elements, paymentMethodsConfig ) => {
 	const customerData = useCustomerData();
 	useEffect( () => {
-		if (
-			paymentMethodsConfig.link !== undefined &&
-			paymentMethodsConfig.card !== undefined
-		) {
+		if ( isLinkEnabled( paymentMethodsConfig ) ) {
 			const shippingAddressFields = {
 				line1: 'shipping-address_1',
 				line2: 'shipping-address_2',

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -209,10 +209,8 @@ export { getStripeServerData, getErrorMessageForTypeAndCode };
  * @return {boolean} True, if enabled; false otherwise.
  */
 export const isLinkEnabled = ( paymentMethodsConfig ) => {
-	return (
-		paymentMethodsConfig.link !== undefined &&
-		paymentMethodsConfig.card !== undefined
-	);
+	// Link is enabled by default if CC is enabled.
+	return paymentMethodsConfig.card !== undefined;
 };
 
 /**

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -209,8 +209,10 @@ export { getStripeServerData, getErrorMessageForTypeAndCode };
  * @return {boolean} True, if enabled; false otherwise.
  */
 export const isLinkEnabled = ( paymentMethodsConfig ) => {
-	// Link is enabled by default if CC is enabled.
-	return paymentMethodsConfig.card !== undefined;
+	return (
+		paymentMethodsConfig.link !== undefined &&
+		paymentMethodsConfig.card !== undefined
+	);
 };
 
 /**

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -349,7 +349,7 @@ class WC_Stripe_Admin_Notices {
 		}
 
 		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $method_class ) {
-			if ( WC_Stripe_UPE_Payment_Method_CC::class === $method_class ) {
+			if ( WC_Stripe_UPE_Payment_Method_CC::class === $method_class || WC_Stripe_UPE_Payment_Method_Link::class === $method_class ) {
 				continue;
 			}
 			$method     = $method_class::STRIPE_ID;

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -276,7 +276,7 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 		$upe_settings['upe_checkout_experience_accepted_payments'] = [
 			'title'   => __( 'Payments accepted on checkout (Early access)', 'woocommerce-gateway-stripe' ),
 			'type'    => 'upe_checkout_experience_accepted_payments',
-			'default' => [ 'card' ],
+			'default' => [ 'card', 'link' ],
 		];
 	}
 	// Insert UPE options below the 'logging' setting.

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -200,6 +200,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			}
 
 			$result['upe_checkout_experience_enabled'] = 'yes';
+			$result['upe_checkout_experience_accepted_payments'][] = 'link';
 
 			return $result;
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -15,12 +15,11 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->stripe_id            = self::STRIPE_ID;
-		$this->title                = __( 'Link', 'woocommerce-gateway-stripe' );
-		$this->is_reusable          = true;
-		$this->supported_currencies = [ 'USD' ];
-		$this->label                = __( 'Stripe Link', 'woocommerce-gateway-stripe' );
-		$this->description          = __(
+		$this->stripe_id   = self::STRIPE_ID;
+		$this->title       = __( 'Link', 'woocommerce-gateway-stripe' );
+		$this->is_reusable = true;
+		$this->label       = __( 'Stripe Link', 'woocommerce-gateway-stripe' );
+		$this->description = __(
 			'Link is a payment method that allows customers to save payment information  and use the payment details
 			for further payments.',
 			'woocommerce-gateway-stripe'
@@ -81,7 +80,11 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 		$cached_account_data = WC_Stripe::get_instance()->account->get_cached_account_data();
 		$account_country     = $cached_account_data['country'] ?? null;
 
-		return 'US' === $account_country;
+		// List of available countries for each PM:
+		// https://docs.stripe.com/payments/payment-methods/integration-options#country-currency-support
+		$country_availablity = [ 'AE', 'AT', 'AU', 'BE', 'BG', 'CA', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GB', 'GI', 'GR', 'HK', 'HR', 'HU', 'IE', 'IT', 'JP', 'LI', 'LT', 'LU', 'LV', 'MT', 'MX', 'MY', 'NL', 'NO', 'NZ', 'PL', 'PT', 'RO', 'SE', 'SG', 'SI', 'SK', 'US' ];
+
+		return in_array( $account_country, $country_availablity, true );
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/test-wc-stripe-payment-request.php
@@ -211,7 +211,19 @@ class WC_Stripe_Payment_Request_Test extends WP_UnitTestCase {
 	}
 
 	public function test_is_at_least_one_payment_request_button_enabled_none_enabled() {
+		// Disable Apple Pay/Google Pay
 		$this->pr->stripe_settings = [ 'payment_request' => false ];
+
+		// Disable Link by Stripe
+		update_option(
+			'woocommerce_stripe_settings',
+			array_merge(
+				get_option( 'woocommerce_stripe_settings', [] ),
+				[
+					'upe_checkout_experience_accepted_payments' => [ 'card' ],
+				]
+			)
+		);
 
 		$this->assertFalse( $this->pr->is_at_least_one_payment_request_button_enabled() );
 	}

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -134,7 +134,7 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 		$this->assertContains( WC_Stripe_UPE_Payment_Gateway::class, $loaded_gateway_classes );
 	}
 
-	public function test_turning_on_upe_with_no_stripe_legacy_payment_methods_enabled_will_not_turn_on_the_upe_gateway_and_default_to_card_only() {
+	public function test_turning_on_upe_with_no_stripe_legacy_payment_methods_enabled_will_not_turn_on_the_upe_gateway_and_default_to_card_and_link() {
 		$this->upe_helper->enable_upe_feature_flag();
 		// Store default stripe options
 		update_option( 'woocommerce_stripe_settings', [] );
@@ -151,7 +151,8 @@ class WC_Stripe_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'no', $stripe_settings['enabled'] );
 		$this->assertEquals( 'yes', $stripe_settings['upe_checkout_experience_enabled'] );
 		$this->assertContains( 'card', $stripe_settings['upe_checkout_experience_accepted_payments'] );
-		$this->assertCount( 1, $stripe_settings['upe_checkout_experience_accepted_payments'] );
+		$this->assertContains( 'link', $stripe_settings['upe_checkout_experience_accepted_payments'] );
+		$this->assertCount( 2, $stripe_settings['upe_checkout_experience_accepted_payments'] );
 	}
 
 	public function test_turning_on_upe_enables_the_correct_upe_methods_based_on_which_legacy_payment_methods_were_enabled_and_vice_versa() {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -705,7 +705,7 @@ function woocommerce_gateway_stripe() {
 			 * @return array WooCommerce checkout fields.
 			 */
 			public function checkout_update_email_field_priority( $fields ) {
-				if ( isset( $fields['billing_email'] ) ) {
+				if ( isset( $fields['billing_email'] ) && WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() ) {
 					// Update the field priority.
 					$fields['billing_email']['priority'] = 1;
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -681,11 +681,11 @@ function woocommerce_gateway_stripe() {
 			 * @return array WooCommerce checkout fields.
 			 */
 			public function checkout_update_email_field_priority( $fields ) {
-				if ( isset( $fields['billing_email'] ) && WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() ) {
+				if ( isset( $fields['billing_email'] ) ) {
 					// Update the field priority.
 					$fields['billing_email']['priority'] = 1;
 
-					// Add extra `wcpay-checkout-email-field` class.
+					// Add extra `stripe-gateway-checkout-email-field` class.
 					$fields['billing_email']['class'][] = 'stripe-gateway-checkout-email-field';
 
 					// Append StripeLink modal trigger button for logged in users.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -564,10 +564,11 @@ function woocommerce_gateway_stripe() {
 
 					if ( 'stripe' === $lpm_gateway_id && isset( $this->stripe_gateway ) && $this->stripe_gateway->is_enabled() ) {
 						$settings['upe_checkout_experience_accepted_payments'][] = 'card';
+						$settings['upe_checkout_experience_accepted_payments'][] = 'link';
 					}
 				}
 				if ( empty( $settings['upe_checkout_experience_accepted_payments'] ) ) {
-					$settings['upe_checkout_experience_accepted_payments'] = [ 'card' ];
+					$settings['upe_checkout_experience_accepted_payments'] = [ 'card', 'link' ];
 				} else {
 					// The 'stripe' gateway must be enabled for UPE if any LPMs were enabled.
 					$settings['enabled'] = 'yes';


### PR DESCRIPTION
Fixes #2437, #2481

## Changes proposed in this Pull Request:

This PR turns Link by Stripe on by default; and updates the valid countries and currencies ([country currency support](https://docs.stripe.com/payments/payment-methods/integration-options#country-currency-support))

<img width="620" alt="Screenshot 2024-03-22 at 2 47 36 AM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/e2e934ec-904b-45c6-ab62-2e7654e7444d">


**Note:** The Link settings implementation is inconsistent with the Payment request button settings; it's actually an enabled PM in the UPE payment methods list, while the PRB is an attr at the settings top level... Link is both a PRB, and an integration in the email field and in the "auto-filled" payment method section of the checkout page.
This PR keeps the current implementation and just adds `Link` to the enabled UPE payment methods list if it's a new installation.

## Testing instructions

**Link not enabled by default when updating**

1. Create a JN site with WC (or install WC manually)
2. Go to `WP-Admin > Plugins > Add new plugin`
3. Search for `WooCommerce Stripe Gateway`, install and activate the plugin
4. Go to `WP-Admin > WooCommerce > Settings > Payments > Stripe`
5. Complete Stripe onboarding
6. In the **Payment Methods** tab in the plugin settings, check that **Link** is disabled
    ![Screenshot 2024-03-25 at 9 29 38 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/f1d369bc-5b60-4c78-ab6e-7800ce7400f9)
7. Checkout this branch (`tweak/autoenable-link-in-payment-element`)
8. Build the extension package
    - `npm run build`
9. Go to `WP-Admin > Plugins > Add new plugin`, and click `Upload Plugin`
10. Upload the generated `woocommerce-gateway-stripe.zip` file from Step 7.
11. When asked click `Replace current with uploaded`
12. Go to `WP-Admin > WooCommerce > Settings > Payments > Stripe`
13. In the **Payment Methods** tab in the plugin settings, check that **Link** is still disabled after the update

**Link enabled by default in new install**

1. Create a JN site with WC (or install WC manually), or delete the plugin and settings vis SSH: 
    - `wp plugin uninstall woocommerce-gateway-stripe`
    - `wp option delete woocommerce_stripe_settings`
2. Go to `WP-Admin > Plugins > Add new plugin`, and click `Upload Plugin`
3. Upload the generated `woocommerce-gateway-stripe.zip` file from earlier.
4. Go to `WP-Admin > WooCommerce > Settings > Payments > Stripe`
5. Complete onboarding with a non-US Stripe account
6. In the **Payment Methods** tab in the plugin settings, check that **Link** is enabled
    ![Screenshot 2024-03-25 at 7 49 55 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/a389f5c4-b1d7-4e1c-b47f-9907762d02ef)

**Link enabled by default in new install**

1. Go to `WP-Admin > WooCommerce > Settings > General`
2. Change the store currency to Euro `EUR`
3. Go to `WP-Admin > WooCommerce > Settings > Payments > Stripe` 
4. In the `Express checkouts` section, make sure **Link** is enabled
5. Go to the store, add a product to the cart, and go to the blocks checkout page
6. Make sure the email is registered with Link ([link.com](https://app.link.com/))
7. Verify that the **Pay with link** button is present at the top of the checkout form
    ![Screenshot 2024-03-25 at 7 49 04 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/528fe140-c5ab-43bb-b369-4681f7a3d4c6)
8. Verify that the **Link** logo is present in the email field:
    ![Screenshot 2024-03-25 at 7 03 32 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/fac8e9bf-1487-48aa-ba8e-36afcf7475fc)
9. If not already logged in to Link, edit the email field (with a registered link email address) and click outside of the field, 
    - Check that the Link modal is displayed
        ![Screenshot 2024-03-25 at 7 38 03 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/788b937f-fa5e-41bc-a716-54705965206f)
10. Go to `WP-Admin > WooCommerce > Settings > Payments > Stripe`
11. In the `Express checkouts` section, make sure **Link** is disabled
12. Go to the store, add a product to the cart, and go to the blocks checkout page
13. Verify that the **Link** logo is not present in the email field
14. Verify that the **Pay with link** button is not displayed
    ![Screenshot 2024-03-25 at 7 51 45 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/330ac9d7-e643-42a4-808e-273cd10645c7)
