### PR TITLE
Use custom order IDs in create intent request

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Fix - Address QIT Security test errors.
 * Fix - Address QIT PHPStan test errors.
 * Update - Specify the JS Stripe API version as 2024-06-20.
+* Tweak - Use order ID from 'get_order_number' in stripe intent metadata.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 
 = 8.6.1 - 2024-08-09 =

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1729,7 +1729,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'customer_name'  => $name,
 			'customer_email' => $email,
 			'site_url'       => esc_url( get_site_url() ),
-			'order_id'       => $order->get_id(),
+			'order_id'       => $order->get_order_number(),
 			'order_key'      => $order->get_order_key(),
 			'payment_type'   => $payment_type,
 		];

--- a/readme.txt
+++ b/readme.txt
@@ -151,6 +151,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Address QIT Security test errors.
 * Fix - Address QIT PHPStan test errors.
 * Update - Specify the JS Stripe API version as 2024-06-20.
+* Tweak - Use order ID from 'get_order_number' in stripe intent metadata.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3397 

Custom order IDs are ignored in the create intent request when the new checkout experience is enabled. 
This error does not happen in the legacy checkout experience because in the legacy experience [get_order_number](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L484) method is used in the metadata ( which is hooked to the `woocommerce_order_number` filter). 

## Changes proposed in this Pull Request:
In this PR, we are using the `get_order_number` instead of `get_id` for in the metadata of create intent request. 

## Testing instructions

1. Install any plugin for custom order IDs (e.g [Custom Order Numbers for WooCommerce](https://wordpress.org/plugins/custom-order-numbers-for-woocommerce/) which is used by the reporter)
2. Update the plugin's settings installed in the previous step to use custom order IDs. ( I have used `#Test -` prefix in my test below)
3. In your Stripe settings page enable the new checkout experience.
4. Enabled logs for the Stripe plugin.
5. Now as a shopper, add a product to your card and complete the checkout with a credit card.
6. Go to **WooCommerce > Status > Logs** and open the log file which includes the recent order logs.
7. Find the log for payment_intents request. 
8. In `develop` notice the metadata field. Notice that it is sending the actual database order ID instead of the custom pre-fixed order ID.

<img width="868" alt="Screenshot 2024-08-30 at 4 44 04 PM" src="https://github.com/user-attachments/assets/0aa3b7ca-288d-4702-ba69-b67df9ccb722">

9. Now checkout to this branch and as a shopper purchase a product again.
10. Find the log for `payment_intents request` for this order. 
11. Notice that now it is sending the custom pre-fixed order ID in the meta data.

<img width="868" alt="Screenshot 2024-08-30 at 4 45 34 PM" src="https://github.com/user-attachments/assets/8022cd75-cb92-4510-8539-02ff10fe89c3">
