### PR TITLE
Removing saved cards when setting is disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Removes the list of saved payment methods when the setting is disabled.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.
 * Tweak - Update WordPress.org screenshots and captions.
 * Fix - Added a feedback message + redirection back to cart when a Cash App payment fails.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -229,13 +229,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Removes all saved payment methods when the setting to save cards is disabled.
 	 *
-	 * @return array An empty list of payment methods
+	 * @param  array $list         List of payment methods passed from wc_get_customer_saved_methods_list().
+	 * @param  int   $customer_id  The customer to fetch payment methods for.
+	 * @return array               Filtered list of customers payment methods.
 	 */
-	public function filter_saved_payment_methods_list( $item, $payment_token ) {
+	public function filter_saved_payment_methods_list( $list, $customer_id ) {
 		if ( ! $this->saved_cards ) {
 			return [];
 		}
-		return $item;
+		return $list;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -222,6 +222,20 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		add_action( 'set_logged_in_cookie', [ $this, 'set_cookie_on_current_request' ] );
 
 		add_action( 'wc_ajax_wc_stripe_save_appearance', [ $this, 'save_appearance_ajax' ] );
+
+		add_filter( 'woocommerce_saved_payment_methods_list', [ $this, 'filter_saved_payment_methods_list' ], 10, 2 );
+	}
+
+	/**
+	 * Removes all saved payment methods when the setting to save cards is disabled.
+	 *
+	 * @return array An empty list of payment methods
+	 */
+	public function filter_saved_payment_methods_list( $item, $payment_token ) {
+		if ( ! $this->saved_cards ) {
+			return [];
+		}
+		return $item;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Removes the list of saved payment methods when the setting is disabled.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.
 * Fix - Added a feedback message + redirection back to cart when a Cash App payment fails.
 * Tweak - Update WordPress.org screenshots and captions.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3142

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Currently, when disabling the "Enable payments via saved cards" settings in the new checkout experience, selecting the previously saved cards is still possible. This PR fixes that by filtering the saved cards when the setting is "on".

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- With "Enable the legacy checkout experience" disabled, go to Stripe settings, and click off Enable payments via saved cards
- Checkout as a user with previously saved payment methods
- On this branch, previously saved payment methods will not be displayed
- Also, you won't be able to save a new card

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
