### PR TITLE
Clear webhook messages upon reconnection

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Tweak - Clears all the latest webhook messages upon reconnection to avoid confusion.
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -404,6 +404,9 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 			return new WP_REST_Response( [ 'message' => $e->getMessage() ], 400 );
 		}
 
+		// Clear the latest webhook error messages to avoid confusion
+		WC_Stripe_Webhook_State::reset_last_webhook_messages();
+
 		return new WP_REST_Response(
 			[
 				'message'       => __( 'Webhooks have been setup successfully.', 'woocommerce-gateway-stripe' ),

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -79,9 +79,7 @@ class WC_Stripe_Webhook_State {
 			// Enforce database consistency. This should only be needed if the user
 			// has modified the database directly. We should not allow timestamps
 			// before monitoring began.
-			self::set_last_webhook_success_at( 0 );
-			self::set_last_webhook_failure_at( 0 );
-			self::set_last_error_reason( self::VALIDATION_SUCCEEDED );
+			self::reset_last_webhook_messages();
 		}
 		return $monitoring_began_at;
 	}
@@ -190,14 +188,56 @@ class WC_Stripe_Webhook_State {
 	}
 
 	/**
+	 * Resets the last webhook success timestamp to 0.
+	 *
+	 * @since 8.7.0
+	 * @return void
+	 */
+	public static function reset_last_webhook_success_at() {
+		self::set_last_webhook_success_at( 0 );
+	}
+
+	/**
+	 * Resets the last webhook failure timestamp to 0.
+	 *
+	 * @since 8.7.0
+	 * @return void
+	 */
+	public static function reset_last_webhook_failure_at() {
+		self::set_last_webhook_failure_at( 0 );
+	}
+
+	/**
+	 * Resets the last error reason to VALIDATION_SUCCEEDED.
+	 *
+	 * @since 8.7.0
+	 * @return void
+	 */
+	public static function reset_last_error_reason() {
+		self::set_last_error_reason( self::VALIDATION_SUCCEEDED );
+	}
+
+	/**
+	 * Resets all webhook messages to their default values.
+	 *
+	 * @since 8.7.0
+	 * @return void
+	 */
+	public static function reset_last_webhook_messages() {
+		self::reset_last_webhook_success_at();
+		self::reset_last_webhook_failure_at();
+		self::reset_last_error_reason();
+	}
+
+	/**
 	 * Gets the status code for the webhook processing.
 	 *
 	 * @since 8.6.0
 	 * @return int The status code for the webhook processing.
 	 */
 	public static function get_webhook_status_code() {
-		$last_success_at     = self::get_last_webhook_success_at();
-		$last_failure_at     = self::get_last_webhook_failure_at();
+		$last_success_at = self::get_last_webhook_success_at();
+		$last_failure_at = self::get_last_webhook_failure_at();
 
 		// Case 1 (Nominal case): Most recent = success
 		if ( $last_success_at > $last_failure_at ) {

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -188,45 +188,15 @@ class WC_Stripe_Webhook_State {
 	}
 
 	/**
-	 * Resets the last webhook success timestamp to 0.
-	 *
-	 * @since 8.7.0
-	 * @return void
-	 */
-	public static function reset_last_webhook_success_at() {
-		self::set_last_webhook_success_at( 0 );
-	}
-
-	/**
-	 * Resets the last webhook failure timestamp to 0.
-	 *
-	 * @since 8.7.0
-	 * @return void
-	 */
-	public static function reset_last_webhook_failure_at() {
-		self::set_last_webhook_failure_at( 0 );
-	}
-
-	/**
-	 * Resets the last error reason to VALIDATION_SUCCEEDED.
-	 *
-	 * @since 8.7.0
-	 * @return void
-	 */
-	public static function reset_last_error_reason() {
-		self::set_last_error_reason( self::VALIDATION_SUCCEEDED );
-	}
-
-	/**
 	 * Resets all webhook messages to their default values.
 	 *
 	 * @since 8.7.0
 	 * @return void
 	 */
 	public static function reset_last_webhook_messages() {
-		self::reset_last_webhook_success_at();
-		self::reset_last_webhook_failure_at();
-		self::reset_last_error_reason();
+		self::set_last_webhook_success_at( 0 );
+		self::set_last_webhook_failure_at( 0 );
+		self::set_last_error_reason( self::VALIDATION_SUCCEEDED );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Tweak - Clears all the latest webhook messages upon reconnection to avoid confusion.
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.
 * Fix - Re-connect promotional surface blinking after disappearing for merchants that have already connected their Stripe account.

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -274,4 +274,21 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->process_webhook();
 		$this->assertMatchesRegularExpression( '/was not signed with the expected signing secret/', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
+
+	/**
+	 * Test for `reset_last_webhook_messages`.
+	 *
+	 * @return void
+	 */
+	public function test_reset_last_webhook_messages() {
+		WC_Stripe_Webhook_State::set_last_webhook_success_at( time() );
+		WC_Stripe_Webhook_State::set_last_webhook_failure_at( time() );
+		WC_Stripe_Webhook_State::set_last_error_reason( 'Some error' );
+
+		WC_Stripe_Webhook_State::reset_last_webhook_messages();
+
+		$this->assertEquals( 0, WC_Stripe_Webhook_State::get_last_webhook_success_at() );
+		$this->assertEquals( 0, WC_Stripe_Webhook_State::get_last_webhook_failure_at() );
+		$this->assertEquals( 'No error', WC_Stripe_Webhook_State::get_last_error_reason() );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3374 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

We add the error message to an option when a webhook issue occurs. The error message remains after the issue is resolved (by reconnecting the webhook using the new OAuth flow), which can confuse some merchants about whether it was fixed.

This PR clears all messages to avoid such confusion. To reduce duplicated code, I am introducing a new helper method to `WC_Stripe_Webhook_State` named `reset_last_webhook_messages`.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Code review should be enough. I have also introduced a new unit test for the new helper method.

If you want to test it manually:

- Checkout to this branch on your environment (`tweak/clear-webhook-messages-upon-reconnection`)
- Follow the testing steps of [this old PR](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1224) to update your latest webhook message options
- Reconnect your webhook by clicking the "Configure webhooks" button on the "Configure connection" modal

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
