### PR TITLE
Fixes paid orders purchased with a 3DS card being stuck as pending payment when non-UPE is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 8.3.1 - xxxx-xx-xx =
+* Fix - Prevents orders purchased using a 3DS card being stuck as "pending payment" for stores with the Legacy Checkout Experience setting enabled.
+
 = 8.3.0 - 2024-05-23 =
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.
 * Add - Include Afterpay (Clearpay in the UK) as a payment method for stores using the updated checkout experience.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -905,7 +905,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				 * This is a stop-gap to fix a critical issue, see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
 				 * be better if we removed the need for additional meta data in favor of refactoring this part of the payment processing.
 				 */
-				$is_awaiting_action = ( $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false ) || wc_string_to_bool( $order->get_meta( WC_Stripe_Helper::PAYMENT_AWAITING_ACTION_META, true ) );
+				$is_awaiting_action = $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false;
 
 				// Voucher payments are only processed via the webhook so are excluded from the above check.
 				if ( ! $is_voucher_payment && $is_awaiting_action ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -857,7 +857,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				}
 
 				// If the order requires some action from the customer, add meta to the order to prevent it from being cancelled by WooCommerce's hold stock settings.
-				WC_Stripe_Helper::set_payment_awaiting_action( $order );
+				WC_Stripe_Helper::set_payment_awaiting_action( $order, false );
+
+				// Prevent processing the payment intent webhooks while also processing the redirect payment (also prevents duplicate Stripe meta stored on the order).
+				$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
+				$order->save();
 			}
 
 			if ( $payment_needed ) {

--- a/readme.txt
+++ b/readme.txt
@@ -128,19 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 8.3.0 - 2024-05-23 =
-* Add - Include Afterpay (Clearpay in the UK) as a payment method for stores using the updated checkout experience.
-* Add - Include Affirm as a payment method for stores using the updated checkout experience.
-* Add - Include Klarna as a payment method for stores using the updated checkout experience.
-* Add - Additional information is displayed on the "Payment methods" page when listing co-branded credit cards.
-* Fix - Resolved an error that could prevent purchasing subscriptions that have a capital letter in the billing period. eg "Year" instead of "year".
-* Fix - The preferred card brand is used when paying with a co-branded credit card.
-* Fix - Prevent duplicate stripe meta data on orders caused by processing redirect payments and webhooks simultaneously.
-* Fix - Processing a refund of a non-card payments (i.e. iDeal, giropay) through the Stripe dashboard was not showing as refunded in WooCommerce for stores with UPE enabled.
-* Fix - Prevent orders that require manual review in Stripe being marked as processing in WooCommerce before approval.
-* Tweak - Credit card brand selection disabled when the "Legacy checkout experience" is enabled.
-* Tweak - Improve performance with handling redirect payments by not constructing every payment gateway on each page load.
-* Tweak - Adds the tracking of a selected card brand when paying using co-branded credit cards.
-* Tweak - Improve the order note message recorded when a subscription-renewal order payment fails.
+= 8.3.1 - xxxx-xx-xx =
+* Fix - Prevents orders purchased using a 3DS card being stuck as "pending payment" for stores with the Legacy Checkout Experience setting enabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3154 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In 8.3.0 we shipped a bug that prevents `payment_intent.succeeded` webhooks from being processed properly when the store has the legacy checkout experience setting enabled.

There's a couple of PRs behind the cause of this issue so I'll try and breakdown how it all led to this problem:
1. In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3037, I introduced some new metadata (`_stripe_payment_awaiting_action`) that we store on orders that require customer confirmation (i.e. payments using a 3DS card)
2. The purpose of this meta is to prevent WooCommerce's hold stock feature from cancelling Stripe orders where the customer still has the 3DS window open, or the customer is paying for the OXXO voucher.
3. This meta is used across both UPE and non-UPE payments.
4. In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3078, I incorrectly used this metadata to also prevent our webhook handlers from processing the payment_intent to avoid duplicate meta being stored on the order.
5. When processing non-UPE payments, I didn't realise we put a 5-minute lock on orders and rely on the incoming webhook to process/validate the payment which leads to [this `WC_Stripe_Helper::remove_payment_awaiting_action( $order );`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/eefdfbcdba7db375fd301915bf53e5beb54f8dd9/includes/class-wc-gateway-stripe.php#L925-L929) never running before the webhook is processed.
6. Because this meta still exists on the non-UPE order purchased with a 3DS, this then causes the webhook to exit early 😢 

There are a couple of ways we can approach fixing this problem:

1. For non-UPE we could make sure we're calling `remove_payment_awaiting_action()` when the customer has completed the checkout so that the webhook continues to used to process the payment.
2. Don't exit early from webhooks when an order still has `_stripe_payment_awaiting_action` and go back to using `_stripe_upe_waiting_for_redirect` instead.

In this PR I decided to go with option 2 as the original purpose of the `_stripe_payment_awaiting_action` was to prevent orders being cancelled by WooCommerce's hold stock feature and it wasn't intended to be used to prevent processing payment intent succeeded webhooks. This is done by reverting https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3078 and so to avoid reintroducing https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3076, I have made it so we're setting `_stripe_upe_waiting_for_redirect` inside our deferred intents implementation.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Enable the Legacy checkout experience and make sure webhooks are setup
2. While on `trunk` purchase a product using a 3DS card: `4000000000003220`
3. Complete the 3DS auth window
4. Once on the order thank-you page, note that the order is still pending payment
5. Open the stripe dashboard and [go to your webhooks](https://dashboard.stripe.com/test/webhooks) and confirm that the latest `payment_intent.succeeded` webhook for the order has been sent.
6. View the order in WooCommerce to confirm it's still stuck with pending payment status
7. Checkout this branch `fix/3154-paid-orders-stuck-as-pending-payment`
8. Add another product to your cart and use a 3DS card again to complete payment: `4000000000003220`
9. Once on the order thank-you page, view the order and confirm it's now set to processing/completed.

#### Other tests
 
Since this PR is reverting https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3078 and fixing it another way, we should double-check the original issue is still fixed:

1. Enable UPE and have webhooks setup
2. Purchase a product using a 3DS card again: `4000000000003220`
3. On completing the checkout, copy the order ID and search this order ID in `wp_wc_orders_meta` table (or `wp_postmeta` if you don't have HPOS enabled)
4. Confirm there's no duplicate stripe meta (i.e. `_stripe_fee` etc)

For the sake of confirming the bug, you can comment out the new line `$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );` inside `process_payment_with_deferred_intent ()` and run the test again and you will see duplicated stripe meta stored on the order.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
