### PR TITLE
fix: unexpected HTML on the shortcode checkout

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -732,12 +732,6 @@ function woocommerce_gateway_stripe() {
 
 					// Add extra `stripe-gateway-checkout-email-field` class.
 					$fields['billing_email']['class'][] = 'stripe-gateway-checkout-email-field';
-
-					if ( is_user_logged_in() ) {
-						// Append StripeLink modal trigger button for logged in users.
-						$fields['billing_email']['label'] = $fields['billing_email']['label']
-                            . ' <button class="stripe-gateway-stripelink-modal-trigger"></button>';
-					}
 				}
 
 				return $fields;

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -733,9 +733,11 @@ function woocommerce_gateway_stripe() {
 					// Add extra `stripe-gateway-checkout-email-field` class.
 					$fields['billing_email']['class'][] = 'stripe-gateway-checkout-email-field';
 
-					// Append StripeLink modal trigger button for logged in users.
-					$fields['billing_email']['label'] = $fields['billing_email']['label']
-						. ' <button class="stripe-gateway-stripelink-modal-trigger"></button>';
+					if ( is_user_logged_in() ) {
+						// Append StripeLink modal trigger button for logged in users.
+						$fields['billing_email']['label'] = $fields['billing_email']['label']
+                            . ' <button class="stripe-gateway-stripelink-modal-trigger"></button>';
+					}
 				}
 
 				return $fields;


### PR DESCRIPTION
When Link is enabled, some unexpected HTML is included in the error message for the required email address field. This is only happening on the shortcode checkout.

Fixes #3099 

## Changes proposed in this Pull Request:
The below bug is fixed in this PR. Removed the `stripe-gateway-stripelink-modal-trigger` button append from PHP end as the append is happening from `hooks.js`

## Testing instructions
To Reproduce

1. Ensure that the Legacy checkout experience is disabled under the Stripe settings tab, at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
2. Ensure Link is enabled under the Payment Methods tab, at `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
3. Create a page that contains the shortcode checkout, if you don't have one already
4. As a shopper, add a product to the cart and go to the shortcode checkout page
5. Ensure that the email address field is empty
6. Click on Place Order
7. Notice the error message contains `<button class="stripe-gateway-stripelink-modal-trigger"></button>`
![image](https://github.com/user-attachments/assets/6df68cb6-3e83-4213-844a-25d83e0b85be)


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
