### PR TITLE
Only load the ECE class (including scripts) if UPE is enabled

### DIFF
--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -65,6 +65,11 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
+		// ECE is only available when UPE checkout is enabled.
+		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			return;
+		}
+
 		// Checks if Stripe Gateway is enabled.
 		if ( empty( $this->stripe_settings ) || ( isset( $this->stripe_settings['enabled'] ) && 'yes' !== $this->stripe_settings['enabled'] ) ) {
 			return;


### PR DESCRIPTION
Fixes #3488

## Changes proposed in this Pull Request:

This is a small PR to make sure we don't load ECE integration code on sites that are still using the legacy checkout experience. Doing so was leading to the following console errors on my local site. 

<img width="500" alt="Screenshot 2024-10-01 at 2 14 42 pm" src="https://github.com/user-attachments/assets/01a0c428-2911-416a-a4c7-527da49d42d7">

> [!important]
> This PR assumes that we don't want to use ECE on stores using the legacy checkout, if that's not a correct assumption, I'll need to change this PR to prevent these errors in a different way. Internal discussion can be found here: p1727763932877939-slack-C05GDK92WGM

## Testing instructions

1. Enable the ECE feature flag by setting the `_wcstripe_feature_ece` option to `'yes'` 
1. Checkout `develop` 
2. `npm run build`
3. Enable the legacy checkout experience
4. Add an item to the checkout and go to checkout. 
5. Open the browser developer tools. 
   - On `develop` you should see the error mentioned above
   - On this branch there should be no errors. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] ~~Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)~~ This is all unreleased code so no changelog will be necessary. 
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)