### PR TITLE
Fix fatal error when subscription classes are unavailable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Fixed fatal errors with subscription helper methods when subscriptions classes (from WooCommerce Subscriptions) are not available.
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.
 * Fix - Hiding BNPL payment methods when the Stripe account country is not supported.
 * Fix - Resolved checkout error with UPE when using test mode customer in live mode or vice versa.

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -19,7 +19,7 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	 * @return bool Whether subscriptions is enabled or not.
 	 */
 	public function is_subscriptions_enabled() {
-		return class_exists( 'WC_Subscriptions' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' );
+		return class_exists( 'WC_Subscriptions' ) && class_exists( 'WC_Subscription' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' );
 	}
 
 	/**
@@ -79,7 +79,7 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	 * @return bool Indicates whether the save payment method checkbox should be displayed or not.
 	 */
 	public function display_save_payment_method_checkbox( $display ) {
-		if ( ! $this->is_subscriptions_enabled() || WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
+		if ( WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
 			return false;
 		}
 		// Only render the "Save payment method" checkbox if there are no subscription products in the cart.

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -79,7 +79,7 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	 * @return bool Indicates whether the save payment method checkbox should be displayed or not.
 	 */
 	public function display_save_payment_method_checkbox( $display ) {
-		if ( class_exists( 'WC_Subscriptions_Cart' ) || WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
+		if ( ! $this->is_subscriptions_enabled() || WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
 			return false;
 		}
 		// Only render the "Save payment method" checkbox if there are no subscription products in the cart.

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -79,7 +79,7 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	 * @return bool Indicates whether the save payment method checkbox should be displayed or not.
 	 */
 	public function display_save_payment_method_checkbox( $display ) {
-		if ( WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
+		if ( class_exists( 'WC_Subscriptions_Cart' ) || WC_Subscriptions_Cart::cart_contains_subscription() || $this->is_changing_payment_method_for_subscription() ) {
 			return false;
 		}
 		// Only render the "Save payment method" checkbox if there are no subscription products in the cart.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Fixed fatal errors with subscription helper methods when subscriptions classes (from WooCommerce Subscriptions) are not available.
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.
 * Fix - Hiding BNPL payment methods when the Stripe account country is not supported.
 * Fix - Resolved checkout error with UPE when using test mode customer in live mode or vice versa.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR fixes an issue when using an old version of WooCommerce that does not support subscriptions (or when some classes are missing for some reason). The `display_save_payment_method_checkbox` function was not checking for the existence of the subscription-related classes before calling `WC_Subscriptions_Cart::cart_contains_subscription()`, causing the error:
```
2023-04-03T01:25:03+00:00 CRITICAL Uncaught Error: Class "WC_Subscriptions_Cart" not found in wp-content/plugins/woocommerce-gateway-stripe/includes/compat/trait-wc-stripe-subscriptions-utilities.php:82
Stack trace:
#0 wp-includes/class-wp-hook.php(308): WC_Stripe_Payment_Gateway->display_save_payment_method_checkbox(true)
#1 wp-includes/plugin.php(205): WP_Hook->apply_filters(true, Array)
#2 wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-gateway-stripe.php(236): apply_filters('wc_stripe_displ...', true)
#3 wp-content/plugins/woocommerce-latest/templates/checkout/payment-method.php(30): WC_Gateway_Stripe->payment_fields()
```

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch on your local environment (`fix/fatal-error-when-subscription-classes-unavailable`)
- Run `npm install`, `npm run build:webpack`, `npm run up`
- Install the WooCommerce Subscriptions extension
- Edit the `woocommerce-subscriptions.php` file putting an `exit` before the class declaration
- Add a Subscription Product to the cart
- Visit the checkout page
- Confirm that you don't see any fatal errors onscreen anymore (on `develop`, it would cause the error above)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
