### PR TITLE
Support custom name and description for Afterpay

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.
 * Fix - Fix Indian subscription processing by forcing the recreation of mandates during switches (upgrading/downgrading).
 * Fix - Add back support for Stripe Link autofill for shortcode checkout.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
@@ -78,24 +78,6 @@ class WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay extends WC_Stripe_UPE_Payme
 	}
 
 	/**
-	 * Return the gateway's description.
-	 *
-	 * @return string
-	 */
-	public function get_description( $payment_details = false ) {
-		if ( $this->is_gb_country() ) {
-			return __(
-				'Allow customers to pay over time with Clearpay.',
-				'woocommerce-gateway-stripe'
-			);
-		}
-		return __(
-			'Allow customers to pay over time with Afterpay.',
-			'woocommerce-gateway-stripe'
-		);
-	}
-
-	/**
 	 * Returns payment method icon.
 	 *
 	 * @return string|null

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
@@ -70,9 +70,11 @@ class WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay extends WC_Stripe_UPE_Payme
 	 */
 	public function get_title( $payment_details = false ) {
 		if ( $this->is_gb_country() ) {
-			return __( 'Clearpay', 'woocommerce-gateway-stripe' );
+			$this->title = __( 'Clearpay', 'woocommerce-gateway-stripe' );
 		}
-		return __( 'Afterpay', 'woocommerce-gateway-stripe' );
+		$this->title = __( 'Afterpay', 'woocommerce-gateway-stripe' );
+
+		return parent::get_title( $payment_details );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
@@ -71,8 +71,9 @@ class WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay extends WC_Stripe_UPE_Payme
 	public function get_title( $payment_details = false ) {
 		if ( $this->is_gb_country() ) {
 			$this->title = __( 'Clearpay', 'woocommerce-gateway-stripe' );
+		} else {
+			$this->title = __( 'Afterpay', 'woocommerce-gateway-stripe' );
 		}
-		$this->title = __( 'Afterpay', 'woocommerce-gateway-stripe' );
 
 		return parent::get_title( $payment_details );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.
 * Fix - Fix Indian subscription processing by forcing the recreation of mandates during switches (upgrading/downgrading).
 * Fix - Add back support for Stripe Link autofill for shortcode checkout.

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -615,6 +615,59 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_payment_methods_support_custom_name_and_description() {
+		$card_method              = $this->mock_payment_methods['card'];
+		$klarna_method            = $this->mock_payment_methods['klarna'];
+		$afterpay_clearpay_method = $this->mock_payment_methods['afterpay_clearpay'];
+		$affirm_method            = $this->mock_payment_methods['affirm'];
+		$p24_method               = $this->mock_payment_methods['p24'];
+		$eps_method               = $this->mock_payment_methods['eps'];
+		$sepa_method              = $this->mock_payment_methods['sepa_debit'];
+		$sofort_method            = $this->mock_payment_methods['sofort'];
+		$bancontact_method        = $this->mock_payment_methods['bancontact'];
+		$ideal_method             = $this->mock_payment_methods['ideal'];
+		$boleto_method            = $this->mock_payment_methods['boleto'];
+		$multibanco_method        = $this->mock_payment_methods['multibanco'];
+		$oxxo_method              = $this->mock_payment_methods['oxxo'];
+		$wechat_pay_method        = $this->mock_payment_methods['wechat_pay'];
+
+		$payment_method_ids = [
+			'card',
+			'klarna',
+			'afterpay_clearpay',
+			'affirm',
+			'p24',
+			'eps',
+			'sepa_debit',
+			'sofort',
+			'bancontact',
+			'ideal',
+			'boleto',
+			'multibanco',
+			'oxxo',
+			'wechat_pay',
+		];
+
+		foreach ( $payment_method_ids as $payment_method_id ) {
+			$payment_method = $this->mock_payment_methods[ $payment_method_id ];
+
+			// Update the payment method settings to have a custom name and description.
+			$original_payment_settings = get_option( 'woocommerce_stripe_' . $payment_method_id . '_settings', [] );
+			$updated_payment_settings = $original_payment_settings;
+			$custom_name = 'Custom Name for ' . $payment_method_id;
+			$custom_description = 'Custom description for ' . $payment_method_id;
+			$updated_payment_settings['title'] = $custom_name;
+			$updated_payment_settings['description'] = $custom_description;
+			update_option( 'woocommerce_stripe_' . $payment_method_id . '_settings', $updated_payment_settings );
+
+			$this->assertEquals( $custom_name, $payment_method->get_title() );
+			$this->assertEquals( $custom_description, $payment_method->get_description() );
+
+			// Restore original settings.
+			update_option( 'woocommerce_stripe_' . $payment_method_id . '_settings', $original_payment_settings );
+		}
+	}
+
 	/**
 	 * Test the type of payment token created for the user.
 	 */

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-method.php
@@ -616,21 +616,6 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	}
 
 	public function test_payment_methods_support_custom_name_and_description() {
-		$card_method              = $this->mock_payment_methods['card'];
-		$klarna_method            = $this->mock_payment_methods['klarna'];
-		$afterpay_clearpay_method = $this->mock_payment_methods['afterpay_clearpay'];
-		$affirm_method            = $this->mock_payment_methods['affirm'];
-		$p24_method               = $this->mock_payment_methods['p24'];
-		$eps_method               = $this->mock_payment_methods['eps'];
-		$sepa_method              = $this->mock_payment_methods['sepa_debit'];
-		$sofort_method            = $this->mock_payment_methods['sofort'];
-		$bancontact_method        = $this->mock_payment_methods['bancontact'];
-		$ideal_method             = $this->mock_payment_methods['ideal'];
-		$boleto_method            = $this->mock_payment_methods['boleto'];
-		$multibanco_method        = $this->mock_payment_methods['multibanco'];
-		$oxxo_method              = $this->mock_payment_methods['oxxo'];
-		$wechat_pay_method        = $this->mock_payment_methods['wechat_pay'];
-
 		$payment_method_ids = [
 			'card',
 			'klarna',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3391 

## Changes proposed in this Pull Request:
If the merchant provides a custom name and/or description for Afterpay, we want this to be shown in the checkout page instead of the default name and description. This is consistent with how other Stripe payment methods behave.

- Tweak the `get_title()` method override to inherit parent method behavior that takes custom  name into account.
- Delete the `get_description()` method override, as the default description is no longer needed, per https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3282.
- Added unit test

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Enable Afterpay: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
2. As a shopper, add a product to cart and go to checkout.
3. Verify that the Afterpaymethod displays the default name (i.e. "Clearpay" in GB, "Afterpay" everywhere else)
4. Verify that there is no description displayed.
5. Go back to the Stripe payment methods page, click "Customize" and add a custom name and description for Afterpay: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
6. Go back to the checkout page and verify you can see the custom name. Select Afterpay to expand it and see the custom description.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

Screenshot 1: Afterpay supporting custom name and description
<img width="771" alt="Screenshot 2024-08-30 at 12 21 27 PM" src="https://github.com/user-attachments/assets/3f067e2a-42f6-45d4-9ee2-b36b77eea400">

