### PR TITLE
Add the test mode and plugin version to the Tracks events recorded through JS

### DIFF
--- a/client/tracking/__tests__/index.test.js
+++ b/client/tracking/__tests__/index.test.js
@@ -5,6 +5,11 @@ jest.mock( '@wordpress/dom-ready', () => ( cb ) => cb() );
 describe( 'tracking', () => {
 	beforeEach( () => {
 		global.wcTracks = undefined;
+
+		global.wc_stripe_settings_params = {
+			is_test_mode: 'yes',
+			plugin_version: '1.2.3',
+		};
 	} );
 
 	it( 'does not fail if the global library is not present in the DOM', () => {
@@ -27,9 +32,10 @@ describe( 'tracking', () => {
 
 		recordEvent( 'event_name', { value: '1' } );
 
-		expect( recordEventMock ).toHaveBeenCalledWith(
-			'event_name',
-			expect.objectContaining( { value: '1' } )
-		);
+		expect( recordEventMock ).toHaveBeenCalledWith( 'event_name', {
+			value: '1',
+			is_test_mode: 'yes',
+			stripe_version: '1.2.3',
+		} );
 	} );
 } );

--- a/client/tracking/index.js
+++ b/client/tracking/index.js
@@ -52,6 +52,8 @@ export function recordEvent( eventName, eventProperties ) {
 
 		// Add default properties to every event.
 		Object.assign( eventProperties, {
+			// The value for test mode is localized from the server on page load,
+			// thus it will only be updated after reloading the page.
 			is_test_mode: wc_stripe_settings_params.is_test_mode ? 'yes' : 'no',
 			stripe_version: wc_stripe_settings_params.plugin_version,
 		} );

--- a/client/tracking/index.js
+++ b/client/tracking/index.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 import domReady from '@wordpress/dom-ready';
 
 const LIBRARY_MOCK = {
@@ -48,6 +49,12 @@ export function recordEvent( eventName, eventProperties ) {
 		if ( ! isEnabled() ) {
 			return;
 		}
+
+		// Add default properties to every event.
+		Object.assign( eventProperties, {
+			is_test_mode: wc_stripe_settings_params.is_test_mode ? 'yes' : 'no',
+			stripe_version: wc_stripe_settings_params.plugin_version,
+		} );
 
 		getLibrary().recordEvent( eventName, eventProperties );
 	} );

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -147,6 +147,8 @@ class WC_Stripe_Settings_Controller {
 			'is_upe_checkout_enabled'   => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			'stripe_oauth_url'          => $oauth_url,
 			'show_customization_notice' => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
+			'is_test_mode'              => $this->gateway->is_in_test_mode(),
+			'plugin_version'            => WC_STRIPE_VERSION,
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Add the following properties to the Tracks events recorded from the client side:
- is_test_mode, flagging whether the Stripe extension is set 
- stripe_version, flagging what's the Stripe plugin version in use

## Testing instructions

1. Ensure that tracking is enabled in WooCommerce's settings, at `siteurl/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` > Allow usage of WooCommerce to be tracked
2. Go to the Stripe plugin Settings tab, at `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
3. Scroll down to the "Advanced settings" section
4. Make sure Stripe is in test mode
5. Toggle "Enable the legacy checkout experience" and save
6. Go to Tracks > Live events
7. Search for %wcstripe_legacy_experience_%
8. Confirm 
   - There's a `wcstripe_legacy_experience_{ enabled | disabled }` event recorded 
   - The event has a `is_test_mode` property with `yes` as its value
   - The event has a `stripe_version` property with `8.1.0` as its value
9. On the plugin's settings tab, disable test mode
10. Toggle "Enable the legacy checkout experience" and save
11. Go to Tracks > Live events, and confirm 
   - There's a `wcstripe_legacy_experience_{ enabled | disabled }` event recorded 
   - The event has a `is_test_mode` property with `no` as its value
   - The event has a `stripe_version` property with `8.1.0` as its value

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
