### PR TITLE
Don't mark Stripe Link as enabled in the admin

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -19,7 +19,6 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 		$this->title       = __( 'Link', 'woocommerce-gateway-stripe' );
 		$this->is_reusable = true;
 		$this->label       = __( 'Stripe Link', 'woocommerce-gateway-stripe' );
-		$this->enabled     = self::is_link_enabled() ? 'yes' : 'no';
 		$this->description = __(
 			'Link is a payment method that allows customers to save payment information  and use the payment details
 			for further payments.',
@@ -33,14 +32,8 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	 * @return bool
 	 */
 	public static function is_link_enabled() {
-
 		// Assume Link is disabled if UPE is disabled.
 		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return false;
-		}
-
-		// Don't mark Link as enabled if we're in the admin so it doesn't show up in the checkout editor page.
-		if ( is_admin() ) {
 			return false;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -19,6 +19,7 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 		$this->title       = __( 'Link', 'woocommerce-gateway-stripe' );
 		$this->is_reusable = true;
 		$this->label       = __( 'Stripe Link', 'woocommerce-gateway-stripe' );
+		$this->enabled     = self::is_link_enabled() ? 'yes' : 'no';
 		$this->description = __(
 			'Link is a payment method that allows customers to save payment information  and use the payment details
 			for further payments.',
@@ -35,6 +36,11 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 
 		// Assume Link is disabled if UPE is disabled.
 		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			return false;
+		}
+
+		// Don't mark Link as enabled if we're in the admin so it doesn't show up in the checkout editor page.
+		if ( is_admin() ) {
 			return false;
 		}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -488,7 +488,7 @@ function woocommerce_gateway_stripe() {
 					$methods = array_filter(
 						$methods,
 						function( $method ) {
-							return ! is_a( $method, 'WC_Stripe_UPE_Payment_Method_Link' );
+							return WC_Stripe_UPE_Payment_Method_Link::class !== $method;
 						}
 					);
 				}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -379,8 +379,8 @@ function woocommerce_gateway_stripe() {
 			public function update_prb_location_settings() {
 				$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 				$prb_locations   = isset( $stripe_settings['payment_request_button_locations'] )
-					? $stripe_settings['payment_request_button_locations']
-					: [];
+				? $stripe_settings['payment_request_button_locations']
+				: [];
 				if ( ! empty( $stripe_settings ) && empty( $prb_locations ) ) {
 					global $post;
 
@@ -481,6 +481,16 @@ function woocommerce_gateway_stripe() {
 					if ( isset( $sofort_settings['enabled'] ) && 'yes' === $sofort_settings['enabled'] ) {
 						$methods[] = WC_Gateway_Stripe_Sofort::class;
 					}
+				}
+
+				// Don't mark Link as enabled if we're in the admin so it doesn't show up in the checkout editor page.
+				if ( is_admin() ) {
+					$methods = array_filter(
+						$methods,
+						function( $method ) {
+							return ! is_a( $method, 'WC_Stripe_UPE_Payment_Method_Link' );
+						}
+					);
 				}
 
 				return $methods;


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3356

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR resolves an issue in which Stripe Link would be marked as incompatible with Checkout block. To decide if a payment method is compatible or not, Checkout block would compare all registered gateways in `woocommerce_payment_gateways` and make sure they have a corresponding JS paymentGateway or expressPaymentGateway. Stripe Link alongside Google Pay and Apple Pay all use the same `stripe` express payment registry, however, in PHP, Stripe Link register its own gateway class `WC_Stripe_UPE_Payment_Method_Link`. This ends up marking it as incompatible.

There are several possible solutions to this, the least intrusive so far, ~~is to mark `WC_Stripe_UPE_Payment_Method_Link` as disabled on all admin requests. This seems to work fine in admin and frontend, and doesn't break anything from what I saw.~~

Sadly changing `$this->enabled` broke certain unit tests that I couldn't figure out how to fix. I moved the logic to the main `woocommerce_payment_gateways` filter call.
 
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->
This code might break any admin logic that depends on Stripe Link being marked enabled. I checked and couldn't find anything.

Another option was to limit disable to only Gutenberg pages, but it was too early to reach for `get_current_screen`.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Before: (those are before and after from a PR https://github.com/woocommerce/woocommerce/pull/52070 but for this PR, both are considred before).
![image](https://github.com/user-attachments/assets/b6178e5d-7070-4811-bdce-2dd859dd73fa)
![image](https://github.com/user-attachments/assets/876180fc-f519-4636-a94c-99b93cb02ea4)

After:
<img width="284" alt="image" src="https://github.com/user-attachments/assets/1b0f566d-59b2-47e3-847c-1f94e0272345">

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

1. Enable Link.
2. Make sure your Checkout page is Checkout block.
3. Go to editor, select the main Checkout block, make sure the sidebar doesn't have any warnings about an incompatible plugin.
4. Do regression testing for Link, making sure it loads on both checkouts and you can place an order with it.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page] (https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply) (Honestly not sure how to write tests for this, as I'm not sure you have E2E flows that cover the editor).
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply) **Does not apply.**
-   [ ] Included this PR in the Release Thread scope (or does not apply) Not sure what is this.
