### PR TITLE
Prevent duplicate failed order emails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.
 * Fix - Fix Indian subscription processing by forcing the recreation of mandates during switches (upgrading/downgrading).

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -624,7 +624,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param int $order_id
 	 * @param array $status_update Optional. Use fields 'to' and 'from' to provide context
 	 *    when a status change has occurred for the order.
-	 * @return null
+	 * @return void
 	 */
 	public function send_failed_order_email( $order_id, $status_update = [] ) {
 		$emails = WC()->mailer()->get_emails();

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -636,8 +636,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		// To prevent duplicate failed order emails, check if a status update
 		// will trigger its own failed order email.
 		if (
-			isset( $status_update['to'] ) &&
-			isset( $status_update['from'] ) &&
+			isset( $status_update['to'], $status_update['from'] ) &&
 			'failed' === $status_update['to'] &&
 			in_array( $status_update['from'], [ 'on-hold', 'pending' ], true )
 		) {

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -622,13 +622,33 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @since 3.1.0
 	 * @version 4.0.0
 	 * @param int $order_id
+	 * @param array $status_update Optional. Use fields 'to' and 'from' to provide context
+	 *    when a status change has occurred for the order.
 	 * @return null
 	 */
-	public function send_failed_order_email( $order_id ) {
+	public function send_failed_order_email( $order_id, $status_update = [] ) {
 		$emails = WC()->mailer()->get_emails();
-		if ( ! empty( $emails ) && ! empty( $order_id ) && isset( $emails['WC_Email_Failed_Order'] ) ) {
-			$emails['WC_Email_Failed_Order']->trigger( $order_id );
+
+		if ( empty( $emails ) || empty( $order_id ) || ! isset( $emails['WC_Email_Failed_Order'] ) ) {
+			return;
 		}
+
+		// To prevent duplicate failed order emails, check if a status update
+		// will trigger its own failed order email.
+		if (
+			isset( $status_update['to'] ) &&
+			isset( $status_update['from'] ) &&
+			'failed' === $status_update['to'] &&
+			in_array( $status_update['from'], [ 'on-hold', 'pending' ], true )
+		) {
+			$callback  = [ $emails['WC_Email_Failed_Order'], 'trigger' ];
+			$hook_name = "woocommerce_order_status_{$status_update['from']}_to_failed_notification";
+			if ( has_action( $hook_name, $callback ) ) {
+				return;
+			}
+		}
+
+		$emails['WC_Email_Failed_Order']->trigger( $order_id );
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -69,17 +69,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		WC_Stripe_Webhook_State::get_monitoring_began_at();
 
 		add_action( $this->deferred_webhook_action, [ $this, 'process_deferred_webhook' ], 10, 2 );
-
-		// For testing only
-		// TODO Remove before merging!
-		add_action(
-			'woocommerce_email_sent',
-			function( $result, $id, $email ) {
-				error_log( 'Email sent: ' . $email->get_heading() );
-			},
-			10,
-			3
-		);
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1134,7 +1134,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return bool
 	 */
 	private function has_failed_order_email_hooks( $status ) {
-		$callback = [ 'WC_Failed_Order_Email', 'trigger' ];
+		$callback = [ 'WC_Email_Failed_Order', 'trigger' ];
 
 		if ( 'pending' === $status ) {
 			return has_action(

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1142,18 +1142,19 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Check if setting an order to failed will trigger a failed order email.
 	 *
 	 * @param string $status The status of the order prior to setting it to failed.
+	 * @return bool
 	 */
 	private function has_failed_order_email_hooks( $status ) {
 		$callback = [ 'WC_Failed_Order_Email', 'trigger' ];
 
-		if ( 'pending' == $status ) {
+		if ( 'pending' === $status ) {
 			return has_action(
 				'woocommerce_order_status_pending_to_failed_notification',
 				$callback
 			);
 		}
 
-		if ( 'on-hold' == $status ) {
+		if ( 'on-hold' === $status ) {
 			return has_action(
 				'woocommerce_order_status_on-hold_to_failed_notification',
 				$callback

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.
 * Fix - Fix Indian subscription processing by forcing the recreation of mandates during switches (upgrading/downgrading).


### PR DESCRIPTION
When an order changes status from pending/on-hold to failed, [a failed-order email is triggered in core](https://github.com/woocommerce/woocommerce/blob/0f2fa403f1ad0dc26bdd82ec3e901cb1794201e6/plugins/woocommerce/includes/emails/class-wc-email-failed-order.php#L40). In our Stripe webhooks code, we also manually trigger these emails when certain processes fail, e.g. `payment_intent.payment_failed`. This causes duplicate emails for some scenarios.

<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1229

## Changes proposed in this Pull Request:
Before manually triggering a failed-order email, we first check if the status change to `failed` will not trigger its own email send.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Stripe webhooks need to be set up and working:
    - Use a tunneling service like ngrok or Jurassic Tube, -or-
    - Test these changes on publicly accessible servers
2. Install the WP Mail Logging plugin: https://wordpress.org/plugins/wp-mail-logging/
4. As a shopper, add a product to cart and go to checkout.
5. Use `4000 0084 0000 1629` as the credit card number, with any expiry date and CVC.
    - This should trigger 3D Secure 2 authentication, but payment will eventually fail. 
    - Click "Complete" to authenticate. 
    - You should see the error banner above the payment element, with a message like `Your card has been declined.`
6. Go to the WP Mail Logging dashboard: `wp-admin/admin.php?page=wpml_plugin_log`
7. You should see a failed order email, with the subject `Order #XY has failed`.
    - You should see only one failed order email.
    - Note: customers re-attempting and again failing will trigger another failed order email. This is expected.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
