### PR TITLE
Fix ECE error for virtual products and when no shipping zones are set up

### DIFF
--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -82,7 +82,9 @@ export const useExpressCheckout = ( {
 				phoneNumberRequired:
 					getExpressCheckoutData( 'checkout' )?.needs_payer_phone ??
 					false,
-				shippingRates: getShippingRates(),
+				...( shippingData?.needsShipping && {
+					shippingRates: getShippingRates(),
+				} ),
 			};
 
 			// Click event from WC Blocks.

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -67,10 +67,10 @@ export const useExpressCheckout = ( {
 
 				// Return a default shipping option, as a non-empty shippingRates array
 				// is required when shippingAddressRequired is true.
-				return [
-					getExpressCheckoutData( 'checkout' )
-						?.default_shipping_option,
-				];
+				const defaultShippingOption = getExpressCheckoutData(
+					'checkout'
+				)?.default_shipping_option;
+				return defaultShippingOption ? [ defaultShippingOption ] : [];
 			};
 
 			const options = {

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -296,8 +296,14 @@ class WC_Stripe_Express_Checkout_Helper {
 
 	/**
 	 * Default shipping option, used by product, cart and checkout pages.
+	 *
+	 * @return void|array
 	 */
 	private function get_default_shipping_option() {
+		if ( wc_get_shipping_method_count( true, true ) === 0 ) {
+			return null;
+		}
+
 		return [
 			'id'          => 'pending',
 			'displayName' => __( 'Pending', 'woocommerce-gateway-stripe' ),


### PR DESCRIPTION
## Changes proposed in this Pull Request:
In #3560, we fixed a scenario that causes ECE to crash on block checkout and block cart whenever the customer's ECE card address is not part of the shipping zones defined by the store. This however introduced a bug that causes a "Developer error" when there are no shipping methods set up, or when using ECE for virtual orders.

This PR fixes that behavior, such that:
- Virtual products should be unaffected by shipping zone setup.
- When there are no shipping zones set up, customers can still use ECE to place orders, similar to how we already let them use CC and other payment methods.
    - This is true for both shippable and virtual orders.
- When there are shipping zones set up, but the customer's ECE card address is not part of any shipping zones defined, or has no shipping methods for it, we give the user a chance to change their address in the ECE modal. This is what #3560 fixed -- we are not undoing this.

## Testing instructions

**When there are no shipping methods defined, I can still use ECE to purchase shippable orders.**
1. Go to WooCommerce > Shipping and delete all shipping zones.
2. As a shopper, verify that you can purchase using ECE in block cart and block checkout.
3. Verify that this ECE behavior is consistent with non-ECE, e.g. credit card.

**When there are shipping methods defined, but my ECE card address is not covered under shipping, I am asked in the modal to change my address for shippable orders.**
1. Go to WooCommerce > Shipping, add a shipping method for Japan, and delete all other shipping zones.
2. Add your Google Pay account to the test group, to easily gain access to multiple addresses: https://groups.google.com/g/googlepay-test-mode-stub-data
3. As a shopper, verify that you are only allowed to push through with a shippable order when you select the Japan address.
4. Verify that this ECE behavior is consistent with non-ECE, e.g. credit card.

**My ability to purchase virtual orders via ECE should not be affected**
1. As a shopper, verify that you can purchase virtual products via ECE regardless of how shipping zones are set up.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply) -- skipped as this is technically part of #3560 
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
