### PR TITLE
Fix Cash App limit notice appearing for amount < 2000

### DIFF
--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -291,7 +291,7 @@ jQuery( function ( $ ) {
 				}
 			}
 		} )
-		.on( 'change', 'input[name="payment_method"]', () => {
+		.on( 'change', '.wc_payment_methods', () => {
 			// Check to see whether we should display the Cash App limit notice.
 			if ( $( 'input#payment_method_stripe_cashapp' ).is( ':checked' ) ) {
 				maybeShowCashAppLimitNotice(

--- a/client/stripe-utils/cash-app-limit-notice-handler.js
+++ b/client/stripe-utils/cash-app-limit-notice-handler.js
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { callWhenElementIsAvailable } from 'wcstripe/blocks/upe/call-when-element-is-available';
 
 /** The amount threshold for displaying the notice. */
-export const CASH_APP_NOTICE_AMOUNT_THRESHOLD = 2000;
+export const CASH_APP_NOTICE_AMOUNT_THRESHOLD = 200000;
 
 /** The class name for the limit notice element. */
 const LIMIT_NOTICE_CLASSNAME = 'wc-block-checkout__payment-method-limit-notice';


### PR DESCRIPTION
Discussed in p1720689007716709-slack-C055WHLA98D

## Changes proposed in this Pull Request:

- Updated `CASH_APP_NOTICE_AMOUNT_THRESHOLD` to `200000`
- Added on change listener on `.wc_payment_methods` instead of `input[name="payment_method"]` to show the notice on page load as well.

## Testing instructions
#### Reproduce the issue
- Use `develop` branch.
- Enable CashApp and some other methods.
- As a shopper add a product to the cart having an amount < 2000.
- Go to the shortcode checkout page and select Cash App.
- You will see the CashApp notice on the page.

<img width="407" alt="Screenshot 2024-07-11 at 18 49 54" src="https://github.com/woocommerce/woocommerce-gateway-stripe/assets/33387139/5395833a-e0d4-4519-8d5a-ed538d408b29">

- Now complete a purchase with CashApp.
- Again add a product to the cart and go to the shortcode checkout page. CashApp is the already selected method now. But there is no notice displayed. 
- Select a different method, then select CashApp again.
- This time the notice is displayed again (for amounts < 2000)

### Test the fix

- Use `fix/cashapp-notice` branch.
- Enable CashApp and some other methods.
- As a shopper add a product to the cart having an amount < 2000.
- Go to the shortcode checkout page and select Cash App. Confirm that there is no notice displayed.
- Now add an expensive product to the cart of amount > 2000.
- You should see the CashApp notice on the page.
- Now complete a purchase with CashApp.
- Again add a product to the cart (amount < 2000) and go to the shortcode checkout page. CashApp is the already selected method now. But there should be no notice displayed. 
- Select a different method, then select CashApp again. Still, there should be no notice.
- Add an expensive product to the cart of amount > 2000 and go to the shortcode checkout page. CashApp is the already selected method now. This time the notice should be present as the amount is > 2000.
- Select a different method, then select CashApp again. The notice should be present.