### PR TITLE
Ensure tokens are deleted when a user is deleted and the admin doesn't have a Stripe Account

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Tweak - Update capabilities to payment methods mapping.
 * Fix - Address QIT Security test errors.
 * Fix - Address QIT PHPStan test errors.
+* Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -400,13 +400,16 @@ class WC_Stripe_Payment_Tokens {
 	}
 
 	/**
-	 * Delete token from Stripe.
+	 * Deletes a token from Stripe.
 	 *
 	 * @since 3.1.0
 	 * @version 4.0.0
+	 *
+	 * @param int              $token_id The WooCommerce token ID.
+	 * @param WC_Payment_Token $token    The WC_Payment_Token object.
 	 */
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
-		$stripe_customer = new WC_Stripe_Customer( get_current_user_id() );
+		$stripe_customer = new WC_Stripe_Customer( $token->get_user_id() );
 		try {
 			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 				if ( in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -149,5 +149,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Update capabilities to payment methods mapping.
 * Fix - Address QIT Security test errors.
 * Fix - Address QIT PHPStan test errors.
+* Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3395

## Changes proposed in this Pull Request:

As discovered in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3370#issuecomment-2319583311, if an admin user deletes a user account, that would typically trigger WC to delete all the tokens and for us to detach them from the Stripe account.

Because of a bug in our `woocommerce_payment_token_deleted()` function, this will only work **if** **the admin user has a Stripe account** and a `cus_xxx` stored in user meta.

This PR fixes that by making sure we use the token's user ID to create the `WC_Stripe_Customer` instance. 

## Testing instructions

1. If your admin user has a Stripe customer ID, delete it.

```php
$customer = new WC_Stripe_Customer( get_current_user_id() );
$customer->delete_id_from_meta();
```

2. In an incognito browser add a product to your cart.
3. On the checkout page choose to create an account.
4. Complete the checkout.
5. Go to the **My Account > Payment methods** page.
6. If you don't have a saved token, create one.
7. View the customer in your Stripe dashboard and confirm the token is saved.

<p align="center">
<img width="765" alt="Screenshot 2024-08-29 at 2 45 54 PM" src="https://github.com/user-attachments/assets/55e04384-c561-4e05-9408-ff675ace7ed2">
</br>
</p> 

8. Search for the user you created in the Users list table in your WP dashboard.
9. Delete the user you created.
10. View the Stripe Dashboard:
   - On `trunk` you'll notice that the token wasn't deleted.
   - On this branch the token should be deleted.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
