### PR TITLE
Add missing PHP unit tests for updating the subscription source to payment method on item repair

### DIFF
--- a/tests/phpunit/admin/migrations/test-class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/tests/phpunit/admin/migrations/test-class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -254,17 +254,11 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test extends WP_UnitTe
 			}
 		);
 
-		$ids_to_migrate  = $this->get_subs_ids_to_migrate();
-		$subscription_id = $ids_to_migrate[0];
-		$subscription    = new WC_Subscription( $subscription_id );
-		$customer_id     = $subscription->get_user_id();
-
-		// Create the legacy token associated with the subscription.
+		$ids_to_migrate     = $this->get_subs_ids_to_migrate();
+		$subscription_id    = $ids_to_migrate[0];
+		$subscription       = new WC_Subscription( $subscription_id );
+		$customer_id        = $subscription->get_user_id();
 		$original_source_id = $subscription->get_meta( self::SOURCE_ID_META_KEY );
-		$original_token     = WC_Helper_Token::create_sepa_token( $original_source_id, $customer_id, $this->legacy_sepa_gateway_id );
-
-		// Create the updated token we expect the subscription to be updated with.
-		$updated_token = WC_Helper_Token::create_sepa_token( $original_source_id, $customer_id, $this->updated_sepa_gateway_id );
 
 		$this->logger_mock
 			->expects( $this->at( 0 ) )


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR includes a couple of PHP unit tests for the changes introduced in [this other PR](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3249).

We're missing testing that the associated payment method was [actually updated](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3249/files#diff-e741eec983218646988b877bb4a984a4071b6064b7905f5ff6ce1c841e525dc2R143-R144). The reason is that we're using a [static method](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3249/files#diff-e741eec983218646988b877bb4a984a4071b6064b7905f5ff6ce1c841e525dc2R132) to retrieve the object we'd need to mock for this test.

I didn't find a way to do it without refactoring the classes we're testing. It'd probably be better to discuss whether we want to do it and handle it separately if so, due to the potential impact it'd have.

## Testing instructions

Confirm the PHP unit tests from the GH tasks pass.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
