### PR TITLE
Reseting payment methods when changing Stripe keys

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.4.0 - xxxx-xx-xx =
+* Tweak - Resets the list of payment methods when any Stripe key is updated.
 * Tweak - Update WooCommerce.com docs links.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.
 * Tweak - Update WordPress.org screenshots and captions.

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -250,6 +250,28 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		}
 
 		update_option( self::STRIPE_GATEWAY_SETTINGS_OPTION_NAME, $settings );
+
+		// Disable all payment methods if all keys are different from the current ones
+		if ( $current_account_keys['publishable_key'] !== $settings['publishable_key']
+			|| $current_account_keys['secret_key'] !== $settings['secret_key']
+			|| $current_account_keys['test_publishable_key'] !== $settings['test_publishable_key']
+			|| $current_account_keys['test_secret_key'] !== $settings['test_secret_key'] ) {
+
+			$is_upe_enabled = 'yes' === $settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ];
+			if ( ! $is_upe_enabled ) {
+				$payment_gateways = WC_Stripe_Helper::get_legacy_payment_methods();
+				foreach ( $payment_gateways as $gateway ) {
+					$gateway->update_option( 'enabled', 'no' );
+				}
+			}
+			$upe_gateway = new WC_Stripe_UPE_Payment_Gateway();
+			$upe_gateway->update_option( 'upe_checkout_experience_accepted_payments', [ 'card', 'link' ] );
+
+			// handle Multibanco separately as it is a non UPE method but it is part of the same settings page.
+			$multibanco = WC_Stripe_Helper::get_legacy_payment_method( 'stripe_multibanco' );
+			$multibanco->update_option( 'enabled', 'no' );
+		}
+
 		$this->account->clear_cache();
 
 		// Gives an instant reply if the connection was succesful or not + rebuild the cache for the next request

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -263,13 +263,14 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 				foreach ( $payment_gateways as $gateway ) {
 					$gateway->update_option( 'enabled', 'no' );
 				}
-			}
-			$upe_gateway = new WC_Stripe_UPE_Payment_Gateway();
-			$upe_gateway->update_option( 'upe_checkout_experience_accepted_payments', [ 'card', 'link' ] );
+			} else {
+				$upe_gateway = new WC_Stripe_UPE_Payment_Gateway();
+				$upe_gateway->update_option( 'upe_checkout_experience_accepted_payments', [ 'card', 'link' ] );
 
-			// handle Multibanco separately as it is a non UPE method but it is part of the same settings page.
-			$multibanco = WC_Stripe_Helper::get_legacy_payment_method( 'stripe_multibanco' );
-			$multibanco->update_option( 'enabled', 'no' );
+				// handle Multibanco separately as it is a non UPE method but it is part of the same settings page.
+				$multibanco = WC_Stripe_Helper::get_legacy_payment_method( 'stripe_multibanco' );
+				$multibanco->update_option( 'enabled', 'no' );
+			}
 		}
 
 		$this->account->clear_cache();

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.4.0 - xxxx-xx-xx =
+* Tweak - Resets the list of payment methods when any Stripe key is updated.
 * Tweak - Update WooCommerce.com docs links.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.
 * Fix - Added a feedback message + redirection back to cart when a Cash App payment fails.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2468

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When a merchant changes their Stripe keys to another account's keys, the new account may not support some of the previously enabled payment methods. This PR forces the reset of the entire payment method list when any key is updated (keeping only the default methods).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch on your local test environment (`tweak/reset-payment-methods-when-changing-stripe-keys`)
- Run `npm install`, `npm run build:webpack`, `npm run up`
- Add your Stripe keys in settings

### Non-UPE

- Enable the "Legacy checkout experience" in settings
- Enable a bunch of payment methods
- Change any key (secret or publishable) to any value
- Confirm that all payment methods were disabled

### UPE

- Disable the "Legacy checkout experience" in settings
- Enable a bunch of payment methods
- Change any key (secret or publishable) to any value
- Confirm that all payment methods were disabled

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
