### PR TITLE
Refactor order locking to use order meta instead of transients

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Dev - Refactor lock_order_payment() to use order meta instead of transients.
 
 = 8.8.1 - 2024-10-28 =
 * Tweak - Disables APMs when using the legacy checkout experience due Stripe deprecation by October 29, 2024.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1682,7 +1682,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$locked_intent = ! empty( $parts[1] ) ? $parts[1] : '';
 
 			// If the lock is still active, return true.
-			if ( time() <= $expiration && ( empty( $intent ) || empty( $locked_intent ) || ( $intent->id ?? '') === $locked_intent ) ) {
+			if ( time() <= $expiration && ( empty( $intent ) || empty( $locked_intent ) || ( $intent->id ?? '' ) === $locked_intent ) ) {
 				return true;
 			}
 		}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1674,10 +1674,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function lock_order_payment( $order, $intent = null ) {
 		$order->read_meta_data( true );
 
-		$existing_lock = $order->get_meta( '_stripe_lock_payment', true ); // In the format of a {expiry_timestamp}|{pi_xxxx}
+		$existing_lock = $order->get_meta( '_stripe_lock_payment', true );
 
 		if ( $existing_lock ) {
-			$parts         = explode( '|', $existing_lock );
+			$parts         = explode( '|', $existing_lock ); // This meta is stored the format {expiry_timestamp}|{pi_xxxx} or {expiry_timestamp} if no intent is passed.
 			$expiration    = (int) $parts[0];
 			$locked_intent = ! empty( $parts[1] ) ? $parts[1] : '';
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1672,17 +1672,25 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return bool            A flag that indicates whether the order is already locked.
 	 */
 	public function lock_order_payment( $order, $intent = null ) {
-		$order_id       = $order->get_id();
-		$transient_name = 'wc_stripe_processing_intent_' . $order_id;
-		$processing     = get_transient( $transient_name );
+		$order->read_meta_data( true );
 
-		// Block the process if the same intent is already being handled.
-		if ( '-1' === $processing || ( isset( $intent->id ) && $processing === $intent->id ) ) {
-			return true;
+		$existing_lock = $order->get_meta( '_stripe_lock_payment', true ); // In the format of a {expiry_timestamp}|{pi_xxxx}
+
+		if ( $existing_lock ) {
+			$parts         = explode( '|', $existing_lock );
+			$expiration    = (int) $parts[0];
+			$locked_intent = ! empty( $parts[1] ) ? $parts[1] : '';
+
+			// If the lock is still active, return true.
+			if ( time() <= $expiration && ( empty( $intent ) || empty( $locked_intent ) || ( $intent && isset( $intent->id ) ? $intent->id : '' ) === $locked_intent ) ) {
+				return true;
+			}
 		}
 
-		// Save the new intent as a transient, eventually overwriting another one.
-		set_transient( $transient_name, empty( $intent ) ? '-1' : $intent->id, 5 * MINUTE_IN_SECONDS );
+		$new_lock = ( time() + 5 * MINUTE_IN_SECONDS ) . ( isset( $intent->id ) ? '|' . $intent->id : '' );
+
+		$order->update_meta_data( '_stripe_lock_payment', $new_lock );
+		$order->save_meta_data();
 
 		return false;
 	}
@@ -1694,8 +1702,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param WC_Order $order The order that is being unlocked.
 	 */
 	public function unlock_order_payment( $order ) {
-		$order_id = $order->get_id();
-		delete_transient( 'wc_stripe_processing_intent_' . $order_id );
+		$order->delete_meta_data( '_stripe_lock_payment' );
+		$order->save_meta_data();
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1682,7 +1682,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$locked_intent = ! empty( $parts[1] ) ? $parts[1] : '';
 
 			// If the lock is still active, return true.
-			if ( time() <= $expiration && ( empty( $intent ) || empty( $locked_intent ) || ( $intent && isset( $intent->id ) ? $intent->id : '' ) === $locked_intent ) ) {
+			if ( time() <= $expiration && ( empty( $intent ) || empty( $locked_intent ) || ( $intent->id ?? '') === $locked_intent ) ) {
 				return true;
 			}
 		}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1677,7 +1677,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$existing_lock = $order->get_meta( '_stripe_lock_payment', true );
 
 		if ( $existing_lock ) {
-			$parts         = explode( '|', $existing_lock ); // This meta is stored the format {expiry_timestamp}|{pi_xxxx} or {expiry_timestamp} if no intent is passed.
+			$parts         = explode( '|', $existing_lock ); // Format is: "{expiry_timestamp}" or "{expiry_timestamp}|{pi_xxxx}" if an intent is passed.
 			$expiration    = (int) $parts[0];
 			$locked_intent = ! empty( $parts[1] ) ? $parts[1] : '';
 

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Dev - Refactor lock_order_payment() to use order meta instead of transients.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -1768,7 +1768,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
 		$order->save();
+
+		$order = wc_get_order( $order_id );
 
 		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
 		$payment_method_mock['id']               = $payment_method_id;
@@ -1799,7 +1802,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'create_and_confirm_intent_for_off_session' )
 			->with(
-				wc_get_order( $order_id ),
+				$order,
 				$prepared_source,
 				$amount
 			)
@@ -1820,7 +1823,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_latest_charge_from_intent' )
 			->willReturn( $this->array_to_object( $charge ) );
 
-		$this->mock_gateway->process_subscription_payment( $amount, wc_get_order( $order_id ), false, false );
+		$this->mock_gateway->process_subscription_payment( $amount, $order, false, false );
 
 		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
@@ -1859,7 +1862,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
+		$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
 		$order->save();
+
+		$order = wc_get_order( $order_id );
 
 		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
 		$payment_method_mock['id']               = $payment_method_id;
@@ -1898,7 +1904,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'create_and_confirm_intent_for_off_session' )
 			->with(
-				wc_get_order( $order_id ),
+				$order,
 				$prepared_source,
 				$amount
 			)
@@ -1919,7 +1925,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->method( 'get_latest_charge_from_intent' )
 			->willReturn( $this->array_to_object( $charge ) );
 
-		$this->mock_gateway->process_subscription_payment( $amount, wc_get_order( $order_id ), false, false );
+		$this->mock_gateway->process_subscription_payment( $amount, $order, false, false );
 
 		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3569
Part of the on-going duplicate order notes/emails issue: #3501

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR introduces a different approach to locking orders that doesn't use transients.

As part of investigating issues where some stores are consistently getting duplicate "Stripe charge completed" order notes and duplicate Order emails, we found that using transients to lock orders isn't a reliable approach - especially for sites with object caching enabled.

This PR refactors our `lock_order_payment()` function to use order meta instead of transients, while still maintaining the exact same behaviour as before (i.e. still a 5-minute hold and still able to pass and intent ID).

> [!WARNING]
> Worth acknowledging that this PR is technically a breaking change for any 3rd-parties that were manually looking for transients `wc_stripe_processing_intent_1234`, however, I don't see any reason why someone would be doing this.
>
> If we have concerns, I could still add the transient in this function so that it remains backwards compatible.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->


_Note: Make sure you have webhooks setup and configured properly_

1. Install and activate the [LiteSpeed Cache](https://wordpress.org/plugins/litespeed-cache/) plugin
2. Enable Object caching by going to **WP Admin > LiteSpeed Cache > Cache > Object** and enable it.
3. While on `develop`, purchase any product with a standard test card `4242424242424242`
4. View the Admin Edit order page and notice that there's duplicate "Stripe charge completed" order notes. If you have emailing enabled, you will also notice duplicate emails being sent.
5. Check out `for/3501-refactor-order-locking` and run the above steps again.
6. Confirm you're no longer seeing duplicate order notes.

| `develop` | this branch |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b2d4fecc-5cc8-45e3-8059-b1763be2c297) | ![image](https://github.com/user-attachments/assets/6f2dd0c9-05f5-4cb5-a455-8993e9b2d790)| 

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
