### PR TITLE
Check if 'WCS_Background_Repairer' class exists

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@
 
 = 8.6.0 - xxxx-xx-xx =
 * Fix - Prevent multiple instances of the "Update the Payment Method" checkbox from displaying on the My Account > Payment Methods page when using the legacy checkout experience.
+ 
+= 8.5.1 - xxxx-xx-xx =
+* Fix - Fixed fatal error caused by non-existent class.
 
 = 8.5.0 - 2024-07-11 =
 * Tweak - Remove Giropay from the list of payment methods (for all versions) due deprecation.

--- a/readme.txt
+++ b/readme.txt
@@ -131,4 +131,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 8.6.0 - xxxx-xx-xx =
 * Fix - Prevent multiple instances of the "Update the Payment Method" checkbox from displaying on the My Account > Payment Methods page when using the legacy checkout experience.
 
+= 8.5.1 - xxxx-xx-xx =
+* Fix - Fixed fatal error caused by non-existent class.
+
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -734,8 +734,8 @@ function woocommerce_gateway_stripe() {
 			 * Initializes updating subscriptions.
 			 */
 			public function initialize_subscriptions_updater() {
-				// The updater depends on WC_Subscriptions. Bail out if not active.
-				if ( ! class_exists( 'WC_Subscriptions' ) ) {
+				// The updater depends on WCS_Background_Repairer. Bail out if class does not exist.
+				if ( ! class_exists( 'WCS_Background_Repairer' ) ) {
 					return;
 				}
 				require_once dirname( __FILE__ ) . '/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php';


### PR DESCRIPTION
Reported in p1720771985321979-slack-C7U3Y3VMY 

## Changes proposed in this Pull Request:
- As per the error log shared in [the forum](https://wordpress.org/support/topic/critical-error-after-latest-update-7/) the fatal error is caused because `WCS_Background_Repairer` is not found. Added a check for this class to avoid the error.

## Testing instructions
