### PR TITLE
Catch error when getting intent from order.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Catch error when getting intent from order.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -68,13 +68,17 @@ class WC_Stripe_Settings_Controller {
 	* @param WC_Order $order The order that is being viewed.
 	*/
 	public function hide_refund_button_for_uncaptured_orders( $order ) {
-		$intent = $this->gateway->get_intent_from_order( $order );
+		try {
+			$intent = $this->gateway->get_intent_from_order( $order );
 
-		if ( $intent && 'requires_capture' === $intent->status ) {
-			$no_refunds_button  = __( 'Refunding unavailable', 'woocommerce-gateway-stripe' );
-			$no_refunds_tooltip = __( 'Refunding via Stripe is unavailable because funds have not been captured for this order. Process order to take payment, or cancel to remove the pre-authorization.', 'woocommerce-gateway-stripe' );
-			echo '<style>.button.refund-items { display: none; }</style>';
-			echo '<span class="button button-disabled">' . $no_refunds_button . wc_help_tip( $no_refunds_tooltip ) . '</span>';
+			if ( $intent && 'requires_capture' === $intent->status ) {
+				$no_refunds_button  = __( 'Refunding unavailable', 'woocommerce-gateway-stripe' );
+				$no_refunds_tooltip = __( 'Refunding via Stripe is unavailable because funds have not been captured for this order. Process order to take payment, or cancel to remove the pre-authorization.', 'woocommerce-gateway-stripe' );
+				echo '<style>.button.refund-items { display: none; }</style>';
+				echo '<span class="button button-disabled">' . $no_refunds_button . wc_help_tip( $no_refunds_tooltip ) . '</span>';
+			}
+		} catch ( WC_Stripe_Exception $e ) {
+			WC_Stripe_Logger::log( 'Error getting intent from order: ' . $e->getMessage() );
 		}
 	}
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -77,7 +77,7 @@ class WC_Stripe_Settings_Controller {
 				echo '<style>.button.refund-items { display: none; }</style>';
 				echo '<span class="button button-disabled">' . $no_refunds_button . wc_help_tip( $no_refunds_tooltip ) . '</span>';
 			}
-		} catch ( WC_Stripe_Exception $e ) {
+		} catch ( Exception $e ) {
 			WC_Stripe_Logger::log( 'Error getting intent from order: ' . $e->getMessage() );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Catch error when getting intent from order.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3329 

## Changes proposed in this Pull Request:
In all other places, the `get_intent_from_order` call is wrapped in try-catch block except the call in `hide_refund_button_for_uncaptured_orders` function. This resulted in an uncaught error reported in #3329. 
Added the try-catch block here and logged the response in case of error.

## Testing instructions
- Enable `Issue an authorization on checkout, and capture later` checkbox in Stripe settings page.
- As a shopper complete a purchase with card.
- From [get_intent_from_order](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L1606) function throw an exception intentionally (`throw new Exception('Test Error');`)
- In your admin dashboard, go to the order edit page.
- In `develop` branch, notice that there is an uncaught error message beside the refund button.

<img width="983" alt="Screenshot 2024-08-20 at 5 24 34 PM" src="https://github.com/user-attachments/assets/3b05c514-8294-41c5-89e5-cbc4e0282731">

- In this branch, confirm that there is no uncaught error.
