### PR TITLE
Fix error in saving settings 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Fix error in saving settings when express payment methods are disabled.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -82,6 +82,8 @@ class WC_Stripe_Payment_Request {
 
 		$this->total_label = str_replace( "'", '', $this->total_label ) . apply_filters( 'wc_stripe_payment_request_total_label_suffix', ' (via WooCommerce)' );
 
+		add_action( 'woocommerce_stripe_updated', [ $this, 'migrate_button_size' ] );
+
 		// Checks if Stripe Gateway is enabled.
 		if ( empty( $this->stripe_settings ) || ( isset( $this->stripe_settings['enabled'] ) && 'yes' !== $this->stripe_settings['enabled'] ) ) {
 			return;
@@ -234,8 +236,6 @@ class WC_Stripe_Payment_Request {
 		add_action( 'woocommerce_checkout_order_processed', [ $this, 'add_order_meta' ], 10, 2 );
 		add_filter( 'woocommerce_login_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
 		add_filter( 'woocommerce_registration_redirect', [ $this, 'get_login_redirect_url' ], 10, 3 );
-
-		add_action( 'woocommerce_stripe_updated', [ $this, 'migrate_button_size' ] );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -134,5 +134,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Fix error in saving settings when express payment methods are disabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION

Fixes #2921 

## Changes proposed in this Pull Request:
We updated the [default payment request button size](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2783) in Stripe `7.8.0`. As the available options for the sizes were changed, we added [an action](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/c8d1fd5fe7172a1e9fe770b782f16b9d4144feba/includes/payment-methods/class-wc-stripe-payment-request.php#L238) to [migrate_button_size](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L1999). However, if express checkout is disabled, we [bail early](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-payment-request.php#L85-L98) and this action is not triggered. This causes the error when saving Stripe settings as the button size data does not match the expected enum during the update call.

In this PR, I have moved the action to the constructor to ensure it is always called on a new installation/updat of the plugin.

## Testing instructions

### Reproduce the issue

1. Create a JN site.
2. Install Stripe `7.7.0` on your site.
3. Connect to your Stripe account.
4. On your Stripe settings page, go to the `Settings` tab and scroll down to the `Advanced settings` section.
5. Enable the new checkout experience from advanced settings.
6. Go to the `Payment methods` tab and disable all express payment methods (Apple Pay / Google Pay / Link)
7. Go to the customization page of Apple Pay / Google Pay. Select `Medium` as the button size.
8. Now go to the `Plugins`. Update to the latest version of the Stripe plugin from there or upload a version >= `7.8.0`.
9. Now refresh the Apple Pay / Google Pay customization page. Notice that there is no selected button size.

<img width="448" alt="Screenshot 2024-08-15 at 7 55 19 PM" src="https://github.com/user-attachments/assets/c5c7ce7b-4ba1-4574-a076-9f3ab21b938f">

10. Click on the `Save changes` button and you will get an error in response. 

### Test the fix

1. Create a JN site.
2. Install Stripe `7.7.0` on your site.
3. Connect to your Stripe account.
4. On your Stripe settings page, go to the `Settings` tab and scroll down to the `Advanced settings` section.
5. Enable the new checkout experience from advanced settings.
6. Go to the `Payment methods` tab and disable all express payment methods (Apple Pay / Google Pay / Link)
7. Go to the customization page of Apple Pay / Google Pay. Select `Medium` as the button size.
8. Build this branch locally.
9. Now go to the `Plugins` and upload the zip file of this build.
10. Now refresh the Apple Pay / Google Pay customization page. Notice that the `Default` size is selected.
11. Click on the `Save changes` button and you should not get any error in response. 