### PR TITLE
Prevent webhook event processing when no secret is set in the store

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
 * Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
+* Tweak - Don't process webhooks when the webhook secret isn't set in the store.
 
 = 8.5.2 - 2024-07-22 =
 * Fix - Fixed errors when using Link to purchase subscription products that could lead to duplicate payment attempts.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -130,7 +130,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		if ( empty( $this->secret ) ) {
-			return $this->validate_request_user_agent( $request_headers );
+			return WC_Stripe_Webhook_State::VALIDATION_FAILED_EMPTY_SECRET;
 		}
 
 		// Check for a valid signature.
@@ -155,21 +155,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		return WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED;
-	}
-
-	/**
-	 * Verify User Agent of the incoming webhook notification. Used as fallback for the cases when webhook secret is missing.
-	 *
-	 * @since 5.0.0
-	 * @version 5.0.0
-	 * @param array $request_headers The request headers from Stripe.
-	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
-	 */
-	private function validate_request_user_agent( $request_headers ) {
-		$ua_is_valid = empty( $request_headers['USER-AGENT'] ) || preg_match( '/Stripe/', $request_headers['USER-AGENT'] );
-		$ua_is_valid = apply_filters( 'wc_stripe_webhook_is_user_agent_valid', $ua_is_valid, $request_headers );
-
-		return $ua_is_valid ? WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED : WC_Stripe_Webhook_State::VALIDATION_FAILED_USER_AGENT_INVALID;
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -24,6 +24,7 @@ class WC_Stripe_Webhook_State {
 	const VALIDATION_SUCCEEDED                 = 'validation_succeeded';
 	const VALIDATION_FAILED_EMPTY_HEADERS      = 'empty_headers';
 	const VALIDATION_FAILED_EMPTY_BODY         = 'empty_body';
+	const VALIDATION_FAILED_EMPTY_SECRET       = 'empty_secret';
 	const VALIDATION_FAILED_USER_AGENT_INVALID = 'user_agent_invalid';
 	const VALIDATION_FAILED_SIGNATURE_INVALID  = 'signature_invalid';
 	const VALIDATION_FAILED_TIMESTAMP_MISMATCH = 'timestamp_out_of_range';
@@ -143,6 +144,11 @@ class WC_Stripe_Webhook_State {
 			return( __( 'The webhook was missing expected body', 'woocommerce-gateway-stripe' ) );
 		}
 
+		if ( self::VALIDATION_FAILED_EMPTY_SECRET === $last_error ) {
+			return( __( 'The webhook secret is not set in the store', 'woocommerce-gateway-stripe' ) );
+		}
+
+		// Legacy failure reason. Removed in 8.6.0.
 		if ( self::VALIDATION_FAILED_USER_AGENT_INVALID == $last_error ) {
 			return( __( 'The webhook received did not come from Stripe', 'woocommerce-gateway-stripe' ) );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -146,5 +146,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Improve UX by using the 3DS verification modal to confirm setup intents for subscription sign-ups, ensuring customers stay on the checkout page.
 * Tweak - Display a notice when the Stripe connect URL is not available.
 * Fix - Prevent displaying the default admin description on the checkout page when a payment method description is empty.
+* Tweak - Don't process webhooks when the webhook secret isn't set in the store.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -227,21 +227,6 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->assertMatchesRegularExpression( '/missing expected body/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
-	// Test custom user agent validator
-	public function test_get_error_custom_user_agent_validator() {
-		$this->cleanup_webhook_secret();
-		add_filter(
-			'wc_stripe_webhook_is_user_agent_valid',
-			function() {
-				return false;
-			}
-		);
-
-		$this->set_valid_request_data();
-		$this->process_webhook();
-		$this->assertMatchesRegularExpression( '/did not come from Stripe/', WC_Stripe_Webhook_State::get_last_error_reason() );
-	}
-
 	// Test user agent validation ignored
 	public function test_skip_user_agent_validation() {
 		// Run test without cleaning up webhook secret.
@@ -257,14 +242,13 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'No error', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
-	// Test failure reason: invalid user agent.
-	public function test_get_error_reason_invalid_user_agent() {
+	// Test failure reason: empty secret.
+	public function test_get_error_reason_empty_secret() {
 		$this->cleanup_webhook_secret();
 
 		$this->set_valid_request_data();
-		$this->request_headers['USER-AGENT'] = 'Other';
 		$this->process_webhook();
-		$this->assertMatchesRegularExpression( '/did not come from Stripe/', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertEquals( 'The webhook secret is not set in the store', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test failure reason: invalid signature.


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- When no webhook secret is set, stop processing incoming webhook events. Not having a webhook secret is possible on Stripe < 8.4.0
- Remove the fallback validation for when the webhook secret isn't set

## Testing instructions

1. Ensure your website is online
2. Check out 8.4.0 or previous versions of Stripe before the "Configure webhooks" button was introduced
3. Under Settings > Account details , click on "Edit account keys". At `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
4. Save
5. Notice it says "Webhooks: Disabled"
6. Configure a webhook in the Stripe dashboard pointing to your site, at https://dashboard.stripe.com/test/webhooks
7. Check out this branch
8. As a shopper, place an order
9. Go to WooCommerce Status > Logs, at `siteurl/wp-admin/admin.php?page=wc-status&tab=logs`
10. Open the latest woocommerce-gateway-stripe log
11. Confirm there's a couple of entries saying, "Incoming webhook failed validation"

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
