### PR TITLE
Fix broken onboarding with a live account

### DIFF
--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return $result;
 			}
 
-			set_transient( 'wcs_stripe_connect_state', $result->state, 6 * HOUR_IN_SECONDS );
+			set_transient( 'wcs_stripe_connect_state_' . $mode, $result->state, 6 * HOUR_IN_SECONDS );
 
 			return $result->oauthUrl; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
@@ -74,7 +74,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// The state parameter is used to protect against CSRF.
 			// It's a unique, randomly generated, opaque, and non-guessable string that is sent when starting the
 			// authentication request and validated when processing the response.
-			if ( get_transient( 'wcs_stripe_connect_state' ) !== $state ) {
+			if ( get_transient( 'wcs_stripe_connect_state_' . $mode ) !== $state ) {
 				return new WP_Error( 'Invalid state received from Stripe server' );
 			}
 
@@ -84,7 +84,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return $response;
 			}
 
-			delete_transient( 'wcs_stripe_connect_state' );
+			delete_transient( 'wcs_stripe_connect_state_' . $mode );
 
 			return $this->save_stripe_keys( $response, $mode );
 		}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3320#issuecomment-2264528830

## Changes proposed in this Pull Request:

This PR fixes the error introduced in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3320, where the transient was been overwritten when rendering 2 Connect OAuth URLs (Live and test).

Before this fix, after choosing (or creating) the account on the Stripe site, the redirect validation failed, and the merchant was redirected again to the onboarding screen:

![image](https://github.com/user-attachments/assets/8f68cf16-ffcf-406f-951f-218dcfa2a0e3)



## Testing instructions

0. Disconnect from Stripe (if needed)
    ![Screenshot_2024-08-02_at_2_43_31 PM](https://github.com/user-attachments/assets/7cc516a1-7981-41db-bba4-43e9df942553)
1. Navigate to WP-Admin > WooCommerce > Settings > Payments > Stripe
2. Click on the `Create or connect an account`, and complete the onboarding on the Stripe site (create or choose an account from the list)
    ![Screenshot_2024-08-02_at_2_46_58 PM](https://github.com/user-attachments/assets/e7bab08b-dfa4-46c9-8e85-933600a29116)
3. Check that the redirect is successful, the plugin is enabled in live mode, and the email in the `Account details` is correct:
![Screenshot 2024-08-02 at 2 49 18 PM](https://github.com/user-attachments/assets/a63c0947-0754-4afd-94e2-94c25ab97bd0)

---

-   [x] Covered with tests (or have a good reason not to test in the description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
