### PR TITLE
Fix undefined check of global variable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Fix - Address Klarna availability based on correct presentment currency rules.
 * Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 * Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
+* Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 8.8.0 - xxxx-xx-xx =
+* Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
+
 = 8.7.0 - xxxx-xx-xx =
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.
@@ -29,7 +32,6 @@
 * Fix - Address Klarna availability based on correct presentment currency rules.
 * Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 * Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
-* Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -1,4 +1,4 @@
-/* global wc_stripe_upe_params */
+/* global wc_stripe_upe_params, wc */
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { getAppearance } from '../styles/upe';
@@ -21,13 +21,24 @@ import {
  * @return  {StripeServerData} Stripe server data.
  */
 const getStripeServerData = () => {
-	// Classic checkout.
+	let data = null;
+
 	// eslint-disable-next-line camelcase
-	if ( typeof wc_stripe_upe_params === 'undefined' ) {
-		return {};
+	if ( typeof wc_stripe_upe_params !== 'undefined' ) {
+		data = wc_stripe_upe_params; // eslint-disable-line camelcase
+	} else if (
+		typeof wc === 'object' &&
+		typeof wc.wcSettings !== 'undefined'
+	) {
+		// 'getSetting' has this data value on block checkout only.
+		data = wc.wcSettings?.getSetting( 'getSetting' ) || null;
 	}
-	// eslint-disable-next-line camelcase
-	return wc_stripe_upe_params;
+
+	if ( ! data ) {
+		throw new Error( 'Stripe initialization data is not available' );
+	}
+
+	return data;
 };
 
 const isNonFriendlyError = ( type ) =>

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -23,8 +23,8 @@ import {
 const getStripeServerData = () => {
 	// Classic checkout.
 	// eslint-disable-next-line camelcase
-	if ( ! wc_stripe_upe_params ) {
-		throw new Error( 'Stripe initialization data is not available' );
+	if ( typeof wc_stripe_upe_params === 'undefined' ) {
+		return {};
 	}
 	// eslint-disable-next-line camelcase
 	return wc_stripe_upe_params;
@@ -210,8 +210,8 @@ export { getStripeServerData, getErrorMessageForTypeAndCode };
  */
 export const isLinkEnabled = ( paymentMethodsConfig ) => {
 	return (
-		paymentMethodsConfig.link !== undefined &&
-		paymentMethodsConfig.card !== undefined
+		paymentMethodsConfig?.link !== undefined &&
+		paymentMethodsConfig?.card !== undefined
 	);
 };
 
@@ -505,16 +505,18 @@ export const getPaymentMethodName = ( paymentMethodType ) => {
  * @return {boolean} Whether the payment method is restricted to selected billing country.
  **/
 export const isPaymentMethodRestrictedToLocation = ( upeElement ) => {
-	const paymentMethodsConfig = getStripeServerData()?.paymentMethodsConfig;
+	const paymentMethodsConfig =
+		getStripeServerData()?.paymentMethodsConfig || {};
 	const paymentMethodType = upeElement.dataset.paymentMethodType;
-	return !! paymentMethodsConfig[ paymentMethodType ].countries.length;
+	return !! paymentMethodsConfig[ paymentMethodType ]?.countries.length;
 };
 
 /**
  * @param {Object} upeElement The selector of the DOM element of particular payment method to mount the UPE element to.
  **/
 export const togglePaymentMethodForCountry = ( upeElement ) => {
-	const paymentMethodsConfig = getStripeServerData()?.paymentMethodsConfig;
+	const paymentMethodsConfig =
+		getStripeServerData()?.paymentMethodsConfig || {};
 	const paymentMethodType = upeElement.dataset.paymentMethodType;
 	const supportedCountries =
 		paymentMethodsConfig[ paymentMethodType ].countries;

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Address Klarna availability based on correct presentment currency rules.
 * Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 * Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
+* Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,5 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Address Klarna availability based on correct presentment currency rules.
 * Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 * Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
-* Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 8.8.0 - xxxx-xx-xx =
+* Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
+
 = 8.7.0 - xxxx-xx-xx =
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.


### PR DESCRIPTION
This PR is mainly an alternate solution to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3369 for fixing #3225.

The original reporter and the PR author of  https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3369 
 and @annemirasol confirmed that the changes in this PR fix the customizer issue described in #3225.

## Changes proposed in this Pull Request:
- Fixed the check for `wc_stripe_upe_params`. When it is undefined (in case the script is not loaded yet), the current check does not work actually and results in the following console error. Checking `typeof` works as expected.

<img width="519" alt="Screenshot 2024-09-06 at 2 34 23 AM" src="https://github.com/user-attachments/assets/7354093b-0d8b-4012-a4b9-326987144f6b">

- Instead of throwing an error, I am returning an empty array when `wc_stripe_upe_params` is undefined.

## Testing instructions
- Intentionally make `wc_stripe_upe_params` undefined. I have tested by changing it [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L345) from `wc_stripe_upe_params` to `wc_stripe_upe_params_2`. This way there exists no `wc_stripe_upe_params` global variable.
- Notice that you are getting the console error in `develop` branch. 
- In this branch you should not get the console error.
- If you are able to reproduce #3225, make sure that it is not happening in this branch. Detailed reproduction steps are described in the issue.