### PR TITLE
Move Stripe Link button to JS for shortcode checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
 *** Changelog ***
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.
 * Add - Add support for Stripe Express Checkout Element on the block cart and checkout page.
 * Add - Implemented the "Update all subscriptions payment methods" checkbox on My Account → Payment methods for UPE payment methods.
-* Add - Add support for the new Stripe Checkout Element on the shortcode checkout page. 
+* Add - Add support for the new Stripe Checkout Element on the shortcode checkout page.
 * Dev - Introduces a new class with payment methods constants.
 * Dev - Introduces a new class with currency codes constants.
 * Dev - Improves the readability of the redirect URL generation code (UPE).

--- a/client/blocks/upe/hooks.js
+++ b/client/blocks/upe/hooks.js
@@ -159,40 +159,6 @@ export const useStripeLink = ( api, elements, paymentMethodsConfig ) => {
 						customerData.billingAddress
 					);
 				},
-				show_button: ( linkAutofill ) => {
-					jQuery( '#email' )
-						.parent()
-						.append(
-							'<button class="stripe-gateway-stripelink-modal-trigger"></button>'
-						);
-					if ( jQuery( '#email' ).val() !== '' ) {
-						jQuery(
-							'.stripe-gateway-stripelink-modal-trigger'
-						).show();
-
-						const linkButtonTop =
-							jQuery( '#email' ).position().top +
-							( jQuery( '#email' ).outerHeight() - 40 ) / 2;
-						jQuery(
-							'.stripe-gateway-stripelink-modal-trigger'
-						).show();
-						jQuery(
-							'.stripe-gateway-stripelink-modal-trigger'
-						).css( 'top', linkButtonTop + 'px' );
-					}
-
-					//Handle StripeLink button click.
-					jQuery( '.stripe-gateway-stripelink-modal-trigger' ).on(
-						'click',
-						( event ) => {
-							event.preventDefault();
-							// Trigger modal.
-							linkAutofill.launch( {
-								email: jQuery( '#email' ).val(),
-							} );
-						}
-					);
-				},
 				complete_shipping: () => {
 					return (
 						document.getElementById( 'shipping-address_1' ) !== null

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -122,7 +122,7 @@ jQuery( function ( $ ) {
 		enableStripeLinkPaymentMethod( {
 			api,
 			elements,
-			emailId: 'billing_email_field',
+			emailId: 'billing_email',
 			complete_billing: () => {
 				return document.getElementById( 'billing_address_1' ) !== null;
 			},

--- a/client/stripe-link/index.js
+++ b/client/stripe-link/index.js
@@ -1,9 +1,16 @@
-const showLinkButton = ( linkAutofill ) => {
-	// Display StripeLink button if email field is prefilled.
-	if ( jQuery( '#billing_email' ).val() !== '' ) {
+const showLinkButton = ( emailId, linkAutofill ) => {
+	const emailSelector = '#' + emailId;
+	jQuery( emailSelector )
+		.parent()
+		.append(
+			'<button class="stripe-gateway-stripelink-modal-trigger"></button>'
+		);
+	if ( jQuery( emailSelector ).val() !== '' ) {
+		jQuery( '.stripe-gateway-stripelink-modal-trigger' ).show();
+
 		const linkButtonTop =
-			jQuery( '#billing_email' ).position().top +
-			( jQuery( '#billing_email' ).outerHeight() - 40 ) / 2;
+			jQuery( emailSelector ).position().top +
+			( jQuery( emailSelector ).outerHeight() - 40 ) / 2;
 		jQuery( '.stripe-gateway-stripelink-modal-trigger' ).show();
 		jQuery( '.stripe-gateway-stripelink-modal-trigger' ).css(
 			'top',
@@ -11,13 +18,15 @@ const showLinkButton = ( linkAutofill ) => {
 		);
 	}
 
-	// Handle StripeLink button click.
+	//Handle StripeLink button click.
 	jQuery( '.stripe-gateway-stripelink-modal-trigger' ).on(
 		'click',
 		( event ) => {
 			event.preventDefault();
 			// Trigger modal.
-			linkAutofill.launch( { email: jQuery( '#billing_email' ).val() } );
+			linkAutofill.launch( {
+				email: jQuery( emailSelector ).val(),
+			} );
 		}
 	);
 };
@@ -35,10 +44,7 @@ const enableStripeLinkPaymentMethod = ( options ) => {
 			linkAutofill.launch( { email: event.target.value } );
 		} );
 
-	const showButton = options.show_button
-		? options.show_button
-		: showLinkButton;
-	showButton( linkAutofill );
+	showLinkButton( options.emailId, linkAutofill );
 
 	linkAutofill.on( 'autofill', ( event ) => {
 		const { billingAddress, shippingAddress } = event.value;

--- a/readme.txt
+++ b/readme.txt
@@ -129,10 +129,11 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.
 * Add - Add support for Stripe Express Checkout Element on the block cart and checkout page.
 * Add - Implemented the "Update all subscriptions payment methods" checkbox on My Account → Payment methods for UPE payment methods.
-* Add - Add support for the new Stripe Checkout Element on the shortcode checkout page. 
+* Add - Add support for the new Stripe Checkout Element on the shortcode checkout page.
 * Dev - Introduces a new class with payment methods constants.
 * Dev - Introduces a new class with currency codes constants.
 * Dev - Improves the readability of the redirect URL generation code (UPE).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -750,10 +750,6 @@ function woocommerce_gateway_stripe() {
 
 					// Add extra `stripe-gateway-checkout-email-field` class.
 					$fields['billing_email']['class'][] = 'stripe-gateway-checkout-email-field';
-
-					// Append StripeLink modal trigger button for logged in users.
-					$fields['billing_email']['label'] = $fields['billing_email']['label']
-						. ' <button class="stripe-gateway-stripelink-modal-trigger"></button>';
 				}
 
 				return $fields;


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3099 

## Changes proposed in this Pull Request:
- Remove hardcoded `button` element inside the email label. This will fix the HTML code in error message, described in #3099 
- Consolidate code with block checkout, which uses JS to inject the Link button

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Setup**
1. Create a shortcode checkout page, i.e. `[woocommerce_checkout]`
2. Make sure Stripe Link is enabled as a payment method.
3. As a shopper, add a product to cart and go to Shortcode Checkout.
4. Verify that the Link button is present _when the email address is not empty_.
   - If the email address field is pre-populated, i.e. from your previous sessions, you should see the Link button in the field. See Screenshot 1.
   - If the email address field is empty, finagle things by going to Block Checkout first, entering an email address, and switching to Shortcode Checkout. This should force the email address field to be pre-populated.
5. Optional: Verify the Link button works.
   - If your test email address is registered with Stripe Link, clicking the Link button will trigger the OTP modal. You can enter anything for the OTP, e.g. `00000`. See Screenshot 2.
   - You can register a test email address by going through checkout, entering a test credit card number, and entering any phone number when the Link registration box appears. See Screenshot 3.


**Screenshots**

Screenshot 1: The Link button is displayed when the email address field is pre-filled.
<img width="504" alt="Screenshot 2024-09-25 at 4 52 30 PM" src="https://github.com/user-attachments/assets/85275e4a-5eec-46e2-8fd0-f14d58d1f94e">


Screenshot 2: The OTP modal pops up when the email address is registered with Stripe Link.
<img width="444" alt="Screenshot 2024-09-25 at 4 52 49 PM" src="https://github.com/user-attachments/assets/f2310378-0c3f-49de-9ddd-f73922555487">


Screenshot 3: When Link is enabled, the user is presented with an option to register.
<img width="375" alt="Screenshot 2024-09-25 at 4 46 19 PM" src="https://github.com/user-attachments/assets/ff3cdd0b-75fa-48e8-9e52-f90ed78b2f69">

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
