### PR TITLE
Fix 'is_live' value in account summary

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,8 @@
 = 9.0.0 - xxxx-xx-xx =
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.
-* Fix - Fix ECE modal not loading on pay for order page when coupon is applied
+* Fix - Fix ECE modal not loading on pay for order page when coupon is applied.
+* Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 
 = 8.9.0 - 2024-11-14 =
 * Update - Enhance webhook processing to enable retrieving orders using payment_intent metadata.

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -57,7 +57,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_account_summary' ],
-				'permission_callback' => [ $this, 'check_permission' ],
+				// 'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
 
@@ -134,7 +134,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 					'supported' => $this->account->get_supported_store_currencies(),
 				],
 				'country'                  => $account['country'] ?? WC()->countries->get_base_country(),
-				'is_live'                  => $account['charges_enabled'] ?? false,
+				'is_live'                  => WC_Stripe_Mode::is_live() && $account['charges_enabled'] ?? false,
 				'test_mode'                => WC_Stripe_Mode::is_test(),
 			]
 		);

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -57,7 +57,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_account_summary' ],
-				// 'permission_callback' => [ $this, 'check_permission' ],
+				'permission_callback' => [ $this, 'check_permission' ],
 			]
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 9.0.0 - xxxx-xx-xx =
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.
-* Fix - Fix ECE modal not loading on pay for order page when coupon is applied
+* Fix - Fix ECE modal not loading on pay for order page when coupon is applied.
+* Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes p1732003649743799-slack-C055WHLA98D

## Changes proposed in this Pull Request:
Return 'is_live' as true in the account summary response when test mode is disabled in gateway settings and charge is enabled in the Stripe account.

## Testing instructions
Code review should be enough.