### PR TITLE
Expand refunds when using the stripe js client in the E2E tests

### DIFF
--- a/tests/e2e/tests/_legacy-experience/order/full-refund.spec.js
+++ b/tests/e2e/tests/_legacy-experience/order/full-refund.spec.js
@@ -103,7 +103,9 @@ test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
 	await test.step( 'check Stripe payment status ', async () => {
 		const stripeClient = stripe( process.env.STRIPE_SECRET_KEY );
 
-		const charge = await stripeClient.charges.retrieve( stripeChargeId );
+		const charge = await stripeClient.charges.retrieve( stripeChargeId, {
+			expand: [ 'refunds' ],
+		} );
 
 		expect( charge.refunded ).toBeTruthy();
 		expect( charge.refunds.data[ 0 ].id ).toBe( stripeRefundId );

--- a/tests/e2e/tests/orders/full-refund.spec.js
+++ b/tests/e2e/tests/orders/full-refund.spec.js
@@ -103,7 +103,9 @@ test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
 	await test.step( 'check Stripe payment status ', async () => {
 		const stripeClient = stripe( process.env.STRIPE_SECRET_KEY );
 
-		const charge = await stripeClient.charges.retrieve( stripeChargeId );
+		const charge = await stripeClient.charges.retrieve( stripeChargeId, {
+			expand: [ 'refunds' ],
+		} );
 
 		expect( charge.refunded ).toBeTruthy();
 		expect( charge.refunds.data[ 0 ].id ).toBe( stripeRefundId );


### PR DESCRIPTION
Fixes #3302

## Changes proposed in this Pull Request:

This PR expands the refunds when querying a charge using the Stripe JS SDK used by the E2E test suite to verify that the refund user case was completed successfully. 

--

We are already doing that when handling the refund webhook:
https://github.com/woocommerce/woocommerce-gateway-stripe/blob/c99365fe240cb2f1d4e0ee06a6ce5f7f9a0537e4/includes/class-wc-stripe-webhook-handler.php#L835-L841

The `expand` param is needed when using an API version newer than `2022-11-15`:
<img width="803" alt="Screenshot 2024-07-22 at 3 22 09 AM" src="https://github.com/user-attachments/assets/bbe118ce-8e50-4807-9f76-e32bea1f6a48">
https://docs.stripe.com/upgrades#2022-11-15

--

This did not fail before, because we are not setting the `api_version` when creating the Stripe client in the E2E tests, so it uses the account default version:
https://github.com/woocommerce/woocommerce-gateway-stripe/blob/c99365fe240cb2f1d4e0ee06a6ce5f7f9a0537e4/tests/e2e/tests/orders/full-refund.spec.js#L104

Which was `2020-08-27`, until last week when I updated it to match the one we are using for both API calls and Webhook events:
https://github.com/woocommerce/woocommerce-gateway-stripe/blob/c99365fe240cb2f1d4e0ee06a6ce5f7f9a0537e4/includes/class-wc-stripe-api.php#L17

<img width="684" alt="Screenshot 2024-07-22 at 3 28 44 AM" src="https://github.com/user-attachments/assets/8593fc8d-7e0e-4fc6-afa0-84bfb5310f44">

We should also consider adding the `api_version` to the initialization of the client in the E2E tests: 
```
const stripeClient = stripe( process.env.STRIPE_SECRET_KEY, {
  apiVersion: '2024-06-20',
} 
```

## Testing instructions
Check that all tests pass