### PR TITLE
Set order payment method title to the customisable title setting rather than the label

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Fix - Resolve an issue where Stripe Payment Method API calls passed the token's database ID instead of the Stripe ID.
 * Fix - Pre-orders set to pay upon release were remaining pending when attempting to pay using Stripe.
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
+* Fix - Set order payment method title to the customizable title setting rather than the default label.
 
 = 8.7.0 - 2024-09-16 =
 * Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1618,7 +1618,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 		$payment_method       = $this->payment_methods[ $payment_method_type ];
-		$payment_method_title = $payment_method->get_label();
+		$payment_method_title = $payment_method->get_title();
 		$payment_method_id    = $payment_method instanceof WC_Stripe_UPE_Payment_Method_CC ? $this->id : $payment_method->id;
 
 		$order->set_payment_method( $payment_method_id );

--- a/readme.txt
+++ b/readme.txt
@@ -148,5 +148,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolve an issue where Stripe Payment Method API calls passed the token's database ID instead of the Stripe ID.
 * Fix - Pre-orders set to pay upon release were remaining pending when attempting to pay using Stripe.
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
+* Fix - Set order payment method title to the customizable title setting rather than the default label.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -2384,18 +2384,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	 * Test test_set_payment_method_title_for_order with custom title.
 	 */
 	public function test_set_payment_method_title_for_order_custom_title() {
-		// SET UP
-		$this->mock_gateway->expects( $this->exactly( 2 ) ) // 2 times because we test 2 payment methods.
-			->method( 'is_subscriptions_enabled' )
-			->willReturn( true );
-
 		$order = WC_Helper_Order::create_order();
-
-		// Subscriptions - note that orders are used here as subscriptions. Subscriptions inherit all order methods so should suffice for testing.
-		$mock_subscription_0 = WC_Helper_Order::create_order();
-		$mock_subscription_1 = WC_Helper_Order::create_order();
-
-		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_order = [ $mock_subscription_0, $mock_subscription_1 ];
 
 		// CARD
 		// Set a custom title.
@@ -2407,8 +2396,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_gateway->set_payment_method_title_for_order( $order, $payment_method_type );
 
 		$this->assertEquals( 'Custom Card Title', $order->get_payment_method_title() );
-		$this->assertEquals( 'Custom Card Title', $mock_subscription_0->get_payment_method_title() );
-		$this->assertEquals( 'Custom Card Title', $mock_subscription_1->get_payment_method_title() );
 
 		// SEPA
 		// Set a custom title.
@@ -2420,7 +2407,5 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_gateway->set_payment_method_title_for_order( $order, $payment_method_type );
 
 		$this->assertEquals( 'Custom SEPA Title', $order->get_payment_method_title() );
-		$this->assertEquals( 'Custom SEPA Title', $mock_subscription_0->get_payment_method_title() );
-		$this->assertEquals( 'Custom SEPA Title', $mock_subscription_1->get_payment_method_title() );
 	}
 }

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -2379,4 +2379,48 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'stripe', $mock_subscription_0->get_payment_method() );
 		$this->assertEquals( 'stripe', $mock_subscription_0->get_payment_method() );
 	}
+
+	/**
+	 * Test test_set_payment_method_title_for_order with custom title.
+	 */
+	public function test_set_payment_method_title_for_order_custom_title() {
+		// SET UP
+		$this->mock_gateway->expects( $this->exactly( 2 ) ) // 2 times because we test 2 payment methods.
+			->method( 'is_subscriptions_enabled' )
+			->willReturn( true );
+
+		$order = WC_Helper_Order::create_order();
+
+		// Subscriptions - note that orders are used here as subscriptions. Subscriptions inherit all order methods so should suffice for testing.
+		$mock_subscription_0 = WC_Helper_Order::create_order();
+		$mock_subscription_1 = WC_Helper_Order::create_order();
+
+		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_order = [ $mock_subscription_0, $mock_subscription_1 ];
+
+		// CARD
+		// Set a custom title.
+		$payment_method_type     = WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID;
+		$payment_method_settings = get_option( "woocommerce_stripe_{$payment_method_type}_settings", [] );
+		$payment_method_settings['title'] = 'Custom Card Title';
+		update_option( "woocommerce_stripe_{$payment_method_type}_settings", $payment_method_settings );
+
+		$this->mock_gateway->set_payment_method_title_for_order( $order, $payment_method_type );
+
+		$this->assertEquals( 'Custom Card Title', $order->get_payment_method_title() );
+		$this->assertEquals( 'Custom Card Title', $mock_subscription_0->get_payment_method_title() );
+		$this->assertEquals( 'Custom Card Title', $mock_subscription_1->get_payment_method_title() );
+
+		// SEPA
+		// Set a custom title.
+		$payment_method_type     = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
+		$payment_method_settings = get_option( "woocommerce_stripe_{$payment_method_type}_settings", [] );
+		$payment_method_settings['title'] = 'Custom SEPA Title';
+		update_option( "woocommerce_stripe_{$payment_method_type}_settings", $payment_method_settings );
+
+		$this->mock_gateway->set_payment_method_title_for_order( $order, $payment_method_type );
+
+		$this->assertEquals( 'Custom SEPA Title', $order->get_payment_method_title() );
+		$this->assertEquals( 'Custom SEPA Title', $mock_subscription_0->get_payment_method_title() );
+		$this->assertEquals( 'Custom SEPA Title', $mock_subscription_1->get_payment_method_title() );
+	}
 }


### PR DESCRIPTION
Fixes #3480

## Changes proposed in this Pull Request:

This PR is a small PR to use the `$payment_method->get_title()` function rather than the `$payment_method->get_label()` when we set the order's payment method title. 

This is in line with other Payment gateways (including WC core gateways like Bank transfer). 

## Testing instructions

1. Disable legacy checkout. 
2. On the Stripe Payment methods page change one of your payment method title to something else.

<p align="center">
<img width="400" alt="Screenshot 2024-09-30 at 10 24 32 am" src="https://github.com/user-attachments/assets/9327b54c-779b-4b32-98a0-ceb0d192a82f">
</br>
<sup>Custom Credit card / debit card title -- <strong>Cards</strong></sup>
</p> 

3. Complete a purchase using that payment method. 
   - On develop, the order's payment method will be displayed as the default - uncustomizable payment method label.
   - On this branch it will be set to the customised value.

| Develop | This Branch |
|--------|--------|
| <img width="200" alt="Screenshot 2024-09-27 at 5 12 31 pm" src="https://github.com/user-attachments/assets/ccd7566f-6606-456d-b025-f1cbfcd41ac0"> | <img width="200" alt="Screenshot 2024-09-27 at 5 13 05 pm" src="https://github.com/user-attachments/assets/480b4561-511f-448c-b389-e9ef3e7477b7"> | 

**OTHER IMPLICATIONS**

This also fixes an issue that was raised in [this comment](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3091#pullrequestreview-2035789883) when we added Clearpay / Afterpay. There Mayisha asks:

> On the order received page the Payment Method is Clearpay / Afterpay instead of just Clearpay or Afterpay. Is this expected?

This PR will also fix that issue because using `get_title()` will change to Clearpay or Afterpay depending on the store context (UK vs the rest of the world). 

| UK | Everywhere else |
|--------|--------|
| <img width="200" alt="Screenshot 2024-09-30 at 10 57 17 am" src="https://github.com/user-attachments/assets/7df0b14b-961d-4ca0-8848-39d93b0fbded"> | <img width="200" alt="Screenshot 2024-09-30 at 10 51 44 am" src="https://github.com/user-attachments/assets/6ac7e913-2e90-4084-ac8d-d2da09424175"> | 

**NOTES**

If you customise a default payment method like Direct bank transfer, you can verify that this PR brings our payment methods in line with the intended outcome.

| <img width="675" alt="Screenshot 2024-09-30 at 10 33 20 am" src="https://github.com/user-attachments/assets/04cc6560-e994-4980-afe3-5214aee0babf"> | <img width="330" alt="Screenshot 2024-09-30 at 10 33 43 am" src="https://github.com/user-attachments/assets/494039b3-0f9f-473a-9f5b-58529c7f1a50"> |
|--------|--------|




---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
