### PR TITLE
[Affirm] - Dynamically display the available purchasing currency on payment method setting screen

### DIFF
--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -51,12 +51,14 @@ export default {
 	affirm: {
 		id: 'affirm',
 		label: __( 'Affirm', 'woocommerce-gateway-stripe' ),
+		// translators: %s is the store currency.
 		description: __(
-			'Allow customers to pay over time with Affirm.',
+			'Allow customers to pay over time with Affirm. Available to all customers paying in %s.',
 			'woocommerce-gateway-stripe'
 		),
 		Icon: icons.affirm,
 		currencies: [ 'USD', 'CAD' ],
+		acceptsDomesticPaymentsOnly: true,
 	},
 	sepa_debit: {
 		id: 'sepa_debit',

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -175,7 +175,7 @@ const getFormattedPaymentMethodDescription = (
 	];
 
 	if ( acceptsDomesticPaymentsOnly ) {
-		return sprintf( description, accountDefaultCurrency.toUpperCase() );
+		return sprintf( description, accountDefaultCurrency?.toUpperCase() );
 	}
 
 	return description;

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import React, { useContext, useState } from 'react';
 import styled from '@emotion/styled';
 import classnames from 'classnames';
@@ -160,6 +160,27 @@ const StyledFees = styled( PaymentMethodFeesPill )`
 	flex: 1 0 auto;
 `;
 
+/**
+ * Formats the payment method description with the account default currency.
+ *
+ * @param {*} method Payment method ID.
+ * @param {*} accountDefaultCurrency Account default currency.
+ */
+const getFormattedPaymentMethodDescription = (
+	method,
+	accountDefaultCurrency
+) => {
+	const { description, acceptsDomesticPaymentsOnly } = PaymentMethodsMap[
+		method
+	];
+
+	if ( acceptsDomesticPaymentsOnly ) {
+		return sprintf( description, accountDefaultCurrency.toUpperCase() );
+	}
+
+	return description;
+};
+
 const GeneralSettingsSection = ( {
 	isChangingDisplayOrder,
 	onSaveChanges,
@@ -233,7 +254,6 @@ const GeneralSettingsSection = ( {
 				const {
 					Icon,
 					label,
-					description,
 					allows_manual_capture: isAllowingManualCapture,
 				} = PaymentMethodsMap[ method ];
 
@@ -256,7 +276,10 @@ const GeneralSettingsSection = ( {
 						<PaymentMethodWrapper>
 							<PaymentMethodDescription
 								Icon={ Icon }
-								description={ description }
+								description={ getFormattedPaymentMethodDescription(
+									method,
+									data.account?.default_currency
+								) }
 								label={ label }
 							/>
 							<StyledFees id={ method } />
@@ -272,7 +295,6 @@ const GeneralSettingsSection = ( {
 				const {
 					Icon,
 					label,
-					description,
 					allows_manual_capture: isAllowingManualCapture,
 				} = PaymentMethodsMap[ method ];
 				const paymentMethodCurrencies =
@@ -309,7 +331,10 @@ const GeneralSettingsSection = ( {
 							<PaymentMethodWrapper>
 								<PaymentMethodDescription
 									Icon={ Icon }
-									description={ description }
+									description={ getFormattedPaymentMethodDescription(
+										method,
+										data.account?.default_currency
+									) }
 									label={ label }
 								/>
 								<StyledFees id={ method } />

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php
@@ -50,4 +50,15 @@ class WC_Stripe_UPE_Payment_Method_Affirm extends WC_Stripe_UPE_Payment_Method {
 	public function requires_automatic_capture() {
 		return false;
 	}
+
+	/**
+	 * Returns whether the payment method is available for the Stripe account's country.
+	 *
+	 * Affirm is only available domestic transactions in the United States or Canada.
+	 *
+	 * @return bool True if the payment method is available for the account's country, false otherwise.
+	 */
+	public function is_available_for_account_country() {
+		return in_array( WC_Stripe::get_instance()->account->get_account_country(), $this->supported_countries, true );
+	}
 }

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -255,7 +255,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					WC_Stripe_UPE_Payment_Method_Alipay::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Giropay::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Klarna::STRIPE_ID,
-					WC_Stripe_UPE_Payment_Method_Affirm::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Eps::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Boleto::STRIPE_ID,


### PR DESCRIPTION
Fixes #3101

> [!note]
> This is based on the PR which introduces Affirm. It should be merged first otherwise this PR will be merged into that PR. 

## Changes proposed in this Pull Request:

Affirm (and other payment methods that might come later) require that the customer purchase in a specific currency based on the merchant's base location. eg Affirm is a domestic payment method only and so customers can only use Affirm if they are in the merchant's base country. This is on top of the prerequisite that the merchant has a presentment currency of USD or CAD. 

In order to make this distinction clear we need to dynamically change the currency mentioned in Affirm's description.

This PR does that. It also ensures that Affirm is only available to merchants with a US or CA base location. ie it's not available to merchants outside of those locations. 

## Testing instructions

### Availability

1. Go to the Stripe settings page. (**WooCommerce > Settings > Payments > Stripe**).
2. Change your Account API keys to an account based **outside** the US or Canada. 
    - eg AU, EU etc. 
3. Go to the payment methods tab.
    - On `develop`/`add/affirm-payment-method` you'll notice that Affirm is listed. 
    - On this branch it shouldn't be listed
5. Change your store currency to USD or CAD. 
6. On `develop`/`add/affirm-payment-method` you'll notice that Affirm is now able to be enabled.
    - If you enable Affirm, it will never actually be available on the checkout because of checkout run time validation. 
7. Change you Account API keys to an account based in the US or Canada.
3. Go to the payment methods tab.
4. On this branch Affirm should be shown listed. 

| AU Based Account | Header |
|--------|--------|
| <p align="center"><img width="689" alt="Screenshot 2024-04-30 at 2 50 35 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/a0e5debe-6d64-49c1-8ece-0fe3e1e91fa3"></br><sup>No Affirm because account isn't eligible</sup></p> | <p align="center"><img width="679" alt="Screenshot 2024-04-30 at 3 01 27 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c05f0e8b-cfb3-4165-a2c9-e18d664fbb74"></br><sup>Affirm is shown because account eligible (US based)</sup></p> | 



### Dynamic Currency Description

1. Make sure you have Account API keys set to an account based in the US.
2. Go to the Payment methods tab and notice that the Affirm description includes USD as the required currency based on you Stripe account. 
3. Switch to a Canada based account. 
4. Go back to the Payment methods tab and notice that the Affirm description includes CAD as the required currency. 


| CAD | USD |
|--------|--------|
| <img width="600" alt="Screenshot 2024-04-30 at 2 58 27 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/b4ede09d-7708-4f93-899a-ff9a4256215f">| <img width="600" alt="Screenshot 2024-04-30 at 2 57 53 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/c9b4d9cb-1803-4e00-b96d-2d89842465ac"> | 



---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply). 
     - Does not apply
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
