### PR TITLE
Add 'get_supported_currencies' function for klarna

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Fix - Address QIT PHPStan test errors.
 * Update - Specify the JS Stripe API version as 2024-06-20.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
+* Fix - Address Klarna availability based on correct presentment currency rules.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
@@ -100,14 +100,14 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 	 */
 	public function get_supported_currencies() {
 		$account         = WC_Stripe::get_instance()->account->get_cached_account_data();
-		$account_country = strtoupper( $account['country'] );
+		$account_country = strtoupper( $account['country'] ?? '' );
 
 		// Countries in the EEA + UK and Switzerland can transact across all other EEA countries as long as the currency matches.
 		$eea_countries = array_merge( WC_Stripe_Helper::get_european_economic_area_countries(), [ 'CH', 'GB' ] );
 
 		// Countries outside the EEA can only transact with customers in their own currency.
 		if ( ! in_array( $account_country, $eea_countries, true ) ) {
-			return [ $account['default_currency'] ];
+			return [ strtoupper( $account['default_currency'] ?? '' ) ];
 		}
 
 		// Stripe account in EEA + UK and Switzerland can present the following as store currencies.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
@@ -83,6 +83,27 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 	}
 
 	/**
+	 * Returns the currencies this UPE method supports for the Stripe account.
+	 *
+	 * @return array Supported currencies.
+	 */
+	public function get_supported_currencies() {
+		$account         = WC_Stripe::get_instance()->account->get_cached_account_data();
+		$account_country = strtoupper( $account['country'] );
+
+		// Countries in the EEA + UK and Switzerland can transact across all other EEA countries as long as the currency matches.
+		$eea_countries = array_merge( WC_Stripe_Helper::get_european_economic_area_countries(), [ 'CH', 'GB' ] );
+
+		// Countries outside the EEA can only transact with customers in their own currency.
+		if ( ! in_array( $account_country, $eea_countries, true ) ) {
+			return [ $account[ 'default_currency' ] ];
+		}
+
+		// EEA currencies can only transact with countries where that currency is the standard currency.
+		return [ 'CHF', 'CZK', 'DKK', 'EUR', 'GBP', 'NOK', 'PLN', 'SEK' ];
+	}
+
+	/**
 	 * Returns whether the payment method is available for the Stripe account's country.
 	 *
 	 * Klarna is available for the following countries: AU, AT, BE, CA, CZ, DK, FI, FR, GR, DE, IE, IT, NL, NZ, NO, PL, PT, ES, SE, CH, GB, US.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
@@ -84,18 +84,17 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 
 	/**
 	 * Returns the currencies this UPE method supports for the Stripe account.
-	 * 
+	 *
 	 * Klarna has unique requirements for domestic transactions. The customer must be located in the same country as the merchant's Stripe account and the currency must match.
 	 * - Stores connected to US account and presenting USD can only transact with customers located in the US.
 	 * - Stores connected to US account and presenting non-USD currency can not transact with customers irrespective of their location.
-	 * 
+	 *
 	 * Additionally, if the merchant is in the EEA, the country they can transact with depends on the presentment currency.
 	 * EUR stores can transact with other EUR countries. Stores with currencies like GBP, CHF, etc. can only transact with customers located in those countries.
 	 * This creates the following unique situations:
 	 *  - Stores presenting EUR, with a Stripe account in any EEA country including Switzerland or the UK can transact with countries where Euros are the standard currency: AT, BE, FI, FR, GR, DE, IE, IT, NL, PT, ES.
 	 *  - Stores presenting GBP with a Stripe account in any EEA country including Switzerland or the UK can transact with: GB.
 	 *  - Stores presenting NOK with a Stripe account in France, for example, cannot sell into France. They can only sell into Norway.
-
 	 *
 	 * @return array Supported currencies.
 	 */
@@ -108,10 +107,10 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 
 		// Countries outside the EEA can only transact with customers in their own currency.
 		if ( ! in_array( $account_country, $eea_countries, true ) ) {
-			return [ $account[ 'default_currency' ] ];
+			return [ $account['default_currency'] ];
 		}
 
-		// Stripe account in EEA + UK and Switzerland can present the following as store currencies. 
+		// Stripe account in EEA + UK and Switzerland can present the following as store currencies.
 		// EEA currencies can only transact with countries where that currency is the standard currency.
 		return [ 'CHF', 'CZK', 'DKK', 'EUR', 'GBP', 'NOK', 'PLN', 'SEK' ];
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
@@ -84,6 +84,18 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 
 	/**
 	 * Returns the currencies this UPE method supports for the Stripe account.
+	 * 
+	 * Klarna has unique requirements for domestic transactions. The customer must be located in the same country as the merchant's Stripe account and the currency must match.
+	 * - Stores connected to US account and presenting USD can only transact with customers located in the US.
+	 * - Stores connected to US account and presenting non-USD currency can not transact with customers irrespective of their location.
+	 * 
+	 * Additionally, if the merchant is in the EEA, the country they can transact with depends on the presentment currency.
+	 * EUR stores can transact with other EUR countries. Stores with currencies like GBP, CHF, etc. can only transact with customers located in those countries.
+	 * This creates the following unique situations:
+	 *  - Stores presenting EUR, with a Stripe account in any EEA country including Switzerland or the UK can transact with countries where Euros are the standard currency: AT, BE, FI, FR, GR, DE, IE, IT, NL, PT, ES.
+	 *  - Stores presenting GBP with a Stripe account in any EEA country including Switzerland or the UK can transact with: GB.
+	 *  - Stores presenting NOK with a Stripe account in France, for example, cannot sell into France. They can only sell into Norway.
+
 	 *
 	 * @return array Supported currencies.
 	 */
@@ -99,6 +111,7 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 			return [ $account[ 'default_currency' ] ];
 		}
 
+		// Stripe account in EEA + UK and Switzerland can present the following as store currencies. 
 		// EEA currencies can only transact with countries where that currency is the standard currency.
 		return [ 'CHF', 'CZK', 'DKK', 'EUR', 'GBP', 'NOK', 'PLN', 'SEK' ];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -151,5 +151,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Address QIT PHPStan test errors.
 * Update - Specify the JS Stripe API version as 2024-06-20.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
+* Fix - Address Klarna availability based on correct presentment currency rules.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -525,6 +525,20 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	 */
 	public function test_payment_methods_with_domestic_restrictions_are_enabled_on_currency_match() {
 		WC_Stripe_Helper::update_main_stripe_settings( [ 'testmode' => 'yes' ] );
+		WC_Stripe::get_instance()->account = $this->getMockBuilder( 'WC_Stripe_Account' )
+				->disableOriginalConstructor()
+				->setMethods(
+					[
+						'get_cached_account_data',
+					]
+				)
+				->getMock();
+		WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn(
+			[
+				'country' => 'US',
+				'default_currency' => 'USD'
+			]
+		);
 
 		$this->set_mock_payment_method_return_value( 'get_woocommerce_currency', 'USD', true );
 

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -536,7 +536,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		WC_Stripe::get_instance()->account->method( 'get_cached_account_data' )->willReturn(
 			[
 				'country' => 'US',
-				'default_currency' => 'USD'
+				'default_currency' => 'USD',
 			]
 		);
 


### PR DESCRIPTION
Fixes #3351

## Changes proposed in this Pull Request:

Added `get_supported_currencies` for Klarna which returns the list of supported currencies based on the Stripe account currency.

## Testing instructions

- Connect your store to an account from the US.
- Change your store currency to EUR.
- Enable Klarna under the Payment Methods tab in the plugin settings.
- As a shopper, add a product to your cart and go to the checkout page.
- Ensure your billing country is the United States.
- In `develop` branch notice that Klarna is displayed. When you select it, the Payment Element isn't displayed. The following error shows up in the browser console.

<img width="4156" alt="356851433-28331e36-25a2-4943-b089-6ee7e3928d48" src="https://github.com/user-attachments/assets/67ba763b-67bb-4e4f-8b0d-1b0faf1c153f">

- In this branch, Klarna is not displayed as the store currency is EUR.
- Confirm that there is not regression around the [fix related to EEA cross border transaction](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3108).