### PR TITLE
ECE on shortcode cart page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,10 +3,11 @@
 = 8.8.0 - xxxx-xx-xx =
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.
-* Add - Add support for Stripe Express Checkout Element on the block cart and checkout page.
 * Add - Implemented the "Update all subscriptions payment methods" checkbox on My Account → Payment methods for UPE payment methods.
-* Add - Add support for the new Stripe Checkout Element on the shortcode checkout page.
-* Add - Add support for the new Stripe Checkout Element on the pay for order page.
+* Add - Add support for the new Stripe Express Checkout Element on the block cart and checkout page.
+* Add - Add support for the new Stripe Express Checkout Element on the shortcode checkout page.
+* Add - Add support for the new Stripe Express Checkout Element on the shortcode cart page.
+* Add - Add support for the new Stripe Express Checkout Element on the pay for order page.
 * Dev - Introduces a new class with payment methods constants.
 * Dev - Introduces a new class with currency codes constants.
 * Dev - Improves the readability of the redirect URL generation code (UPE).

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -618,7 +618,10 @@ jQuery( function ( $ ) {
 		},
 	};
 
-	wcStripeECE.init();
+	// We don't need to initialize ECE on the checkout page now because it will be initialized by updated_checkout event.
+	if ( ! getExpressCheckoutData( 'is_checkout_page' ) ) {
+		wcStripeECE.init();
+	}
 
 	// We need to refresh ECE data when total is updated.
 	$( document.body ).on( 'updated_cart_totals', () => {

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -479,5 +479,21 @@ jQuery( function ( $ ) {
 		},
 	};
 
-	wcStripeECE.init();
+	// We don't need to initialize ECE on the checkout page now because it will be initialized by updated_checkout event.
+	if (
+		! getExpressCheckoutData( 'is_checkout_page' ) ||
+		getExpressCheckoutData( 'is_pay_for_order' )
+	) {
+		wcStripeECE.init();
+	}
+
+	// We need to refresh ECE data when total is updated.
+	$( document.body ).on( 'updated_cart_totals', () => {
+		wcStripeECE.init();
+	} );
+
+	// We need to refresh ECE data when total is updated.
+	$( document.body ).on( 'updated_checkout', () => {
+		wcStripeECE.init();
+	} );
 } );

--- a/client/entrypoints/express-checkout/styles.scss
+++ b/client/entrypoints/express-checkout/styles.scss
@@ -1,3 +1,7 @@
 #wc-stripe-express-checkout-element iframe {
 	max-width: unset;
 }
+
+#wc-stripe-express-checkout-element {
+	margin-bottom: 12px;
+}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -86,7 +86,7 @@ class WC_Stripe_Express_Checkout_Element {
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
 
 		add_action( 'woocommerce_after_add_to_cart_form', [ $this, 'display_express_checkout_button_html' ], 1 );
-		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_button_html' ], 25 );
+		add_action( 'woocommerce_proceed_to_checkout', [ $this, 'display_express_checkout_button_html' ] );
 		add_action( 'woocommerce_checkout_before_customer_details', [ $this, 'display_express_checkout_button_html' ], 1 );
 		add_action( 'woocommerce_pay_order_before_payment', [ $this, 'display_express_checkout_button_html' ], 1 );
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -408,11 +408,15 @@ class WC_Stripe_Express_Checkout_Element {
 	 * Display express checkout button separator.
 	 */
 	public function display_express_checkout_button_separator_html() {
-		if ( ! is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) ) {
+		if ( ! is_checkout() && ! is_cart() && ! is_wc_endpoint_url( 'order-pay' ) ) {
 			return;
 		}
 
 		if ( is_checkout() && ! in_array( 'checkout', $this->express_checkout_helper->get_button_locations(), true ) ) {
+			return;
+		}
+
+		if ( is_cart() && ! in_array( 'cart', $this->express_checkout_helper->get_button_locations(), true ) ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -131,10 +131,11 @@ If you get stuck, you can ask for help in the Plugin Forum.
 = 8.8.0 - xxxx-xx-xx =
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.
-* Add - Add support for Stripe Express Checkout Element on the block cart and checkout page.
 * Add - Implemented the "Update all subscriptions payment methods" checkbox on My Account → Payment methods for UPE payment methods.
-* Add - Add support for the new Stripe Checkout Element on the shortcode checkout page.
-* Add - Add support for the new Stripe Checkout Element on the pay for order page.
+* Add - Add support for the new Stripe Express Checkout Element on the block cart and checkout page.
+* Add - Add support for the new Stripe Express Checkout Element on the shortcode checkout page.
+* Add - Add support for the new Stripe Express Checkout Element on the shortcode cart page.
+* Add - Add support for the new Stripe Express Checkout Element on the pay for order page.
 * Dev - Introduces a new class with payment methods constants.
 * Dev - Introduces a new class with currency codes constants.
 * Dev - Improves the readability of the redirect URL generation code (UPE).


### PR DESCRIPTION
Fixes #3409 

## Changes proposed in this Pull Request:
The main implementation for shortcode was done in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3436. In this PR I have fixed a few issues on shortcode cart block.
- Showing the ECE button before 'proceed to checkout' button on the cart page.
- Fixed spacing between the buttons on cart page.
- Refreshing the ECE button when the cart total is updated (both on checkout and cart pages). The cart total is updated when the shipping rate is changed or the number of items is changed.

## Testing instructions
- Enable the ECE feature flag (return `true` from `is_stripe_ece_enabled` function or in your database add an option `_wcstripe_feature_ece` and set `yes` as the value).
- Enable Google Pay/ Apple Pay from the Stripe settings page.
- As a shopper add a product to your cart and go to the shortcode checkout page.

<img width="547" alt="Screenshot 2024-10-01 at 11 50 08 PM" src="https://github.com/user-attachments/assets/f59008ab-efb8-4a89-bfa4-49ba86f0e13f">

- Confirm that the new ECE buttons are displayed.
- Pay with the ECE button and confirm that the order is placed successfully.
- Test by increasing/decresing item counts and by changing shipping rates and then paying via ECE buttons.