### PR TITLE
Update PRB payment method generation to use PaymentMethods rather than sources

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -69,8 +69,8 @@ jQuery( function( $ ) {
 			};
 		},
 
-		processSource: function( source, paymentRequestType ) {
-			var data = wc_stripe_payment_request.getOrderData( source, paymentRequestType );
+		processPaymentMethod: function( paymentMethod, paymentRequestType ) {
+			var data = wc_stripe_payment_request.getOrderData( paymentMethod, paymentRequestType );
 
 			return $.ajax( {
 				type:    'POST',
@@ -85,18 +85,20 @@ jQuery( function( $ ) {
 		 *
 		 * @since 3.1.0
 		 * @version 4.0.0
-		 * @param {PaymentResponse} source Payment Response instance.
+		 * @param {Object} evt The event object containing payment details and user information.
+		 * @param {string} paymentRequestType - The type of payment request, either 'google_pay' or 'apple_pay'.
 		 *
-		 * @return {Object}
+		 * @return {Object} Processed order data for further handling, potentially including shipping, billing, and payment method information.
 		 */
 		getOrderData: function( evt, paymentRequestType ) {
-			var source   = evt.source;
-			var email    = source.owner.email;
-			var phone    = source.owner.phone;
-			var billing  = source.owner.address;
-			var name     = source.owner.name ?? evt.payerName;
-			var shipping = evt.shippingAddress;
-			var data     = {
+			var paymentMethod = evt.paymentMethod;
+			console.log( 'paymentRequestType', paymentRequestType );
+			var email         = paymentMethod.billing_details.email;
+			var phone         = paymentMethod.billing_details.phone;
+			var billing       = paymentMethod.billing_details.address;
+			var name          = paymentMethod.billing_details.name ?? evt.payerName;
+			var shipping      = evt.shippingAddress;
+			var data          = {
 				_wpnonce:                  wc_stripe_payment_request_params.nonce.checkout,
 				billing_first_name:        name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
 				billing_last_name:         name?.split( ' ' )?.slice( 1 )?.join( ' ' ) || '-',
@@ -123,7 +125,7 @@ jQuery( function( $ ) {
 				payment_method:            'stripe',
 				ship_to_different_address: 1,
 				terms:                     1,
-				stripe_source:             source.id,
+				'wc-stripe-payment-method': paymentMethod.id,
 				payment_request_type:      paymentRequestType
 			};
 
@@ -480,12 +482,12 @@ jQuery( function( $ ) {
 					} );
 				} );
 
-				paymentRequest.on( 'source', function( evt ) {
+				paymentRequest.on( 'paymentmethod', function( evt ) {
 					// Check if we allow prepaid cards.
 					if ( 'no' === wc_stripe_payment_request_params.stripe.allow_prepaid_card && 'prepaid' === evt.source.card.funding ) {
 						wc_stripe_payment_request.abortPayment( evt, wc_stripe_payment_request.getErrorMessageHTML( wc_stripe_payment_request_params.i18n.no_prepaid_card ) );
 					} else {
-						$.when( wc_stripe_payment_request.processSource( evt, paymentRequestType ) ).then( function( response ) {
+						$.when( wc_stripe_payment_request.processPaymentMethod( evt, paymentRequestType ) ).then( function( response ) {
 							if ( 'success' === response.result ) {
 								wc_stripe_payment_request.completePayment( evt, response.redirect );
 							} else {

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -125,6 +125,7 @@ jQuery( function( $ ) {
 				ship_to_different_address:      1,
 				terms:                          1,
 				'wc-stripe-payment-method':     paymentMethod.id,
+				stripe_source:                  paymentMethod.id, // Needed to process the payment in legacy checkout mode.
 				payment_request_type:           paymentRequestType,
 				'wc-stripe-is-deferred-intent': true,
 			};

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -125,7 +125,7 @@ jQuery( function( $ ) {
 				ship_to_different_address:      1,
 				terms:                          1,
 				'wc-stripe-payment-method':     paymentMethod.id,
-				payment_request_type:           paymentRequestType
+				payment_request_type:           paymentRequestType,
 				'wc-stripe-is-deferred-intent': true,
 			};
 

--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -86,47 +86,47 @@ jQuery( function( $ ) {
 		 * @since 3.1.0
 		 * @version 4.0.0
 		 * @param {Object} evt The event object containing payment details and user information.
-		 * @param {string} paymentRequestType - The type of payment request, either 'google_pay' or 'apple_pay'.
+		 * @param {string} paymentRequestType The type of payment request, either 'google_pay' or 'apple_pay'.
 		 *
-		 * @return {Object} Processed order data for further handling, potentially including shipping, billing, and payment method information.
+		 * @return {Object} Processed order data for further handling, including shipping, billing, and payment method information.
 		 */
 		getOrderData: function( evt, paymentRequestType ) {
 			var paymentMethod = evt.paymentMethod;
-			console.log( 'paymentRequestType', paymentRequestType );
 			var email         = paymentMethod.billing_details.email;
 			var phone         = paymentMethod.billing_details.phone;
 			var billing       = paymentMethod.billing_details.address;
 			var name          = paymentMethod.billing_details.name ?? evt.payerName;
 			var shipping      = evt.shippingAddress;
 			var data          = {
-				_wpnonce:                  wc_stripe_payment_request_params.nonce.checkout,
-				billing_first_name:        name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
-				billing_last_name:         name?.split( ' ' )?.slice( 1 )?.join( ' ' ) || '-',
-				billing_company:           '',
-				billing_email:             null !== email   ? email : evt.payerEmail,
-				billing_phone:             null !== phone   ? phone : evt.payerPhone && evt.payerPhone.replace( '/[() -]/g', '' ),
-				billing_country:           null !== billing ? billing.country : '',
-				billing_address_1:         null !== billing ? billing.line1 : '',
-				billing_address_2:         null !== billing ? billing.line2 : '',
-				billing_city:              null !== billing ? billing.city : '',
-				billing_state:             null !== billing ? billing.state : '',
-				billing_postcode:          null !== billing ? billing.postal_code : '',
-				shipping_first_name:       '',
-				shipping_last_name:        '',
-				shipping_company:          '',
-				shipping_country:          '',
-				shipping_address_1:        '',
-				shipping_address_2:        '',
-				shipping_city:             '',
-				shipping_state:            '',
-				shipping_postcode:         '',
-				shipping_method:           [ null === evt.shippingOption ? null : evt.shippingOption.id ],
-				order_comments:            '',
-				payment_method:            'stripe',
-				ship_to_different_address: 1,
-				terms:                     1,
-				'wc-stripe-payment-method': paymentMethod.id,
-				payment_request_type:      paymentRequestType
+				_wpnonce:                       wc_stripe_payment_request_params.nonce.checkout,
+				billing_first_name:             name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
+				billing_last_name:              name?.split( ' ' )?.slice( 1 )?.join( ' ' ) || '-',
+				billing_company:                '',
+				billing_email:                  null !== email   ? email : evt.payerEmail,
+				billing_phone:                  null !== phone   ? phone : evt.payerPhone && evt.payerPhone.replace( '/[() -]/g', '' ),
+				billing_country:                null !== billing ? billing.country : '',
+				billing_address_1:              null !== billing ? billing.line1 : '',
+				billing_address_2:              null !== billing ? billing.line2 : '',
+				billing_city:                   null !== billing ? billing.city : '',
+				billing_state:                  null !== billing ? billing.state : '',
+				billing_postcode:               null !== billing ? billing.postal_code : '',
+				shipping_first_name:            '',
+				shipping_last_name:             '',
+				shipping_company:               '',
+				shipping_country:               '',
+				shipping_address_1:             '',
+				shipping_address_2:             '',
+				shipping_city:                  '',
+				shipping_state:                 '',
+				shipping_postcode:              '',
+				shipping_method:                [ null === evt.shippingOption ? null : evt.shippingOption.id ],
+				order_comments:                 '',
+				payment_method:                 'stripe',
+				ship_to_different_address:      1,
+				terms:                          1,
+				'wc-stripe-payment-method':     paymentMethod.id,
+				payment_request_type:           paymentRequestType
+				'wc-stripe-is-deferred-intent': true,
 			};
 
 			if ( shipping ) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
 * Fix - Set order payment method title to the customizable title setting rather than the default label.
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
+* Fix - Switch Google Pay and Apple Pay PRB flow to create PaymentMethod (pm_) instead of Source (src_), utilizing deferred intent processing.
 
 = 8.7.0 - 2024-09-16 =
 * Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.

--- a/client/blocks/normalize.js
+++ b/client/blocks/normalize.js
@@ -56,6 +56,7 @@ const normalizeOrderData = ( paymentMethodEvent, paymentRequestType ) => {
 		ship_to_different_address: 1,
 		terms: 1,
 		'wc-stripe-payment-method': paymentMethod.id,
+		stripe_source: paymentMethod.id, // Needed to process the payment in legacy checkout mode.
 		payment_request_type: paymentRequestType,
 		'wc-stripe-is-deferred-intent': true,
 	};

--- a/client/blocks/normalize.js
+++ b/client/blocks/normalize.js
@@ -14,16 +14,17 @@ import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
 /**
  * Normalizes order data received upon creating an order using the store's AJAX API.
  *
- * @param {Object} sourceEvent - The source event that triggered the creation of the order.
+ * @param {Object} paymentMethodEvent - The payment method event that triggered the creation of the order.
  * @param {string} paymentRequestType - The payment request type.
  */
-const normalizeOrderData = ( sourceEvent, paymentRequestType ) => {
-	const { source } = sourceEvent;
-	const email = source?.owner?.email;
-	const phone = source?.owner?.phone;
-	const billing = source?.owner?.address;
-	const name = source?.owner?.name ?? sourceEvent.payerName;
-	const shipping = sourceEvent?.shippingAddress;
+const normalizeOrderData = ( paymentMethodEvent, paymentRequestType ) => {
+	const paymentMethod = paymentMethodEvent.paymentMethod;
+	const email = paymentMethod.billing_details.email;
+	const phone = paymentMethod.billing_details.phone;
+	const billing = paymentMethod.billing_details.address;
+	const shipping = paymentMethodEvent.shippingAddress;
+	const name =
+		paymentMethod.billing_details.name ?? paymentMethodEvent.payerName;
 
 	const data = {
 		_wpnonce: getBlocksConfiguration()?.nonce?.checkout,
@@ -31,9 +32,9 @@ const normalizeOrderData = ( sourceEvent, paymentRequestType ) => {
 			name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
 		billing_last_name: name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',
 		billing_company: '',
-		billing_email: email ?? sourceEvent?.payerEmail,
+		billing_email: email ?? paymentMethodEvent?.payerEmail,
 		billing_phone:
-			phone ?? sourceEvent?.payerPhone?.replace( '/[() -]/g', '' ),
+			phone ?? paymentMethodEvent?.payerPhone?.replace( '/[() -]/g', '' ),
 		billing_country: billing?.country ?? '',
 		billing_address_1: billing?.line1 ?? '',
 		billing_address_2: billing?.line2 ?? '',
@@ -49,13 +50,14 @@ const normalizeOrderData = ( sourceEvent, paymentRequestType ) => {
 		shipping_city: '',
 		shipping_state: '',
 		shipping_postcode: '',
-		shipping_method: [ sourceEvent?.shippingOption?.id ],
+		shipping_method: [ paymentMethodEvent?.shippingOption?.id ],
 		order_comments: '',
 		payment_method: 'stripe',
 		ship_to_different_address: 1,
 		terms: 1,
-		stripe_source: source.id,
+		'wc-stripe-payment-method': paymentMethod.id,
 		payment_request_type: paymentRequestType,
+		'wc-stripe-is-deferred-intent': true,
 	};
 
 	if ( shipping ) {

--- a/client/blocks/payment-request/hooks.js
+++ b/client/blocks/payment-request/hooks.js
@@ -186,7 +186,7 @@ export const useProcessPaymentHandler = (
 ) => {
 	useEffect( () => {
 		const handler = paymentRequest?.on(
-			'source',
+			'paymentmethod',
 			paymentProcessingHandler(
 				stripe,
 				paymentRequestType,
@@ -196,7 +196,7 @@ export const useProcessPaymentHandler = (
 
 		return () => {
 			// Need to use `?.` here in case paymentRequest is null.
-			handler?.removeEventListener( 'source' );
+			handler?.removeEventListener( 'paymentmethod' );
 		};
 	}, [ stripe, paymentRequest, paymentRequestType, setExpressPaymentError ] );
 };

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
 * Fix - Set order payment method title to the customizable title setting rather than the default label.
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
+* Fix - Switch Google Pay and Apple Pay PRB flow to create PaymentMethod (pm_) instead of Source (src_), utilizing deferred intent processing.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3506

## Changes proposed in this Pull Request:

- Updates the PRB JS code so it creates a PaymentMethod object (`pm_`) rather than a source `src_`.
- Update the PRB flow so it goes via the new deferred intent flow rather than legacy payment processing.

## Testing instructions

**GENERAL TESTING**

1. Make sure the ECE feature flag isn't set.
2. Enable the express payment buttons.
3. Complete purchases using PRBs on the product, cart and checkout pages. 
4. Confirm that payments are completed as expected.

**SUBSCRIPTIONS FREE TRIAL**

1. Create a **virtual** subscription product with a free trial ([screenshot](https://github.com/user-attachments/assets/59ae7b99-4faf-46a4-baf4-8493dfae1479))
2. Purchase the product using a PRB.
3. On `develop` there are 4 things to notice. 
   1. The resulting payment method will be a source (`src_`).
   2. There will be set up intent request with a failure with the [following error message](https://github.com/user-attachments/assets/6b1e1768-7bac-4281-958f-dd7301a91674). 
   3. The `src_` [won't be attached to the customer](https://github.com/user-attachments/assets/23cdfe71-ba68-4329-a93e-060b0c1f0672). 
   4. There is [no payment method token saved in the WooCommerce store](https://github.com/user-attachments/assets/c1dd0c20-20a9-4c46-a51c-c2251ffae64d). _Note that the source when it was created is reusable and in my testing it does work for future renewal payments._ 
5. On this branch the resulting payment method will be a `pm_` and will be attached to the customer.
6. Because the PM is attached to the customer, there is a saved token. 

| Before | After |
|--------|--------|
| <img width="878" alt="Screenshot 2024-10-14 at 10 02 09 am" src="https://github.com/user-attachments/assets/d58072e5-45d7-46d9-8cc9-f06046db1e5c"> | <img width="612" alt="Screenshot 2024-10-14 at 10 02 35 am" src="https://github.com/user-attachments/assets/2c951474-f1ac-4882-9c07-6ea10d0a447b"><img width="885" alt="Screenshot 2024-10-14 at 10 02 48 am" src="https://github.com/user-attachments/assets/8b26bced-f0a3-442e-8e0a-2bb3ad2fb56e">| 

7. Process a renewal. Note that it is successful.

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
