### PR TITLE
Initial groundwork for generating test mode Stripe Connect URLs

### DIFF
--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -47,10 +47,15 @@ const ButtonWrapper = styled.div`
 	}
 `;
 
-const ConnectStripeAccount = ( { oauthUrl } ) => {
+const ConnectStripeAccount = ( { oauthUrl, testOauthUrl } ) => {
 	const handleCreateOrConnectAccount = () => {
 		recordEvent( 'wcstripe_create_or_connect_account_click', {} );
 		window.location.assign( oauthUrl );
+	};
+
+	const handleCreateOrConnectTestAccount = () => {
+		recordEvent( 'wcstripe_create_or_connect_test_account_click', {} );
+		window.location.assign( testOauthUrl );
 	};
 
 	return (
@@ -70,38 +75,58 @@ const ConnectStripeAccount = ( { oauthUrl } ) => {
 					) }
 				</InformationText>
 
-				{ oauthUrl && (
-					<TermsOfServiceText>
-						{ interpolateComponents( {
-							mixedString: __(
-								'By clicking "Create or connect an account", you agree to the {{tosLink}}Terms of service.{{/tosLink}}',
-								'woocommerce-gateway-stripe'
-							),
-							components: {
-								tosLink: (
-									// eslint-disable-next-line jsx-a11y/anchor-has-content
-									<a
-										target="_blank"
-										rel="noreferrer"
-										href="https://wordpress.com/tos"
-									/>
+				{ oauthUrl || testOauthUrl ? (
+					<>
+						<TermsOfServiceText>
+							{ interpolateComponents( {
+								mixedString: __(
+									'By clicking "Create or connect an account", you agree to the {{tosLink}}Terms of service.{{/tosLink}}',
+									'woocommerce-gateway-stripe'
 								),
-							},
-						} ) }
-					</TermsOfServiceText>
-				) }
-				{ oauthUrl ? (
-					<ButtonWrapper>
-						<Button
-							variant="primary"
-							onClick={ handleCreateOrConnectAccount }
-						>
-							{ __(
-								'Create or connect an account',
-								'woocommerce-gateway-stripe'
+								components: {
+									tosLink: (
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
+											target="_blank"
+											rel="noreferrer"
+											href="https://wordpress.com/tos"
+										/>
+									),
+								},
+							} ) }
+						</TermsOfServiceText>
+						<ButtonWrapper>
+							{ oauthUrl && (
+								<Button
+									variant="primary"
+									onClick={ handleCreateOrConnectAccount }
+								>
+									{ __(
+										'Create or connect an account',
+										'woocommerce-gateway-stripe'
+									) }
+								</Button>
 							) }
-						</Button>
-					</ButtonWrapper>
+							{ testOauthUrl && (
+								<Button
+									variant={
+										oauthUrl ? 'secondary' : 'primary'
+									}
+									onClick={ handleCreateOrConnectTestAccount }
+								>
+									{ oauthUrl
+										? __(
+												'Create or connect a test account instead',
+												'woocommerce-gateway-stripe'
+										  )
+										: __(
+												'Create or connect a test account',
+												'woocommerce-gateway-stripe'
+										  ) }
+								</Button>
+							) }
+						</ButtonWrapper>
+					</>
 				) : (
 					<InlineNotice isDismissible={ false } status="error">
 						{ interpolateComponents( {

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -49,6 +49,7 @@ if ( newAccountContainer ) {
 	ReactDOM.render(
 		<ConnectStripeAccount
 			oauthUrl={ wc_stripe_settings_params.stripe_oauth_url }
+			testOauthUrl={ wc_stripe_settings_params.stripe_test_oauth_url }
 		/>,
 		newAccountContainer
 	);

--- a/client/settings/stripe-auth-account/stripe-auth-actions.js
+++ b/client/settings/stripe-auth-account/stripe-auth-actions.js
@@ -1,4 +1,5 @@
 /* global wc_stripe_settings_params */
+import { __ } from '@wordpress/i18n';
 import { React } from 'react';
 import { Button } from '@wordpress/components';
 import ConfigureWebhookButton from './configure-webhook-button';
@@ -23,7 +24,15 @@ const StripeAuthActions = ( { testMode, displayWebhookConfigure } ) => {
 						: wc_stripe_settings_params.stripe_oauth_url
 				}
 				text={
-					testMode ? 'Connect a test account' : 'Connect an account'
+					testMode
+						? __(
+								'Create or connect a test account',
+								'woocommerce-gateway-stripe'
+						  )
+						: __(
+								'Create or connect an account',
+								'woocommerce-gateway-stripe'
+						  )
 				}
 			/>
 			{ displayWebhookConfigure && (

--- a/client/settings/stripe-auth-account/stripe-auth-actions.js
+++ b/client/settings/stripe-auth-account/stripe-auth-actions.js
@@ -17,7 +17,11 @@ const StripeAuthActions = ( { testMode, displayWebhookConfigure } ) => {
 		<div className="woocommerce-stripe-auth__actions">
 			<Button
 				variant="primary"
-				href={ wc_stripe_settings_params.stripe_oauth_url }
+				href={
+					testMode
+						? wc_stripe_settings_params.stripe_test_oauth_url
+						: wc_stripe_settings_params.stripe_oauth_url
+				}
 				text={
 					testMode ? 'Connect a test account' : 'Connect an account'
 				}

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -130,9 +130,10 @@ class WC_Stripe_Settings_Controller {
 		);
 
 		$oauth_url = woocommerce_gateway_stripe()->connect->get_oauth_url();
-		if ( is_wp_error( $oauth_url ) ) {
-			$oauth_url = '';
-		}
+		$oauth_url = is_wp_error( $oauth_url ) ? '' : $oauth_url;
+
+		$test_oauth_url = woocommerce_gateway_stripe()->connect->get_oauth_url( '', 'test' );
+		$test_oauth_url = is_wp_error( $test_oauth_url ) ? '' : $test_oauth_url;
 
 		$message = sprintf(
 		/* translators: 1) Html strong opening tag 2) Html strong closing tag */
@@ -146,6 +147,7 @@ class WC_Stripe_Settings_Controller {
 			'i18n_out_of_sync'          => $message,
 			'is_upe_checkout_enabled'   => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			'stripe_oauth_url'          => $oauth_url,
+			'stripe_test_oauth_url'     => $test_oauth_url,
 			'show_customization_notice' => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
 			'is_test_mode'              => $this->gateway->is_in_test_mode(),
 			'plugin_version'            => WC_STRIPE_VERSION,

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1123,20 +1123,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Get the connection URL.
-	 *
-	 * @return string Connection URL.
-	 */
-	public function get_connection_url( $return_url = '' ) {
-		$api     = new WC_Stripe_Connect_API();
-		$connect = new WC_Stripe_Connect( $api );
-
-		$url = $connect->get_oauth_url( $return_url );
-
-		return is_wp_error( $url ) ? null : $url;
-	}
-
-	/**
 	 * Get help text to display during quick setup.
 	 *
 	 * @return string

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -46,37 +46,41 @@ class WC_Stripe_Account {
 	/**
 	 * Gets and caches the data for the account connected to this site.
 	 *
+	 * @param string|null $mode Optional. The mode to get the account data for. 'live' or 'test'. Default will use the current mode.
 	 * @return array Account data or empty if failed to retrieve account data.
 	 */
-	public function get_cached_account_data() {
-		if ( ! $this->connect->is_connected() ) {
+	public function get_cached_account_data( $mode = null ) {
+		if ( ! $this->connect->is_connected( $mode ) ) {
 			return [];
 		}
 
-		$account = $this->read_account_from_cache();
+		$account = $this->read_account_from_cache( $mode );
 
 		if ( ! empty( $account ) ) {
 			return $account;
 		}
 
-		return $this->cache_account();
+		return $this->cache_account( $mode );
 	}
 
 	/**
 	 * Read the account from the WP option we cache it in.
 	 *
+	 * @param string|null $mode Optional. The mode to get the account data for. 'live' or 'test'. Default will use the current mode.
 	 * @return array empty when no data found in transient, otherwise returns cached data
 	 */
-	private function read_account_from_cache() {
-		$account_cache = json_decode( wp_json_encode( get_transient( $this->get_transient_key() ) ), true );
+	private function read_account_from_cache( $mode = null ) {
+		$account_cache = json_decode( wp_json_encode( get_transient( $this->get_transient_key( $mode ) ) ), true );
 
 		return false === $account_cache ? [] : $account_cache;
 	}
 
 	/**
 	 * Caches account data for a period of time.
+	 *
+	 * @param string|null $mode Optional. The mode to get the account data for. 'live' or 'test'. Default will use the current mode.
 	 */
-	private function cache_account() {
+	private function cache_account( $mode = null ) {
 		$expiration = 2 * HOUR_IN_SECONDS;
 
 		// need call_user_func() as (  $this->stripe_api )::retrieve this syntax is not supported in php < 5.2
@@ -90,19 +94,27 @@ class WC_Stripe_Account {
 		$account_cache = $account;
 
 		// Create or update the account option cache.
-		set_transient( $this->get_transient_key(), $account_cache, $expiration );
+		set_transient( $this->get_transient_key( $mode ), $account_cache, $expiration );
 
 		return json_decode( wp_json_encode( $account ), true );
 	}
 
 	/**
-	 * Checks Stripe connection mode if it is test mode or live mode
+	 * Fetches the transient key for the account data for a given mode.
+	 * If no mode is provided, it will use the current mode.
 	 *
+	 * @param string|null $mode Optional. The mode to get the account data for. 'live' or 'test'. Default will use the current mode.
 	 * @return string Transient key of test mode when testmode is enabled, otherwise returns the key of live mode.
 	 */
-	private function get_transient_key() {
+	private function get_transient_key( $mode = null ) {
 		$settings_options = get_option( 'woocommerce_stripe_settings', [] );
-		$key              = isset( $settings_options['testmode'] ) && 'yes' === $settings_options['testmode'] ? self::TEST_ACCOUNT_OPTION : self::LIVE_ACCOUNT_OPTION;
+
+		// If the mode is not provided, we'll check the current mode.
+		if ( ! in_array( $mode, [ 'test', 'live' ] ) ) {
+			$mode = isset( $settings_options['testmode'] ) && 'yes' === $settings_options['testmode'] ? 'test' : 'live';
+		}
+
+		$key = 'test' === $mode ? self::TEST_ACCOUNT_OPTION : self::LIVE_ACCOUNT_OPTION;
 
 		return $key;
 	}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -109,14 +109,12 @@ class WC_Stripe_Account {
 	private function get_transient_key( $mode = null ) {
 		$settings_options = get_option( 'woocommerce_stripe_settings', [] );
 
-		// If the mode is not provided, we'll check the current mode.
-		if ( ! in_array( $mode, [ 'test', 'live' ] ) ) {
+		// If the mode is not provided or is invalid, we'll check the current mode.
+		if ( is_null( $mode ) || ! in_array( $mode, [ 'test', 'live' ] ) ) {
 			$mode = isset( $settings_options['testmode'] ) && 'yes' === $settings_options['testmode'] ? 'test' : 'live';
 		}
 
-		$key = 'test' === $mode ? self::TEST_ACCOUNT_OPTION : self::LIVE_ACCOUNT_OPTION;
-
-		return $key;
+		return 'test' === $mode ? self::TEST_ACCOUNT_OPTION : self::LIVE_ACCOUNT_OPTION;
 	}
 
 	/**

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -39,15 +39,26 @@ class WC_Stripe_API {
 	 */
 	public static function get_secret_key() {
 		if ( ! self::$secret_key ) {
-			$options         = get_option( 'woocommerce_stripe_settings' );
-			$secret_key      = $options['secret_key'] ?? '';
-			$test_secret_key = $options['test_secret_key'] ?? '';
-
-			if ( isset( $options['testmode'] ) ) {
-				self::set_secret_key( 'yes' === $options['testmode'] ? $test_secret_key : $secret_key );
-			}
+			self::set_secret_key_for_mode();
 		}
 		return self::$secret_key;
+	}
+
+	/**
+	 * Set secret key based on mode.
+	 *
+	 * @param string|null $mode Optional. The mode to set the secret key for. 'live' or 'test'. Default will set the secret for the currently active mode.
+	 */
+	public static function set_secret_key_for_mode( $mode = null ) {
+		$options         = get_option( 'woocommerce_stripe_settings' );
+		$secret_key      = $options['secret_key'] ?? '';
+		$test_secret_key = $options['test_secret_key'] ?? '';
+
+		if ( is_null( $mode ) || ! in_array( $mode, [ 'test', 'live' ] ) ) {
+			$mode = isset( $options['testmode'] ) && 'yes' === $options['testmode'] ? 'test' : 'live';
+		}
+
+		self::set_secret_key( 'test' === $mode ? $test_secret_key : $secret_key );
 	}
 
 	/**

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -54,10 +54,10 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			$request = [
 				'returnUrl'    => $return_url,
 				'businessData' => $business_data,
-				'mode'         => $mode,
 			];
 
-			return $this->request( 'POST', '/stripe/oauth-init', $request );
+			$path = 'test' === $mode ? '/stripe-sandbox/oauth-init' : '/stripe/oauth-init';
+			return $this->request( 'POST', $path, $request );
 		}
 
 		/**
@@ -67,11 +67,12 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 		 *
 		 * @return array
 		 */
-		public function get_stripe_oauth_keys( $code ) {
+		public function get_stripe_oauth_keys( $code, $mode = 'live' ) {
 
 			$request = [ 'code' => $code ];
 
-			return $this->request( 'POST', '/stripe/oauth-keys', $request );
+			$path = 'test' === $mode ? '/stripe-sandbox/oauth-keys' : '/stripe/oauth-keys';
+			return $this->request( 'POST', $path, $request );
 		}
 
 		/**
@@ -93,10 +94,6 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			}
 
 			$url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
-
-			if ( isset( $body['mode'] ) && 'test' === $body['mode'] ) {
-				$url = str_replace( 'api.woocommerce.com', 'api-staging.woocommerce.com', $url ); // TODO: replace this once we know the format of a test request to api.woocommerce.com.
-			}
 
 			$url = apply_filters( 'wc_connect_server_url', $url );
 			$url = trailingslashit( $url ) . ltrim( $path, '/' );

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -18,11 +18,12 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 		/**
 		 * Send request to Connect Server to initiate Stripe OAuth
 		 *
-		 * @param  string $return_url return address.
+		 * @param string $return_url The URL to return to after the OAuth is completed.
+		 * @param string $mode       Optional. The mode to connect to. 'live' or 'test'. Default is 'live'.
 		 *
-		 * @return array
+		 * @return array|WP_Error The response from the server.
 		 */
-		public function get_stripe_oauth_init( $return_url ) {
+		public function get_stripe_oauth_init( $return_url, $mode = 'live' ) {
 
 			$current_user                   = wp_get_current_user();
 			$business_data                  = [];
@@ -53,6 +54,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			$request = [
 				'returnUrl'    => $return_url,
 				'businessData' => $business_data,
+				'mode'         => $mode,
 			];
 
 			return $this->request( 'POST', '/stripe/oauth-init', $request );
@@ -91,6 +93,11 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			}
 
 			$url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
+
+			if ( isset( $body['mode'] ) && 'test' === $body['mode'] ) {
+				$url = str_replace( 'api.woocommerce.com', 'api-staging.woocommerce.com', $url ); // TODO replace this once we know the format of a test request to api.woocommerce.com.
+			}
+
 			$url = apply_filters( 'wc_connect_server_url', $url );
 			$url = trailingslashit( $url ) . ltrim( $path, '/' );
 

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -95,7 +95,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			$url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
 
 			if ( isset( $body['mode'] ) && 'test' === $body['mode'] ) {
-				$url = str_replace( 'api.woocommerce.com', 'api-staging.woocommerce.com', $url ); // TODO replace this once we know the format of a test request to api.woocommerce.com.
+				$url = str_replace( 'api.woocommerce.com', 'api-staging.woocommerce.com', $url ); // TODO: replace this once we know the format of a test request to api.woocommerce.com.
 			}
 
 			$url = apply_filters( 'wc_connect_server_url', $url );

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -101,7 +101,6 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			}
 
 			$url = trailingslashit( WOOCOMMERCE_CONNECT_SERVER_URL );
-
 			$url = apply_filters( 'wc_connect_server_url', $url );
 			$url = trailingslashit( $url ) . ltrim( $path, '/' );
 

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -33,11 +33,12 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		/**
 		 * Gets the OAuth URL for Stripe onboarding flow
 		 *
-		 * @param  string $return_url url to return to after oauth flow.
+		 * @param string $return_url The URL to return to after OAuth flow.
+		 * @param string $mode       Optional. The mode to connect to. 'live' or 'test'. Default is 'live'.
 		 *
 		 * @return string|WP_Error
 		 */
-		public function get_oauth_url( $return_url = '' ) {
+		public function get_oauth_url( $return_url = '', $mode = 'live' ) {
 
 			if ( empty( $return_url ) ) {
 				$return_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings' );
@@ -49,7 +50,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			$return_url = add_query_arg( '_wpnonce', wp_create_nonce( 'wcs_stripe_connected' ), $return_url );
 
-			$result = $this->api->get_stripe_oauth_init( $return_url );
+			$result = $this->api->get_stripe_oauth_init( $return_url, $mode );
 
 			if ( is_wp_error( $result ) ) {
 				return $result;

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -64,8 +64,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		/**
 		 * Initiate OAuth connection request to Connect Server
 		 *
-		 * @param  string $state State token to prevent request forgery.
-		 * @param  string $code  OAuth code.
+		 * @param string $state State token to prevent request forgery.
+		 * @param string $code  OAuth code.
+		 * @param string $mode  Optional. The mode to connect to. 'live' or 'test'. Default is 'live'.
 		 *
 		 * @return string|WP_Error
 		 */
@@ -124,7 +125,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		/**
 		 * Saves stripe keys after OAuth response
 		 *
-		 * @param  array $result OAuth response result.
+		 * @param array $result OAuth response result.
+		 * @param string $mode Optional. The mode to connect to. 'live' or 'test'. Default is 'live'.
 		 *
 		 * @return array|WP_Error
 		 */

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -192,4 +192,68 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		set_transient( 'wcstripe_account_data_test', $account );
 		$this->assertEquals( 'US', $this->account->get_account_country() );
 	}
+
+	/**
+	 * Test for get_cached_account_data() with test mode parameter.
+	 */
+	public function test_get_cached_account_data_test_mode() {
+		$this->mock_connect->method( 'is_connected' )->with( 'test' )->willReturn( true );
+
+		// Test mode account data.
+		$account = [
+			'id'      => 'acct_1234',
+			'email'   => 'test@example.com',
+			'country' => 'US',
+		];
+		set_transient( 'wcstripe_account_data_test', $account );
+
+		$this->assertSame( $this->account->get_cached_account_data( 'test' ), $account );
+	}
+
+	/**
+	 * Test for get_cached_account_data() with live mode parameter.
+	 */
+	public function test_get_cached_account_data_live_mode() {
+		$this->mock_connect->method( 'is_connected' )->with( 'live' )->willReturn( true );
+
+		// Live mode account data.
+		$account = [
+			'id'      => 'acct_1234',
+			'email'   => 'live@example.com',
+			'country' => 'US',
+		];
+		set_transient( 'wcstripe_account_data_live', $account );
+
+		$this->assertSame( $this->account->get_cached_account_data( 'test' ), $account );
+	}
+
+	/**
+	 * Test for get_cached_account_data() with no mode parameter.
+	 */
+	public function test_get_cached_account_data_no_mode() {
+		$stripe_settings = get_option( 'woocommerce_stripe_settings' );
+		$this->mock_connect->method( 'is_connected' )->with( null )->willReturn( true );
+
+		$test_account = [
+			'id'      => 'acct_test-1234',
+			'email'   => 'john@example.com',
+		];
+
+		$live_account = [
+			'id'      => 'acct_live-1234',
+			'email'   => 'john@example.com',
+		];
+		set_transient( 'wcstripe_account_data_test', $test_account );
+		set_transient( 'wcstripe_account_data_live', $live_account );
+
+		// Enable test mode.
+		$stripe_settings['testmode'] = 'yes';
+		// Confirm test mode data is returned.
+		$this->assertSame( $this->account->get_cached_account_data(), $test_account );
+
+		// Enable live mode.
+		$stripe_settings['testmode'] = 'no';
+		// Confirm live mode data is returned.
+		$this->assertSame( $this->account->get_cached_account_data(), $live_account );
+	}
 }

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -224,7 +224,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		];
 		set_transient( 'wcstripe_account_data_live', $account );
 
-		$this->assertSame( $this->account->get_cached_account_data( 'test' ), $account );
+		$this->assertSame( $this->account->get_cached_account_data( 'live' ), $account );
 	}
 
 	/**
@@ -246,13 +246,17 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		set_transient( 'wcstripe_account_data_test', $test_account );
 		set_transient( 'wcstripe_account_data_live', $live_account );
 
-		// Enable test mode.
+		// Enable TEST mode.
 		$stripe_settings['testmode'] = 'yes';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
 		// Confirm test mode data is returned.
 		$this->assertSame( $this->account->get_cached_account_data(), $test_account );
 
-		// Enable live mode.
+		// Enable LIVE mode.
 		$stripe_settings['testmode'] = 'no';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
 		// Confirm live mode data is returned.
 		$this->assertSame( $this->account->get_cached_account_data(), $live_account );
 	}

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -29,7 +29,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		$stripe_settings                         = get_option( 'woocommerce_stripe_settings' );
 		$stripe_settings['enabled']              = 'yes';
 		$stripe_settings['testmode']             = 'yes';
-		$stripe_settings['test_publishable_key'] = self::LIVE_SECRET_KEY;
+		$stripe_settings['secret_key']           = self::LIVE_SECRET_KEY;
 		$stripe_settings['test_secret_key']      = self::TEST_SECRET_KEY;
 		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 	}

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Class WC_Stripe_API
+ *
+ * @package WooCommerce_Stripe/Tests/WC_Stripe_API
+ */
+
+/**
+ * Class WC_Stripe_API tests.
+ */
+class WC_Stripe_API_Test extends WP_UnitTestCase {
+
+	/**
+	 * Secret key for test mode.
+	 */
+	const TEST_SECRET_KEY = 'sk_test_key_123';
+
+	/**
+	 * Secret key for live mode.
+	 */
+	const LIVE_SECRET_KEY = 'sk_live_key_123';
+
+	/**
+	 * Setup environment for tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$stripe_settings                         = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['enabled']              = 'yes';
+		$stripe_settings['testmode']             = 'yes';
+		$stripe_settings['test_publishable_key'] = self::LIVE_SECRET_KEY;
+		$stripe_settings['test_secret_key']      = self::TEST_SECRET_KEY;
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+	}
+
+	/**
+	 * Tear down environment after tests.
+	 */
+	public function tear_down() {
+		delete_option( 'woocommerce_stripe_settings' );
+		WC_Stripe_API::set_secret_key( null );
+		parent::tear_down();
+	}
+
+	/**
+	 * Test get_secret_key and set_secret_key.
+	 */
+	public function test_set_secret_key() {
+		$secret_key = 'sk_test_key';
+		WC_Stripe_API::set_secret_key( $secret_key );
+
+		$this->assertEquals( $secret_key, WC_Stripe_API::get_secret_key() );
+	}
+
+	/**
+	 * Test WC_Stripe_API::set_secret_key_for_mode() with no parameter.
+	 */
+	public function test_set_secret_key_for_mode_no_parameter() {
+		// Base test - current mode is test.
+		WC_Stripe_API::set_secret_key_for_mode();
+
+		$this->assertEquals( self::TEST_SECRET_KEY, WC_Stripe_API::get_secret_key() );
+
+		// Enable live mode.
+		$stripe_settings = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['testmode'] = 'no';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
+		WC_Stripe_API::set_secret_key_for_mode();
+
+		$this->assertEquals( self::LIVE_SECRET_KEY, WC_Stripe_API::get_secret_key() );
+	}
+
+	/**
+	 * Test WC_Stripe_API::set_secret_key_for_mode() with mode parameters.
+	 */
+	public function test_set_secret_key_for_mode_with_parameter() {
+		WC_Stripe_API::set_secret_key_for_mode( 'test' );
+		$this->assertEquals( self::TEST_SECRET_KEY, WC_Stripe_API::get_secret_key() );
+
+		WC_Stripe_API::set_secret_key_for_mode( 'live' );
+		$this->assertEquals( self::LIVE_SECRET_KEY, WC_Stripe_API::get_secret_key() );
+
+		// Invalid parameters will set the secret key to the current mode.
+		WC_Stripe_API::set_secret_key_for_mode( 'invalid' );
+		$this->assertEquals( self::TEST_SECRET_KEY, WC_Stripe_API::get_secret_key() );
+
+		// Set the mode to live and test the invalid parameter.
+		$stripe_settings = get_option( 'woocommerce_stripe_settings' );
+		$stripe_settings['testmode'] = 'no';
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
+
+		WC_Stripe_API::set_secret_key_for_mode( 'invalid' );
+		$this->assertEquals( self::LIVE_SECRET_KEY, WC_Stripe_API::get_secret_key() );
+	}
+}


### PR DESCRIPTION
Fixes #3291 

## Changes proposed in this Pull Request:

This PR updates the `WC_Stripe_Connect_API` class to add general support for generating test mode Stripe Connect URLs. It also updates the placeholder URL being used for the **Connect a test account** button on the **Configure connection** modal - it was previously using the live URL. 

## Testing instructions

1. Checkout this branch. 
2. Run `npm run build`
3. Go to **WooCommerce > Settings > Payments > Stripe > Settings (tab)**
4. Click **Configure connection** to option the Stripe Connect modal. 
5. Click on **Test** tab. 
6. Click on **Create or connect a test account** button. 
7. You should land on a Stripe connect page with test mode labels. 

<p align="center">
<img width="1092" alt="Screenshot 2024-07-29 at 5 21 07 PM" src="https://github.com/user-attachments/assets/de7bc593-dd5b-48b8-a034-27bd6e677524">
</p> 

8. Clicking the **Create or connect an account** on the **Live** tab should still direct you to the live mode connect page. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
