### PR TITLE
Display tooltips on the connect screen if the oauth URL fails to load

### DIFF
--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -7,6 +7,7 @@ import CardBody from '../card-body';
 import StripeBanner from 'wcstripe/components/stripe-banner';
 import { recordEvent } from 'wcstripe/tracking';
 import InlineNotice from 'wcstripe/components/inline-notice';
+import Tooltip from 'wcstripe/components/tooltip';
 
 const CardWrapper = styled( Card )`
 	max-width: 560px;
@@ -35,6 +36,7 @@ const ButtonWrapper = styled.div`
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
+	gap: 16px;
 
 	> :last-child {
 		box-shadow: none;
@@ -58,6 +60,32 @@ const ConnectStripeAccount = ( { oauthUrl, testOauthUrl } ) => {
 		window.location.assign( testOauthUrl );
 	};
 
+	const connectButton = (
+		<Button
+			variant="primary"
+			onClick={ handleCreateOrConnectAccount }
+			disabled={ ! oauthUrl }
+		>
+			{ __(
+				'Create or connect an account',
+				'woocommerce-gateway-stripe'
+			) }
+		</Button>
+	);
+
+	const connectTestButton = (
+		<Button
+			variant="secondary"
+			onClick={ handleCreateOrConnectTestAccount }
+			disabled={ ! testOauthUrl }
+		>
+			{ __(
+				'Create or connect a test account',
+				'woocommerce-gateway-stripe'
+			) }
+		</Button>
+	);
+
 	return (
 		<CardWrapper>
 			<StripeBanner />
@@ -74,7 +102,6 @@ const ConnectStripeAccount = ( { oauthUrl, testOauthUrl } ) => {
 						'woocommerce-gateway-stripe'
 					) }
 				</InformationText>
-
 				{ oauthUrl || testOauthUrl ? (
 					<>
 						<TermsOfServiceText>
@@ -96,34 +123,29 @@ const ConnectStripeAccount = ( { oauthUrl, testOauthUrl } ) => {
 							} ) }
 						</TermsOfServiceText>
 						<ButtonWrapper>
-							{ oauthUrl && (
-								<Button
-									variant="primary"
-									onClick={ handleCreateOrConnectAccount }
-								>
-									{ __(
-										'Create or connect an account',
+							{ ! oauthUrl ? (
+								<Tooltip
+									content={ __(
+										'An issue occurred generating a connection to Stripe. Please try again or connect in test mode.',
 										'woocommerce-gateway-stripe'
 									) }
-								</Button>
-							) }
-							{ testOauthUrl && (
-								<Button
-									variant={
-										oauthUrl ? 'secondary' : 'primary'
-									}
-									onClick={ handleCreateOrConnectTestAccount }
 								>
-									{ oauthUrl
-										? __(
-												'Create or connect a test account instead',
-												'woocommerce-gateway-stripe'
-										  )
-										: __(
-												'Create or connect a test account',
-												'woocommerce-gateway-stripe'
-										  ) }
-								</Button>
+									{ connectButton }
+								</Tooltip>
+							) : (
+								connectButton
+							) }
+							{ ! testOauthUrl ? (
+								<Tooltip
+									content={ __(
+										'An issue occurred generating a connection to Stripe in test mode. Please try again or connect in live mode.',
+										'woocommerce-gateway-stripe'
+									) }
+								>
+									{ connectTestButton }
+								</Tooltip>
+							) : (
+								connectTestButton
 							) }
 						</ButtonWrapper>
 					</>


### PR DESCRIPTION
Fixes #3316

## Changes proposed in this Pull Request:

This PR adds tooltips to the OAuth connect UI when the connect URLs fail being generated. 

| Live URL empty | Test URL empty |
|--------|--------|
| <img width="590" alt="Screenshot 2024-07-29 at 1 41 47 PM" src="https://github.com/user-attachments/assets/55a27c42-fce2-4a3d-8fdf-b1f589b52d8e"> | <img width="590" alt="Screenshot 2024-07-29 at 1 41 35 PM" src="https://github.com/user-attachments/assets/dec1b5c1-f509-4acb-9c77-3286977ac8b7"> | 

## Testing instructions

**ERROR STATES**

<p align="center">
<img width="400" alt="Screenshot 2024-07-29 at 1 53 09 PM" src="https://github.com/user-attachments/assets/7f58459c-943e-47dc-82ad-b6daf114f181">
</p> 

1. Checkout this branch and run `npm run build`.
2. Backup your Stripe settings by renaming it or delete the `woocommerce_stripe_settings` option.
1. Change the script params generated in [`WC_Stripe_Settings_Controller::admin_scripts()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/issue/3316-allow-connecting-test-account/includes/admin/class-wc-stripe-settings-controller.php#L148-L149). Change both `stripe_oauth_url` and `stripe_test_oauth_url` to `''`. 
2. Refresh the Stripe plugin settings and you should see the connect UI with the error message shown.
3. Restore the `stripe_oauth_url` or `stripe_test_oauth_url` in the script params. 
4. If the Live or Test URL is empty, both buttons will load. The button that corresponds to the empty URL will be disabled and will display a tooltip on hover. 

| Live URL empty | Test URL empty |
|--------|--------|
| <img width="590" alt="Screenshot 2024-07-29 at 1 41 47 PM" src="https://github.com/user-attachments/assets/55a27c42-fce2-4a3d-8fdf-b1f589b52d8e"> | <img width="590" alt="Screenshot 2024-07-29 at 1 41 35 PM" src="https://github.com/user-attachments/assets/dec1b5c1-f509-4acb-9c77-3286977ac8b7"> | 

> [!important]
> To test the tooltips make sure you have 1 URL that is empty and the other URL should be the  one that was generated.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
