### PR TITLE
Re-enable Stripe Link for shortcode checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Add back support for Stripe Link autofill for shortcode checkout.
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -103,6 +103,11 @@ jQuery( function ( $ ) {
 	}
 
 	function maybeEnableStripeLinkPaymentMethod( elements, paymentMethodType ) {
+		const isCheckout = getStripeServerData()?.isCheckout;
+		if ( ! isCheckout ) {
+			return;
+		}
+
 		if ( paymentMethodType !== 'card' ) {
 			return;
 		}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -166,6 +166,7 @@ function createStripePaymentMethod(
  *
  * @param {Object} api The API object.
  * @param {string} domElement The selector of the DOM element of particular payment method to mount the UPE element to.
+ * @return {Object} An object containing the Stripe Elements object and the Stripe Payment Element.
  **/
 export async function mountStripePaymentElement( api, domElement ) {
 	/*
@@ -194,6 +195,8 @@ export async function mountStripePaymentElement( api, domElement ) {
 		gatewayUPEComponents[ paymentMethodType ].upeElement ||
 		( await createStripePaymentElement( api, paymentMethodType ) );
 	upeElement.mount( domElement );
+
+	return gatewayUPEComponents[ paymentMethodType ];
 }
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Add back support for Stripe Link autofill for shortcode checkout.
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3379 

## Changes proposed in this Pull Request:
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
In moving to deferred intents (>= 8.0.0), we unintentionally dropped Stripe Link autofill functionality for shortcode checkouts.

This PR adds back support for Stripe Link autofill in shortcode checkouts.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Set up Stripe Link and shortcode checkout.
   - Ensure that the Legacy checkout experience is disabled in the Stripe settings tab, at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`.
   - Ensure Stripe Link is enabled in the Stripe Payment Methods tab, at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`.
   - Create a shortcode checkout page, i.e. `[woocommerce_checkout]`
2. Test "new email" scenario:
   - Get a test email from https://10minutemail.com/ or a similar service. This can be skipped if you're fairly certain that your test email has not been registered with Stripe Link yet.
   - Add a product to your cart and go to the shortcode checkout page.
   - Enter your name, billing/shipping details, and test credit card info.
   - As you type the test credit card info, a box asking you to register with Stripe Link should appear. (See Screenshot 1.)
   - Enter any phone number, e.g. `(800) 555-0175`.
3. Test "returning email" scenario:
   - Add a product to your cart and go to the shortcode checkout page.
   - Depending on whether the email address field is blank or not when you load the shortcode checkout page, do the following: 
       - Email address field is not blank: you should see the Stripe Link logo beside the email address field. Clicking the logo should launch the autofill modal. (See Screenshots 2 and 3.)
       - Email address field is blank: type in the same email you used in the "new email" scenario. The Stripe Link autofill modal should appear, asking you for the one-time code. Note: you can force this path by testing on an incognito browser. (See Screenshot 3.)
   - Enter "000000" as the one-time code. It should bring up the customer information attached to this email address, the same one you entered in the "new email" scenario.
   - Click "Autofill checkout" and verify that the name, billing and shipping address fields, and credit card information have been autofilled correctly.
4. Test for unintended regressions:
   - Verify that these changes did not affect blocks checkout by running through the "new email" and "returning email" scenarios for the blocks checkout.
   - Verify that legacy checkout is unaffected:
       - Enable the Legacy checkout experience in the Stripe settings tab, at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`.
       - Add a product to the cart and go through shortcode checkout.
       - Add a product to the cart and go through blocks checkout.
   - Verify that this does not affect checkouts when Stripe Link is not enabled.
       - Disable Stripe Link in the Stripe Payment Methods tab, at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`.
       - Add a product to the cart and go through shortcode checkout.
       - Verify that no Stripe Link elements (e.g. autofill modal, logo beside email address, registration box) appear during the checkout process.
       - Go through the same for blocks checkout.
       
Known limitations/expected behavior of Stripe Link autofill modal:
- You can only launch the autofill modal once per page load. You will need to refresh the page to reset the process.
- If the email address is not registered, clicking the logo will not give any feedback.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply) -- DevTools only

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

**Screenshots**

Screenshot 1: registering with Stripe Link
<img width="808" alt="register-with-stripe-link" src="https://github.com/user-attachments/assets/5c03bc45-4792-419b-9378-bfeae12ad47b">

Screenshot 2: email address field with the Link logo
<img width="549" alt="stripe-link-button" src="https://github.com/user-attachments/assets/e95f41da-3db3-4d37-8841-ffd425f1d9ab">

Screenshot 3: the Link autofill modal
<img width="476" alt="stripe-autofill-modal" src="https://github.com/user-attachments/assets/b024e931-2184-4d7e-afcc-72fc4cdaf59c">

