### PR TITLE
Add api_version param to create webhook API call

### DIFF
--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -132,12 +132,12 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 				'callback'            => [ $this, 'configure_webhooks' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
-					'live_mode'      => [
+					'live_mode'  => [
 						'description'       => __( 'Whether the account is in live mode.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'secret_key'           => [
+					'secret_key' => [
 						'description'       => __( 'Your Stripe API Secret, obtained from your Stripe dashboard.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
 						'validate_callback' => [ $this, 'validate_secret_key' ],
@@ -417,7 +417,8 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 				'setup_intent.succeeded',
 				'setup_intent.setup_failed',
 			],
-			'url' => WC_Stripe_Helper::get_webhook_url(),
+			'url'            => WC_Stripe_Helper::get_webhook_url(),
+			'api_version'    => WC_Stripe_API::STRIPE_API_VERSION,
 		];
 
 		$response = WC_Stripe_API::request( $request, 'webhook_endpoints', 'POST' );


### PR DESCRIPTION
Fixes #

## Changes proposed in this Pull Request:

This PR adds the parameter `api_version` to the [create webhook](https://docs.stripe.com/api/webhook_endpoints/create) endpoint, which is required if the account is of type connected account.

![image](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/c1872806-1a6b-4e71-a895-57d8fa764680)

## Testing instructions
1. Checkout this branch.
2. run `npm run build`
3. Navigate to `WP-Admin > WooCommerce > Settings > Payments`
4. Click `Stripe` in the list and then in the `Settings` tab of the plugin settings.
5. Click `Edit account keys` to open the API keys modal.
6. Click on the `Live` tab of the modal.
7. Click on the `Configure webhooks` button
8. Check that the webhook was correctly created
    ![Screenshot 2024-07-11 at 11 26 27 AM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/a52d360f-a248-4c5e-b540-de46a81df38f)

    ![Screenshot 2024-07-11 at 11 27 23 AM](https://github.com/woocommerce/woocommerce-gateway-stripe/assets/407542/72fdc653-6241-40e3-8ddd-7944061d3450)
