### PR TITLE
Update the subscriptions sources to payment methods if they were migrated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 = 8.5.0 - 2024-xx-xx =
 * Tweak - Additional visual improvement for the webhook configuration notice.
 * Add - Allow changing display order of payment methods in the new checkout experience.
+* Add - Update the payment method associated with a subscription to a PaymentMethod when it's using a Stripe Source that was migrated to PaymentMethods.
 * Fix - Prevent subscriptions using Legacy SEPA from switching to Manual Renewal when disabling the Legacy experience.
 * Tweak - Add a notice in checkout for Cash App transactions above 2000 USD to inform customers about the decline risk.
 * Tweak - Improve the display of warning messages related to webhook configuration.
@@ -13,8 +14,6 @@
 * Fix - Ensure subscriptions purchased with iDEAL or Bancontact are correctly set to SEPA debit prior to processing the intitial payment.
 * Tweak - Stripe API version updated to support 2024-06-20.
 * Fix - Ensure SEPA tokens are attached to customers in the legacy checkout experience when the payment method is saved. This addresses subscription recurring payment "off-session" errors with SEPA.
-* Tweak - Limit the configure webhooks button to 1 click per minute to prevent multiple webhook creations.
-* Fix - Address Klarna currency rules to ensure correct presentment and availability based on merchant and customer locations.
 
 = 8.4.0 - 2024-06-13 =
 * Tweak - Resets the list of payment methods when any Stripe key is updated.

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -63,7 +63,7 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	}
 
 	/**
-	 * Attempts to to update the payment method for renewals from Sources to PaymentMethods.
+	 * Attempts to update the payment method for renewals from Sources to PaymentMethods.
 	 *
 	 * @param WC_Subscription $subscription The subscription for which the payment method must be updated.
 	 */

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -19,15 +19,9 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce detects that the stripe_sepa payment gateway as no longer available.
  * This causes the Subscription to change to Manual renewal, and automatic renewals to fail.
  *
- * This class fixes failing automatic renewals by:
- *   - Retrieving all the subscriptions that are using the stripe_sepa payment gateway.
- *   - Iterating over each subscription.
- *   - Retrieving an Updated (Payment Methods API) token based on the Legacy (Sources API) token associated with the subscription.
- *       - If none is found, we create a new Updated (Payment Methods API) token based on the Legacy (Sources API) token.
- *       - If it can't be created, we skip the migration.
- *   - Associating this replacement token to the subscription.
- *
- * This class extends the WCS_Background_Repairer for scheduling and running the individual migration actions.
+ * This class updates the following for the given subscription:
+ *   - Setting the associated gateway ID to the one used for the updated checkout experience `stripe_sepa_debit`, so it doesn't switch to Manual Renewal.
+ *   - Updating the payment method used for renewals to the migrated pm_, if any.
  */
 class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -124,7 +124,7 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 		$source_id = $subscription->get_meta( self::SOURCE_ID_META_KEY );
 
 		// Bail out if the subscription is already using a pm_.
-		if ( ! str_starts_with( $source_id, 'src_' ) ) {
+		if ( 0 === strpos( $source_id, 'src_' ) ) {
 			throw new \Exception( sprintf( 'The subscription is not using a Stripe Source for renewals.', $subscription->get_id() ) );
 		}
 

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -130,7 +130,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 			return;
 		}
 
-		// It's possible that the Legacy SEPA gateway ID was updated by the reparing above, but that the Stripe account
+		// It's possible that the Legacy SEPA gateway ID was updated by the repairing above, but that the Stripe account
 		// hadn't been migrated from src_ to pm_ at the time.
 		// Thus, we keep checking if the associated payment method is a source in subsequent renewals.
 		$subscription_source = $subscription->get_meta( '_stripe_source_id' );

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -135,7 +135,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		// Thus, we keep checking if the associated payment method is a source in subsequent renewals.
 		$subscription_source = $subscription->get_meta( '_stripe_source_id' );
 
-		if ( str_starts_with( $subscription_source, 'src_' ) ) {
+		if ( 0 === strpos( $subscription_source, 'src_' ) ) {
 			$token_updater = new WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update();
 			$token_updater->maybe_update_subscription_source( $subscription );
 		}

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -6,7 +6,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Handles migrating the tokens of Subscriptions using SEPA's Legacy gateway ID.
+ * Handles repairing the Subscriptions using SEPA's Legacy payment method.
  *
  * This class extends the WCS_Background_Repairer for scheduling and running the individual migration actions.
  */

--- a/readme.txt
+++ b/readme.txt
@@ -131,6 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 8.5.0 - 2024-xx-xx =
 * Tweak - Additional visual improvement for the webhook configuration notice.
 * Add - Allow changing display order of payment methods in the new checkout experience.
+* Add - Update the payment method associated with a subscription to a PaymentMethod when it's using a Stripe Source that was migrated to PaymentMethods.
 * Fix - Prevent subscriptions using Legacy SEPA from switching to Manual Renewal when disabling the Legacy experience.
 * Tweak - Add a notice in checkout for Cash App transactions above 2000 USD to inform customers about the decline risk.
 * Tweak - Improve the display of warning messages related to webhook configuration.


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Stripe accounts will undergo a migration to move their Sources to PaymentMethods. This PR updates the payment method associated with subscriptions from src_ to the migrated pm_, if the migration already took place in the account.

- Update the payment method associated with a subscription when it's a src_ and it was already migrated to pm_
- Run this update during the Repairer job that also updates the associated gateway ID
- Also, run this during subsequent renewals because it's possible that the Stripe account hasn't been migrated at the time we repair all subscriptions

## Testing instructions

Setup
1. Ensure webhooks are set up on the testing site and that the site is publicly accessible
2. Set EUR as the store currency
3. Enable the Legacy checkout experience
4. Enable SEPA under the Stripe payment methods
5. Find a Stripe account that can use Sources _and_ that has at least one customer with Sources migrated to PaymentMethods. DM me if yours hasn't been migrated 🙂 

**Testing the migration and subsequent renewals** 

1. Log in with a shopper that has at least one payment method migrated from Sources to PaymentMethods. 
    If you use my account, use customer [cus_PuO841WftotzWl](https://dashboard.stripe.com/test/customers/cus_PuO841WftotzWl)
    On the usermeta of a shopper, set wp__stripe_customer_id to cus_PuO841WftotzWl
    There are two SEPA payment methods that end in 3201. One of them is a src_ src_1PEHjXGwE7I87pM0KSAsG4If , and the other is a pm_ created by the migration pm_1PG2BmGwE7I87pM0FaxCi8UN
3. Purchase a subscription using this Source as the payment method
4. As the merchant, renew this subscription
5. Notice it gets processed successfully, all good
6. Disable the Legacy checkout experience to start using the PaymentMethods API
7. As the merchant, go edit this subscription
8. Notice that under "Payment method", it says "Manual Renewal" and that the renewal was processed successfully 
9. On the sidebar at the right, run "Process renewal"
10. Confirm that:
  - The renewal is processed successfully
  - Under "Payment method", it now says "SEPA debit"
  - Under Billing > Edit (The pencil icon) > Stripe Source ID, it now has a `pm_`
 11. Process another renewal
 12. Confirm it's successfully processed


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
