### PR TITLE
Show ECE button in settings preview

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Add - Show ECE button preview on settings page.
 
 = 8.8.1 - 2024-10-28 =
 * Tweak - Disables APMs when using the legacy checkout experience due Stripe deprecation by October 29, 2024.

--- a/client/entrypoints/payment-request-settings/__tests__/payment-request-settings-locations.test.js
+++ b/client/entrypoints/payment-request-settings/__tests__/payment-request-settings-locations.test.js
@@ -55,6 +55,8 @@ const getMockPaymentRequestLocations = (
 ];
 
 describe( 'PaymentRequestsSettingsSection', () => {
+	const globalValues = global.wc_stripe_payment_request_settings_params;
+
 	beforeEach( () => {
 		usePaymentRequestEnabledSettings.mockReturnValue(
 			getMockPaymentRequestEnabledSettings( true, jest.fn() )
@@ -63,6 +65,18 @@ describe( 'PaymentRequestsSettingsSection', () => {
 		usePaymentRequestLocations.mockReturnValue(
 			getMockPaymentRequestLocations( true, true, true, jest.fn() )
 		);
+
+		global.wc_stripe_payment_request_settings_params = {
+			...globalValues,
+			key: 'pk_test_123',
+			locale: 'en',
+			is_ece_enabled: true,
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		global.wc_stripe_payment_request_settings_params = globalValues;
 	} );
 
 	it( 'should enable express checkout locations when express checkout is enabled', () => {

--- a/client/entrypoints/payment-request-settings/__tests__/payment-request-settings.test.js
+++ b/client/entrypoints/payment-request-settings/__tests__/payment-request-settings.test.js
@@ -57,6 +57,7 @@ const getMockPaymentRequestLocations = (
 ];
 
 describe( 'PaymentRequestsSettingsSection', () => {
+	const globalValues = global.wc_stripe_payment_request_settings_params;
 	beforeEach( () => {
 		usePaymentRequestEnabledSettings.mockReturnValue(
 			getMockPaymentRequestEnabledSettings( true, jest.fn() )
@@ -65,6 +66,18 @@ describe( 'PaymentRequestsSettingsSection', () => {
 		usePaymentRequestLocations.mockReturnValue(
 			getMockPaymentRequestLocations( true, true, true, jest.fn() )
 		);
+
+		global.wc_stripe_payment_request_settings_params = {
+			...globalValues,
+			key: 'pk_test_123',
+			locale: 'en',
+			is_ece_enabled: true,
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		global.wc_stripe_payment_request_settings_params = globalValues;
 	} );
 
 	it( 'renders settings with defaults', () => {

--- a/client/entrypoints/payment-request-settings/express-checkout-button-preview.js
+++ b/client/entrypoints/payment-request-settings/express-checkout-button-preview.js
@@ -1,0 +1,117 @@
+/* global wc_stripe_payment_request_settings_params */
+
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { Elements, ExpressCheckoutElement } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import { getDefaultBorderRadius } from 'wcstripe/express-checkout/utils';
+import InlineNotice from 'components/inline-notice';
+
+const buttonSizeToPxMap = {
+	small: 40,
+	default: 48,
+	large: 56,
+};
+
+/* eslint-disable camelcase */
+const stripePromise = loadStripe(
+	wc_stripe_payment_request_settings_params.key,
+	{
+		locale: wc_stripe_payment_request_settings_params.stripe_locale,
+	}
+);
+/* eslint-enable camelcase */
+
+const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
+	const [ canRenderButtons, setCanRenderButtons ] = useState( true );
+
+	const options = {
+		mode: 'payment',
+		amount: 1000,
+		currency: 'usd',
+		appearance: {
+			variables: {
+				borderRadius: `${ getDefaultBorderRadius() }px`,
+				spacingUnit: '6px',
+			},
+		},
+	};
+
+	const height = buttonSizeToPxMap[ size ] || buttonSizeToPxMap.medium;
+
+	const mapThemeConfigToButtonTheme = ( paymentMethod, buttonTheme ) => {
+		switch ( buttonTheme ) {
+			case 'dark':
+				return 'black';
+			case 'light':
+				return 'white';
+			case 'light-outline':
+				if ( paymentMethod === 'googlePay' ) {
+					return 'white';
+				}
+
+				return 'white-outline';
+			default:
+				return 'black';
+		}
+	};
+
+	const type = buttonType === 'default' ? 'plain' : buttonType;
+
+	const buttonOptions = {
+		buttonHeight: Math.min( Math.max( height, 40 ), 55 ),
+		buttonTheme: {
+			googlePay: mapThemeConfigToButtonTheme( 'googlePay', theme ),
+			applePay: mapThemeConfigToButtonTheme( 'applePay', theme ),
+		},
+		buttonType: {
+			googlePay: type,
+			applePay: type,
+		},
+		paymentMethods: {
+			link: 'never',
+			googlePay: 'always',
+			applePay: 'always',
+		},
+		layout: { overflow: 'never' },
+	};
+
+	const onReady = ( { availablePaymentMethods } ) => {
+		if ( availablePaymentMethods ) {
+			setCanRenderButtons( true );
+		} else {
+			setCanRenderButtons( false );
+		}
+	};
+
+	if ( canRenderButtons ) {
+		return (
+			<div
+				key={ `${ buttonType }-${ theme }` }
+				style={ { minHeight: `${ height }px`, width: '100%' } }
+			>
+				<Elements stripe={ stripePromise } options={ options }>
+					<ExpressCheckoutElement
+						options={ buttonOptions }
+						onClick={ () => {} }
+						onReady={ onReady }
+					/>
+				</Elements>
+			</div>
+		);
+	}
+
+	return (
+		<InlineNotice icon status="error" isDismissible={ false }>
+			{ __(
+				'Failed to preview the Apple Pay or Google Pay button. ' +
+					'Ensure your store uses HTTPS on a publicly available domain ' +
+					"and you're viewing this page in a Safari or Chrome browser. " +
+					'Your device must be configured to use Apple Pay or Google Pay.',
+				'woocommerce-gateway-stripe'
+			) }
+		</InlineNotice>
+	);
+};
+
+export default ExpressCheckoutPreviewComponent;

--- a/client/entrypoints/payment-request-settings/express-checkout-button-preview.js
+++ b/client/entrypoints/payment-request-settings/express-checkout-button-preview.js
@@ -17,7 +17,7 @@ const buttonSizeToPxMap = {
 const stripePromise = loadStripe(
 	wc_stripe_payment_request_settings_params.key,
 	{
-		locale: wc_stripe_payment_request_settings_params.stripe_locale,
+		locale: wc_stripe_payment_request_settings_params.locale,
 	}
 );
 /* eslint-enable camelcase */

--- a/client/entrypoints/payment-request-settings/express-checkout-button-preview.js
+++ b/client/entrypoints/payment-request-settings/express-checkout-button-preview.js
@@ -1,7 +1,7 @@
 /* global wc_stripe_payment_request_settings_params */
 
 import { __ } from '@wordpress/i18n';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { Elements, ExpressCheckoutElement } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import { getDefaultBorderRadius } from 'wcstripe/express-checkout/utils';
@@ -13,17 +13,16 @@ const buttonSizeToPxMap = {
 	large: 56,
 };
 
-/* eslint-disable camelcase */
-const stripePromise = loadStripe(
-	wc_stripe_payment_request_settings_params.key,
-	{
-		locale: wc_stripe_payment_request_settings_params.locale,
-	}
-);
-/* eslint-enable camelcase */
-
 const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 	const [ canRenderButtons, setCanRenderButtons ] = useState( true );
+
+	/* eslint-disable camelcase */
+	const stripePromise = useMemo( () => {
+		return loadStripe( wc_stripe_payment_request_settings_params.key, {
+			locale: wc_stripe_payment_request_settings_params.locale,
+		} );
+	}, [] );
+	/* eslint-enable camelcase */
 
 	const options = {
 		mode: 'payment',

--- a/client/entrypoints/payment-request-settings/payment-request-settings-section.js
+++ b/client/entrypoints/payment-request-settings/payment-request-settings-section.js
@@ -1,3 +1,5 @@
+/* global wc_stripe_payment_request_settings_params */
+
 import { ADMIN_URL, getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import React, { useMemo } from 'react';
@@ -131,6 +133,8 @@ const PaymentRequestsSettingsSection = () => {
 	const accountId = useAccount().data?.account?.id;
 	const [ publishableKey ] = useAccountKeysPublishableKey();
 	const [ testPublishableKey ] = useAccountKeysTestPublishableKey();
+	const isECEEnabled =
+		wc_stripe_payment_request_settings_params.is_ece_enabled; // eslint-disable-line camelcase
 
 	const stripePromise = useMemo( () => {
 		return loadStripe(
@@ -261,16 +265,18 @@ const PaymentRequestsSettingsSection = () => {
 				/>
 				<p>{ __( 'Preview', 'woocommerce-gateway-stripe' ) }</p>
 				<LoadableAccountSection numLines={ 7 }>
-					<Elements stripe={ stripePromise }>
-						<PaymentRequestButtonPreview />
-					</Elements>
-
-					<ExpressCheckoutPreviewComponent
-						stripe={ stripePromise }
-						buttonType={ buttonType }
-						theme={ theme }
-						size={ size }
-					/>
+					{ isECEEnabled ? (
+						<ExpressCheckoutPreviewComponent
+							stripe={ stripePromise }
+							buttonType={ buttonType }
+							theme={ theme }
+							size={ size }
+						/>
+					) : (
+						<Elements stripe={ stripePromise }>
+							<PaymentRequestButtonPreview />
+						</Elements>
+					) }
 				</LoadableAccountSection>
 			</CardBody>
 		</Card>

--- a/client/entrypoints/payment-request-settings/payment-request-settings-section.js
+++ b/client/entrypoints/payment-request-settings/payment-request-settings-section.js
@@ -11,6 +11,7 @@ import interpolateComponents from 'interpolate-components';
 import { Elements } from '@stripe/react-stripe-js';
 import { loadStripe } from '@stripe/stripe-js';
 import PaymentRequestButtonPreview from './payment-request-button-preview';
+import ExpressCheckoutPreviewComponent from './express-checkout-button-preview';
 import {
 	usePaymentRequestEnabledSettings,
 	usePaymentRequestLocations,
@@ -263,6 +264,13 @@ const PaymentRequestsSettingsSection = () => {
 					<Elements stripe={ stripePromise }>
 						<PaymentRequestButtonPreview />
 					</Elements>
+
+					<ExpressCheckoutPreviewComponent
+						stripe={ stripePromise }
+						buttonType={ buttonType }
+						theme={ theme }
+						size={ size }
+					/>
 				</LoadableAccountSection>
 			</CardBody>
 		</Card>

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -40,7 +40,7 @@ class WC_Stripe_Payment_Requests_Controller {
 		wp_enqueue_script( 'wc-stripe-payment-request-settings' );
 
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		$params = [
+		$params          = [
 			'key'            => 'yes' === $stripe_settings['testmode'] ? $stripe_settings['test_publishable_key'] : $stripe_settings['publishable_key'],
 			'locale'         => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
 			'is_ece_enabled' => WC_Stripe_Feature_Flags::is_stripe_ece_enabled(),

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -39,6 +39,17 @@ class WC_Stripe_Payment_Requests_Controller {
 		);
 		wp_enqueue_script( 'wc-stripe-payment-request-settings' );
 
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$params = [
+			'key'           => 'yes' === $stripe_settings['testmode'] ? $stripe_settings['test_publishable_key'] : $stripe_settings['publishable_key'],
+			'stripe_locale' => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+		];
+		wp_localize_script(
+			'wc-stripe-payment-request-settings',
+			'wc_stripe_payment_request_settings_params',
+			$params
+		);
+
 		wp_register_style(
 			'wc-stripe-payment-request-settings',
 			plugins_url( 'build/payment_requests_settings.css', WC_STRIPE_MAIN_FILE ),

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -41,8 +41,9 @@ class WC_Stripe_Payment_Requests_Controller {
 
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$params = [
-			'key'           => 'yes' === $stripe_settings['testmode'] ? $stripe_settings['test_publishable_key'] : $stripe_settings['publishable_key'],
-			'stripe_locale' => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+			'key'            => 'yes' === $stripe_settings['testmode'] ? $stripe_settings['test_publishable_key'] : $stripe_settings['publishable_key'],
+			'locale'         => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+			'is_ece_enabled' => WC_Stripe_Feature_Flags::is_stripe_ece_enabled(),
 		];
 		wp_localize_script(
 			'wc-stripe-payment-request-settings',

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add error logging in ECE critical Ajax requests.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the block cart and block checkout pages.
 * Add - Add support for Stripe Link payments via the new Stripe Checkout Element on the product, cart, checkout and pay for order pages.
+* Add - Show ECE button preview on settings page.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3578 

## Changes proposed in this Pull Request:
- Added `ExpressCheckoutPreviewComponent` component to display the ECE button on the settings page.
- The component is created under `client/entrypoints/payment-request-settings/`. When we finally clean up the PRB codes, we will rename everything in this folder from `payment-request` to `express-checkout-element`.

## Testing instructions
- Go to the `<your_site>/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods&area=payment_requests` page.
- Enable the ECE feature flag and confirm that the ECE button is rendered.
- Disable the ECE feature flag and confirm that the PRB button is rendered.