### PR TITLE
Allow saved credit cards with a source ID (`src_`) to be used/displayed with the new checkout experience

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,7 +32,7 @@
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
 * Tweak - Add order lock for redirect payments.
 * Fix - Missing Stripe Fee and Stripe Payout details on orders that were captured manually.
-* Fix - Allow legacy `src_` payment methods linked to a saved credit card to be displayed on the checkout and My Account pages when the new checkout experience enabled.
+* Fix - Allow legacy `src_` payment methods linked to a saved credit card to be displayed on the checkout and My Account pages when the new checkout experience is enabled.
 
 = 8.7.0 - 2024-09-16 =
 * Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
 * Fix - Set order payment method title to the customizable title setting rather than the default label.
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
+* Fix - Allow legacy `src_` payment methods linked to a saved credit card to be displayed on the checkout and My Account pages when the new checkout experience enabled.
 
 = 8.7.0 - 2024-09-16 =
 * Add - Introduces a new promotional surface to encourage merchants with the legacy checkout experience and APMs enabled to use the new checkout experience.

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -270,10 +270,10 @@ class WC_Stripe_Payment_Tokens {
 
 					// Remove the following deprecated tokens:
 					// - APM tokens from before Split PE was in place.
-					// - Tokens using the sources API. Payments using these will fail with the PaymentMethods API.
+					// - Non-credit card tokens using the sources API. Payments using these will fail with the PaymentMethods API.
 					if (
 						( 'stripe' === $token->get_gateway_id() && WC_Stripe_Payment_Methods::SEPA === $token->get_type() ) ||
-						str_starts_with( $token->get_token(), 'src_' )
+						! $this->is_valid_payment_method_id( $token->get_token(), $this->get_payment_method_type_from_token( $token ) )
 					) {
 						$deprecated_tokens[ $token->get_token() ] = $token;
 						continue;

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -603,6 +603,24 @@ class WC_Stripe_Payment_Tokens {
 	}
 
 	/**
+	 * Returns true if the payment method ID is valid for the given payment method type.
+	 *
+	 * Payment method IDs beginning with 'src_' are only valid for card payment methods.
+	 *
+	 * @param string $payment_method_id   The payment method ID (e.g. 'pm_123' or 'src_123').
+	 * @param string $payment_method_type The payment method type.
+	 *
+	 * @return bool
+	 */
+	public function is_valid_payment_method_id( $payment_method_id, $payment_method_type = '' ) {
+		if ( str_starts_with( $payment_method_id, 'pm_' ) ) {
+			return true;
+		}
+
+		return str_starts_with( $payment_method_id, 'src_' ) && WC_Stripe_Payment_Methods::CARD === $payment_method_type;
+	}
+
+	/**
 	 * Controls the output for SEPA on the my account page.
 	 *
 	 * @since 4.0.0

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -613,11 +613,11 @@ class WC_Stripe_Payment_Tokens {
 	 * @return bool
 	 */
 	public function is_valid_payment_method_id( $payment_method_id, $payment_method_type = '' ) {
-		if ( str_starts_with( $payment_method_id, 'pm_' ) ) {
+		if ( 0 === strpos( $payment_method_id, 'pm_' ) ) {
 			return true;
 		}
 
-		return str_starts_with( $payment_method_id, 'src_' ) && WC_Stripe_Payment_Methods::CARD === $payment_method_type;
+		return 0 === strpos( $payment_method_id, 'src_' ) && WC_Stripe_Payment_Methods::CARD === $payment_method_type;
 	}
 
 	/**

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -316,11 +316,11 @@ class WC_Stripe_Payment_Tokens {
 
 				// Create a new token when:
 				// - The payment method doesn't have an associated token in WooCommerce.
-				// - The payment method is not a source.
+				// - The payment method is a valid PaymentMethodID (i.e. only support IDs starting with "src_" when using the card payment method type.
 				// - The payment method belongs to the gateway ID being retrieved or the gateway ID is empty (meaning we're looking for all payment methods).
 				if (
 					! isset( $stored_tokens[ $payment_method->id ] ) &&
-					! str_starts_with( $payment_method->id, 'src_' ) &&
+					$this->is_valid_payment_method_id( $payment_method->id, $payment_method_type ) &&
 					( $this->is_valid_payment_method_type_for_gateway( $payment_method_type, $gateway_id ) || empty( $gateway_id ) )
 				) {
 					$token                      = $this->add_token_to_user( $payment_method, $customer );

--- a/readme.txt
+++ b/readme.txt
@@ -157,5 +157,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Resolved an issue which caused the WeChat Pay payment icon to not be displayed on shortcode checkout pages.
 * Fix - Set order payment method title to the customizable title setting rather than the default label.
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
+* Fix - Allow legacy `src_` payment methods linked to a saved credit card to be displayed on the checkout and My Account pages when the new checkout experience enabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 * Fix - Update Cash App payments to avoid confirming on creation, resolving issues with generic payment failures in live mode.
 * Tweak - Add order lock for redirect payments.
 * Fix - Missing Stripe Fee and Stripe Payout details on orders that were captured manually.
-* Fix - Allow legacy `src_` payment methods linked to a saved credit card to be displayed on the checkout and My Account pages when the new checkout experience enabled.
+* Fix - Allow legacy `src_` payment methods linked to a saved credit card to be displayed on the checkout and My Account pages when the new checkout experience is enabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-payment-tokens.php
+++ b/tests/phpunit/test-class-wc-stripe-payment-tokens.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class WC_Stripe_Payment_Tokens tests.
+ */
+class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
+
+	/**
+	 * WC_Stripe_Payment_Tokens instance.
+	 *
+	 * @var WC_Stripe_Payment_Tokens
+	 */
+	private $stripe_payment_tokens;
+
+	public function set_up() {
+		parent::set_up();
+		$this->stripe_payment_tokens = new WC_Stripe_Payment_Tokens();
+	}
+
+	public function test_is_valid_payment_method_id() {
+		$this->assertTrue( $this->stripe_payment_tokens->is_valid_payment_method_id( 'pm_1234567890' ) );
+		$this->assertTrue( $this->stripe_payment_tokens->is_valid_payment_method_id( 'pm_1234567890', 'card' ) );
+		$this->assertTrue( $this->stripe_payment_tokens->is_valid_payment_method_id( 'pm_1234567890', 'sepa' ) );
+
+		// Test with source id (only card payment method type is valid).
+		$this->assertTrue( $this->stripe_payment_tokens->is_valid_payment_method_id( 'src_1234567890', 'card' ) );
+		$this->assertFalse( $this->stripe_payment_tokens->is_valid_payment_method_id( 'src_1234567890', 'sepa' ) );
+		$this->assertFalse( $this->stripe_payment_tokens->is_valid_payment_method_id( 'src_1234567890', 'giropay' ) );
+	}
+}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3498

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As part of updating/migrating SEPA tokens over to `pm_` IDs, we also worked on a change (see https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3241) that removed support for displaying and storing any legacy `src_` tokens.
This fix was introduced because payment method requests with SEPA `src_` tokens would failed.

From Stripe's docs on sources (https://docs.stripe.com/sources), they do however still support source tokens for card payments and so we should continue to support them in our extension.

![image](https://github.com/user-attachments/assets/48f155fc-3331-43de-b927-34498011fb98)

While investigating https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3498, we found that Google Pay and Apple Pay were still create valid credit card payment methods beginning with `src_` and so our changes to remove/hide all saved cards with sources unexpectedly impacted customers that purchased using our Payment Request buttons.

The changes in this PR brings back support for displaying and storing payment methods starting with `src_` but only for credit cards.

Proposed changes:
- df909d63f8cab522a6c486c53a997b16dbe50548 - Introduces a new helper function to validate payment method IDs (i.e. only allow source IDs if the payment method is 'card')
- d6bc810179e52a1bda457ef19a4b46018dc285be - Don't delete any saved sources when the type is 'CC'
- 3f03fd17b497b879d9936935f7a26da8f4641960 - Allow for legacy sources to be stored in the `woocommerce_payment_tokens` table if the payment method type is 'card'

> [!NOTE]
> In @james-allan 's PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3510, he's updating our Payment Request buttons implementation so that any new saved cards will be created as `pm_` IDs.
> 
> In this PR, I'm fixing the issue for stores with existing customers with these saved legacy tokens.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

For the purpose of testing, I removed all my existing saved cards via the **My Account > Payment methods** page.

1. Enable WooCommerce Subscriptions and create a simple subscription product
2. Enable New Checkout experience and Apple Pay/Google Pay payment method
3. Make sure you're not using the new ECE feature (`_wcstripe_feature_ece` is set to 'no' in wp-options)
4. While on `trunk`, go to My Account > payment methods and confirm you have no saved payment methods
5. Purchase a subscription product using Google Pay or Apple Pay
6. From the stripe dashboard, navigate to the latest transaction and notice the payment method is a src token: ![image](https://github.com/user-attachments/assets/2b7bf926-10e4-490e-b32b-884b40930c5c)
7. Navigate to My Account > Payment methods and notice there's no saved card.![image](https://github.com/user-attachments/assets/1d9bcd27-b54e-4ecf-b96f-e4d4b96c2997)
9. Look in `wp_woocommerce_payment_tokens` table and notice there's no saved stripe tokens.
10. Checkout this branch
11. Refresh the My Account > Payment methods page to pull the latest saved methods from Stripe.
12. Confirm you now have a saved credit card.
13. Check the `wp_woocommerce_payment_tokens` table again and confirm you now see the saved `src_` token with type 'CC'.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
