### PR TITLE
Capture off-session payments immediately so we can fetch charge information

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Display the payment decline reason on the checkout when using Cash App or WeChat.
 * Fix - Re-enable the "Place order" button on the block checkout after closing the WeChat or Cash App payment modal.
 * Fix - When SEPA tokens are added via the My Account > Payment methods page, ensure they are attached to the Stripe customer.
+* Fix - Ensure immediate balance transaction assignment for subscription renewals by specifying capture_method => automatic in Stripe payment intents.
 
 = 8.5.1 - 2024-07-12 =
 * Fix - Fixed fatal error caused by non-existent class.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1753,6 +1753,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'off_session'          => 'true',
 			'confirm'              => 'true',
 			'confirmation_method'  => 'automatic',
+			'capture_method'       => 'automatic',
 		];
 
 		if ( isset( $full_request['statement_descriptor'] ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -135,5 +135,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Display the payment decline reason on the checkout when using Cash App or WeChat.
 * Fix - Re-enable the "Place order" button on block checkout after closing the WeChat or Cash App payment modal.
 * Fix - When SEPA tokens are added via the My Account > Payment methods page, ensure they are attached to the Stripe customer.
+* Fix - Ensure immediate balance transaction assignment for subscription renewals by specifying capture_method => automatic in Stripe payment intents.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -145,6 +145,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 				'off_session'          => 'true',
 				'confirm'              => 'true',
 				'confirmation_method'  => 'automatic',
+				'capture_method'       => 'automatic',
 			];
 			foreach ( $expected_request_body_values as $key => $value ) {
 				$this->assertArrayHasKey( $key, $request_args['body'] );

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -185,7 +185,6 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 			// Assert: the request body does not contains these keys.
 			$expected_missing_request_body_keys = [
 				'capture', // No need to capture with a payment intent.
-				'capture_method', // The default ('automatic') is what we want in this case, so we leave it off.
 				'expand[]',
 			];
 			foreach ( $expected_missing_request_body_keys as $key ) {


### PR DESCRIPTION
Fixes #3274

## Changes proposed in this Pull Request:

In v8.5.0 of Stripe we bumped the Stripe API version to `2024-06-20`. One effect of that is the default payment intent `capture_method` was changed to async (see Stripe [changelog here](https://docs.stripe.com/upgrades#2024-04-10)). This means that when we create payment intents without a `capture_method` the response won't include a charge that has a balance translation. Instead Stripe will charge the payment asynchronisly and attach the charge later. 

This change causes the subscription renewal flow to no longer receive the balance transaction information immediately and therefore not assign Stripe fees via [`process_response()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/fix/issue-3274-capture-subscription-renewal-immediately/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L544-L547).

This PR fixes that by making sure we specify `capture_method => automatic` so the payment is charged immediately and the response includes a completed charge. 

## Testing instructions

1. Purchase a subscription product using Stripe. 
2. From the **WooCommerce > Subscriptions** list table view the subscription you just purchased.
3. From the actions drop down select **"Process Renewal"**
4. Save the subscription. 
5. View the newly created renewal order. 
   - On `develop` you'll notice that there are no Stripe fees.
   - On this branch fees will be displayed. 

| `develop` | This branch |
|--------|--------|
| <img width="462" alt="Screenshot 2024-07-17 at 7 35 02 PM" src="https://github.com/user-attachments/assets/5640761b-2814-40c4-9f4a-02cb845b87ea"> | <img width="335" alt="Screenshot 2024-07-17 at 7 37 51 PM" src="https://github.com/user-attachments/assets/2be2e79d-e541-4523-97c1-bd46f40c146f"> | 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
