### PR TITLE
Prevent tokens associated with sources from being displayed with the updated checkout experience

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Fix - Ensure subscriptions purchased with iDEAL or Bancontact are correctly set to SEPA debit prior to processing the intitial payment.
 * Tweak - Stripe API version updated to support 2024-06-20.
 * Fix - Ensure SEPA tokens are attached to customers in the legacy checkout experience when the payment method is saved. This addresses subscription recurring payment "off-session" errors with SEPA.
+* Fix - Prevent saved SEPA Sources from being displayed as available payment methods when the Updated checkout experience is enabled.
 
 = 8.4.0 - 2024-06-13 =
 * Tweak - Resets the list of payment methods when any Stripe key is updated.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -262,9 +262,9 @@ class WC_Stripe_Payment_Tokens {
 		}
 
 		try {
-			$stored_tokens        = [];
-			$deprecated_tokens    = [];
-			$tokens_using_sources = [];
+			$stored_tokens = [];
+
+			$deprecated_tokens = [];
 
 			foreach ( $tokens as $token ) {
 				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
@@ -273,11 +273,6 @@ class WC_Stripe_Payment_Tokens {
 					if ( 'stripe' === $token->get_gateway_id() && 'sepa' === $token->get_type() ) {
 						$deprecated_tokens[ $token->get_token() ] = $token;
 						continue;
-					}
-
-					// List the tokens using sources to check whether they were migrated on the Stripe side later on.
-					if ( str_starts_with( $token->get_token(), 'src_' ) ) {
-						$tokens_using_sources[ $token->get_token() ] = $token;
 					}
 
 					$stored_tokens[ $token->get_token() ] = $token;
@@ -310,16 +305,6 @@ class WC_Stripe_Payment_Tokens {
 			foreach ( $payment_methods as $payment_method ) {
 				if ( ! isset( $payment_method->type ) ) {
 					continue;
-				}
-
-				// Remove the token locally when:
-				// - The payment method is listed within the tokens in WooCommerce using sources.
-				// - It was migrated to a payment method on the Stripe side.
-				if (
-					isset( $tokens_using_sources[ $payment_method->id ] ) &&
-					! empty( $payment_method->metadata->migrated_payment_method )
-				) {
-					$deprecated_tokens[ $payment_method->id ] = $tokens_using_sources[ $payment_method->id ];
 				}
 
 				// Retrieve the real APM behind SEPA PaymentMethods.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -262,9 +262,9 @@ class WC_Stripe_Payment_Tokens {
 		}
 
 		try {
-			$stored_tokens = [];
-
-			$deprecated_tokens = [];
+			$stored_tokens        = [];
+			$deprecated_tokens    = [];
+			$tokens_using_sources = [];
 
 			foreach ( $tokens as $token ) {
 				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
@@ -273,6 +273,11 @@ class WC_Stripe_Payment_Tokens {
 					if ( 'stripe' === $token->get_gateway_id() && 'sepa' === $token->get_type() ) {
 						$deprecated_tokens[ $token->get_token() ] = $token;
 						continue;
+					}
+
+					// List the tokens using sources to check whether they were migrated on the Stripe side later on.
+					if ( str_starts_with( $token->get_token(), 'src_' ) ) {
+						$tokens_using_sources[ $token->get_token() ] = $token;
 					}
 
 					$stored_tokens[ $token->get_token() ] = $token;
@@ -305,6 +310,16 @@ class WC_Stripe_Payment_Tokens {
 			foreach ( $payment_methods as $payment_method ) {
 				if ( ! isset( $payment_method->type ) ) {
 					continue;
+				}
+
+				// Remove the token locally when:
+				// - The payment method is listed within the tokens in WooCommerce using sources.
+				// - It was migrated to a payment method on the Stripe side.
+				if (
+					isset( $tokens_using_sources[ $payment_method->id ] ) &&
+					! empty( $payment_method->metadata->migrated_payment_method )
+				) {
+					$deprecated_tokens[ $payment_method->id ] = $tokens_using_sources[ $payment_method->id ];
 				}
 
 				// Retrieve the real APM behind SEPA PaymentMethods.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -310,8 +310,13 @@ class WC_Stripe_Payment_Tokens {
 				// Retrieve the real APM behind SEPA PaymentMethods.
 				$payment_method_type = $this->get_original_payment_method_type( $payment_method );
 
+				// Create a new token when:
+				// - The payment method doesn't have an associated token in WooCommerce.
+				// - The payment method is not a source.
+				// - The payment method belongs to the gateway ID being retrieved or the gateway ID is empty (meaning we're looking for all payment methods).
 				if (
 					! isset( $stored_tokens[ $payment_method->id ] ) &&
+					! str_starts_with( $payment_method->id, 'src_' ) &&
 					( $this->is_valid_payment_method_type_for_gateway( $payment_method_type, $gateway_id ) || empty( $gateway_id ) )
 				) {
 					$token                      = $this->add_token_to_user( $payment_method, $customer );

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -262,15 +262,19 @@ class WC_Stripe_Payment_Tokens {
 		}
 
 		try {
-			$stored_tokens = [];
-
+			$stored_tokens     = [];
 			$deprecated_tokens = [];
 
 			foreach ( $tokens as $token ) {
 				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
 
-					// APM tokens from before Split PE was in place that will get removed.
-					if ( 'stripe' === $token->get_gateway_id() && 'sepa' === $token->get_type() ) {
+					// Remove the following deprecated tokens:
+					// - APM tokens from before Split PE was in place.
+					// - Tokens using the sources API. Payments using these will fail with the PaymentMethods API.
+					if (
+						( 'stripe' === $token->get_gateway_id() && 'sepa' === $token->get_type() ) ||
+						str_starts_with( $token->get_token(), 'src_' )
+					) {
 						$deprecated_tokens[ $token->get_token() ] = $token;
 						continue;
 					}

--- a/readme.txt
+++ b/readme.txt
@@ -145,5 +145,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Ensure SEPA tokens are attached to customers in the legacy checkout experience when the payment method is saved. This addresses subscription recurring payment "off-session" errors with SEPA.
 * Tweak - Limit the configure webhooks button to 1 click per minute to prevent multiple webhook creations.
 * Fix - Address Klarna currency rules to ensure correct presentment and availability based on merchant and customer locations.
+* Fix - Prevent saved SEPA Sources from being displayed as available payment methods when the Updated checkout experience is enabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3134

## Changes proposed in this Pull Request:

- Stop creating tokens for sources attached to the customer when the updated checkout experience (PaymentMethods API) is used.
- Delete the local tokens associated with sources.

This PR doesn't handle creating tokens because they will already be created. If sources were migrated for the merchant account, the shopper will have payment methods attached for these sources. We're [already creating tokens](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.4.0/includes/class-wc-stripe-payment-tokens.php#L313-L319) for payment methods that exist in Stripe and not locally. 

## Testing instructions

#### Setup
1. Select EUR as the store currency
3. Check out 8.0.1. There's an error in later versions where SEPA payment methods aren't attached to the customer on the Legacy experience
5. As a merchant, enable the Legacy experience
4. Enable SEPA under the Payment methods tab
6. As a shopper, go to My account > Payment methods > Add payment methods
7. Add some SEPA payment methods. Find some account numbers [here](https://docs.stripe.com/sources/sepa-debit#testing)
8. Checkout the latest Stripe version
9. As a merchant, disable the Legacy experience. This will make requests go through the Payment Methods API

#### Confirm src_ tokens are not displayed

1. In the database, go to the `woocommerce_payment_token` table
2. Retrieve the tokens for the shopper you used to add payment methods
3. Confirm there are no rows where the `gateway_id` = `stripe_sepa_debit` and the `token` = `src_%`
4. As a shopper, go to the checkout page
5. Confirm no payment methods are displayed for SEPA
6. Confirm step 3 is still true

#### Confirm existing src_ tokens are deleted

1. Check out `develop`
2. As a shopper, go to the checkout page
3. Confirm some payment methods are displayed for SEPA
4. In the database, go to the `woocommerce_payment_token` table
5. Retrieve the tokens for the shopper you used to add payment methods
7. Confirm there are some rows where the `gateway_id` = `stripe_sepa_debit` and the `token` = `src_%`
8. Check out this branch
9. Go to the checkout page
10. Confirm no payment methods are displayed for SEPA
11. On the `woocommerce_payment_token` table, confirm there are no rows where the `gateway_id` = `stripe_sepa_debit` and the `token` = `src_%` for this shopper

#### Confirm migrated payment methods are created

ℹ️ You'll need to reach out to Stripe for them to perform the migration for you.

1. Request Stripe to run the src_ migration on your account. Reach out to them in Slack with your Stripe account number.
2. Go to you Stripe dashboard > The customer you used in previous steps
3. Confirm there are some SEPA payment methods using `pm_` instead of `src_`
4. As a shopper, go to the checkout page
5. Confirm there are some saved SEPA payment methods displayed
6. Confirm you can place an order with them
7. On the `woocommerce_payment_token` table:
  - Confirm there are no rows where the `gateway_id` = `stripe_sepa_debit` and the `token` = `src_%` for this shopper
  - Confirm there are tokens `gateway_id` = `stripe_sepa_debit` with a `token` = `pm_%` value for this shopper

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
