### PR TITLE
Fix failing co-branded card PHP Unit test

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -810,19 +810,6 @@ class WC_Stripe_Intent_Controller {
 
 		$request = $this->build_base_payment_intent_request_params( $payment_information );
 
-		// Retrieve the payment method object from Stripe.
-		$payment_method = WC_Stripe_API::get_payment_method( $payment_information['payment_method'] );
-
-		// Add the updated preferred credit card brand when defined
-		$preferred_brand = $payment_method->card->networks->preferred ?? null;
-		if ( isset( $preferred_brand ) ) {
-			$request['payment_method_options'] = [
-				'card' => [
-					'brand' => $preferred_brand,
-				],
-			];
-		}
-
 		$order = $payment_information['order'];
 
 		// Run the necessary filter to make sure mandate information is added when it's required.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -810,8 +810,11 @@ class WC_Stripe_Intent_Controller {
 
 		$request = $this->build_base_payment_intent_request_params( $payment_information );
 
+		// Retrieve the payment method object from Stripe.
+		$payment_method = WC_Stripe_API::get_payment_method( $payment_information['payment_method'] );
+
 		// Add the updated preferred credit card brand when defined
-		$preferred_brand = $payment_information['payment_method_details']->card->networks->preferred ?? null;
+		$preferred_brand = $payment_method->card->networks->preferred ?? null;
 		if ( isset( $preferred_brand ) ) {
 			$request['payment_method_options'] = [
 				'card' => [

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -757,7 +757,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$this->validate_selected_payment_method_type( $payment_information, $order->get_billing_country() );
 
 			$payment_needed        = $this->is_payment_needed( $order->get_id() );
-			$payment_method        = $payment_information['payment_method_details'];
 			$payment_method_id     = $payment_information['payment_method'];
 			$selected_payment_type = $payment_information['selected_payment_type'];
 			$upe_payment_method    = $this->payment_methods[ $selected_payment_type ] ?? null;
@@ -783,6 +782,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			if ( '' !== $selected_payment_type ) {
 				$this->set_selected_payment_type_for_order( $order, $selected_payment_type );
 			}
+
+			// Retrieve the payment method object from Stripe.
+			$payment_method = $this->stripe_request( 'payment_methods/' . $payment_method_id );
 
 			// Throw an exception when the payment method is a prepaid card and it's disallowed.
 			$this->maybe_disallow_prepaid_card( $payment_method );
@@ -819,15 +821,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			// Set the selected UPE payment method type title in the WC order.
 			$this->set_payment_method_title_for_order( $order, $selected_payment_type );
 
-			// Set the preferred card brand for the order, when set.
-			// Retrieve the preferred card brand for the payment method.
-			$preferred_brand = $payment_method->card->networks->preferred ?? null;
-			if ( WC_Stripe_Co_Branded_CC_Compatibility::is_wc_supported() && $preferred_brand ) {
-				$this->set_preferred_card_brand_for_order( $order, $preferred_brand );
-				if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
-					wc_admin_record_tracks_event( 'wcstripe_co_branded_cc_preferred_brand_selected', [ 'brand' => $preferred_brand ] );
-				}
-			}
+			// Save the preferred card brand on the order.
+			$this->maybe_set_preferred_card_brand_for_order( $order, $payment_method );
 
 			$redirect = $this->get_return_url( $order );
 
@@ -2028,9 +2023,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		$payment_method_types = $this->get_payment_method_types_for_intent_creation( $selected_payment_type, $order->get_id() );
 
-		// Retrieve the payment method object from Stripe.
-		$payment_method_details = WC_Stripe_API::get_payment_method( $payment_method_id );
-
 		$payment_information = [
 			'amount'                        => $amount,
 			'currency'                      => $currency,
@@ -2042,7 +2034,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'order'                         => $order,
 			'payment_initiated_by'          => 'initiated_by_customer', // initiated_by_merchant | initiated_by_customer.
 			'payment_method'                => $payment_method_id,
-			'payment_method_details'        => $payment_method_details,
 			'payment_type'                  => 'single', // single | recurring.
 			'save_payment_method_to_store'  => $save_payment_method_to_store,
 			'selected_payment_type'         => $selected_payment_type,
@@ -2068,6 +2059,26 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 
 		return $payment_information;
+	}
+
+	/**
+	 * Conditionally stores the card brand to the order meta.
+	 *
+	 * @param WC_Order $order          The WC Order for which we're processing a payment.
+	 * @param stdClass $payment_method The payment method object.
+	 */
+	private function maybe_set_preferred_card_brand_for_order( WC_Order $order, stdClass $payment_method ) {
+		// Retrieve the preferred card brand for the payment method.
+		$preferred_brand = $payment_method->card->networks->preferred ?? null;
+		if ( WC_Stripe_Co_Branded_CC_Compatibility::is_wc_supported() && $preferred_brand ) {
+
+			$order->update_meta_data( '_stripe_card_brand', $preferred_brand );
+			$order->save_meta_data();
+
+			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
+				wc_admin_record_tracks_event( 'wcstripe_co_branded_cc_preferred_brand_selected', [ 'brand' => $preferred_brand ] );
+			}
+		}
 	}
 
 	/**
@@ -2196,17 +2207,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	private function set_customer_id_for_order( WC_Order $order, string $customer_id ) {
 		$order->update_meta_data( '_stripe_customer_id', $customer_id );
-		$order->save_meta_data();
-	}
-
-	/**
-	 * Set the preferred card brand for the order.
-	 *
-	 * @param WC_Order $order The order.
-	 * @param string   $brand The value to be set.
-	 */
-	private function set_preferred_card_brand_for_order( WC_Order $order, string $brand ) {
-		$order->update_meta_data( '_stripe_card_brand', $brand );
 		$order->save_meta_data();
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2067,7 +2067,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @param WC_Order $order          The WC Order for which we're processing a payment.
 	 * @param stdClass $payment_method The payment method object.
 	 */
-	private function maybe_set_preferred_card_brand_for_order( WC_Order $order, stdClass $payment_method ) {
+	private function maybe_set_preferred_card_brand_for_order( WC_Order $order, $payment_method ) {
 		// Retrieve the preferred card brand for the payment method.
 		$preferred_brand = $payment_method->card->networks->preferred ?? null;
 		if ( WC_Stripe_Co_Branded_CC_Compatibility::is_wc_supported() && $preferred_brand ) {

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -38,7 +38,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		'type' => 'card',
 		'card' => [
 			'brand'     => 'visa',
-			'network'   => 'visa',
+			'networks'  => [ 'preferred' => 'visa' ],
 			'exp_month' => '7',
 			'funding'   => 'credit',
 			'last4'     => '4242',
@@ -2065,6 +2065,18 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 					'payment_method' => $payment_method_id,
 					'order_id'       => $order_id,
 				]
+			);
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'stripe_request' )
+			->with(
+				"payment_methods/$payment_method_id",
+			)
+			->will(
+				$this->returnValue(
+					$this->array_to_object( self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE )
+				)
 			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This unit test is failing because the [request](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/release/8.3.0/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L2010) to retrieve the payment method object from Stripe wasn't being mocked, and because the [payment method object mock](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/release/8.3.0/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php#L41) in the unit test doesn't have the [expected](https://docs.stripe.com/api/payment_methods/object) structure for the `card->networks` property.

- Retrieve the payment method object from Stripe outside `WC_Stripe_UPE_Payment_Gateway::prepare_payment_information_from_request()`
- For `WC_Stripe_UPE_Payment_Gateway`, use the existing `stripe_request` method instead of the static `WC_Stripe_API::get_payment_method()` to retrieve the payment method object from Stripe
- Mock the return value of `WC_Stripe_UPE_Payment_Gateway::stripe_request()` in the co-branded card PHP Unit test.

## Testing instructions


**Setup**
- Connect a Stripe account from France to your store.
- Set your store currency to EUR.

**Regression test for placing an order with co-branded cards**

1. As a shopper, add a product to the cart and proceed to checkout
2. Enter the details of a co-branded card, like `4000 0025 0000 1001`
3. On the dropdown at the right of the field, select "Cartes bancaires"
4. Place the order
5. Confirm the order is placed and has a "Processing" status
6. On the database, go to wp_wc_order_meta and look for the metas for the order ID you just placed
7. Confirm it has a meta with the key `_stripe_card_brand` and the value `cartes_bancaires`


**Regression test for reusing a payment intent with co-branded cards**
(This flow actually fails in develop)

1. As a shopper, add a product to the cart and proceed to checkout
2. Enter the details of a failing card, like `4000 0000 0000 0002`
3. Place the order
4. Try again using the details of a co-branded card, like `4000 0025 0000 1001`
5. On the dropdown at the right of the field, select "Cartes bancaires"
5. Confirm the order is placed and has a "Processing" status
6. On the database, go to wp_wc_order_meta and look for the metas for the order ID you just placed
7. Confirm it has a meta with the key `_stripe_card_brand` and the value `cartes_bancaires`

**Other assertions**
- Confirm the PHP Unit tests from the automated tasks passed in this PR.
- Confirm you can place an order with a regular card.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
