### PR TITLE
Show PRB on cart and product page when there are required custom checkout fields

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@
 
 = 8.2.0 - xxxx-xx-xx =
 
+= 8.1.1 - xxxx-xx-xx =
+* Fix - Do not hide PRB on cart and product page when there are required custom checkout fields.
+
 = 8.1.0 - 2024-03-28 =
 * Add - Include Stripe account details to the settings page.
 * Add - Include Stripe API version in logs.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -976,11 +976,6 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
-		// Don't show on cart if there are required checkout fields.
-		if ( is_cart() && $this->has_required_checkout_fields() ) {
-			return false;
-		}
-
 		// Don't show on checkout if disabled.
 		if ( is_checkout() && ! $this->should_show_prb_on_checkout_page() ) {
 			return false;
@@ -988,11 +983,6 @@ class WC_Stripe_Payment_Request {
 
 		// Don't show if product page PRB is disabled.
 		if ( $this->is_product() && ! $this->should_show_prb_on_product_pages() ) {
-			return false;
-		}
-
-		// Don't show on product if there are required checkout fields.
-		if ( $this->is_product() && $this->has_required_checkout_fields() ) {
 			return false;
 		}
 
@@ -1068,54 +1058,6 @@ class WC_Stripe_Payment_Request {
 			! $should_show_on_product_page,
 			$post
 		);
-	}
-
-	/**
-	 * Returns true if the checkout has any required fields other than the default ones, false otherwise.
-	 * to not be empty.
-	 *
-	 * @since 8.0.0
-	 *
-	 * @return boolean
-	 */
-	public function has_required_checkout_fields() {
-		// Default WooCommerce Core required fields for billing and shipping.
-		$default_required_fields = [
-			'billing_first_name',
-			'billing_last_name',
-			'billing_country',
-			'billing_address_1',
-			'billing_city',
-			'billing_state',
-			'billing_postcode',
-			'billing_phone',
-			'billing_email',
-			'shipping_first_name',
-			'shipping_last_name',
-			'shipping_country',
-			'shipping_address_1',
-			'shipping_city',
-			'shipping_state',
-			'shipping_postcode',
-		];
-
-		$fields = WC()->checkout()->get_checkout_fields();
-		$fields = array_merge(
-			$fields['billing'] ?? [],
-			$fields['shipping'] ?? [],
-			$fields['order'] ?? [],
-			$fields['account'] ?? []
-		);
-
-		foreach ( $fields as $field_key => $field_data ) {
-			if ( false === array_search( $field_key, $default_required_fields, true ) ) {
-				if ( isset( $field_data['required'] ) && true === $field_data['required'] ) {
-					return true;
-				}
-			}
-		}
-
-		return false;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 8.2.0 - xxxx-xx-xx =
+= 8.1.1 - xxxx-xx-xx =
+* Fix - Do not hide PRB on cart and product page when there are required custom checkout fields.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2992

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2886 as part of fixing an issue related to required checkout fields breaking Google Pay or Apple Pay, we had hidden the PRBs from cart and product page when there are custom required checkout fields. This PR reverts the changes made for cart and product pages and will continue to show the PRBs on the pages.

## Changes proposed in this Pull Request:
- Removed the check for required custom checkout fields and not hiding the Google/Apple Pay on cart and product page any more.

## Testing instructions
- Go to `develop` branch.
- Go to **Appearance -> Customize -> WooCommerce -> Checkout** and make the `Company` field required.
- Go to **WooCommerce -> Settings -> Payments -> Stripe**. Customize Google/Apple Pay button locations and select Checkout, Cart, and Product.
- As a shopper go to a single product page and find that there are no Google/Apple Pay button on the page.
- Add the product to the cart, go to the cart page and find that there are no Google/Apple Pay button on the page.
- Go to the checkout page and the Google/Apple pay button should be present.
- Now check out this branch.
- Check the single product page, cart page and checkout page again. Google/Apple pay button should be present on all three pages. Confirm that the button exists both on shortcode and block cart and checkout pages.
- Try to purchase with Google Pay from cart or product page. You should see an error notice on the page.

![error notice prb](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/92b50b45-24b5-41c0-a025-1693e95081d9)

- Go to the checkout page, add a value to the `Company` field. Try to purchase with Google Pay and it should be successful without any errors.
- Check the order data in your wp-admin and make sure the company name is there.