### PR TITLE
Define the Stripe API version we use in the JS Stripe instance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Tweak - Update capabilities to payment methods mapping.
 * Fix - Address QIT Security test errors.
 * Fix - Address QIT PHPStan test errors.
+* Update - Specify the JS Stripe API version as 2024-06-20.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -78,7 +78,10 @@ export default class WCStripeAPI {
 	}
 
 	createStripe( key, locale, betas = [] ) {
-		const options = { locale };
+		const options = {
+			locale,
+			apiVersion: this.options.apiVersion,
+		};
 
 		if ( betas.length ) {
 			options.betas = betas;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -375,6 +375,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'isUPEEnabled' => true,
 			'key'          => $this->publishable_key,
 			'locale'       => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+			'apiVersion'   => WC_Stripe_API::STRIPE_API_VERSION,
 		];
 
 		$enabled_billing_fields = [];

--- a/readme.txt
+++ b/readme.txt
@@ -147,5 +147,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Update capabilities to payment methods mapping.
 * Fix - Address QIT Security test errors.
 * Fix - Address QIT PHPStan test errors.
+* Update - Specify the JS Stripe API version as 2024-06-20.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

While doing some work with Cash App I noticed that if I chose Cash App on the checkout, and then without completing the payment I closed the QR code modal, I was being redirected to the order received page. 

This is not expected because we explicitly have code designed to handle that situation:

https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad3eafbaa4d7931da8bd9779a7a63a25ec5ac643/client/classic/upe/payment-processing.js#L481-L485

After investigating why that was happening, I discovered that it's because the payment intent status is `requires_source_action ` rather than the expected `requires_action`. And this was because of an API version update in 2019. 

| <img width="400" alt="Screenshot 2024-08-29 at 4 38 06 PM" src="https://github.com/user-attachments/assets/687b266e-a37a-495a-a82a-582423691b63"> | <img width="400" alt="Screenshot 2024-08-29 at 4 38 30 PM" src="https://github.com/user-attachments/assets/91cc1b27-1371-4356-9184-8a15372cd31e"><img width="400" alt="Screenshot 2024-08-29 at 4 40 04 PM" src="https://github.com/user-attachments/assets/43eb2c87-d154-4075-b487-aeaa7c865a7a"> |
|--------|--------|


This PR ensures that we won't somehow use really old versions of the API in JS. I've used the same API version we use for the server side API.

## Testing instructions

Given this PR is bumping the API version, we'll need to confirm no front end flow is broken by this change. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
