### PR TITLE
Disable ECE for incompatible tax scenarios

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.8.0 - xxxx-xx-xx =
+* Tweak - Disable ECE when cart has virtual products and tax is based on customer billing or shipping address.
 * Fix - Updates the display logic for the OAuth re-connect promotional surface to follow the latest changes made to the connection settings object.
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.8.0 - xxxx-xx-xx =
+* Tweak - Disable ECE when cart has virtual products and tax is based on customer billing or shipping address.
 * Fix - Updates the display logic for the OAuth re-connect promotional surface to follow the latest changes made to the connection settings object.
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.

--- a/tests/phpunit/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/test-wc-stripe-express-checkout-helper.php
@@ -21,6 +21,9 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		WC_Stripe::get_instance()->connect = $wc_stripe_connect_mock;
 	}
 
+	/**
+	 * Test should_show_express_checkout_button, tax logic.
+	 */
 	public function test_hides_ece_if_cannot_compute_taxes() {
 		$wc_stripe_ece_helper_mock = $this->createPartialMock(
 			WC_Stripe_Express_Checkout_Helper::class,
@@ -58,5 +61,29 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		// Do not hide if taxes are not based on customer billing or shipping address.
 		update_option( 'woocommerce_tax_based_on', 'base' );
 		$this->assertTrue( $wc_stripe_ece_helper_mock->should_show_express_checkout_button() );
+	}
+
+	/**
+	 * Test has_virtual_product.
+	 */
+	public function test_has_virtual_product_checkout() {
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+			define( 'WOOCOMMERCE_CHECKOUT', true );
+		}
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$this->assertFalse( $wc_stripe_ece_helper->has_virtual_product() );
+
+		$product = WC_Helper_Product::create_simple_product();
+
+		WC()->session->init();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		$this->assertFalse( $wc_stripe_ece_helper->has_virtual_product() );
+
+		$virtual_product = WC_Helper_Product::create_simple_product();
+		$virtual_product->set_virtual( true );
+		$virtual_product->save();
+
+		WC()->cart->add_to_cart( $virtual_product->get_id(), 1 );
+		$this->assertTrue( $wc_stripe_ece_helper->has_virtual_product() );
 	}
 }

--- a/tests/phpunit/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/test-wc-stripe-express-checkout-helper.php
@@ -13,12 +13,12 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 
-		$wc_stripe_connect_mock = $this->getMockBuilder( 'WC_Stripe_Connect' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'is_connected' ] )
-			->getMock();
-		$wc_stripe_connect_mock->method( 'is_connected' )->willReturn( true );
-		WC_Stripe::get_instance()->connect = $wc_stripe_connect_mock;
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['enabled']              = 'yes';
+		$stripe_settings['testmode']             = 'yes';
+		$stripe_settings['test_publishable_key'] = 'pk_test_key';
+		$stripe_settings['test_secret_key']      = 'sk_test_key';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}
 
 	/**

--- a/tests/phpunit/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/test-wc-stripe-express-checkout-helper.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * These tests make assertions against class WC_Stripe_Express_Checkout_Helper.
+ *
+ * @package WooCommerce_Stripe/Tests/WC_Stripe_Express_Checkout_Helper
+ */
+
+/**
+ * WC_Stripe_Express_Checkout_Helper class.
+ */
+class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
+	public function set_up() {
+		parent::set_up();
+
+		$wc_stripe_connect_mock = $this->getMockBuilder( 'WC_Stripe_Connect' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'is_connected' ] )
+			->getMock();
+		$wc_stripe_connect_mock->method( 'is_connected' )->willReturn( true );
+		WC_Stripe::get_instance()->connect = $wc_stripe_connect_mock;
+	}
+
+	public function test_hides_ece_if_cannot_compute_taxes() {
+		$wc_stripe_ece_helper_mock = $this->createPartialMock(
+			WC_Stripe_Express_Checkout_Helper::class,
+			[
+				'is_product',
+				'allowed_items_in_cart',
+				'should_show_ece_on_cart_page',
+				'should_show_ece_on_checkout_page',
+				'has_virtual_product',
+			]
+		);
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( false );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_cart_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'has_virtual_product' )->willReturn(
+			true,
+			true,
+			false,
+			true,
+		);
+		$wc_stripe_ece_helper_mock->testmode = true;
+
+		// Hide if cart has virtual product and tax is based on shipping or billing address.
+		update_option( 'woocommerce_tax_based_on', 'billing' );
+		$this->assertFalse( $wc_stripe_ece_helper_mock->should_show_express_checkout_button() );
+
+		update_option( 'woocommerce_tax_based_on', 'shipping' );
+		$this->assertFalse( $wc_stripe_ece_helper_mock->should_show_express_checkout_button() );
+
+		// Do not hide if there are no virtual products.
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'has_virtual_product' )->willReturn( false );
+		$this->assertTrue( $wc_stripe_ece_helper_mock->should_show_express_checkout_button() );
+
+		// Do not hide if taxes are not based on customer billing or shipping address.
+		update_option( 'woocommerce_tax_based_on', 'base' );
+		$this->assertTrue( $wc_stripe_ece_helper_mock->should_show_express_checkout_button() );
+	}
+}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Part of #3472 

## Changes proposed in this Pull Request:
When the cart contains a virtual product and taxes are computed based on customer shipping or billing address, we are unable to display the correct tax computation in the ECE modal. This is because the address attached to the ECE card is not available to us until the payment is submitted.

For these cases, instead of presenting a possibly incorrect total to the customer, we are opting to hide ECE instead, similar to the WooPayments approach.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Make sure ECE is enabled.
    - add `_wcstripe_feature_ece` with a value of `yes` to `wp_options`
2. Make sure `Apple Pay/Google Pay` is enabled as payment methods.
3. Turn on `Enable tax rates and calculations` in WooCommerce > Settings > General.
4. Set up taxes in WooCommerce > Settings > Tax
   - `No, I will enter prices exclusive of tax`
   - Calculate tax based on: `Customer shipping address` or `Customer billing address`
5. As a shopper, add a virtual product, e.g. "Album",  to your cart.
6. Verify that express checkout does NOT appear in the cart and checkout pages.
7. Add a shippable product to your cart.
8. Verify that express checkout reappears in the cart and checkout pages.
9. Remove the shippable product from your cart.
10. Change "Calculate tax based on" to `Shop base address`.
11. Verify that express checkout still appears in the cart and checkout pages.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
