### PR TITLE
Fix empty space for express checkout container

### DIFF
--- a/client/blocks/express-checkout/express-checkout-component.js
+++ b/client/blocks/express-checkout/express-checkout-component.js
@@ -29,6 +29,31 @@ const getPaymentMethodsOverride = ( enabledPaymentMethod ) => {
 	};
 };
 
+// Visual adjustments to horizontally align the buttons.
+const adjustButtonHeights = ( buttonOptions, expressPaymentMethod ) => {
+	// Apple Pay has a nearly imperceptible height difference. We increase it by 1px here.
+	if ( buttonOptions.buttonTheme.applePay === 'black' ) {
+		if ( expressPaymentMethod === 'applePay' ) {
+			buttonOptions.buttonHeight = buttonOptions.buttonHeight + 0.4;
+		}
+	}
+
+	// GooglePay with the white theme has a 2px height difference due to its border.
+	if (
+		expressPaymentMethod === 'googlePay' &&
+		buttonOptions.buttonTheme.googlePay === 'white'
+	) {
+		buttonOptions.buttonHeight = buttonOptions.buttonHeight - 2;
+	}
+
+	// Clamp the button height to the allowed range 40px to 55px.
+	buttonOptions.buttonHeight = Math.max(
+		40,
+		Math.min( buttonOptions.buttonHeight, 55 )
+	);
+	return buttonOptions;
+};
+
 const ExpressCheckoutComponent = ( {
 	api,
 	billing,
@@ -77,7 +102,7 @@ const ExpressCheckoutComponent = ( {
 	return (
 		<ExpressCheckoutElement
 			options={ {
-				...buttonOptions,
+				...adjustButtonHeights( buttonOptions, expressPaymentMethod ),
 				...getPaymentMethodsOverride( expressPaymentMethod ),
 			} }
 			onClick={ onButtonClick }

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -6,6 +6,7 @@ import ApplePayPreview from './apple-pay-preview';
 import GooglePayPreview from './google-pay-preview';
 import { loadStripe } from 'wcstripe/blocks/load-stripe';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
+import { checkPaymentMethodIsAvailable } from 'wcstripe/express-checkout/utils/check-payment-method-availability';
 
 const stripePromise = loadStripe();
 
@@ -19,13 +20,15 @@ const expressCheckoutElementsGooglePay = ( api ) => ( {
 		/>
 	),
 	edit: <GooglePayPreview />,
-	canMakePayment: () => {
+	canMakePayment: ( { cart } ) => {
 		// eslint-disable-next-line camelcase
 		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
 			return false;
 		}
 
-		return true;
+		return new Promise( ( resolve ) => {
+			checkPaymentMethodIsAvailable( 'googlePay', api, cart, resolve );
+		} );
 	},
 	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
 	supports: {
@@ -43,13 +46,15 @@ const expressCheckoutElementsApplePay = ( api ) => ( {
 		/>
 	),
 	edit: <ApplePayPreview />,
-	canMakePayment: () => {
+	canMakePayment: ( { cart } ) => {
 		// eslint-disable-next-line camelcase
 		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
 			return false;
 		}
 
-		return true;
+		return new Promise( ( resolve ) => {
+			checkPaymentMethodIsAvailable( 'applePay', api, cart, resolve );
+		} );
 	},
 	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
 	supports: {

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -1,3 +1,5 @@
+/* global wc_stripe_express_checkout_params */
+
 import { PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT } from './constants';
 import { ExpressCheckoutContainer } from './express-checkout-container';
 import ApplePayPreview from './apple-pay-preview';
@@ -17,7 +19,14 @@ const expressCheckoutElementsGooglePay = ( api ) => ( {
 		/>
 	),
 	edit: <GooglePayPreview />,
-	canMakePayment: () => true,
+	canMakePayment: () => {
+		// eslint-disable-next-line camelcase
+		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
+			return false;
+		}
+
+		return true;
+	},
 	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
 	supports: {
 		features: getBlocksConfiguration()?.supports ?? [],
@@ -34,7 +43,14 @@ const expressCheckoutElementsApplePay = ( api ) => ( {
 		/>
 	),
 	edit: <ApplePayPreview />,
-	canMakePayment: () => true,
+	canMakePayment: () => {
+		// eslint-disable-next-line camelcase
+		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
+			return false;
+		}
+
+		return true;
+	},
 	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
 	supports: {
 		features: getBlocksConfiguration()?.supports ?? [],

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -27,7 +27,9 @@ const api = new WCStripeAPI(
 );
 
 const upeMethods = getPaymentMethodsConstants();
-Object.entries( getBlocksConfiguration()?.paymentMethodsConfig )
+const paymentMethodsConfig =
+	getBlocksConfiguration()?.paymentMethodsConfig ?? {};
+Object.entries( paymentMethodsConfig )
 	.filter( ( [ upeName ] ) => upeName !== 'link' )
 	.filter( ( [ upeName ] ) => upeName !== 'giropay' ) // Skip giropay as it was deprecated by Jun, 30th 2024.
 	.forEach( ( [ upeName, upeConfig ] ) => {

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -1,0 +1,58 @@
+import ReactDOM from 'react-dom';
+import { ExpressCheckoutElement, Elements } from '@stripe/react-stripe-js';
+import { memoize } from 'lodash';
+
+export const checkPaymentMethodIsAvailable = memoize(
+	( paymentMethod, api, cart, resolve ) => {
+		// Create the DIV container on the fly
+		const containerEl = document.createElement( 'div' );
+
+		// Ensure the element is hidden and doesn’t interfere with the page layout.
+		containerEl.style.display = 'none';
+
+		document.querySelector( 'body' ).appendChild( containerEl );
+
+		const root = ReactDOM.createRoot( containerEl );
+
+		root.render(
+			<Elements
+				stripe={ api.loadStripe() }
+				options={ {
+					mode: 'payment',
+					paymentMethodCreation: 'manual',
+					amount: Number( cart.cartTotals.total_price ),
+					currency: cart.cartTotals.currency_code.toLowerCase(),
+				} }
+			>
+				<ExpressCheckoutElement
+					onLoadError={ () => resolve( false ) }
+					options={ {
+						paymentMethods: {
+							amazonPay: 'never',
+							applePay:
+								paymentMethod === 'applePay'
+									? 'always'
+									: 'never',
+							googlePay:
+								paymentMethod === 'googlePay'
+									? 'always'
+									: 'never',
+							link: 'never',
+							paypal: 'never',
+						},
+					} }
+					onReady={ ( event ) => {
+						let canMakePayment = false;
+						if ( event.availablePaymentMethods ) {
+							canMakePayment =
+								event.availablePaymentMethods[ paymentMethod ];
+						}
+						resolve( canMakePayment );
+						root.unmount();
+						containerEl.remove();
+					} }
+				/>
+			</Elements>
+		);
+	}
+);


### PR DESCRIPTION
Fixes #3470 

## Changes proposed in this Pull Request:
- Return 'false' for 'canMakePayment' only when express checkout is disabled.
- Added 'checkPaymentMethodIsAvailable' function for blocks (same as WooPayments)

## Reproduce the issues
- Enable the ECE feature flag (return `true` from `is_stripe_ece_enabled` function or in your database add an option `_wcstripe_feature_ece` and set `yes` as the value).
- Enable Google Pay/ Apple Pay from the Stripe settings page.
- Go to `localhost:8082`, add a product to your cart and check the block cart and checkout page.
- Notice that there is an empty express checkout section displayed. (Issue 1)
- Use a publicly accessible link for your site (jurassic tube or ngrok).
- Add many or expensive products to your cart so that the cart total is beyond $1,000,000.00 USD (or 1.000.000,00 EUR). - Notice that an empty express checkout section is loaded. (Issue 2)
- Now disable Google Pay/ Apple Pay from the Stripe settings page.
- Add a product to your cart and check the block cart and checkout page.
- Notice that there is an empty express checkout section displayed. (Issue 3)


## Screenshots
**Cart page**

<img width="373" alt="Screenshot 2024-09-30 at 1 25 13 PM" src="https://github.com/user-attachments/assets/d31d23eb-1c54-4aef-a786-b4b9bfcedc87">

**Checkout page**

<img width="627" alt="Screenshot 2024-09-30 at 1 24 47 PM" src="https://github.com/user-attachments/assets/76aba114-115f-480e-89b8-89b334f989f0">

## Testing instructions
Follow the steps to reproduce the issues in this branch and confirm that the empty express checkout section is not displayed anymore.