### PR TITLE
Use SDK to process payment/setup intents next actions - eg 3DS modals 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - When SEPA tokens are added via the My Account > Payment methods page, ensure they are attached to the Stripe customer.
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.
+* Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 
 = 8.5.2 - 2024-07-22 =
 * Fix - Fixed errors when using Link to purchase subscription products that could lead to duplicate payment attempts.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2049,6 +2049,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'shipping'                      => $shipping_details,
 			'token'                         => $token,
 			'return_url'                    => $this->get_return_url_for_redirect( $order, $save_payment_method_to_store ),
+			'use_stripe_sdk'                => 'true', // We want to use the SDK to handle next actions via the client payment elements. See https://docs.stripe.com/api/setup_intents/create#create_setup_intent-use_stripe_sdk
 		];
 
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - When SEPA tokens are added via the My Account > Payment methods page, ensure they are attached to the Stripe customer.
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.
-
+* Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3239 

## Changes proposed in this Pull Request:

When using a 3DS card to sign up to free trial subscriptions, customers were redirected to a 3DS page rather than using the popup modal. This is different from how 3DS cards are usually confirmed when a payment is required upfront.

This different flow for setup intents could lead to issues when the customer fails the 3DS because rather than the error message being shown on the checkout where they can reattempt, the customer is redirected to an order received page where the order fails and the customer needs to find their own way back to the checkout. 

This PR improves the UX of signing up to subscriptions with a 3DS card by using the `use_stripe_sdk` flag. Stripe's docs describe this arg as: 

> Set to `true` when confirming server-side and using Stripe.js, iOS, or Android client-side SDKs to handle the next actions. 
> <sup>src: https://docs.stripe.com/api/payment_intents/create#create_payment_intent-use_stripe_sdk</sup>

We already use this property to set up intents on the **My Account > Payment methods** Page too ([here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.4.0/includes/class-wc-stripe-intent-controller.php#L1012)).

## Testing instructions

1. Install WooCommerce Subscriptions. 
2. Create a product with a free trial. 
3. Add the free trial subscription product to your cart. 
4. On checkout enter the 3DS card. eg `4000002760003184`
5. Place the order. 
6. Notice that the standard 3DS modal pops up.
   - On `develop` you would have been redirected to a different page all together. 
7. Fail/Complete the 3DS request and verify that the error message is shown on checkout or you're redirected to the order received page as intended.
  
<p align="center">
<img width="250" alt="Screenshot 2024-07-23 at 1 28 27 PM" src="https://github.com/user-attachments/assets/fc533bdc-55af-4fab-b01d-18ee6ea399a8">
</p> 

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
