### PR TITLE
Repair legacy SEPA subscriptions prior to renewal

### DIFF
--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -104,7 +104,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 	/**
 	 * Updates subscriptions which need updating prior to it renewing.
 	 *
-	 * This function is a back stop to prevent subscription renewals from failing if we haven't ran the repair yet.
+	 * This function is a backstop to prevent subscription renewals from failing if we haven't ran the repair yet.
 	 *
 	 * @param int $subscription_id The subscription ID which is about to renew.
 	 */

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -24,8 +24,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		$this->repair_hook    = 'wc_stripe_subscriptions_legacy_sepa_token_repair';
 		$this->log_handle     = 'woocommerce-gateway-stripe-subscriptions-legacy-sepa-tokens-repairs';
 
-		// Repair subscriptions prior to renewal as a backstop. Hooked onto 1 to run before the actual renewal.
-		add_action( 'woocommerce_scheduled_subscription_payment', [ $this, 'maybe_migrate_before_renewal' ], 1 );
+		// Repair subscriptions prior to renewal as a backstop. Hooked onto 0 to run before the actual renewal.
+		add_action( 'woocommerce_scheduled_subscription_payment', [ $this, 'maybe_migrate_before_renewal' ], 0 );
 	}
 
 	/**

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -24,7 +24,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		$this->repair_hook    = 'wc_stripe_subscriptions_legacy_sepa_token_repair';
 		$this->log_handle     = 'woocommerce-gateway-stripe-subscriptions-legacy-sepa-tokens-repairs';
 
-		add_action( 'woocommerce_scheduled_subscription_payment', 'maybe_migrate_before_renewal' );
+		add_action( 'woocommerce_scheduled_subscription_payment', [ $this, 'maybe_migrate_before_renewal' ] );
 	}
 
 	/**

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -24,7 +24,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		$this->repair_hook    = 'wc_stripe_subscriptions_legacy_sepa_token_repair';
 		$this->log_handle     = 'woocommerce-gateway-stripe-subscriptions-legacy-sepa-tokens-repairs';
 
-		add_action( 'woocommerce_scheduled_subscription_payment', [ $this, 'maybe_migrate_before_renewal' ] );
+		// Repair subscriptions prior to renewal as a backstop. Hooked onto 1 to run before the actual renewal.
+		add_action( 'woocommerce_scheduled_subscription_payment', [ $this, 'maybe_migrate_before_renewal' ], 1 );
 	}
 
 	/**

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -118,7 +118,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		if ( $subscription && $subscription->get_payment_method() === WC_Gateway_Stripe_Sepa::ID ) {
 			$this->repair_item( $subscription_id );
 			// Unschedule the repair action as it's no longer needed.
-			as_unschedule_single_action( $this->repair_hook, array( 'repair_object' => $subscription_id ) );
+			as_unschedule_action( $this->repair_hook, [ 'repair_object' => $subscription_id ] );
 		}
 	}
 }

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -117,6 +117,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 
 		if ( $subscription && $subscription->get_payment_method() === WC_Gateway_Stripe_Sepa::ID ) {
 			$this->repair_item( $subscription_id );
+			// Unschedule the repair action as it's no longer needed.
+			as_unschedule_single_action( $this->repair_hook, array( 'repair_object' => $subscription_id ) );
 		}
 	}
 }


### PR DESCRIPTION
> [!Note]
> This PR is based on the branch for https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3242 because that PR fixes payment tokens for legacy SEPA and so testing this branch without those changes will cause issues.

## Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3139 we introduced a repair script to migrate subscriptions which were using legacy SEPA tokens to the new SEPA UPE method. 

This uses a background repair script in Subscriptions which uses Action Scheduler to run the jobs. This takes time (at least 1 hour by default) to complete. 

This means there's potential for subscriptions to renew, before we've had a chance to update them. This PR fixes that by making sure we update subscriptions right before they renew. 

We do this by hooking in early on the `woocommerce_scheduled_subscription_payment` hook, prior to the renewal being triggered, and updating the subscription.  

## Testing instructions

1. Checkout this branch.
2. Enable **legacy checkout experience** in Stripe plugin settings.
3. Set your store currency to EUR
4. Enable SEPA.
5. Purchase a subscription using SEPA. 
6. Disable **Legacy checkout experience**. 
7. Go to WooCommerce > Subscriptions
8. Note that the subscription you just purchased is set to manual renewal. 


| <img width="832" alt="Screenshot 2024-07-04 at 6 23 24 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/e3d27335-1d46-4036-b60b-4a1ce47fa3f2"> | <img width="286" alt="Screenshot 2024-07-04 at 6 23 33 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/ad76eac4-edba-4ab2-b5cd-7baad6239e7d"> |
|--------|--------|

9. Edit the subscription.
10. From the actions drop down in the top right corner selete "Process Renewal"
11. Save the subscription to run the action. 
12. The subscription should be updated to the new SEPA and the renewal should fire. 

<img width="321" alt="Screenshot 2024-07-04 at 6 23 55 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/e491176d-1143-455c-874a-b6b27214721a">

13. Check the update logs at **WooCommerce > Status > Logs > "woocommerce-gateway-stripe-subscriptions-legacy-sepa-tokens-repairs"**


<img width="963" alt="Screenshot 2024-07-04 at 6 31 21 PM" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/8490476/0950761e-f024-4a6e-82fd-5dc63c4f97bb">

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
