### PR TITLE
Fix wrong iso code for UK for Alipay and WeChat

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Tweak - Use order ID from 'get_order_number' in stripe intent metadata.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 * Fix - Address Klarna availability based on correct presentment currency rules.
+* Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/client/utils/use-payment-method-currencies.js
+++ b/client/utils/use-payment-method-currencies.js
@@ -32,7 +32,7 @@ const getAliPayCurrencies = ( isUpeEnabled ) => {
 		case 'CA':
 			upeCurrencies = [ 'CAD', 'CNY' ];
 			break;
-		case 'UK':
+		case 'GB':
 			upeCurrencies = [ 'GBP', 'CNY' ];
 			break;
 		case 'HK':
@@ -124,7 +124,7 @@ const getWechatPayCurrencies = () => {
 		case 'SG':
 			upeCurrencies = [ 'SGD', 'CNY' ];
 			break;
-		case 'UK':
+		case 'GB':
 			upeCurrencies = [ 'GBP', 'CNY' ];
 			break;
 		case 'US':

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-alipay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-alipay.php
@@ -59,7 +59,7 @@ class WC_Stripe_UPE_Payment_Method_Alipay extends WC_Stripe_UPE_Payment_Method {
 			case 'CA':
 				$currency = [ 'CAD', 'CNY' ];
 				break;
-			case 'UK':
+			case 'GB':
 				$currency = [ 'GBP', 'CNY' ];
 				break;
 			case 'HK':

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-wechat-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-wechat-pay.php
@@ -18,7 +18,7 @@ class WC_Stripe_UPE_Payment_Method_Wechat_Pay extends WC_Stripe_UPE_Payment_Meth
 		$this->stripe_id            = self::STRIPE_ID;
 		$this->title                = __( 'WeChat Pay', 'woocommerce-gateway-stripe' );
 		$this->is_reusable          = false;
-		$this->supported_countries  = [ 'AT', 'AU', 'BE', 'CA', 'CH', 'DE', 'DK', 'ES', 'FI', 'FR', 'HK', 'IE', 'IT', 'JP', 'LU', 'NL', 'NO', 'PT', 'SE', 'SG', 'UK', 'US' ];
+		$this->supported_countries  = [ 'AT', 'AU', 'BE', 'CA', 'CH', 'DE', 'DK', 'ES', 'FI', 'FR', 'HK', 'IE', 'IT', 'JP', 'LU', 'NL', 'NO', 'PT', 'SE', 'SG', 'GB', 'US' ];
 		$this->supported_currencies = [
 			'AUD',
 			'CAD',
@@ -81,7 +81,7 @@ class WC_Stripe_UPE_Payment_Method_Wechat_Pay extends WC_Stripe_UPE_Payment_Meth
 			case 'SG':
 				$currency = [ 'SGD', 'CNY' ];
 				break;
-			case 'UK':
+			case 'GB':
 				$currency = [ 'GBP', 'CNY' ];
 				break;
 			case 'US':

--- a/readme.txt
+++ b/readme.txt
@@ -154,5 +154,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Use order ID from 'get_order_number' in stripe intent metadata.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 * Fix - Address Klarna availability based on correct presentment currency rules.
+* Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
The ISO code for the United Kingdom is wrongly set as 'UK' for AliPay and WeChat. 

## Changes proposed in this Pull Request:
- Used the correct iso code 'GB' for United Kingdom.

## Testing instructions
- Connect to a UK Stripe account.
- Set your store currency to USD.
- Go to the Stripe settings page and check the payment method list.
- In `develop` branch notice that
    - WeChat is not on the list.
    - AliPay is available on the list. it has the currency requirement pill but when you click on the currency requirement notice, it only mentions CNY.
- Set store currency to GBP.
    - WeChat is still not on the list.
    - AliPay is available on the list. it still has the currency requirement pill that mentions CNY.

<img width="809" alt="Screenshot 2024-09-05 at 1 14 57 AM" src="https://github.com/user-attachments/assets/4afb3cf9-775b-490a-a152-9d8582281acc">

- Now check this branch.
- Set your store currency to USD.
    - AliPay and WeChat are present in the list. They have the currency requirement pill mentioning both CNY and GBP.

<img width="809" alt="Screenshot 2024-09-05 at 1 05 27 AM" src="https://github.com/user-attachments/assets/120f2232-5acc-434a-9f83-c27a014eef9d">

- Set store currency to GBP.
    - AliPay and WeChat are present in the list without any currency requirement pill.

<img width="809" alt="Screenshot 2024-09-05 at 1 06 09 AM" src="https://github.com/user-attachments/assets/ed3b136d-360e-455f-88d4-2779b52b53a5">
