### PR TITLE
Fix duplicate emails and order notes when processing setup intent requests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Tweak - Use order ID from 'get_order_number' in stripe intent metadata.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 * Fix - Address Klarna availability based on correct presentment currency rules.
+* Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -795,11 +795,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$this->update_saved_payment_method( $payment_method_id, $order );
 			}
 
+			// Lock the order before we create and confirm the payment/setup intents to prevent Stripe sending the success webhook before this request is completed.
+			$this->lock_order_payment( $order );
+
 			if ( $payment_needed ) {
 				// Throw an exception if the minimum order amount isn't met.
 				$this->validate_minimum_order_amount( $order );
 
-				$this->lock_order_payment( $order );
 				// Create a payment intent, or update an existing one associated with the order.
 				$payment_intent = $this->process_payment_intent_for_order( $order, $payment_information );
 			} else {

--- a/readme.txt
+++ b/readme.txt
@@ -155,5 +155,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 * Fix - Address Klarna availability based on correct presentment currency rules.
 * Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
+* Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3414 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3331 (shipped in 6.6.1) we added `lock_order_payment()` and `unlock_order_payment()` to the start and end of our `process_payment_with_deferred_intent()` function to fix an issue with duplicate order notes and order emails being sent.

Because the `lock_order_payment()` was only added inside the `$payment_needed` condition, the bug was unfortunately still present for our setup intent requests (i.e. Subscriptions with no initial payment).

To fix this, I've moved the lock to be outside of the `$payment_needed` condition but still before the payment and setup intents are created/confirmed. This will cause our webhook handler to exit early ([code ref](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/88fc09add69f71ad1ca4c8b3dfccc3d2d5385211/includes/class-wc-stripe-webhook-handler.php#L1002-L1004)) while the order is locked and let `process_payment_with_deferred_intent()` finish processing the payment and marking the order as processing/completed.

To help visualise the issue, here's a very rough timeline of how the duplicate customer emails & order notes issue occurs:

```
Timeline A: Checkout Process                             Timeline B: Webhook handling
------------------------------------------------         ------------------------------------------------
1. Customer purchases trial subscription product         1. -
------------------------------------------------         ------------------------------------------------
2. process_payment_with_deferred_intent() is called      2. - 
------------------------------------------------         ------------------------------------------------
3. We fetch an instance of $order which is "pending"     3. - 
------------------------------------------------         ------------------------------------------------
4. Send request to create and confirm setup intent       4. Stripe sends the `setup_intent.succeeded` webhook
------------------------------------------------         ------------------------------------------------
5. Save the new intent to the order                      5. Order is fetched by intent ID and still has pending status.
------------------------------------------------         ------------------------------------------------
6. Save the payment method                               6. Check if order payment is locked
------------------------------------------------         ------------------------------------------------
7. Calls $order->payment_complete()                      7. Calls $order->payment_complete()
------------------------------------------------         ------------------------------------------------
8. Order status transitions from pending to processing   8. Order status transitions from pending to processing
------------------------------------------------         ------------------------------------------------
```

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

> [!IMPORTANT]
> To replicate this issue you need to have the `setup_intent.succeeded` webhook processed at the same time that `process_payment_with_deferred_intent()` is still processing the payment for the current order.
>
> Specifically, we want the order to still have a "pending" status when an instance is fetched in our webhook handling code.
>
> Since we cannot easily control when Stripe sends the webhook, I was able to consistently replicate this by adding a `sleep(2);` just before `$order->payment_complete();` in our `process_payment_with_deferred_intent()` ([here in the code](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/88fc09add69f71ad1ca4c8b3dfccc3d2d5385211/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L909))
>
> **How does this happen?**
> It's hard to pin-point exactly how this would happen however, Stripe controls when the webhooks are sent and there's a lot of processing between sending our intent requests -> receiving the response -> completing the payment/checkout process.
>
> This means if there's any unexpected lag or delays (i.e. slow DB reads, slow API request, slow third party code), it could cause both the webhook handling and process payment functions to have a pending order and try to mark it as completed at the same time, resulting in duplicate emails and order notes.

1. Activate the latest Woo Subscriptions and create a subscription product with free trial
2. Enable the cards payment method and new checkout experience.
3. Make sure webhooks are setup correctly so that your test site is receiving them (I use ngrok)
4. Enable customer emails and if using a local site, activate something like WP Mail Logging plugin to easily test emails. 
5. Add a free trial subscription to your cart
6. While on `develop` complete the checkout using the standard `4242424242424242` card
7. On completion, view the Edit Order admin page and confirm there's duplicate order notes ![image](https://github.com/user-attachments/assets/603ec27a-130c-4ac4-b11e-ccb415b46a2a)
9. Open WP Mail Logging and confirm that two emails for the same order ID were sent a few seconds apart: ![image](https://github.com/user-attachments/assets/8e9e554a-c8e4-441a-be91-81f36a0be4e9)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
