### PR TITLE
Hide BNPLs on the checkout pages when capture later is enabled.

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php
@@ -43,15 +43,6 @@ class WC_Stripe_UPE_Payment_Method_Affirm extends WC_Stripe_UPE_Payment_Method {
 	}
 
 	/**
-	 * Returns whether the payment method requires automatic capture.
-	 *
-	 * @inheritDoc
-	 */
-	public function requires_automatic_capture() {
-		return false;
-	}
-
-	/**
 	 * Returns whether the payment method is available for the Stripe account's country.
 	 *
 	 * Affirm is only available domestic transactions in the United States or Canada.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -246,8 +246,8 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		}
 
 		// This part ensures that when payment limits for the currency declared, those will be respected (e.g. BNPLs).
-		if ( [] !== $this->get_limits_per_currency() ) {
-			return $this->is_inside_currency_limits( $current_store_currency );
+		if ( [] !== $this->get_limits_per_currency() && ! $this->is_inside_currency_limits( $current_store_currency ) ) {
+			return false;
 		}
 
 		// If cart or order contains subscription, enable payment method if it's reusable.


### PR DESCRIPTION
Fixes #3121

## Changes proposed in this Pull Request:

- Flag Affirm as not compatible with capture later.
- Continue with the checks for `is_enabled_at_checkout()` when the currency limit check passes instead of returning early.

## Testing instructions

Regression test - Confirm BNPLs continue to be displayed
1. Ensure your store currency is USD
At `wp-admin/admin.php?page=wc-settings&tab=general`
2. Connect your store with a Stripe account from the US
At `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
3. Enable Affirm, Afterpay, and Klarna under the Payment Methods tab
At `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
4. As a shopper, add a product to the cart. Ensure the order total is over 50 USD
5. Go to both the block and shortcode checkout pages
6. Confirm Affirm, Afterpay, and Klarna are displayed as available payment methods.

Confirm the BNPL payment methods aren't displayed when Capture later is enabled
1. Enable "Issue an authorization on checkout, and capture later"
At `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
2. Go to both the block and shortcode checkout pages
3. Confirm that neither Affirm, Afterpay, or Klarna is displayed

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
