### PR TITLE
[ECE] Use the correct property to check if product needs shipping

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@
 * Fix - Resolve a fatal error by casting product price and subscription sign up fee to 'float' while adding them.
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
-* Fix - Use the correct attribute to check if a product variation needs shipping to show shipping options on the express checkout payment modal.
+* Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 = 8.9.0 - 2024-11-14 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Fix - Resolve a fatal error by casting product price and subscription sign up fee to 'float' while adding them.
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
+* Fix - Use the correct attribute to check if a product variation needs shipping to show shipping options on the express checkout payment modal.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 = 8.9.0 - 2024-11-14 =

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -513,7 +513,8 @@ jQuery( function ( $ ) {
 							const needsShipping =
 								! wcStripeECE.paymentAborted &&
 								getExpressCheckoutData( 'product' )
-									.needs_shipping === response.needs_shipping;
+									.requestShipping ===
+									response.requestShipping;
 
 							if ( ! isDeposits && needsShipping ) {
 								elements.update( {
@@ -553,8 +554,8 @@ jQuery( function ( $ ) {
 									if (
 										! wcStripeECE.paymentAborted &&
 										getExpressCheckoutData( 'product' )
-											.needs_shipping ===
-											response.needs_shipping
+											.requestShipping ===
+											response.requestShipping
 									) {
 										elements.update( {
 											amount: response.total.amount,

--- a/readme.txt
+++ b/readme.txt
@@ -122,7 +122,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Resolve a fatal error by casting product price and subscription sign up fee to 'float' while adding them.
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
-* Fix - Use the correct attribute to check if a product variation needs shipping to show shipping options on the express checkout payment modal.
+* Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -122,6 +122,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Resolve a fatal error by casting product price and subscription sign up fee to 'float' while adding them.
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
+* Fix - Use the correct attribute to check if a product variation needs shipping to show shipping options on the express checkout payment modal.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
This PR fixes an issue where variable subscriptions are showing shipping options in the Google Pay modal.

**Note**: This issue happens for the first variation selection only.

## Changes proposed in this Pull Request:
The `needs_shipping` attribute is undefined here. The correct attribute to check if shipping is needed is `requestShipping`. If you trace back to the `expressCheckoutGetSelectedProductData` and the ajax function [ajax_get_selected_product_data](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php#L203), you will find that there is no `needs_shipping` set here.

## Testing instructions
- Create a variable subscription product with virtual variations. ( Note: In `Default Form Values` do not select any variation as default).

<img width="975" alt="Screenshot 2024-11-29 at 12 10 14 AM" src="https://github.com/user-attachments/assets/69e13bfa-b493-4279-88ba-6c744518a4d2">

- Create 2 shipping methods on your site (free, flat rate)
- As a shopper go to this product page.
- At first, no variation is selected.

<img width="955" alt="Screenshot 2024-11-29 at 12 54 28 AM" src="https://github.com/user-attachments/assets/cdd65e14-a31e-4649-914b-310af0e2796b">

- In `develop` select a variation from the dropdown. Then click the Google Pay button. Notice that the Google Pay modal shows shipping options. (🔴)

<img width="615" alt="Screenshot 2024-11-29 at 3 27 18 PM" src="https://github.com/user-attachments/assets/646b4bcc-7374-46ad-bad1-e419da478158">

- Checkout this branch and refresh the product page. Select a variation from the dropdown. Then click the Google Pay button. Confirm that the Google Pay modal does not show any shipping options.

<img width="615" alt="Screenshot 2024-11-29 at 3 25 52 PM" src="https://github.com/user-attachments/assets/ddbe4b63-105f-4ef4-8f03-52802a3523b4">

- Confirm that simple subscriptions and simple/variable products that need shipping are working correctly.