### PR TITLE
Use Stripe-side info when displaying webhook status

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 8.9.0 - xxxx-xx-xx =
+* Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Improve error message displayed when payment method creation fails in classic checkout.
 * Dev - Replace two occurrences of payment method names with their constant equivalents.
 * Fix - Hide express checkout when credit card payments are not enabled.

--- a/client/components/webhook-description/__tests__/index.test.js
+++ b/client/components/webhook-description/__tests__/index.test.js
@@ -25,7 +25,7 @@ describe( 'WebhookDescription', () => {
 			};
 		} );
 
-		render( <WebhookDescription isWebhookSecretEntered={ true } /> );
+		render( <WebhookDescription isWebhookEnabled={ true } /> );
 
 		expect(
 			screen.queryByTestId( 'webhook-information' )
@@ -44,7 +44,7 @@ describe( 'WebhookDescription', () => {
 			};
 		} );
 
-		render( <WebhookDescription isWebhookSecretEntered={ false } /> );
+		render( <WebhookDescription isWebhookEnabled={ false } /> );
 
 		expect(
 			screen.queryByTestId( 'webhook-information' )
@@ -64,7 +64,7 @@ describe( 'WebhookDescription', () => {
 			};
 		} );
 
-		render( <WebhookDescription isWebhookSecretEntered={ false } /> );
+		render( <WebhookDescription isWebhookEnabled={ false } /> );
 
 		expect(
 			screen.queryByTestId( 'webhook-information' )

--- a/client/components/webhook-description/index.js
+++ b/client/components/webhook-description/index.js
@@ -31,7 +31,7 @@ const WebhookDescriptionInner = styled.div`
 	}
 `;
 
-export const WebhookDescription = ( { isWebhookSecretEntered } ) => {
+export const WebhookDescription = ( { isWebhookEnabled } ) => {
 	const {
 		code,
 		message,
@@ -40,10 +40,9 @@ export const WebhookDescription = ( { isWebhookSecretEntered } ) => {
 	} = useWebhookStateMessage();
 	const isWarningMessage = code === 3 || code === 4;
 	const isSuccessMessage = code === 1;
-	const isSuccessMessageWithSecret =
-		isSuccessMessage && isWebhookSecretEntered;
+	const isSuccessMessageWithSecret = isSuccessMessage && isWebhookEnabled;
 	const webhookDescriptionClassesAr = [];
-	if ( isWebhookSecretEntered ) {
+	if ( isWebhookEnabled ) {
 		webhookDescriptionClassesAr.push( 'expanded' );
 	}
 	if ( isWarningMessage ) {
@@ -52,7 +51,7 @@ export const WebhookDescription = ( { isWebhookSecretEntered } ) => {
 
 	return (
 		<WebhookDescriptionWrapper>
-			{ ! isWebhookSecretEntered && <WebhookInformation /> }
+			{ ! isWebhookEnabled && <WebhookInformation /> }
 			<WebhookDescriptionInner
 				className={ webhookDescriptionClassesAr.join( ' ' ) }
 			>

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -7,10 +7,6 @@ import styled from '@emotion/styled';
 import SectionStatus from '../section-status';
 import Tooltip from 'wcstripe/components/tooltip';
 import { useAccount } from 'wcstripe/data/account';
-import {
-	useAccountKeysTestWebhookSecret,
-	useAccountKeysWebhookSecret,
-} from 'wcstripe/data/account-keys';
 import { WebhookDescription } from 'wcstripe/components/webhook-description';
 
 const AccountDetailsContainer = styled.div`
@@ -108,28 +104,20 @@ const PayoutsSection = () => {
 };
 
 const WebhooksSection = () => {
-	const [ testWebhookSecret ] = useAccountKeysTestWebhookSecret();
-	const [ webhookSecret ] = useAccountKeysWebhookSecret();
 	const { data } = useAccount();
-	const isTestModeEnabled = Boolean( data.testmode );
-
-	const isWebhookSecretEntered = Boolean(
-		isTestModeEnabled ? testWebhookSecret : webhookSecret
-	);
+	const isWebhookEnabled = Boolean( data.is_webhook_enabled );
 
 	return (
 		<>
 			<AccountSection>
 				<Label>{ __( 'Webhook', 'woocommerce-gateway-stripe' ) }</Label>
-				<SectionStatus isEnabled={ isWebhookSecretEntered }>
-					{ isWebhookSecretEntered
+				<SectionStatus isEnabled={ isWebhookEnabled }>
+					{ isWebhookEnabled
 						? __( 'Enabled', 'woocommerce-gateway-stripe' )
 						: __( 'Disabled', 'woocommerce-gateway-stripe' ) }
 				</SectionStatus>
 			</AccountSection>
-			<WebhookDescription
-				isWebhookSecretEntered={ isWebhookSecretEntered }
-			/>
+			<WebhookDescription isWebhookEnabled={ isWebhookEnabled } />
 		</>
 	);
 };

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -96,6 +96,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 				'webhook_status_message'  => WC_Stripe_Webhook_State::get_webhook_status_message(),
 				'webhook_url'             => WC_Stripe_Helper::get_webhook_url(),
 				'configured_webhook_urls' => WC_Stripe_Webhook_State::get_configured_webhook_urls(),
+				'is_webhook_enabled'      => $this->account->is_webhook_enabled(),
 				'oauth_connections'       => [
 					'test' => $this->get_account_oauth_connection_data( 'test' ),
 					'live' => $this->get_account_oauth_connection_data( 'live' ),

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -13,6 +13,9 @@ class WC_Stripe_Account {
 	const LIVE_ACCOUNT_OPTION = 'wcstripe_account_data_live';
 	const TEST_ACCOUNT_OPTION = 'wcstripe_account_data_test';
 
+	const LIVE_WEBHOOK_STATUS_OPTION = 'wcstripe_webhook_status_live';
+	const TEST_WEBHOOK_STATUS_OPTION = 'wcstripe_webhook_status_test';
+
 	const STATUS_COMPLETE        = 'complete';
 	const STATUS_NO_ACCOUNT      = 'NOACCOUNT';
 	const STATUS_RESTRICTED_SOON = 'restricted_soon';
@@ -129,6 +132,10 @@ class WC_Stripe_Account {
 	public function clear_cache() {
 		delete_transient( self::LIVE_ACCOUNT_OPTION );
 		delete_transient( self::TEST_ACCOUNT_OPTION );
+
+		// Clear the webhook status cache.
+		delete_transient( self::LIVE_WEBHOOK_STATUS_OPTION );
+		delete_transient( self::TEST_WEBHOOK_STATUS_OPTION );
 	}
 
 	/**
@@ -379,8 +386,16 @@ class WC_Stripe_Account {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$is_testmode     = ( ! empty( $stripe_settings['testmode'] ) && 'yes' === $stripe_settings['testmode'] ) ? true : false;
 		$key             = $is_testmode ? 'test_webhook_data' : 'webhook_data';
+
 		if ( empty( $stripe_settings[ $key ]['id'] ) || empty( $stripe_settings[ $key ]['secret'] ) ) {
 			return false;
+		}
+
+		// Check if we have a cached status.
+		$cache_key     = $is_testmode ? self::TEST_WEBHOOK_STATUS_OPTION : self::LIVE_WEBHOOK_STATUS_OPTION;
+		$cached_status = get_transient( $cache_key );
+		if ( false !== $cached_status ) {
+			return 'enabled' === $cached_status;
 		}
 
 		try {
@@ -388,7 +403,14 @@ class WC_Stripe_Account {
 			$webhook_secret = $stripe_settings[ $key ]['secret'];
 			WC_Stripe_API::set_secret_key( $webhook_secret );
 			$webhook = $this->stripe_api::request( [], 'webhook_endpoints/' . $webhook_id, 'GET' );
-			return ! empty( $webhook->status ) && 'enabled' === $webhook->status;
+
+			// Cache the status for 2 hours.
+			$webhook_status = ! empty( $webhook->status ) && 'enabled' === $webhook->status ?
+				'enabled' :
+				'disabled';
+			set_transient( $cache_key, $webhook_status, 2 * HOUR_IN_SECONDS );
+
+			return 'enabled' === $webhook_status;
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::log( 'Unable to determine webhook status: .;' . $e->getMessage() );
 			return false;

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -369,4 +369,29 @@ class WC_Stripe_Account {
 			}
 		}
 	}
+
+	/**
+	 * Determine if the webhook is enabled by checking with Stripe.
+	 *
+	 * @return bool
+	 */
+	public function is_webhook_enabled() {
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$is_testmode     = ( ! empty( $stripe_settings['testmode'] ) && 'yes' === $stripe_settings['testmode'] ) ? true : false;
+		$key             = $is_testmode ? 'test_webhook_data' : 'webhook_data';
+		if ( empty( $stripe_settings[ $key ]['id'] ) || empty( $stripe_settings[ $key ]['secret'] ) ) {
+			return false;
+		}
+
+		try {
+			$webhook_id     = $stripe_settings[ $key ]['id'];
+			$webhook_secret = $stripe_settings[ $key ]['secret'];
+			WC_Stripe_API::set_secret_key( $webhook_secret );
+			$webhook = $this->stripe_api::request( [], 'webhook_endpoints/' . $webhook_id, 'GET' );
+			return ! empty( $webhook->status ) && 'enabled' === $webhook->status;
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log( 'Unable to determine webhook status: .;' . $e->getMessage() );
+			return false;
+		}
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 8.9.0 - xxxx-xx-xx =
+* Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Improve error message displayed when payment method creation fails in classic checkout.
 * Dev - Replace two occurrences of payment method names with their constant equivalents.
 * Fix - Hide express checkout when credit card payments are not enabled.

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -365,4 +365,69 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		// Confirm that all expected request call params were called.
 		$this->assertEmpty( WC_Helper_Stripe_Api::$expected_request_call_params );
 	}
+
+	/**
+	 * Tests for is_webhook_enabled().
+	 */
+	public function test_is_webhook_enabled() {
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+
+		// False if webhook secrets are not set.
+		$stripe_settings['testmode']          = 'yes';
+		$stripe_settings['test_webhook_data'] = [
+			'id'     => 'wh_123_test',
+			'secret' => '',
+		];
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->assertFalse( $this->account->is_webhook_enabled() );
+
+		$stripe_settings['test_webhook_data'] = [];
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->assertFalse( $this->account->is_webhook_enabled() );
+
+		unset( $stripe_settings['test_webhook_data'] );
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->assertFalse( $this->account->is_webhook_enabled() );
+
+		$stripe_settings['testmode']          = 'yes';
+		$stripe_settings['webhook_data']      = [
+			'id'     => 'wh_123',
+			'secret' => 'wh_secret_123',
+		];
+		$stripe_settings['test_webhook_data'] = [
+			'id'     => 'wh_123_test',
+			'secret' => 'wh_secret_123_test',
+		];
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		WC_Helper_Stripe_Api::$expected_request_call_params = [
+			[ [], 'webhook_endpoints/wh_123_test', 'GET' ],
+			[ [], 'webhook_endpoints/wh_123_test', 'GET' ],
+		];
+
+		// Assert that it correctly reads the webhook status field.
+		WC_Helper_Stripe_Api::$request_response = (object) [
+			'id'     => 'wh_123_test',
+			'status' => 'disabled',
+		];
+		$this->assertFalse( $this->account->is_webhook_enabled() );
+
+		WC_Helper_Stripe_Api::$request_response = (object) [
+			'id'     => 'wh_123_test',
+			'status' => 'enabled',
+		];
+		$this->assertTrue( $this->account->is_webhook_enabled() );
+
+		// Assert that it queries the correct webhook (live).
+		$stripe_settings['testmode'] = 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		WC_Helper_Stripe_Api::$expected_request_call_params = [
+			[ [], 'webhook_endpoints/wh_123', 'GET' ],
+		];
+		WC_Helper_Stripe_Api::$request_response = (object) [
+			'id'     => 'wh_123_test',
+			'status' => 'enabled',
+		];
+		$this->assertTrue( $this->account->is_webhook_enabled() );
+	}
 }

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -379,14 +379,17 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 			'secret' => '',
 		];
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->clear_webhook_status_cache();
 		$this->assertFalse( $this->account->is_webhook_enabled() );
 
 		$stripe_settings['test_webhook_data'] = [];
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->clear_webhook_status_cache();
 		$this->assertFalse( $this->account->is_webhook_enabled() );
 
 		unset( $stripe_settings['test_webhook_data'] );
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->clear_webhook_status_cache();
 		$this->assertFalse( $this->account->is_webhook_enabled() );
 
 		$stripe_settings['testmode']          = 'yes';
@@ -410,12 +413,14 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 			'id'     => 'wh_123_test',
 			'status' => 'disabled',
 		];
+		$this->clear_webhook_status_cache();
 		$this->assertFalse( $this->account->is_webhook_enabled() );
 
 		WC_Helper_Stripe_Api::$request_response = (object) [
 			'id'     => 'wh_123_test',
 			'status' => 'enabled',
 		];
+		$this->clear_webhook_status_cache();
 		$this->assertTrue( $this->account->is_webhook_enabled() );
 
 		// Assert that it queries the correct webhook (live).
@@ -428,6 +433,15 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 			'id'     => 'wh_123_test',
 			'status' => 'enabled',
 		];
+		$this->clear_webhook_status_cache();
 		$this->assertTrue( $this->account->is_webhook_enabled() );
+
+		// Assert that it uses the cached status.
+		$this->assertTrue( $this->account->is_webhook_enabled() );
+	}
+
+	private function clear_webhook_status_cache() {
+		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
+		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
 	}
 }


### PR DESCRIPTION
Instead of determining webhook status ('Enabled' vs 'Disabled') by using the presence or absence of secret keys, we check the actual status using Stripe API.

<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3512

## Changes proposed in this Pull Request:
In Stripe's Settings page, Account Status section, we display the webhook status as "Enabled" or "Disabled", based on the presence or absence of a webhook secret in the settings store. If the webhook has been disabled or deleted outside of WooCommerce, this approach leads to an inaccurate webhook status.

In this PR, we will display a more accurate webhook status by retrieving it using a Stripe API call. 


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Set up a publicly accessible WooCommerce store, e.g. using tunneling via ngrok or JT, or upload this branch's build to a JN site.
2. Connect your store to your Stripe account.
3. On successfully connecting, you should see the webhook status as "Enabled".
4. Go to https://dashboard.stripe.com/test/webhooks, making sure you're on the correct Stripe account and mode (test/live). You should see the webhook for your store.
5. Click on the webhook to load its details page. 
6. On the upper right corner, you should see a three-dot menu. Disable the webhook.
7. Go back to your WooCommerce store, and reload the Stripe settings page.
8. In `develop`, the webhook status still shows as `Enabled`. 
9. In this branch, the webhook status now shows `Disabled`.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
