### PR TITLE
Remove WC_Account parameter from the constructor of WC_Stripe_UPE_Payment_Gateway

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 8.3.1 - xxxx-xx-xx =
+* Fix - Error on some enviroments due to the parameter in the WC_Stripe_UPE_Payment_Gateway constructor method.
+
 = 8.3.0 - 2024-05-23 =
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.
 * Add - Include Afterpay (Clearpay in the UK) as a payment method for stores using the updated checkout experience.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -123,13 +123,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public $action_scheduler_service;
 
 	/**
-	 * WC_Stripe_Account instance.
-	 *
-	 * @var WC_Stripe_Account
-	 */
-	private $account;
-
-	/**
 	 * Array mapping payment method string IDs to classes
 	 *
 	 * @var WC_Stripe_UPE_Payment_Method[]
@@ -139,8 +132,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Constructor
 	 */
-	public function __construct( WC_Stripe_Account $account ) {
-		$this->account      = $account;
+	public function __construct() {
 		$this->id           = self::ID;
 		$this->method_title = __( 'Stripe', 'woocommerce-gateway-stripe' );
 		/* translators: link */
@@ -389,7 +381,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['addPaymentReturnURL']              = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']             = $enabled_billing_fields;
 		$stripe_params['cartContainsSubscription']         = $this->is_subscription_item_in_cart();
-		$stripe_params['accountCountry']                   = $this->account->get_account_country();
+		$stripe_params['accountCountry']                   = WC_Stripe::get_instance()->account->get_account_country();
 
 		// Add appearance settings.
 		$stripe_params['appearance']          = get_transient( $this->get_appearance_transient_key() );
@@ -489,7 +481,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public function get_upe_enabled_at_checkout_payment_method_ids( $order_id = null ) {
 		$is_automatic_capture_enabled = $this->is_automatic_capture_enabled();
 		$available_method_ids         = [];
-		$account_domestic_currency    = $this->account->get_account_default_currency();
+		$account_domestic_currency    = WC_Stripe::get_instance()->account->get_account_default_currency();
 		foreach ( $this->get_upe_enabled_payment_method_ids() as $payment_method_id ) {
 			if ( ! isset( $this->payment_methods[ $payment_method_id ] ) ) {
 				continue;
@@ -1526,7 +1518,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return false;
 		}
 
-		$account_domestic_currency = $this->account->get_account_default_currency();
+		$account_domestic_currency = WC_Stripe::get_instance()->account->get_account_default_currency();
 
 		return $this->payment_methods[ $payment_method_id ]->is_enabled_at_checkout( null, $account_domestic_currency );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -128,19 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 8.3.0 - 2024-05-23 =
-* Add - Include Afterpay (Clearpay in the UK) as a payment method for stores using the updated checkout experience.
-* Add - Include Affirm as a payment method for stores using the updated checkout experience.
-* Add - Include Klarna as a payment method for stores using the updated checkout experience.
-* Add - Additional information is displayed on the "Payment methods" page when listing co-branded credit cards.
-* Fix - Resolved an error that could prevent purchasing subscriptions that have a capital letter in the billing period. eg "Year" instead of "year".
-* Fix - The preferred card brand is used when paying with a co-branded credit card.
-* Fix - Prevent duplicate stripe meta data on orders caused by processing redirect payments and webhooks simultaneously.
-* Fix - Processing a refund of a non-card payments (i.e. iDeal, giropay) through the Stripe dashboard was not showing as refunded in WooCommerce for stores with UPE enabled.
-* Fix - Prevent orders that require manual review in Stripe being marked as processing in WooCommerce before approval.
-* Tweak - Credit card brand selection disabled when the "Legacy checkout experience" is enabled.
-* Tweak - Improve performance with handling redirect payments by not constructing every payment gateway on each page load.
-* Tweak - Adds the tracking of a selected card brand when paying using co-branded credit cards.
-* Tweak - Improve the order note message recorded when a subscription-renewal order payment fails.
+= 8.3.1 - xxxx-xx-xx =
+* Fix - Error on some enviroments due to the parameter in the WC_Stripe_UPE_Payment_Gateway constructor method.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1989,7 +1989,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
-		$this->assertEquals( 'visa', $final_order->get_meta( '_stripe_card_brand', true ) );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -577,7 +577,7 @@ function woocommerce_gateway_stripe() {
 			}
 
 			protected function disable_upe( $settings ) {
-				$upe_gateway            = new WC_Stripe_UPE_Payment_Gateway( $this->account );
+				$upe_gateway            = new WC_Stripe_UPE_Payment_Gateway();
 				$upe_enabled_method_ids = $upe_gateway->get_upe_enabled_payment_method_ids();
 				foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $method_class ) {
 					if ( ! defined( "$method_class::LPM_GATEWAY_CLASS" ) || ! in_array( $method_class::STRIPE_ID, $upe_enabled_method_ids, true ) ) {
@@ -687,7 +687,7 @@ function woocommerce_gateway_stripe() {
 				}
 
 				if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-					$this->stripe_gateway = new WC_Stripe_UPE_Payment_Gateway( $this->account );
+					$this->stripe_gateway = new WC_Stripe_UPE_Payment_Gateway();
 
 					return $this->stripe_gateway;
 				}


### PR DESCRIPTION
Fixes #3151

Gateways are initiated by WooCommerce without providing any arguments for them, thus triggering the reported error. [Ref](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/class-wc-payment-gateways.php#L103)

This error isn't triggered on my tests for some reason, but it makes sense following the stack trace from WooCommerce. Looks like it happens when other extensions call `WooCommerce->payment_gateways()`.

## Changes proposed in this Pull Request:

- Remove the argument for the WC_Stripe_UPE_Payment_Argument, which was introduced in [this PR](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3040) shipped in 8.3.0, the last release.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

I haven't been able to replicate the described issue. The following steps are for testing regressions:

1. Enable BNPLs: Klarna, Affirm, and Afterpay
2. Confirm the following flows work as expected:
   - [Is unavailable on checkout based on the store currency and the account country's default currency](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/v8.3.0-%E2%80%90-Release-testing-instructions#is-unavailable-on-checkout-based-on-the-store-currency-and-the-account-countrys-default-currency)
   - [Is unavailable on checkout based on the customer's billing country](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/v8.3.0-%E2%80%90-Release-testing-instructions#is-unavailable-on-checkout-based-on-the-customers-billing-country)
3. Test enabling and disabling the Legacy checkout experience works properly


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
