### PR TITLE
Add check for array in reorder function

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -656,6 +656,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * @return WC_Payment_Gateway[] The same list of gateways, but with the Stripe methods in the right order.
 	 */
 	public function reorder_available_payment_gateways( $gateways ) {
+		if ( ! is_array( $gateways ) ) {
+			return $gateways;
+		}
+
 		$ordered_available_stripe_methods = [];
 
 		// Keep a record of where Stripe was found in the $gateways array so we can insert the Stripe methods in the right place.


### PR DESCRIPTION
Fixes #3057 

We got a few reports about a fatal error in the `reorder_available_payment_gateways` function.

```
PHP Fatal error: Uncaught TypeError: array_keys(): Argument #1 ($array) must be of type array, null given in /www/xxxxxxx/public/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-gateway-stripe.php:661
```

## Changes proposed in this Pull Request:
I could not reproduce it locally. I have added a harmless safety check to bail early if the parameter is not an array.

## Testing instructions
- Set store currency to Euro.
- Enable the legacy checkout experience.
- Enable card and a few more payment methods from the Stripe settings page.
- Reorder some of the payment methods.
- As a shopper, add a product to your cart and go to the checkout page.
- The enabled payment methods should appear in their saved order.