### PR TITLE
Fix incorrect appearance of 'Use a New Payment Method' button

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 8.9.0 - xxxx-xx-xx =
+* Fix - Show 'Use a New Payment Method' radio button for logged in users only when card saving is enabled.
+
 = 8.8.0 - xxxx-xx-xx =
 * Fix - Update URL and path constants to support use of symlinked plugin.
 * Tweak - Disable ECE when cart has virtual products and tax is based on customer billing or shipping address.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -561,7 +561,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function payment_fields() {
 		try {
-			$display_tokenization = $this->supports( 'tokenization' ) && is_checkout();
+			$display_tokenization = $this->supports( 'tokenization' ) && is_checkout() && $this->saved_cards;
 
 			// Output the form HTML.
 			?>
@@ -587,7 +587,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			<?php
 			if ( $display_tokenization ) {
 				$this->tokenization_script();
-				$this->saved_payment_methods();
+				if ( is_user_logged_in() ) {
+					$this->saved_payment_methods();
+				}
 			}
 			?>
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,9 @@ If you get stuck, you can ask for help in the Plugin Forum.
 
 == Changelog ==
 
+= 8.9.0 - xxxx-xx-xx =
+* Fix - Show 'Use a New Payment Method' radio button for logged in users only when card saving is enabled.
+
 = 8.8.0 - xxxx-xx-xx =
 * Fix - Update URL and path constants to support use of symlinked plugin.
 * Tweak - Disable ECE when cart has virtual products and tax is based on customer billing or shipping address.


### PR DESCRIPTION
Fixes #3252

## Changes proposed in this Pull Request:
- Showing the 'Use a New Payment Method' radio button for logged in users only when card saving is enabled

## Testing instructions

1. Enable the 'New Checkout Experience', enable `card` payment method and disable the 'Enable payments via saved cards' checkboxes in the Stripe settings page.
2. Create a free product with $0 price.
3. Create two shipping zones for two locations with different shipping rates. i,e
    i. Location - US, free shipping.
    ii. Location - UK, flat rate - $20. (This is the one we will select on the checkout page to trigger the bug)
4. Ensure the customer is not logged in.
5. Add the free product to the car
6. Go to the shortcode checkout page (cart total shows $0.00).
7. Select the US as the shipping location. Shipping method should be free shipping and there should be no payment methods (as the cart total is ))
8. Now, change the address and select a UK location.
9. Cart total will update to $20. Shipping method should be flat rate shipping and card payment method should be displayed.
10. In `develop`, observe the "Use a new payment method" radio button displayed in the card payment section.
11. Checkout to this branch.
12. Repeat steps 1-9 and confirm that the "Use a new payment method" radio button is NOT displayed.
13. Repeat the reproduction steps for a logged in customer. Confirm that the "Use a new payment method" radio button is NOT displayed as 'Enable payments via saved cards' is disabled.
14. Now enable the 'Enable payments via saved cards' checkbox.
15. Repeat the reproduction steps and confirm that the radio button is visible when the customer is logged in but not visible for the logged out (guest) customer.