### PR TITLE
Prevent Payment Intents being passed to `process_response()` and marking orders as on-hold with an irrelevant order note

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@
 * Fix - Pre-orders set to pay upon release were remaining pending when attempting to pay using Stripe.
 * Fix - Ensure subscription renewal order statement descriptors include the order number suffix.
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
+* Fix - Resolved an issue where some orders were incorrectly marked as 'on-hold' with an order note indicating manual payment capture was required.
 
 = 8.7.0 - 2024-09-16 =
 * Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -659,12 +659,11 @@ class WC_Stripe_Intent_Controller {
 				// Use the last charge within the intent to proceed.
 				$gateway = $this->get_gateway();
 				$charge  = $gateway->get_latest_charge_from_intent( $intent );
+
 				if ( ! empty( $charge ) ) {
 					$gateway->process_response( $charge, $order );
-				} else {
-					// TODO: Add implementation for setup intents.
-					$gateway->process_response( $intent, $order );
 				}
+
 				$gateway->save_intent_to_order( $order, $intent );
 			}
 		} catch ( WC_Stripe_Exception $e ) {

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -439,7 +439,10 @@ trait WC_Stripe_Subscriptions_Trait {
 
 				// Use the last charge within the intent or the full response body in case of SEPA.
 				$latest_charge = $this->get_latest_charge_from_intent( $response );
-				$this->process_response( ( ! empty( $latest_charge ) ) ? $latest_charge : $response, $renewal_order );
+
+				if ( ! empty( $latest_charge ) ) {
+					$this->process_response( $latest_charge, $renewal_order );
+				}
 			}
 
 			// TODO: Remove when SEPA is migrated to payment intents.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -438,7 +438,7 @@ trait WC_Stripe_Subscriptions_Trait {
 				do_action( 'wc_gateway_stripe_process_payment', $response, $renewal_order );
 
 				// Use the last charge within the intent or the full response body in case of SEPA.
-				$latest_charge = $this->get_latest_charge_from_intent( $response );
+				$latest_charge = 'stripe_sepa' === $this->id ? $response : $this->get_latest_charge_from_intent( $response );
 
 				if ( ! empty( $latest_charge ) ) {
 					$this->process_response( $latest_charge, $renewal_order );

--- a/readme.txt
+++ b/readme.txt
@@ -149,5 +149,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Pre-orders set to pay upon release were remaining pending when attempting to pay using Stripe.
 * Fix - Ensure subscription renewal order statement descriptors include the order number suffix.
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
+* Fix - Resolved an issue where some orders were incorrectly marked as 'on-hold' with an order note indicating manual payment capture was required.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2404 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I haven't been able to reproduce this issue on the latest Stripe changes, however merchants are still reporting that some of their orders are being incorrectly marked as on-hold with the following order notes:

![image](https://github.com/user-attachments/assets/d294f197-b181-4782-a2e1-d3bbba932107)

In trying to understand how this could be possible, I found 2 areas of our code where we could unintentionally pass a Payment Intent object to our `process_response()` function. Because Payment Intent objects do not have a `captured` param, that will cause [this condition](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e9606a7ecb96a0b8ff8bd883fdbd122b700413e9/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L552) to not pass, resulting in the order being marked as on-hold with an irrelevant order note, then though the payment has been successful (see [code here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e9606a7ecb96a0b8ff8bd883fdbd122b700413e9/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L607))

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

> [!NOTE]
> I've tried many things to reproduce this issue naturally but I could not, so please excuse the hackery in these testing instructions 😄 

1. Make sure you have legacy checkout experience disabled and the "Issue an authorization on checkout, and capture later" setting also disabled.
1. Inside `process_subscription_payment()` tweak [this code](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e9606a7ecb96a0b8ff8bd883fdbd122b700413e9/includes/compat/trait-wc-stripe-subscriptions.php#L440-L442) slightly and manually set `$latest_charge` to `null`, to force the intent response to be used instead:

```
// Use the last charge within the intent or the full response body in case of SEPA.
$latest_charge = null;
$this->process_response( ( ! empty( $latest_charge ) ) ? $latest_charge : $response, $renewal_order );
```
3. While on `trunk`, process a subscription renewal order
4. Note the subscription is on-hold and the latest renewal order is on-hold
5. View the renewal order and confirm the "Stripe charge authorized" order note is present.
6. Switch to this branch and purchase a new subscription or reactivate your existing subscription.
7. With `$latest_charge` set to `null`, the subscription will remain on-hold until the `payment_intent.succeeded` webhook comes in and processes the renewal payment via the webhook handler and sets the subscription back to active.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
