### PR TITLE
Defer webhook processing when a webhook is received but we're expecting a UPE redirect

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@
 * Fix - When using a saved payment method, update the payment method's address immediately upon checkout. Fixes issues where Stripe may throw address validation errors.
 * Tweak - Add a statement descriptor preview for Cash App Payments.
 * Add - Allow customizing the title and description of the UPE payment methods.
-* Fix - Ensure payments processed via a redirect are processed via the webhook if the redirect never occurs. Fixes issues with orders being left in a pending payment state.
+* Fix - Ensure payments via redirect are processed through the webhook if the redirect never occurs. Resolves issues of orders being left as pending payment.
 
 = 8.4.0 - 2024-06-13 =
 * Tweak - Resets the list of payment methods when any Stripe key is updated.

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - When using a saved payment method, update the payment method's address immediately upon checkout. Fixes issues where Stripe may throw address validation errors.
 * Tweak - Add a statement descriptor preview for Cash App Payments.
 * Add - Allow customizing the title and description of the UPE payment methods.
+* Fix - Ensure payments processed via a redirect are processed via the webhook if the redirect never occurs. Fixes issues with orders being left in a pending payment state.
 
 = 8.4.0 - 2024-06-13 =
 * Tweak - Resets the list of payment methods when any Stripe key is updated.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1100,6 +1100,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		if ( $intent && $intent->id === $intent_id ) {
 			$charge = $this->get_latest_charge_from_intent( $intent );
 
+			WC_Stripe_Logger::log( "Processing Stripe PaymentIntent {$intent_id} for order {$order->get_id()} via deferred webhook." );
+
 			do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
 			$this->process_response( $charge, $order );
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1075,13 +1075,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					}
 
 					// Check if the order is still in a valid state to process the webhook.
-					if ( ! $order->has_status(
-						apply_filters(
-							'wc_stripe_allowed_payment_processing_statuses',
-							[ 'pending', 'failed' ],
-							$order
-						)
-					) ) {
+					if ( ! $order->has_status( apply_filters( 'wc_stripe_allowed_payment_processing_statuses', [ 'pending', 'failed' ], $order ) ) ) {
 						WC_Stripe_Logger::log( "Skipped processing deferred webhook for Stripe PaymentIntent {$intent_id} for order {$order->get_id()} - payment already complete." );
 						return;
 					}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1074,6 +1074,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 						throw new Exception( "Missing required data: 'intent_id' is missing for the deferred {$webhook_type} event." );
 					}
 
+					// Check if the order is still in a valid state to process the webhook.
+					if ( ! $order->has_status(
+						apply_filters(
+							'wc_stripe_allowed_payment_processing_statuses',
+							[ 'pending', 'failed' ],
+							$order
+						)
+					) ) {
+						return;
+					}
+
 					$this->handle_deferred_payment_intent_succeeded( $order, $intent_id );
 					break;
 				default:

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1067,11 +1067,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$intent_id = $additional_data['intent_id'] ?? '';
 
 					if ( empty( $order ) ) {
-						throw new Exception( "Missing required data: 'order_id' is invalid or not found for the deferred {$webhook_type} event." );
+						throw new Exception( "Missing required data. 'order_id' is invalid or not found for the deferred '{$webhook_type}' event." );
 					}
 
 					if ( empty( $intent_id ) ) {
-						throw new Exception( "Missing required data: 'intent_id' is missing for the deferred {$webhook_type} event." );
+						throw new Exception( "Missing required data. 'intent_id' is missing for the deferred '{$webhook_type}' event." );
 					}
 
 					// Check if the order is still in a valid state to process the webhook.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1103,14 +1103,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	protected function handle_deferred_payment_intent_succeeded( $order, $intent_id ) {
 		$intent = $this->get_intent_from_order( $order );
 
-		if ( $intent && $intent->id === $intent_id ) {
-			$charge = $this->get_latest_charge_from_intent( $intent );
-
-			WC_Stripe_Logger::log( "Processing Stripe PaymentIntent {$intent_id} for order {$order->get_id()} via deferred webhook." );
-
-			do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
-			$this->process_response( $charge, $order );
+		if ( ! $intent || $intent->id !== $intent_id ) {
+			WC_Stripe_Logger::log( "Skipped processing deferred webhook for Stripe PaymentIntent {$intent_id} for order {$order->get_id()} - intent ID stored on order ({$intent->id}) doesn't match." );
+			return;
 		}
+
+		$charge = $this->get_latest_charge_from_intent( $intent );
+
+		WC_Stripe_Logger::log( "Processing Stripe PaymentIntent {$intent_id} for order {$order->get_id()} via deferred webhook." );
+
+		do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
+		$this->process_response( $charge, $order );
+
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1066,10 +1066,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				case 'payment_intent.amount_capturable_updated':
 					$order         = isset( $additional_data['order_id'] ) ? wc_get_order( $additional_data['order_id'] ) : null;
 					$intent_id     = $additional_data['intent_id'] ?? '';
-					$error_message = 'Missing required data: %s is invalid or not found for the deferred payment_intent.succeeded event';
+					$error_message = 'Missing required data: %s is invalid or not found for the deferred payment_intent.succeeded event.';
 
 					if ( empty( $order ) ) {
-						throw new Exception( sprintf( $error_message, 'order' ) );
+						throw new Exception( sprintf( $error_message, 'order_id' ) );
 					}
 
 					if ( empty( $intent_id ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -26,6 +26,28 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	protected $secret;
 
 	/**
+	 * The Action Scheduler service.
+	 *
+	 * @var WC_Stripe_Action_Scheduler_Service
+	 */
+	protected $action_scheduler_service;
+
+	/**
+	 * How long to wait before processing a deferred webhook.
+	 *
+	 * @var int
+	 */
+	protected $deferred_webhook_delay = 2 * MINUTE_IN_SECONDS;
+
+
+	/**
+	 * The Action Scheduler hook to use when retrying a webhook.
+	 *
+	 * @var string
+	 */
+	protected $deferred_webhook_action = 'wc_stripe_deferred_webhook';
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 4.0.0
@@ -38,12 +60,16 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$secret_key           = ( $this->testmode ? 'test_' : '' ) . 'webhook_secret';
 		$this->secret         = ! empty( $stripe_settings[ $secret_key ] ) ? $stripe_settings[ $secret_key ] : false;
 
+		$this->action_scheduler_service = new WC_Stripe_Action_Scheduler_Service();
+
 		add_action( 'woocommerce_api_wc_stripe', [ $this, 'check_for_webhook' ] );
 
 		// Get/set the time we began monitoring the health of webhooks by fetching it.
 		// This should be roughly the same as the activation time of the version of the
 		// plugin when this code first appears.
 		WC_Stripe_Webhook_State::get_monitoring_began_at();
+
+		add_action( $this->deferred_webhook_action, [ $this, 'process_deferred_webhook' ], 10, 2 );
 	}
 
 	/**
@@ -911,7 +937,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				// Voucher payments are only processed via the webhook so are excluded from the above check.
 				// Wallets are also processed via the webhook, not redirection.
 				if ( ! $is_voucher_payment && ! $is_wallet_payment && $is_awaiting_action ) {
-					WC_Stripe_Logger::log( "Stripe UPE waiting for redirect. The status for order $order_id might need manual adjustment." );
+					WC_Stripe_Logger::log( "Stripe UPE waiting for redirect. Scheduled deferred webhook processing. The status for order $order_id might need manual adjustment." );
+
+					// Schedule a job to check on the status of this intent.
+					$this->defer_webhook_processing(
+						$notification,
+						[
+							'order_id'  => $order_id,
+							'intent_id' => $intent->id,
+						]
+					);
+
 					do_action( 'wc_gateway_stripe_process_payment_intent_incomplete', $order );
 					return;
 				}
@@ -994,6 +1030,81 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		$this->unlock_order_payment( $order );
+	}
+
+	/**
+	 * Schedules a job to run in the future to check on the status of a webhook.
+	 *
+	 * Each Webhook type which is deferred should be supported by @see process_deferred_webhook().
+	 *
+	 * @param stdClass $webhook_notification The webhook payload received from Stripe.
+	 * @param array    $additional_data      Additional data to pass to the scheduled job.
+	 */
+	protected function defer_webhook_processing( $webhook_notification, $additional_data ) {
+		$this->action_scheduler_service->schedule_job(
+			time() + $this->deferred_webhook_delay,
+			$this->deferred_webhook_action,
+			[
+				'type' => $webhook_notification->type,
+				'data' => $additional_data,
+			]
+		);
+	}
+
+	/**
+	 * Processes a deferred webhook event.
+	 *
+	 * Deferred webhooks are scheduled by @see defer_webhook_processing().
+	 *
+	 * @param string $webhook_type    The webhook event name/type.
+	 * @param array  $additional_data Additional data passed to the scheduled job.
+	 */
+	public function process_deferred_webhook( $webhook_type, $additional_data ) {
+		try {
+			switch ( $webhook_type ) {
+				case 'payment_intent.succeeded':
+				case 'payment_intent.amount_capturable_updated':
+					$order         = isset( $additional_data['order_id'] ) ? wc_get_order( $additional_data['order_id'] ) : null;
+					$intent_id     = $additional_data['intent_id'] ?? '';
+					$error_message = 'Missing required data: %s is invalid or not found for the deferred payment_intent.succeeded event';
+
+					if ( empty( $order ) ) {
+						throw new Exception( sprintf( $error_message, 'order' ) );
+					}
+
+					if ( empty( $intent_id ) ) {
+						throw new Exception( sprintf( $error_message, 'intent_id' ) );
+					}
+
+					$this->handle_deferred_payment_intent_succeeded( $order, $intent_id );
+					break;
+				default:
+					throw new Exception( "Unsupported webhook type: {$webhook_type}" );
+					break;
+			}
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log( 'Error processing deferred webhook: ' . $e->getMessage() );
+
+			// This will be caught by Action Scheduler and logged as an error.
+			throw $e;
+		}
+	}
+
+	/**
+	 * Handles a deferred payment_intent.succeeded event.
+	 *
+	 * @param WC_Order $order     The order object.
+	 * @param string   $intent_id The payment intent ID.
+	 */
+	protected function handle_deferred_payment_intent_succeeded( $order, $intent_id ) {
+		$intent = $this->get_intent_from_order( $order );
+
+		if ( $intent && $intent->id === $intent_id ) {
+			$charge = $this->get_latest_charge_from_intent( $intent );
+
+			do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
+			$this->process_response( $charge, $order );
+		}
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1064,16 +1064,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			switch ( $webhook_type ) {
 				case 'payment_intent.succeeded':
 				case 'payment_intent.amount_capturable_updated':
-					$order         = isset( $additional_data['order_id'] ) ? wc_get_order( $additional_data['order_id'] ) : null;
-					$intent_id     = $additional_data['intent_id'] ?? '';
-					$error_message = 'Missing required data: %s is invalid or not found for the deferred payment_intent.succeeded event.';
+					$order     = isset( $additional_data['order_id'] ) ? wc_get_order( $additional_data['order_id'] ) : null;
+					$intent_id = $additional_data['intent_id'] ?? '';
 
 					if ( empty( $order ) ) {
-						throw new Exception( sprintf( $error_message, 'order_id' ) );
+						throw new Exception( "Missing required data: 'order_id' is invalid or not found for the deferred {$webhook_type} event." );
 					}
 
 					if ( empty( $intent_id ) ) {
-						throw new Exception( sprintf( $error_message, 'intent_id' ) );
+						throw new Exception( "Missing required data: 'intent_id' is missing for the deferred {$webhook_type} event." );
 					}
 
 					$this->handle_deferred_payment_intent_succeeded( $order, $intent_id );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -39,7 +39,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	protected $deferred_webhook_delay = 2 * MINUTE_IN_SECONDS;
 
-
 	/**
 	 * The Action Scheduler hook to use when retrying a webhook.
 	 *

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1082,6 +1082,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 							$order
 						)
 					) ) {
+						WC_Stripe_Logger::log( "Skipped processing deferred webhook for Stripe PaymentIntent {$intent_id} for order {$order->get_id()} - payment already complete." );
 						return;
 					}
 

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - When using a saved payment method, update the payment method's address immediately upon checkout. Fixes issues where Stripe may throw address validation errors.
 * Add - Allow customizing the title and description of the UPE payment methods.
 * Tweak - Add a statement descriptor preview for Cash App Payments.
-* Fix - Ensure payments processed via a redirect are processed via the webhook if the redirect never occurs. Fixes issues with orders being left in a pending payment state.
+* Fix - Ensure payments via redirect are processed through the webhook if the redirect never occurs. Resolves issues of orders being left as pending payment.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -134,5 +134,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - When using a saved payment method, update the payment method's address immediately upon checkout. Fixes issues where Stripe may throw address validation errors.
 * Add - Allow customizing the title and description of the UPE payment methods.
 * Tweak - Add a statement descriptor preview for Cash App Payments.
+* Fix - Ensure payments processed via a redirect are processed via the webhook if the redirect never occurs. Fixes issues with orders being left in a pending payment state.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * These tests make assertions against class WC_Stripe_Webhook_State.
+ *
+ * @package WooCommerce_Stripe/Tests/Webhook_State
+ */
+
+/**
+ * WC_Stripe_Webhook_State_Test class.
+ */
+class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
+
+	/**
+	 * The webhook handler instance for testing.
+	 *
+	 * @var WC_Stripe_Webhook_Handler
+	 */
+	private $webhook_handler;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->webhook_handler = new WC_Stripe_Webhook_Handler();
+	}
+
+	/**
+	 * Test process_deferred_webhook with unsupported webhook type.
+	 */
+	public function test_process_deferred_webhook_invalid_type() {
+		$this->expectExceptionMessage( 'Unsupported webhook type: event-id' );
+		$this->webhook_handler->process_deferred_webhook( 'event-id', [] );
+	}
+}

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -20,7 +20,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	/**
 	 * Mock card payment intent template.
 	 */
-	const MOCK_CARD_PAYMENT_INTENT_TEMPLATE = [
+	const MOCK_PAYMENT_INTENT = [
 		'id'                 => 'pi_mock',
 		'object'             => 'payment_intent',
 		'status'             => 'succeeded',
@@ -130,6 +130,16 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'intent_id' => 'pi_wrong_id',
 		];
 
+		$this->mock_webhook_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods(
+				[
+					'get_intent_from_order',
+					'get_latest_charge_from_intent',
+					'process_response',
+				]
+			)
+			->getMock();
+
 		// Mock the get intent from order to return the mock intent.
 		$this->mock_webhook_handler->expects( $this->once() )
 			->method( 'get_intent_from_order' )
@@ -139,7 +149,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 						return $passed_order instanceof WC_Order && $order->get_id() === $passed_order->get_id();
 					}
 				)
-			)->willReturn( (object) self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE );
+			)->willReturn( (object) self::MOCK_PAYMENT_INTENT );
 
 		// Expect the get latest charge from intent to be called.
 		$this->mock_webhook_handler->expects( $this->never() )
@@ -159,13 +169,23 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$data  = [
 			'order_id' => $order->get_id(),
-			'intent_id' => self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE['id'],
+			'intent_id' => self::MOCK_PAYMENT_INTENT['id'],
 		];
+
+		$this->mock_webhook_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods(
+				[
+					'get_intent_from_order',
+					'get_latest_charge_from_intent',
+					'process_response',
+				]
+			)
+			->getMock();
 
 		// Mock the get intent from order to return the mock intent.
 		$this->mock_webhook_handler->expects( $this->once() )
 			->method( 'get_intent_from_order' )
-			->willReturn( (object) self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE );
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT );
 
 		// Expect the get latest charge from intent to be called.
 		$this->mock_webhook_handler->expects( $this->once() )
@@ -175,7 +195,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler->expects( $this->once() )
 			->method( 'process_response' )
 			->with(
-				self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE['charges']['data'][0],
+				self::MOCK_PAYMENT_INTENT['charges']['data'][0],
 				$this->callback(
 					function( $passed_order ) use ( $order ) {
 						return $passed_order instanceof WC_Order && $order->get_id() === $passed_order->get_id();

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -79,7 +79,14 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->expects( $this->once() )
 			->method( 'handle_deferred_payment_intent_succeeded' )
-			->with( $order, $intent_id );
+			->with(
+				$this->callback(
+					function( $passed_order ) use ( $order ) {
+						return $passed_order instanceof WC_Order && $order->get_id() === $passed_order->get_id();
+					}
+				),
+				$this->equalTo( $intent_id ),
+			);
 
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 	}

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -34,12 +34,29 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->webhook_handler->process_deferred_webhook( 'event-id', [] );
 	}
 
+	/**
+	 * Test process_deferred_webhook with invalid args.
+	 */
 	public function test_process_deferred_webhook_invalid_args() {
+		// No data
+		$data = []; // No data.
+
+		$this->expectExceptionMessage( "Missing required data: 'order_id' is invalid or not found for the deferred payment_intent.succeeded event." );
+		$this->webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
+
+		// Invalid order_id
 		$data = [
-			'order_id' => 'invalid_order_id',
+			'order_id' => 9999,
 		];
 
-		$this->expectExceptionMessage( 'Unsupported webhook type: event-id' );
-		$this->webhook_handler->process_deferred_webhook( 'charge.succeeded', $data );
+		$this->expectExceptionMessage( "Missing required data: 'order_id' is invalid or not found for the deferred payment_intent.succeeded event." );
+		$this->webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
+
+		// No payment intent
+		$order = WC_Helper_Order::create_order();
+		$data['order_id'] = $order->get_id();
+
+		$this->expectExceptionMessage( "Missing required data: 'intent_id' is missing for the deferred payment_intent.succeeded event." );
+		$this->webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 	}
 }

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -84,7 +84,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		// No data.
 		$data = [];
 
-		$this->expectExceptionMessage( "Missing required data: 'order_id' is invalid or not found for the deferred payment_intent.succeeded event." );
+		$this->expectExceptionMessage( "Missing required data. 'order_id' is invalid or not found for the deferred 'payment_intent.succeeded' event." );
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 
 		// Invalid order_id.
@@ -92,14 +92,14 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'order_id' => 9999,
 		];
 
-		$this->expectExceptionMessage( "Missing required data: 'order_id' is invalid or not found for the deferred payment_intent.succeeded event." );
+		$this->expectExceptionMessage( "Missing required data. 'order_id' is invalid or not found for the deferred 'payment_intent.succeeded' event." );
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 
 		// No payment intent.
 		$order = WC_Helper_Order::create_order();
 		$data['order_id'] = $order->get_id();
 
-		$this->expectExceptionMessage( "Missing required data: 'intent_id' is missing for the deferred payment_intent.succeeded event." );
+		$this->expectExceptionMessage( "Missing required data. 'intent_id' is missing for the deferred 'payment_intent.succeeded' event." );
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 	}
 

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -67,7 +67,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Undocumented function
+	 * Test process_deferred_webhook with valid args.
 	 */
 	public function test_test_process_deferred_webhook() {
 		$order     = WC_Helper_Order::create_order();

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -33,4 +33,13 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->expectExceptionMessage( 'Unsupported webhook type: event-id' );
 		$this->webhook_handler->process_deferred_webhook( 'event-id', [] );
 	}
+
+	public function test_process_deferred_webhook_invalid_args() {
+		$data = [
+			'order_id' => 'invalid_order_id',
+		];
+
+		$this->expectExceptionMessage( 'Unsupported webhook type: event-id' );
+		$this->webhook_handler->process_deferred_webhook( 'charge.succeeded', $data );
+	}
 }

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -18,6 +18,26 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	private $mock_webhook_handler;
 
 	/**
+	 * Mock card payment intent template.
+	 */
+	const MOCK_CARD_PAYMENT_INTENT_TEMPLATE = [
+		'id'                 => 'pi_mock',
+		'object'             => 'payment_intent',
+		'status'             => 'succeeded',
+		'charges'            => [
+			'total_count' => 1,
+			'data'        => [
+				[
+					'id'                     => 'ch_mock',
+					'captured'               => true,
+					'payment_method_details' => [],
+					'status'                 => 'succeeded',
+				],
+			],
+		],
+	];
+
+	/**
 	 * Set up the test.
 	 */
 	public function set_up() {
@@ -27,6 +47,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			->setMethods(
 				[
 					'handle_deferred_payment_intent_succeeded',
+					'get_intent_from_order',
+					'get_latest_charge_from_intent',
+					'process_response',
 				]
 			)
 			->getMock();
@@ -36,6 +59,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * Test process_deferred_webhook with unsupported webhook type.
 	 */
 	public function test_process_deferred_webhook_invalid_type() {
+		$this->mock_webhook_handler->expects( $this->never() )
+			->method( 'handle_deferred_payment_intent_succeeded' );
+
 		$this->expectExceptionMessage( 'Unsupported webhook type: event-id' );
 		$this->mock_webhook_handler->process_deferred_webhook( 'event-id', [] );
 	}
@@ -44,13 +70,16 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * Test process_deferred_webhook with invalid args.
 	 */
 	public function test_process_deferred_webhook_invalid_args() {
-		// No data
-		$data = []; // No data.
+		$this->mock_webhook_handler->expects( $this->never() )
+			->method( 'handle_deferred_payment_intent_succeeded' );
+
+		// No data.
+		$data = [];
 
 		$this->expectExceptionMessage( "Missing required data: 'order_id' is invalid or not found for the deferred payment_intent.succeeded event." );
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 
-		// Invalid order_id
+		// Invalid order_id.
 		$data = [
 			'order_id' => 9999,
 		];
@@ -58,7 +87,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->expectExceptionMessage( "Missing required data: 'order_id' is invalid or not found for the deferred payment_intent.succeeded event." );
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 
-		// No payment intent
+		// No payment intent.
 		$order = WC_Helper_Order::create_order();
 		$data['order_id'] = $order->get_id();
 
@@ -69,7 +98,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	/**
 	 * Test process_deferred_webhook with valid args.
 	 */
-	public function test_test_process_deferred_webhook() {
+	public function test_process_deferred_webhook() {
 		$order     = WC_Helper_Order::create_order();
 		$intent_id = 'pi_mock_1234';
 		$data      = [
@@ -86,6 +115,46 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 					}
 				),
 				$this->equalTo( $intent_id ),
+			);
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
+	}
+
+	/**
+	 * Test successful deferred webhook.
+	 */
+	public function test_process_of_successful_payment_intent_deferred_webhook() {
+		$order = WC_Helper_Order::create_order();
+		$data  = [
+			'order_id' => $order->get_id(),
+			'intent_id' => self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE['id'],
+		];
+
+		// Mock the get intent from order to return the mock intent.
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'get_intent_from_order' )
+			->with(
+				$this->callback(
+					function( $passed_order ) use ( $order ) {
+						return $passed_order instanceof WC_Order && $order->get_id() === $passed_order->get_id();
+					}
+				)
+			)->willReturn( (object) self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE );
+
+		// Expect the get latest charge from intent to be called.
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'get_latest_charge_from_intent' );
+
+		// Expect the process response to be called with the charge and order.
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'process_response' )
+			->with(
+				self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE['charges']['data'][0],
+				$this->callback(
+					function( $passed_order ) use ( $order ) {
+						return $passed_order instanceof WC_Order && $order->get_id() === $passed_order->get_id();
+					}
+				)
 			);
 
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -190,6 +190,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php';
 				require_once dirname( __FILE__ ) . '/includes/abstracts/abstract-wc-stripe-payment-gateway.php';
 				require_once dirname( __FILE__ ) . '/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php';
+				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-action-scheduler-service.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-state.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-handler.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-sepa-payment-token.php';
@@ -231,7 +232,6 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-woo-compat-utils.php';
 				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect.php';
 				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect-api.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-action-scheduler-service.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-order-handler.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-payment-tokens.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-customer.php';


### PR DESCRIPTION
Fixes #3192 

## Changes proposed in this Pull Request:

We've had reports from a number of merchants experiencing an issue where orders are being left as pending-payment. After investigating, it turns out the issue is that successful webhooks are being received but are being skipped with the Stripe log entry:

```php
"Stripe UPE waiting for redirect. The status for order {$order_id} might need manual adjustment."
```

I haven't been able to fully understand what causes this myself, however, what we do know is that this impacts payment methods like P24, iDEAL etc where the customer is redirected offsite and redirected back to the site where we'd process the payment via args in redirect URL.

I suspect what is happening is: 

1. The customer isn't being redirected by their bank. These payment methods integrate with a number of banking institutes across Europe and so any one of them could have a different flow that doesn't end in them being redirected back. 
2. Similar to above, if the process of completing the payment has the customer use their mobile, the redirect that eventually occurs may be invalid because the nonce in the URL is only valid for the logged in user session on the original device. 
3. Any another reason the URL redirect may be invalid.

This PR fixes this by making sure we process the successful webhook, but we wait at least 2 minutes to allow a potential redirect to occur. Given the successful payment webhook has been received, 2 minutes should be more than enough time for the redirect to occur if it's going to. We could adjust this if we want to give more or less time. 

## Testing instructions

**Reproducing the bug**
1. Make sure you have webhooks set up and your store is publicly accessible so they can be processed. ie use a JN site or ngrok. 
1. Set your Stripe plugin API credentials to a EU account. 
2. Set your store currency to EUR. 
3. Enable a payment method with a redirect involved eg Przelewy24, iDEAL, EPS, giropay etc. 
5. Add a product to your cart. 
6. On checkout select the redirect payment method.
7. Once you're at the Stripe site where you can choose to authorize or deny the payment, copy the URL. 
8. Put that url into your mobile device to simulate the customer using a different device to complete the payment. 
9. Click "Authorize payment" on your phone. 
10. Go back to your browser and open up the order list table in WP admin.
11. Notice the order is set to pending payment.
12. View the Stripe logs and you should see the `Stripe UPE waiting for redirect. The status for order 7674 might need manual adjustment.` message. 

**Confirm the fix**

13. Checkout this branch.
14. Repeat the steps above. 
15. At step 11 you will see a slightly different log entry: <code>Stripe UPE waiting for redirect. <strong>Scheduled deferred webhook processing.</strong> The status for order 7675 might need manual adjustment.</code>
16. Go to **WooCommerce → Status → Scheduled actions (tab)**. 
17. Search for `wc_stripe_deferred_webhook`. 
18. You should see a pending scheduled action for the order.
<p align="center">
<img width="1217" alt="Screenshot 2024-06-24 at 4 49 36 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/544c2717-88f8-4a5f-a93c-762019eabf7f">
</p>
20. Wait the 2 minutes or manually run the action. 
21. When that action runs, the order should be processing. 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
