### PR TITLE
Fixes checkout errors for customers that have one-word billing names setup in Apple Pay/Google Pay

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -99,7 +99,7 @@ jQuery( function( $ ) {
 			var data     = {
 				_wpnonce:                  wc_stripe_payment_request_params.nonce.checkout,
 				billing_first_name:        name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
-				billing_last_name:         name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',
+				billing_last_name:         name?.split( ' ' )?.slice( 1 )?.join( ' ' ) || '-',
 				billing_company:           '',
 				billing_email:             null !== email   ? email : evt.payerEmail,
 				billing_phone:             null !== phone   ? phone : evt.payerPhone && evt.payerPhone.replace( '/[() -]/g', '' ),

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 8.2.0 - xxxx-xx-xx =
 * Add - Enable custom styling of the Payment Elements for stores using the updated checkout experience.
 * Fix - Ensure the hold stock setting does not cancel pending stripe orders that are still waiting for customer action (eg confirm 3DS or complete payment redirect).
+* Fix - Prevent checkout errors when customers with one-word names process payment using Apple Pay or Google Pay.
 * Tweak - Remove the functionality for saving the customized statement descriptors.
 * Tweak - Remove unused WC_Stripe_Old_Settings_UPE_Toggle_Controller class and related scripts.
 * Update - Save the Stripe default appearance settings in a transient instead of the browsers local storage.

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 8.2.0 - xxxx-xx-xx =
 * Add - Enable custom styling of the Payment Elements for stores using the updated checkout experience.
 * Fix - Ensure the hold stock setting does not cancel pending stripe orders that are still waiting for customer action (eg confirm 3DS or complete payment redirect).
+* Fix - Prevent checkout errors when customers with one-word names process payment using Apple Pay or Google Pay.
 * Tweak - Remove the functionality for saving the customized statement descriptors.
 * Tweak - Remove unused WC_Stripe_Old_Settings_UPE_Toggle_Controller class and related scripts.
 * Update - Save the Stripe default appearance settings in a transient instead of the browsers local storage.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1776 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Apple Pay and Google Pay allow customers to leave the last name blank when adding payment method and billing address details, however, this throws errors on the checkout because the last name is a required field.

To fix this issue, I'm setting the default `billing_last_name` to `-` instead of an empty string. For the record, WooPayments has the same changes ([see code](https://github.com/Automattic/woocommerce-payments/blob/c6ebbaf8af2e95be8345f37f285518090f4495f7/client/payment-request/utils/normalize.js#L50))

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/bacefe77-e9f9-4386-9af3-86889f54cd7d)

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Go into your user profile settings in WP Admin and delete the last name, billing last name and shipping last name to make sure it won't be submitted on checkout
2. I'm not sure if this is needed but because I tested using Google Pay, I went to https://myaccount.google.com/profile and removed my last name from my personal information, saved payment method and addresses.
3. Make sure Apple Pay and Google Pay is enabled
4. Add a product to your cart and navigate to the checkout
5. While on `develop`, click on the Apple Pay/Google Pay button and try to complete the payment
6. You should see an error on the Google Pay modal and the following error on the checkout page:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/b792e8fc-cd82-4ddd-8935-9874862271cf)
7. Switch to this branch (`fix/1776-one-word-names-payment-requests`) and re-run the test to confirm the empty billing last name is now populated with `-`.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
