### PR TITLE
Fixes orders that require manual review due to risk/fraud rules being marked as processing/completed before approval

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Add - Additional information is displayed on the "Payment methods" page when listing co-branded credit cards.
 * Fix - Prevent duplicate stripe meta data on orders caused by processing redirect payments and webhooks simultaneously.
 * Fix - Processing a refund of a non-card payments (i.e. iDeal, giropay) through the Stripe dashboard was not showing as refunded in WooCommerce for stores with UPE enabled.
+* Fix - Prevent orders that require manual review in Stripe being marked as processing in WooCommerce before approval.
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 
 = 8.2.0 - 2024-04-11 =

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2111,17 +2111,19 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 8.3.0
 	 *
-	 * @param WC_Order $order          The order.
-	 * @param string   $default_status The default status to return if the metadata is not set. Defaults to the payment complete status.
+	 * @param WC_Order $order The order.
 	 *
 	 * @return string The status of the order before it was put on hold.
 	 */
-	protected function get_stripe_order_status_before_hold( $order, $default_status = null ) {
-		if ( is_null( $default_status ) ) {
-			$default_status = apply_filters( 'woocommerce_payment_complete_order_status', $order->needs_processing() ? 'processing' : 'completed', $order->get_id(), $order );
+	protected function get_stripe_order_status_before_hold( $order ) {
+		$before_hold_status = $order->get_meta( '_stripe_status_before_hold', true );
+
+		if ( ! empty( $before_hold_status ) ) {
+			return $before_hold_status;
 		}
 
-		return $order->get_meta( '_stripe_status_before_hold', true ) ?? $default_payment_complete_status;
+		$default_before_hold_status = $order->needs_processing() ? 'processing' : 'completed';
+		return apply_filters( 'woocommerce_payment_complete_order_status', $default_before_hold_status, $order->get_id(), $order );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2131,14 +2131,15 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 8.3.0
 	 *
-	 * @param WC_Order    $order  The order.
-	 * @param string|null $status The status to store. Accepts 'default_payment_complete' which will fetch the default status for payment complete orders.
+	 * @param WC_Order  $order  The order.
+	 * @param string    $status The order status to store. Accepts 'default_payment_complete' which will fetch the default status for payment complete orders.
 	 *
 	 * @return void
 	 */
 	protected function set_stripe_order_status_before_hold( $order, $status ) {
 		if ( 'default_payment_complete' === $status ) {
-			$status = apply_filters( 'woocommerce_payment_complete_order_status', $order->needs_processing() ? 'processing' : 'completed', $order->get_id(), $order );
+			$payment_complete_status = $order->needs_processing() ? 'processing' : 'completed';
+			$status                  = apply_filters( 'woocommerce_payment_complete_order_status', $payment_complete_status, $order->get_id(), $order );
 		}
 
 		$order->update_meta_data( '_stripe_status_before_hold', $status );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2116,7 +2116,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return string The status of the order before it was put on hold.
 	 */
 	protected function get_stripe_order_status_before_hold( $order ) {
-		$before_hold_status = $order->get_meta( '_stripe_status_before_hold', true );
+		$before_hold_status = $order->get_meta( '_stripe_status_before_hold' );
 
 		if ( ! empty( $before_hold_status ) ) {
 			return $before_hold_status;

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -578,6 +578,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				 */
 				if ( 'manual_review' === $this->get_risk_outcome( $response ) ) {
 					$this->set_stripe_order_status_before_hold( $order, 'default_payment_complete', false );
+					$order->set_transaction_id( $response->id ); // Save the transaction ID to link the order to the Stripe charge ID. This is to fix reviews that result in refund.
 				} else {
 					$order->payment_complete( $response->id );
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2130,14 +2130,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @since 8.3.0
 	 *
 	 * @param WC_Order    $order  The order.
-	 * @param string|null $status The status to store. Defaults to the current order status. Also accepts 'default_payment_complete' which will fetch the default status for payment complete orders.
+	 * @param string|null $status The status to store. Accepts 'default_payment_complete' which will fetch the default status for payment complete orders.
 	 *
 	 * @return void
 	 */
-	protected function set_stripe_order_status_before_hold( $order, $status = null ) {
-		if ( empty( $status ) ) {
-			$status = $order->get_status();
-		} elseif ( 'default_payment_complete' === $status ) {
+	protected function set_stripe_order_status_before_hold( $order, $status ) {
+		if ( 'default_payment_complete' === $status ) {
 			$status = apply_filters( 'woocommerce_payment_complete_order_status', $order->needs_processing() ? 'processing' : 'completed', $order->get_id(), $order );
 		}
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -567,7 +567,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			if ( 'succeeded' === $response->status ) {
 				/**
 				 * If the response has a succeeded status but also has a risk/fraud outcome that requires manual review, don't mark the order as
-				 * processing/completed if it has already been handled by the `review.open` webhook.
+				 * processing/completed. This will be handled by the incoming review.open webhook.
 				 *
 				 * Depending on when Stripe sends their events and how quickly it is processed by the store, the review.open webhook (which marks orders as on-hold)
 				 * can be processed before or after the payment_intent.success webhook. This difference can lead to orders being incorrectly marked as processing/completed
@@ -576,7 +576,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				 * If the review.open webhook was processed before the payment_intent.success, set the processing/completed status in `_stripe_status_before_hold`
 				 * to ensure the review.closed event handler will update the status to the proper status.
 				 */
-				if ( 'manual_review' === $this->get_risk_outcome( $response ) && $this->get_stripe_order_status_before_hold( $order, false ) ) {
+				if ( 'manual_review' === $this->get_risk_outcome( $response ) ) {
 					$this->set_stripe_order_status_before_hold( $order, 'default_payment_complete', false );
 				} else {
 					$order->payment_complete( $response->id );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -577,7 +577,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				 * to ensure the review.closed event handler will update the status to the proper status.
 				 */
 				if ( 'manual_review' === $this->get_risk_outcome( $response ) ) {
-					$this->set_stripe_order_status_before_hold( $order, 'default_payment_complete', false );
+					$this->set_stripe_order_status_before_hold( $order, 'default_payment_complete' );
 					$order->set_transaction_id( $response->id ); // Save the transaction ID to link the order to the Stripe charge ID. This is to fix reviews that result in refund.
 				} else {
 					$order->payment_complete( $response->id );
@@ -2131,11 +2131,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @param WC_Order    $order  The order.
 	 * @param string|null $status The status to store. Defaults to the current order status. Also accepts 'default_payment_complete' which will fetch the default status for payment complete orders.
-	 * @param bool        $save   Whether to save the order.
 	 *
 	 * @return void
 	 */
-	protected function set_stripe_order_status_before_hold( $order, $status = null, $save = true ) {
+	protected function set_stripe_order_status_before_hold( $order, $status = null ) {
 		if ( empty( $status ) ) {
 			$status = $order->get_status();
 		} elseif ( 'default_payment_complete' === $status ) {
@@ -2143,10 +2142,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		$order->update_meta_data( '_stripe_status_before_hold', $status );
-
-		if ( $save && is_callable( [ $order, 'save' ] ) ) {
-			$order->save();
-		}
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -463,7 +463,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		/**
 		 * If the response has a succeeded status but also has a risk/fraud outcome that requires manual review, don't mark the order as
-		 * processing/completed if it has already been handled by the `review.open` webhook.
+		 * processing/completed. This will be handled by the incoming review.open webhook.
 		 *
 		 * Depending on when Stripe sends their events and how quickly it is processed by the store, the review.open webhook (which marks orders as on-hold)
 		 * can be processed before or after the payment_intent.success webhook. This difference can lead to orders being incorrectly marked as processing/completed
@@ -472,9 +472,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		 * If the review.open webhook was processed before the payment_intent.success, set the processing/completed status in `_stripe_status_before_hold`
 		 * to ensure the review.closed event handler will update the status to the proper status.
 		 */
-		if ( 'manual_review' === $this->get_risk_outcome( $notification ) && $this->get_stripe_order_status_before_hold( $order, false ) ) {
-			$this->set_stripe_order_status_before_hold( $order, 'default_payment_complete', false );
-		} else {
+		if ( 'manual_review' !== $this->get_risk_outcome( $notification ) ) {
 			$order->payment_complete( $notification->data->object->id );
 
 			/* translators: transaction id */

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -769,6 +769,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$message = sprintf( __( 'The opened review for this order is now closed. Reason: (%s)', 'woocommerce-gateway-stripe' ), $notification->data->object->reason );
 
 		if (
+			( ! empty( $notification->data->object->closed_reason ) && 'approved' === $notification->data->object->closed_reason ) &&
 			$order->has_status( 'on-hold' ) &&
 			apply_filters( 'wc_stripe_webhook_review_change_order_status', true, $order, $notification ) &&
 			! $order->get_meta( '_stripe_status_final', false )

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -310,7 +310,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$this->set_stripe_order_status_before_hold( $order, $order->get_status(), false );
+		$this->set_stripe_order_status_before_hold( $order, $order->get_status() );
 
 		$message = sprintf(
 		/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
@@ -724,7 +724,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		$this->set_stripe_order_status_before_hold( $order, $order->get_status(), false );
+		$this->set_stripe_order_status_before_hold( $order, $order->get_status() );
 
 		$message = sprintf(
 		/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag 3) The reason type. */

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Additional information is displayed on the "Payment methods" page when listing co-branded credit cards.
 * Fix - Prevent duplicate stripe meta data on orders caused by processing redirect payments and webhooks simultaneously.
 * Fix - Processing a refund of a non-card payments (i.e. iDeal, giropay) through the Stripe dashboard was not showing as refunded in WooCommerce for stores with UPE enabled.
+* Fix - Prevent orders that require manual review in Stripe being marked as processing in WooCommerce before approval.
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2679 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

> [!NOTE]
> This PR requires a bit more testing but I'm pushing up my current changes to get an initial review of the approach taken. I've only tested basic flows like processing high-risk fraud payments, payments flagged for manual review via custom rules, and regular non-risk payments. Areas I still need to test:
> - [x] how subscription purchases and renewals are handled
> - [x] 3DS cards
> - [x] APM that requires redirect
> - [x] `review.open` webhook sent before and after payment_intent/charge.succeeded webhook

The way we handle payments/charges that have been flagged for manual review by Stripe is we do the following:
1. Process the `payment_intent.succeeded` webhook and mark the order as processing/completed
2. If the charge requires manual review, Stripe will send an `review.open` event, which we listen for and put that order on-hold and store its current status in `_stripe_status_before_hold` metadata.
3. Store manager reviews the risky payment and approves it from their Stripe dashboard
4. We then process the `review.closed` webhook by restoring the status of the order back to its original status stored in `_stripe_status_before_hold`.

This flow relies heavily on the order in which these webhooks are sent/processed.
The succeeded event needs to come first and then `review.open`.

The issue described in #2679 is what happens when the `review.open` webhook is sent/processed first, the order is put on-hold and then the `payment_intent.succeeded` event is handled soon after, which then updates the status to processing. This results in the order in WooCommerce being processing/completed and ready to ship, but still waiting for manual approval in Stripe.

The expected behaviour is for orders to remain on-hold until the payment risk has been manually looked and approved, regardless of the order in which the webhooks are processed.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Make sure you have Stripe webhooks set up and working with your test store (I personally use ngrok on my local site)
2. Set up a custom review rule in Stripe Dashboard by going to https://dashboard.stripe.com/test/settings/radar/rules
3. Click on `Add Rule` within the Review Rules section:
![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/677daa85-d989-4b0d-adfe-dc3a28b35b16)
4. Set the "Review if" condition to something that will cause purchases by your test customer to be flagged by the rule. For example I created a rule with **`Review if :email_domain: = 'example.com'`**
5. Go back to your store and attempt to purchase an product using any card.
6. View the order from the WP Admin > Edit Order page and confirm the order is on-hold and has note: ![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/2e40338e-828c-4553-8112-8aa55787a37b)
7. View the order meta and confirm `_stripe_status_before_hold` is set to processing.
8. Go to https://dashboard.stripe.com/test/radar/reviews to see active payments that require review.
9. Approve the payment then wait for the `review.closed` webhook to be processed on your store.
10. Confirm the on-hold order is now set to processing.
11. Disable the review rule in Stripe and make a test purchase again with `4242424242424242` to confirm successful payments are working and don't have the on hold meta set.

### More tests

- Other [risk-related test cards](https://docs.stripe.com/testing?testing-method=card-numbers#fraud-prevention) (like the failure cases)
- When purchasing a subscription product, the parent order and subscription should remain on-hold while there's a pending manual review. Once approved, the order should be processing and subscription should be activated.
- Responding with "refund" instead of approving, should result in the order being refunded

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
