### PR TITLE
Fix fatal error when canceling uncaptured orders due to non-expanded refunds in Stripe API response

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Prevent fatal error when canceling uncaptured orders by ensuring refunds array is expanded in Stripe API response.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1124,7 +1124,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 					if ( ! empty( $result->error ) ) {
 						$response = $result;
 					} else {
-						$charge   = $this->get_latest_charge_from_intent( $result );
+						$charge   = $this->get_charge_object( $result->latest_charge, [ 'expand[]' => 'refunds' ] );
 						$response = end( $charge->refunds->data );
 					}
 				}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1124,8 +1124,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 					if ( ! empty( $result->error ) ) {
 						$response = $result;
 					} else {
-						$charge   = $this->get_charge_object( $result->latest_charge, [ 'expand[]' => 'refunds' ] );
-						$response = end( $charge->refunds->data );
+						$charge = $this->get_charge_object( $result->latest_charge, [ 'expand[]' => 'refunds' ] );
+
+						if ( isset( $charge->refunds->data ) ) {
+							$response = end( $charge->refunds->data );
+						}
 					}
 				}
 			}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1124,7 +1124,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 					if ( ! empty( $result->error ) ) {
 						$response = $result;
 					} else {
-						$charge = $this->get_charge_object( $result->latest_charge, [ 'expand[]' => 'refunds' ] );
+						$charge = $this->get_charge_object( $result->latest_charge, [ 'expand' => [ 'refunds' ] ] );
 
 						if ( isset( $charge->refunds->data ) ) {
 							$response = end( $charge->refunds->data );

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -342,7 +342,9 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
 			$captured = $order->get_meta( '_stripe_charge_captured', true );
+
 			if ( 'no' === $captured ) {
+				// To cancel a pre-auth, we need to refund the charge.
 				$this->process_refund( $order_id );
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -137,5 +137,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Add - Log incoming webhook events and their request body.
 * Add - Show UPE payment methods in saved order on block checkout page.
 * Tweak - Delete the notice about the missing customization options on the updated checkout experience.
+* Fix - Prevent fatal error when canceling uncaptured orders by ensuring refunds array is expanded in Stripe API response.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3371

## Changes proposed in this Pull Request:

When we bumped the Stripe API version in 8.5.0 to `2024-06-20` we introduced the potential for a fatal error when cancelling uncaptured orders. 

In version `2022-11-15`, Stripe changed the default response for charges to no longer automatically expand the `refunds` property.

<p align="center">
<img width="700" alt="Screenshot 2024-08-22 at 8 15 08 PM" src="https://github.com/user-attachments/assets/a2098f78-d682-4813-8ed0-cad47412c55a">
</br>
<sup><code>refunds</code> no longer expanded. Source: <a href="https://docs.stripe.com/upgrades#2022-11-15">https://docs.stripe.com/upgrades#2022-11-15<a></sup>
</p> 

This caused a fatal error when attempting to cancel an uncaptured charge because we expected the charge object to have refund data. This PR fixes that by making sure we fetch the charge and expand the refunds array before attempting to access it.


## Testing instructions

1. Go to **WooCommerce > Settings > Payments > Stripe > Settings**
2. Enable the **"issue an authorization on checkout, and capture later"** option
3. Purchase a product using Stripe
4. Attempt to cancel the order. 
   - On `develop` you will receive the following error. 
   - On this branch no error should occur.

```
PHP Fatal error:  Uncaught Error: Attempt to modify property "data" on null in /wp-content/plugins/woocommerce-gateway-stripe/includes/abstracts/abstract-wc-stripe-payment-gateway.php:1130
Stack trace:
#0 /wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-order-handler.php(348): WC_Stripe_Payment_Gateway->process_refund(8772)
#1 /wp-includes/class-wp-hook.php(326): WC_Stripe_Order_Handler->cancel_payment(8772)
#2 /wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#3 /wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#4 /wp-content/plugins/woocommerce/includes/class-wc-order.php(416): do_action('woocommerce_ord...', 8772, Object(Automattic\WooCommerce\Admin\Overrides\Order), Array)
#5 /wp-content/plugins/woocommerce/includes/class-wc-order.php(257): WC_Order->status_transition()
#6 /wp-content/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php(768): WC_Order->save()
#7 /wp-includes/class-wp-hook.php(326): WC_Meta_Box_Order_Data::save(8772)
#8 /wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#9 /wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#10 /wp-content/plugins/woocommerce/src/Internal/Admin/Orders/Edit.php(313): do_action('woocommerce_pro...', 8772, Object(Automattic\WooCommerce\Admin\Overrides\Order))
```

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
