### PR TITLE
Pre-fill user info for Link in the Payment Element (block checkout)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Add - Pre-fill user email and phone number for Link in the Payment Element and block checkout.
 * Remove - Remove Link autofill modal feature.
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -20,6 +20,7 @@ import {
 	maybeShowCashAppLimitNotice,
 	removeCashAppLimitNotice,
 } from 'wcstripe/stripe-utils/cash-app-limit-notice-handler';
+import { isLinkEnabled } from 'wcstripe/stripe-utils';
 
 /**
  * Gets the Stripe element options.
@@ -27,7 +28,7 @@ import {
  * @return {Object} The Stripe element options.
  */
 const getStripeElementOptions = () => {
-	const options = {
+	let options = {
 		fields: {
 			billingDetails: {
 				name: 'never',
@@ -48,6 +49,26 @@ const getStripeElementOptions = () => {
 			googlePay: 'never',
 		},
 	};
+
+	// Prefill Link customer data if available.
+	if ( isLinkEnabled() ) {
+		const userEmail = document.getElementById( 'email' )?.value;
+		if ( userEmail ) {
+			const userPhone =
+				document.getElementById( 'billing-phone' )?.value ||
+				document.getElementById( 'shipping-phone' )?.value;
+
+			options = {
+				...options,
+				defaultValues: {
+					billingDetails: {
+						email: userEmail,
+						phone: userPhone,
+					},
+				},
+			};
+		}
+	}
 
 	return options;
 };

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Add - Pre-fill user email and phone number for Link in the Payment Element and block checkout.
 * Remove - Remove Link autofill modal feature.
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Partial fix for #3619

## Changes proposed in this Pull Request:
For a better user experience for Link in the Payment Element, we will pre-fill the email address and phone number fields, using the Payment Element's `defaultValues` parameter.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Enable Link as a payment method.

**Unregistered user**
1. As a shopper, add a product to cart and go to **block checkout**.
2. Enter your test email address, one that is NOT registered with Link.
3. Complete shipping/billing details and enter a phone number.
4. In the Payment Element, after filling in the card number, expiry and CVC, you should see the option `Save your info for secure 1-click checkout with Link` appear.
5. Check the checkbox. You should see pre-filled email address and phone number fields. See Screenshot 1.
6. Verify that you can complete the purchase without any problem.

**Screenshot 1: Notice how the email address and phone number are pre-filled.**
<img width="600" alt="Screenshot 2024-11-21 at 1 37 18 PM" src="https://github.com/user-attachments/assets/a469072f-8c91-4605-8601-2588210b4f38">



**Registered user**
1. As a shopper, add a product to cart and go to **block checkout**.
2. Enter your test email address, one that is registered with Link.
   - You can use the now-registered email address from the previous test.
3. In the Payment Element, notice your Link-registered email address with challenge code boxes. Since we are in test mode, you may enter any 5-digit number to authenticate. See Screensot 2.
5. You should now see your saved credit cards. See Screenshot 3.
6. Verify that you can complete the purchase without any problem.

**Screenshot 2: Notice how the email address is pre-filled.**
<img width="600" alt="Screenshot 2024-11-21 at 1 38 51 PM" src="https://github.com/user-attachments/assets/b7916b1a-7341-48cd-8dfa-eff8ba430638">


**Screenshot 3: After authentication via challenge code, user's saved credit cards are available for use.**
<img width="600" alt="Screenshot 2024-11-21 at 1 45 05 PM" src="https://github.com/user-attachments/assets/d1cf3e27-91c7-4a68-ad4a-c2807bc1adb8">


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
