### PR TITLE
Add Stripe App OAuth scheduled refresh connection

### DIFF
--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -265,7 +265,11 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 							&& ! $settings['test_secret_key'];
 
 		if ( $is_deleting_account ) {
-			$settings['enabled'] = 'no';
+			$settings['enabled']              = 'no';
+			$settings['connection_type']      = '';
+			$settings['test_connection_type'] = '';
+			$settings['refresh_token']        = '';
+			$settings['test_refresh_token']   = '';
 			$this->record_manual_account_disconnect_track_event( 'yes' === $settings['testmode'] );
 		} else {
 			$this->record_manual_account_key_update_track_event( 'yes' === $settings['testmode'] );

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -89,7 +89,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 		}
 
 		/**
-		 * Send request to the Connect Server for Stripe App refreshed keys
+		 * Sends a request to the Connect Server for Stripe App refreshed keys.
 		 *
 		 * @since 8.6.0
 		 *

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -89,6 +89,24 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 		}
 
 		/**
+		 * Send request to the Connect Server for Stripe App refreshed keys
+		 *
+		 * @since 8.6.0
+		 *
+		 * @param string $refresh_token Stripe App OAuth refresh token.
+		 * @param string $mode          Optional. The mode to refresh keys for. 'live' or 'test'. Default is 'live'.
+		 *
+		 * @return array
+		 */
+		public function refresh_stripe_app_oauth_keys( $refresh_token, $mode = 'live' ) {
+			$request = [
+				'refreshToken' => $refresh_token,
+				'mode'         => $mode,
+			];
+			return $this->request( 'POST', '/stripe/app-oauth-keys-refresh', $request );
+		}
+
+		/**
 		 * General OAuth request method.
 		 *
 		 * @param string $method request method.

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -178,6 +178,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				// Stripe App OAuth access_tokens expire after 1 hour:
 				// https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token
 				$this->schedule_connection_refresh();
+			} else {
+				// Make sure that all refresh actions are cancelled before scheduling it.
+				$this->unschedule_connection_refresh();
 			}
 
 			try {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -367,15 +367,18 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', time() );
 
 				WC_Stripe_Logger::log( 'OAuth connection refresh failed: ' . print_r( $response, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+
+				// If after 10 attempts we are unable to refresh the connection keys, we don't re-schedule anymore,
+				// in this case an error message is show in the account status indicating that the API keys are not
+				// valid and that a reconnection is necessary.
+				if ( $retries < 10 ) {
+					// Re-schedule the connection refresh
+					$this->schedule_connection_refresh();
+				}
 			}
 
-			// If after 10 attempts we are unable to refresh the connection keys, we don't re-schedule anymore,
-			// in this case an error message is show in the account status indicating that the API keys are not
-			// valid and that a reconnection is necessary.
-			if ( $retries < 10 ) {
-				// Re-schedule the connection refresh
-				$this->schedule_connection_refresh();
-			}
+			// save_stripe_keys() schedules a connection_refresh after saving the keys,
+			// we don't need to do it explicitly here.
 		}
 	}
 }

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				// https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token
 				$this->schedule_connection_refresh();
 			} else {
-				// Make sure that all refresh actions are cancelled before scheduling it.
+				// Make sure that all refresh actions are cancelled if they haven't connected via the app.
 				$this->unschedule_connection_refresh();
 			}
 
@@ -317,7 +317,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			 * Filters the frequency with which the App OAuth connection should be refreshed.
 			 * Access tokens expire in 1 hour, and there seem to be no way to customize that from the Stripe Dashboard:
 			 * https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token
-			 * We schedule the connection refresh every 50 minutues.
+			 * We schedule the connection refresh every 55 minutues.
 			 *
 			 * @param int $interval refresh interval
 			 *
@@ -328,7 +328,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// Make sure that all refresh actions are cancelled before scheduling it.
 			$this->unschedule_connection_refresh();
 
-			as_schedule_single_action( time() + $interval, 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID );
+			as_schedule_single_action( time() + $interval, 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID, true, 0 );
 		}
 
 		/**

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -328,7 +328,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// Make sure that all refresh actions are cancelled before scheduling it.
 			$this->unschedule_connection_refresh();
 
-			as_schedule_single_action( time() + $interval, 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID, true, 0 );
+			as_schedule_single_action( time() + $interval, 'wc_stripe_refresh_connection', [], WC_Stripe_Action_Scheduler_Service::GROUP_ID, false, 0 );
 		}
 
 		/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3338

## Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3339 introduced the Stripe App OAuth flow, this PR added the scheduled refresh connection.

The implementation is the same one we did for Square... the only difference is the addition of the options with stats and retry count.

https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token

## Testing instructions
1. To test the Stripe App OAuth flow, we need to configure the plugin to use keys from an account connected to another platform. If you don't have an account connected to a 3rd party platform, ping me in slack.
2. Navigate to WP-Admin > WooCommerce > Settings > Payments > Stripe
    > /wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe
3. Click the `Configure connection` button and in the modal, mouse over the `Create or connect a test account` button, check that the URL is `https://marketplace.stripe.com`:
    <img width="1419" alt="Screenshot_2024-08-05_at_2_26_59 AM" src="https://github.com/user-attachments/assets/edbd3f52-41a7-41ad-9971-7ee887b4b114">
4. Click the `Create or connect a test account` button.
5. Login to Stripe (if needed)
6. Complete the Stripe App Oauth process, selecting an account, accepting the permissions and installing the app:
    ![image (2)](https://github.com/user-attachments/assets/9b754244-4fb2-4ff5-b4ff-535ea41e79bf)
7. Check that the flow was successful by verifying the keys `test_refresh_token` and `test_connection_type` in the plugin settings:
    > `wp option pluck woocommerce_stripe_settings test_secret_key`
    > `wp option pluck woocommerce_stripe_settings test_refresh_token`
    > `wp option pluck woocommerce_stripe_settings test_connection_type`
    <img width="742" alt="354987278-a1ca0376-f8dd-4db4-800d-a1e875e1c7ed-2" src="https://github.com/user-attachments/assets/c900211a-9060-4661-a4a1-d55ead133927">
8. Check the value of options `wc_stripe_test_oauth_updated_at` and `wc_stripe_test_oauth_failed_attempts`
    > `wp option get wc_stripe_test_oauth_updated_at`
    > `wp option get wc_stripe_test_oauth_failed_attempts`
    ![Screenshot 2024-08-08 at 4 51 24 PM](https://github.com/user-attachments/assets/103b0eb9-7e1f-4a87-8dd8-dbfcedc84de0)
9. Go to the Scheduled Actions page and manually run the `wc_stripe_refresh connection` hook:
    > /wp-admin/tools.php?page=action-scheduler&status=pending
    ![Screenshot_2024-08-08_at_5_17_53 PM](https://github.com/user-attachments/assets/896afb23-82f0-4f1a-ba6f-062d8dc5e90e)
10. Check that another scheduled execution was created for if in 55 minutes.
11. Check that `test_secret_key`, `test_refresh_token` and `wc_stripe_test_oauth_updated_at` were all updated... and that `wc_stripe_test_oauth_failed_attempts` is still 0
    > `wp option pluck woocommerce_stripe_settings test_secret_key`
    > `wp option pluck woocommerce_stripe_settings test_refresh_token`
    > `wp option get wc_stripe_test_oauth_updated_at`
    > `wp option get wc_stripe_test_oauth_failed_attempts`
12. Update the settings with the following:
    > `wp option update wc_stripe_test_oauth_failed_attempts 8`
    > `wp option patch update woocommerce_stripe_settings test_refresh_token 'rt_QcfOstcg6SjnmxiOsFXsmAlFwYU0e3Pa826pQIM6Ui6Se0Jv'`
13. Go to the Scheduled Actions page and manually run the `wc_stripe_refresh connection` hook again
14. Check that another scheduled execution was created for if in 55 minutes.
15. Check that `test_secret_key` nor `wc_stripe_test_oauth_updated_at` were NOT updated... and that `wc_stripe_test_oauth_failed_attempts` is now 9 
    > `wp option pluck woocommerce_stripe_settings test_secret_key`
    > `wp option get wc_stripe_test_oauth_updated_at`
    > `wp option get wc_stripe_test_oauth_failed_attempts`
16. Go to the Scheduled Actions page and manually run the `wc_stripe_refresh connection` hook again
17. Check that **NO** scheduled execution was created for this hook
18. Check that `test_secret_key` and `wc_stripe_test_oauth_updated_at` were NOT updated... and that `wc_stripe_test_oauth_failed_attempts` is now 10 
    > `wp option pluck woocommerce_stripe_settings test_secret_key`
    > `wp option get wc_stripe_test_oauth_updated_at`
    > `wp option get wc_stripe_test_oauth_failed_attempts`

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
