### PR TITLE
Automatically configure webhooks after the completing the OAuth flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,6 @@
 * Tweak - Minor text updates to webhook-related configuration labels and buttons.
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
-* Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
 * Tweak - Automatically configure webhooks after completing the OAuth Stripe flow.
 * Tweak - Don't process webhooks when the webhook secret isn't set in the store.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
 * Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
+* Tweak - Automatically configure webhooks after completing the OAuth Stripe flow.
 
 = 8.5.2 - 2024-07-22 =
 * Fix - Fixed errors when using Link to purchase subscription products that could lead to duplicate payment attempts.

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -380,8 +380,17 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 
 		WC_Rate_Limiter::set_rate_limit( $rate_limit_key, 60 );
 
+		$settings     = get_option( self::STRIPE_GATEWAY_SETTINGS_OPTION_NAME, [] );
+		$secret       = wc_clean( wp_unslash( $request->get_param( 'secret' ) ) );
+		$saved_secret = $settings[ $live_mode ? 'secret_key' : 'test_secret_key' ];
+
+		// If the secret received is masked and it matches the saved secret, use the raw saved secret.
+		if ( $secret === $this->mask_key_value( $saved_secret ) ) {
+			$secret = $saved_secret;
+		}
+
 		try {
-			$response = $this->account->configure_webhooks( $environment );
+			$response = $this->account->configure_webhooks( $environment, $secret );
 		} catch ( Exception $e ) {
 			return new WP_REST_Response( [ 'message' => $e->getMessage() ], 400 );
 		}

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -380,76 +380,11 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 
 		WC_Rate_Limiter::set_rate_limit( $rate_limit_key, 60 );
 
-		$settings     = get_option( self::STRIPE_GATEWAY_SETTINGS_OPTION_NAME, [] );
-		$secret       = wc_clean( wp_unslash( $request->get_param( 'secret' ) ) );
-		$saved_secret = $settings[ $live_mode ? 'secret_key' : 'test_secret_key' ];
-
-		// Check if the user is configuring the opposite mode. ie if the store is in live mode and is configuring webhooks for test mode.
-		$is_test_mode_enabled    = ! empty( $settings['testmode'] ) && 'yes' === $settings['testmode'];
-		$configure_opposite_mode = ( $live_mode && $is_test_mode_enabled ) || ( ! $live_mode && ! $is_test_mode_enabled );
-
-		// If the user has changed the secret key in the UI, use that to create the webhook.
-		if ( $secret !== $this->mask_key_value( $saved_secret ) ) {
-			WC_Stripe_API::set_secret_key( $secret );
-		} elseif ( $configure_opposite_mode ) {
-			// If the request is to configure webhooks for the mode not currently active, use the saved secret key for that mode.
-			WC_Stripe_API::set_secret_key( $saved_secret );
+		try {
+			$response = $this->account->configure_webhooks( $environment );
+		} catch ( Exception $e ) {
+			return new WP_REST_Response( [ 'message' => $e->getMessage() ], 400 );
 		}
-
-		$request = [
-			// The list of events we listen to based on WC_Stripe_Webhook_Handler::process_webhook()
-			'enabled_events' => [
-				'source.chargeable',
-				'source.canceled',
-				'charge.succeeded',
-				'charge.failed',
-				'charge.captured',
-				'charge.dispute.created',
-				'charge.dispute.closed',
-				'charge.refunded',
-				'charge.refund.updated',
-				'review.opened',
-				'review.closed',
-				'payment_intent.succeeded',
-				'payment_intent.payment_failed',
-				'payment_intent.amount_capturable_updated',
-				'payment_intent.requires_action',
-				'setup_intent.succeeded',
-				'setup_intent.setup_failed',
-			],
-			'url'            => WC_Stripe_Helper::get_webhook_url(),
-			'api_version'    => WC_Stripe_API::STRIPE_API_VERSION,
-		];
-
-		$response = WC_Stripe_API::request( $request, 'webhook_endpoints', 'POST' );
-
-		if ( isset( $response->error->message ) ) {
-			// Translators: %s is the error message from the Stripe API.
-			return new WP_REST_Response( [ 'message' => sprintf( __( 'There was a problem setting up your webhooks. %s', 'woocommerce-gateway-stripe' ), $response->error->message ) ], 400 );
-		}
-
-		if ( ! isset( $response->secret, $response->id ) ) {
-			return new WP_REST_Response( [ 'message' => __( 'There was a problem setting up your webhooks, please try again later.', 'woocommerce-gateway-stripe' ) ], 400 );
-		}
-
-		$webhook_secret_setting = $live_mode ? 'webhook_secret' : 'test_webhook_secret';
-		$webhook_data_setting   = $live_mode ? 'webhook_data' : 'test_webhook_data';
-		$configured_webhook_id  = $settings[ $webhook_data_setting ]['id'] ?? null;
-
-		// If there's an existing Webhook set up, delete it first to avoid duplicate Webhooks at Stripe.
-		if ( $configured_webhook_id ) {
-			WC_Stripe_API::request( [], "webhook_endpoints/{$configured_webhook_id}", 'DELETE' );
-		}
-
-		// Save the Webhook secret and ID.
-		$settings[ $webhook_secret_setting ] = wc_clean( $response->secret );
-		$settings[ $webhook_data_setting ]   = [
-			'id'     => wc_clean( $response->id ),
-			'url'    => wc_clean( $response->url ),
-			'secret' => WC_Stripe_API::get_secret_key(),
-		];
-
-		update_option( self::STRIPE_GATEWAY_SETTINGS_OPTION_NAME, $settings );
 
 		return new WP_REST_Response(
 			[

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -242,7 +242,7 @@ class WC_Stripe_Account {
 	 * @throws Exception If there was a problem setting up the webhooks.
 	 * @return object The response from the API.
 	 */
-	public function configure_webhooks( $mode = 'live' ) {
+	public function configure_webhooks( $mode = 'live', $secret_key = '' ) {
 		$request = [
 			// The list of events we listen to based on WC_Stripe_Webhook_Handler::process_webhook()
 			'enabled_events' => [
@@ -267,6 +267,11 @@ class WC_Stripe_Account {
 			'url'            => WC_Stripe_Helper::get_webhook_url(),
 			'api_version'    => WC_Stripe_API::STRIPE_API_VERSION,
 		];
+
+		// If a secret key is provided, use it to configure the webhooks.
+		if ( $secret_key ) {
+			WC_Stripe_API::set_secret_key( $secret_key );
+		}
 
 		$response = WC_Stripe_API::request( $request, 'webhook_endpoints', 'POST' );
 

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -270,6 +270,7 @@ class WC_Stripe_Account {
 
 		// If a secret key is provided, use it to configure the webhooks.
 		if ( $secret_key ) {
+			$previous_secret = WC_Stripe_API::get_secret_key();
 			WC_Stripe_API::set_secret_key( $secret_key );
 		}
 
@@ -291,6 +292,11 @@ class WC_Stripe_Account {
 		// If there's an existing Webhook set up, delete it first to avoid duplicate Webhooks at Stripe.
 		if ( $configured_webhook_id ) {
 			WC_Stripe_API::request( [], "webhook_endpoints/{$configured_webhook_id}", 'DELETE' );
+		}
+
+		// Restore the previous secret key if we changed it.
+		if ( $secret_key && isset( $previous_secret ) ) {
+			WC_Stripe_API::set_secret_key( $previous_secret );
 		}
 
 		$settings = get_option( WC_Stripe::STRIPE_GATEWAY_SETTINGS_OPTION_NAME, [] );

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -156,8 +156,12 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			update_option( self::SETTINGS_OPTION, $options );
 
-			// Automatically configure webhooks for the account now that we have the keys.
-			WC_Stripe::get_instance()->account->configure_webhooks( $is_test ? 'test' : 'live', $secret_key );
+			try {
+				// Automatically configure webhooks for the account now that we have the keys.
+				WC_Stripe::get_instance()->account->configure_webhooks( $is_test ? 'test' : 'live', $secret_key );
+			} catch ( Exception $e ) {
+				return new WP_Error( 'wc_stripe_webhook_error', $e->getMessage() );
+			}
 
 			return $result;
 		}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -147,6 +147,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			update_option( self::SETTINGS_OPTION, $options );
 
+			// Automatically configure webhooks for the account now that we have the keys.
+			WC_Stripe::get_instance()->account->configure_webhooks( $is_test ? 'test' : 'live' );
+
 			return $result;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -146,5 +146,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
 * Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
+* Tweak - Automatically configure webhooks after completing the OAuth Stripe flow.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -146,7 +146,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Minor text updates to webhook-related configuration labels and buttons.
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
-* Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
 * Tweak - Automatically configure webhooks after completing the OAuth Stripe flow.
 * Tweak - Don't process webhooks when the webhook secret isn't set in the store.
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -85,6 +85,11 @@ function woocommerce_gateway_stripe() {
 		class WC_Stripe {
 
 			/**
+			 * The option name for the Stripe gateway settings.
+			 */
+			const STRIPE_GATEWAY_SETTINGS_OPTION_NAME = 'woocommerce_stripe_settings';
+
+			/**
 			 * The *Singleton* instance of this class
 			 *
 			 * @var WC_Stripe


### PR DESCRIPTION
Fixes #3292

## Changes proposed in this Pull Request:

After the user completes the OAuth Stripe flow, we now configure the webhooks automatically. This will make it a lot simpler for merchants and make it far more likely that sites will have their webhooks configured correctly. 

## Testing instructions

1. Go to **WooCommerce > Settings > Payments > Stripe (settings).**
2. Open the Account keys/connection modal.
3. Go to the the **Test** tab.
   - The test tab wont work until we are able to connect to test accounts via the OAuth flow - https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3291. 
4. Click the **Connect and account** button. 
6. You will be redirected to the OAuth page hosted by Stripe.
7. Login and select an account.
8. Click **Connect**.
9. At this point you can abandon the rest of the set up and just click the "Return to WooCommerce Inc." on the left.
10. Once you're back on the site, reopen the account keys modal.
11. You should see that the webhooks have been configured - the Webhooks status will configured and the webhook URL will appear at the bottom.
12. Check your webhooks in the Stripe Dashboard and confirm the webhook was created.

----

<p align="center">
<img width="450" alt="Screenshot 2024-07-19 at 4 30 32 PM" src="https://github.com/user-attachments/assets/ca86411c-6771-4777-be68-46189620d328">
<img width="800" alt="Screenshot 2024-08-02 at 3 15 51 PM" src="https://github.com/user-attachments/assets/7683f526-78ff-4dfe-9ef7-4f5ea6b7c89e">

<br>
<sup>Webhooks configured after OAuth flow</sup>
</p> 

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
