### PR TITLE
Fix duplicate order notes/emails on subscription renewal orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Fix - Prevent marking renewal orders as processing/completed multiple times due to handling the Stripe webhook in parallel.
 
 = 8.8.1 - 2024-10-28 =
 * Tweak - Disables APMs when using the legacy checkout experience due Stripe deprecation by October 29, 2024.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -506,6 +506,8 @@ trait WC_Stripe_Subscriptions_Trait {
 
 			/* translators: error message */
 			$renewal_order->update_status( 'failed' );
+			$this->unlock_order_payment( $renewal_order );
+
 			return;
 		}
 
@@ -557,9 +559,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
 		}
 
-		if ( 'stripe_sepa' !== $this->id ) {
-			$this->unlock_order_payment( $renewal_order );
-		}
+		$this->unlock_order_payment( $renewal_order );
 	}
 
 	/**

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -499,11 +499,6 @@ trait WC_Stripe_Subscriptions_Trait {
 
 				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 			}
-
-			// TODO: Remove when SEPA is migrated to payment intents.
-			if ( 'stripe_sepa' !== $this->id ) {
-				$this->unlock_order_payment( $renewal_order );
-			}
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 
@@ -560,6 +555,10 @@ trait WC_Stripe_Subscriptions_Trait {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
+		}
+
+		if ( 'stripe_sepa' !== $this->id ) {
+			$this->unlock_order_payment( $renewal_order );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Fix - Prevent marking renewal orders as processing/completed multiple times due to handling the Stripe webhook in parallel.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3568
Part of the on-going duplicate order notes/emails issue: #3501

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
During the subscription renewal order payment process, the order payment is locked before initiating the first Stripe create/confirm intent request ([code reference](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/45963144feeef876dc4b4dd16dbe6a0d738abf5c/includes/compat/trait-wc-stripe-subscriptions.php#L448)).

In the current develop branch, the order is being unlocked prematurely ([code reference](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/45963144feeef876dc4b4dd16dbe6a0d738abf5c/includes/compat/trait-wc-stripe-subscriptions.php#L505)). Here's the current sequence:

```
1. process_subscription_payment( $amount, $renewal_order )
2. lock_order_payment( $renewal_order )
3. create_and_confirm_intent_for_off_session( ... )
4. unlock_order_payment( $renewal_order )
5. get_latest_charge_from_intent()                // sends a "GET charges/ID" request off to Stripe
6. process_response( $charge, $renewal_order )    // marks the order from pending -> processing/completed status
```

When there are delays in fetching the latest charge from Stripe or if the `payment_intent.succeeded` webhook is sent quickly, the current request and incoming webhook may be processed in parallel, leading to both requests calling `$renewal_order->payment_complete()` and adding the "Stripe charge completed." order note.

This results in duplicate emails being sent to customers and third-party code hooked to status transitions is fired multiple times.

### Solution

This PR addresses the issue by moving the unlock step to occur after processing the response and handling any exceptions. This ensures the order remains locked until all necessary actions are complete, preventing parallel handling conflicts.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

To replicate this consistently, I had to add a small `sleep( 2 );` between fetching the latest charge from Stripe and calling `process_response()` ([here](https://href.li/?https://github.com/woocommerce/woocommerce-gateway-stripe/blob/9cfc896a4b8ba790a482094df827df294680855f/includes/compat/trait-wc-stripe-subscriptions.php#L556)). While it seems hacky, this change simulates a slow Stripe request to fetch a charge object and assists with giving time for the `payment_intent.succeeded` webhook to be sent

```
$latest_charge = $this->get_latest_charge_from_intent( $response );
sleep( 2 );
$this->process_response( ( ! empty( $latest_charge ) ) ? $latest_charge : $response, $renewal_order );
```

1. Activate WooCommerce Subscriptions and purchase a subscription product with any successful card `4242424242424242`
2. While on `develop` process a renewal order using the "Process renewal" action on the Edit Subscription page
3. While visiting admin Edit Order page for new renewal order and the admin Edit Subscription page, notice the double order notes.
4. Checkout this branch and add the same `sleep( 2 )` in the code.
5. Confirm no duplicate order notes.

| `develop` | this PR |
|--------|--------|
|![image](https://github.com/user-attachments/assets/63ddca0b-93e3-41db-b823-d066727ef5d4)| ![image](https://github.com/user-attachments/assets/d508fff2-4fe1-4768-af8d-3dc7ff6a0b61) | 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
