### PR TITLE
No longer record source migration failures in subscription order notes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Tweak - Remove the subscription order notes added each time a source wasn't migrated.
 
 = 8.8.1 - 2024-10-28 =
 * Tweak - Disables APMs when using the legacy checkout experience due Stripe deprecation by October 29, 2024.

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -40,16 +40,6 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	const SOURCE_ID_META_KEY = '_stripe_source_id';
 
 	/**
-	 * Exception code used when the migration of a subscription is skipped because the source is a card.
-	 */
-	const CARD_SKIPPED_CODE = 1;
-
-	/**
-	 * Exception code used when the migration of a subscription is skipped because the source hasn't been migrated to a payment method yet.
-	 */
-	const NOT_MIGRATED_YET_CODE = 2;
-
-	/**
 	 * Gateway ID for the Updated SEPA payment method.
 	 *
 	 * @var string
@@ -139,12 +129,12 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 
 		// Bail out, if the source object isn't expected to be migrated. eg Card sources are not migrated.
 		if ( isset( $source_object->type ) && 'card' === $source_object->type ) {
-			throw new \Exception( sprintf( 'Skipping migration of subscription #%d. Source is a card.', $subscription->get_id() ), self::CARD_SKIPPED_CODE );
+			throw new \Exception( sprintf( 'Skipping migration of subscription #%d. Source is a card.', $subscription->get_id() ) );
 		}
 
 		// Bail out if the src_ hasn't been migrated to pm_ yet.
 		if ( ! isset( $source_object->metadata->migrated_payment_method ) ) {
-			throw new \Exception( sprintf( 'The Source has not been migrated to PaymentMethods on the Stripe account.', $subscription->get_id() ), self::NOT_MIGRATED_YET_CODE );
+			throw new \Exception( sprintf( 'The Source has not been migrated to PaymentMethods on the Stripe account.', $subscription->get_id() ) );
 		}
 
 		// Get the payment method ID that was migrated from the source.

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -40,12 +40,12 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	const SOURCE_ID_META_KEY = '_stripe_source_id';
 
 	/**
-	 * Exception code used when the migration of a subscription is skipped.
+	 * Exception code used when the migration of a subscription is skipped because the source is a card.
 	 */
 	const CARD_SKIPPED_CODE = 1;
 
 	/**
-	 * Exception code used when the migration of a subscription is skipped.
+	 * Exception code used when the migration of a subscription is skipped because the source hasn't been migrated to a payment method yet.
 	 */
 	const NOT_MIGRATED_YET_CODE = 2;
 

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -40,6 +40,16 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	const SOURCE_ID_META_KEY = '_stripe_source_id';
 
 	/**
+	 * Exception code used when the migration of a subscription is skipped.
+	 */
+	const CARD_SKIPPED_CODE = 1;
+
+	/**
+	 * Exception code used when the migration of a subscription is skipped.
+	 */
+	const NOT_MIGRATED_YET_CODE = 2;
+
+	/**
 	 * Gateway ID for the Updated SEPA payment method.
 	 *
 	 * @var string
@@ -70,14 +80,10 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	public function maybe_update_subscription_source( WC_Subscription $subscription ) {
 		try {
 			$this->set_subscription_updated_payment_method( $subscription );
-
-			$order_note = __( 'Stripe Gateway: The payment method used for renewals was updated from Sources to PaymentMethods.', 'woocommerce-gateway-stripe' );
+			$subscription->add_order_note( __( 'Stripe Gateway: The payment method used for renewals was updated from Sources to PaymentMethods.', 'woocommerce-gateway-stripe' ) );
 		} catch ( \Exception $e ) {
-			/* translators: Reason why the subscription payment method wasn't updated */
-			$order_note = sprintf( __( 'Stripe Gateway: A Source is used for renewals but could not be updated to PaymentMethods. Reason: %s', 'woocommerce-gateway-stripe' ), $e->getMessage() );
+			WC_Stripe_Logger::log( $e->getMessage() );
 		}
-
-		$subscription->add_order_note( $order_note );
 	}
 
 	/**
@@ -131,14 +137,14 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 		// Retrieve the source object from the API.
 		$source_object = WC_Stripe_API::get_payment_method( $source_id );
 
-		// Bail out (with no error), if the source object isn't expected to be migrated. eg Card sources are not migrated.
+		// Bail out, if the source object isn't expected to be migrated. eg Card sources are not migrated.
 		if ( isset( $source_object->type ) && 'card' === $source_object->type ) {
-			return;
+			throw new \Exception( sprintf( 'Skipping migration of subscription #%d. Source is a card.', $subscription->get_id() ), self::CARD_SKIPPED_CODE );
 		}
 
 		// Bail out if the src_ hasn't been migrated to pm_ yet.
 		if ( ! isset( $source_object->metadata->migrated_payment_method ) ) {
-			throw new \Exception( sprintf( 'The Source has not been migrated to PaymentMethods on the Stripe account.', $subscription->get_id() ) );
+			throw new \Exception( sprintf( 'The Source has not been migrated to PaymentMethods on the Stripe account.', $subscription->get_id() ), self::NOT_MIGRATED_YET_CODE );
 		}
 
 		// Get the payment method ID that was migrated from the source.

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -131,6 +131,11 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 		// Retrieve the source object from the API.
 		$source_object = WC_Stripe_API::get_payment_method( $source_id );
 
+		// Bail out (with no error), if the source object isn't expected to be migrated. eg Card sources are not migrated.
+		if ( isset( $source_object->type ) && 'card' === $source_object->type ) {
+			return;
+		}
+
 		// Bail out if the src_ hasn't been migrated to pm_ yet.
 		if ( ! isset( $source_object->metadata->migrated_payment_method ) ) {
 			throw new \Exception( sprintf( 'The Source has not been migrated to PaymentMethods on the Stripe account.', $subscription->get_id() ) );

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -129,7 +129,7 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 
 		// Bail out, if the source object isn't expected to be migrated. eg Card sources are not migrated.
 		if ( isset( $source_object->type ) && 'card' === $source_object->type ) {
-			throw new \Exception( sprintf( 'Skipping migration of subscription #%d. Source is a card.', $subscription->get_id() ) );
+			throw new \Exception( sprintf( 'Skipping migration of Source for subscription #%d. Source is a card.', $subscription->get_id() ) );
 		}
 
 		// Bail out if the src_ hasn't been migrated to pm_ yet.

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Tweak - Remove the subscription order notes added each time a source wasn't migrated.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/migrations/test-class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/tests/phpunit/admin/migrations/test-class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -328,9 +328,6 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test extends WP_UnitTe
 		$this->updater->maybe_migrate_before_renewal( $subscription_id );
 
 		$subscription = new WC_Subscription( $subscription_id );
-		$notes        = wc_get_order_notes(
-			[ 'order_id' => $subscription_id ]
-		);
 
 		// Confirm the subscription's payment method remains the same.
 		$this->assertEquals( $pm_id, $subscription->get_meta( self::SOURCE_ID_META_KEY ) );
@@ -355,9 +352,6 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test extends WP_UnitTe
 		$this->updater->maybe_migrate_before_renewal( $subscription_id );
 
 		$subscription = new WC_Subscription( $subscription_id );
-		$notes        = wc_get_order_notes(
-			[ 'order_id' => $subscription_id ]
-		);
 
 		// Confirm the subscription's payment method remains the same.
 		$this->assertEquals( $source_id, $subscription->get_meta( self::SOURCE_ID_META_KEY ) );

--- a/tests/phpunit/admin/migrations/test-class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/tests/phpunit/admin/migrations/test-class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -334,12 +334,6 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test extends WP_UnitTe
 
 		// Confirm the subscription's payment method remains the same.
 		$this->assertEquals( $pm_id, $subscription->get_meta( self::SOURCE_ID_META_KEY ) );
-
-		// Confirm a note is added when the Source wasn't migrated to PaymentMethods.
-		$this->assertEquals(
-			'Stripe Gateway: A Source is used for renewals but could not be updated to PaymentMethods. Reason: The subscription is not using a Stripe Source for renewals.',
-			$notes[0]->content
-		);
 	}
 
 	public function test_maybe_update_subscription_legacy_payment_method_adds_note_when_source_not_migrated() {
@@ -367,12 +361,6 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test extends WP_UnitTe
 
 		// Confirm the subscription's payment method remains the same.
 		$this->assertEquals( $source_id, $subscription->get_meta( self::SOURCE_ID_META_KEY ) );
-
-		// Confirm a note is added when the Source wasn't migrated to PaymentMethods.
-		$this->assertEquals(
-			'Stripe Gateway: A Source is used for renewals but could not be updated to PaymentMethods. Reason: The Source has not been migrated to PaymentMethods on the Stripe account.',
-			$notes[0]->content
-		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3565

## Changes proposed in this Pull Request:

This PR updates the `WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update` class to make sure it doesn't attempt to migrate source objects which are cards. 

Stripe have confirmed they don't intend on migrating Source cards and so the note we were adding to subscriptions is confusing.
 
## Testing instructions

1. Checkout of Stripe 8.7.0
   - `git checkout 8.7.0`
   - `npm run build`
   - ❗ This is important because in 8.8 we updated express payment methods to use `pm_xxx`
2. Purchase a subscription product using an express checkout method like Google Pay.
   - Make sure to disable ECE if you have that feature flag enabled.
3. You should end up with a subscription with a source object.
   - You can verify either via the database or [via the edit subscription admin screen](https://github.com/user-attachments/assets/ac965885-0bac-4a94-9311-ecd5dc19d073).
4. Renew the subscription by choosing the[ **Process Renewal** action on the Edit Subscription screen](https://woocommerce.com/document/subscriptions/add-or-modify-a-subscription/update-an-existing-subscription/#process-a-renewal) or via the Scheduled Actions. 
   - On `develop`, in the subscription's notes you should see the following note.
   - On this branch there should be no note. 

<p align="center">
<img width="300" src="https://github.com/user-attachments/assets/e786442a-67ed-4e04-a684-c4bfb6a6820c" alt="Image">
</br>
<sup>Note added to a subscription after failing to migrate a source to a payment method.</sup>
</p>

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
