### PR TITLE
Fix E2E setup error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "woocommerce-gateway-stripe",
-      "version": "8.5.1",
+      "version": "8.5.2",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -15,7 +15,7 @@ fi
 
 # If no --base_url received, setup the docker test environment.
 
-DEBUG=false
+DEBUG=true
 
 # Override custom user/password from local.env, if any.
 ADMIN_USER=admin

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -34,7 +34,7 @@ if ! docker info > /dev/null 2>&1; then
 fi
 
 step "Starting E2E docker containers"
-CWD="$CWD" E2E_ROOT="$E2E_ROOT" redirect_output docker-compose -p wcstripe-e2e -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d wordpress
+CWD="$CWD" E2E_ROOT="$E2E_ROOT" redirect_output docker compose -p wcstripe-e2e -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d wordpress
 
 step "Configuring Wordpress"
 # Wait for containers to be started up before setup.

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -15,7 +15,7 @@ fi
 
 # If no --base_url received, setup the docker test environment.
 
-DEBUG=true
+DEBUG=false
 
 # Override custom user/password from local.env, if any.
 ADMIN_USER=admin

--- a/tests/e2e/tests/_legacy-experience/checkout/sca-card.spec.js
+++ b/tests/e2e/tests/_legacy-experience/checkout/sca-card.spec.js
@@ -30,6 +30,8 @@ test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
 	) {
 		await page.waitForTimeout( 1000 );
 	}
+	// Not ideal, but the iframe body gets repalced after load, so a waitFor does not work here.
+	await page.waitForTimeout( 2000 );
 
 	await page
 		.frame( {
@@ -38,7 +40,7 @@ test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
 		.getByRole( 'button', { name: 'Complete' } )
 		.click();
 
-	await page.waitForNavigation();
+	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'

--- a/tests/e2e/tests/checkout/blocks/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/sca-card.spec.js
@@ -29,6 +29,8 @@ test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 	) {
 		await page.waitForTimeout( 1000 );
 	}
+	// Not ideal, but the iframe body gets repalced after load, so a waitFor does not work here.
+	await page.waitForTimeout( 2000 );
 
 	await page
 		.frame( {
@@ -37,7 +39,7 @@ test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 		.getByRole( 'button', { name: 'Complete' } )
 		.click();
 
-	await page.waitForNavigation();
+	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'

--- a/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
@@ -27,6 +27,8 @@ test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
 	) {
 		await page.waitForTimeout( 1000 );
 	}
+	// Not ideal, but the iframe body gets repalced after load, so a waitFor does not work here.
+	await page.waitForTimeout( 2000 );
 
 	await page
 		.frame( {
@@ -35,7 +37,7 @@ test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
 		.getByRole( 'button', { name: 'Complete' } )
 		.click();
 
-	await page.waitForNavigation();
+	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes the E2E setup errors:

![Screenshot 2024-08-02 at 3 08 08 PM](https://github.com/user-attachments/assets/b18c687f-35c2-47d5-9c46-7e0c06cf6ef7)

![Screenshot 2024-08-02 at 3 07 52 PM](https://github.com/user-attachments/assets/985f20f8-752d-4d64-a240-21371dc069c8)

The command `docker-compose` no longer being available in the runner images, so this PR replaces it with `docker compose` (without the dash)

https://docs.docker.com/compose/#compose-v2-and-the-new-docker-compose-command

![Screenshot 2024-08-02 at 3 22 40 PM](https://github.com/user-attachments/assets/3ede12db-903e-47a1-ba71-f871e4ae8c1a)


## Testing instructions

Verify that all checks pass:


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
