### PR TITLE
Rewording invalid keys error message

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.6.0 - xxxx-xx-xx =
+* Tweak - Improves the wording of the invalid Stripe keys error, instructing merchants to click the "Configure connection" button instead of manually setting the keys.
 * Add - Includes a new promotional surface to encourage merchants to re-connect their Stripe account using the new flow.
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 8.6.0 - xxxx-xx-xx =
-* Tweak - Improves the wording of the invalid Stripe keys error, instructing merchants to click the "Configure connection" button instead of manually setting the keys.
+* Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.
 * Add - Includes a new promotional surface to encourage merchants to re-connect their Stripe account using the new flow.
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.

--- a/client/data/account-keys/actions.js
+++ b/client/data/account-keys/actions.js
@@ -68,7 +68,7 @@ export function* saveAccountKeys( accountKeys ) {
 		yield dispatch( 'core/notices' ).createSuccessNotice(
 			isDisconnecting
 				? __( 'Account disconnected.', 'woocommerce-gateway-stripe' )
-				: __( 'Account keys saved.', 'woocommerce-gateway-stripe' )
+				: __( 'Account connected.', 'woocommerce-gateway-stripe' )
 		);
 	} catch ( e ) {
 		error = e;
@@ -79,7 +79,7 @@ export function* saveAccountKeys( accountKeys ) {
 						'woocommerce-gateway-stripe'
 				  )
 				: __(
-						'Error saving account keys.',
+						'Error connecting account.',
 						'woocommerce-gateway-stripe'
 				  )
 		);

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -147,23 +147,25 @@ const AccountDetails = () => {
 					{ isTestModeEnabled
 						? interpolateComponents( {
 								mixedString: __(
-									"Seems like the test keys we've saved for you are no longer valid. If you recently updated them, enter the new test keys from your {{accountLink}}Stripe Account{{/accountLink}}.",
+									'Seems like the current connected test account is no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.',
 									'woocommerce-gateway-stripe'
 								),
 								components: {
 									accountLink: (
-										<ExternalLink href="https://dashboard.stripe.com/test/apikeys" />
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings" />
 									),
 								},
 						  } )
 						: interpolateComponents( {
 								mixedString: __(
-									"Seems like the live keys we've saved for you are no longer valid. If you recently updated them, enter the new live keys from your {{accountLink}}Stripe Account{{/accountLink}}.",
+									'Seems like the current connected live account is no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.',
 									'woocommerce-gateway-stripe'
 								),
 								components: {
 									accountLink: (
-										<ExternalLink href="https://dashboard.stripe.com/apikeys" />
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings" />
 									),
 								},
 						  } ) }

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -3,7 +3,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import React from 'react';
 import { ExternalLink, Icon } from '@wordpress/components';
 import { help } from '@wordpress/icons';
-import interpolateComponents from 'interpolate-components';
 import styled from '@emotion/styled';
 import SectionStatus from '../section-status';
 import Tooltip from 'wcstripe/components/tooltip';
@@ -144,31 +143,20 @@ const AccountDetails = () => {
 		return (
 			<AccountDetailsContainer>
 				<AccountDetailsError>
-					{ isTestModeEnabled
-						? interpolateComponents( {
-								mixedString: __(
-									"Seems like the test API keys we've saved for you are no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.",
+					{ createInterpolateElement(
+						isTestModeEnabled
+							? __(
+									"Seems like the test API keys we've saved for you are no longer valid. If you recently updated them, use the <strong>Configure Connection</strong> button below to reconnect.",
 									'woocommerce-gateway-stripe'
-								),
-								components: {
-									accountLink: (
-										// eslint-disable-next-line jsx-a11y/anchor-has-content
-										<a href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings" />
-									),
-								},
-						  } )
-						: interpolateComponents( {
-								mixedString: __(
-									"Seems like the live API keys we've saved for you are no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.",
+							  )
+							: __(
+									"Seems like the live API keys we've saved for you are no longer valid. If you recently updated them, use the <strong>Configure Connection</strong> button below to reconnect.",
 									'woocommerce-gateway-stripe'
-								),
-								components: {
-									accountLink: (
-										// eslint-disable-next-line jsx-a11y/anchor-has-content
-										<a href="/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings" />
-									),
-								},
-						  } ) }
+							  ),
+						{
+							strong: <strong />,
+						}
+					) }
 				</AccountDetailsError>
 			</AccountDetailsContainer>
 		);

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -147,7 +147,7 @@ const AccountDetails = () => {
 					{ isTestModeEnabled
 						? interpolateComponents( {
 								mixedString: __(
-									'Seems like the current connected test account is no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.',
+									"Seems like the test API keys we've saved for you are no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.",
 									'woocommerce-gateway-stripe'
 								),
 								components: {
@@ -159,7 +159,7 @@ const AccountDetails = () => {
 						  } )
 						: interpolateComponents( {
 								mixedString: __(
-									'Seems like the current connected live account is no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.',
+									"Seems like the live API keys we've saved for you are no longer valid. If you recently updated them, go to {{accountLink}}your settings{{/accountLink}} and use the Configure Connection button to reconnect.",
 									'woocommerce-gateway-stripe'
 								),
 								components: {

--- a/client/settings/payment-settings/account-keys-connection-status.js
+++ b/client/settings/payment-settings/account-keys-connection-status.js
@@ -58,7 +58,7 @@ export const AccountKeysConnectionStatus = ( { formRef } ) => {
 			) {
 				dispatch( 'core/notices' ).createErrorNotice(
 					__(
-						'Only live account keys should be entered.',
+						'Only a live account should be connected.',
 						'woocommerce-gateway-stripe'
 					)
 				);
@@ -79,7 +79,7 @@ export const AccountKeysConnectionStatus = ( { formRef } ) => {
 			) {
 				dispatch( 'core/notices' ).createErrorNotice(
 					__(
-						'Only test account keys should be entered.',
+						'Only a test account should be connected.',
 						'woocommerce-gateway-stripe'
 					)
 				);

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -211,7 +211,7 @@ class WC_Stripe_Admin_Notices {
 
 					$notice_message = sprintf(
 					/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-						__( 'Stripe is almost ready. To get started, go to %1$syour settings%2$s and use the Configure Connection button to connect.', 'woocommerce-gateway-stripe' ),
+						__( 'Stripe is almost ready. To get started, go to %1$syour settings%2$s and use the <strong>Configure Connection</strong> button to connect.', 'woocommerce-gateway-stripe' ),
 						'<a href="' . $setting_link . '">',
 						'</a>'
 					);
@@ -227,7 +227,7 @@ class WC_Stripe_Admin_Notices {
 
 						$notice_message = sprintf(
 						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-							__( 'Stripe is in test mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the Configure Connection button to reconnect.', 'woocommerce-gateway-stripe' ),
+							__( 'Stripe is in test mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the <strong>Configure Connection</strong> button to reconnect.', 'woocommerce-gateway-stripe' ),
 							'<a href="' . $setting_link . '">',
 							'</a>'
 						);
@@ -242,7 +242,7 @@ class WC_Stripe_Admin_Notices {
 
 						$message = sprintf(
 						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-							__( 'Stripe is in live mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the Configure Connection button to reconnect.', 'woocommerce-gateway-stripe' ),
+							__( 'Stripe is in live mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the <strong>Configure Connection</strong> button to reconnect.', 'woocommerce-gateway-stripe' ),
 							'<a href="' . $setting_link . '">',
 							'</a>'
 						);
@@ -258,7 +258,7 @@ class WC_Stripe_Admin_Notices {
 
 					$message = sprintf(
 					/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-						__( 'Your customers cannot use Stripe on checkout, because we couldn\'t connect to your account. Please go to %1$syour settings%2$s and use the Configure Connection button to connect.', 'woocommerce-gateway-stripe' ),
+						__( 'Your customers cannot use Stripe on checkout, because we couldn\'t connect to your account. Please go to %1$syour settings%2$s and use the <strong>Configure Connection</strong> button to connect.', 'woocommerce-gateway-stripe' ),
 						'<a href="' . $setting_link . '">',
 						'</a>'
 					);

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -211,7 +211,7 @@ class WC_Stripe_Admin_Notices {
 
 					$notice_message = sprintf(
 					/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-						__( 'Stripe is almost ready. To get started, %1$sset your Stripe account keys%2$s.', 'woocommerce-gateway-stripe' ),
+						__( 'Stripe is almost ready. To get started, go to %1$syour settings%2$s and use the Configure Connection button to connect.', 'woocommerce-gateway-stripe' ),
 						'<a href="' . $setting_link . '">',
 						'</a>'
 					);
@@ -258,7 +258,7 @@ class WC_Stripe_Admin_Notices {
 
 					$message = sprintf(
 					/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-						__( 'Your customers cannot use Stripe on checkout, because we couldn\'t connect to your account. Please go to your settings and, %1$sset your Stripe account keys%2$s.', 'woocommerce-gateway-stripe' ),
+						__( 'Your customers cannot use Stripe on checkout, because we couldn\'t connect to your account. Please go to %1$syour settings%2$s and use the Configure Connection button to connect.', 'woocommerce-gateway-stripe' ),
 						'<a href="' . $setting_link . '">',
 						'</a>'
 					);
@@ -295,7 +295,7 @@ class WC_Stripe_Admin_Notices {
 			if ( 'yes' === $changed_keys_notice ) {
 				$message = sprintf(
 				/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-					__( 'The public and/or secret keys for the Stripe gateway have been changed. This might cause errors for existing customers and saved payment methods. %1$sClick here to learn more%2$s.', 'woocommerce-gateway-stripe' ),
+					__( 'Credentials used for the Stripe gateway have been changed. This might cause errors for existing customers and saved payment methods. %1$sClick here to learn more%2$s.', 'woocommerce-gateway-stripe' ),
 					'<a href="https://woocommerce.com/document/stripe/customization/database-cleanup/" target="_blank">',
 					'</a>'
 				);

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -227,7 +227,7 @@ class WC_Stripe_Admin_Notices {
 
 						$notice_message = sprintf(
 						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-							__( 'Stripe is in test mode however your test keys may not be valid. Test keys start with pk_test and sk_test or rk_test. Please go to your settings and, %1$sset your Stripe account keys%2$s.', 'woocommerce-gateway-stripe' ),
+							__( 'Stripe is in live mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the Configure Connection button to reconnect.', 'woocommerce-gateway-stripe' ),
 							'<a href="' . $setting_link . '">',
 							'</a>'
 						);

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -227,7 +227,7 @@ class WC_Stripe_Admin_Notices {
 
 						$notice_message = sprintf(
 						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-							__( 'Stripe is in live mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the Configure Connection button to reconnect.', 'woocommerce-gateway-stripe' ),
+							__( 'Stripe is in test mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the Configure Connection button to reconnect.', 'woocommerce-gateway-stripe' ),
 							'<a href="' . $setting_link . '">',
 							'</a>'
 						);
@@ -242,7 +242,7 @@ class WC_Stripe_Admin_Notices {
 
 						$message = sprintf(
 						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-							__( 'Stripe is in live mode however your live keys may not be valid. Live keys start with pk_live and sk_live or rk_live. Please go to your settings and, %1$sset your Stripe account keys%2$s.', 'woocommerce-gateway-stripe' ),
+							__( 'Stripe is in live mode however your API keys may not be valid. Please go to %1$syour settings%2$s and use the Configure Connection button to reconnect.', 'woocommerce-gateway-stripe' ),
 							'<a href="' . $setting_link . '">',
 							'</a>'
 						);

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.6.0 - xxxx-xx-xx =
-* Tweak - Improves the wording of the invalid Stripe keys error, instructing merchants to click the "Configure connection" button instead of manually setting the keys.
+* Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.
 * Add - Includes a new promotional surface to encourage merchants to re-connect their Stripe account using the new flow.
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.6.0 - xxxx-xx-xx =
+* Tweak - Improves the wording of the invalid Stripe keys error, instructing merchants to click the "Configure connection" button instead of manually setting the keys.
 * Add - Includes a new promotional surface to encourage merchants to re-connect their Stripe account using the new flow.
 * Add - Added filter to enable updating Level 3 data based on order data.
 * Add - Replace account key sharing and replace it with an OAuth connect flow allowing users to connect their Stripe account automatically without the need to find keys.

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -251,7 +251,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 				[
 					'keys',
 				],
-				'/and use the Configure Connection button to reconnect/',
+				'/and use the \<strong\>Configure Connection\<\/strong\> button to reconnect/',
 			],
 			[
 				[
@@ -289,7 +289,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 				[
 					'page' => 'wc-settings',
 				],
-				'/and use the Configure Connection button to reconnect/',
+				'/and use the \<strong\>Configure Connection\<\/strong\> button to reconnect/',
 			],
 			[
 				[
@@ -406,7 +406,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 					'sca',
 					'changed_keys',
 				],
-				'/and use the Configure Connection button to reconnect/',
+				'/and use the \<strong\>Configure Connection\<\/strong\> button to reconnect/',
 			],
 			[
 				[
@@ -423,7 +423,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 					'sca',
 					'changed_keys',
 				],
-				'/and use the Configure Connection button to reconnect/',
+				'/and use the \<strong\>Configure Connection\<\/strong\> button to reconnect/',
 			],
 			[
 				[

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -251,7 +251,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 				[
 					'keys',
 				],
-				'/set your Stripe account keys/',
+				'/and use the Configure Connection button to reconnect/',
 			],
 			[
 				[
@@ -289,7 +289,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 				[
 					'page' => 'wc-settings',
 				],
-				'/set your Stripe account keys/',
+				'/and use the Configure Connection button to reconnect/',
 			],
 			[
 				[
@@ -306,7 +306,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 				[
 					'keys',
 				],
-				'/your test keys may not be valid/',
+				'/Stripe is in test mode however your API keys may not be valid/',
 			],
 			[
 				[
@@ -344,7 +344,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 				[
 					'keys',
 				],
-				'/your live keys may not be valid/',
+				'/Stripe is in live mode however your API keys may not be valid/',
 			],
 			[
 				[
@@ -406,7 +406,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 					'sca',
 					'changed_keys',
 				],
-				'/set your Stripe account keys/',
+				'/and use the Configure Connection button to reconnect/',
 			],
 			[
 				[
@@ -423,7 +423,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 					'sca',
 					'changed_keys',
 				],
-				'/set your Stripe account keys/',
+				'/and use the Configure Connection button to reconnect/',
 			],
 			[
 				[


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3345
More context: p1723056032998639-slack-C055WHLA98D

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Since we changed the API keys connection flow recently, requiring merchants to click the Connect button instead of inputting keys manually, we need to update all the messaging to reflect that.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Testing all the updated messages may be tricky, so I believe reviewing the grammar should be enough. Also, confirm that the tests are still passing. But if you want to see the new messages, you can force them to show up:

- Checkout to this branch on your local environment (`tweak/rewording-invalid-keys-error-message`)
- Run `npm install`, `npm build:webpack` and `npm up`

### Frontend error messages

- Edit `client/settings/account-details/index.js#142` and set `hasAccountError` to `true`
- Run `npm build:webpack`
- Access the settings page `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
- Confirm that you can see the following error message:
![Screenshot 2024-08-08 at 13 29 26](https://github.com/user-attachments/assets/ecd2bb42-eb5e-4d6f-b823-f8f08eb4d9d4)

### Backend error messages

- Edit `includes/admin/class-wc-stripe-admin-notices.php#205` and set `$secret` to `''`
- Go to the general settings page (`wp-admin/admin.php?page=wc-settings`)
- Confirm that you can see this notice:
![Screenshot 2024-08-08 at 13 39 12](https://github.com/user-attachments/assets/6af7ff17-b624-45fa-a8fd-077b80c0de23)
- Set `$test_pub_key` and `$test_secret_key` to `''` (when test mode is enabled, or the live keys when not)
- Confirm that you can see this notice:
![Screenshot 2024-08-08 at 13 41 53](https://github.com/user-attachments/assets/163ffa52-dfbf-4972-9738-4b5d3b46a229)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

cc @diegocurbelo @aheckler @james-allan 