### PR TITLE
Add title, description and gatewayId for express payment methods

### DIFF
--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -17,7 +17,8 @@ const paymentRequestPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
 	title: 'Stripe',
 	description: __(
-		'This will show users the ApplePay, GooglePay, or Stripe Link button depending on their browser and logged in status.'
+		'This will show users the ApplePay, GooglePay, or Stripe Link button depending on their browser and logged in status.',
+		'woocommerce-gateway-stripe'
 	),
 	gatewayId: 'stripe',
 	content: <PaymentRequestExpress stripe={ componentStripePromise } />,

--- a/client/blocks/payment-request/index.js
+++ b/client/blocks/payment-request/index.js
@@ -1,4 +1,5 @@
 import { getSetting } from '@woocommerce/settings';
+import { __ } from '@wordpress/i18n';
 import { PAYMENT_METHOD_NAME } from './constants';
 import { PaymentRequestExpress } from './payment-request-express';
 import { applePayImage } from './apple-pay-preview';
@@ -14,6 +15,11 @@ const componentStripePromise = loadStripe();
 
 const paymentRequestPaymentMethod = {
 	name: PAYMENT_METHOD_NAME,
+	title: 'Stripe',
+	description: __(
+		'This will show users the ApplePay, GooglePay, or Stripe Link button depending on their browser and logged in status.'
+	),
+	gatewayId: 'stripe',
 	content: <PaymentRequestExpress stripe={ componentStripePromise } />,
 	edit: <ApplePayPreview />,
 	canMakePayment: ( cartData ) => {


### PR DESCRIPTION
This PR ads `title`, `description` and `gatewayId` props to express payment methods to be displayed in the editor. These are used to display the available express payment methods to a merchant, once they click on the express checkout block.

This is parallel work with https://github.com/woocommerce/woocommerce/pull/50791 and the `feature/express-payment-improvements` branch should be used to test. However this should also work with the current release of WC, and can be safely merged and released before the work in Core is released.

If these props are no provided, the `name` is used instead and the list will look like this:

![Screenshot 2024-09-04 at 11 21 33](https://github.com/user-attachments/assets/36e3e1f5-a6f7-4679-a9af-e5dc41d3afde)

After this PR, the list should look like this:

![Screenshot 2024-09-04 at 11 20 13](https://github.com/user-attachments/assets/f3f43f30-f85e-405b-bdc8-b268fe96e095)


The link for the Stripe payment method should take you to the Stripe settings.


#### Testing instructions

1. Visit the checkout page in the editor
2. Click on the express payment block
3. See on the right hand sidebar that the list of Express Payment methods shows, and that the Stripe method have a title, description and the link goes to the Stripe settings page.
4. Smoke test with current WC version and make sure the express method still works as expected.

-------------------
-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
