### PR TITLE
Update WooCommerce.com docs links

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.4.0 - xxxx-xx-xx =
+* Tweak - Update WooCommerce.com docs links.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.
 * Tweak - Update WordPress.org screenshots and captions.
 * Fix - Added a feedback message + redirection back to cart when a Cash App payment fails.

--- a/client/settings/advanced-settings-section/experimental-features.js
+++ b/client/settings/advanced-settings-section/experimental-features.js
@@ -121,10 +121,10 @@ const ExperimentalFeatures = () => {
 							<ExternalLink href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" />
 						),
 						learnMoreLink: (
-							<ExternalLink href="https://woo.com/document/stripe/admin-experience/new-checkout-experience/" />
+							<ExternalLink href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" />
 						),
 						supportLink: (
-							<ExternalLink href="https://woo.com/document/stripe/admin-experience/new-checkout-experience/" />
+							<ExternalLink href="https://woocommerce.com/my-account/create-a-ticket?select=18627" />
 						),
 						newLineElement: <br />,
 					}

--- a/client/settings/notices/legacy-experience-transition/index.js
+++ b/client/settings/notices/legacy-experience-transition/index.js
@@ -97,7 +97,7 @@ const LegacyExperienceTransitionNotice = ( {
 					) }
 				</DisableLegacyButton>
 				<LearnMoreAnchor
-					href="https://woo.com/document/stripe/admin-experience/new-checkout-experience/"
+					href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/"
 					className="components-button is-tertiary"
 					target="_blank"
 					rel="noreferrer"

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -39,7 +39,7 @@ const PaymentRequestDescription = () => (
 				'woocommerce-gateway-stripe'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/stripe/#express-checkouts">
+		<ExternalLink href="https://woocommerce.com/document/stripe/customer-experience/express-checkouts/">
 			{ __( 'Learn more', 'woocommerce-gateway-stripe' ) }
 		</ExternalLink>
 	</>

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -186,7 +186,7 @@ const PaymentRequestSection = () => {
 												<a
 													target="_blank"
 													rel="noreferrer"
-													href="https://woocommerce.com/document/stripe/#stripe-link"
+													href="https://woocommerce.com/document/stripe/customer-experience/express-checkouts/#link-by-stripe"
 												/>
 											),
 										},

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -34,7 +34,7 @@ const GeneralSettingsDescription = () => (
 			</ExternalLink>
 		</p>
 		<p>
-			<ExternalLink href="https://woocommerce.com/my-account/create-a-ticket?select=18627">
+			<ExternalLink href="https://woocommerce.com/my-account/contact-support/?select=18627">
 				{ __( 'Get support', 'woocommerce-gateway-stripe' ) }
 			</ExternalLink>
 		</p>

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -34,7 +34,7 @@ const GeneralSettingsDescription = () => (
 			</ExternalLink>
 		</p>
 		<p>
-			<ExternalLink href="https://woocommerce.com/contact-us/">
+			<ExternalLink href="https://woocommerce.com/my-account/create-a-ticket?select=18627">
 				{ __( 'Get support', 'woocommerce-gateway-stripe' ) }
 			</ExternalLink>
 		</p>
@@ -64,12 +64,6 @@ const PaymentsAndTransactionsDescription = () => (
 				'woocommerce-gateway-stripe'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/stripe/#faq">
-			{ __(
-				'View Frequently Asked Questions',
-				'woocommerce-gateway-stripe'
-			) }
-		</ExternalLink>
 	</>
 );
 

--- a/client/settings/payment-settings/test-mode-checkbox.js
+++ b/client/settings/payment-settings/test-mode-checkbox.js
@@ -30,7 +30,7 @@ const TestModeCheckbox = () => {
 						),
 						learnMoreLink: (
 							// eslint-disable-next-line jsx-a11y/anchor-has-content
-							<a href="https://stripe.com/docs/testing" />
+							<a href="https://woocommerce.com/document/stripe/customer-experience/testing/" />
 						),
 					},
 				} ) }

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -165,7 +165,7 @@ class WC_Stripe_Admin_Notices {
 				$message = sprintf(
 				/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 					__( 'WooCommerce Stripe - We recently made changes to Stripe that may impact the appearance of your checkout. If your checkout has changed unexpectedly, please follow these %1$sinstructions%2$s to fix.', 'woocommerce-gateway-stripe' ),
-					'<a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">',
+					'<a href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" target="_blank">',
 					'</a>'
 				);
 
@@ -296,7 +296,7 @@ class WC_Stripe_Admin_Notices {
 				$message = sprintf(
 				/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 					__( 'The public and/or secret keys for the Stripe gateway have been changed. This might cause errors for existing customers and saved payment methods. %1$sClick here to learn more%2$s.', 'woocommerce-gateway-stripe' ),
-					'<a href="https://woocommerce.com/document/stripe-fixing-customer-errors" target="_blank">',
+					'<a href="https://woocommerce.com/document/stripe/customization/database-cleanup/" target="_blank">',
 					'</a>'
 				);
 

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -174,7 +174,7 @@ class WC_Stripe_Inbox_Notes {
 			$note->add_action(
 				'learn-more',
 				__( 'Learn more', 'woocommerce-gateway-stripe' ),
-				'https://woocommerce.com/document/stripe/#apple-pay'
+				'https://woocommerce.com/document/stripe/troubleshooting/apple-pay-private-window/'
 			);
 			$note->save();
 		} catch ( Exception $e ) {} // @codingStandardsIgnoreLine.

--- a/includes/admin/class-wc-stripe-privacy.php
+++ b/includes/admin/class-wc-stripe-privacy.php
@@ -93,7 +93,7 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 		$message = sprintf(
 		/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			esc_html__( 'By using this extension, you may be storing personal data or sharing data with an external service. %1$sLearn more about how this works, including what you may want to include in your privacy policy%2$s.', 'woocommerce-gateway-stripe' ),
-			'<a href="https://woocommerce.com/document/privacy-payments/#section-3" target="_blank">',
+			'<a href="https://woocommerce.com/document/privacy-payments/#how-payment-providers-use-data" target="_blank">',
 			'</a>'
 		);
 

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -263,7 +263,7 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 				__( 'Try the new payment experience (Early access) %1$sGet early access to a new, smarter payment experience on checkout and let us know what you think by %2$s. We recommend this feature for experienced merchants as the functionality is currently limited. %3$s', 'woocommerce-gateway-stripe' ),
 				'<br />',
 				'<a href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" target="_blank">submitting your feedback</a>',
-				'<a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">Learn more</a>'
+				'<a href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" target="_blank">Learn more</a>'
 			),
 			'type'        => 'checkbox',
 			'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -39,7 +39,7 @@ class WC_Stripe_UPE_Availability_Note {
 		$message = sprintf(
 		/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
 			__( 'Get early access to an improved checkout experience, now available to select merchants. %1$sLearn more%2$s.', 'woocommerce-gateway-stripe' ),
-			'<a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">',
+			'<a href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" target="_blank">',
 			'</a>'
 		);
 		$note->set_content( $message );

--- a/includes/notes/class-wc-stripe-upe-stripelink-note.php
+++ b/includes/notes/class-wc-stripe-upe-stripelink-note.php
@@ -25,7 +25,7 @@ class WC_Stripe_UPE_StripeLink_Note {
 	/**
 	 * Link to Stripe Link documentation.
 	 */
-	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/stripe/#stripe-link';
+	const NOTE_DOCUMENTATION_URL = 'https://woocommerce.com/document/stripe/setup-and-configuration/express-checkouts/';
 
 	/**
 	 * Get the note.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.4.0 - xxxx-xx-xx =
+* Tweak - Update WooCommerce.com docs links.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.
 * Fix - Added a feedback message + redirection back to cart when a Cash App payment fails.
 * Tweak - Update WordPress.org screenshots and captions.

--- a/tests/phpunit/test-class-wc-stripe-upe-availability-note.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-availability-note.php
@@ -15,7 +15,7 @@ class WC_Stripe_UPE_Availability_Note_Test extends WP_UnitTestCase {
 			$note = WC_Stripe_UPE_Availability_Note::get_note();
 
 			$this->assertSame( 'Boost your sales with the new payment experience in Stripe', $note->get_title() );
-			$this->assertSame( 'Get early access to an improved checkout experience, now available to select merchants. <a href="https://woocommerce.com/document/stripe/#new-checkout-experience" target="_blank">Learn more</a>.', $note->get_content() );
+			$this->assertSame( 'Get early access to an improved checkout experience, now available to select merchants. <a href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" target="_blank">Learn more</a>.', $note->get_content() );
 			$this->assertSame( 'info', $note->get_type() );
 			$this->assertSame( 'wc-stripe-upe-availability-note', $note->get_name() );
 			$this->assertSame( 'woocommerce-gateway-stripe', $note->get_source() );


### PR DESCRIPTION
This PR updates and corrects a few docs links we have sprinkled around the codebase. It partially addresses #2931, but it doesn't add any _new_ links, so we should leave that issue open still IMHO.

CC @csmcneill if you'd like to add any thoughts. :) 