### PR TITLE
Fix blinking re-connect promotional surface

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.
 * Fix - Fix possible fatal errors when Stripe settings format is invalid during account connection.
 * Fix - Clear webhook state after reconfiguring webhooks to remove outdated error and success statuses.
 * Add - Log incoming webhook events and their request body.

--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -212,7 +212,7 @@ const PromotionalBannerSection = ( {
 	);
 
 	let BannerContent = null;
-	if ( ! isConnectedViaOAuth ) {
+	if ( isConnectedViaOAuth === false ) {
 		BannerContent = <ReConnectAccountBanner />;
 	} else if ( ! isUpeEnabled ) {
 		BannerContent = <NewCheckoutExperienceBanner />;

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.
 * Fix - Fix possible fatal errors when Stripe settings format is invalid during account connection.
 * Fix - Clear webhook state after reconfiguring webhooks to remove outdated error and success statuses.
 * Add - Log incoming webhook events and their request body.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3362

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

The re-connect promotional surface introduced here blinks before disappearing for merchants who have already connected their Stripe accounts. This is happening because the value of the variable we check for the display (`isConnectedViaOAuth`) can be `undefined`, which, on the original implementation, would be considered `false` as well.

The fix consists of making a specific check for the `true` value when deciding if we should display the promotional surface.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

- Checkout to the `develop` branch
- Run `npm install`, `npm run build:webpack` and `npm up`
- Use the new OAuth flow to connect your Stripe account
- Go to the extension settings page (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`)
- Notice the re-connect promotional surface blinking before disappearing
- Checkout to this branch on your local environment (`fix/fix-blinking-re-connect-banner`)
- Run `npm run build:webpack`
- Go to the extension settings page again (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe`)
- Confirm that the blinking bug is not happening anymore

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
