### PR TITLE
Update the interface of the "Enable updated experience" setting

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,8 @@
 * Tweak - Remove unused UPE title field.
 * Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 * Add - Enable the updated checkout experience (UPE) by default for new accounts.
-* Tweak - Add WooCommerce as a plugin dependency
+* Tweak - Add WooCommerce as a plugin dependency.
+* Tweak - Update the interface for the setting to toggle the New checkout experience to make it relative to the Legacy one instead.
 * Fix - Resolved an issue with subscription when attaching customers directly without 3DS due to Indian payment regulations.
 
 = 8.0.1 - 2024-03-13 =

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -31,7 +31,7 @@ describe( 'AdvancedSettings', () => {
 
 		expect( screen.queryByText( 'Debug mode' ) ).toBeInTheDocument();
 		expect(
-			screen.queryByText( 'New checkout experience' )
+			screen.queryByText( 'Legacy checkout experience' )
 		).toBeInTheDocument();
 	} );
 

--- a/client/settings/advanced-settings-section/experimental-features.js
+++ b/client/settings/advanced-settings-section/experimental-features.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
@@ -11,6 +11,7 @@ import { STORE_NAME } from '../../data/constants';
 const ExperimentalFeatures = () => {
 	const dispatch = useDispatch();
 	const [ isUpeEnabled, setIsUpeEnabled ] = useIsUpeEnabled();
+	const [ isLegacyEnabled, setIsLegacyEnabled ] = useState( ! isUpeEnabled );
 	const { isSaving } = useSettings();
 	const savingError = useGetSavingError();
 	const { setIsUpeEnabledLocally } = useContext( UpeToggleContext );
@@ -90,23 +91,29 @@ const ExperimentalFeatures = () => {
 		setIsUpeEnabledLocally,
 	] );
 
+	// The checkbox control uses the opposite value of the UPE state since 8.1.0.
+	const setIsLegacyExperienceEnabled = ( value ) => {
+		setIsUpeEnabled( ! value );
+		setIsLegacyEnabled( value );
+	};
+
 	return (
 		<>
 			<h4 ref={ headingRef } tabIndex="-1">
 				{ __(
-					'New checkout experience',
+					'Legacy checkout experience',
 					'woocommerce-gateway-stripe'
 				) }
 			</h4>
 			<CheckboxControl
 				data-testid="new-checkout-experience-checkbox"
 				label={ __(
-					'Enable the updated checkout experience',
+					'Enable the legacy checkout experience',
 					'woocommerce-gateway-stripe'
 				) }
 				help={ createInterpolateElement(
 					__(
-						'Get access to a smarter payment experience on checkout and let us know what you think by <feedbackLink>submitting your feedback</feedbackLink>. We recommend this feature for experienced merchants as the functionality is currently limited. <learnMoreLink>Learn more</learnMoreLink>',
+						'If you enable this, your store may stop processing payments in the near future as Stripe will no longer support this integration. <learnMoreLink>Learn more</learnMoreLink>.<newLineElement />Going back to the legacy experience? Reach out to us througbh our <feedbackLink>feedback form</feedbackLink> or <supportLink>support channel</supportLink>.',
 						'woocommerce-gateway-stripe'
 					),
 					{
@@ -114,12 +121,16 @@ const ExperimentalFeatures = () => {
 							<ExternalLink href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" />
 						),
 						learnMoreLink: (
-							<ExternalLink href="https://woocommerce.com/document/stripe/#new-checkout-experience" />
+							<ExternalLink href="https://woo.com/document/stripe/admin-experience/new-checkout-experience/" />
 						),
+						supportLink: (
+							<ExternalLink href="https://woo.com/document/stripe/admin-experience/new-checkout-experience/" />
+						),
+						newLineElement: <br />,
 					}
 				) }
-				checked={ isUpeEnabled }
-				onChange={ setIsUpeEnabled }
+				checked={ isLegacyEnabled }
+				onChange={ setIsLegacyExperienceEnabled }
 			/>
 		</>
 	);

--- a/client/settings/advanced-settings-section/experimental-features.js
+++ b/client/settings/advanced-settings-section/experimental-features.js
@@ -113,7 +113,7 @@ const ExperimentalFeatures = () => {
 				) }
 				help={ createInterpolateElement(
 					__(
-						'If you enable this, your store may stop processing payments in the near future as Stripe will no longer support this integration. <learnMoreLink>Learn more</learnMoreLink>.<newLineElement />Going back to the legacy experience? Reach out to us througbh our <feedbackLink>feedback form</feedbackLink> or <supportLink>support channel</supportLink>.',
+						'If you enable this, your store may stop processing payments in the near future as Stripe will no longer support this integration. <learnMoreLink>Learn more</learnMoreLink>.<newLineElement />Going back to the legacy experience? Reach out to us through our <feedbackLink>feedback form</feedbackLink> or <supportLink>support channel</supportLink>.',
 						'woocommerce-gateway-stripe'
 					),
 					{

--- a/client/settings/upe-toggle/__tests__/provider.test.js
+++ b/client/settings/upe-toggle/__tests__/provider.test.js
@@ -85,7 +85,12 @@ describe( 'UpeToggleContextProvider', () => {
 		);
 
 		expect( apiFetch ).not.toHaveBeenCalled();
-		expect( recordEvent ).toHaveBeenCalledWith( 'wcstripe_upe_disabled' );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_legacy_experience_enabled',
+			{
+				source: 'settings-tab-checkbox',
+			}
+		);
 		expect( childrenMock ).toHaveBeenCalledWith( {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),
@@ -140,7 +145,12 @@ describe( 'UpeToggleContextProvider', () => {
 
 		await waitFor( () => expect( apiFetch ).toHaveReturned() );
 
-		expect( recordEvent ).toHaveBeenCalledWith( 'wcstripe_upe_disabled' );
+		expect( recordEvent ).toHaveBeenCalledWith(
+			'wcstripe_legacy_experience_enabled',
+			{
+				source: 'settings-tab-checkbox',
+			}
+		);
 		expect( childrenMock ).toHaveBeenCalledWith( {
 			isUpeEnabled: false,
 			setIsUpeEnabled: expect.any( Function ),

--- a/client/settings/upe-toggle/provider.js
+++ b/client/settings/upe-toggle/provider.js
@@ -7,10 +7,12 @@ import { recordEvent } from 'wcstripe/tracking';
 
 function trackUpeToggle( isEnabled ) {
 	const eventName = isEnabled
-		? 'wcstripe_upe_enabled'
-		: 'wcstripe_upe_disabled';
+		? 'wcstripe_legacy_experience_disabled'
+		: 'wcstripe_legacy_experience_enabled';
 
-	recordEvent( eventName );
+	recordEvent( eventName, {
+		source: 'settings-tab-checkbox',
+	} );
 }
 
 const UpeToggleContextProvider = ( { children, defaultIsUpeEnabled } ) => {

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Remove unused UPE title field.
 * Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 * Add - Enable the updated checkout experience (UPE) by default for new accounts.
+* Tweak - Add WooCommerce as a plugin dependency.
+* Tweak - Update the interface for the setting to toggle the New checkout experience to make it relative to the Legacy one instead.
 * Fix - Resolved an issue with subscription when attaching customers directly without 3DS due to Indian payment regulations.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Update the label for the "Enable updated experience" setting under the Settings tab. The value of this checkbox must be the opposite of isUpeEnabled
- Update the Tracks event for recording the toggle of the selected checkout experience from `wcstripe_upe_{ enabled | disabled }` to `wcstripe_legacy_experience_{ enabled | disabled }`

## Testing instructions

For testing Track events, ensure that tracking is enabled in WooCommerce's settings, at `siteurl/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` > Allow usage of WooCommerce to be tracked

1. Go to the Stripe plugin Settings tab, at `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
2. Scroll down to the "Advanced settings" section
3. Confirm that there's a setting called "Enable the legacy checkout experience"
4. When the Legacy experience is enabled, confirm the UI matches that when UPE is disabled. [Ref](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/v8.0.0-%E2%80%90-Release-testing-instructions#settings-interface---disabled-new-checkout-experience-or-upe)
5. When the Legacy experience is disabled, confirm that the UI matches that when UPE is enabled. [Ref](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/v8.0.0-%E2%80%90-Release-testing-instructions#settings-interface---enabled-new-checkout-experience-or-upe)
6. Go to Tracks > Live events
7. Search for %wcstripe_legacy_experience_%
8. Confirm 
   - There's a `wcstripe_legacy_experience_enabled` event recorded for when you enabled the Legacy experience
   - There's a `wcstripe_legacy_experience_disabled` event recorded for when you disabled the Legacy experience
   - Both events have a `source` property with `settings-tab-checkbox` as its value

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
