### PR TITLE
Process payment intent webhook for successful card purchases asynchronously 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Update - Process successful payment intent webhooks asynchronously.
 
 = 8.8.1 - 2024-10-28 =
 * Tweak - Disables APMs when using the legacy checkout experience due Stripe deprecation by October 29, 2024.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -928,22 +928,20 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 			case 'payment_intent.succeeded':
 			case 'payment_intent.amount_capturable_updated':
-				$charge = $this->get_latest_charge_from_intent( $intent );
-
 				WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
 
-				/**
-				 * Check if the order is awaiting further action from the customer. If so, do not process the payment via the webhook, let the redirect handle it.
-				 *
-				 * This is a stop-gap to fix a critical issue, see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
-				 * be better if we removed the need for additional meta data in favor of refactoring this part of the payment processing.
-				 */
-				$is_awaiting_action = $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false;
+				$process_webhook_async = apply_filters( 'wc_stripe_process_payment_intent_webhook_async', true, $order, $intent, $notification );
+				$is_awaiting_action    = $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false;
 
-				// Voucher payments are only processed via the webhook so are excluded from the above check.
-				// Wallets are also processed via the webhook, not redirection.
-				if ( ! $is_voucher_payment && ! $is_wallet_payment && $is_awaiting_action ) {
-					WC_Stripe_Logger::log( "Stripe UPE waiting for redirect. Scheduled deferred webhook processing. The status for order $order_id might need manual adjustment." );
+				// Process the webhook now if it's for a voucher or wallet payment , or if filtered to process immediately and order is not awaiting action.
+				if ( $is_voucher_payment || $is_wallet_payment || ( ! $process_webhook_async && ! $is_awaiting_action ) ) {
+					$charge = $this->get_latest_charge_from_intent( $intent );
+
+					do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
+
+					$this->process_response( $charge, $order );
+				} else {
+					WC_Stripe_Logger::log( "Processing $notification->type ($intent->id) webhook asynchronously for order $order_id. " );
 
 					// Schedule a job to check on the status of this intent.
 					$this->defer_webhook_processing(
@@ -954,14 +952,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 						]
 					);
 
-					do_action( 'wc_gateway_stripe_process_payment_intent_incomplete', $order );
-					return;
+					if ( $is_awaiting_action ) {
+						do_action( 'wc_gateway_stripe_process_payment_intent_incomplete', $order );
+					}
 				}
 
-				do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
-
-				// Process valid response.
-				$this->process_response( $charge, $order );
 				break;
 			default:
 				if ( $is_voucher_payment && 'payment_intent.payment_failed' === $notification->type ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1118,6 +1118,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		$charge = $this->get_latest_charge_from_intent( $intent );
 
+		if ( ! $charge ) {
+			WC_Stripe_Logger::log( "Skipped processing deferred webhook for Stripe PaymentIntent {$intent_id} for order {$order->get_id()} - no charge found." );
+			return;
+		}
+
 		WC_Stripe_Logger::log( "Processing Stripe PaymentIntent {$intent_id} for order {$order->get_id()} via deferred webhook." );
 
 		do_action( 'wc_gateway_stripe_process_payment', $charge, $order );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -941,7 +941,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 					$this->process_response( $charge, $order );
 				} else {
-					WC_Stripe_Logger::log( "Processing $notification->type ($intent->id) webhook asynchronously for order $order_id. " );
+					WC_Stripe_Logger::log( "Processing $notification->type ($intent->id) asynchronously for order $order_id." );
 
 					// Schedule a job to check on the status of this intent.
 					$this->defer_webhook_processing(

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Update - Process successful payment intent webhooks asynchronously.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3574
Part of the on-going duplicate order notes/emails issue: #3501

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR extends on what we introduced in #3217 and now processes most `payment_intent.succeeded|amount_capturable_updated` webhooks requests asynchronously.

The goal with this change is to prevent our webhook handler from processing incoming payment requests in parallel with our current payment request. This issue has been impacting our merchants for many months and years and results in duplicate order notes and emails being sent, as well as duplicate pending -> processing/completed status transition hooks being fired.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

> [!NOTE]
> Because we are still locking orders payments, the method I've been using to test these changes is replacing our `lock_order_payment()` function with a simple `return false;`
> ```
>/**
>  * Locks an order for payment intent processing for 5 minutes.
>  *
>  * @since 4.2
>  * @param WC_Order $order  The order that is being paid.
>  * @param stdClass $intent The intent that is being processed.
>  * @return bool            A flag that indicates whether the order is already locked.
>  */
>public function lock_order_payment( $order, $intent = null ) {
>	return false;
>}
>```
>
> With this change, orders will never be locked meaning we will rely solely on these changes to process webhooks asynchronously.

1. Ensure the new checkout experience is enabled.
2. Setup your test site to receive/handle incoming Stripe webhooks
3. Purchase a product with a successful card `4242424242424242`
4. View the Edit Order page and confirm no duplicate order notes (even though we've disabled order locking)
5. Go to **WooCommerce > Status > Scheduled Actions** and search the new order ID
6. Confirm you see a pending scheduled `wc_stripe_deferred_webhook` action for this order:
![image](https://github.com/user-attachments/assets/5b497629-8771-4f90-90b4-a1eca6f1cb6e)
7. Wait for this scheduled action to be pulled off the queue automatically, or manually run it yourself and confirm no duplicate order notes.
8. With Stripe logs enabled, in the logs you should find a log for "Skipped processing deferred webhook for Stripe PaymentIntent pi_xxxx for order 1234 - **payment already complete.**"

Because this PR is touching our webhook handling, we should also test:
- Payments that require redirect/flagged for awaiting payment
- Using a Wallet payment method like CashApp, confirm that webhooks are processed immediately.
- using a Voucher payment method like OXXO, confirm webhooks are processed immediately and not deferred.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
