### PR TITLE
Split E2E workflow runner in Default and Legacy checkouts

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -10,7 +10,13 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    name: "WP=latest, WC=latest, PHP=7.4"
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        checkout: [ 'Default', 'Legacy' ]
+
+    name: ${{ matrix.checkout }} WP=latest, WC=latest, PHP=7.4"
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -74,18 +80,18 @@ jobs:
           STRIPE_SECRET_KEY: ${{ secrets.E2E_STRIPE_SECRET_KEY }}
         run: npm run test:e2e-setup
 
-      - name: Run E2E tests
+      - name: Run ${{ matrix.checkout }} E2E tests
         shell: bash
         env:
           STRIPE_PUB_KEY: ${{ secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.E2E_STRIPE_SECRET_KEY }}
-        run: npm run test:e2e
+        run: npm run test:e2e${{ matrix.checkout == 'Legacy' && '-legacy' || '' }}
       
-      - name: Upload E2E test results
+      - name: Upload ${{ matrix.checkout }} E2E test results
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: WP_latest-WC_latest-results
+          name: ${{ matrix.checkout }}-WP_latest-WC_latest-results
           path: tests/e2e/test-results
           if-no-files-found: ignore
           retention-days: 14

--- a/package.json
+++ b/package.json
@@ -150,8 +150,10 @@
     "test:e2e-up": "./tests/e2e/bin/up.sh",
     "test:e2e-down": "./tests/e2e/bin/down.sh",
     "test:e2e-cleanup": "npm run test:e2e-down && ./tests/e2e/bin/cleanup.sh",
-    "test:e2e": "./tests/e2e/bin/run-tests.sh",
-    "test:e2e-debug": "npm run test:e2e -- --debug"
+    "test:e2e": "./tests/e2e/bin/run-tests.sh --project=default",
+    "test:e2e-debug": "npm run test:e2e -- --debug",
+    "test:e2e-legacy": "./tests/e2e/bin/run-tests.sh --project=legacy",
+    "test:e2e-legacy-debug": "npm run test:e2e-legacy -- --debug"
   },
   "engines": {
     "node": ">=16.17.0",

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -30,9 +30,9 @@ const config = {
 	outputDir: '../test-results/output',
 
 	/* Retry on CI only */
-	retries: CI ? 2 : 0,
+	retries: CI ? 3 : 0,
 
-	workers: 4,
+	workers: 5,
 
 	// Reporter to use. See https://playwright.dev/docs/test-reporters
 	reporter: [
@@ -87,11 +87,10 @@ const config = {
 		{
 			name: 'legacy-setup',
 			testMatch: '_legacy-experience/legacy.setup.js',
-			dependencies: [ 'default' ],
 			use: { ...devices[ 'Desktop Chrome' ] },
 		},
 		{
-			name: 'legacy-experience',
+			name: 'legacy',
 			testMatch: '/_legacy-experience/**/*.spec.js',
 			dependencies: [ 'legacy-setup' ],
 			use: { ...devices[ 'Desktop Chrome' ] },

--- a/tests/e2e/tests/_legacy-experience/woocommerce-blocks/sca-card.spec.js
+++ b/tests/e2e/tests/_legacy-experience/woocommerce-blocks/sca-card.spec.js
@@ -37,7 +37,7 @@ test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 		.getByRole( 'button', { name: 'Complete' } )
 		.click();
 
-	await page.waitForNavigation();
+	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 		'Order received'

--- a/tests/e2e/tests/orders/full-refund.spec.js
+++ b/tests/e2e/tests/orders/full-refund.spec.js
@@ -34,7 +34,7 @@ test( 'merchant can issue a full refund @smoke', async ( { browser } ) => {
 			config.get( 'cards.basic' )
 		);
 		await userPage.locator( 'text=Place order' ).click();
-		await userPage.waitForNavigation();
+		await userPage.waitForURL( '**/checkout/order-received/**' );
 
 		await expect( userPage.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR splits the E2E test suite (and its runner) into two: the default checkout experience tests and the legacy checkout.

We still need to fix the flakiness on some tests, but we an focus on just one checkout at a time.

## Testing instructions

Verify that all checks pass in this PR
![Screenshot 2024-08-08 at 8 31 47 PM](https://github.com/user-attachments/assets/91f2249b-00f5-4c6f-9ee9-934664171d35)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
