### PR TITLE
[Cash App] Add support for adding Cash App tokens via My Account page

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -164,7 +164,7 @@ export default class WCStripeAPI {
 	/**
 	 * Creates and confirms a setup intent.
 	 *
-	 * @param {Object}   paymentMethod         Payment method data.
+	 * @param {Object}   paymentMethod Payment method data.
 	 *
 	 * @return {Promise} Promise containing the setup intent.
 	 */

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -216,10 +216,11 @@ export default class WCStripeAPI {
 
 						if ( setupIntent.status === 'succeeded' ) {
 							window.location.href = returnURL;
-
-							// Return 'redirect_to_url' so the calling function is aware of the redirect.
 							return 'redirect_to_url';
 						}
+
+						// When the setup intent is incomplete, we need to notify the calling function that the set up didn't complete.
+						return 'incomplete';
 					} );
 			} else {
 				// Card Payments.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -197,14 +197,13 @@ export default class WCStripeAPI {
 				return response.data.next_action.type;
 			}
 
-			let setupIntentPromise = null;
-
 			if ( response.data.payment_type === 'cashapp' ) {
 				// Cash App Payments.
 				const returnURL = decodeURIComponent(
 					response.data.return_url
 				);
-				setupIntentPromise = this.getStripe()
+
+				return this.getStripe()
 					.confirmCashappSetup( response.data.client_secret, {
 						return_url: returnURL,
 					} )
@@ -222,23 +221,21 @@ export default class WCStripeAPI {
 						// When the setup intent is incomplete, we need to notify the calling function that the set up didn't complete.
 						return 'incomplete';
 					} );
-			} else {
-				// Card Payments.
-				setupIntentPromise = this.getStripe()
-					.confirmCashappSetup( response.data.client_secret, {
-						return_url: response.data.return_url,
-					} )
-					.then( ( confirmedSetupIntent ) => {
-						const { setupIntent, error } = confirmedSetupIntent;
-						if ( error ) {
-							throw error;
-						}
-
-						return setupIntent;
-					} );
 			}
 
-			return setupIntentPromise;
+			// Card Payments.
+			return this.getStripe()
+				.confirmCashappSetup( response.data.client_secret, {
+					return_url: response.data.return_url,
+				} )
+				.then( ( confirmedSetupIntent ) => {
+					const { setupIntent, error } = confirmedSetupIntent;
+					if ( error ) {
+						throw error;
+					}
+
+					return setupIntent;
+				} );
 		} );
 	}
 

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -164,12 +164,12 @@ export default class WCStripeAPI {
 	/**
 	 * Creates and confirms a setup intent.
 	 *
-	 * @param {Object} paymentMethod Payment method data.
-	 * @param {Object} options       Additional options.
+	 * @param {Object}   paymentMethod         Payment method data.
+	 * @param {Function} setCustomerRedirected Function to call which flags the customer has been redirected.
 	 *
 	 * @return {Promise} Promise containing the setup intent.
 	 */
-	setupIntent( paymentMethod, options = {} ) {
+	setupIntent( paymentMethod, setCustomerRedirected = null ) {
 		return this.request(
 			this.getAjaxUrl( 'create_and_confirm_setup_intent' ),
 			{
@@ -214,8 +214,6 @@ export default class WCStripeAPI {
 						if ( error ) {
 							throw error;
 						}
-
-						const { setCustomerRedirected } = options;
 
 						if ( setupIntent.status === 'succeeded' ) {
 							if ( setCustomerRedirected ) {

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -165,11 +165,10 @@ export default class WCStripeAPI {
 	 * Creates and confirms a setup intent.
 	 *
 	 * @param {Object}   paymentMethod         Payment method data.
-	 * @param {Function} setCustomerRedirected Function to call which flags the customer has been redirected.
 	 *
 	 * @return {Promise} Promise containing the setup intent.
 	 */
-	setupIntent( paymentMethod, setCustomerRedirected = null ) {
+	setupIntent( paymentMethod ) {
 		return this.request(
 			this.getAjaxUrl( 'create_and_confirm_setup_intent' ),
 			{
@@ -216,11 +215,10 @@ export default class WCStripeAPI {
 						}
 
 						if ( setupIntent.status === 'succeeded' ) {
-							if ( setCustomerRedirected ) {
-								setCustomerRedirected();
-							}
 							window.location.href = returnURL;
-							return setupIntent;
+
+							// Return 'redirect_to_url' so the calling function is aware of the redirect.
+							return 'redirect_to_url';
 						}
 					} );
 			} else {

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -164,7 +164,7 @@ export default class WCStripeAPI {
 	/**
 	 * Creates and confirms a setup intent.
 	 *
-	 * @param {Object}   paymentMethod Payment method data.
+	 * @param {Object} paymentMethod Payment method data.
 	 *
 	 * @return {Promise} Promise containing the setup intent.
 	 */

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -225,9 +225,7 @@ export default class WCStripeAPI {
 
 			// Card Payments.
 			return this.getStripe()
-				.confirmCashappSetup( response.data.client_secret, {
-					return_url: response.data.return_url,
-				} )
+				.confirmCardSetup( response.data.client_secret )
 				.then( ( confirmedSetupIntent ) => {
 					const { setupIntent, error } = confirmedSetupIntent;
 					if ( error ) {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -286,7 +286,7 @@ export const createAndConfirmSetupIntent = (
 	setCustomerRedirected
 ) => {
 	return api
-		.setupIntent( paymentMethod )
+		.setupIntent( paymentMethod, setCustomerRedirected )
 		.then( function ( confirmedSetupIntent ) {
 			if ( confirmedSetupIntent === 'redirect_to_url' ) {
 				setCustomerRedirected();

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1024,6 +1024,8 @@ class WC_Stripe_Intent_Controller {
 					'id'            => $setup_intent->id,
 					'client_secret' => $setup_intent->client_secret,
 					'next_action'   => $setup_intent->next_action,
+					'payment_type'  => $payment_type,
+					'return_url'    => rawurlencode( $payment_information['return_url'] ),
 				],
 				200
 			);

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -437,7 +437,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			}
 		} elseif ( is_wc_endpoint_url( 'add-payment-method' ) ) {
-			$stripe_params['cartTotal'] = 0;
+			$stripe_params['cartTotal']    = 0;
+			$stripe_params['customerData'] = [ 'billing_country' => WC()->customer->get_billing_country() ];
 		}
 
 		// Pre-orders and free trial subscriptions don't require payments.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
@@ -84,7 +84,7 @@ class WC_Stripe_UPE_Payment_Method_Cash_App_Pay extends WC_Stripe_UPE_Payment_Me
 		 * This is because setup intents with a saved payment method (token) fail. While we wait for a solution to this issue, we
 		 * disable Cash App Pay for zero amount orders.
 		 */
-		if ( $this->get_current_order_amount() <= 0 ) {
+		if ( ! is_add_payment_method_page() && $this->get_current_order_amount() <= 0 ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #3179 

## Changes proposed in this Pull Request:

This PR adds support for customers to add Cash App tokens on the **My Account → Payment methods** page. 

This was a fairly simple set of changes. 

I needed to update the `setupIntent()` function which is used on the Add payment method page. It was only capable of setting up card payments, this PR updates this function to also handle Cash App setups. 

The other changes on this PR facilitate that change. ie passing the payment type and return url in the AJAX response and enabling stopping the form being submitted 

## Testing instructions

0. **Setup**
   - Your customer will need a US billing address, otherwise it won't be displayed.
   - Checkout this branch and make sure to build assets (eg `npm run build`).
   - Change your Stripe Plugin credentials to a US based account.
   - Change your store currency to USD.
   - Enable Cash App Pay from the Stripe payment methods screen.
   - Optional. Delete all Cash App tokens so you can verify and use new tokens. 
1. Go to **My Account → Payment methods**
2. Click **Add payment method**. 
3. Select Cash App Payments. 
4. Click **Add payment method**.
5. The Cash App Payment modal should pop up. 

<p align="center">
<img width="300" alt="Screenshot 2024-06-06 at 4 39 40 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/e2b78bb2-3251-4d85-a34b-f172343f64d6">
</p>

7. Using your mobile device scan the QR code and complete payment at Stripe's test site. 
8. Once complete you will be redirected to the payment methods list and you should have a newly created token. 
9. Complete a new purchase using that new token to verify it works. 




---



-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
