### PR TITLE
Fix JS errors with ECE on the shortcode checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Fixes some JS console errors when making a purchase with the Stripe Express Checkout Element on the shortcode checkout.
 * Fix - Updates the display logic for the OAuth re-connect promotional surface to follow the latest changes made to the connection settings object.
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -62,9 +62,9 @@ export const onConfirmHandler = async (
 	event,
 	order = 0 // Order ID for the pay for order flow.
 ) => {
-	const { error: submitError } = await elements.submit();
-	if ( submitError ) {
-		return abortPayment( event, submitError.message );
+	const submitResponse = await elements.submit();
+	if ( submitResponse?.error ) {
+		return abortPayment( event, submitResponse?.error?.message );
 	}
 
 	const { paymentMethod, error } = await stripe.createPaymentMethod( {

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -229,9 +229,12 @@ const getRequiredFieldDataFromShortcodeCheckoutForm = ( data ) => {
 				}
 
 				// if shipping same as billing is selected, copy the billing field to shipping field.
-				const shipToDiffAddress = document
-					.getElementById( 'ship-to-different-address' )
-					.querySelector( 'input' ).checked;
+				const shipToDiffAddressField = document.getElementById(
+					'ship-to-different-address'
+				);
+				const shipToDiffAddress =
+					shipToDiffAddressField &&
+					shipToDiffAddressField.querySelector( 'input' ).checked;
 				if ( ! shipToDiffAddress ) {
 					const shippingFieldName = name.replace(
 						'billing_',

--- a/readme.txt
+++ b/readme.txt
@@ -129,6 +129,7 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.8.0 - xxxx-xx-xx =
+* Fix - Fixes some JS console errors when making a purchase with the Stripe Express Checkout Element on the shortcode checkout.
 * Fix - Updates the display logic for the OAuth re-connect promotional surface to follow the latest changes made to the connection settings object.
 * Fix - Remove unexpected HTML in error message for shortcode checkout.
 * Fix - Ensure ordering for Stripe payment methods is saved even when setting up from scratch.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3446

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When any error happens on the payment confirmation flow for the Express Checkout Element (for the shortcode checkout), the `abortPayment` function is called, which triggers `payment.paymentFailed( { reason: 'fail' } )`. Because of this, any error unrelated to the payment itself would trigger this function.

This PR fixes two issues with our JS code to avoid that:
- The return value for the `elements.submit()` as the `error` property only exists when it fails. Successful responses are empty.
- The verification for a shipment to the same address. When purchasing digital products, the `#ship-to-different-address` input field does not exist. This was throwing another error.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout and build the `develop` branch on your test environment
- Enable the ECE feature flag. You can do it by hardcoding `is_stripe_ece_enabled` to `true`
- Connect your Stripe account
- Create a digital product
- Create a shortcode checkout page
- As a shopper, try to purchase this product using the shortcode checkout and any ECE method (Google Pay, Apple Pay)
- Notice the error message on your browser console
![Screenshot 2024-10-02 at 17 01 25](https://github.com/user-attachments/assets/6f5422dd-e46f-4374-935a-011426e041ab)
- Checkout and build this branch instead `fix/js-errors-with-shortcode-checkout-ece`
- Repeat the purchase process
- Confirm that no errors are logged on your browser console

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
