### PR TITLE
Improving Stripe account ID display

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.2.0 - xxxx-xx-xx =
+* Tweak - Improve the display of the Stripe account ID in the settings page.
 * Add - Enable custom styling of the Payment Elements for stores using the updated checkout experience.
 * Fix - Alipay icon not being displayed on the Block checkout page.
 * Fix - Ensure the hold stock setting does not cancel pending stripe orders that are still waiting for customer action (eg confirm 3DS or complete payment redirect).

--- a/client/settings/payment-settings/__tests__/account-details-section.test.js
+++ b/client/settings/payment-settings/__tests__/account-details-section.test.js
@@ -215,9 +215,11 @@ describe( 'AccountDetailsSection', () => {
 		] );
 
 		render( <AccountDetailsSection setModalType={ setModalTypeMock } /> );
-		const stripeAccountDetails = screen.getByText(
-			/test@example.com \(acct_123\)/i
-		);
-		expect( stripeAccountDetails ).toBeInTheDocument();
+
+		const stripeAccountEmail = screen.getByText( /test@example.com/i );
+		expect( stripeAccountEmail ).toBeInTheDocument();
+
+		const stripeAccountId = screen.getByText( /acct_123/i );
+		expect( stripeAccountId ).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/payment-settings/account-details-section.js
+++ b/client/settings/payment-settings/account-details-section.js
@@ -22,6 +22,12 @@ const HeaderDetails = styled.div`
 	}
 `;
 
+const StripeAccountId = styled.span`
+	font-size: 12px;
+	color: #757575;
+	margin-left: auto;
+`;
+
 // @todo - remove setModalType as prop
 const AccountSettingsDropdownMenu = ( {
 	setModalType,
@@ -78,8 +84,8 @@ const AccountDetailsSection = ( { setModalType, setKeepModalContent } ) => {
 			<CardHeader>
 				<HeaderDetails>
 					<h4>
-						{ data.account?.email && data.account?.id
-							? data.account.email + ' (' + data.account.id + ')'
+						{ data.account?.email
+							? data.account.email
 							: __(
 									'Account status',
 									'woocommerce-gateway-stripe'
@@ -92,6 +98,9 @@ const AccountDetailsSection = ( { setModalType, setKeepModalContent } ) => {
 						</Pill>
 					) }
 				</HeaderDetails>
+				{ data.account?.id && (
+					<StripeAccountId>{ data.account.id }</StripeAccountId>
+				) }
 				<AccountSettingsDropdownMenu
 					setModalType={ setModalType }
 					setKeepModalContent={ setKeepModalContent }

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.2.0 - xxxx-xx-xx =
+* Tweak - Improve the display of the Stripe account ID in the settings page.
 * Add - Enable custom styling of the Payment Elements for stores using the updated checkout experience.
 * Fix - Alipay icon not being displayed on the Block checkout page.
 * Fix - Ensure the hold stock setting does not cancel pending stripe orders that are still waiting for customer action (eg confirm 3DS or complete payment redirect).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3065

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR just improves the display of the Stripe account ID on the settings page, using the new official design as a reference. The ID will now be displayed before the dropdown menu and not after the email address.

Preview:
- Desktop
![Screenshot 2024-04-10 at 13 36 18](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/80d1d149-7daf-4248-90a8-078c58d208b4)

- Mobile
![Screenshot 2024-04-10 at 13 50 12](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/27620a88-c4e3-4442-b501-fc4ecd3752d8)

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch on your local environment (`tweak/improve-stripe-account-id-display`)
- Run `npm install` and `npm run build:webpack`
- Start your environment with `npm run up`
- Add your Stripe account keys to the store (live keys)
- Confirm that you can see the new design on the settings page (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
