### PR TITLE
Fix mandate creation for subscriptions and saved payment methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Fix mandate creation for subscriptions and saved payment methods.
 * Tweak - Render the Klarna payment page in the store locale.
 * Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint.
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -925,7 +925,7 @@ class WC_Stripe_Intent_Controller {
 			$request['return_url'] = $payment_information['return_url'];
 		}
 
-		if ( $payment_information['save_payment_method_to_store'] ) {
+		if ( $payment_information['save_payment_method_to_store'] || ! empty( $payment_information['has_subscription'] ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2046,6 +2046,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'token'                         => $token,
 			'return_url'                    => $this->get_return_url_for_redirect( $order, $save_payment_method_to_store ),
 			'use_stripe_sdk'                => 'true', // We want to use the SDK to handle next actions via the client payment elements. See https://docs.stripe.com/api/setup_intents/create#create_setup_intent-use_stripe_sdk
+			'has_subscription'              => $this->has_subscription( $order->get_id() ),
 		];
 
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Fix mandate creation for subscriptions and saved payment methods.
 * Tweak - Render the Klarna payment page in the store locale.
 * Tweak - Update the Apple Pay domain registration flow to use the new Stripe API endpoint.
 * Fix - Resolve an error for checkout block where 'wc_stripe_upe_params' is undefined due to the script registering the variable not being loaded yet.


### PR DESCRIPTION
When purchasing subscriptions, we want to set `setup_future_usage` to `off_session`. We are already doing this when the user is not using saved payment methods [1, 2]. We want this same behavior even when using saved cards.

[1] We set `setup_future_usage` to `off_session` [when `save_payment_to_store` is `true`](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7f20b587b53f7cd822e7b186608943588a73ef9e/includes/class-wc-stripe-intent-controller.php#L929). 
[2]`save_payment_to_store` is [set to `true` when the order has subscriptions](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7f20b587b53f7cd822e7b186608943588a73ef9e/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L2142). However, this field is [set to `false` when the payment is already saved](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7f20b587b53f7cd822e7b186608943588a73ef9e/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L2137).
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3393 

## Changes proposed in this Pull Request:
We want `setup_future_usage` to be `off_session` regardless of whether or not `save_payment_to_store` is true if the order has a subscription. In this PR, we introduce a payment information field `has_subscription` that will be used when building the intent creation request. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Follow the "To Reproduce" instructions in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3393, to set up your store to use saved payment methods, Indian recurring payment cards and purchase subscriptions.
2. Verify that the `_stripe_mandate_id` meta is set when using a _saved_ payment method.
3. Verify that the `_stripe_mandate_id` meta is set when using a _new_ payment method.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
