### PR TITLE
Fix unexpected date in the past for the mandate's start_date when renewing a subscription

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** Changelog ***
 
 = 8.2.0 - xxxx-xx-xx =
+
+= 8.1.1 - xxxx-xx-xx =
 * Fix - Issue with subscription renewal when the `start_date` of the mandate is set in the past.
 
 = 8.1.0 - 2024-03-28 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.2.0 - xxxx-xx-xx =
+* Fix - Issue with subscription renewal when the `start_date` of the mandate is set in the past.
 
 = 8.1.0 - 2024-03-28 =
 * Add - Include Stripe account details to the settings page.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -707,7 +707,7 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		$mandate_options['amount']          = $sub_amount;
 		$mandate_options['reference']       = $order->get_id();
-		$mandate_options['start_date']      = $sub->get_time( 'start' );
+		$mandate_options['start_date']      = time();
 		$mandate_options['supported_types'] = [ 'india' ];
 
 		return $mandate_options;

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 8.2.0 - xxxx-xx-xx =
+= 8.1.1 - xxxx-xx-xx =
 * Fix - Issue with subscription renewal when the `start_date` of the mandate is set in the past.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.2.0 - xxxx-xx-xx =
+* Fix - Issue with subscription renewal when the `start_date` of the mandate is set in the past.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2946 

Some merchants have encountered the following error in their subscription renewals. In most of the reports, the subscriptions are imported and the start date is in the past.

> Mandate or subscription cannot have start date before yesterday in IST. Expected start_date to be at or after 2024-02-20 18:30 UTC (1708453800) but was 2024-01-21 17:37 UTC (1705858639).

## Changes proposed in this Pull Request:
According to the [Stripe docs](https://docs.stripe.com/api/setup_intents/create#create_setup_intent-payment_method_options-card-mandate_options-start_date)

```
Start date of the mandate or subscription. Start date should not be lesser than yesterday.
```

As it can be the start date of the subscription or the mandate itself, I have changed the date [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/compat/trait-wc-stripe-subscriptions.php#L710) to use the current time. As the current time can be considered as the start date of this mandate which will be created with this request.

## Testing instructions

1. Use the `develop` branch
2. Install Woo Subscriptions.
3. Create a subscription product if you don't already have one.
4. Connect to a Indian Stripe account and set your store currency to INR.
5. As a shopper, subscribe to a product using a Indian card (`4000003560000123`)
6. In your database, find the `_stripe_mandate_id` order meta created for the parent order. Delete this entry from your database.
7. From both the order meta and post meta table, find the start date of your subscription and set the date to past (a date in last week or last month).
8. Go to your subscription edit page and make sure the start date is set in the past.
9. Now as a shopper, find the subscription in My account -> Subscriptions and renew it using card `4000003560000123` ( or the previously saved card).
10. The payment will fail with a similar error as the following 

> Mandate or subscription cannot have start date before yesterday in IST. Expected start_date to be at or after 2024-02-20 18:30 UTC (1708453800) but was 2024-01-21 17:37 UTC (1705858639).

11. Find the `payment_intents request` in your logs and check the `start_date` in `mandate_options`. Convert this to date format and you will find it set to the past date which you have set in the database as the strat date of this subscription.
12. Now check out to this branch and try renewing the subscription.
13. This time the renewal should be successful.
14. Find the `payment_intents request` in your logs and check the `start_date` in `mandate_options`. Convert this to date format and you will find it set to current date.