### PR TITLE
Include the 'return_url' parameter for setup_intents in the Legacy checkout experience

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Fix - Display the payment decline reason on the checkout when using Cash App or WeChat.
 * Fix - Re-enable the "Place order" button on the block checkout after closing the WeChat or Cash App payment modal.
 * Fix - When SEPA tokens are added via the My Account > Payment methods page, ensure they are attached to the Stripe customer.
+* Fix - Prevent failures creating SetupIntents when using a non-saved payment method on the Legacy checkout experience.
 
 = 8.5.1 - 2024-07-12 =
 * Fix - Fixed fatal error caused by non-existent class.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1699,6 +1699,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$setup_intent = WC_Stripe_API::request(
 			[
 				'payment_method' => $prepared_source->source,
+				'return_url'     => $this->get_stripe_return_url( $order ),
 				'customer'       => $prepared_source->customer,
 				'confirm'        => 'true',
 			],

--- a/readme.txt
+++ b/readme.txt
@@ -135,5 +135,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Display the payment decline reason on the checkout when using Cash App or WeChat.
 * Fix - Re-enable the "Place order" button on block checkout after closing the WeChat or Cash App payment modal.
 * Fix - When SEPA tokens are added via the My Account > Payment methods page, ensure they are attached to the Stripe customer.
+* Fix - Prevent failures creating SetupIntents when using a non-saved payment method on the Legacy checkout experience.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3284

## Changes proposed in this Pull Request:

- Include the `return_url` parameter in the POST `setup_intents` request we send in the Legacy experience when using a non-saved payment method.

Since we updated the Stripe API version in 8.5.0, this request started to fail due to the missing `return_url` parameter. This PR adds it.

## Testing instructions

1. Enable the Legacy checkout experience
2. Create a subscription product with free trial
3. As a shopper, add this subscription to the cart and go to the checkout page
4. Enter a new card payment method, like 4242424242424242
5. Place the order
6. Go to the Stripe dashboard logs, at `https://dashboard.stripe.com/test/logs`
7. Look for the last POST request to `v1/setup_intents`
8. Confirm it has a 200 status

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
