### PR TITLE
Fix misalignment on disabled payment methods

### DIFF
--- a/client/settings/general-settings-section/payment-method-checkbox.js
+++ b/client/settings/general-settings-section/payment-method-checkbox.js
@@ -24,7 +24,7 @@ const AlertIcon = styled( Icon )`
 `;
 
 const IconWrapper = styled.span`
-	margin-right: 12px;
+	margin-right: 8px;
 	flex-shrink: 0;
 `;
 


### PR DESCRIPTION
Smallest fix and detail ever, but I couldn't unsee it after I noticed it.

## Changes proposed in this Pull Request:

- Reduce the margin of the disabled icon on the Payment Methods settings page.

| Before | After |
|--------|--------|
| <img width=400 src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/a1f71204-b296-48d3-8577-8e2d28acd27d"> | <img width=400 src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/ea8d0c5a-c7a7-47dd-abbd-02ce7bd74049"> | 

This probably doesn't deserve a changelog entry, but glad to add one if convenient.

## Testing instructions

1. Set Euro as the currency store
2. Go to the Settings page > Payment methods tab, at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
3. Confirm that the icons of disabled payment methods, like OXXO and Boleto, and their titles are vertically aligned with the enabled ones

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)