### PR TITLE
Make ECE feature flag enabled by default for new accounts only

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Fix - Hide express checkout when credit card payments are not enabled.
 * Fix - Fix issues when detaching payment methods on staging sites (with the new checkout experience enabled).
 * Fix - Display a notice if taxes vary by customer's billing address when checking out using the Stripe Express Checkout Element.
-* Tweak - Makes the new Stripe Express Checkout Element enabled by default.
+* Tweak - Makes the new Stripe Express Checkout Element enabled by default in new accounts.
 * Dev - Add multiple unit tests for the Stripe Express Checkout Element implementation (for both frontend and backend).
 * Fix - Check if taxes are enabled when applying ECE tax compatibility check.
 * Fix - Fix ECE error when initial address on load is not defined as a shipping zone.

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -14,7 +14,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_stripe_ece_enabled() {
-		return 'yes' === get_option( self::ECE_FEATURE_FLAG_NAME, 'yes' );
+		return 'yes' === get_option( self::ECE_FEATURE_FLAG_NAME, 'no' );
 	}
 
 	/**

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -214,6 +214,17 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		}
 
 		/**
+		 * Enable Stripe express checkout element for new connections.
+		 */
+		private function enable_ece_in_new_accounts() {
+			$existing_stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+
+			if ( empty( $existing_stripe_settings ) ) {
+				update_option( WC_Stripe_Feature_Flags::ECE_FEATURE_FLAG_NAME, 'yes' );
+			}
+		}
+
+		/**
 		 * Gets default Stripe settings
 		 */
 		private function get_default_stripe_config() {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -173,6 +173,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			unset( $options['account_id'] );
 			unset( $options['test_account_id'] );
 
+			// Enable ECE for new connections.
+			$this->enable_ece_in_new_accounts();
+
 			WC_Stripe_Helper::update_main_stripe_settings( $options );
 
 			// Similar to what we do for webhooks, we save some stats to help debug oauth problems.

--- a/readme.txt
+++ b/readme.txt
@@ -114,7 +114,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hide express checkout when credit card payments are not enabled.
 * Fix - Fix issues when detaching payment methods on staging sites (with the new checkout experience enabled).
 * Fix - Display a notice if taxes vary by customer's billing address when checking out using the Stripe Express Checkout Element.
-* Tweak - Makes the new Stripe Express Checkout Element enabled by default.
+* Tweak - Makes the new Stripe Express Checkout Element enabled by default in new accounts.
 * Dev - Add multiple unit tests for the Stripe Express Checkout Element implementation (for both frontend and backend).
 * Fix - Check if taxes are enabled when applying ECE tax compatibility check.
 * Fix - Fix ECE error when initial address on load is not defined as a shipping zone.


### PR DESCRIPTION
As we have discussed in peNR48-102-p2, we are enabling ECE for the new accounts.

## Changes proposed in this Pull Request:
- Setting the feature flag during authentication for new accounts.

## Testing instructions

#### Existing account
- Build this branch (`npm run build`)
- In a JN site, install the latest Stripe plugin (`8.8.2`)
- Connect to your Stripe account and enable express checkout on the Stripe settings page.
- As a shopper go to the checkout page and confirm that you see the PRB buttons.
- Now upload this build to your site to update the plugin.
- As a shopper go to the checkout page and confirm that you still see the PRB buttons.

#### New account
- Build this branch (`npm run build`)
- In another JN site install this build in the first place.
- Connect to your Stripe account and enable express checkout on the Stripe settings page.
- As a shopper go to the checkout page and confirm that you see the ECE buttons.