### PR TITLE
Add WC Order Attribution data when processing Express Payment button requests

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -141,6 +141,9 @@ jQuery( function( $ ) {
 
 			data = wc_stripe_payment_request.getRequiredFieldDataFromCheckoutForm( data );
 
+			// Add order attribution data if it's available.
+			data = wc_stripe_payment_request.getOrderAttributionData( data );
+
 			return data;
 		},
 
@@ -163,7 +166,7 @@ jQuery( function( $ ) {
 						if ( ! data[ name ] ) {
 							data[ name ] = value;
 						}
-	
+
 						// if shipping same as billing is selected, copy the billing field to shipping field.
 						const shipToDiffAddress = $( '#ship-to-different-address' ).find( 'input' ).is( ':checked' );
 						if ( ! shipToDiffAddress ) {
@@ -175,6 +178,31 @@ jQuery( function( $ ) {
 					}
 				});
 			}
+
+			return data;
+		},
+
+		/**
+		 * Adds order attribution data, if it's available to the order data for submission.
+		 *
+		 * @param {Object} data Order data.
+		 * @return {Object}
+		 */
+		getOrderAttributionData: function( data ) {
+			var orderAttributionData = $( '#wc-stripe-payment-request-wrapper wc-order-attribution-inputs' );
+
+			if ( ! orderAttributionData.length ) {
+				return data;
+			}
+
+			orderAttributionData.find( 'input' ).each( function() {
+				var name = $( this ).attr( 'name' );
+				var value = $( this ).val();
+
+				if ( name && value ) {
+					data[ name ] = value;
+				}
+			} );
 
 			return data;
 		},

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Prevent orders that require manual review in Stripe being marked as processing in WooCommerce before approval.
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 * Fix - Resolved an error that could prevent purchasing subscriptions that have a capital letter in the billing period. eg "Year" instead of "year".
+* Fix - Ensure Order Attribution data is correctly set when processing a payment with an Express Payment button. eg Apple Pay or Google Pay.
 
 = 8.2.0 - 2024-04-11 =
 * Tweak - Improve the display of the Stripe account ID in the settings page.

--- a/client/api/blocks.js
+++ b/client/api/blocks.js
@@ -68,6 +68,7 @@ export const updateShippingDetails = ( shippingOption ) => {
 export const createOrder = ( sourceEvent, paymentRequestType ) => {
 	let data = normalizeOrderData( sourceEvent, paymentRequestType );
 	data = getRequiredFieldDataFromCheckoutForm( data );
+	data = getOrderAttributionData( data );
 
 	return $.ajax( {
 		type: 'POST',
@@ -106,6 +107,31 @@ const getRequiredFieldDataFromCheckoutForm = ( data ) => {
 			}
 		} );
 	}
+
+	return data;
+};
+
+/**
+ *
+ * @param {*} data
+ */
+const getOrderAttributionData = ( data ) => {
+	const orderAttributionData = document.querySelector(
+		'#wc-stripe-payment-request-wrapper wc-order-attribution-inputs'
+	);
+
+	if ( ! orderAttributionData.length ) {
+		return data;
+	}
+
+	orderAttributionData.find( 'input' ).forEach( ( field ) => {
+		const name = field.name;
+		const value = field.value;
+
+		if ( name && value ) {
+			data[ name ] = value;
+		}
+	} );
 
 	return data;
 };

--- a/client/blocks/payment-request/payment-request-express.js
+++ b/client/blocks/payment-request/payment-request-express.js
@@ -147,6 +147,7 @@ const PaymentRequestExpressComponent = ( {
 				'woocommerce-gateway-stripe'
 			) }
 		>
+			<wc-order-attribution-inputs />
 			<PaymentRequestButtonElement
 				onClick={ onPaymentRequestButtonClick }
 				options={ {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -892,7 +892,6 @@ class WC_Stripe_Payment_Request {
 			<!-- Add an order attribution container for WC core to populate. -->
 			<wc-order-attribution-inputs></wc-order-attribution-inputs>
 		</div>
-
 		<?php
 		$this->display_payment_request_button_separator_html();
 	}

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -889,7 +889,10 @@ class WC_Stripe_Payment_Request {
 				?>
 				<!-- A Stripe Element will be inserted here. -->
 			</div>
+			<!-- Add an order attribution container for WC core to populate. -->
+			<wc-order-attribution-inputs></wc-order-attribution-inputs>
 		</div>
+
 		<?php
 		$this->display_payment_request_button_separator_html();
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Prevent orders that require manual review in Stripe being marked as processing in WooCommerce before approval.
 * Tweak - Improve performance with handling redirect payments by not constructing every payment gateways on each page load.
 * Fix - Resolved an error that could prevent purchasing subscriptions that have a capital letter in the billing period. eg "Year" instead of "year".
+* Fix - Ensure Order Attribution data is correctly set when processing a payment with an Express Payment button. eg Apple Pay or Google Pay.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3022

## Changes proposed in this Pull Request:

When a store has Order Attribution data enabled, payments via express payment buttons (Apple Pay, Google Pay etc) were missing this order attribution data. 

This PR fixes that by:

1. Including a `<wc-order-attribution-inputs></wc-order-attribution-inputs>` element where ever we include the express payment button. 
    - This element will be automatically populated by WC core with the attribution data so we can stay at an arms length from the implementation layer. 
2. When we submit the AJAX request to process the express payment button, we submit whatever input elements were populated.
    - WC core will then pull the required fields out of the request and handle the attribution.
   
## Testing instructions

1. Enable Order attribution in **WooCommerce → Settings → Advanced → Features**

<p align="center">
<img width="500" alt="Screenshot 2024-05-01 at 10 53 20 AM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/1d65cc81-5a72-4700-94e1-386a0b798409">
</p>

2. Set up Stripe and enable Express Payment buttons. ⚠️ Remember you may need to add your domain to your stripe settings. See this doc: https://woocommerce.com/document/stripe/setup-and-configuration/express-checkouts/#apple-pay-requirements
3. Purchase a product using Google Pay or Apple Pay. 
4. View the order in your admin dashboard and notice that there is no order attribution data.

| <img width="312" alt="Screenshot 2024-05-01 at 10 58 00 AM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/323d381e-c2f8-4ab4-a6b3-03f0416fca70"> | <img width="893" alt="Screenshot 2024-05-01 at 10 58 27 AM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/9c97073f-b45f-442e-90e6-d0820c805428"> |
|--------|--------|

5. Checkout this branch (`fix/3022-order-attribution-express-buttons`).
6. Purchase a product using Apple Pay or Google Pay again. 
6. View the order in the dashboard. This time it should have attribution data.

| <img width="297" alt="Screenshot 2024-05-01 at 11 03 54 AM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/e00066b2-4578-441d-8199-f7703101d95e"> | <img width="894" alt="Screenshot 2024-05-01 at 11 03 28 AM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/71bd2e5a-aa87-4be8-8422-109ff1eb0c05"> |
|--------|--------|




---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
