### PR TITLE
Ensure manually captured orders have the Stripe fee and payout meta added to them

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
 * Fix - Set order payment method title to the customizable title setting rather than the default label.
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
+* Fix - Missing Stripe Fee and Stripe Payout details on orders that were captured manually.
 
 = 8.7.0 - 2024-09-16 =
 * Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2297,4 +2297,23 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		return true;
 	}
+
+	/**
+	 * Retrieves the balance transaction ID from the Stripe charge.
+	 *
+	 * @param stdClass $charge The charge object.
+	 *
+	 * @return string|null The balance transaction ID.
+	 */
+	public function get_balance_transaction_id_from_charge( $charge ) {
+		$balance_transaction_id = null;
+
+		if ( ! empty( $charge->balance_transaction->id ) ) {
+			$balance_transaction_id = $charge->balance_transaction->id;
+		} elseif ( ! empty( $charge->balance_transaction ) && is_string( $charge->balance_transaction ) ) {
+			$balance_transaction_id = $charge->balance_transaction;
+		}
+
+		return $balance_transaction_id;
+	}
 }

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -320,7 +320,11 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 						$order->save();
 					}
 
-					$this->update_fees( $order, $result->balance_transaction->id );
+					$balance_transaction_id = $this->get_balance_transaction_id_from_charge( $result );
+
+					if ( ! empty( $balance_transaction_id ) ) {
+						$this->update_fees( $order, $balance_transaction_id );
+					}
 				}
 
 				// This hook fires when admin manually changes order status to processing or completed.

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
 * Fix - Set order payment method title to the customizable title setting rather than the default label.
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
+* Fix - Missing Stripe Fee and Stripe Payout details on orders that were captured manually.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -525,4 +525,47 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 			->setMethods( $methods )
 			->getMock();
 	}
+
+	public function test_get_balance_transaction_id_from_charge() {
+		$expected_balance_transaction_id = 'txn_test123';
+		$balance_transaction_object      = (object) [
+			'id' => $expected_balance_transaction_id,
+		];
+
+		$charge_expanded = (object) [
+			'id'                  => 'ch_test123',
+			'balance_transaction' => $balance_transaction_object,
+		];
+		$this->assertEquals( $expected_balance_transaction_id, $this->gateway->get_balance_transaction_id_from_charge( $charge_expanded ) );
+
+		$charge_non_expanded             = (object) [
+			'id' => 'ch_test123',
+			'balance_transaction' => $expected_balance_transaction_id,
+		];
+		$this->assertEquals( $expected_balance_transaction_id, $this->gateway->get_balance_transaction_id_from_charge( $charge_non_expanded ) );
+
+		/**
+		 * ------------------------------------
+		 * Test invalid cases.
+		 * ------------------------------------
+		 */
+		$charge_no_balance_transaction_id = (object) [
+			'id' => 'ch_test123',
+		];
+		$this->assertEquals( null, $this->gateway->get_balance_transaction_id_from_charge( $charge_no_balance_transaction_id ) );
+
+		$charge_no_balance_transaction = (object) [
+			'id'                  => 'ch_test123',
+			'balance_transaction' => null,
+		];
+		$this->assertEquals( null, $this->gateway->get_balance_transaction_id_from_charge( $charge_no_balance_transaction ) );
+
+		$charge_no_balance_transaction_object = (object) [
+			'id'                  => 'ch_test123',
+			'balance_transaction' => (object) [],
+		];
+		$this->assertEquals( null, $this->gateway->get_balance_transaction_id_from_charge( $charge_no_balance_transaction_object ) );
+
+		$this->assertEquals( null, $this->gateway->get_balance_transaction_id_from_charge( null ) );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3507

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When **Issue an authorization on checkout, and capture later** is enabled, the order does not have the Stripe fee or payout meta after being captured.

From the debug logs:

```
[11-Oct-2024 02:11:48 UTC] PHP Warning:  Attempt to read property "id" on string in /Users/matt/local/woo/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-order-handler.php on line 326
```

As of Stripe API version 2022-11-15 ([Stripe API upgrade docs](https://docs.stripe.com/upgrades#2022-11-15)), PaymentIntents no longer build/expand the charge object and so even though our request is expanding `charges.data.balance_transaction`, the charge object will not exist, causing our later code that calls `$charge->balance_transaction->id` to then fail.

This PR fixes this issue by introducing a new helper function `get_balance_transaction_id_from_charge()` which will fetch the balance transaction ID from the charge object when the balance_transaction field is either expanded (object) or non-expanded (just the balance transaction ID).

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. Make sure "Enable the legacy checkout experience" is **disabled**.
2. Make sure "Issue an authorization on checkout, and capture later" is enabled.
3. Purchase a simple product using a test credit card `4242`.
4. Go to WP Admin > Orders and visit the Edit Order page for the new on-hold order
5. Manually capture the payment by updating the order status to processing.
6. Once the page reloads, confirm the Stripe Fee and Payout information is correctly set on the order.![image](https://github.com/user-attachments/assets/d6696adc-32ab-4022-978f-788fda39952d)
8. On `develop` this meta will be missing.


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
