### PR TITLE
[webpack] Do not generate filenames with underscores

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** Changelog ***
 
 = 9.4.0 - xxxx-xx-xx =
+
+* Dev - Do not generate filenames with underscores.
 * Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.
 * Dev - Implements the new Stripe order class into the express checkout classes.
 * Dev - Implements the new Stripe order class into the wp-admin related classes.

--- a/includes/admin/class-wc-stripe-amazon-pay-controller.php
+++ b/includes/admin/class-wc-stripe-amazon-pay-controller.php
@@ -17,7 +17,7 @@ class WC_Stripe_Amazon_Pay_Controller {
 	 */
 	public function admin_scripts() {
 		// Webpack generates an assets file containing a dependencies array for our built JS file.
-		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/amazon_pay_settings.asset.php';
+		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/amazon-pay-settings.asset.php';
 		$asset_metadata    = file_exists( $script_asset_path )
 			? require $script_asset_path
 			: [
@@ -26,7 +26,7 @@ class WC_Stripe_Amazon_Pay_Controller {
 			];
 		wp_register_script(
 			'wc-stripe-amazon-pay-settings',
-			plugins_url( 'build/amazon_pay_settings.js', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/amazon-pay-settings.js', WC_STRIPE_MAIN_FILE ),
 			$asset_metadata['dependencies'],
 			$asset_metadata['version'],
 			true
@@ -51,7 +51,7 @@ class WC_Stripe_Amazon_Pay_Controller {
 
 		wp_register_style(
 			'wc-stripe-amazon-pay-settings',
-			plugins_url( 'build/amazon_pay_settings.css', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/amazon-pay-settings.css', WC_STRIPE_MAIN_FILE ),
 			[ 'wc-components' ],
 			$asset_metadata['version']
 		);

--- a/includes/admin/class-wc-stripe-payment-gateways-controller.php
+++ b/includes/admin/class-wc-stripe-payment-gateways-controller.php
@@ -28,7 +28,7 @@ class WC_Stripe_Payment_Gateways_Controller {
 	}
 
 	public function register_payments_scripts() {
-		$payment_gateways_script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/payment_gateways.asset.php';
+		$payment_gateways_script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/payment-gateways.asset.php';
 		$payment_gateways_script_asset      = file_exists( $payment_gateways_script_asset_path )
 			? require_once $payment_gateways_script_asset_path
 			: [
@@ -38,7 +38,7 @@ class WC_Stripe_Payment_Gateways_Controller {
 
 		wp_register_script(
 			'woocommerce_stripe_payment_gateways_page',
-			plugins_url( 'build/payment_gateways.js', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/payment-gateways.js', WC_STRIPE_MAIN_FILE ),
 			$payment_gateways_script_asset['dependencies'],
 			$payment_gateways_script_asset['version'],
 			true
@@ -49,7 +49,7 @@ class WC_Stripe_Payment_Gateways_Controller {
 		);
 		wp_register_style(
 			'woocommerce_stripe_payment_gateways_page',
-			plugins_url( 'build/payment_gateways.css', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/payment-gateways.css', WC_STRIPE_MAIN_FILE ),
 			[ 'wc-components' ],
 			$payment_gateways_script_asset['version']
 		);

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -19,7 +19,7 @@ class WC_Stripe_Payment_Requests_Controller {
 	 */
 	public function admin_scripts() {
 		// Webpack generates an assets file containing a dependencies array for our built JS file.
-		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/payment_requests_settings.asset.php';
+		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/payment-requests-settings.asset.php';
 		$asset_metadata    = file_exists( $script_asset_path )
 			? require $script_asset_path
 			: [
@@ -28,7 +28,7 @@ class WC_Stripe_Payment_Requests_Controller {
 			];
 		wp_register_script(
 			'wc-stripe-payment-request-settings',
-			plugins_url( 'build/payment_requests_settings.js', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/payment-requests-settings.js', WC_STRIPE_MAIN_FILE ),
 			$asset_metadata['dependencies'],
 			$asset_metadata['version'],
 			true
@@ -53,7 +53,7 @@ class WC_Stripe_Payment_Requests_Controller {
 
 		wp_register_style(
 			'wc-stripe-payment-request-settings',
-			plugins_url( 'build/payment_requests_settings.css', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/payment-requests-settings.css', WC_STRIPE_MAIN_FILE ),
 			[ 'wc-components' ],
 			$asset_metadata['version']
 		);

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -188,7 +188,7 @@ class WC_Stripe_Settings_Controller {
 		}
 
 		// Webpack generates an assets file containing a dependencies array for our built JS file.
-		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe_settings.asset.php';
+		$script_asset_path = WC_STRIPE_PLUGIN_PATH . '/build/upe-settings.asset.php';
 		$script_asset      = file_exists( $script_asset_path )
 			? require $script_asset_path
 			: [
@@ -198,14 +198,14 @@ class WC_Stripe_Settings_Controller {
 
 		wp_register_script(
 			'woocommerce_stripe_admin',
-			plugins_url( 'build/upe_settings.js', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/upe-settings.js', WC_STRIPE_MAIN_FILE ),
 			$script_asset['dependencies'],
 			$script_asset['version'],
 			true
 		);
 		wp_register_style(
 			'woocommerce_stripe_admin',
-			plugins_url( 'build/upe_settings.css', WC_STRIPE_MAIN_FILE ),
+			plugins_url( 'build/upe-settings.css', WC_STRIPE_MAIN_FILE ),
 			[ 'wc-components' ],
 			$script_asset['version']
 		);

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -110,7 +110,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * Registers the UPE JS scripts.
 	 */
 	private function register_upe_payment_method_script_handles() {
-		$asset_path   = WC_STRIPE_PLUGIN_PATH . '/build/upe_blocks.asset.php';
+		$asset_path   = WC_STRIPE_PLUGIN_PATH . '/build/upe-blocks.asset.php';
 		$version      = WC_STRIPE_VERSION;
 		$dependencies = [];
 		if ( file_exists( $asset_path ) ) {
@@ -125,14 +125,14 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 
 		wp_enqueue_style(
 			'wc-stripe-blocks-checkout-style',
-			WC_STRIPE_PLUGIN_URL . '/build/upe_blocks.css',
+			WC_STRIPE_PLUGIN_URL . '/build/upe-blocks.css',
 			[],
 			$version
 		);
 
 		wp_register_script(
 			'wc-stripe-blocks-integration',
-			WC_STRIPE_PLUGIN_URL . '/build/upe_blocks.js',
+			WC_STRIPE_PLUGIN_URL . '/build/upe-blocks.js',
 			array_merge( [ 'stripe' ], $dependencies ),
 			$version,
 			true

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -329,7 +329,7 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
-		$asset_path   = WC_STRIPE_PLUGIN_PATH . '/build/express_checkout.asset.php';
+		$asset_path   = WC_STRIPE_PLUGIN_PATH . '/build/express-checkout.asset.php';
 		$version      = WC_STRIPE_VERSION;
 		$dependencies = [];
 		if ( file_exists( $asset_path ) ) {
@@ -345,7 +345,7 @@ class WC_Stripe_Express_Checkout_Element {
 		wp_register_script( 'stripe', 'https://js.stripe.com/v3/', '', '3.0', true );
 		wp_register_script(
 			'wc_stripe_express_checkout',
-			WC_STRIPE_PLUGIN_URL . '/build/express_checkout.js',
+			WC_STRIPE_PLUGIN_URL . '/build/express-checkout.js',
 			array_merge( [ 'jquery', 'stripe' ], $dependencies ),
 			$version,
 			true
@@ -353,7 +353,7 @@ class WC_Stripe_Express_Checkout_Element {
 
 		wp_enqueue_style(
 			'wc_stripe_express_checkout_style',
-			WC_STRIPE_PLUGIN_URL . '/build/express_checkout.css',
+			WC_STRIPE_PLUGIN_URL . '/build/express-checkout.css',
 			[],
 			$version
 		);

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -395,7 +395,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		wp_register_script(
 			'wc-stripe-upe-classic',
-			WC_STRIPE_PLUGIN_URL . '/build/upe_classic.js',
+			WC_STRIPE_PLUGIN_URL . '/build/upe-classic.js',
 			array_merge( [ 'stripe', 'wc-checkout' ], $dependencies ),
 			$version,
 			true
@@ -413,7 +413,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		wp_register_style(
 			'wc-stripe-upe-classic',
-			WC_STRIPE_PLUGIN_URL . '/build/upe_classic.css',
+			WC_STRIPE_PLUGIN_URL . '/build/upe-classic.css',
 			[],
 			$version
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.4.0 - xxxx-xx-xx =
+* Dev - Do not generate filenames with underscores.
 * Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.
 * Dev - Implements the new Stripe order class into the express checkout classes.
 * Dev - Implements the new Stripe order class into the wp-admin related classes.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -57,14 +57,14 @@ module.exports = {
 	},
 	entry: {
 		index: './client/blocks/index.js',
-		payment_requests_settings:
+		'payment-requests-settings':
 			'./client/entrypoints/payment-request-settings/index.js',
-		upe_classic: './client/classic/upe/index.js',
-		upe_blocks: './client/blocks/upe/index.js',
-		upe_settings: './client/settings/index.js',
-		payment_gateways: './client/entrypoints/payment-gateways/index.js',
-		express_checkout: './client/entrypoints/express-checkout/index.js',
-		amazon_pay_settings:
+		'upe-classic': './client/classic/upe/index.js',
+		'upe-blocks': './client/blocks/upe/index.js',
+		'upe-settings': './client/settings/index.js',
+		'payment-gateways': './client/entrypoints/payment-gateways/index.js',
+		'express-checkout': './client/entrypoints/express-checkout/index.js',
+		'amazon-pay-settings':
 			'./client/entrypoints/amazon-pay-settings/index.js',
 	},
 };


### PR DESCRIPTION
Fixes #2603

## Changes proposed in this Pull Request:

The [WordPress coding style guide](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/) requires that filenames use hyphens for word separators instead of underscores. Currently this project's webpack configuration generates resource files with underscores in the name, which blocks deployment on wpcom as the style is enforced.

Changing filenames is risky because we [can't be certain](https://www.hyrumslaw.com/) what downstream code makes assumptions about them. For this change I think the risk is reduced because these files are generated by webpack, and they are not really part of the public api of the plugin.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

## Testing instructions

If this breaks I'd expect it to break loudly, blocking all transactions.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry both in changelog.txt and readme.txt
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
