### PR TITLE
Fix potential mandate errors if subscription period includes uppercase

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 8.3.0 - xxxx-xx-xx =
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
+* Fix - Resolved an error that could prevent purchasing subscriptions that have a capital letter in the billing period. eg "Year" instead of "year".
 
 = 8.2.0 - 2024-04-11 =
 * Tweak - Improve the display of the Stripe account ID in the settings page.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -696,7 +696,7 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		if ( 1 === count( $subscriptions ) ) {
 			$mandate_options['amount_type']    = 'fixed';
-			$mandate_options['interval']       = $sub->get_billing_period();
+			$mandate_options['interval']       = strtolower( $sub->get_billing_period() );
 			$mandate_options['interval_count'] = $sub->get_billing_interval();
 		} else {
 			// If there are multiple subscriptions the amount_type becomes 'maximum' so we can charge anything

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -683,16 +683,11 @@ trait WC_Stripe_Subscriptions_Trait {
 		// If the amount is 0 we don't need to create a mandate since we won't be charging anything.
 		// And there won't be any renewal for this free subscription.
 		if ( 0 === $sub_amount ) {
-			return $request;
+			return [];
 		}
 
 		// Get the first subscription associated with this order.
 		$sub = reset( $subscriptions );
-
-		// If the amount zero we just return since mandate is not required and can not be created with zero amount.
-		if ( 0 === $sub_amount ) {
-			return [];
-		}
 
 		if ( 1 === count( $subscriptions ) ) {
 			$mandate_options['amount_type']    = 'fixed';

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 8.3.0 - xxxx-xx-xx =
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
+* Fix - Resolved an error that could prevent purchasing subscriptions that have a capital letter in the billing period. eg "Year" instead of "year".
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3072 

## Changes proposed in this Pull Request:

In an uncommon circumstance, if the subscriptions billing period is somehow set to 'Yearly' (note the capital letter). Stripe may throw an error when attempting to generate the mandate data.

<img width="1093" alt="Screenshot 2024-04-16 at 2 34 11 pm" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/37d360ff-b657-4cc4-949a-19d71a4e4af5">

I suspect that stores which run into this issue may have imported their subscriptions or something because billing periods with capital letters is not standard.

## Testing instructions

Note: Given this requires an uncommon situation, there is some custom code involved to mimic what I believe may have happened.

1. Install and activate Woo Subscriptions. 
2. Conditional. Create a subscription product if you don't already have one.
3. In the admin dashboard create a new subscription (WooCommerce > Subscriptions > Add new) 
4. Add the product and set the customer ID to your current user. 
5. Save
6. From the edit subscription's actions dropdown create a pending **parent** order. 
9. From the edit subscription's actions dropdown create a pending **renewal** order.
11. Using a plugin like WP console. Run the following code snippet to set your subscription to 'Yearly'.
12. Attempt to pay for the subscription renewal order using Stripe.
    - On `develop` you will get the error mentioned above.
    - On this branch the payment should succeed.  


```php
$subscription = wcs_get_subscription( 7163 ); // Replace with the subscription ID you created.
$subscription->set_billing_period( 'Year' ); 
$subscription->save();
```

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
