### PR TITLE
Set transaction URL for Stripe APMs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.
 * Fix - Add back support for Stripe Link autofill for shortcode checkout.
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -379,11 +379,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @version 4.0.0
 	 */
 	public function get_transaction_url( $order ) {
-		if ( $this->testmode ) { // @phpstan-ignore-line (testmode is defined in the classes that use this class)
-			$this->view_transaction_url = 'https://dashboard.stripe.com/test/payments/%s';
-		} else {
-			$this->view_transaction_url = 'https://dashboard.stripe.com/payments/%s';
-		}
+		$this->view_transaction_url = WC_Stripe_Helper::get_transaction_url( $this->testmode );
 
 		return parent::get_transaction_url( $order );
 	}

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1516,4 +1516,12 @@ class WC_Stripe_Helper {
 
 		return $url_host === $webhook_host && $url_path === $webhook_path;
 	}
+
+	public static function get_transaction_url( $is_test_mode = false ) {
+		if ( $is_test_mode ) {
+			return 'https://dashboard.stripe.com/test/payments/%s';
+		}
+
+		return 'https://dashboard.stripe.com/payments/%s';
+	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -661,4 +661,21 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		</fieldset>
 		<?php
 	}
+
+	/**
+	 * Gets the transaction URL.
+	 * Overrides WC_Payment_Gateway::get_transaction_url().
+	 *
+	 * @param  WC_Order $order Order object.
+	 * @return string
+	 */
+	public function get_transaction_url( $order ) {
+		if ( $this->testmode ) {
+			$this->view_transaction_url = 'https://dashboard.stripe.com/test/payments/%s';
+		} else {
+			$this->view_transaction_url = 'https://dashboard.stripe.com/payments/%s';
+		}
+
+		return parent::get_transaction_url( $order );
+	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -670,11 +670,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_transaction_url( $order ) {
-		if ( $this->testmode ) {
-			$this->view_transaction_url = 'https://dashboard.stripe.com/test/payments/%s';
-		} else {
-			$this->view_transaction_url = 'https://dashboard.stripe.com/payments/%s';
-		}
+		$this->view_transaction_url = WC_Stripe_Helper::get_transaction_url( $this->testmode );
 
 		return parent::get_transaction_url( $order );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.
 * Fix - Add back support for Stripe Link autofill for shortcode checkout.
 * Fix - Fix undefined method error caused by settings refactor when connecting Stripe account.
 * Fix - Fix multiple compatibility issues and deprecation warnings when running the extension on PHP 8.1.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3061 

## Changes proposed in this Pull Request:
When viewing order details, we want the charge ID to link to the Stripe dashboard. We are already doing this for CCs, by [overriding get_transaction_url() inside WC_Stripe_Payment_Gateway](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/05a1284876c575da4961725f9bbd557e701e095e/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L381). We want to do this inside `WC_Stripe_UPE_Payment_Method` as well, to have the same behavior for APMs.

**BEFORE: charge ID does not link to Stripe dashboard**
<img width="472" alt="Screenshot 2024-08-28 at 9 59 16 AM" src="https://github.com/user-attachments/assets/41528566-b5f7-49d3-9518-40bca7355a5d">

**AFTER: charge ID links to Stripe dashboard**
<img width="472" alt="Screenshot 2024-08-28 at 9 59 36 AM" src="https://github.com/user-attachments/assets/5d279d0a-ebf2-4ac5-9804-30bb7b548862">

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Enable APMs (e.g. Alipay) as a payment method in the Stripe settings: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
2. As a shopper, add a product to your cart and go to checkout. Use an APM, e.g. Alipay, to pay.
3. As the merchant, go to the order details page: `wp-admin/admin.php?page=wc-orders&action=edit&id=<ORDER-ID-FROM-PREVIOUS-STEP>`
4. Under the "Order #<ID> details" header, you should see something like "AlipayPayment via Alipay (py_3Ps8zuIMUtoK6Gfh0UF2DfWd)." The charge ID should link to the Stripe dashboard payments page, e.g. `https://dashboard.stripe.com/test/payments/py_3Ps8zuIMUtoK6Gfh0UF2DfWd`
5. Test for regressions by going through checkout using a credit card, and verifying that credit card order IDs are still linked to the Stripe dashboard.

 
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
