### PR TITLE
Removing duplicated customization notices

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Remove the duplicated customization notice in the settings screen.
 * Add - Include Cash App as a payment method for stores using the updated checkout experience.
 * Fix - Fixed fatal errors with subscription helper methods when subscriptions classes (from WooCommerce Subscriptions) are not available.
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -111,7 +111,6 @@ const PaymentSettingsPanel = () => {
 							/>
 						</LoadableAccountSection>
 					</LoadableSettingsSection>
-					<CustomizationOptionsNotice />
 				</SettingsSection>
 			) }
 			<SettingsSection Description={ GeneralSettingsDescription }>

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Remove the duplicated customization notice in the settings screen.
 * Add - Include Cash App as a payment method for stores using the updated checkout experience.
 * Fix - Fixed fatal errors with subscription helper methods when subscriptions classes (from WooCommerce Subscriptions) are not available.
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3160

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Since the [Stripe promotional banner was merged](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3050), the customization notice related to the new checkout experience is displayed twice:
![Screenshot 2024-05-28 at 3 54 27 PM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/cb295261-5413-4f8a-8fcf-a02e330b8d11)

This PR just removes the duplicated notice.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch on your local environment (`fix/double-customization-notices`)
- Run `npm install`, `npm run build:webpack` and `npm run up`
- Access the payment settings page: `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
- Confirm that you can see only one notice 
<img width="1106" alt="Screenshot 2024-05-28 at 13 13 18" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/f20df07d-873b-4674-9234-0607f89c4b73">


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
