### PR TITLE
[BNPL] Don't validate currency limit in non-checkout contexts

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -605,8 +605,14 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 */
 	public function is_inside_currency_limits( $current_store_currency ): bool {
 		// Pay for order page will check for the current order total instead of the cart's.
-		$order_amount        = $this->get_current_order_amount();
-		$amount              = WC_Stripe_Helper::get_stripe_amount( $order_amount, strtolower( $current_store_currency ) );
+		$order_amount = $this->get_current_order_amount();
+		$amount       = WC_Stripe_Helper::get_stripe_amount( $order_amount, strtolower( $current_store_currency ) );
+
+		// Don't engage in limits verification in non-checkout context (cart is not available or empty).
+		if ( $amount <= 0 ) {
+			return true;
+		}
+
 		$account_country     = WC_Stripe::get_instance()->account->get_account_country();
 		$range               = null;
 		$limits_per_currency = $this->get_limits_per_currency();

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -106,6 +106,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
+		delete_option( 'woocommerce_stripe_settings' );
 		$this->reset_payment_method_mocks();
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

For BNPL, skip checking the currency limit when the order total is zero.

Afterpay isn't being displayed on the Block checkout due to this check.


## Testing instructions

1. Enable all the BNPLs: Affirm, Klarna, Afterpay
2. Confirm that all of them are displayed on both the block and shortcode checkout when the order total is within the currency limit
3. Confirm that **none** of them are displayed on both the block and shortcode checkout when the order total is zero
 Wrong original instruction - ~Confirm that all of them are displayed on both the block and shortcode checkout when the order total is zero~
4. Confirm that none of them are displayed in either the block or shortcode checkout when the order total is not within the currency limit

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
