### PR TITLE
[ECE] Hide express payment buttons on switch subscription page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 9.0.0 - xxxx-xx-xx =
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.
+* Fix - Do not load express payment buttons on switch subscription page.
 
 = 8.9.0 - 2024-11-14 =
 * Update - Enhance webhook processing to enable retrieving orders using payment_intent metadata.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -87,7 +87,7 @@ class WC_Stripe_Express_Checkout_Element {
 
 		// Don't load for switch subscription page.
 		if ( isset( $_GET['switch-subscription'] ) ) {
-			return true;
+			return;
 		}
 
 		add_action( 'template_redirect', [ $this, 'set_session' ] );

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -85,6 +85,11 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
+		// Don't load for switch subscription page.
+		if ( isset( $_GET['switch-subscription'] ) ) {
+			return true;
+		}
+
 		add_action( 'template_redirect', [ $this, 'set_session' ] );
 		add_action( 'template_redirect', [ $this, 'handle_express_checkout_redirect' ] );
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -106,7 +106,7 @@ class WC_Stripe_Payment_Request {
 
 		// Don't load for switch subscription page.
 		if ( isset( $_GET['switch-subscription'] ) ) {
-			return true;
+			return;
 		}
 
 		$this->init();

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -104,6 +104,11 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
+		// Don't load for switch subscription page.
+		if ( isset( $_GET['switch-subscription'] ) ) {
+			return true;
+		}
+
 		$this->init();
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,5 +113,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 9.0.0 - xxxx-xx-xx =
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.
+* Fix - Do not load express payment buttons on switch subscription page.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3608 

## Changes proposed in this Pull Request:
As switch subscription page is basically the product page, when paid with ECE/PRB the full amount is charged instead of the difference. We are hiding the PRB/ECE buttons from the switch subscription page. 

## Testing instructions
- Enable the new checkout experience.
- Enable the ECE feature flag.
- Enable Google/Apple Pay from Stripe settings page.
- Install the `WooCommerce Subscription` plugin.
- Go to 'WooCommerce > Settings > Subscriptions' page. Enable subscription switching and prorating.
- Create a variable subscription product with 2 variations (Blue: 50 USD and Red: 60 USD).
- As a shopper, purchase the Blue variation.
- From 'My Account > Subscriptions' page find your subscription.
- Click on upgrade your subscription button.
- You will be taken to the product page to switch the product variation.
- In `develop` branch, you can see the ECE button on this page. 

<img width="1470" alt="Screenshot 2024-11-18 at 1 21 49 PM" src="https://github.com/user-attachments/assets/26a160d2-53a9-4c09-a3a5-8723dca55fbd">

- On this branch, you should not see the ECE button on the switch subscription page.
- Confirm that the ECE buttons are rendered correctly on cart and checkout pages when you click the switch button and it is added to the cart.