### PR TITLE
Exclude Pay for Order page from logic hiding ECE when taxes may be inaccurate

### DIFF
--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -600,6 +600,7 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Hide if cart/product doesn't require shipping and tax is based on billing or shipping address.
 		if (
+			! $this->is_pay_for_order_page() &&
 			(
 				( is_product() && ! $this->product_needs_shipping( $this->get_product() ) ) ||
 				( ( is_cart() || is_checkout() ) && ! WC()->cart->needs_shipping() )

--- a/tests/phpunit/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/test-wc-stripe-express-checkout-helper.php
@@ -60,12 +60,14 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'allowed_items_in_cart',
 				'should_show_ece_on_cart_page',
 				'should_show_ece_on_checkout_page',
+				'is_pay_for_order_page',
 			]
 		);
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( false );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_cart_page' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_pay_for_order_page' )->willReturnOnConsecutiveCalls( true, false );
 		$wc_stripe_ece_helper_mock->testmode = true;
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
@@ -82,6 +84,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		WC()->session->init();
 		WC()->cart->add_to_cart( $virtual_product->get_id(), 1 );
+
+		// Do not hide if Pay for Order page.
+		update_option( 'woocommerce_tax_based_on', 'shipping' );
+		$this->assertTrue( $wc_stripe_ece_helper_mock->should_show_express_checkout_button() );
 
 		// Hide if cart has virtual product and tax is based on shipping or billing address.
 		update_option( 'woocommerce_calc_taxes', 'yes' );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:
In #3493, we hide ECE buttons when taxes are enabled, based on customer shipping or billing address, and the cart is not shippable.

In this PR, we exclude the Pay for Order page in that logic, as taxes have already been computed when the order was created, and is already reflected in the total.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions, 
1. Enable ECE.
2. Enable taxes in WooCommerce > Settings > General.
3. Set `Calculate tax based on` to `Customer shipping address` in WooCommerce > Settings > Tax
4. Create an order via wp-admin Orders > Add order. Take note that whatever taxes apply get computed when you enter the billing/shipping address for the customer.
5. Verify that the Pay for Order page displays ECE buttons, regardless of whether the order is shippable or non-shippable.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply) -- changelog fixed as PR is supplemental to #3493
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
