### PR TITLE
Fix Stripe Link errors and potential duplicate payments when purchasing a subscription product

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 8.5.2 - 2024-xx-xx =
+* Fix - Fixed errors when using Link to purchase subscription products that could lead to duplicate payment attempts.
+
 = 8.5.1 - 2024-07-12 =
 * Fix - Fixed fatal error caused by non-existent class.
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2188,6 +2188,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$customer = new WC_Stripe_Customer( $user->ID );
 		$customer->clear_cache();
 
+		// If the payment method object is a Link payment method, use the Link payment method instance to create the payment token.
 		if ( isset( $payment_method_object->type ) && 'link' === $payment_method_object->type ) {
 			$payment_method_instance = $this->payment_methods['link'];
 		} else {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2188,8 +2188,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$customer = new WC_Stripe_Customer( $user->ID );
 		$customer->clear_cache();
 
+		if ( isset( $payment_method_object->type ) && 'link' === $payment_method_object->type ) {
+			$payment_method_instance = $this->payment_methods['link'];
+		} else {
+			$payment_method_instance = $this->payment_methods[ $payment_method_type ];
+		}
+
 		// Create a payment token for the user in the store.
-		$payment_method_instance = $this->payment_methods[ $payment_method_type ];
 		$payment_method_instance->create_payment_token_for_user( $user->ID, $payment_method_object );
 
 		// Add the payment method information to the order.

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
-= 8.5.1 - 2024-07-12 =
-* Fix - Fixed fatal error caused by non-existent class.
+= 8.5.2 - 2024-xx-xx =
+* Fix - Fixed errors when using Link to purchase subscription products that could lead to duplicate payment attempts.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3299 

## Changes proposed in this Pull Request:

When you're logged into Stripe Link and the checkout fields are pre-populated for you, if you purchase a subscription product you will receive the following error. 

<p align="center">
<img width="1101" alt="Screenshot 2024-07-22 at 6 57 00 PM" src="https://github.com/user-attachments/assets/6293df31-6ed0-42a1-95a5-2be1276e6707">
</p> 

Despite receiving the error, the payment was successfully taken because the error occurred after the payment - when the payment method is saved to the customer in WooCommerce. 

**This error occurs because when the customer submits the checkout, the selected payment method is `'stripe'` (card), and so we attempt to save the payment method object as a card token and not as a Link token.**

This PR fixes that by making sure that if a checkout card form is submitted but the saved payment method type is Link, we use the Link payment gateway instance to save it, not the card gateway. 

## Testing instructions

**REPLICATE THE BUG**

1. Install and enable Subscriptions 
2. Create a subscription product if you don't have one. 
3. Enable Link from Stripe payment methods.

<p align="center">
<img width="600" alt="Screenshot 2024-07-22 at 7 07 38 PM" src="https://github.com/user-attachments/assets/4dd819d2-b7c1-405c-bb1d-c01f7bd04d8b">
</p> 

4. If you don't have a Link account setup:
   - Place a simple product in your cart. 
   - On checkout use the Link payment method to complete the payment.
      - Note: you can use dummy data like `00000000` for the 2FA code.
   - This should create a link account with a card.
6. Place the subscription product in the cart.
7. Go to the checkout page and log into Link.
     - Click this **Link** to login if you're not already logged in.

<p align="center">
<img width="685" alt="Screenshot 2024-07-22 at 7 58 10 PM" src="https://github.com/user-attachments/assets/6461d8d8-0249-45fd-a817-40c36eee614e">
</p> 

8. Once you have the cart pre-filled (see screenshot below) click the **Sign up now** button. 

<p align="center">
<img width="1149" alt="Screenshot 2024-07-22 at 6 55 33 PM" src="https://github.com/user-attachments/assets/7882b60c-0700-431b-9e22-2bea0444f74f">
</p> 

9. You should receive the error I mentioned above and the following warnings in your error log. 
10. If you check your Stripe Dashboard you will see that payment was taken, despite the error on checkout.

```
PHP Warning:  Undefined property: stdClass::$card in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 86
PHP Warning:  Attempt to read property "exp_month" on null in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 86
PHP Warning:  Undefined property: stdClass::$card in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 87
PHP Warning:  Attempt to read property "exp_year" on null in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 87
PHP Warning:  Undefined property: stdClass::$card in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 88
PHP Warning:  Attempt to read property "brand" on null in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 88
PHP Warning:  Undefined property: stdClass::$card in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 89
PHP Warning:  Attempt to read property "last4" on null in /wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php on line 89
```

**VERIFY THE FIX**

1. Repeat the steps above on this branch.
2. The error shouldn't occur and you should be redirected to the order received page as expected.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
