### PR TITLE
Prevent php warnings if `last_payment_error` has no `source`.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Ensure payments via redirect are processed through the webhook if the redirect never occurs. Resolves issues of orders being left as pending payment.
 * Add - Introduce a way for store managers to automatically configure webhooks on their Stripe account with a single button in the admin settings.
 * Fix - Ensure subscriptions purchased with iDEAL or Bancontact are correctly set to SEPA debit prior to processing the intitial payment.
+* Fix - PHP warnings within the WC_Stripe_Intent_Controller class.
 
 = 8.4.0 - 2024-06-13 =
 * Tweak - Resets the list of payment methods when any Stripe key is updated.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -129,8 +129,10 @@ class WC_Stripe_Intent_Controller {
 					// Currently, Stripe saves the payment method even if the authentication fails for 3DS cards.
 					// Although, the card is not stored in DB we need to remove the source from the customer on Stripe
 					// in order to keep the sources in sync with the data in DB.
-					$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
-					$customer->delete_source( $intent->last_payment_error->source->id );
+					if ( isset( $intent->last_payment_error->source ) ) {
+						$customer = new WC_Stripe_Customer( $current_user->ID );
+						$customer->delete_source( $intent->last_payment_error->source->id );
+					}
 				} else {
 					$metadata = $intent->metadata;
 					if ( isset( $metadata->save_payment_method ) && 'true' === $metadata->save_payment_method ) {

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Ensure payments via redirect are processed through the webhook if the redirect never occurs. Resolves issues of orders being left as pending payment.
 * Add - Introduce a way for store managers to automatically configure webhooks on their Stripe account with a single button in the admin settings.
 * Fix - Ensure subscriptions purchased with iDEAL or Bancontact are correctly set to SEPA debit prior to processing the intitial payment.
+* Fix - PHP warnings within the WC_Stripe_Intent_Controller class.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This fixes the php warnings:

```
Warning:  Undefined property: stdClass::$source in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-intent-controller.php on line 134
Warning:  Attempt to read property "id" on null in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-intent-controller.php on line 134
```

## Testing instructions

Place an order with stripe test card `4000008260003178` and clicking "FAIL" in the 3DS popup. Without this patch, it will throw those 2 php warnings. With this patch, no warnings.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
