### PR TITLE
Attach SEPA sources to the customer when saving legacy SEPA payment methods 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Ensure payments via redirect are processed through the webhook if the redirect never occurs. Resolves issues of orders being left as pending payment.
 * Add - Introduce a way for store managers to automatically configure webhooks on their Stripe account with a single button in the admin settings.
 * Fix - Ensure subscriptions purchased with iDEAL or Bancontact are correctly set to SEPA debit prior to processing the intitial payment.
+* Fix - Ensure SEPA tokens are attached to customers in the legacy checkout experience when the payment method is saved. This addresses subscription recurring payment "off-session" errors with SEPA.
 
 = 8.4.0 - 2024-06-13 =
 * Tweak - Resets the list of payment methods when any Stripe key is updated.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -843,6 +843,27 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$source_object = self::get_source_object( wc_clean( wp_unslash( $_POST['stripe_source'] ) ) );
 			$source_id     = $source_object->id;
 			$customer->maybe_create_customer();
+
+			// Check if the customer opted to save the payment method to file.
+			$maybe_saved_card    = isset( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] ) && ! empty( $_POST[ 'wc-' . $payment_method . '-new-payment-method' ] );
+			$is_sepa_source      = isset( $source_object->type ) && 'sepa_debit' === $source_object->type;
+			$save_payment_method = $force_save_source || ( $user_id && $this->saved_cards && $maybe_saved_card );
+
+			/**
+			 * Save the SEPA source to the customer if force save source is true or the user is logged in and the user has opted to save the payment method.
+			 *
+			 * We only need to save SEPA sources here. Saving card payment methods are handled by setup intents later in the flow. @see WC_Gateway_Stripe::process_payment().
+			 */
+			if ( $is_sepa_source && $save_payment_method ) {
+				$response = $customer->attach_source( $source_object->id );
+
+				if ( ! empty( $response->error ) ) {
+					throw new WC_Stripe_Exception( print_r( $response, true ), $this->get_localized_error_message_from_response( $response ) );
+				}
+				if ( is_wp_error( $response ) ) {
+					throw new WC_Stripe_Exception( $response->get_error_message(), $response->get_error_message() );
+				}
+			}
 		} elseif ( $this->is_using_saved_payment_method() ) {
 			// Use an existing token, and then process the payment.
 			$wc_token_id = isset( $_POST[ 'wc-' . $payment_method . '-payment-token' ] ) ? wc_clean( wp_unslash( $_POST[ 'wc-' . $payment_method . '-payment-token' ] ) ) : '';

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -863,6 +863,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				if ( is_wp_error( $response ) ) {
 					throw new WC_Stripe_Exception( $response->get_error_message(), $response->get_error_message() );
 				}
+
+				// Save the payment method to the customer.
+				$this->save_payment_method( $source_object );
 			}
 		} elseif ( $this->is_using_saved_payment_method() ) {
 			// Use an existing token, and then process the payment.

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -23,6 +23,9 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		$this->scheduled_hook = 'wc_stripe_schedule_subscriptions_legacy_sepa_token_repairs';
 		$this->repair_hook    = 'wc_stripe_subscriptions_legacy_sepa_token_repair';
 		$this->log_handle     = 'woocommerce-gateway-stripe-subscriptions-legacy-sepa-tokens-repairs';
+
+		// Repair subscriptions prior to renewal as a backstop. Hooked onto 0 to run before the actual renewal.
+		add_action( 'woocommerce_scheduled_subscription_payment', [ $this, 'maybe_migrate_before_renewal' ], 0 );
 	}
 
 	/**
@@ -96,5 +99,26 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		}
 
 		return $items_to_repair;
+	}
+
+	/**
+	 * Updates subscriptions which need updating prior to it renewing.
+	 *
+	 * This function is a backstop to prevent subscription renewals from failing if we haven't ran the repair yet.
+	 *
+	 * @param int $subscription_id The subscription ID which is about to renew.
+	 */
+	public function maybe_migrate_before_renewal( $subscription_id ) {
+		if ( ! class_exists( 'WC_Subscriptions' ) || ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			return;
+		}
+
+		$subscription = wcs_get_subscription( $subscription_id );
+
+		if ( $subscription && $subscription->get_payment_method() === WC_Gateway_Stripe_Sepa::ID ) {
+			$this->repair_item( $subscription_id );
+			// Unschedule the repair action as it's no longer needed.
+			as_unschedule_action( $this->repair_hook, [ 'repair_object' => $subscription_id ] );
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Ensure payments via redirect are processed through the webhook if the redirect never occurs. Resolves issues of orders being left as pending payment.
 * Add - Introduce a way for store managers to automatically configure webhooks on their Stripe account with a single button in the admin settings.
 * Fix - Ensure subscriptions purchased with iDEAL or Bancontact are correctly set to SEPA debit prior to processing the intitial payment.
+* Fix - Ensure SEPA tokens are attached to customers in the legacy checkout experience when the payment method is saved. This addresses subscription recurring payment "off-session" errors with SEPA.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2964 we remove a piece of code that would attach a payment method/source to a customer. The intent of that change was to fix an issue with Indian-based merchants where attaching a PM to a customer before a setup intent occurred would lead to errors (see below). 

> PaymentMethods of type `card` cannot be attached to Customers directly without 3DS due to Indian payment regulations. Please instead provide the PaymentMethod and Customer alongside a SetupIntent or PaymentIntent with the `setup_future_usage` parameter. See https://support.stripe.com/questions/guide-for-saving-cards-in-india for more details.

For card payments, not attaching the payment method to the customer at this point was fine, because later in the flow we'd set up the intent with the `setup_future_usage` parameter as the Stripe error suggested. ie in the `process_payment()` (used by cards) we call the [`prepare_source()` function](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.4.0/includes/class-wc-gateway-stripe.php#L404) and then later call [`create_intent()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.4.0/includes/class-wc-gateway-stripe.php#L423) which creates a setup intent with the off session flag.

This is not the case for SEPA however. In the process_payment() function used by SEPA. It calls [prepare_source()](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.4.0/includes/payment-methods/class-wc-gateway-stripe-sepa.php#L307-L308) but that isn’t followed up by an intent.

This means that when using SEPA on the legacy checkout experience to purchase subscriptions or to save the payment method, the token would never be attached/saved to the customer in Stripe. 

This PR fixes that by restoring the code that was removed as part of #2964 but limits the saving to SEPA, cards should remain unchanged and should continue to use it's intent flow. 

## Testing instructions

**REPLICATE THE BUG**

1. Checkout `develop`
2. Enable the legacy checkout experience in Stripe settings. 
3. Enable saved payment methods.
4. Set your store to EUR currency.
5. Enable SEPA. 
6. Add a standard product to your cart. 
7. On the classic checkout<sup>*</sup> choose SEPA
     - \* SEPA doesn't work on the Block Checkout in legacy mode. 
9. Enter any valid SEPA IBAN (`DE89370400440532013000`)
10. Check the box to save the payment method. 
11. Complete the purchase. 
12. In your Stripe Dashboard view the customer object at **Customers** (menu item) and then viewing your customer.
13. notice that under payment methods, it wasn't saved. 
14. In WooCommerce on the My Account > Payment methods tab, you will notice the token was also not saved there. 

| WooCommerce | Stripe |
|--------|--------|
| <img width="865" alt="Screenshot 2024-07-04 at 3 00 25 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/eeab5283-bfb5-4d11-8cd3-ce9bb81925a2"> | <img width="794" alt="Screenshot 2024-07-04 at 3 15 12 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/03f03ec4-bff0-4e2a-90dc-d85d1f479584"> | 

**CONFIRM THE FIX**

15. Checkout this branch `fix/saving-sepa-pms-on-legacy-upe`. 
16. Follow the steps above. 
17. After confirming at Stripe and WooCommerce you should see the payment method is saved. 

| WooCommerce | Stripe |
|--------|--------|
| <img width="855" alt="Screenshot 2024-07-04 at 3 19 09 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/4eac07db-2b6f-40fc-9498-d50c0d8950c7"> | <img width="785" alt="Screenshot 2024-07-04 at 3 19 43 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/375147e9-0462-4903-bb4f-98e6dddf98a3"> | 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
