### PR TITLE
Fix order total for partial capture

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
+* Fix - Mismatch in total in order after partial capture via Stripe dashboard
 
 = 8.5.2 - 2024-07-22 =
 * Fix - Fixed errors when using Link to purchase subscription products that could lead to duplicate payment attempts.

--- a/readme.txt
+++ b/readme.txt
@@ -144,5 +144,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
+* Fix - Mismatch in total in order after partial capture via Stripe dashboard
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
**Fixes #2799**

This PR addresses two issues related to order status updates and partial capture:

1. Prevents changes to the order total when updating the order status during a partial capture.
2. Adds a refund entry with the message "Partial Capture" to accurately reflect partial refunds in line with Stripe's charge details.

## Changes proposed in this Pull Request:
- **Webhook `process_webhook_capture`**:
  - Prevents modification of the order total during status changes.
  - Introduces a partial refund entry to ensure the order total remains unaffected by status changes.
  - Add an status change from "on_hold" to "processing"

- **Order Notes**:
  - Adjusts the number representation to a float with two decimal places for consistency and clarity.

## Testing instructions
⚠️ Note: you need to have [webhooks working](https://woo.com/document/stripe/#webhooks) in order to receive the capture webhook from Stripe.
1. Enable auth and capture from the Stripe settings.
   - WooCommerce → Settings → Payments → Stripe → Settings (Transaction preferences)
2. Purchase any product.
3. Go to the Stripe Dashboard and view the transaction. 
![screenshot-dashboard stripe com-2024 07 26-13_53_21](https://github.com/user-attachments/assets/24182a98-c55c-4c59-8be8-e5899edbf2e9)

4. Click the capture button and enter an amount below the full total. eg $15 ⇒ $5 
![Screenshot from 2024-07-26 13-25-26](https://github.com/user-attachments/assets/aefddcbf-9c42-461c-8bb4-4d7bfdd2552d)

5. View the order in WooCommerce with the following information:
   - It's on processing status
   - The order has a partial refund with the no-capture amount
   - The order total doesn't change
   
![Screenshot from 2024-07-26 13-27-14](https://github.com/user-attachments/assets/8169745f-9552-441e-8fd2-5f52fb36304a)
![Screenshot from 2024-07-26 13-27-04](https://github.com/user-attachments/assets/a1591f93-253f-45ff-9ad9-2f6c899ba536)


6. If you change the order status to any status, you will no see any total change

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
