### PR TITLE
Fix ECE crash when address has no defined shipping rates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 8.9.0 - xxxx-xx-xx =
 * Tweak - Makes the new Stripe Express Checkout Element enabled by default.
 * Dev - Add multiple unit tests for the Stripe Express Checkout Element implementation (for both frontend and backend).
+* Fix - Fix ECE error when initial address on load is not defined as a shipping zone.
 * Fix - Corrected card brand capitalization on the My Account → Subscription page.
 * Fix - Displays a specific message when an authentication error occurs during checkout for 3DS cards (shortcode version).
 * Fix - Show 'Use a New Payment Method' radio button for logged in users only when card saving is enabled.

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -45,8 +45,9 @@ export const useExpressCheckout = ( {
 	const onButtonClick = useCallback(
 		( event ) => {
 			const getShippingRates = () => {
-				// shippingRates will only be populated when the Apple Pay/Google Pay address (default or selected)
-				// is defined as a shipping zone in WooCommerce.
+				// shippingData.shippingRates[ 0 ].shipping_rates will be non-empty
+				// only when the express checkout element's default shipping address
+				// has a shipping method defined in WooCommerce.
 				if (
 					shippingData?.shippingRates[ 0 ]?.shipping_rates?.length > 0
 				) {
@@ -61,8 +62,8 @@ export const useExpressCheckout = ( {
 					);
 				}
 
-				// Return a default shipping option as a non-empty shippingRates array is
-				// required when shippingAddressRequired is true.
+				// Return a default shipping option, as a non-empty shippingRates array
+				// is required when shippingAddressRequired is true.
 				return [
 					getExpressCheckoutData( 'checkout' )
 						?.default_shipping_option,

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -44,6 +44,31 @@ export const useExpressCheckout = ( {
 
 	const onButtonClick = useCallback(
 		( event ) => {
+			const getShippingRates = () => {
+				// shippingRates will only be populated when the Apple Pay/Google Pay address (default or selected)
+				// is defined as a shipping zone in WooCommerce.
+				if (
+					shippingData?.shippingRates[ 0 ]?.shipping_rates?.length > 0
+				) {
+					return shippingData.shippingRates[ 0 ].shipping_rates.map(
+						( r ) => {
+							return {
+								id: r.rate_id,
+								amount: parseInt( r.price, 10 ),
+								displayName: r.name,
+							};
+						}
+					);
+				}
+
+				// Return a default shipping option as a non-empty shippingRates array is
+				// required when shippingAddressRequired is true.
+				return [
+					getExpressCheckoutData( 'checkout' )
+						?.default_shipping_option,
+				];
+			};
+
 			const options = {
 				lineItems: normalizeLineItems( billing?.cartTotalItems ),
 				emailRequired: true,
@@ -51,15 +76,7 @@ export const useExpressCheckout = ( {
 				phoneNumberRequired:
 					getExpressCheckoutData( 'checkout' )?.needs_payer_phone ??
 					false,
-				shippingRates: shippingData?.shippingRates[ 0 ]?.shipping_rates?.map(
-					( r ) => {
-						return {
-							id: r.rate_id,
-							amount: parseInt( r.price, 10 ),
-							displayName: r.name,
-						};
-					}
-				),
+				shippingRates: getShippingRates(),
 			};
 
 			// Click event from WC Blocks.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -97,18 +97,7 @@ jQuery( function ( $ ) {
 				}
 
 				if ( getExpressCheckoutData( 'is_product_page' ) ) {
-					// Despite the name of the property, this seems to be just a single option that's not in an array.
-					const {
-						shippingOptions: shippingOption,
-					} = getExpressCheckoutData( 'product' );
-
-					return [
-						{
-							id: shippingOption.id,
-							amount: shippingOption.amount,
-							displayName: shippingOption.label,
-						},
-					];
+					return getExpressCheckoutData( 'product' )?.shippingOptions;
 				}
 
 				return options.displayItems

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -168,11 +168,6 @@ class WC_Stripe_Express_Checkout_Element {
 	 * @return array  The settings used for the Stripe express checkout element in JavaScript.
 	 */
 	public function javascript_params() {
-		$needs_shipping = 'no';
-		if ( ! is_null( WC()->cart ) && WC()->cart->needs_shipping() ) {
-			$needs_shipping = 'yes';
-		}
-
 		return [
 			'ajax_url'           => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'             => [
@@ -199,14 +194,7 @@ class WC_Stripe_Express_Checkout_Element {
 				/* translators: Do not translate the [option] placeholder */
 				'unknown_shipping' => __( 'Unknown shipping option "[option]".', 'woocommerce-gateway-stripe' ),
 			],
-			'checkout'           => [
-				'url'               => wc_get_checkout_url(),
-				'currency_code'     => strtolower( get_woocommerce_currency() ),
-				'country_code'      => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
-				'needs_shipping'    => $needs_shipping,
-				// Defaults to 'required' to match how core initializes this option.
-				'needs_payer_phone' => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
-			],
+			'checkout'           => $this->express_checkout_helper->get_checkout_data(),
 			'button'             => $this->express_checkout_helper->get_button_settings(),
 			'is_pay_for_order'   => $this->express_checkout_helper->is_pay_for_order_page(),
 			'has_block'          => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -252,12 +252,7 @@ class WC_Stripe_Express_Checkout_Helper {
 				'pending' => true,
 			];
 
-			$data['shippingOptions'] = [
-				'id'     => 'pending',
-				'label'  => __( 'Pending', 'woocommerce-gateway-stripe' ),
-				'detail' => '',
-				'amount' => 0,
-			];
+			$data['shippingOptions'] = [ $this->get_default_shipping_option() ];
 		}
 
 		$data['displayItems'] = $items;
@@ -275,6 +270,39 @@ class WC_Stripe_Express_Checkout_Helper {
 		$data['validVariationSelected'] = ! empty( $variation_id ) ? $this->is_product_supported( $product ) : true;
 
 		return apply_filters( 'wc_stripe_payment_request_product_data', $data, $product );
+	}
+
+	/**
+	 * JS params data used by cart and checkout pages.
+	 *
+	 * @param array $data
+	 */
+	public function get_checkout_data() {
+		$data = [
+			'url'                     => wc_get_checkout_url(),
+			'currency_code'           => strtolower( get_woocommerce_currency() ),
+			'country_code'            => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
+			'needs_shipping'          => 'no',
+			'needs_payer_phone'       => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),
+			'default_shipping_option' => $this->get_default_shipping_option(),
+		];
+
+		if ( ! is_null( WC()->cart ) && WC()->cart->needs_shipping() ) {
+			$data['needs_shipping'] = 'yes';
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Default shipping option, used by product, cart and checkout pages.
+	 */
+	private function get_default_shipping_option() {
+		return [
+			'id'          => 'pending',
+			'displayName' => __( 'Pending', 'woocommerce-gateway-stripe' ),
+			'amount'      => 0,
+		];
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 8.9.0 - xxxx-xx-xx =
 * Tweak - Makes the new Stripe Express Checkout Element enabled by default.
 * Dev - Add multiple unit tests for the Stripe Express Checkout Element implementation (for both frontend and backend).
+* Fix - Fix ECE error when initial address on load is not defined as a shipping zone.
 * Fix - Corrected card brand capitalization on the My Account → Subscription page.
 * Fix - Displays a specific message when an authentication error occurs during checkout for 3DS cards (shortcode version).
 * Fix - Show 'Use a New Payment Method' radio button for logged in users only when card saving is enabled.

--- a/tests/phpunit/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/test-wc-stripe-express-checkout-helper.php
@@ -67,4 +67,27 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		WC()->cart->add_to_cart( $shippable_product->get_id(), 1 );
 		$this->assertTrue( $wc_stripe_ece_helper_mock->should_show_express_checkout_button() );
 	}
+
+	/**
+	 * Test for get_checkout_data().
+	 */
+	public function test_get_checkout_data() {
+		// Local setup
+		update_option( 'woocommerce_checkout_phone_field', 'optional' );
+		update_option( 'woocommerce_default_country', 'US' );
+		update_option( 'woocommerce_currency', 'USD' );
+		WC()->cart->empty_cart();
+
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$checkout_data        = $wc_stripe_ece_helper->get_checkout_data();
+
+		$this->assertNotEmpty( $checkout_data['url'] );
+		$this->assertEquals( 'usd', $checkout_data['currency_code'] );
+		$this->assertEquals( 'US', $checkout_data['country_code'] );
+		$this->assertEquals( 'no', $checkout_data['needs_shipping'] );
+		$this->assertFalse( $checkout_data['needs_payer_phone'] );
+		$this->assertArrayHasKey( 'id', $checkout_data['default_shipping_option'] );
+		$this->assertArrayHasKey( 'displayName', $checkout_data['default_shipping_option'] );
+		$this->assertArrayHasKey( 'amount', $checkout_data['default_shipping_option'] );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3538 

## Changes proposed in this Pull Request:
For block cart and block checkout, when Apple Pay, Google Pay or Link loads and the default address (first address, or last selected address) is not defined under Shipping, we get an `IntegrationError` and the cart/checkout page gets stuck trying to load the modal.

This happens because for block cart and block checkout, we pass a potentially empty `shippingRates` array option to ECE. When `shippingRates` is empty but `shippingAddressRequired` is `true`, the Stripe JS library throws an error and bails ([Stripe docs](https://docs.stripe.com/js/element/events/on_click?type=expressCheckoutElement#element_on_click-handler-resolve-shippingAddressRequired)).

This issue does not happen inside the Product and shortcode pages because we are always passing a non-empty "pending" `shippingRates` array when ECE loads.

To fix the issue, we will do the same for block cart and block checkout: when we do not have shipping rates for the current address, we will pass a "pending" shipping rates array. With this change, ECE will not crash the page, and the user has a chance to change to a valid shipping address, in case of multiple available addresses.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Join the Google Pay test group to easily get multiple shipping addresses available to your account: https://groups.google.com/g/googlepay-test-mode-stub-data
2. As the merchant, set up your shipping zones such that only Japan is defined, with a free or flat rate shipping.
3. As the shopper, clear cookies and add a product to your cart.
4. For both block cart and block checkout, verify the following behavior:
   - On `develop`: Google Pay modal does not launch and the page is stuck loading.
   - On this branch: 
      - Google Pay modal launches without any error.
      - Shopper still cannot proceed with the purchase if an address other than Japan is selected.
      - Shipping computation is correct when selecting a valid shipping address.
6. Regression test: the product, shortcode cart and shortcode checkout pages should not be affected and should behave the same as above.

**Google Pay**
| Before | After |
| ------------- | ------------- |
| <img width="891" alt="Screenshot 2024-10-29 at 1 05 19 PM" src="https://github.com/user-attachments/assets/34390c46-8288-483b-b930-73bcb2cbd3fb">  | <img width="891" alt="Screenshot 2024-10-29 at 1 06 01 PM" src="https://github.com/user-attachments/assets/ae0bb00e-170b-4434-832b-4c598a1ccd38"> |


**Apple Pay**
| Before | After |
| ------------- | ------------- |
| <img width="617" alt="Screenshot 2024-10-30 at 12 18 37 PM" src="https://github.com/user-attachments/assets/32348e0a-cf84-435c-81d7-b7bf70bc2f2a"> | <img width="617" alt="Screenshot 2024-10-30 at 12 19 07 PM" src="https://github.com/user-attachments/assets/c72afb1c-9765-4cc7-b7ed-223c7220bb46"> |


**Link**
| Before | After |
| ------------- | ------------- |
| <img width="535" alt="Screenshot 2024-10-30 at 12 29 41 PM" src="https://github.com/user-attachments/assets/faccbff6-eee8-430a-adca-5528f414e806"> | <img width="535" alt="Screenshot 2024-10-30 at 12 27 15 PM" src="https://github.com/user-attachments/assets/bb43a0db-1395-4c18-a16e-78ca35873dbd"> |


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
