### PR TITLE
Prevents duplicate stripe meta stored on orders caused by the redirect flow and webhook event being processed at the same time

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.3.0 - xxxx-xx-xx =
+* Fix - Prevent duplicate stripe meta data on orders caused by processing redirect payments and webhooks simultaneously.
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 
 = 8.2.0 - 2024-04-11 =

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -880,7 +880,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
 				// be better if we removed the need for additional meta data in favor of refactoring
 				// this part of the payment processing.
-				if ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) {
+				if ( ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) || wc_string_to_bool( $order->get_meta( WC_Stripe_Helper::PAYMENT_AWAITING_ACTION_META, true ) ) ) {
 					WC_Stripe_Logger::log( "Stripe UPE waiting for redirect. The status for order $order_id might need manual adjustment." );
 					do_action( 'wc_gateway_stripe_process_payment_intent_incomplete', $order );
 					return;

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.3.0 - xxxx-xx-xx =
+* Fix - Prevent duplicate stripe meta data on orders caused by processing redirect payments and webhooks simultaneously.
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3076 
Related: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When processing a UPE payment redirect flow and handling the incoming `payment_intent.succeeded` webhook at the same time, both functions call `process_response` which results in duplicate meta being saved on the order:

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/2275145/7d9b6f65-73b0-4de1-9ee6-bbbaf538981a)

Before Stripe 8.0, the `process_payment()` function used to set `_stripe_upe_waiting_for_redirect` in order meta to signal that the payment of the order will be processed on redirect, and then in the `payment_intent.succeeded` webhook handling, we would return early (avoid calling `process_response()`) if the order had this meta.

With the new deferred intents process payment function, we recently added some new meta to flag orders as "awaiting action" (i.e. 3DS confirmation, or APM redirect), however, we're not using this meta in our webhook handling code which can result in the duplicate meta.

This PR fixes the duplicate meta problem by ensuring we check for the new "awaiting action" meta when processing the `payment_intent.succeeded` webhook, similar to how we used to check for `_stripe_upe_waiting_for_redirect`.

> [!NOTE]
> Now that deferred intents is shipped, we can actually remove all of the previous code that uses `_stripe_upe_waiting_for_redirect`, but I wasn't sure if we wanted to do that in this PR or in a later PR that removes all of the old non-deferred intents related code 🤷 Open to opinions!

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Make sure the New Checkout Experience is enabled
2. Make sure you have webhook event handling is set up to process events sent from Stripe.
3. Purchase a product using a payment method that is handled by the redirect flow (i.e. 3ds card `4000002760003184`)
4. Complete and confirm the payment
5. Confirm the order is processing
6. Copy the new order ID and look in the `wc_orders_meta` table to confirm there's no duplicate meta.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
