### PR TITLE
Set correct payment method when using Link

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
@@ -14,6 +15,7 @@
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 = 8.9.0 - 2024-11-14 =

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2490,11 +2490,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	protected function get_upe_gateway_id_for_order( $payment_method ) {
 		$token_gateway_type = $payment_method->get_retrievable_type();
 
-		if ( WC_Stripe_Payment_Methods::CARD !== $token_gateway_type ) {
-			return $this->payment_methods[ $token_gateway_type ]->id;
+		if ( WC_Stripe_Payment_Methods::CARD === $token_gateway_type ||
+			WC_Stripe_Payment_Methods::LINK === $token_gateway_type ) {
+			return $this->id;
 		}
 
-		return $this->id;
+		return $this->payment_methods[ $token_gateway_type ]->id;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1614,10 +1614,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		$payment_method    = $this->payment_methods[ $payment_method_type ];
 		$payment_method_id = $payment_method instanceof WC_Stripe_UPE_Payment_Method_CC ? $this->id : $payment_method->id;
-		$is_stripe_link    = isset( $stripe_payment_method->type ) && WC_Stripe_Payment_Methods::LINK === $stripe_payment_method->type;
+		$is_stripe_link    = WC_Stripe_Payment_Methods::LINK === $payment_method_type ||
+			( isset( $stripe_payment_method->type ) && WC_Stripe_Payment_Methods::LINK === $stripe_payment_method->type );
 
 		// Stripe Link uses the main gateway to process payments, however Link payments should use the title of the Link payment method.
 		if ( $is_stripe_link && isset( $this->payment_methods[ WC_Stripe_Payment_Methods::LINK ] ) ) {
+			$payment_method_id    = $this->id;
 			$payment_method_title = $this->payment_methods[ WC_Stripe_Payment_Methods::LINK ]->get_title( $stripe_payment_method );
 		} else {
 			$payment_method_title = $payment_method->get_title( $stripe_payment_method );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -24,6 +24,8 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 			for further payments.',
 			'woocommerce-gateway-stripe'
 		);
+
+		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );
 	}
 
 	/**
@@ -108,5 +110,31 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	 */
 	public function requires_automatic_capture() {
 		return false;
+	}
+
+	/**
+	 * Filters the gateway title to reflect Link as the payment method.
+	 */
+	public function filter_gateway_title( $title, $id ) {
+		global $theorder;
+
+		// If $theorder is empty (i.e. non-HPOS), fallback to using the global post object.
+		if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
+			$theorder = wc_get_order( $GLOBALS['post']->ID );
+		}
+
+		if ( ! is_object( $theorder ) ) {
+			return $title;
+		}
+
+		$method_title = $theorder->get_payment_method_title();
+
+		if ( 'stripe' === $id && ! empty( $method_title ) ) {
+			if ( 'Link' === $method_title ) {
+				return $method_title;
+			}
+		}
+
+		return $title;
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
@@ -124,6 +125,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -2347,7 +2347,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		WC_Subscriptions_Helpers::$wcs_get_subscriptions_for_order = [ $mock_subscription_0, $mock_subscription_1 ];
 
-		$this->mock_gateway->expects( $this->exactly( 3 ) ) // 3 times because we test 3 payment methods.
+		$this->mock_gateway->expects( $this->exactly( 4 ) ) // 4 times because we test 4 payment methods.
 			->method( 'is_subscriptions_enabled' )
 			->willReturn( true );
 
@@ -2382,6 +2382,17 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// Cards should be set to `stripe`.
 		$this->assertEquals( 'stripe', $order->get_payment_method() );
 		$this->assertEquals( 'Credit / Debit Card', $order->get_payment_method_title() );
+
+		$this->assertEquals( 'stripe', $mock_subscription_0->get_payment_method() );
+		$this->assertEquals( 'stripe', $mock_subscription_0->get_payment_method() );
+
+		/**
+		 * Link
+		 */
+		$this->mock_gateway->set_payment_method_title_for_order( $order, WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID );
+		// Cards should be set to `stripe`.
+		$this->assertEquals( 'stripe', $order->get_payment_method() );
+		$this->assertEquals( 'Link', $order->get_payment_method_title() );
 
 		$this->assertEquals( 'stripe', $mock_subscription_0->get_payment_method() );
 		$this->assertEquals( 'stripe', $mock_subscription_0->get_payment_method() );


### PR DESCRIPTION
Fixes #3633, #3577 

## Changes proposed in this Pull Request:
1. When using Link with a card that triggers 3DS, the payment method is incorrectly set to `stripe_link`. This should be `stripe`, as Link uses the main gateway to process payments. 

   This change also fixes #3577, where subscriptions purchased with Link and a 3DS card [gets set to `Manual Renewal` because `stripe_link` "payment gateway" does not support subscriptions.](https://github.com/Automattic/woocommerce-subscriptions-core/blob/13977b5084a37030282342d828e91c141ba64d9a/includes/class-wc-subscription.php#L2220)

2. This PR adds a filter to display `Payment via Link` instead of `Payment via Credit / Debit Card` inside the Edit Order page.

## Testing instructions

**Testing Link, no 3DS**
1. Enable Link as a payment method, and make sure you are in test mode.
2. As a shopper, add a product to cart and go to checkout.
3. Choose `Credit / Debit card` as your payment option.
4. If your email address is already registered with Link:
   - If you see challenge code field, enter `000000` to log in to your Link account.
   - If you see a box with buttons that say `Use <4-digit number>` or `Pay another way`, click `Use <4-digit number>` to reveal the challenge code field.
   - Use `4242424242424242` for the credit card.
5. If your email address is not yet registered with Link:
   - Use `4242424242424242` for the credit card.
   - Make sure `Save your info for secure 1-click checkout with Link` is checked.
7. Complete the purchase.
8. In wp-admin, view the Edit Order page and verify that the subheader says `Payment via Link`. See screenshot below.

| Before | After |
|---|---|
| <img width="400" alt="Screenshot 2024-12-04 at 10 28 43 AM" src="https://github.com/user-attachments/assets/6589b017-13ab-4165-b2cc-f2c333aeafe1">| <img width="400" alt="Screenshot 2024-12-04 at 10 29 01 AM" src="https://github.com/user-attachments/assets/c7dc3908-0d11-48b5-bc1d-d830d0987ab3"> | 




**Testing Link, with 3DS**
10. Make another purchase, but this time, use `4000003800000446` which will trigger 3DS authentication. Complete the purchase and verify that the Edit Order page says `Payment via Link`.

| Before | After |
|---|---|
| <img width="400" alt="Screenshot 2024-12-04 at 10 32 31 AM" src="https://github.com/user-attachments/assets/c1ff7a6d-509c-4011-984e-c7b41de7e3bf"> | <img width="400" alt="Screenshot 2024-12-04 at 10 33 39 AM" src="https://github.com/user-attachments/assets/36900523-4f85-4910-bd6c-9485e406d39c"> | 

**Testing Link for subscriptions, with 3DS**
12. Make a subscription purchase using `4000003800000446`, and verify in My Account > Subscriptions that it does not say "Manual Renewal".

| Before | After |
|---|---|
| <img width="506" alt="Screenshot 2024-12-04 at 10 37 19 AM" src="https://github.com/user-attachments/assets/a3b020c5-5745-4bde-9509-24d78e33d1f5"> | <img width="506" alt="Screenshot 2024-12-04 at 10 38 57 AM" src="https://github.com/user-attachments/assets/fd2acaa4-214d-4f28-a544-680e4c8b851a"> | 

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
