### PR TITLE
Declare compatibility with the Cart and Checkout blocks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@
 * Add - Include WeChat Pay as a payment method for stores using the updated checkout experience.
 * Fix - Resolve invalid recurring shipping method errors when attempting to purchase multiple subscriptions with Apple Pay or Google Pay.
 * Fix - Deprecation errors on PHP 8.2 caused by using the deprecated constant FILTER_SANITIZE_STRING.
-* Update - Declare compatibility with teh Cart and Checkout blocks.
+* Update - Declare compatibility with the Cart and Checkout blocks.
 
 = 8.3.0 - 2024-05-23 =
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Add - Include WeChat Pay as a payment method for stores using the updated checkout experience.
 * Fix - Resolve invalid recurring shipping method errors when attempting to purchase multiple subscriptions with Apple Pay or Google Pay.
 * Fix - Deprecation errors on PHP 8.2 caused by using the deprecated constant FILTER_SANITIZE_STRING.
+* Update - Declare compatibility with teh Cart and Checkout blocks.
 
 = 8.3.0 - 2024-05-23 =
 * Add - Add a new dismissible banner to promote Stripe products to the settings page.

--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Include WeChat Pay as a payment method for stores using the updated checkout experience.
 * Fix - Resolve invalid recurring shipping method errors when attempting to purchase multiple subscriptions with Apple Pay or Google Pay.
 * Fix - Deprecation errors on PHP 8.2 caused by using the deprecated constant FILTER_SANITIZE_STRING.
-* Update - Declare compatibility with teh Cart and Checkout blocks.
+* Update - Declare compatibility with the Cart and Checkout blocks.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -142,5 +142,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Include WeChat Pay as a payment method for stores using the updated checkout experience.
 * Fix - Resolve invalid recurring shipping method errors when attempting to purchase multiple subscriptions with Apple Pay or Google Pay.
 * Fix - Deprecation errors on PHP 8.2 caused by using the deprecated constant FILTER_SANITIZE_STRING.
+* Update - Declare compatibility with teh Cart and Checkout blocks.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -822,6 +822,7 @@ add_action(
 	'before_woocommerce_init',
 	function() {
 		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 		}
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce/issues/47920, @gedex reported that various extensions are listed as incompatible in `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&paged=1&s` due to the Cart and Checkout blocks. While looking into this issue, I noticed that `WooCommerce Stripe Payment Gateway` also appears as an incompatible extension. The reason for that is, that this extension does not explicitly declared compatibility. In [FAQ: Cart and Checkout Blocks by Default](https://developer.woocommerce.com/2023/11/06/faq-extending-cart-and-checkout-blocks/), detailed information about declaring compatibility can be found. 

This PR declared compatibility to the Cart and Checkout blocks, but adding the following code:
```php
\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
```

## Testing instructions

### User facing

1. Before checking out this PR, ensure to have a testing site where both `WooCommerce` and `WooCommerce Stripe Payment Gateway` are installed and activated.
2. Go to `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&paged=1&s`.
3. Verify that `WooCommerce Stripe Gateway` is listed as an incompatible extension. 

<img width="1179" alt="Screenshot 2024-05-30 at 18 46 43" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/3323310/ac2851ee-e427-453a-b307-b00cf894cc52">

4. Check out this PR.
5. Go to `/wp-admin/plugins.php?plugin_status=incompatible_with_feature&paged=1&s` again.
6. Verify that `WooCommerce Stripe Gateway` is no longer listed as an incompatible extension. 

<img width="1183" alt="Screenshot 2024-05-30 at 18 47 03" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/3323310/ff8a0979-f545-4be0-a041-7b888db18a07">

### Developer facing

1. Before checking out this PR, ensure to have a testing site where both `WooCommerce` and `WooCommerce Stripe Payment Gateway` are installed and activated and a testing enviornemnt with WP-CLI.
2. Open a terminal.
3. Run the following command:
```sh
wp eval 'do_action("before_woocommerce_init"); print_r(Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_features_for_plugin("woocommerce-gateway-stripe/woocommerce-gateway-stripe.php"));'
```
4. Verify to see this result:
```sh
Array
(
    [compatible] => Array
        (
            [0] => custom_order_tables
        )

    [incompatible] => Array
        (
        )

    [uncertain] => Array
        (
            [0] => analytics
            [1] => new_navigation
            [2] => product_block_editor
            [3] => cart_checkout_blocks
            [4] => marketplace
            [5] => order_attribution
            [6] => hpos_fts_indexes
        )
)
```
5. Check out this PR.
6. Run the command from step 3. again.
7. Verify to see this result now:
```sh
Array
(
    [compatible] => Array
        (
            [0] => cart_checkout_blocks
            [1] => custom_order_tables
        )

    [incompatible] => Array
        (
        )

    [uncertain] => Array
        (
            [0] => analytics
            [1] => new_navigation
            [2] => product_block_editor
            [3] => marketplace
            [4] => order_attribution
            [5] => hpos_fts_indexes
        )
)
```


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
