### PR TITLE
Fix subscriptions renewals after disabling Legacy when using SEPA

### DIFF
--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -70,6 +70,8 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		self::$has_attached_integration_hooks = true;
 
+		add_filter( 'woocommerce_subscription_get_payment_method', [ $this, 'use_sepa_updated_checkout_gateway_id_for_subscriptions' ] );
+
 		add_action( 'woocommerce_subscriptions_change_payment_before_submit', [ $this, 'differentiate_change_payment_method_form' ] );
 		add_action( 'wcs_resubscribe_order_created', [ $this, 'delete_resubscribe_meta' ], 10 );
 		add_action( 'wcs_renewal_order_created', [ $this, 'delete_renewal_meta' ], 10 );
@@ -895,6 +897,22 @@ trait WC_Stripe_Subscriptions_Trait {
 		);
 
 		exit;
+	}
+
+	/**
+	 * Filters the return value of 'WC_Subscription::get_payment_method()'.
+	 *
+	 * Returns 'stripe_sepa_debit' if UPE is enabled and the gateway is 'stripe_sepa'.
+	 *
+	 * @param string $value The payment method ID.
+	 * @return string
+	 */
+	public function use_sepa_updated_checkout_gateway_id_for_subscriptions( $value ) {
+		if ( 'stripe_sepa' === $value && WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			return 'stripe_sepa_debit';
+		}
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
We have two different payment gateway IDs for SEPA depending on whether we use the Legacy experience:
- `stripe_sepa`, when the Legacy experience is enabled (Sources API)
- `stripe_sepa_debit` when the Legacy experience is disabled (Payment Methods API)

When purchasing a subscription using the Sources API, we set `stripe_sepa` as its associated payment method gateway.
 
<img width="400" alt="image" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/41606954/04520b0a-8428-47d0-947f-7dbc5c80b3b1">

Because we use a different payment gateway ID when switching to the Payment Methods API, WooCommerce detects the `stripe_sepa` payment gateway as no longer available. This causes the Subscription to change to Manual renewal, and automatic renewals to fail.

With this PR, we're simply returning the updated name for the SEPA gateway for subscriptions when using the Payment Methods API.

- This filter is applied by WooCommerce core at [WC_Data::get_prop()](https://github.com/woocommerce/woocommerce/blob/8.8.3/plugins/woocommerce/includes/abstracts/abstract-wc-data.php#L884)
- Because of the [webhook prefix](https://github.com/woocommerce/woocommerce/blob/8.8.3/plugins/woocommerce/includes/abstracts/abstract-wc-data.php#L863), this filter only runs for WC_Data instances with the `subscription` [object_type](https://github.com/Automattic/woocommerce-subscriptions-core/blob/7.0.0/includes/class-wc-subscription.php#L33-L38)

This property is used to define manual renewals through this flow
>WC_Subscription::is_manual()
>WC_Subscriptions_Payment_Gateways::has_available_payment_method()
>wc_get_payment_gateway_by_order() 
>WC_Order::get_payment_method()
>WC_Data::get_prop()

An alternative and probably more robust approach would be to update the DB to use the correct payment gateway ID. Diving into that other approach separately.

Fixes #

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

- Check out 8.0.1. There's an error in later versions where SEPA payment methods can't be saved on the Legacy experience
- Enable the Legacy experience
- As a shopper, add a subscription to your cart
- Use a SEPA src_ payment method to purchase the subscription. Like `AT611904300234573201`
- Check out the latest version
- As a shopper, go to My account > Subscriptions. Notice that "SEPA" is listed as the payment method
- As a merchant, go to the Edit order page for the subscription. Notice:
    - Under payment method, it says "SEPA"
    - "Process renewal" works fine
- Disable the legacy experience
- As the shopper, go to My account > Subscriptions. Confirm that "SEPA" continues to be the payment method for this subscription. In `develop`, it'd be "Manual renewal" at this point
- As a merchant, go to the Edit order page for the subscription. Confirm that:
    - Under payment method, it says continues to be "SEPA". In `develop`, it'd say "Manual renewal"
    - "Process renewal" works fine. In `develop`, renewal fails

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
