### PR TITLE
Add an admin notice for SEPA subscriptions migrations after disabling legacy checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Tweak - Use order ID from 'get_order_number' in stripe intent metadata.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 * Fix - Address Klarna availability based on correct presentment currency rules.
+* Add - Display an admin notice on the WooCommerce > Subscriptions screen for tracking the progress of SEPA subscriptions migrations after the legacy checkout is disabled.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@
 * Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 * Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
 * Add - Display an admin notice on the WooCommerce > Subscriptions screen for tracking the progress of SEPA subscriptions migrations after the legacy checkout is disabled.
+* Add - Introduce a new tool on the WooCommerce > Status > Tools screen to restart the legacy SEPA subscriptions update.
 
 = 8.6.1 - 2024-08-09 =
 * Tweak - Improves the wording of the invalid Stripe keys errors, instructing merchants to click the "Configure connection" button instead of manually setting the keys.

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -455,6 +455,12 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		$settings = WC_Stripe_Helper::get_stripe_settings();
+
+		// If the new UPE is enabled, we need to remove the flag to ensure legacy SEPA tokens are updated flag.
+		if ( $is_upe_enabled && ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			delete_option( 'woocommerce_stripe_subscriptions_legacy_sepa_tokens_updated' );
+		}
+
 		$settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = $is_upe_enabled ? 'yes' : 'disabled';
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -330,7 +330,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 			'name'     => __( 'Stripe Legacy SEPA Token Update', 'woocommerce-gateway-stripe' ),
 			'desc'     => __( 'This will restart the legacy Stripe SEPA update process.', 'woocommerce-gateway-stripe' ),
 			'button'   => __( 'Restart SEPA token update', 'woocommerce-gateway-stripe' ),
-			'callback' => [ $this, 'restart_migration' ],
+			'callback' => [ $this, 'restart_update' ],
 		];
 
 		return $tools;
@@ -356,9 +356,10 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 	}
 
 	/**
-	 * Restarts the migration process.
+	 * Restarts the legacy token update process.
 	 */
-	public function restart_migration() {
+	public function restart_update() {
+		// Clear the option to allow the update to be scheduled again.
 		delete_option( 'woocommerce_stripe_subscriptions_legacy_sepa_tokens_updated' );
 
 		$this->maybe_update();

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -100,7 +100,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 	 *
 	 * Overrides the parent class function to make two changes:
 	 * 1. Don't schedule an action if one already exists.
-	 * 2. Schedules the migration to happen in one minute instead of in one hour.
+	 * 2. Schedules the migration to happen in two minutes instead of in one hour.
 	 * 3. Delete the transient which stores the progress of the repair.
 	 *
 	 * @param int $item The ID of the subscription to migrate.

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -237,7 +237,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		$notice = new WCS_Admin_Notice( 'notice notice-warning is-dismissible' );
 		$notice->set_html_content(
 			'<h4>' . esc_html__( 'SEPA subscription update in progress', 'woocommerce-gateway-stripe' ) . '</h4>' .
-			'<p>' . __( "We are currently updating customer subscriptions that use the legacy Stripe SEPA Direct Debit payment method. During this update, you may notice that some subscriptions appear as manual renewals. Don't worry—renewals should continue to process as normal. Please be aware this process may take some time.", 'woocommerce-gateway-stripe' ) . '</p>' .
+			'<p>' . __( "We are currently updating customer subscriptions that use the legacy Stripe SEPA Direct Debit payment method. During this update, you may notice that some subscriptions appear as manual renewals. Don't worry—renewals will continue to process as normal. Please be aware this process may take some time.", 'woocommerce-gateway-stripe' ) . '</p>' .
 			'<p>' . $progress . '</p>'
 		);
 

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -212,15 +212,14 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 			delete_transient( $this->display_notice_transient );
 		}
 
-		$is_still_scheduling_jobs = (bool) as_next_scheduled_action( $this->scheduled_hook );
-		$action_progress          = $this->get_scheduled_action_counts();
+		$action_progress = $this->get_scheduled_action_counts();
 
 		if ( ! $action_progress ) {
 			return;
 		}
 
 		// If we're still in the process of scheduling jobs, show a note to the user.
-		if ( $is_still_scheduling_jobs ) {
+		if ( (bool) as_next_scheduled_action( $this->scheduled_hook ) ) {
 			// translators: %1$s: <strong> tag, %2$s: </strong> tag, %3$s: <i> tag. %4$s: </i> tag.
 			$progress = sprintf( __( '%1$sProgress: %2$s %3$sWe are still identifying all subscriptions that require updating.%4$s', 'woocommerce-gateway-stripe' ), '<strong>', '</strong>', '<i>', '</i>' );
 		} else {

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -125,7 +125,6 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 				'return'         => 'ids',
 				'type'           => 'shop_subscription',
 				'posts_per_page' => 20,
-				'paged'          => $page,
 				'status'         => 'any',
 				'paged'          => $page,
 				'payment_method' => WC_Gateway_Stripe_Sepa::ID,

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -174,7 +174,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 			[
 				'return'         => 'ids',
 				'type'           => 'shop_subscription',
-				'limit'          => 1,
+				'status'         => 'any',
+				'posts_per_page' => 1,
 				'payment_method' => WC_Gateway_Stripe_Sepa::ID,
 			]
 		);

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -198,6 +198,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 		);
 
 		if ( empty( $subscriptions ) ) {
+			delete_transient( $this->display_notice_transient );
 			return;
 		}
 

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -105,7 +105,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 	 */
 	protected function update_item( $item ) {
 		if ( ! as_next_scheduled_action( $this->repair_hook, [ 'repair_object' => $item ] ) ) {
-			as_schedule_single_action( gmdate( 'U' ) + MINUTE_IN_SECONDS, $this->repair_hook, [ 'repair_object' => $item ] );
+			as_schedule_single_action( gmdate( 'U' ) + ( 2 * MINUTE_IN_SECONDS ), $this->repair_hook, [ 'repair_object' => $item ] );
 		}
 
 		unset( $this->items_to_repair[ $item ] );

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -222,7 +222,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 			delete_transient( $this->display_notice_transient );
 		}
 
-		$is_still_scheduling_jobs = is_numeric( as_next_scheduled_action( $this->scheduled_hook ) );
+		$is_still_scheduling_jobs = (bool) as_next_scheduled_action( $this->scheduled_hook );
 		$action_progress          = $this->get_scheduled_action_counts();
 
 		if ( ! $action_progress ) {

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -305,15 +305,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends WCS_Background
 			return '-';
 		}
 
-		// If the next scheduled action is within the next 3 hours, display the time diff.
-		if ( $next_scheduled_time <= $current_time + ( 3 * HOUR_IN_SECONDS ) ) {
-			// translators: %s: human-readable time diff (eg "in 2 hours").
-			return sprintf( _x( 'in %s', 'next scheduled action time', 'woocommerce-gateway-stripe' ), human_time_diff( $current_time, $next_scheduled_time ) );
-		}
-
-		$datetime = new WC_DateTime( "@{$next_scheduled_time}" );
-		$datetime->set_utc_offset( wc_timezone_offset() );
-
-		return $datetime->date_i18n( wc_date_format() . ' ' . wc_time_format() );
+		// translators: %s: human-readable time diff (eg "in 2 hours").
+		return sprintf( _x( 'in %s', 'next scheduled action time', 'woocommerce-gateway-stripe' ), human_time_diff( $current_time, $next_scheduled_time ) );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -154,5 +154,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Tweak - Use order ID from 'get_order_number' in stripe intent metadata.
 * Fix - Ensure payment tokens are detached from Stripe when a user is deleted, regardless of if the admin user has a Stripe account.
 * Fix - Address Klarna availability based on correct presentment currency rules.
+* Add - Display an admin notice on the WooCommerce > Subscriptions screen for tracking the progress of SEPA subscriptions migrations after the legacy checkout is disabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -158,5 +158,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Use correct ISO country code of United Kingdom in supported country and currency list of AliPay and WeChat.
 * Fix - Prevent duplicate order notes and emails being sent when purchasing subscription products with no initial payment.
 * Add - Display an admin notice on the WooCommerce > Subscriptions screen for tracking the progress of SEPA subscriptions migrations after the legacy checkout is disabled.
+* Add - Introduce a new tool on the WooCommerce > Status > Tools screen to restart the legacy SEPA subscriptions update.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3363 

## Changes proposed in this Pull Request:

This PR adds an admin notice to the WooCommerce > Subscriptions screen if the store has unmigrated Sepa subscriptions after disabling the legacy checkout. 

<p align="center">
<img width="1987" alt="Screenshot 2024-09-06 at 12 41 23 PM" src="https://github.com/user-attachments/assets/a6f950df-a107-47c1-bd54-0fd26fdc1961">
</p> 

This notice is to better communicate the situation where a merchant deactivates the legacy checkout, notice their subscriptions have been converted to manual renewal and then contact us or worse, re-enable the legacy checkout.

Given the way this migration occurs, there's usually a period (1 hour) after the merchant has deactivate the legacy mode that their subscriptions will appear as manual. 

## Testing instructions

There are 3 states this notice can take: 

**INITIAL NOTICE**

1. Run the follow code snippet to mimic you're store having legacy SEPA subscriptions. 
 

```php 
delete_option( 'woocommerce_stripe_subscriptions_legacy_sepa_tokens_updated' );
delete_transient( 'wc_stripe_legacy_sepa_tokens_repair_progress' );

// Replace the following subscription IDs with ones on your store. 
foreach ( [9043,9040,9037,9020,8919,8914,8912] as $subscription_id ) { 
    $subscription = wcs_get_subscription( $subscription_id );
    
    $subscription->set_payment_method( WC_Gateway_Stripe_Sepa::ID );
    $subscription->save();
}
```

2. Make sure legacy checkout experience is disabled. 
3. Go to the **WooCommerce → Subscriptions screen**
4. You should see the notice with no progress information. 

<img width="2390" alt="Screenshot 2024-09-06 at 11 22 55 AM" src="https://github.com/user-attachments/assets/d4fd4403-7161-4fa5-ae9e-9588936bafa8">

This notice is shown between the time when the merchant has deactivated the legacy experience but it hasn't started generating actions. **Expected uptime:** 1 minute after deactivating legacy checkout. 

**NEXT UPDATE NOTICE**

1. Wait 1 minute for the initial job to run and for it to start scheduling individual actions.
2. Refresh the page. 
3. You will now see a notice explaining that the next expected update will occur in ~1 hour.
 
<img width="2375" alt="Screenshot 2024-09-05 at 6 42 34 PM" src="https://github.com/user-attachments/assets/7f7a3b85-a87e-41c2-8df9-21b427bc77e8">

4. If you keep refreshing the page, it will keep updating. 

This notice is shown after the merchant disables the legacy checkout experience and before the individual actions start processing. **Expected uptime:** 1 hour after deactivating legacy checkout. 

**PROGRESS NOTICE**

1. Wait the hour for the individual actions to start running or run them manually.
   - To run them manually search the **Tools → Scheduled Actions** for `wc_stripe_subscriptions_legacy_sepa_token_repair`. 
3. Once the jobs start running, you will see a different notice that includes a progress. 

<img width="2382" alt="Screenshot 2024-09-06 at 12 37 33 PM" src="https://github.com/user-attachments/assets/0ed1fc89-f26b-402c-aec8-4e386f15b119">

This notice will be shown from when the first individual action is completed until all actions are completed (ie no pending). **Expected uptime:** 🤷‍♂️ this will depend on how many subscriptions there are to migrate. In my case if I let the actions run naturally via the AS queue, this notice isn't shown at all because all 4-5 actions are processed at once.  

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
