### PR TITLE
Update capabilities to payment methods mapping

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Fix - Fix error in saving settings when express payment methods are disabled.
 * Fix - Catch error when getting intent from order.
 * Fix - Handle undefined array key when no matching customer account is found when guest customers checkout.
+* Tweak - Update capabilities to payment methods mapping.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -202,7 +202,8 @@ const GeneralSettingsSection = ( {
 				.filter(
 					( method ) =>
 						isTestModeEnabled ||
-						capabilities.hasOwnProperty( `${ method }_payments` )
+						capabilities.hasOwnProperty( `${ method }_payments` ) ||
+						capabilities.hasOwnProperty( method )
 				)
 				.filter( ( id ) => id !== 'link' )
 		: orderedPaymentMethodIds;

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -1,11 +1,10 @@
 import { __, sprintf } from '@wordpress/i18n';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import classnames from 'classnames';
 import { Button } from '@wordpress/components';
 import { Icon as IconComponent, dragHandle } from '@wordpress/icons';
 import { Reorder } from 'framer-motion';
-import UpeToggleContext from '../upe-toggle/context';
 import PaymentMethodsMap from '../../payment-methods-map';
 import PaymentMethodDescription from './payment-method-description';
 import CustomizePaymentMethod from './customize-payment-method';
@@ -15,7 +14,7 @@ import {
 	useGetOrderedPaymentMethodIds,
 	useManualCapture,
 } from 'wcstripe/data';
-import { useAccount, useGetCapabilities } from 'wcstripe/data/account';
+import { useAccount } from 'wcstripe/data/account';
 import PaymentMethodFeesPill from 'wcstripe/components/payment-method-fees-pill';
 
 const List = styled.ul`
@@ -183,9 +182,7 @@ const GeneralSettingsSection = ( {
 	isChangingDisplayOrder,
 	onSaveChanges,
 } ) => {
-	const { isUpeEnabled } = useContext( UpeToggleContext );
 	const [ customizationStatus, setCustomizationStatus ] = useState( {} );
-	const capabilities = useGetCapabilities();
 	const [ isManualCaptureEnabled ] = useManualCapture();
 	const [ enabledPaymentMethodIds ] = useEnabledPaymentMethodIds();
 	const {
@@ -193,20 +190,8 @@ const GeneralSettingsSection = ( {
 		setOrderedPaymentMethodIds,
 	} = useGetOrderedPaymentMethodIds();
 	const { data } = useAccount();
-	const isTestModeEnabled = Boolean( data.testmode );
 
-	// Hide payment methods that are not part of the account capabilities if UPE is enabled in live mode.
-	// Show all methods in test mode.
-	const availablePaymentMethods = isUpeEnabled
-		? orderedPaymentMethodIds
-				.filter(
-					( method ) =>
-						isTestModeEnabled ||
-						capabilities.hasOwnProperty( `${ method }_payments` ) ||
-						capabilities.hasOwnProperty( method )
-				)
-				.filter( ( id ) => id !== 'link' )
-		: orderedPaymentMethodIds;
+	const availablePaymentMethods = orderedPaymentMethodIds;
 
 	// Remove Sofort if it's not enabled. Hide from the new merchants and keep it for the old ones who are already using this gateway, until we remove it completely.
 	// Stripe is deprecating Sofort https://support.stripe.com/questions/sofort-is-being-deprecated-as-a-standalone-payment-method.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -730,7 +730,7 @@ class WC_Stripe_Helper {
 
 		foreach ( $payment_method_ids as $payment_method_id ) {
 			$key            = $payment_method_id . '_payments';
-			$has_capability = isset( $data['capabilities'][ $key ] );
+			$has_capability = isset( $data['capabilities'][ $key ] ) || isset( $data['capabilities'][ $payment_method_id ] );
 			if ( $has_capability || $testmode ) {
 				$payment_method_ids_with_capability[] = $payment_method_id;
 			}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -735,10 +735,12 @@ class WC_Stripe_Helper {
 
 		foreach ( $payment_method_ids as $payment_method_id ) {
 			$key            = $payment_method_id . '_payments';
-			$has_capability = isset( $data['capabilities'][ $key ] ) || isset( $data['capabilities'][ $payment_method_id ] );
+			// Check if the payment method has capabilities set in the account data.
+			// Generally the key is the payment method id appended with '_payments' (i.e. 'card_payments', 'sepa_debit_payments', 'klarna_payments').
+			// In some cases, the Stripe account might have the legacy key set. For example, for Klarna, the legacy key is 'klarna'.
+			// For card, the legacy key is 'legacy_payments'.
+			$has_capability = isset( $data['capabilities'][ $key ] ) || isset( $data['capabilities'][ $payment_method_id ] ) || ( 'card' === $payment_method_id && $data['capabilities']['legacy_payments'] );
 			if ( $has_capability ) {
-				$payment_method_ids_with_capability[] = $payment_method_id;
-			} elseif ( 'card' === $payment_method_id && $data['capabilities']['legacy_payments'] ) { // `legacy_payments` is the legacy capability key for card in Stripe.
 				$payment_method_ids_with_capability[] = $payment_method_id;
 			}
 		}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -739,7 +739,7 @@ class WC_Stripe_Helper {
 			// Generally the key is the payment method id appended with '_payments' (i.e. 'card_payments', 'sepa_debit_payments', 'klarna_payments').
 			// In some cases, the Stripe account might have the legacy key set. For example, for Klarna, the legacy key is 'klarna'.
 			// For card, the legacy key is 'legacy_payments'.
-			$has_capability = isset( $data['capabilities'][ $key ] ) || isset( $data['capabilities'][ $payment_method_id ] ) || ( 'card' === $payment_method_id && $data['capabilities']['legacy_payments'] );
+			$has_capability = isset( $data['capabilities'][ $key ] ) || isset( $data['capabilities'][ $payment_method_id ] ) || ( 'card' === $payment_method_id && isset( $data['capabilities']['legacy_payments'] ) );
 			if ( $has_capability ) {
 				$payment_method_ids_with_capability[] = $payment_method_id;
 			}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -726,12 +726,19 @@ class WC_Stripe_Helper {
 			return [];
 		}
 
+		// Return all payment methods if in test mode.
+		if ( $testmode ) {
+			return $payment_method_ids;
+		}
+
 		$payment_method_ids_with_capability = [];
 
 		foreach ( $payment_method_ids as $payment_method_id ) {
 			$key            = $payment_method_id . '_payments';
 			$has_capability = isset( $data['capabilities'][ $key ] ) || isset( $data['capabilities'][ $payment_method_id ] );
-			if ( $has_capability || $testmode ) {
+			if ( $has_capability ) {
+				$payment_method_ids_with_capability[] = $payment_method_id;
+			} elseif ( 'card' === $payment_method_id && $data['capabilities']['legacy_payments'] ) { // `legacy_payments` is the legacy capability key for card in Stripe.
 				$payment_method_ids_with_capability[] = $payment_method_id;
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -141,5 +141,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Fix error in saving settings when express payment methods are disabled.
 * Fix - Catch error when getting intent from order.
 * Fix - Handle undefined array key when no matching customer account is found when guest customers checkout.
+* Tweak - Update capabilities to payment methods mapping.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:
- We are already filtering out the payment methods in the backend which do not have capabilities in the Stripe account. Removed the duplicate filtering from frontend in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3375/commits/6dc17143187ad768f6b69fbd13847948df39469f
- If the payment method was enabled in Stripe dashboard, it might have different key in the `capabilities` object. For example `klarna` instead of `klarna_payments`. With the changes in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3375/commits/d7b4cede298664d0ad249491e4b065e130e5d621 we are considering both type of keys (`pm` and `pm_payments`) to check availability of the payment methods in the corresponding Stripe account.

## Testing instructions
- Connect to your Stripe account.
- Enable `live` mode.
- From `network` tab, check the capabilities of your account from `<your_site>/wp-json/wc/v3/wc_stripe/account`.
- Ensure that the payment methods that are not present in your `capabilities` object, are hidden from the payment methods list.
- Enable `test` mode and confirm that all the payment methods are displayed irrespective of their `capabilities` status.

#### Note
Asked here p1724345677895689/1724279352.583359-slack-C06RFP01Z7G to confirm about the correct key for `card`method.