### PR TITLE
Don't return unavailable payment methods in the list of `enabled_payment_method_ids` when fetching and updating Stripe settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
 * Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 * Fix - Resolved an issue with subscription when attaching customers directly without 3DS due to Indian payment regulations.
+* Fix - Error saving Stripe settings when testmode is enabled without any Stripe test API keys saved yet.
 * Tweak - Update the Stripe JS library to 1.36.0.
 * Tweak - Removed the "Early Access" pill and "Disable" option from the Stripe payment methods dropdown menu.
 * Tweak - Remove unused UPE title field.

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -224,7 +224,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'is_test_mode_enabled'                  => $this->gateway->is_in_test_mode(),
 
 				/* Settings > Payments accepted on checkout */
-				'enabled_payment_method_ids'            => array_intersect( $enabled_payment_method_ids, $available_payment_method_ids ), // only fetch enabled payment methods that are available.
+				'enabled_payment_method_ids'            => array_values( array_intersect( $enabled_payment_method_ids, $available_payment_method_ids ) ), // only fetch enabled payment methods that are available.
 				'available_payment_method_ids'          => $available_payment_method_ids,
 				'ordered_payment_method_ids'            => array_values( array_diff( $available_payment_method_ids, [ 'link' ] ) ), // exclude Link from this list as it is a express methods.
 				'individual_payment_method_settings'    => $is_upe_enabled ? [] : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -215,6 +215,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	public function get_settings() {
 		$is_upe_enabled               = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
 		$available_payment_method_ids = $is_upe_enabled ? WC_Stripe_Helper::get_upe_settings_available_payment_method_ids( $this->gateway ) : WC_Stripe_Helper::get_legacy_available_payment_method_ids();
+		$enabled_payment_method_ids   = $is_upe_enabled ? WC_Stripe_Helper::get_upe_settings_enabled_payment_method_ids( $this->gateway ) : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
 
 		return new WP_REST_Response(
 			[
@@ -223,7 +224,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'is_test_mode_enabled'                  => $this->gateway->is_in_test_mode(),
 
 				/* Settings > Payments accepted on checkout */
-				'enabled_payment_method_ids'            => $is_upe_enabled ? WC_Stripe_Helper::get_upe_settings_enabled_payment_method_ids( $this->gateway ) : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids(),
+				'enabled_payment_method_ids'            => array_intersect( $enabled_payment_method_ids, $available_payment_method_ids ), // only fetch enabled payment methods that are available.
 				'available_payment_method_ids'          => $available_payment_method_ids,
 				'ordered_payment_method_ids'            => array_values( array_diff( $available_payment_method_ids, [ 'link' ] ) ), // exclude Link from this list as it is a express methods.
 				'individual_payment_method_settings'    => $is_upe_enabled ? [] : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Issue with rendering Sepa on checkout page when card is disabled in non-UPE mode.
 * Fix - Resolved an issue in processing subscription payments with currencies not supported for mandate data.
 * Fix - Resolved an issue with subscription when attaching customers directly without 3DS due to Indian payment regulations.
+* Fix - Error saving Stripe settings when testmode is enabled without any Stripe test API keys saved yet.
 * Tweak - Update the Stripe JS library to 1.36.0.
 * Tweak - Removed the "Early Access" pill and "Disable" option from the Stripe payment methods dropdown menu.
 * Tweak - Remove unused UPE title field.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3026 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

There's an error currently in Stripe where toggling on test mode results in not being able to save your Stripe settings. The error found in the network tab tells us this issue is caused by a validation error on trying to save `enabled_payment_method_ids`:

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/97255d06-dd8b-4d29-8416-7976e080e5c7)


After some investigation, I found out this error is likely caused by a combination of these two recent changes we have made:
- https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2870
- https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3020

This is a bit complicated so let me try and explain 😅 

When the Stripe settings are loaded in, we populate the `enabled_payment_method_ids` value using `WC_Stripe_Helper::get_upe_settings_enabled_payment_method_ids( $this->gateway )` and as of #3020, the Link payment method is added to the list of enabled payment method ids by default for freshly connected accounts.

When we go to update/save the settings, we validate the `enabled_payment_method_ids` param against the list of available payment methods of the connected Stripe account (based on country, currency etc) by calling `WC_Stripe_Helper::get_upe_settings_available_payment_method_ids()`.

This discrepancy between the value we use to load the settings and the value we use to validate the settings is what is causing the issue.

For the specific case reported in #3026, when a fresh store enables test mode and doesn't have any Stripe test keys saved yet, Link is not in the available list of payment methods because `WC_Stripe_UPE_Payment_Method_Link::is_available_for_account_country()` returns false. The reason for this is because test mode without any test API keys is treated as not connected to Stripe and so the `$cached_account_data` variable called in `is_available_for_account_country()` returns empty, therefore Link is not available.

### What is changing in this pull request?

Coming up with an elegant fix for this was a bit tricky however, what I ended up going with was making sure the list of enabled payment methods we return when calling `GET /wc-stripe/settings` are only payment methods that are available.

This means stores that have Link enabled by default, when it's not available, won't be trying to saving Link as an enabled payment method.

I'm open to other options for fixing this issue 😃 

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Pull the latest `develop` branch
2. Disconnect your Stripe account 
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/66afe0ad-4482-4d55-96e1-1c4fd47bbafe)
3. Go through the Connect process
4. Once back in Woo Stripe settings, make sure the **Enable the legacy checkout experience** and **Enable test mode** settings are disabled.
5. Save the settings
6. Enable test mode and hit save settings
7. Now try to save the settings again and you should notice **Error saving settings**
8. Open the Network tab of your browser console and confirm the `rest_not_in_enum` error
9. Checkout this branch and try to save your settings again. Should be no eerors

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
