### PR TITLE
Fix ECE modal not loading on pay for order page when coupon is applied

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 9.0.0 - xxxx-xx-xx =
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.
+* Fix - Fix ECE modal not loading on pay for order page when coupon is applied
 
 = 8.9.0 - 2024-11-14 =
 * Update - Enhance webhook processing to enable retrieving orders using payment_intent metadata.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -245,6 +245,13 @@ class WC_Stripe_Express_Checkout_Element {
 			];
 		}
 
+		if ( $order->get_total_discount() ) {
+			$items[] = [
+				'label'  => __( 'Discount', 'woocommerce-gateway-stripe' ),
+				'amount' => - WC_Stripe_Helper::get_stripe_amount( $order->get_total_discount(), $currency ),
+			];
+		}
+
 		if ( $order->get_shipping_total() ) {
 			$shipping_label = sprintf(
 			// Translators: %s is the name of the shipping method.

--- a/readme.txt
+++ b/readme.txt
@@ -112,5 +112,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.0.0 - xxxx-xx-xx =
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.
+* Fix - Fix ECE modal not loading on pay for order page when coupon is applied
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
When an order uses a coupon, the express payment modal does not load on the pay for order page. The issue happens because we are not sending the coupon as a line item when loading the modal on the pay for order page. This results in a mismatch in the `total`.

## Changes proposed in this Pull Request:
- Adding the `coupon` amount as a line item. 

## Testing instructions
- Enable the new checkout experience.
- Enable the ECE feature flag.
- Enable the express payment methods on Stripe settings page (Google Pay/Apple Pay and Link).
- As an admin, go to the order creation page.
- Add a product to the order and add a coupon.
- Add a customer and create the order.
- Open the 'Customer payment page →' link as the customer.
- Notice that the express checkout buttons are loading fine.
- Now in `develop` branch, click on the `Link` or `Google Pay` button.
- Notice that the corresponding modal never loads.

<img width="748" alt="Screenshot 2024-11-15 at 7 12 18 PM" src="https://github.com/user-attachments/assets/8f788bc2-4b51-4846-a7a5-e8910dc88b7c">

- In this branch, the modals should load correctly. 
- Confirm that the amounts (subtotal, coupon, total) displayed on the modal are correct.
- Confirm that the final charged amount is correct.