### PR TITLE
After automatically configuring a webhook, delete any previously configured ones sent to the current site

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
 * Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
+* Fix - After configuring webhooks automatically ensure only the latest webhook endpoint is active, deleting duplicates configured manually.
 
 = 8.5.2 - 2024-07-22 =
 * Fix - Fixed errors when using Link to purchase subscription products that could lead to duplicate payment attempts.

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -435,8 +435,8 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 		$webhook_secret_setting = $live_mode ? 'webhook_secret' : 'test_webhook_secret';
 		$webhook_data_setting   = $live_mode ? 'webhook_data' : 'test_webhook_data';
 
-		// Delete any previously configured manual webhooks. Exclude the current webhook ID from the deletion.
-		$this->account->delete_previously_configured_manual_webhooks( $response->id );
+		// Delete any previously configured webhooks. Exclude the current webhook ID from the deletion.
+		$this->account->delete_previously_configured_webhooks( $response->id );
 
 		// Save the Webhook secret and ID.
 		$settings[ $webhook_secret_setting ] = wc_clean( $response->secret );

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -441,6 +441,9 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 			WC_Stripe_API::request( [], "webhook_endpoints/{$configured_webhook_id}", 'DELETE' );
 		}
 
+		// Delete any previously configured manual webhooks. Exclude the current webhook ID from the deletion.
+		$this->account->delete_previously_configured_manual_webhooks( $response->id );
+
 		// Save the Webhook secret and ID.
 		$settings[ $webhook_secret_setting ] = wc_clean( $response->secret );
 		$settings[ $webhook_data_setting ]   = [

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -434,12 +434,6 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 
 		$webhook_secret_setting = $live_mode ? 'webhook_secret' : 'test_webhook_secret';
 		$webhook_data_setting   = $live_mode ? 'webhook_data' : 'test_webhook_data';
-		$configured_webhook_id  = $settings[ $webhook_data_setting ]['id'] ?? null;
-
-		// If there's an existing Webhook set up, delete it first to avoid duplicate Webhooks at Stripe.
-		if ( $configured_webhook_id ) {
-			WC_Stripe_API::request( [], "webhook_endpoints/{$configured_webhook_id}", 'DELETE' );
-		}
 
 		// Delete any previously configured manual webhooks. Exclude the current webhook ID from the deletion.
 		$this->account->delete_previously_configured_manual_webhooks( $response->id );

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -251,11 +251,11 @@ class WC_Stripe_Account {
 	}
 
 	/**
-	 * Deletes any previously configured manual webhooks.
+	 * Deletes any previously configured webhooks that are sent to the current site's webhook URL.
 	 *
 	 * @param string $exclude_webhook_id Webhook ID to exclude from deletion.
 	 */
-	public function delete_previously_configured_manual_webhooks( $exclude_webhook_id = '' ) {
+	public function delete_previously_configured_webhooks( $exclude_webhook_id = '' ) {
 		$webhooks = $this->stripe_api::retrieve( 'webhook_endpoints' );
 
 		if ( is_wp_error( $webhooks ) || ! isset( $webhooks->data ) || empty( $webhooks->data ) ) {
@@ -268,7 +268,6 @@ class WC_Stripe_Account {
 			$exclude_webhook_id ? "Deleting all webhooks sent to {$webhook_url} except for {$exclude_webhook_id}" : "Deleting all webhooks sent to {$webhook_url}"
 		);
 
-		// Delete any webhook that matches the current site's webhook URL.
 		foreach ( $webhooks->data as $webhook ) {
 			if ( ! isset( $webhook->id, $webhook->url ) ) {
 				continue;

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -258,7 +258,7 @@ class WC_Stripe_Account {
 				continue;
 			}
 
-			// Skip the webhook we're excluding it from deletion.
+			// Skip the webhook we're excluding from deletion.
 			if ( $exclude_webhook_id && $webhook->id === $exclude_webhook_id ) {
 				continue;
 			}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -280,7 +280,7 @@ class WC_Stripe_Account {
 			}
 
 			// Delete the webhook if it matches the current site's webhook URL.
-			if ( $webhook->url === $webhook_url ) {
+			if ( WC_Stripe_Helper::is_webhook_url( $webhook->url, $webhook_url ) ) {
 				$this->stripe_api::request(
 					[],
 					"webhook_endpoints/{$webhook->id}",

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -249,7 +249,7 @@ class WC_Stripe_Account {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 
 		WC_Stripe_Logger::log(
-			$exclude_webhook_id ? "Deleting all webooks sent to {$webhook_url}" : "Deleting all webooks sent to {$webhook_url} except for {$exclude_webhook_id}"
+			$exclude_webhook_id ? "Deleting all webooks sent to {$webhook_url} except for {$exclude_webhook_id}" : "Deleting all webooks sent to {$webhook_url}"
 		);
 
 		// Delete any webhook that matches the current site's webhook URL.

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -265,7 +265,7 @@ class WC_Stripe_Account {
 
 			// Delete the webhook if it matches the current site's webhook URL.
 			if ( $webhook->url === $webhook_url ) {
-				self::request(
+				$this->stripe_api::request(
 					[],
 					"webhook_endpoints/{$webhook->id}",
 					'DELETE'

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -249,7 +249,7 @@ class WC_Stripe_Account {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 
 		WC_Stripe_Logger::log(
-			$exclude_webhook_id ? "Deleting all webooks sent to {$webhook_url} except for {$exclude_webhook_id}" : "Deleting all webooks sent to {$webhook_url}"
+			$exclude_webhook_id ? "Deleting all webhooks sent to {$webhook_url} except for {$exclude_webhook_id}" : "Deleting all webhooks sent to {$webhook_url}"
 		);
 
 		// Delete any webhook that matches the current site's webhook URL.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1391,4 +1391,39 @@ class WC_Stripe_Helper {
 	public static function is_wallet_payment_method( $order ) {
 		return in_array( $order->get_meta( '_stripe_upe_payment_type' ), [ 'wechat_pay', 'cashapp' ], true );
 	}
+
+	/**
+	 * Checks if a given URL matches the current site's Webhook URL.
+	 *
+	 * This function ignores trailing slashes and compares the host and path of the URLs.
+	 * The protocol is not compared.
+	 *
+	 * @param string $url         The URL to check.
+	 * @param string $webhook_url The webhook URL to compare against.
+	 *
+	 * @return bool Whether the URL is a webhook URL.
+	 */
+	public static function is_webhook_url( $url, $webhook_url = '' ) {
+		if ( empty( $webhook_url ) ) {
+			$webhook_url = self::get_webhook_url();
+		}
+
+		$url         = untrailingslashit( trim( strtolower( $url ) ) );
+		$webhook_url = untrailingslashit( trim( strtolower( $webhook_url ) ) );
+
+		// If the URLs are the exact same, no need to compare further.
+		if ( $url === $webhook_url ) {
+			return true;
+		}
+
+		$webhook_url_parts = wp_parse_url( $url );
+		$url_parts         = wp_parse_url( $webhook_url );
+
+		$url_host     = $url_parts['host'] ?? '';
+		$url_path     = $url_parts['path'] ?? '';
+		$webhook_host = $webhook_url_parts['host'] ?? '';
+		$webhook_path = $webhook_url_parts['path'] ?? '';
+
+		return $url_host === $webhook_host && $url_path === $webhook_path;
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -146,5 +146,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
 * Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
+* Fix - After configuring webhooks automatically ensure only the latest webhook endpoint is active, deleting duplicates configured manually.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/helpers/class-wc-helper-stripe-api.php
+++ b/tests/phpunit/helpers/class-wc-helper-stripe-api.php
@@ -79,9 +79,18 @@ class WC_Helper_Stripe_Api {
 	public static function request( $request, $api = 'charges', $method = 'POST', $with_headers = false ) {
 		// If the expected request calls params are set, check if the params match the expected params.
 		if ( ! is_null( self::$expected_request_call_params ) ) {
+			$passed_params   = [ $request, $api, $method, $with_headers ];
 			$expected_params = array_shift( self::$expected_request_call_params );
 
-			if ( $expected_params !== $request ) {
+			// Fill in missing expected params with default values.
+			$expected_params = [
+				$expected_params[0],
+				$expected_params[1] ?? 'charges',
+				$expected_params[2] ?? 'POST',
+				$expected_params[3] ?? false,
+			];
+
+			if ( $expected_params !== $passed_params ) {
 				throw new Exception( 'Expected request params do not match the actual request params.' );
 			}
 		}

--- a/tests/phpunit/helpers/class-wc-helper-stripe-api.php
+++ b/tests/phpunit/helpers/class-wc-helper-stripe-api.php
@@ -14,16 +14,79 @@
 class WC_Helper_Stripe_Api {
 
 	/**
-	 * retrieve data. This is the equivalent mock for WC_Stripe_API::retrieve
+	 * Retrieve response.
+	 *
+	 * Use this to mock what should be returned from WC_Stripe_API::retrieve()
+	 *
+	 * @var array
+	 */
+	public static $retrieve_response = [
+		'id'    => '1234',
+		'email' => 'test@example.com',
+	];
+
+	/**
+	 * Request response.
+	 *
+	 * Use this to mock what should be returned from WC_Stripe_API::request()
+	 *
+	 * @var array
+	 */
+	public static $request_response = [];
+
+	/**
+	 * The expected request calls params.
+	 *
+	 * Use this to check if the expected params are passed to WC_Stripe_API::request()
+	 *
+	 * @var array
+	 */
+	public static $expected_request_call_params = null;
+
+	/**
+	 * Reset the helper.
+	 */
+	public static function reset() {
+		self::$retrieve_response = [
+			'id'    => '1234',
+			'email' => 'test@example.com',
+		];
+		self::$request_response = [];
+		self::$expected_request_call_params = null;
+	}
+
+	/**
+	 * Retrieve data. This is the equivalent mock for WC_Stripe_API::retrieve
 	 *
 	 * @param string data type
 	 *
 	 * @return array retrieved data mock
 	 */
 	public static function retrieve( $key = 'account' ) {
-		return [
-			'id'    => '1234',
-			'email' => 'test@example.com',
-		];
+		return self::$retrieve_response;
+	}
+
+	/**
+	 * Request data. This is the equivalent mock for WC_Stripe_API::request()
+	 *
+	 * @param array $request     Request data.
+	 * @param string $api        API endpoint.
+	 * @param string $method     Request method.
+	 * @param bool $with_headers Include headers in the response.
+	 *
+	 * @return array $response
+	 */
+	public static function request( $request, $api = 'charges', $method = 'POST', $with_headers = false ) {
+		// If the expected request calls params are set, check if the params match the expected params.
+		if ( ! is_null( self::$expected_request_call_params ) ) {
+			$expected_params = array_shift( self::$expected_request_call_params );
+
+			if ( $expected_params !== $request ) {
+				throw new Exception( 'Expected request params do not match the actual request params.' );
+			}
+		}
+
+		// The returned value should be mocked in the test.
+		return self::$request_response;
 	}
 }

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -195,7 +195,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'US', $this->account->get_account_country() );
 	}
 
-	/*
+	/**
 	 * Test for get_cached_account_data() with test mode parameter.
 	 */
 	public function test_get_cached_account_data_test_mode() {

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -236,6 +236,9 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		];
 
 		$this->account->delete_previously_configured_manual_webhooks( 'wh_456' );
+
+		// Confirm that all expected request call params were called.
+		$this->assertEmpty( WC_Helper_Stripe_Api::$expected_request_call_params );
 	}
 
 	/**
@@ -274,7 +277,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 
 		// Assert that the webhooks are deleted.
 		WC_Helper_Stripe_Api::$expected_request_call_params = [
-			[ [], 'webhook_endpoints/wh_123abc', 'DELETE' ],
+			[ [], 'webhook_endpoints/wh_123', 'DELETE' ],
 			[ [], 'webhook_endpoints/wh_456', 'DELETE' ],
 			[ [], 'webhook_endpoints/wh_101112', 'DELETE' ],
 		];

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -264,9 +264,9 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests for delete_previously_configured_manual_webhooks() with an excluded webhook.
+	 * Tests for delete_previously_configured_webhooks() with an excluded webhook.
 	 */
-	public function test_delete_previously_configured_manual_webhooks_with_exclusion() {
+	public function test_delete_previously_configured_webhooks_with_exclusion() {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 
 		// Mock the API retrieve.
@@ -313,16 +313,16 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 			[ [], 'webhook_endpoints/wh_161718', 'DELETE' ],
 		];
 
-		$this->account->delete_previously_configured_manual_webhooks( 'wh_456' );
+		$this->account->delete_previously_configured_webhooks( 'wh_456' );
 
 		// Confirm that all expected request call params were called.
 		$this->assertEmpty( WC_Helper_Stripe_Api::$expected_request_call_params );
 	}
 
 	/**
-	 * Tests for delete_previously_configured_manual_webhooks()
+	 * Tests for delete_previously_configured_webhooks()
 	 */
-	public function test_delete_previously_configured_manual_webhooks_without_exclusion() {
+	public function test_delete_previously_configured_webhooks_without_exclusion() {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 
 		// Mock the API retrieve.
@@ -360,7 +360,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 			[ [], 'webhook_endpoints/wh_101112', 'DELETE' ],
 		];
 
-		$this->account->delete_previously_configured_manual_webhooks();
+		$this->account->delete_previously_configured_webhooks();
 
 		// Confirm that all expected request call params were called.
 		$this->assertEmpty( WC_Helper_Stripe_Api::$expected_request_call_params );

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -274,7 +274,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 
 		// Assert that the webhooks are deleted.
 		WC_Helper_Stripe_Api::$expected_request_call_params = [
-			[ [], 'webhook_endpoints/wh_123', 'DELETE' ],
+			[ [], 'webhook_endpoints/wh_123abc', 'DELETE' ],
 			[ [], 'webhook_endpoints/wh_456', 'DELETE' ],
 			[ [], 'webhook_endpoints/wh_101112', 'DELETE' ],
 		];

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -202,28 +202,28 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 
 		// Mock the API retrieve.
-		WC_Helper_Stripe_Api::$retrieve_response = [
+		WC_Helper_Stripe_Api::$retrieve_response = (object) [
 			'data' => [
-				[
+				(object) [
 					'id' => 'wh_000', // Invalid data - no URL.
 				],
-				[
+				(object) [
 					'id'  => 'wh_123',
 					'url' => $webhook_url, // Should be deleted.
 				],
-				[
+				(object) [
 					'id'  => 'wh_456',
 					'url' => $webhook_url, // Should not be deleted - excluded.
 				],
-				[
+				(object) [
 					'id'  => 'wh_789',
 					'url' => 'https://some-other-site.com', // Should not be deleted - different URL.
 				],
-				[
+				(object) [
 					'id'  => 'wh_101112',
 					'url' => $webhook_url, // Should be deleted.
 				],
-				[
+				(object) [
 					'url' => $webhook_url, // Invalid data - no ID.
 				],
 			],
@@ -245,28 +245,28 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$webhook_url = WC_Stripe_Helper::get_webhook_url();
 
 		// Mock the API retrieve.
-		WC_Helper_Stripe_Api::$retrieve_response = [
+		WC_Helper_Stripe_Api::$retrieve_response = (object) [
 			'data' => [
-				[
+				(object) [
 					'id' => 'wh_000', // Invalid data - no URL.
 				],
-				[
+				(object) [
 					'id'  => 'wh_123',
 					'url' => $webhook_url, // Should be deleted.
 				],
-				[
+				(object) [
 					'id'  => 'wh_456',
 					'url' => $webhook_url, // Should be deleted.
 				],
-				[
+				(object) [
 					'id'  => 'wh_789',
 					'url' => 'https://some-other-site.com', // Should not be deleted - different URL.
 				],
-				[
+				(object) [
 					'id'  => 'wh_101112',
 					'url' => $webhook_url, // Should be deleted.
 				],
-				[
+				(object) [
 					'url' => $webhook_url, // Invalid data - no ID.
 				],
 			],
@@ -280,5 +280,8 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		];
 
 		$this->account->delete_previously_configured_manual_webhooks();
+
+		// Confirm that all expected request call params were called.
+		$this->assertEmpty( WC_Helper_Stripe_Api::$expected_request_call_params );
 	}
 }

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -294,6 +294,14 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 				(object) [
 					'url' => $webhook_url, // Invalid data - no ID.
 				],
+				(object) [
+					'id'  => 'wh_131415',
+					'url' => str_replace( 'https', 'http', $webhook_url ), // Should be deleted - different protocol.
+				],
+				(object) [
+					'id'  => 'wh_161718',
+					'url' => $webhook_url . '/', // Should be deleted - trailing slash.
+				],
 			],
 		];
 
@@ -301,6 +309,8 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		WC_Helper_Stripe_Api::$expected_request_call_params = [
 			[ [], 'webhook_endpoints/wh_123', 'DELETE' ],
 			[ [], 'webhook_endpoints/wh_101112', 'DELETE' ],
+			[ [], 'webhook_endpoints/wh_131415', 'DELETE' ],
+			[ [], 'webhook_endpoints/wh_161718', 'DELETE' ],
 		];
 
 		$this->account->delete_previously_configured_manual_webhooks( 'wh_456' );


### PR DESCRIPTION
Fixes #3270 

## Changes proposed in this Pull Request:

Merchants previously set up webhooks manually by creating the endpoint and copying the webhook secret into their Stripe settings. In 8.5.0 we introduced a button that could be used to configure the webhooks automatically. 

If they used the option to configure webhooks, they would end up with 2 endpoints. The original 1 they manually set up and the 2nd one we set up automatically. As we've discovered in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3326, if a store has multiple endpoints set up, they will process multiple webhooks leading to duplicate order notes and emails etc. 

This PR makes sure that after we configure their webhooks, we delete any webhook that is sent to the current site. This should prevent any previously set up webhook being sent and leading multiple webhooks. 

## Testing instructions

1. Go to your Stripe dashboard and the Webhooks page
    - https://dashboard.stripe.com/test/webhooks
2. Manually create 2 webhooks
   - One should be sent to your local site. 
   - The other one should be sent to a made up URL. eg `https://example.com/?wc-api=wc_stripe`
3. In your WP Admin dashboard go to **WooCommerce → Settings → Payments → Stripe → Settings (tab)**
4. Open the keys/connection modal.
5. Click the **Reconfigure webhooks** button
6. Check your webhooks in the Stripe dashboard. 
   - You should have a 1 new one.
   - All previously configured webhooks that were sent to your site should have been deleted.
   - Any other webhooks sent to different sites should remain unaffected.
7. If you check your Stripe logs in the dashboard or in WC you will see the requests to delete those duplicate webhooks. 

**BEFORE**
<p align="center">
<img width="1191" alt="Screenshot 2024-08-02 at 1 02 07 PM" src="https://github.com/user-attachments/assets/223b7d8f-c8b9-4ab6-be70-7c39d3a0551a">
</br>
<sup>3 duplicate webhooks all being sent to my local site. 1 sent to another site</sup>
</p> 

**AFTER**

<p align="center">
<img width="1018" alt="Screenshot 2024-08-02 at 1 09 14 PM" src="https://github.com/user-attachments/assets/199324aa-2ca7-4e48-8f99-f98f3752f191">
</br>
<sup>1 webhook being sent to my local site. 1 still sent to another site (undeleted)</sup>
</p> 


| <img width="480" alt="Screenshot 2024-08-02 at 1 12 34 PM" src="https://github.com/user-attachments/assets/f5c85209-b4bb-49b0-9197-6be745a91b69"> | <img width="773" alt="Screenshot 2024-08-02 at 1 15 42 PM" src="https://github.com/user-attachments/assets/6c000f1c-0a51-4668-ba5d-f8f563a57429"> |
|--------|--------|

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
