### PR TITLE
UPE banner for APM enabled merchants

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.7.0 - xxxx-xx-xx =
+* Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.
 * Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.

--- a/client/settings/payment-settings/__tests__/promotional-banner-section.test.js
+++ b/client/settings/payment-settings/__tests__/promotional-banner-section.test.js
@@ -3,11 +3,17 @@ import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PromotionalBannerSection from '../promotional-banner-section';
+import { useEnabledPaymentMethodIds } from 'wcstripe/data';
 
 jest.mock( '@wordpress/data' );
 
 jest.mock( 'wcstripe/data/account', () => ( {
 	useAccount: jest.fn(),
+} ) );
+
+jest.mock( 'wcstripe/data', () => ( {
+	useEnabledPaymentMethodIds: jest.fn().mockReturnValue( [ [ 'card' ] ] ),
+	useTestMode: jest.fn().mockReturnValue( [ false ] ),
 } ) );
 
 const noticesDispatch = {
@@ -66,6 +72,21 @@ describe( 'PromotionalBanner', () => {
 		);
 		expect(
 			screen.queryByTestId( 're-connect-account-banner' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'Display the APM version of the new checkout experience promotional surface when any APM is enabled', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [ [ 'card', 'ideal' ] ] );
+
+		render(
+			<PromotionalBannerSection
+				setShowPromotionalBanner={ setShowPromotionalBanner }
+				isConnectedViaOAuth={ true }
+			/>
+		);
+
+		expect(
+			screen.queryByTestId( 'new-checkout-apms-banner' )
 		).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -8,7 +8,7 @@ import bannerIllustration from './banner-illustration.svg';
 import bannerIllustrationReConnect from './banner-illustration-re-connect.svg';
 import Pill from 'wcstripe/components/pill';
 import { recordEvent } from 'wcstripe/tracking';
-import { useTestMode } from 'wcstripe/data';
+import { useEnabledPaymentMethodIds, useTestMode } from 'wcstripe/data';
 
 const NewPill = styled( Pill )`
 	border-color: #674399;
@@ -66,7 +66,12 @@ const PromotionalBannerSection = ( {
 		'core/notices'
 	);
 	const [ isTestModeEnabled ] = useTestMode();
-	const [ hasAPMEnabled, hasAPMOrder ] = [ false, false ];
+	const [ enabledPaymentMethodIds ] = useEnabledPaymentMethodIds();
+	const hasAPMEnabled =
+		[ ...enabledPaymentMethodIds ].splice(
+			[ ...enabledPaymentMethodIds ].indexOf( 'card' ),
+			1
+		).length > 0;
 
 	const handleButtonClick = () => {
 		const callback = async () => {
@@ -268,7 +273,7 @@ const PromotionalBannerSection = ( {
 	if ( isConnectedViaOAuth === false ) {
 		BannerContent = <ReConnectAccountBanner />;
 	} else if ( ! isUpeEnabled ) {
-		if ( hasAPMEnabled && hasAPMOrder ) {
+		if ( hasAPMEnabled ) {
 			BannerContent = <NewCheckoutExperienceAPMsBanner />;
 		} else {
 			BannerContent = <NewCheckoutExperienceBanner />;

--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -1,8 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { useDispatch } from '@wordpress/data';
 import { React } from 'react';
-import { Card, Button } from '@wordpress/components';
+import { Card, Button, ExternalLink } from '@wordpress/components';
 import styled from '@emotion/styled';
+import interpolateComponents from 'interpolate-components';
 import CardBody from '../card-body';
 import bannerIllustration from './banner-illustration.svg';
 import bannerIllustrationReConnect from './banner-illustration-re-connect.svg';
@@ -171,15 +172,22 @@ const PromotionalBannerSection = ( {
 					</NewPill>
 					<h4>
 						{ __(
-							'Boost sales and checkout conversion',
+							'Enable new Stripe checkout to continue accepting non-card payments',
 							'woocommerce-gateway-stripe'
 						) }
 					</h4>
 					<p>
-						{ __(
-							'Disable the legacy checkout to boost sales, increase order value, and reach new customers with Klarna, Afterpay, Affirm, Link and many others APMs, a one-click checkout.',
-							'woocommerce-gateway-stripe'
-						) }
+						{ interpolateComponents( {
+							mixedString: __(
+								'Stripe will end support for non-card payment methods in the {{StripeLegacyLink}}legacy checkout on October 29, 2024{{/StripeLegacyLink}}. To continue accepting non-card payments, you must enable the new checkout experience or remove non-card payment methods from your checkout to avoid payment disruptions.',
+								'woocommerce-gateway-stripe'
+							),
+							components: {
+								StripeLegacyLink: (
+									<ExternalLink href="https://support.stripe.com/topics/shutdown-of-the-legacy-sources-api-for-non-card-payment-methods" />
+								),
+							},
+						} ) }
 					</p>
 				</CardColumn>
 				<CardColumn>
@@ -199,7 +207,7 @@ const PromotionalBannerSection = ( {
 					onClick={ handleButtonClick }
 				>
 					{ __(
-						'Disable the legacy checkout',
+						'Enable the new checkout',
 						'woocommerce-gateway-stripe'
 					) }
 				</MainCTALink>

--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -68,10 +68,7 @@ const PromotionalBannerSection = ( {
 	const [ isTestModeEnabled ] = useTestMode();
 	const [ enabledPaymentMethodIds ] = useEnabledPaymentMethodIds();
 	const hasAPMEnabled =
-		[ ...enabledPaymentMethodIds ].splice(
-			[ ...enabledPaymentMethodIds ].indexOf( 'card' ),
-			1
-		).length > 0;
+		enabledPaymentMethodIds.filter( ( e ) => e !== 'card' ).length > 0;
 
 	const handleButtonClick = () => {
 		const callback = async () => {
@@ -166,7 +163,7 @@ const PromotionalBannerSection = ( {
 	);
 
 	const NewCheckoutExperienceAPMsBanner = () => (
-		<CardBody>
+		<CardBody data-testid="new-checkout-apms-banner">
 			<CardInner>
 				<CardColumn>
 					<NewPill>

--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -172,7 +172,7 @@ const PromotionalBannerSection = ( {
 					</NewPill>
 					<h4>
 						{ __(
-							'Enable new Stripe checkout to continue accepting non-card payments',
+							'Enable the new Stripe checkout to continue accepting non-card payments',
 							'woocommerce-gateway-stripe'
 						) }
 					</h4>

--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -66,6 +66,7 @@ const PromotionalBannerSection = ( {
 		'core/notices'
 	);
 	const [ isTestModeEnabled ] = useTestMode();
+	const [ hasAPMEnabled, hasAPMOrder ] = [ false, false ];
 
 	const handleButtonClick = () => {
 		const callback = async () => {
@@ -159,6 +160,58 @@ const PromotionalBannerSection = ( {
 		</CardBody>
 	);
 
+	const NewCheckoutExperienceAPMsBanner = () => (
+		<CardBody>
+			<CardInner>
+				<CardColumn>
+					<NewPill>
+						{ __( 'New', 'woocommerce-gateway-stripe' ) }
+					</NewPill>
+					<h4>
+						{ __(
+							'Boost sales and checkout conversion',
+							'woocommerce-gateway-stripe'
+						) }
+					</h4>
+					<p>
+						{ __(
+							'Enable the new checkout to boost sales, increase order value, and reach new customers with Klarna, Afterpay, Affirm and Link, a one-click checkout.',
+							'woocommerce-gateway-stripe'
+						) }
+					</p>
+				</CardColumn>
+				<CardColumn>
+					<BannerIllustration
+						src={ bannerIllustration }
+						alt={ __(
+							'New Checkout',
+							'woocommerce-gateway-stripe'
+						) }
+					/>
+				</CardColumn>
+			</CardInner>
+			<ButtonsRow>
+				<MainCTALink
+					variant="secondary"
+					data-testid="enable-the-new-checkout"
+					onClick={ handleButtonClick }
+				>
+					{ __(
+						'Enable the new checkout',
+						'woocommerce-gateway-stripe'
+					) }
+				</MainCTALink>
+				<DismissButton
+					variant="secondary"
+					onClick={ handleBannerDismiss }
+					data-testid="dismiss"
+				>
+					{ __( 'Dismiss', 'woocommerce-gateway-stripe' ) }
+				</DismissButton>
+			</ButtonsRow>
+		</CardBody>
+	);
+
 	const NewCheckoutExperienceBanner = () => (
 		<CardBody>
 			<CardInner>
@@ -215,7 +268,11 @@ const PromotionalBannerSection = ( {
 	if ( isConnectedViaOAuth === false ) {
 		BannerContent = <ReConnectAccountBanner />;
 	} else if ( ! isUpeEnabled ) {
-		BannerContent = <NewCheckoutExperienceBanner />;
+		if ( hasAPMEnabled && hasAPMOrder ) {
+			BannerContent = <NewCheckoutExperienceAPMsBanner />;
+		} else {
+			BannerContent = <NewCheckoutExperienceBanner />;
+		}
 	}
 
 	return (

--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -180,7 +180,7 @@ const PromotionalBannerSection = ( {
 					</h4>
 					<p>
 						{ __(
-							'Enable the new checkout to boost sales, increase order value, and reach new customers with Klarna, Afterpay, Affirm and Link, a one-click checkout.',
+							'Disable the legacy checkout to boost sales, increase order value, and reach new customers with Klarna, Afterpay, Affirm, Link and many others APMs, a one-click checkout.',
 							'woocommerce-gateway-stripe'
 						) }
 					</p>
@@ -198,11 +198,11 @@ const PromotionalBannerSection = ( {
 			<ButtonsRow>
 				<MainCTALink
 					variant="secondary"
-					data-testid="enable-the-new-checkout"
+					data-testid="disable-the-legacy-checkout"
 					onClick={ handleButtonClick }
 				>
 					{ __(
-						'Enable the new checkout',
+						'Disable the legacy checkout',
 						'woocommerce-gateway-stripe'
 					) }
 				</MainCTALink>

--- a/readme.txt
+++ b/readme.txt
@@ -133,6 +133,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.
 
 = 8.7.0 - xxxx-xx-xx =
+* Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.
 * Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Prevent duplicate failed-order emails from being sent.
 * Fix - Support custom name and description for Afterpay.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3434

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR introduces a new promotional surface to promote the new checkout experience for merchants with any APMs enabled. Preview for the current version:
![Screenshot 2024-09-12 at 10 59 29](https://github.com/user-attachments/assets/235efcaa-e4a3-4f32-92e0-4303ccedb871)

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Apply this branch to your environment (`add/upe-banner-for-apm-enabled-merchants`)
- Connect your Stripe account
- Enable the legacy checkout experience
- Enable any APMs (any other payment method than Credit Card) on `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`
- Confirm that you are able to see the new promotional surface on `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods` and `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
