### PR TITLE
Slight improvement to performance with handling UPE redirect payments 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Ensure the hold stock setting does not cancel pending stripe orders that are still waiting for customer action (eg confirm 3DS or complete payment redirect).
 * Tweak - Remove the functionality for saving the customized statement descriptors.
 * Tweak - Remove unused WC_Stripe_Old_Settings_UPE_Toggle_Controller class and related scripts.
+* Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 * Update - Save the Stripe default appearance settings in a transient instead of the browsers local storage.
 
 = 8.1.1 - 2024-04-04 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.3.0 - xxxx-xx-xx =
+* Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 
 = 8.2.0 - 2024-04-11 =
 * Tweak - Improve the display of the Stripe account ID in the settings page.
@@ -10,7 +11,6 @@
 * Fix - Prevent checkout errors when customers with one-word names process payment using Apple Pay or Google Pay.
 * Tweak - Remove the functionality for saving the customized statement descriptors.
 * Tweak - Remove unused WC_Stripe_Old_Settings_UPE_Toggle_Controller class and related scripts.
-* Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 * Update - Save the Stripe default appearance settings in a transient instead of the browsers local storage.
 * Tweak - Update Link by Stripe branding assets.
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -34,8 +34,6 @@ class WC_Stripe_Intent_Controller {
 
 		add_action( 'wc_ajax_wc_stripe_update_order_status', [ $this, 'update_order_status_ajax' ] );
 		add_action( 'wc_ajax_wc_stripe_update_failed_order', [ $this, 'update_failed_order_ajax' ] );
-
-		add_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] );
 	}
 
 	/**
@@ -669,19 +667,6 @@ class WC_Stripe_Intent_Controller {
 		wp_send_json_success();
 	}
 
-	/*
-	 * Check for a UPE redirect payment method on order received page or setup intent on payment methods page.
-	 *
-	 * @since 5.6.0
-	 * @version 5.6.0
-	 */
-	public function maybe_process_upe_redirect() {
-		$gateway = $this->get_gateway();
-		if ( is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
-			$gateway->maybe_process_upe_redirect();
-		}
-	}
-
 	/**
 	 * Creates and confirm a payment intent with the given payment information.
 	 * Used for dPE.
@@ -1070,5 +1055,21 @@ class WC_Stripe_Intent_Controller {
 	 */
 	private function is_delayed_confirmation_required( $payment_methods ) {
 		return in_array( 'boleto', $payment_methods, true ) || in_array( 'oxxo', $payment_methods, true );
+	}
+
+	/*
+	 * Check for a UPE redirect payment method on order received page or setup intent on payment methods page.
+	 *
+	 * @deprecated 8.2.0
+	 * @since 5.6.0
+	 * @version 5.6.0
+	 */
+	public function maybe_process_upe_redirect() {
+		wc_deprecated_function( __FUNCTION__, '8.2', 'WC_Stripe_UPE_Payment_Gateway::maybe_process_upe_redirect' );
+
+		$gateway = $this->get_gateway();
+		if ( is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
+			$gateway->maybe_process_upe_redirect();
+		}
 	}
 }

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1057,7 +1057,7 @@ class WC_Stripe_Intent_Controller {
 		return in_array( 'boleto', $payment_methods, true ) || in_array( 'oxxo', $payment_methods, true );
 	}
 
-	/*
+	/**
 	 * Check for a UPE redirect payment method on order received page or setup intent on payment methods page.
 	 *
 	 * @deprecated 8.2.0
@@ -1065,7 +1065,7 @@ class WC_Stripe_Intent_Controller {
 	 * @version 5.6.0
 	 */
 	public function maybe_process_upe_redirect() {
-		wc_deprecated_function( __FUNCTION__, '8.2', 'WC_Stripe_UPE_Payment_Gateway::maybe_process_upe_redirect' );
+		wc_deprecated_function( __FUNCTION__, '8.2', 'WC_Stripe_Order_Handler::maybe_process_redirect_order' );
 
 		$gateway = $this->get_gateway();
 		if ( is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1060,12 +1060,12 @@ class WC_Stripe_Intent_Controller {
 	/**
 	 * Check for a UPE redirect payment method on order received page or setup intent on payment methods page.
 	 *
-	 * @deprecated 8.2.0
+	 * @deprecated 8.3.0
 	 * @since 5.6.0
 	 * @version 5.6.0
 	 */
 	public function maybe_process_upe_redirect() {
-		wc_deprecated_function( __FUNCTION__, '8.2', 'WC_Stripe_Order_Handler::maybe_process_redirect_order' );
+		wc_deprecated_function( __FUNCTION__, '8.3', 'WC_Stripe_Order_Handler::maybe_process_redirect_order' );
 
 		$gateway = $this->get_gateway();
 		if ( is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -42,6 +42,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 	/**
 	 * Processes payments.
+	 *
 	 * Note at this time the original source has already been
 	 * saved to a customer card (if applicable) from process_payment.
 	 *
@@ -199,6 +200,21 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @version 4.0.0
 	 */
 	public function maybe_process_redirect_order() {
+		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+
+		if ( is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
+			$gateway->maybe_process_upe_redirect();
+		} else {
+			$this->maybe_process_legacy_redirect();
+		}
+	}
+
+	/**
+	 * Processes redirect payment for stores with legacy checkout experience enabled.
+	 *
+	 * @since 8.2.0
+	 */
+	private function maybe_process_legacy_redirect() {
 		if ( ! is_order_received_page() || empty( $_GET['client_secret'] ) || empty( $_GET['source'] ) ) {
 			return;
 		}

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -212,7 +212,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Processes redirect payment for stores with legacy checkout experience enabled.
 	 *
-	 * @since 8.2.0
+	 * @since 8.3.0
 	 */
 	private function maybe_process_legacy_redirect() {
 		if ( ! is_order_received_page() || empty( $_GET['client_secret'] ) || empty( $_GET['source'] ) ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -217,8 +217,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 
 		add_action( 'wc_ajax_wc_stripe_save_appearance', [ $this, 'save_appearance_ajax' ] );
-
-		add_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -217,6 +217,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 
 		add_action( 'wc_ajax_wc_stripe_save_appearance', [ $this, 'save_appearance_ajax' ] );
+
+		add_action( 'wp', [ $this, 'maybe_process_upe_redirect' ] );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Ensure the hold stock setting does not cancel pending stripe orders that are still waiting for customer action (eg confirm 3DS or complete payment redirect).
 * Tweak - Remove the functionality for saving the customized statement descriptors.
 * Tweak - Remove unused WC_Stripe_Old_Settings_UPE_Toggle_Controller class and related scripts.
+* Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 * Update - Save the Stripe default appearance settings in a transient instead of the browsers local storage.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2325 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

On `trunk` there are a few performance-related issues with our `WC_Stripe_Intent_Controller::maybe_process_upe_redirect` which were called out in #2325. These issues are:

1. On every page request (on the `wp` hook), we're calling `WC_Stripe_Intent_Controller::get_gateway()` which then calls `WC()->payment_gateways()->payment_gateways()` to check if UPE gateway class is being used. Calling this function constructs each payment gateway loaded in WooCommerce, which isn't necessary on every page load.
2. The instantiating every gateway issue listed above is also happening on stores with UPE disabled.
3. We have two similar functions checking for payment redirects running on `wp` (`maybe_process_upe_redirect` and `maybe_process_redirect_order`)

This PR addresses these issues by making the following changes:
- Call `WC_Stripe::get_instance()->get_main_stripe_gateway();` instead of `WC_Stripe_Intent_Controller::get_gateway()` to check if UPE is being used.
- Refactor the existing `WC_Stripe_Order_Handler::maybe_process_redirect_order()` to handle payment redirects for both legacy and UPE stripe settings.
- Deprecate the `WC_Stripe_Intent_Controller::maybe_process_upe_redirect()` now that it's handled in WC_Stripe_Order_Handler

> [!WARNING]
> There's technically a breaking change with this PR which is that we will no longer handle legacy payment redirect flows when UPE is enabled. I'm not sure if this was an intended feature, but previously we only handled UPE payment redirects when UPE was enabled, but non-UPE payment redirects were always handled regardless of settings.
>
> Since we're moving away from the legacy checkout experience I don't think this is a big deal.

The other thing I wanted to call out is my original solution was to move the UPE payment redirect handling to the main UPE gateway class (14a7bf3a074a7c5471deb5c98d3e23d3ede07d2b) but this relied heavily on the UPE gateway being instantiated before the `wp` hook was triggered and from my testing it was fine, but I noticed the UPE gateway class is loaded at different times depending on the page (i.e. it's loaded very early when viewing an admin page versus frontend page), so I opted to use the` WC_Stripe_Order_Handler` to group all the redirect code together but also for consistency/reliability with when it's hooked on.

Open to other suggestions :)

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

I don't have any performance testing tools installed locally apart from Query Monitor so the testing on this PR involves confirming that the UPE payment redirect flows is still working as expected.

1. Make sure Stripe UPE is enabled and you have a redirect payment method enabled (i.e. iDEAL)
2. Add a product to your cart and visit the checkout
3. Complete the payment using iDEAL and after being redirected back to your store, confirm the payment was processed.

With query monitor:
1. Visit the shop/checkout page and open query monitor
2. Confirm there's now only one redirect handler function registered on the `wp` hook: 
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/68a0f385-1acc-4b18-8fff-3a273e12d335)

I couldn't test a redirect payment flow on the legacy checkout due to this error:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/05426757-a7c5-4ef2-a2af-69e2b947fc36)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
