### PR TITLE
Fix failing E2E tests due to login step failure

### DIFF
--- a/tests/e2e/utils/user.js
+++ b/tests/e2e/utils/user.js
@@ -18,7 +18,7 @@ export async function login( page, username, password, retries = 3 ) {
 			if ( await page.url().includes( 'wp-login.php' ) ) {
 				await page.fill( 'input[name="log"]', username );
 				await page.fill( 'input[name="pwd"]', password );
-				await page.click( 'text=Log In' );
+				await page.click( 'input[value="Log In"]' );
 			}
 			await page.waitForLoadState( 'networkidle' );
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:
Fixes failing e2e tests by updating the selector for the login button.

The old selector no longer works because a screen reader element, `<h1 class="screen-reader-text">Log In</h1>`, is being selected instead of the button we want.

Error log:
```
- Trying to log-in as admin...
User log-in failed, Retrying... 1/1. page.click: Timeout 30000ms exceeded.
Call log:
  - waiting for locator('text=Log In')
  -   locator resolved to 2 elements. Proceeding with the first one: <h1 class="screen-reader-text">Log In</h1>
  - attempting click action
  -   waiting for element to be visible, enabled and stable
  -   element is visible, enabled and stable
  -   scrolling into view if needed
  -   done scrolling
  -   element is outside of the viewport
```

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
E2E tests (Default) do not fail at the login step.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
