### PR TITLE
Bump minimum supported versions

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,25 +16,25 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '7.7.0'
+            woocommerce: '7.8.0'
           - woocommerce_support_policy: L-1
-            woocommerce: '7.6.1'
+            woocommerce: '7.7.0'
           - woocommerce_support_policy: L-2
-            woocommerce: '7.5.1'
+            woocommerce: '7.6.1'
           # WordPress
           - wordpress_support_policy: L
-            wordpress: '6.2'
+            wordpress: '6.5'
           - wordpress_support_policy: L-1
-            wordpress: '6.1'
+            wordpress: '6.4'
           - wordpress_support_policy: L-2
-            wordpress: '6.0'
+            wordpress: '6.3'
           # PHP
           - php_support_policy: L
-            php: '8.0'
+            php: '8.1'
           - php_support_policy: L-1
-            php: '7.4'
+            php: '8.0'
           - php_support_policy: L-2
-            php: '7.3'
+            php: '7.4'
 
     name: Stable (PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }})
     env:

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -30,11 +30,11 @@ jobs:
             wordpress: '6.3'
           # PHP
           - php_support_policy: L
-            php: '8.1'
-          - php_support_policy: L-1
             php: '8.0'
-          - php_support_policy: L-2
+          - php_support_policy: L-1
             php: '7.4'
+          - php_support_policy: L-2
+            php: '7.3'
 
     name: Stable (PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }})
     env:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 8.2.0 - xxxx-xx-xx =
+= 8.2.0 - 2024-04-11 =
 * Tweak - Improve the display of the Stripe account ID in the settings page.
 * Add - Enable custom styling of the Payment Elements for stores using the updated checkout experience.
 * Fix - Alipay icon not being displayed on the Block checkout page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Tweak - Remove the functionality for saving the customized statement descriptors.
 * Tweak - Remove unused WC_Stripe_Old_Settings_UPE_Toggle_Controller class and related scripts.
 * Update - Save the Stripe default appearance settings in a transient instead of the browsers local storage.
+* Tweak - Update Link by Stripe branding assets.
 
 = 8.1.1 - 2024-04-04 =
 * Fix - Do not hide PRB on cart and product page when there are required custom checkout fields.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "8.1.1",
+  "version": "8.2.0",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === WooCommerce Stripe Payment Gateway ===
 Contributors: woocommerce, automattic, royho, akeda, mattyza, bor0, woothemes
 Tags: credit card, stripe, apple pay, payment request, google pay, sepa, bancontact, alipay, giropay, ideal, p24, woocommerce, automattic
-Requires at least: 6.1
-Tested up to: 6.4.2
+Requires at least: 6.2
+Tested up to: 6.5.2
 Requires PHP: 7.4
 Stable tag: 8.1.1
 License: GPLv3
@@ -137,5 +137,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Remove the functionality for saving the customized statement descriptors.
 * Tweak - Remove unused WC_Stripe_Old_Settings_UPE_Toggle_Controller class and related scripts.
 * Update - Save the Stripe default appearance settings in a transient instead of the browsers local storage.
+* Tweak - Update Link by Stripe branding assets.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, bancont
 Requires at least: 6.2
 Tested up to: 6.5.2
 Requires PHP: 7.4
-Stable tag: 8.1.1
+Stable tag: 8.2.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe
@@ -128,7 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 8.2.0 - xxxx-xx-xx =
+= 8.2.0 - 2024-04-11 =
 * Tweak - Improve the display of the Stripe account ID in the settings page.
 * Add - Enable custom styling of the Payment Elements for stores using the updated checkout experience.
 * Fix - Alipay icon not being displayed on the Block checkout page.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -7,10 +7,10 @@
  * Author URI: https://woocommerce.com/
  * Version: 8.1.1
  * Requires Plugins: woocommerce
- * Requires at least: 6.1
- * Tested up to: 6.5.0
- * WC requires at least: 8.2
- * WC tested up to: 8.7
+ * Requires at least: 6.2
+ * Tested up to: 6.5.2
+ * WC requires at least: 8.5
+ * WC tested up to: 8.8
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
- * Version: 8.1.1
+ * Version: 8.2.0
  * Requires Plugins: woocommerce
  * Requires at least: 6.2
  * Tested up to: 6.5.2
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_STRIPE_VERSION', '8.1.1' ); // WRCS: DEFINED_VERSION.
+define( 'WC_STRIPE_VERSION', '8.2.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.3.0' );
 define( 'WC_STRIPE_MIN_WC_VER', '7.4' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '7.5' );


### PR DESCRIPTION
This PR bumps the minimum supported versions and updates the GitHub test flows L, L1 and L2 versions; except for PHP, there is an open issue for 8.1+ compatibility https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2411.
And adds a missing changelog entry for the new Stripe Link assets https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2984
