### PR TITLE
Exclude voucher payments from the check that prevent webhook processing of payments which require further action

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -899,11 +899,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 				WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
 
-				// TODO: This is a stop-gap to fix a critical issue, see
-				// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
-				// be better if we removed the need for additional meta data in favor of refactoring
-				// this part of the payment processing.
-				if ( ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) || wc_string_to_bool( $order->get_meta( WC_Stripe_Helper::PAYMENT_AWAITING_ACTION_META, true ) ) ) {
+				/**
+				 * Check if the order is awaiting further action from the customer. If so, do not process the payment via the webhook, let the redirect handle it.
+				 *
+				 * This is a stop-gap to fix a critical issue, see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
+				 * be better if we removed the need for additional meta data in favor of refactoring this part of the payment processing.
+				 */
+				$is_awaiting_action = ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) || wc_string_to_bool( $order->get_meta( WC_Stripe_Helper::PAYMENT_AWAITING_ACTION_META, true ) );
+
+				// Voucher payments are only processed via the webhook so are excluded from the above check.
+				if ( ! $is_voucher_payment && $is_awaiting_action ) {
 					WC_Stripe_Logger::log( "Stripe UPE waiting for redirect. The status for order $order_id might need manual adjustment." );
 					do_action( 'wc_gateway_stripe_process_payment_intent_incomplete', $order );
 					return;


### PR DESCRIPTION
Fixes #3125 

## Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3078, we prevented double processing of payments that could occur if the UPE redirect processed the payment right as the webhook was received. 

This PR prevented the webhook from processing the payment so long as the payment required further action (eg logging into your bank in the case of payment methods like iDEAL or bancontact etc) and we'd process the payment once the customer arrived back on the store. 

This inadvertently affected voucher payment methods because: 

1. They require "further action" from the customer (taking the voucher to a participating convenience store), however,
2. They are only processed via a webhook, there's no eventual redirect. 

This PR fixes the issue of Voucher methods not processing the payment by excluding it from the logic that prevents `further_action` payments from webhook processing.  

## Testing instructions

1. Create a Stripe account located in Mexico.
2. Set up webhooks following this guide: [**WooCommerce Stripe** - Setting up webhooks](https://woocommerce.com/document/stripe/setup-and-configuration/stripe-webhooks/)
3. Set the API credentials and webhook in the plugin settings.
4. Set the store currency to MXN.
5. Enable Oxxo.
6. Complete a purchase using Oxxo.
   - You will need to use an address in Mexico. 
8. Wait the 3 minutes Stripe takes to process the test payment.
9. Confirm the order in Stripe is Complete.
10. Review the order in WC:
   - On `develop` the order will still be on-hold.
   - On this branch the payment should be complete. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply).
    - No changelog neeeded, this isn't broken in the public release (8.2)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
