### PR TITLE
Improves Stripes compatibility with Pre-Orders when paying for pre-orders from the pay-for-order page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Fix multiple issues related to the reuse of Cash App Pay tokens (as a saved payment method) when subscribing.
 * Fix - Corrected translation text domain in UPE checkout integration.
+* Fix - Pre-orders set to pay upon release were remaining pending when attempting to pay using Stripe.
 
 = 8.7.0 - 2024-09-16 =
 * Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.

--- a/includes/compat/trait-wc-stripe-pre-orders.php
+++ b/includes/compat/trait-wc-stripe-pre-orders.php
@@ -68,6 +68,18 @@ trait WC_Stripe_Pre_Orders_Trait {
 	}
 
 	/**
+	 * Returns true if the pre-order completed.
+	 *
+	 * @since 8.8.0
+	 *
+	 * @param  int $order_id
+	 * @return bool
+	 */
+	public function is_pre_order_completed( $order_id ) {
+		return $this->is_pre_orders_enabled() && class_exists( 'WC_Pre_Orders_Order' ) && 'completed' === WC_Pre_Orders_Order::get_pre_order_status( $order_id );
+	}
+
+	/**
 	 * Returns boolean on whether current cart contains a pre-order item.
 	 *
 	 * @since 5.8.0

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Fix empty error message for Express Payments when order creation fails.
 * Fix - Fix multiple issues related to the reuse of Cash App Pay tokens (as a saved payment method) when subscribing.
 * Fix - Corrected translation text domain in UPE checkout integration.
+* Fix - Pre-orders set to pay upon release were remaining pending when attempting to pay using Stripe.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3455

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When a pre-order product set to pay upon-release is purchased using the Pay Later payment method, upon release/completion, the order is marked as pending payment and an "Pre-Order available" email is sent to the customer with a link to pay for the pre-order.

![image](https://github.com/user-attachments/assets/cdc38e6f-b565-4e62-8430-1aa812508786)

Clicking on this pay-for-order link (or going through the My Account > Orders > Pay flow) and attempting to complete payment using Stripe results in no charge being taken and the order remaining `pending` :x: 

> [!NOTE]
> This issue only impacts stores with Legacy checkout **disabled**.

While digging into this problem, I found the issue was coming from our `is_payment_needed()` function incorrectly returning `false`, however, I would've expected it to return `true` as I need to pay for the pre-order that had just been released/completed.

This is because the logic inside `is_payment_needed()` didn't support paying for upon release pre-orders via the Pay for Order page and only supported pre-orders with an upfront cost.

To fix this issue, this PR:
1. Introduces a new `is_pre_order_completed()` helper to determine the status of the pre-order. (`completed` meaning the pre-order has been released)
2. Refactor `is_payment_needed()` to allow upon-release pre-orders purchased with Pay Later to be paid for using Stripe.

While testing my changes, I also discovered a different issue where paying for a "charge upfront pre-order" using a declining card (`4000000000000002`) and then going to My Account > Orders and attempting to pay for it using Stripe, wasn't charging the customer, but the order was going to pre-ordered (active/started) status.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Have the Pre Orders extension activated and disable the Stripe Legacy checkout feature
2. Go to **WooCommerce > Settings > Payment methods** and enable the Pay Later payment method
3. Create a pre-order product with a release in 1+ days and set to charge upon release.![image](https://github.com/user-attachments/assets/fee782e4-6430-4349-bd3a-3b45a47c5408)
4. Purchase this pre-order product through the checkout using the Pay Later method
5. Go to **WooCommerce > Pre-orders > Actions > Complete** and manually mark your product as released: ![image](https://github.com/user-attachments/assets/31373e4b-386c-44bb-a0fd-542fd585db5c)
6. Using WP Mail Logging, open the "Pre-order is now available" email and click on the Pay link
7. Complete the order using Stripe
8. While on `develop` branch, the order will remain pending payment and the transaction will not appear in Stripe.
9. While on this branch, the should go to processing and the transaction appears in Stripe.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)