### PR TITLE
Fix address fields mapping for Google Pay and UAE addresses

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,11 +2,11 @@
 
 = 8.8.0 - xxxx-xx-xx =
 * Fix - Fix Google Pay address fields mapping for UAE addresses.
+* Fix - Fix empty error message for Express Payments when order creation fails.
 * Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint.
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.7.0 - xxxx-xx-xx =
-* Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** Changelog ***
 
 = 8.8.0 - xxxx-xx-xx =
-* Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint. 
+* Fix - Fix Google Pay address fields mapping for UAE addresses.
+* Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint.
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.7.0 - xxxx-xx-xx =

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1693,6 +1693,8 @@ class WC_Stripe_Payment_Request {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
 		}
 
+		$this->fix_address_fields_mapping();
+
 		// Normalizes billing and shipping state values.
 		$this->normalize_state();
 
@@ -2065,5 +2067,37 @@ class WC_Stripe_Payment_Request {
 		}
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_shipping_methods );
+	}
+
+	/**
+	 * Performs special mapping for address fields for specific contexts.
+	 */
+	private function fix_address_fields_mapping() {
+		$billing_country  = ! empty( $_POST['billing_country'] ) ? wc_clean( wp_unslash( $_POST['billing_country'] ) ) : '';
+		$shipping_country = ! empty( $_POST['shipping_country'] ) ? wc_clean( wp_unslash( $_POST['shipping_country'] ) ) : '';
+
+		// For UAE, Google Pay stores the emirate in "region", which gets mapped to the "state" field,
+		// but WooCommerce expects it in the "city" field.
+		if ( 'AE' === $billing_country ) {
+			$billing_state = ! empty( $_POST['billing_state'] ) ? wc_clean( wp_unslash( $_POST['billing_state'] ) ) : '';
+			$billing_city  = ! empty( $_POST['billing_city'] ) ? wc_clean( wp_unslash( $_POST['billing_city'] ) ) : '';
+
+			// Move the state (emirate) to the city field.
+			if ( empty( $billing_city ) && ! empty( $billing_state ) ) {
+				$_POST['billing_city']  = $billing_state;
+				$_POST['billing_state'] = '';
+			}
+		}
+
+		if ( 'AE' === $shipping_country ) {
+			$shipping_state = ! empty( $_POST['shipping_state'] ) ? wc_clean( wp_unslash( $_POST['shipping_state'] ) ) : '';
+			$shipping_city  = ! empty( $_POST['shipping_city'] ) ? wc_clean( wp_unslash( $_POST['shipping_city'] ) ) : '';
+
+			// Move the state (emirate) to the city field.
+			if ( empty( $shipping_city ) && ! empty( $shipping_state ) ) {
+				$_POST['shipping_city']  = $shipping_state;
+				$_POST['shipping_state'] = '';
+			}
+		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -130,11 +130,11 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 = 8.8.0 - xxxx-xx-xx =
 * Fix - Fix Google Pay address fields mapping for UAE addresses.
+* Fix - Fix empty error message for Express Payments when order creation fails.
 * Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint.
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.7.0 - xxxx-xx-xx =
-* Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.
 * Fix - Link APM charge IDs in Order Details page to their Stripe dashboard payments page.

--- a/readme.txt
+++ b/readme.txt
@@ -129,7 +129,8 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.8.0 - xxxx-xx-xx =
-* Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint. 
+* Fix - Fix Google Pay address fields mapping for UAE addresses.
+* Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint.
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.7.0 - xxxx-xx-xx =


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3430 

## Changes proposed in this Pull Request:
When using Google Pay with a UAE shipping address, we get the error `Shipping Town / City is a required field.` on checkout. This is because Google Pay stores the emirate in "region", [which gets mapped to the "state" field](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7108f35a2aaebce59914f5dacc3bfe01dab2c1a9/client/blocks/normalize.js#L75) in WooCommerce. For UAE, WooCommerce [expects the emirate to be stored in the "city" field](https://github.com/woocommerce/woocommerce/blob/d87c3d38d72c12469f1bf9c35364d77076a93e66/plugins/woocommerce/includes/class-wc-countries.php#L856).

This PR adds an address field mapping step on the checkout form data if the shipping or billing country is UAE. The approach is similar to [a corrective step that we do for Apple Pay and HK](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7108f35a2aaebce59914f5dacc3bfe01dab2c1a9/includes/payment-methods/class-wc-stripe-payment-request.php#L1492).

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Add a UAE address in your Google Pay account: https://payments.google.com/gp/w/u/0/home/addressbook
   - For example: PO Box 12345, Abu Dhabi, United Arab Emirates
2. Make sure you are NOT in the Google Pay API Test Cards allowlist: https://groups.google.com/g/googlepay-test-mode-stub-data
   - If you are in the allowlist Google group, you will have access to the test address data set only, which does not include UAE.
3. Make sure test mode is enabled in Stripe, to avoid actual charges: `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
4. As a shopper, add a product to your cart, and go to checkout.
   - **Important**: Make sure the shipping and biling form fields are clear. If they are pre-populated (due to autofill), clear them out first. Reason: We have added behavior in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2886 to pull in data from the checkout form for required fields. If you have been testing with a different address that has a city, this may get pulled in.
7. Click the "Buy with Google Pay" button to open the modal.
8. Make sure to choose the UAE address as the shipping address.
9. Click Pay.
10. Before fix: Notice the payment fails with the error "Shipping Town / City is a required field."
11. Fixed: Your order should succeed. Verify that it shows the correct shipping address.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

**Before: Checkout fails because the "city" field is empty.**
<img width="500" alt="Screenshot 2024-09-10 at 3 52 12 PM" src="https://github.com/user-attachments/assets/57e6ae09-ef9f-4595-981c-d06f8e2d7b2b">


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
