### PR TITLE
[E2E] Expand the address 2 field before attempting to fill out the checkout details

### DIFF
--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -242,6 +242,10 @@ export async function setupBlocksCheckout( page, billingDetails = null ) {
 				'.components-form-token-field__suggestions-list > li:first-child'
 			)
 			.click();
+		// Expand the address 2 field.
+		await page
+			.locator( '.wc-block-components-address-form__address_2-toggle' )
+			.click();
 
 		for ( const fieldName of Object.keys( billingDetails ) ) {
 			if (


### PR DESCRIPTION
## Changes proposed in this Pull Request:

WooCommerce `9.0` changed the block checkout to include a new toggle to show the address 2 (apartment suite) field. 

<p align="center">
<img width="1111" alt="Screenshot 2024-06-19 at 12 33 17 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ba1a5853-63fb-4349-8418-449d5e2ce1c1">
</p>

This PR fixes that e2e tests which were failing because it couldn't fill out the address 2 field. 

## Testing instructions


1. Run the e2e tests on develop.
   - `npm run test:e2e-setup -- --base_url=https://example.ninja/`
3. You should see an error like this:

<img width="1534" alt="Screenshot 2024-06-19 at 12 39 05 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ace86c86-7057-4329-a54f-71c9f16f7369">

4. Run the e2e tests on this branch.
5. Tests should pass. 
    - Note you may have the refund test fail, rerunning will usually fix that. 

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
