### PR TITLE
Adjust failing e2e subscription tests

### DIFF
--- a/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
@@ -83,7 +83,7 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 		await page.click(
 			'input[id^="radio-control-wc-payment-method-saved-tokens-"]'
 		);
-		await page.click( 'text=Place Order' );
+		await page.click( 'text=Renew subscription' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
 		);

--- a/tests/e2e/tests/woocommerce-blocks/subscription-product.spec.js
+++ b/tests/e2e/tests/woocommerce-blocks/subscription-product.spec.js
@@ -45,7 +45,7 @@ test( 'customer can purchase a subscription product @smoke @blocks @subscription
 	await setupBlocksCheckout( page, customerData );
 	await fillCardDetails( page, config.get( 'cards.basic' ) );
 
-	await page.locator( 'text=Place Order' ).click();
+	await page.locator( 'text=Sign up now' ).click();
 	await page.waitForNavigation();
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(


### PR DESCRIPTION
Fixes #3032

## Changes proposed in this Pull Request:

- Update the strings E2E tests try to locate when processing subscriptions. These were updated recently by the Subscription extension, thus the current tests can't locate the old string.

## Testing instructions

Confirm all of the e2e subscriptions tests [running](https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/8544203710/job/23409710754?pr=3039) in this PR pass. Alternatively, run them on a JN site, as explained in https://github.com/woocommerce/woocommerce-gateway-stripe/tree/develop/tests/e2e

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
