### PR TITLE
Adding limits to Cash App purchases

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Add a limit of 2000 USD for purchases using Cash App as a payment method.
 * Fix - Removes the list of saved payment methods when the setting is disabled.
 * Tweak - Update WooCommerce.com docs links.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
@@ -36,6 +36,14 @@ class WC_Stripe_UPE_Payment_Method_Cash_App_Pay extends WC_Stripe_UPE_Payment_Me
 			'Cash App is a popular consumer app in the US that allows customers to bank, invest, send, and receive money using their digital wallet.',
 			'woocommerce-gateway-stripe'
 		);
+		$this->limits_per_currency          = [
+			'USD' => [
+				'US' => [
+					'min' => 100,
+					'max' => 200000,
+				], // Represents USD 1 - 2,000 USD.
+			],
+		];
 
 		// Cash App Pay supports subscriptions. Init subscriptions so it can process subscription payments.
 		$this->maybe_init_subscriptions();

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.4.0 - xxxx-xx-xx =
+* Fix - Add a limit of 2000 USD for purchases using Cash App as a payment method.
 * Fix - Removes the list of saved payment methods when the setting is disabled.
 * Tweak - Update WooCommerce.com docs links.
 * Fix - Correctly setting the preferred card brand when creating and updating a payment intent.

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -601,6 +601,13 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 					$this->returnValue( $store_currency )
 				);
 
+			$payment_method
+				->expects( $this->any() )
+				->method( 'is_inside_currency_limits' )
+				->will(
+					$this->returnValue( true )
+				);
+
 			if ( $payment_method->is_reusable() ) {
 				$this->assertTrue( $payment_method->is_enabled_at_checkout( null, $account_currency ), "Payment method {$payment_method_id} is not enabled" );
 			} else {


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3198

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

See: https://href.li/?https://docs.stripe.com/payments/cash-app-pay#payment-limits-and-options

Cash App has a limit of 2000 USD in purchases. This PR adds this limit following the existing currency limit feature.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout to this branch on your local environment (`fix/cash-app-purchase-limits`)
- Run `npm install`, `npm run build:webpack` and `npm run up`
- Connect your Stripe account (you must use a US account)
- Enable Cash App in both your store settings and the Stripe dashboard
- As a shopper, add some products to your cart (below 2000 USD)
- Confirm that you can use Cash App to pay for it
- Add more products, above the 2000 USD
- Confirm that Cash App is not an option anymore

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
