### PR TITLE
Fix checkout field render errors in the WordPress customizer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.
 * Fix - Fix possible fatal errors when Stripe settings format is invalid during account connection.
 * Fix - Clear webhook state after reconfiguring webhooks to remove outdated error and success statuses.
+* Fix - Fix race condition which caused checkout fields to fail to render in the WordPress customizer preview pane after settings updates.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -22,87 +22,70 @@ const api = new WCStripeAPI(
 	}
 );
 
-const registerPaymentMethods = () => {
-	const upeMethods = getPaymentMethodsConstants();
-	Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
-		.filter( ( [ upeName ] ) => upeName !== 'link' )
-		.filter( ( [ upeName ] ) => upeName !== 'giropay' ) // Skip giropay as it was deprecated by Jun, 30th 2024.
-		.forEach( ( [ upeName, upeConfig ] ) => {
-			let iconName = upeName;
+const upeMethods = getPaymentMethodsConstants();
+Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
+	.filter( ( [ upeName ] ) => upeName !== 'link' )
+	.filter( ( [ upeName ] ) => upeName !== 'giropay' ) // Skip giropay as it was deprecated by Jun, 30th 2024.
+	.forEach( ( [ upeName, upeConfig ] ) => {
+		let iconName = upeName;
 
-			// Afterpay/Clearpay have different icons for UK merchants.
-			if ( upeName === 'afterpay_clearpay' ) {
-				iconName =
-					getBlocksConfiguration()?.accountCountry === 'GB'
-						? 'clearpay'
-						: 'afterpay';
-			}
+		// Afterpay/Clearpay have different icons for UK merchants.
+		if ( upeName === 'afterpay_clearpay' ) {
+			iconName =
+				getBlocksConfiguration()?.accountCountry === 'GB'
+					? 'clearpay'
+					: 'afterpay';
+		}
 
-			const Icon = Icons[ iconName ];
+		const Icon = Icons[ iconName ];
 
-			registerPaymentMethod( {
-				name: upeMethods[ upeName ],
-				content: getDeferredIntentCreationUPEFields(
-					upeName,
-					upeMethods,
-					api,
-					upeConfig.description,
-					upeConfig.testingInstructions,
-					upeConfig.showSaveOption ?? false
-				),
-				edit: getDeferredIntentCreationUPEFields(
-					upeName,
-					upeMethods,
-					api,
-					upeConfig.description,
-					upeConfig.testingInstructions,
-					upeConfig.showSaveOption ?? false
-				),
-				savedTokenComponent: <SavedTokenHandler api={ api } />,
-				canMakePayment: ( cartData ) => {
-					const billingCountry = cartData.billingAddress.country;
-					const isRestrictedInAnyCountry = !! upeConfig.countries.length;
-					const isAvailableInTheCountry =
-						! isRestrictedInAnyCountry ||
-						upeConfig.countries.includes( billingCountry );
+		registerPaymentMethod( {
+			name: upeMethods[ upeName ],
+			content: getDeferredIntentCreationUPEFields(
+				upeName,
+				upeMethods,
+				api,
+				upeConfig.description,
+				upeConfig.testingInstructions,
+				upeConfig.showSaveOption ?? false
+			),
+			edit: getDeferredIntentCreationUPEFields(
+				upeName,
+				upeMethods,
+				api,
+				upeConfig.description,
+				upeConfig.testingInstructions,
+				upeConfig.showSaveOption ?? false
+			),
+			savedTokenComponent: <SavedTokenHandler api={ api } />,
+			canMakePayment: ( cartData ) => {
+				const billingCountry = cartData.billingAddress.country;
+				const isRestrictedInAnyCountry = !! upeConfig.countries.length;
+				const isAvailableInTheCountry =
+					! isRestrictedInAnyCountry ||
+					upeConfig.countries.includes( billingCountry );
 
-					return isAvailableInTheCountry && !! api.getStripe();
-				},
-				// see .wc-block-checkout__payment-method styles in blocks/style.scss
-				label: (
-					<>
-						<span>
-							{ upeConfig.title }
-							<Icon alt={ upeConfig.title } />
-						</span>
-					</>
-				),
-				ariaLabel: 'Stripe',
-				supports: {
-					// Use `false` as fallback values in case server provided configuration is missing.
-					showSavedCards:
-						getBlocksConfiguration()?.showSavedCards ?? false,
-					showSaveOption: upeConfig.showSaveOption ?? false,
-					features: getBlocksConfiguration()?.supports ?? [],
-				},
-			} );
+				return isAvailableInTheCountry && !! api.getStripe();
+			},
+			// see .wc-block-checkout__payment-method styles in blocks/style.scss
+			label: (
+				<>
+					<span>
+						{ upeConfig.title }
+						<Icon alt={ upeConfig.title } />
+					</span>
+				</>
+			),
+			ariaLabel: 'Stripe',
+			supports: {
+				// Use `false` as fallback values in case server provided configuration is missing.
+				showSavedCards:
+					getBlocksConfiguration()?.showSavedCards ?? false,
+				showSaveOption: upeConfig.showSaveOption ?? false,
+				features: getBlocksConfiguration()?.supports ?? [],
+			},
 		} );
-};
-
-// If this script is running in the customizer preview pane, wait for wc_stripe_upe_params to be defined on the window before registering payment methods
-if ( wp.customize ) {
-	const upeParamsReady = new Promise( ( resolve ) => {
-		const interval = setInterval( () => {
-			if ( window.wc_stripe_upe_params !== undefined ) {
-				clearInterval( interval );
-				resolve();
-			}
-		}, 10 );
 	} );
-	upeParamsReady.then( registerPaymentMethods );
-} else {
-	registerPaymentMethods();
-}
 
 // Register Stripe Payment Request.
 registerExpressPaymentMethod( paymentRequestPaymentMethod );

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -22,70 +22,87 @@ const api = new WCStripeAPI(
 	}
 );
 
-const upeMethods = getPaymentMethodsConstants();
-Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
-	.filter( ( [ upeName ] ) => upeName !== 'link' )
-	.filter( ( [ upeName ] ) => upeName !== 'giropay' ) // Skip giropay as it was deprecated by Jun, 30th 2024.
-	.forEach( ( [ upeName, upeConfig ] ) => {
-		let iconName = upeName;
+const registerPaymentMethods = () => {
+	const upeMethods = getPaymentMethodsConstants();
+	Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
+		.filter( ( [ upeName ] ) => upeName !== 'link' )
+		.filter( ( [ upeName ] ) => upeName !== 'giropay' ) // Skip giropay as it was deprecated by Jun, 30th 2024.
+		.forEach( ( [ upeName, upeConfig ] ) => {
+			let iconName = upeName;
 
-		// Afterpay/Clearpay have different icons for UK merchants.
-		if ( upeName === 'afterpay_clearpay' ) {
-			iconName =
-				getBlocksConfiguration()?.accountCountry === 'GB'
-					? 'clearpay'
-					: 'afterpay';
-		}
+			// Afterpay/Clearpay have different icons for UK merchants.
+			if ( upeName === 'afterpay_clearpay' ) {
+				iconName =
+					getBlocksConfiguration()?.accountCountry === 'GB'
+						? 'clearpay'
+						: 'afterpay';
+			}
 
-		const Icon = Icons[ iconName ];
+			const Icon = Icons[ iconName ];
 
-		registerPaymentMethod( {
-			name: upeMethods[ upeName ],
-			content: getDeferredIntentCreationUPEFields(
-				upeName,
-				upeMethods,
-				api,
-				upeConfig.description,
-				upeConfig.testingInstructions,
-				upeConfig.showSaveOption ?? false
-			),
-			edit: getDeferredIntentCreationUPEFields(
-				upeName,
-				upeMethods,
-				api,
-				upeConfig.description,
-				upeConfig.testingInstructions,
-				upeConfig.showSaveOption ?? false
-			),
-			savedTokenComponent: <SavedTokenHandler api={ api } />,
-			canMakePayment: ( cartData ) => {
-				const billingCountry = cartData.billingAddress.country;
-				const isRestrictedInAnyCountry = !! upeConfig.countries.length;
-				const isAvailableInTheCountry =
-					! isRestrictedInAnyCountry ||
-					upeConfig.countries.includes( billingCountry );
+			registerPaymentMethod( {
+				name: upeMethods[ upeName ],
+				content: getDeferredIntentCreationUPEFields(
+					upeName,
+					upeMethods,
+					api,
+					upeConfig.description,
+					upeConfig.testingInstructions,
+					upeConfig.showSaveOption ?? false
+				),
+				edit: getDeferredIntentCreationUPEFields(
+					upeName,
+					upeMethods,
+					api,
+					upeConfig.description,
+					upeConfig.testingInstructions,
+					upeConfig.showSaveOption ?? false
+				),
+				savedTokenComponent: <SavedTokenHandler api={ api } />,
+				canMakePayment: ( cartData ) => {
+					const billingCountry = cartData.billingAddress.country;
+					const isRestrictedInAnyCountry = !! upeConfig.countries.length;
+					const isAvailableInTheCountry =
+						! isRestrictedInAnyCountry ||
+						upeConfig.countries.includes( billingCountry );
 
-				return isAvailableInTheCountry && !! api.getStripe();
-			},
-			// see .wc-block-checkout__payment-method styles in blocks/style.scss
-			label: (
-				<>
-					<span>
-						{ upeConfig.title }
-						<Icon alt={ upeConfig.title } />
-					</span>
-				</>
-			),
-			ariaLabel: 'Stripe',
-			supports: {
-				// Use `false` as fallback values in case server provided configuration is missing.
-				showSavedCards:
-					getBlocksConfiguration()?.showSavedCards ?? false,
-				showSaveOption: upeConfig.showSaveOption ?? false,
-				features: getBlocksConfiguration()?.supports ?? [],
-			},
+					return isAvailableInTheCountry && !! api.getStripe();
+				},
+				// see .wc-block-checkout__payment-method styles in blocks/style.scss
+				label: (
+					<>
+						<span>
+							{ upeConfig.title }
+							<Icon alt={ upeConfig.title } />
+						</span>
+					</>
+				),
+				ariaLabel: 'Stripe',
+				supports: {
+					// Use `false` as fallback values in case server provided configuration is missing.
+					showSavedCards:
+						getBlocksConfiguration()?.showSavedCards ?? false,
+					showSaveOption: upeConfig.showSaveOption ?? false,
+					features: getBlocksConfiguration()?.supports ?? [],
+				},
+			} );
 		} );
+};
+
+// If this script is running in the customizer preview pane, wait for wc_stripe_upe_params to be defined on the window before registering payment methods
+if ( wp.customize ) {
+	const upeParamsReady = new Promise( ( resolve ) => {
+		const interval = setInterval( () => {
+			if ( window.wc_stripe_upe_params !== undefined ) {
+				clearInterval( interval );
+				resolve();
+			}
+		}, 10 );
 	} );
+	upeParamsReady.then( registerPaymentMethods );
+} else {
+	registerPaymentMethods();
+}
 
 // Register Stripe Payment Request.
 registerExpressPaymentMethod( paymentRequestPaymentMethod );

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.
 * Fix - Fix possible fatal errors when Stripe settings format is invalid during account connection.
 * Fix - Clear webhook state after reconfiguring webhooks to remove outdated error and success statuses.
+* Fix - Fix race condition which caused checkout fields to fail to render in the WordPress customizer preview pane after settings updates.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.


### PR DESCRIPTION
Issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3225

## Changes proposed in this Pull Request:

**Description:** 

This PR fixes a rendering bug in the WordPress customizer. Previously, changes to [settings with `'transport' => 'refresh'`](https://developer.wordpress.org/reference/classes/WP_Customize_Setting/__construct/) in the WordPress customizer caused the `upe_blocks.js` script to throw an error, preventing the checkout fields from rendering. This error was caused by a race condition where the `upe_blocks.js` script expected `window.wc_stripe_upe_params` to be defined, but the `upe_blocks.js` script was sometimes executing before `window.wc_stripe_upe_params` had been [loaded by wp_localize_script](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7eec27eb1d99b4bbc13ed8c91e20593f1a8b9bd0/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L343-L347).

All of this is explained in much more detail in the original issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3225

This PR configures React to wait for `wc_stripe_upe_params` to be defined on the window before rendering the payment elements in [the `/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js` file](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js). This logic is only applied when `wp.customize` is set, so there should be no impact outside of the WordPress customizer.

In the commits, you'll see that I first considered an approach where payment method registration would be delayed until `wc_stripe_upe_params` was defined. This code was not as clean as I wanted, and it caused a "no payment methods available" banner to flash before the payment elements rendered. I reverted these changes and opted to delay rendering in React instead.

I did not write a regression test because it would require testing a race condition across iframe boundaries, which tends to be complex. Additionally, regression may be less critical since this issues won't impact users' production sites as it's only present in the customizer. If a test is necessary, please tell me exactly what test would make sense here (e2e, Jest, ect.) and I would be glad to help with writing it.

**Questions for the PR author:**
- **How can this code break?**

This code is fairly self-contained, and it shouldn't break unless major changes are made to the `wp.customize` API or the localization of `wc_stripe_upe_params` changes.

- What are we doing to make sure this code doesn't break?

I'm happy to help with any additional measures that are necessary.

## Testing instructions

Since this issue is caused by a race condition, it's difficult to test manually. I included detailed notes about how to reproduce the error with browser CPU throttling in the initial issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3225 

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
