### PR TITLE
Use ubuntu-22.04 for PHP tests flow for now

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   beta-compatibility:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast:    false
       max-parallel: 10


### PR DESCRIPTION
## Changes proposed in this Pull Request:

The image for `ubuntu-latest` has been updated; it no longer includes SVN.
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
- https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md


This PR pins `ubuntu-22.04` for now.

## Testing instructions
Check that the GitHub checks pass