### PR TITLE
Persisting the dispute status when closed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.8.0 - xxxx-xx-xx =
+* Add - Introduce a new meta data that persists the status of a dispute.
 * Fix - Fix mandate creation for subscriptions and saved payment methods.
 * Fix - Fix Google Pay address fields mapping for UAE addresses.
 * Tweak - Render the Klarna payment page in the store locale.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -384,6 +384,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			// Mark final so that order status is not overridden by out-of-sequence events.
 			$order->update_meta_data( '_stripe_status_final', true );
 
+			// Mark the dispute status.
+			$order->update_meta_data( 'dispute_status', $status );
+
 			// Fail order if dispute is lost, or else revert to pre-dispute status.
 			$order_status = 'lost' === $status ? 'failed' : $this->get_stripe_order_status_before_hold( $order );
 			$order->update_status( $order_status, $message );
@@ -583,7 +586,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund( $notification ) {
 		$refund_object = $this->get_refund_object( $notification );
-		$order = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
@@ -598,11 +601,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id = $order->get_id();
 
 		if ( 'stripe' === substr( (string) $order->get_payment_method(), 0, 6 ) ) {
-			$charge        = $order->get_transaction_id();
-			$captured      = $order->get_meta( '_stripe_charge_captured' );
-			$refund_id     = $order->get_meta( '_stripe_refund_id' );
-			$currency      = $order->get_currency();
-			$raw_amount    = $refund_object->amount;
+			$charge     = $order->get_transaction_id();
+			$captured   = $order->get_meta( '_stripe_charge_captured' );
+			$refund_id  = $order->get_meta( '_stripe_refund_id' );
+			$currency   = $order->get_currency();
+			$raw_amount = $refund_object->amount;
 
 			if ( ! in_array( strtolower( $currency ), WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
 				$raw_amount /= 100;

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -385,7 +385,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$order->update_meta_data( '_stripe_status_final', true );
 
 			// Mark the dispute status.
-			$order->update_meta_data( 'dispute_status', $status );
+			$order->update_meta_data( '_dispute_closed_status', $status );
 
 			// Fail order if dispute is lost, or else revert to pre-dispute status.
 			$order_status = 'lost' === $status ? 'failed' : $this->get_stripe_order_status_before_hold( $order );

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.8.0 - xxxx-xx-xx =
+* Add - Introduce a new meta data that persists the status of a dispute.
 * Fix - Fix mandate creation for subscriptions and saved payment methods.
 * Fix - Fix Google Pay address fields mapping for UAE addresses.
 * Tweak - Render the Klarna payment page in the store locale.

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -21,10 +21,10 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * Mock card payment intent template.
 	 */
 	const MOCK_PAYMENT_INTENT = [
-		'id'                 => 'pi_mock',
-		'object'             => 'payment_intent',
-		'status'             => 'succeeded',
-		'charges'            => [
+		'id'      => 'pi_mock',
+		'object'  => 'payment_intent',
+		'status'  => 'succeeded',
+		'charges' => [
 			'total_count' => 1,
 			'data'        => [
 				[
@@ -96,7 +96,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 
 		// No payment intent.
-		$order = WC_Helper_Order::create_order();
+		$order            = WC_Helper_Order::create_order();
 		$data['order_id'] = $order->get_id();
 
 		$this->expectExceptionMessage( "Missing required data. 'intent_id' is missing for the deferred 'payment_intent.succeeded' event." );
@@ -110,7 +110,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order     = WC_Helper_Order::create_order();
 		$intent_id = 'pi_mock_1234';
 		$data      = [
-			'order_id' => $order->get_id(),
+			'order_id'  => $order->get_id(),
 			'intent_id' => $intent_id,
 		];
 
@@ -134,7 +134,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_mismatch_intent_id_process_deferred_webhook() {
 		$order = WC_Helper_Order::create_order();
 		$data  = [
-			'order_id' => $order->get_id(),
+			'order_id'  => $order->get_id(),
 			'intent_id' => 'pi_wrong_id',
 		];
 
@@ -168,7 +168,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_process_of_successful_payment_intent_deferred_webhook() {
 		$order = WC_Helper_Order::create_order();
 		$data  = [
-			'order_id' => $order->get_id(),
+			'order_id'  => $order->get_id(),
 			'intent_id' => self::MOCK_PAYMENT_INTENT['id'],
 		];
 
@@ -197,5 +197,92 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			);
 
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
+	}
+
+	/**
+	 * Test for `process_webhook_dispute_closed`
+	 *
+	 * @param string $charge_id       Charge ID.
+	 * @param string $dispute_status  Dispute status.
+	 * @param array  $expected_metas   Expected order metas.
+	 * @param string $expected_status Expected order status.
+	 * @return void
+	 * @dataProvider provide_test_process_webhook_dispute_closed
+	 * @throws WC_Data_Exception When order creation fails.
+	 */
+	public function test_process_webhook_dispute_closed( $charge_id, $dispute_status, $expected_metas, $expected_status ) {
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( $charge_id );
+		$order->update_meta_data( '_stripe_status_before_hold', 'completed' );
+		$order->save();
+
+		$notification = (object) [
+			'data' => (object) [
+				'object' => (object) [
+					'charge' => $charge_id,
+					'status' => $dispute_status,
+				],
+			],
+		];
+
+		$this->mock_webhook_handler->process_webhook_dispute_closed( $notification );
+
+		// Reload the order.
+		$order = wc_get_order( $order->get_id() );
+
+		foreach ( $expected_metas as $meta_key => $meta_value ) {
+			$this->assertSame( $meta_value, get_post_meta( $order->get_id(), $meta_key, true ) );
+		}
+
+		$this->assertSame( $expected_status, $order->get_status() );
+	}
+
+	/**
+	 * Provider for `test_process_webhook_dispute_closed`
+	 *
+	 * @return array
+	 */
+	public function provide_test_process_webhook_dispute_closed() {
+		return [
+			'order not found' => [
+				'charge id'       => '',
+				'dispute status'  => '',
+				'expected metas'  => [],
+				'expected status' => 'pending',
+			],
+			'dispute lost'    => [
+				'charge id'       => '123',
+				'dispute status'  => 'lost',
+				'expected metas'  => [
+					'_stripe_status_final'   => '1',
+					'_dispute_closed_status' => 'lost',
+				],
+				'expected status' => 'failed',
+			],
+			'dispute won'     => [
+				'charge id'       => '123',
+				'dispute status'  => 'won',
+				'expected metas'  => [
+					'_stripe_status_final'   => '1',
+					'_dispute_closed_status' => 'won',
+				],
+				'expected status' => 'completed',
+			],
+			'inquiry closed'  => [
+				'charge id'       => '123',
+				'dispute status'  => 'warning_closed',
+				'expected metas'  => [
+					'_stripe_status_final'   => '1',
+					'_dispute_closed_status' => 'warning_closed',
+				],
+				'expected status' => 'completed',
+			],
+			'unknown status'  => [
+				'charge id'       => '123',
+				'dispute status'  => 'unknown',
+				'expected metas'  => [],
+				'expected status' => 'pending',
+			],
+		];
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes 4465-gh-woocommerce/woocommerce-subscriptions

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR introduces a new meta that will persist the status of a dispute after it is closed. This will be useful for adequately changing a subscription status (as in the issue that raised this PR).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Code review should be enough. Check if the tests are still passing. I have introduced specific tests for this change.

You can also test the dispute flow (a bit hard) and check if the new meta is present on the affected order.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
