### PR TITLE
Fix subscription processing with mandates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Fix Indian subscription processing by forcing the recreation of mandates during switches (upgrading/downgrading).
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -688,7 +688,8 @@ trait WC_Stripe_Subscriptions_Trait {
 		$cart_contain_switches = WC_Subscriptions_Switcher::cart_contains_switches();
 		if ( $cart_contain_switches ) {
 			foreach ( WC()->cart->cart_contents as $cart_item ) {
-				$sub_amount += (int) WC_Subscriptions_Product::get_price( $cart_item['data'] );
+				$subscription_price = WC_Subscriptions_Product::get_price( $cart_item['data'] );
+				$sub_amount        += (int) WC_Stripe_Helper::get_stripe_amount( $subscription_price, $currency );
 			}
 
 			// Get the first cart item associated with this order.
@@ -708,7 +709,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			}
 
 			foreach ( $subscriptions as $sub ) {
-				$sub_amount += WC_Stripe_Helper::get_stripe_amount( $sub->get_total() );
+				$sub_amount += WC_Stripe_Helper::get_stripe_amount( $sub->get_total(), $currency );
 			}
 
 			// Get the first subscription associated with this order.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -611,7 +611,7 @@ trait WC_Stripe_Subscriptions_Trait {
 				return $request;
 			}
 
-		$subscriptions_for_renewal_order = function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ? wcs_get_subscriptions_for_renewal_order( $order ) : [];
+			$subscriptions_for_renewal_order = function_exists( 'wcs_get_subscriptions_for_renewal_order' ) ? wcs_get_subscriptions_for_renewal_order( $order ) : [];
 
 			// Check if mandate already exists.
 			if ( 1 === count( $subscriptions_for_renewal_order ) ) {
@@ -714,7 +714,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			// Get the first subscription associated with this order.
 			$sub = reset( $subscriptions );
 
-			$sub_billing_period = strtolower( $sub->get_billing_period() );
+			$sub_billing_period   = strtolower( $sub->get_billing_period() );
 			$sub_billing_interval = $sub->get_billing_interval();
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Fix Indian subscription processing by forcing the recreation of mandates during switches (upgrading/downgrading).
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3230

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR fixes the processing of subscriptions when using mandates (i.e., when using Indian credit cards). 

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

### Renewal

- Instructions based [on the testing steps of the original issue](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3230)
- Checkout to this branch on your local environment (`fix/subscriptions-switch-with-mandates`)
- Set your store and Stripe account currency to `Indian Rupee`
- Install and enable the subscriptions extension, and enable switching on `wp-admin/admin.php?page=wc-settings&tab=subscriptions`
- Create a variable subscription with two variations with prices ₹1,000/month and ₹2,000/month.
- First, buy ₹1,000/month subscription on, say, the 1st of the month. This will set up an autopay mandate of ₹1,000.
- Now upgrade to the ₹2,000/month subscription in the middle of the month *. The switch will happen successfully
- On the renewal day*, the payment should succeed
- On the `develop` branch it should fail

\* You can force the renewal on the subscription details page (wp-admin) by selecting "Process renewal" in the dropdown box. @james-allan gave some tips on how to easily test this [here](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3323#issuecomment-2275153628).

### Subscription edit

- With your store currency set to `Indian Rupee`, purchase a subscription
- Confirm that you cannot edit this subscription on wp-admin (it is not possible to replace it with another subscription product)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
