### PR TITLE
Ensure payment methods aren't detached on local or staging sites when the new checkout experience is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.
 * Fix - Fix possible fatal errors when Stripe settings format is invalid during account connection.
 * Fix - Clear webhook state after reconfiguring webhooks to remove outdated error and success statuses.
+* Fix - Prevent payment methods from being detached from Stripe customers on non-production sites when a WP user is deleted with the new checkout experience enabled.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -567,11 +567,7 @@ class WC_Stripe_Customer {
 			return false;
 		}
 
-		if ( ! WC_Stripe_API::should_detach_payment_method_from_customer() ) {
-			return false;
-		}
-
-		$response = WC_Stripe_API::request( [], "payment_methods/$payment_method_id/detach", 'POST' );
+		$response = WC_Stripe_API::detach_payment_method_from_customer( $this->get_id(), $payment_method_id );
 
 		$this->clear_cache();
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -567,6 +567,10 @@ class WC_Stripe_Customer {
 			return false;
 		}
 
+		if ( ! WC_Stripe_API::should_detach_payment_method_from_customer() ) {
+			return false;
+		}
+
 		$response = WC_Stripe_API::request( [], "payment_methods/$payment_method_id/detach", 'POST' );
 
 		$this->clear_cache();

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -400,16 +400,13 @@ class WC_Stripe_Payment_Tokens {
 	}
 
 	/**
-	 * Deletes a token from Stripe.
+	 * Delete token from Stripe.
 	 *
 	 * @since 3.1.0
 	 * @version 4.0.0
-	 *
-	 * @param int              $token_id The WooCommerce token ID.
-	 * @param WC_Payment_Token $token    The WC_Payment_Token object.
 	 */
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
-		$stripe_customer = new WC_Stripe_Customer( $token->get_user_id() );
+		$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
 		try {
 			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -400,13 +400,16 @@ class WC_Stripe_Payment_Tokens {
 	}
 
 	/**
-	 * Delete token from Stripe.
+	 * Deletes a token from Stripe.
 	 *
 	 * @since 3.1.0
 	 * @version 4.0.0
+	 *
+	 * @param int              $token_id The WooCommerce token ID.
+	 * @param WC_Payment_Token $token    The WC_Payment_Token object.
 	 */
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
-		$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
+		$stripe_customer = new WC_Stripe_Customer( $token->get_user_id() );
 		try {
 			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.
 * Fix - Fix possible fatal errors when Stripe settings format is invalid during account connection.
 * Fix - Clear webhook state after reconfiguring webhooks to remove outdated error and success statuses.
+* Fix - Prevent payment methods from being detached from Stripe customers on non-production sites when a WP user is deleted with the new checkout experience enabled.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.


### PR DESCRIPTION
Fixes #3358 

## Changes proposed in this Pull Request:

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2672, we added a new function that prevents payment methods from being detached from the Stripe customer on non-production sites. 

That new function was only added to the `detach_payment_method_from_customer()` function which is only called on sites with the legacy checkout enabled. 

When a WP user is deleted, WooCommerce calls the `wc_delete_user_data()` function which deletes all the user's payment tokens ([code ref](https://github.com/woocommerce/woocommerce/blob/9.1.0/plugins/woocommerce/includes/wc-user-functions.php#L907-L909)).

When the payment token is deleted, the WC Stripe plugin hooks in and in the `woocommerce_payment_token_deleted()` function ([code ref](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.6.0/includes/class-wc-stripe-payment-tokens.php#L408-L423)), it detaches the payment methods in Stripe -- this is where the flow slits.

If `WC_Stripe_Feature_Flags::is_upe_checkout_enabled()` passes (new checkout experience) we call [`$stripe_customer->detach_payment_method()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.5.0/includes/class-wc-stripe-payment-tokens.php#L413), on stores with the legacy checkout we call [`$stripe_customer->delete_source()`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.5.0/includes/class-wc-stripe-payment-tokens.php#L417) instead.

The `delete_source()` flow (legacy) eventually calls `WC_Stripe_API::detach_payment_method_from_customer()` which calls `should_detach_payment_method_from_customer()`. That's the function that checks the WP environment before detaching the source in Stripe.

`detach_payment_method()` (new checkout experience) does not lead to `should_detach_payment_method_from_customer()`, it just [detaches the source directly](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.5.0/includes/class-wc-stripe-customer.php#L541).

**This PR fixes that.** 
**Deleting a source and deleting a payment method will use the same core API function which checks the environment before detaching the PM.** 

## Testing instructions

1. Make sure the new checkout experience is enabled. 
2. Add the following code snippet to your site. 

```php
define( WP_ENVIRONMENT_TYPE, 'local' );
```

3. Because you'll be testing in test mode, you'll need to comment out [this line](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8.5.0/includes/class-wc-stripe-api.php#L386).
    - payment methods are always deleted while in test mode.
3. In an incognito browser window purchase an order and create an account.
4. On the My Account > Payment methods page add a payment method. 
5. In your Stripe Dashboard check the customer and note the payment method is attached.

<p align="center">
<img width="739" alt="Screenshot 2024-08-21 at 2 18 30 PM" src="https://github.com/user-attachments/assets/c2ed1fb9-3b4b-4d9e-9fbe-76ecc10581b5">
</p>  

7. Go to the Users list table in your Admin dashboard. 
8. Delete the user you just created.
    - On `develop` the payment method for that user would be detached from stripe. 
    - On this branch the payment method should **not** be detached. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
