### PR TITLE
Fix cashapp color description

### DIFF
--- a/client/styles/upe/__tests__/index.js
+++ b/client/styles/upe/__tests__/index.js
@@ -168,7 +168,7 @@ describe( 'Getting styles for automated theming', () => {
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
 				},
 				'.Text--redirect': {
-					color: 'rgb(109, 109, 109)',
+					color: 'rgb(0,0,0)',
 					fontFamily:
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
 				},


### PR DESCRIPTION
This fix that the cashapp payment method description is white and not visible

https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3416

Fixes #

Just edited the css

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
before:
![brave_ERaTPHF7op](https://github.com/user-attachments/assets/6ae02201-7a2a-487b-bd4b-e54db24fa5b8)
after:
![image](https://github.com/user-attachments/assets/1f467826-8a92-44d8-ad94-2cd6fc610fe2)


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
