### PR TITLE
Don't call `process_response()` inside `process_payment_with_deferred_intent()` for orders that require action/confirmation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.9.0 - xxxx-xx-xx =
+* Fix - Prevent marking orders on-hold with order note "Process order to take payment" when the payment has failed.
 
 = 8.8.0 - 2024-10-17 =
 * Fix - Update URL and path constants to support use of symlinked plugin.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -885,7 +885,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$redirect = $return_url;
 			}
 
-			if ( $payment_needed ) {
+			if ( $payment_needed && ! in_array( $payment_intent->status, [ 'requires_confirmation', 'requires_action' ], true ) ) {
 				// Use the last charge within the intent to proceed.
 				$charge = $this->get_latest_charge_from_intent( $payment_intent );
 

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the Plugin Forum.
 == Changelog ==
 
 = 8.9.0 - xxxx-xx-xx =
+* Fix - Prevent marking orders on-hold with order note "Process order to take payment" when the payment has failed.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -452,7 +452,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		// We only use this when handling mandates.
 		$this->mock_gateway
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->once() )
 			->method( 'get_latest_charge_from_intent' )
 			->willReturn( null );
 
@@ -539,7 +539,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		// We only use this when handling mandates.
 		$this->mock_gateway
-			->expects( $saved_token ? $this->never() : ( $free_order ? $this->once() : $this->exactly( 2 ) ) )
+			->expects( $saved_token ? $this->never() : $this->once() )
 			->method( 'get_latest_charge_from_intent' )
 			->willReturn( null );
 
@@ -1378,7 +1378,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			'payment_method_details' => $payment_intent_mock,
 		];
 		$this->mock_gateway
-			->expects( $this->exactly( 2 ) )
+			->expects( $this->once() )
 			->method( 'get_latest_charge_from_intent' )
 			->willReturn( $this->array_to_object( $charge ) );
 
@@ -1387,7 +1387,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$client_secret = $payment_intent_mock->client_secret;
 
 		$this->assertEquals( 'success', $response['result'] );
-		$this->assertEquals( 'processing', $final_order->get_status() );
+		$this->assertEquals( 'pending', $final_order->get_status() ); // Order status should be pending until 3DS is completed.
 		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
 		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
 		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3517

---

Related issue: #3505 
Ticket: 8789458-zd-a8c
Slack thread: p1728030982720319-slack-C7U3Y3VMY (tread carefully in that slack thread as there's 3 different issues related to `process_response()` being called incorrectly. This PR fixes one of them 😅)

---

There is a bug within the `process_payment_with_deferred_intent()` function caused by reusing existing payment intents, which leads to failing orders being incorrectly marked as "on-hold." Merchants are shown the following order note, instructing them to incorrectly change the order status to "processing" in order to capture the payment:

![image](https://github.com/user-attachments/assets/82275243-a770-4c77-b50f-af9512175be7)

### Explanation

1. When a customer uses a card requiring further action/confirmation (e.g., a 3DS card), the `process_payment_with_deferred_intent()` function first creates a payment intent and modifies the redirect URL to either send the customer off-site or display the SCA confirmation window.
2. Before returning from `process_payment_with_deferred_intent()`, the function checks the [`$payment_needed` flag](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/197c4d43fb11f0007d4f9f389983a675aa6fc485/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L888-L890). If this flag is set, the latest charge from the intent is fetched, and `process_response()` is called if it exists.
3. In cases where the payment requires additional confirmation (like with 3DS), no charge exists on the intent yet meaning [this condition](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/197c4d43fb11f0007d4f9f389983a675aa6fc485/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L892-L893) fails, and the function proceeds to redirect the customer for confirmation.

### Problem

When the first payment attempt fails and the customer tries to pay again, the previous intent is reused (see our `process_payment_intent_for_order()` function)

On the second payment attempt, the intent now contains the failed charge from the previous attempt. When we reach the [$payment_needed check](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/197c4d43fb11f0007d4f9f389983a675aa6fc485/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L888-L895), the latest_charge is the failed charge from the prior payment.

Calling `process_response()` with this failed charge leads to [this logic](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/197c4d43fb11f0007d4f9f389983a675aa6fc485/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L599-L608) being run which is responsible for placing the order "on-hold" and adding the confusing order note.

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

For payments that require further action/confirmation, we expect these to be handled by our `process_upe_redirect_payment()` function which calls `process_order_for_confirmed_intent()` which then later calls `process_response()` only when the redirecting charge is successful.

Given this, this PR adds an extra condition to make sure we don't call `process_response()` inside `process_payment_with_deferred_intent()` when the payment intent requires confirmation/action.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

1. While on `develop` branch
1. Enable the new checkout experience
2. Make sure capture later is disabled: ![Image](https://github.com/user-attachments/assets/4e434d3d-c6c6-4e35-bb37-df43c3673ff1)
3. Purchase a product using a 3DS card that will decline: `4000008260003178`
4. On the SCA window, press "Complete" ![Image](https://github.com/user-attachments/assets/74e96092-0445-404f-9ab1-934c465c2fbd)
5. The checkout will fail.
6. Try again using the same 3DS card: `4000008260003178`
7. Before pressing Fail or Complete, open a new window and visit the WP Admin Edit Order page for this order
9. Notice that the order is set to on-hold with an order note telling merchants to mark the order as processing to take payment :x:
10. Finish the checkout successfully (using `4242` card) to mark the order as completed.
11. Checkout this branch and run through the steps again using different test cards:
   - `4000002760003184` (successful 3DS card)
   - `4000008260003178` (failing 3DS card)
   - `4242424242424242` (successful card)
   - `4000000000000341` (declining card)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)