### PR TITLE
Do not load ECE button if total amount is 0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Tweak - Do not load ECE button if the total amount is 0.
 
 = 8.8.1 - 2024-10-28 =
 * Tweak - Disables APMs when using the legacy checkout experience due Stripe deprecation by October 29, 2024.

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -1,7 +1,7 @@
-import { getSetting } from '@woocommerce/settings';
+/* global wc */
 
 export const getBlocksConfiguration = () => {
-	const stripeServerData = getSetting( 'stripe_data', null );
+	const stripeServerData = wc?.wcSettings?.getSetting( 'stripe_data', null );
 
 	if ( ! stripeServerData ) {
 		throw new Error( 'Stripe initialization data is not available' );

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -544,6 +544,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		}
 
 		// Don't show if the total price is 0.
+		// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
 		if ( 0.0 === (float) WC()->cart->get_total( false )
 			|| ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() )
 		) {

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -543,6 +543,13 @@ class WC_Stripe_Express_Checkout_Helper {
 			return false;
 		}
 
+		// Don't show if the total price is 0.
+		if ( 0.0 === (float) WC()->cart->get_total( false )
+			|| ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() )
+		) {
+			return false;
+		}
+
 		if ( $this->is_product() && in_array( $this->get_product()->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
 			$stock_availability = array_column( $this->get_product()->get_available_variations(), 'is_in_stock' );
 			// Don't show if all product variations are out-of-stock.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -545,7 +545,7 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Don't show if the total price is 0.
 		// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
-		if ( ( ( is_cart() || is_checkout() ) && 0.0 === (float) WC()->cart->get_total( false ) )
+		if ( ( ! ( $this->is_pay_for_order_page() || $this->is_product() ) && 0.0 === (float) WC()->cart->get_total( false ) )
 			|| ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() )
 		) {
 			return false;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -545,7 +545,7 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Don't show if the total price is 0.
 		// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
-		if ( 0.0 === (float) WC()->cart->get_total( false )
+		if ( ( ( is_cart() || is_checkout() ) && 0.0 === (float) WC()->cart->get_total( false ) )
 			|| ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() )
 		) {
 			return false;

--- a/readme.txt
+++ b/readme.txt
@@ -122,5 +122,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Tweak - Do not load ECE button if the total amount is 0.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:
- Not loading the ECE button when your cart total amount is `0`. Because ECE expects the amount to be greater than `0`.

- Fixed the following console error.
``` Uncaught Typeerror: Can not read properties of undefined (reading 'wcSettings')```


## Testing instructions
- Create a free product.
- Add the product to your cart and go to the cart/checkout page.
- In `develop` branch, you should see the following console error.

<img width="431" alt="Screenshot 2024-10-28 at 8 33 14 PM" src="https://github.com/user-attachments/assets/d23d3db9-0980-424a-bc0c-50abab88230e">

- In this branch, you should not see any console errors.

**Note**: the branch name is misleading as I initially targeted a different fix. The trial subscription will be fixed in a separate issue as it needs some more investigation (It's still under spike in WooPayments as well). 

