### PR TITLE
Enabling Link on the Express Shortcode Checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Fix the display and usage of the Link payment method on the shortcode checkout page with the Stripe Express Checkout Element.
 * Fix - Updates the display logic for the OAuth re-connect promotional surface to follow the latest changes made to the connection settings object.
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -20,7 +20,10 @@ import {
 	shippingAddressChangeHandler,
 	shippingRateChangeHandler,
 } from 'wcstripe/express-checkout/event-handler';
-import { getStripeServerData } from 'wcstripe/stripe-utils';
+import {
+	getPaymentMethodTypes,
+	getStripeServerData,
+} from 'wcstripe/stripe-utils';
 import { getAddToCartVariationParams } from 'wcstripe/utils';
 import './styles.scss';
 
@@ -140,6 +143,7 @@ jQuery( function ( $ ) {
 				currency: options.currency,
 				paymentMethodCreation: 'manual',
 				appearance: getExpressCheckoutButtonAppearance(),
+				paymentMethodTypes: getPaymentMethodTypes(),
 			} );
 
 			const eceButton = wcStripeECE.createButton(

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -8,6 +8,7 @@ import {
 	getExpressCheckoutButtonAppearance,
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
+	getExpressPaymentMethodTypes,
 	normalizeLineItems,
 } from 'wcstripe/express-checkout/utils';
 import {
@@ -20,10 +21,7 @@ import {
 	shippingAddressChangeHandler,
 	shippingRateChangeHandler,
 } from 'wcstripe/express-checkout/event-handler';
-import {
-	getPaymentMethodTypes,
-	getStripeServerData,
-} from 'wcstripe/stripe-utils';
+import { getStripeServerData } from 'wcstripe/stripe-utils';
 import { getAddToCartVariationParams } from 'wcstripe/utils';
 import './styles.scss';
 
@@ -143,7 +141,7 @@ jQuery( function ( $ ) {
 				currency: options.currency,
 				paymentMethodCreation: 'manual',
 				appearance: getExpressCheckoutButtonAppearance(),
-				paymentMethodTypes: getPaymentMethodTypes(),
+				paymentMethodTypes: getExpressPaymentMethodTypes(),
 			} );
 
 			const eceButton = wcStripeECE.createButton(

--- a/client/express-checkout/tracking.js
+++ b/client/express-checkout/tracking.js
@@ -6,6 +6,7 @@ export const trackExpressCheckoutButtonClick = ( paymentMethod, source ) => {
 	const expressPaymentTypeEvents = {
 		google_pay: 'gpay_button_click',
 		apple_pay: 'applepay_button_click',
+		link: 'link_button_click',
 	};
 
 	const event = expressPaymentTypeEvents[ paymentMethod ];
@@ -22,6 +23,7 @@ export const trackExpressCheckoutButtonLoad = debounce(
 		const expressPaymentTypeEvents = {
 			googlePay: 'gpay_button_load',
 			applePay: 'applepay_button_load',
+			link: 'link_button_load',
 		};
 
 		for ( const paymentMethod of paymentMethods ) {

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -130,7 +130,7 @@ export const getExpressCheckoutButtonStyleSettings = () => {
 		paymentMethods: {
 			applePay: 'always',
 			googlePay: 'always',
-			link: 'never',
+			link: 'auto',
 			paypal: 'never',
 			amazonPay: 'never',
 		},

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -1,5 +1,7 @@
 /* global wc_stripe_express_checkout_params */
 
+import { getPaymentMethodTypes } from 'wcstripe/stripe-utils';
+
 export * from './normalize';
 
 /**
@@ -250,3 +252,21 @@ const getRequiredFieldDataFromShortcodeCheckoutForm = ( data ) => {
 
 	return data;
 };
+
+/**
+ * Get array of payment method types to use with intent. Filtering out the method types not part of Express Checkout.
+ *
+ * @param {string} paymentMethodType Payment method type Stripe ID.
+ * @return {Array} Array of payment method types to use with intent, for Express Checkout.
+ */
+export const getExpressPaymentMethodTypes = ( paymentMethodType = null ) =>
+	getPaymentMethodTypes( paymentMethodType ).filter( ( type ) =>
+		[
+			'link',
+			'google_pay',
+			'apple_pay',
+			'paypal',
+			'amazon_pay',
+			'klarna',
+		].includes( type )
+	);

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Fix the display and usage of the Link payment method on the shortcode checkout page with the Stripe Express Checkout Element.
 * Fix - Updates the display logic for the OAuth re-connect promotional surface to follow the latest changes made to the connection settings object.
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3499

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR fixes the display and usage of the Link payment method when purchasing a product on the shortcode checkout with Express Checkout Element enabled.

The method was disabled by default (should be set to `auto` in `paymentMethods`), and in additional to that, it requires the `paymentMethodTypes` option to be provided.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout and build the `develop` branch on your test environment
- Connect your Stripe account
- Enable Link on your Stripe dashboard and the extension settings page (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`). Legacy checkout experience must be disabled
- Enable ECE. You can do it by hardcoding `is_stripe_ece_enabled` to `true`
- Create a shortcode checkout page
- As a shopper, add any product to your cart
- Go to the shortcode checkout page and confirm that Link is not available
- Checkout and build this branch instead (`add/enable-link-on-the-express-shortcode-checkout`)
- Repeat the purchase process
- Confirm that Link is available now and that you can complete a purchase with it
![Screenshot 2024-10-02 at 18 33 31](https://github.com/user-attachments/assets/451b1f53-4411-4f9c-8d80-d09abfc37271) 

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
