### PR TITLE
Fix E2E test suite compatibility with Woo 9.2

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         checkout: [ 'Default', 'Legacy' ]
 
-    name: ${{ matrix.checkout }} WP=latest, WC=latest, PHP=7.4"
+    name: ${{ matrix.checkout }} WP=latest, WC=latest, PHP=7.4
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -227,21 +227,12 @@ export async function setupBlocksCheckout( page, billingDetails = null ) {
 	if ( billingDetails ) {
 		await page
 			.getByLabel( 'Country/Region' )
-			.fill( billingDetails[ 'country' ] );
-		await page
-			.locator(
-				'.components-form-token-field__suggestions-list > li:first-child'
-			)
-			.click();
+			.selectOption( { label: billingDetails[ 'country' ] } );
 
 		await page
 			.getByLabel( 'State', { exact: true } )
-			.fill( billingDetails[ 'state' ] );
-		await page
-			.locator(
-				'.components-form-token-field__suggestions-list > li:first-child'
-			)
-			.click();
+			.selectOption( { label: billingDetails[ 'state' ] } );
+
 		// Expand the address 2 field.
 		await page
 			.locator( '.wc-block-components-address-form__address_2-toggle' )


### PR DESCRIPTION
Fixes #3388

## Changes proposed in this Pull Request:

This PR updates the selector for the `Country` and `State` fields in the checkout... which now use regular `select`
 fields instead of the searchable ones from before:

![image-2](https://github.com/user-attachments/assets/2c65ed01-376a-4e76-8609-850bc2da9340)


## Testing instructions

Check that all tests pass