### PR TITLE
Pre-fill user info for Link in the Payment Element (classic checkout) 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
-* Add - Pre-fill user email and phone number for Link in the Payment Element and block checkout.
+* Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -82,6 +82,15 @@ function createStripePaymentElement( api, paymentMethodType = null ) {
 	};
 
 	const elements = api.getStripe().elements( options );
+
+	const attachDefaultValuesUpdateEvent = ( element ) => {
+		if ( document.getElementById( element ) ) {
+			document.getElementById( element ).onblur = function () {
+				updatePaymentElementDefaultValues();
+			};
+		}
+	};
+
 	const createdStripePaymentElement = elements.create( 'payment', {
 		...getUpeSettings(),
 		...getDefaultValues(),
@@ -103,17 +112,8 @@ function createStripePaymentElement( api, paymentMethodType = null ) {
 		isLinkEnabled() &&
 		paymentMethodType === 'card'
 	) {
-		if ( document.getElementById( 'billing_email' ) ) {
-			document.getElementById( 'billing_email' ).onblur = function () {
-				updatePaymentElementDefaultValues();
-			};
-		}
-
-		if ( document.getElementById( 'billing_phone' ) ) {
-			document.getElementById( 'billing_phone' ).onblur = function () {
-				updatePaymentElementDefaultValues();
-			};
-		}
+		attachDefaultValuesUpdateEvent( 'billing_email' );
+		attachDefaultValuesUpdateEvent( 'billing_phone' );
 	}
 
 	return createdStripePaymentElement;

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -3,6 +3,8 @@ import {
 	appendPaymentMethodIdToForm,
 	getPaymentMethodTypes,
 	initializeUPEAppearance,
+	isLinkEnabled,
+	getDefaultValues,
 	getStripeServerData,
 	getUpeSettings,
 	showErrorCheckout,
@@ -82,6 +84,7 @@ function createStripePaymentElement( api, paymentMethodType = null ) {
 	const elements = api.getStripe().elements( options );
 	const createdStripePaymentElement = elements.create( 'payment', {
 		...getUpeSettings(),
+		...getDefaultValues(),
 		wallets: {
 			applePay: 'never',
 			googlePay: 'never',
@@ -92,7 +95,40 @@ function createStripePaymentElement( api, paymentMethodType = null ) {
 	gatewayUPEComponents[
 		paymentMethodType
 	].upeElement = createdStripePaymentElement;
+
+	// When email or phone is updated and Link is enabled, we need to
+	// update the payment element to update its default values.
+	if (
+		getStripeServerData()?.isCheckout &&
+		isLinkEnabled() &&
+		paymentMethodType === 'card'
+	) {
+		if ( document.getElementById( 'billing_email' ) ) {
+			document.getElementById( 'billing_email' ).onblur = function () {
+				updatePaymentElementDefaultValues();
+			};
+		}
+
+		if ( document.getElementById( 'billing_phone' ) ) {
+			document.getElementById( 'billing_phone' ).onblur = function () {
+				updatePaymentElementDefaultValues();
+			};
+		}
+	}
+
 	return createdStripePaymentElement;
+}
+
+/**
+ * Updates the payment element's default values.
+ */
+function updatePaymentElementDefaultValues() {
+	if ( ! gatewayUPEComponents?.card?.upeElement ) {
+		return;
+	}
+
+	const paymentElement = gatewayUPEComponents.card.upeElement;
+	paymentElement.update( getDefaultValues() );
 }
 
 /**

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -417,6 +417,32 @@ export const getUpeSettings = () => {
 };
 
 /**
+ * Craft the defaultValues parameter, used to pre-fill
+ * user email and phone number for Link in the Payment Element.
+ *
+ * @return {Object} The defaultValues object for the Payment Element.
+ */
+export const getDefaultValues = () => {
+	const userEmail = document.getElementById( 'billing_email' )?.value;
+	if ( ! userEmail ) {
+		return {};
+	}
+
+	const userPhone =
+		document.getElementById( 'billing_phone' )?.value ||
+		document.getElementById( 'shipping_phone' )?.value;
+
+	return {
+		defaultValues: {
+			billingDetails: {
+				email: userEmail,
+				phone: userPhone,
+			},
+		},
+	};
+};
+
+/**
  * Show error notice at top of checkout form.
  * Will try to use a translatable message using the message code if available
  *

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
-* Add - Pre-fill user email and phone number for Link in the Payment Element and block checkout.
+* Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
 * Update - Improve accuracy of webhook status information displayed in settings page.
 * Tweak - Standardize ECE Express payment buttons on Pay for Order page to match cart and checkout itemization behavior.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Completes #3619 

## Changes proposed in this Pull Request:
Similar to #3620 for block checkout, we will pre-fill the email address and phone number fields in the classic (shortcode) checkout, to improve the user experience for Link in the Payment Element.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Enable Link as a payment method.

**Unregistered user**
1. As a shopper, add a product to cart and go to **classic/shortcode checkout**.
2. Enter your test email address, one that is NOT registered with Link.
3. Complete shipping/billing details and enter a phone number.
4. In the Payment Element, after filling in the card number, expiry and CVC, you should see the option `Save your info for secure 1-click checkout with Link` appear.
5. Check the checkbox. You should see pre-filled email address and phone number fields. See Screenshot 1.
6. Verify that you can complete the purchase without any problem.

**Screenshot 1: Notice how the email address and phone number are pre-filled.**
<img width="482" alt="Screenshot 2024-11-22 at 11 10 43 AM" src="https://github.com/user-attachments/assets/ab54a2fc-ccca-46b9-91c4-13428fdb303f">


**Registered user**
1. As a shopper, add a product to cart and go to **classic/shortcode checkout**.
2. Enter your test email address, one that is registered with Link.
   - You can use the now-registered email address from the previous test.
3. In the Payment Element, notice your Link-registered email address with challenge code boxes. Since we are in test mode, you may enter any 5-digit number to authenticate. See Screensot 2.
5. You should now see your saved credit cards. See Screenshot 3.
6. Verify that you can complete the purchase without any problem.

**Screenshot 2: Notice how the email address is pre-filled.**
<img width="489" alt="Screenshot 2024-11-22 at 11 13 19 AM" src="https://github.com/user-attachments/assets/86942a92-e69f-4e5a-bc25-9f904dae6582">


**Screenshot 3: After authentication via challenge code, user's saved credit cards are available for use.**
<img width="476" alt="Screenshot 2024-11-22 at 11 14 00 AM" src="https://github.com/user-attachments/assets/7a4e3dd6-9aee-4322-9277-f8b76702713d">


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
