### PR TITLE
When there's no promotional banner content, don't include an empty card

### DIFF
--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -219,9 +219,11 @@ const PromotionalBannerSection = ( {
 	}
 
 	return (
-		<BannerCard data-testid="promotional-banner-card">
-			{ BannerContent }
-		</BannerCard>
+		BannerContent && (
+			<BannerCard data-testid="promotional-banner-card">
+				{ BannerContent }
+			</BannerCard>
+		)
 	);
 };
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

When there's no promotional banner content, don't include the promotional banner container. By including the empty container, there's a line being shown on the settings page.

<p align="center">
<img width="1096" alt="Screenshot 2024-08-08 at 3 28 50 PM" src="https://github.com/user-attachments/assets/c35857b6-6852-4c6f-ba99-028fae8e3910">
</br>
<sup>Notice the line at the top of the screen. That's the empty card which has a border style.</sup>
</p> 

This PR fixes that by making sure we only include the promotional banner container when there's a banner to display.

## Testing instructions

1. Pull the latest develop.
2. Run `npm run build`.
1. Force the `is_connected_via_oauth()` function to return `true`. 
1. At the top of the settings page you will see the empty banner container (line).
5. Checkout this branch. 
2. Run `npm run build`.
1. At the top of the settings page there should be no empty banner container (line).
2. Make sure the banner is still displayed on this branch by forcing `is_connected_via_oauth()` to return `false`. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
