### PR TITLE
Improving visuals for webhook warning messages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,6 @@
 *** Changelog ***
 = 8.5.0 - 2024-xx-xx =
+* Tweak - Improve the display of warning messages related to webhook configuration.
 * Fix - When using a saved payment method, update the payment method's address immediately upon checkout. Fixes issues where Stripe may throw address validation errors.
 * Tweak - Add a statement descriptor preview for Cash App Payments.
 * Add - Allow customizing the title and description of the UPE payment methods.

--- a/client/settings/account-details/__tests__/account-details.test.js
+++ b/client/settings/account-details/__tests__/account-details.test.js
@@ -66,4 +66,26 @@ describe( 'AccountDetails', () => {
 
 		expect( screen.queryByTestId( 'help' ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders the warning icon and the paragraph with the "warning" class when there\'s a warning message', () => {
+		const mockedWarningMessage = 'Warning: random message';
+		useAccount.mockReturnValue( {
+			data: {
+				account: {
+					settings: {
+						payouts: {},
+					},
+					payouts_enabled: false,
+					charges_enabled: false,
+				},
+				webhook_status_message: mockedWarningMessage,
+			},
+		} );
+		render( <AccountDetails /> );
+
+		expect( screen.queryByTestId( 'warning' ) ).toBeInTheDocument();
+		expect( screen.queryByText( mockedWarningMessage ) ).toHaveClass(
+			'warning'
+		);
+	} );
 } );

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -41,15 +41,10 @@ const Label = styled.p`
 	margin: 0;
 `;
 
-const WebhookDescription = styled.div`
+const WebhookDescriptionWrapper = styled.div`
 	font-size: 12px;
 	font-style: normal;
 	color: rgb( 117, 117, 117 );
-
-	.expanded {
-		display: flex;
-		align-items: stretch;
-	}
 
 	> span {
 		align-self: center;
@@ -61,6 +56,11 @@ const WebhookDescription = styled.div`
 		padding: 4px 8px;
 		border-radius: 2px;
 	}
+`;
+
+const WebhookDescription = styled.div`
+	display: flex;
+	align-items: center;
 `;
 
 const WarningIcon = styled( Icon )`
@@ -159,27 +159,29 @@ const WebhooksSection = () => {
 						: __( 'Disabled', 'woocommerce-gateway-stripe' ) }
 				</SectionStatus>
 			</AccountSection>
-			<WebhookDescription
-				className={ isWebhookSecretEntered ? 'expanded' : '' }
-			>
-				{ isWarningMessage && (
-					<span data-testid="warning">
-						<WarningIcon icon={ warning } size="16" />
-					</span>
-				) }
+			<WebhookDescriptionWrapper>
 				{ ! isWebhookSecretEntered && <WebhookInformation /> }
-				<p className={ isWarningMessage ? 'warning' : '' }>
-					{ message }{ ' ' }
-					<Button
-						disabled={ requestStatus === 'pending' }
-						onClick={ refreshMessage }
-						isBusy={ requestStatus === 'pending' }
-						isLink
-					>
-						{ __( 'Refresh', 'woocommerce-gateway-stripe' ) }
-					</Button>
-				</p>
-			</WebhookDescription>
+				<WebhookDescription
+					className={ isWebhookSecretEntered ? 'expanded' : '' }
+				>
+					{ isWarningMessage && (
+						<span data-testid="warning">
+							<WarningIcon icon={ warning } size="16" />
+						</span>
+					) }
+					<p className={ isWarningMessage ? 'warning' : '' }>
+						{ message }{ ' ' }
+						<Button
+							disabled={ requestStatus === 'pending' }
+							onClick={ refreshMessage }
+							isBusy={ requestStatus === 'pending' }
+							isLink
+						>
+							{ __( 'Refresh', 'woocommerce-gateway-stripe' ) }
+						</Button>
+					</p>
+				</WebhookDescription>
+			</WebhookDescriptionWrapper>
 		</>
 	);
 };

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -2,8 +2,8 @@ import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import React from 'react';
 import { Button, ExternalLink, Icon } from '@wordpress/components';
+import { warning, help } from '@wordpress/icons';
 import interpolateComponents from 'interpolate-components';
-import { help } from '@wordpress/icons';
 import styled from '@emotion/styled';
 import useWebhookStateMessage from './use-webhook-state-message';
 import SectionStatus from './section-status';
@@ -45,6 +45,25 @@ const WebhookDescription = styled.div`
 	font-size: 12px;
 	font-style: normal;
 	color: rgb( 117, 117, 117 );
+	display: flex;
+	align-items: stretch;
+
+	> span {
+		align-self: center;
+	}
+
+	p.warning {
+		background-color: #fcf9e8;
+		color: #674600;
+		padding: 4px 8px;
+		border-radius: 2px;
+	}
+`;
+
+const WarningIcon = styled( Icon )`
+	fill: #674600;
+	padding: 5px;
+	margin: 1em 0;
 `;
 
 const AccountDetailsError = styled.p`
@@ -125,6 +144,7 @@ const WebhooksSection = () => {
 	);
 
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
+	const isWarningMessage = message.includes( 'Warning: ' );
 
 	return (
 		<>
@@ -137,8 +157,13 @@ const WebhooksSection = () => {
 				</SectionStatus>
 			</AccountSection>
 			<WebhookDescription>
+				{ isWarningMessage && (
+					<span data-testid="warning">
+						<WarningIcon icon={ warning } size="16" />
+					</span>
+				) }
 				{ ! isWebhookSecretEntered && <WebhookInformation /> }
-				<p>
+				<p className={ isWarningMessage ? 'warning' : '' }>
 					{ message }{ ' ' }
 					<Button
 						disabled={ requestStatus === 'pending' }

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -144,7 +144,7 @@ const WebhooksSection = () => {
 	);
 
 	const { message, requestStatus, refreshMessage } = useWebhookStateMessage();
-	const isWarningMessage = message.includes( 'Warning: ' );
+	const isWarningMessage = message?.includes( 'Warning: ' ) || false;
 
 	return (
 		<>

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -45,8 +45,11 @@ const WebhookDescription = styled.div`
 	font-size: 12px;
 	font-style: normal;
 	color: rgb( 117, 117, 117 );
-	display: flex;
-	align-items: stretch;
+
+	.expanded {
+		display: flex;
+		align-items: stretch;
+	}
 
 	> span {
 		align-self: center;
@@ -156,7 +159,9 @@ const WebhooksSection = () => {
 						: __( 'Disabled', 'woocommerce-gateway-stripe' ) }
 				</SectionStatus>
 			</AccountSection>
-			<WebhookDescription>
+			<WebhookDescription
+				className={ isWebhookSecretEntered ? 'expanded' : '' }
+			>
 				{ isWarningMessage && (
 					<span data-testid="warning">
 						<WarningIcon icon={ warning } size="16" />

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import React from 'react';
 import { Button, ExternalLink, Icon } from '@wordpress/components';
-import { warning, help } from '@wordpress/icons';
+import { help, warning } from '@wordpress/icons';
 import interpolateComponents from 'interpolate-components';
 import styled from '@emotion/styled';
 import useWebhookStateMessage from './use-webhook-state-message';

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.5.0 - 2024-xx-xx =
+* Tweak - Improve the display of warning messages related to webhook configuration.
 * Fix - When using a saved payment method, update the payment method's address immediately upon checkout. Fixes issues where Stripe may throw address validation errors.
 * Add - Allow customizing the title and description of the UPE payment methods.
 * Tweak - Add a statement descriptor preview for Cash App Payments.

--- a/readme.txt
+++ b/readme.txt
@@ -129,11 +129,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.5.0 - 2024-xx-xx =
-<<<<<<< HEAD
-* Tweak - Improve the display of warning messages related to webhook configuration.
-=======
 * Tweak - Add a notice in checkout for Cash App transactions above 2000 USD to inform customers about the decline risk.
->>>>>>> develop
+* Tweak - Improve the display of warning messages related to webhook configuration.
 * Fix - When using a saved payment method, update the payment method's address immediately upon checkout. Fixes issues where Stripe may throw address validation errors.
 * Add - Allow customizing the title and description of the UPE payment methods.
 * Tweak - Add a statement descriptor preview for Cash App Payments.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2551

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

The displayed message is not highlighted enough when there's some issue with the Stripe webhook configuration. This PR changes the visuals as below: 
![Screenshot 2024-06-18 at 17 39 08](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/99fd3203-5e63-4c30-b5e0-a4bc106c8d00)

When there are no warning messages, the original visual remains:
![Screenshot 2024-06-18 at 18 08 36](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/10187816/7b269b3b-fdf1-499b-972d-04ee65ac6f8a)

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

It is a bit tricky to test this change with actual errors from the webhook configuration on your Stripe account, so I believe the simplest way to do it is:
- Access the Stripe settings page on your store: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
- Confirm that the webhook message visuals remains the same (if everything is OK with your configuration)
- Comment out lines 180-227 from `includes/class-wc-stripe-webhook-state.php`
- Confirm that you can see the new visuals now (with the forced warning message)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
