### PR TITLE
Fix missing error message in Express Payments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.

--- a/client/blocks/payment-request/event-handlers.js
+++ b/client/blocks/payment-request/event-handlers.js
@@ -177,7 +177,7 @@ const performPayment = ( stripe, evt, setExpressPaymentError ) => (
 		// to extract the actual message from the notice.
 		const div = document.createElement( 'div' );
 		div.innerHTML = createOrderResponse.messages;
-		const errorMessage = div?.firstChild?.textContent ?? '';
+		const errorMessage = div?.firstElementChild?.textContent ?? '';
 
 		setExpressPaymentError( errorMessage );
 	}

--- a/client/blocks/payment-request/event-handlers.js
+++ b/client/blocks/payment-request/event-handlers.js
@@ -173,7 +173,7 @@ const performPayment = ( stripe, evt, setExpressPaymentError ) => (
 	} else {
 		evt.complete( 'fail' );
 
-		// WooCommerce returns a messege embedded in a notice via HTML here, so we need
+		// WooCommerce returns a message embedded in a notice via HTML here, so we need
 		// to extract the actual message from the notice.
 		const div = document.createElement( 'div' );
 		div.innerHTML = createOrderResponse.messages;

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.7.0 - xxxx-xx-xx =
+* Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

When the shopper is using Express Payment, e.g. GooglePay, and the order creation fails due to account creation errors, the error message is not displayed. (see Screenshots 1 and 2)

The empty error message is caused by `firstChild` returning a text node (i.e. `\n`) when retrieving the error message from WooCommerce. To fix this, we use `firstElementChild` to ensure we get the first Element node.

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2430 

## Changes proposed in this Pull Request:
- Use `firstElementChild` when retrieving the error message from WooCommerce, to ensure we get an `Element` node.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

(As the merchant, on any browser)
1. Enable Apple Pay/Google Pay: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
2. Disable guest checkout, but allow customers to create an account during checkout and on the My Accounts page (See Screenshot 4): `wp-admin/admin.php?page=wc-settings&tab=account`

(As the shopper, on a Chrome browser)
1. Add a product to your cart and go to checkout.
2. Make sure you can see the Google Pay button in the checkout page:
   - You need to be running on a publicly accessible server, or you need to have local tunneling setup (e.g. ngrok, Jurassic Tube)
   - In the same browser, you need to be logged in to a Google Pay account that has a payment method added: pay.google.com
   - To avoid accidental charges on your real cards, join the Google Pay API Test Cards allowlist, using the same Google account for your shopper's Google Pay: https://groups.google.com/g/googlepay-test-mode-stub-data
3. On a separate tab, register your Google Pay email address with the store, using the "My account" page in `/my-account`. You may skip this if your email is already registered.
4. **Important: log out**. If you do not see the "Log out" link, refresh the "My account" page.
5. Go back to checkout, and click the Google Pay button. A modal with fake test data (test credit cards and billing info) should pop up. (See Screenshot 1)
6. Click "Pay".
7. You should get a generic message at the bottom saying "There was an error processing your order."
7. Close the modal.
8. You should see a red box above the Google Pay button, with an error message saying, "An account is already registered with your email address. Please log in."


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->
## Screenshots

**Screenshot 1: Google Pay modal with generic error.**
<img width="1360" alt="Screenshot 2024-09-06 at 12 24 47 PM" src="https://github.com/user-attachments/assets/03c5c961-fa1c-4b38-8182-392330f86031">

^-^-^-^-^-^-^-^-^
**Screenshot 2: After dismissing the Google Pay modal, we see the error box with an empty message.**
<img width="879" alt="Screenshot 2024-09-06 at 12 13 25 PM" src="https://github.com/user-attachments/assets/51a0cfa6-5b28-49c9-b691-94062551520e">

^-^-^-^-^-^-^-^-^
**Screenshot 3: Fixed error box**
<img width="879" alt="Screenshot 2024-09-06 at 12 12 50 PM" src="https://github.com/user-attachments/assets/e6371449-5674-4e3b-9df5-c1509b5bc8c3">

^-^-^-^-^-^-^-^-^
**Screenshot 4: Account settings setup for the store**
<img width="707" alt="Screenshot 2024-09-06 at 1 29 59 PM" src="https://github.com/user-attachments/assets/e74e0f27-8cee-42a9-9ced-8ce86b873a16">


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
