### PR TITLE
Fix custom product type price calculation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
 * Update - Improve accuracy of webhook status information displayed in settings page.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -98,7 +98,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		} elseif ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) { // Grouped and external products should not be added to the cart.
+		} elseif ( in_array( $product_type, $this->express_checkout_helper->supported_product_types(), true ) ) {
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -100,7 +100,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
 		}
 
-		if ( in_array( $product_type, [ 'simple', 'variation', 'subscription', 'subscription_variation', 'booking' ], true ) ) {
+		if ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) {
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -98,9 +98,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		}
-
-		if ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) {
+		} elseif ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) { // Grouped and external products should not be added to the cart.
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1458,7 +1458,9 @@ class WC_Stripe_Payment_Request {
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		} else {
+		}
+
+		if ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) {
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1458,9 +1458,7 @@ class WC_Stripe_Payment_Request {
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		}
-
-		if ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) {
+		} elseif ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) { // Grouped and external products should not be added to the cart.
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1458,7 +1458,7 @@ class WC_Stripe_Payment_Request {
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		} elseif ( ! in_array( $product_type, [ 'grouped', 'external' ], true ) ) { // Grouped and external products should not be added to the cart.
+		} elseif ( in_array( $product_type, $this->supported_product_types(), true ) ) {
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1458,9 +1458,7 @@ class WC_Stripe_Payment_Request {
 			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
 
 			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		}
-
-		if ( in_array( $product_type, [ 'simple', 'variation', 'subscription', 'subscription_variation' ], true ) ) {
+		} else {
 			WC()->cart->add_to_cart( $product->get_id(), $qty );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
 * Update - Improve accuracy of webhook status information displayed in settings page.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3202

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When purchasing custom product types using express checkout (payment request buttons or express checkout element), the price is calculated as 0, because currently we only add to cart the following types: `variable`, `variable-subscription`, `simple`, `variation`, `subscription`, and `subscription_variation`. See:

```php
if ( ( 'variable' === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
	$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );

	$data_store   = WC_Data_Store::load( 'product' );
	$variation_id = $data_store->find_matching_product_variation( $product, $attributes );

	WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
}

if ( in_array( $product_type, [ 'simple', 'variation', 'subscription', 'subscription_variation' ], true ) ) {
	WC()->cart->add_to_cart( $product->get_id(), $qty );
}
```

The fix consists of reversing the second condition to check only for those product types that we do not want to consider when adding to the cart (`grouped` and `external`)

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

I could not find a good extension to create custom product types, so I have included a hardcoding below step to reproduce the scenario.

- Checkout and build this branch on your test environment (`fix/custom-product-types-price-calculation`)
- Enable express checkout payment methods (Apple Pay, Google Pay, Link)

### Payment Request Button

- Make sure ECE is disabled. You can hardcode `is_stripe_ece_enabled` return to `false`
- To emulate a custom product type, hardcode it on `includes/payment-methods/class-wc-stripe-payment-request.php#1449` like:
```php
$product_type = 'random-type';
```
- As a shopper, add a product to your cart
- Go to the checkout page
- Complete the purchase using any express payment method
- Confirm the final price is correct in the modal
<img width="390" alt="Screenshot 2024-12-02 at 14 13 32" src="https://github.com/user-attachments/assets/0e397d72-7ba1-46e9-b627-970205160580">

### Express Checkout Element

- Make sure ECE is enabled. You can hardcode `is_stripe_ece_enabled` return to `true`
- To emulate a custom product type, hardcode it on `includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php#89` like:
```php
$product_type = 'random-type';
```
- As a shopper, add a product to your cart
- Go to the checkout page
- Complete the purchase using any express payment method
- Confirm the final price is correct in the modal

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
