### PR TITLE
Fix PHP warning caused by undefined array key when fetching customer account with no matching results

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Handle undefined array key when no matching customer account is found when guest customers checkout.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -238,7 +238,7 @@ class WC_Stripe_Customer {
 			return [];
 		}
 
-		return $search_response->data[0];
+		return $search_response->data[0] ?? [];
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -137,5 +137,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Handle undefined array key when no matching customer account is found when guest customers checkout.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3372 

## Changes proposed in this Pull Request:

In 8.6.0 (via https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3149) we added a new method for attempting to fetch an account based on guest customer email and name. 

That new method if it returns 0 results would cause the following error:

```
PHP Warning:  Undefined array key 0 in /plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-customer.php on line 241
```

This PR fixes that. 

## Testing instructions

1. In an incognito window (we need a guest customer).
2. Add a product to your cart. 
3. On checkout enter an email address and name that won't match any results in your Stripe account.
    - Eg `abc123def@example.com` `Johnny` `Doe`
4. Place the order. 
   - On develop you will see the error message above.
   - On this branch there should be no error. 
   - 
---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
