### PR TITLE
Add cart empty check when checking for allowed products for express checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
 * Tweak - Update links to plugin documentation and Stripe documentation.
+* Tweak - Add empty check for cart when checking for allowed products for express checkout.
 
 = 8.9.0 - 2024-11-14 =
 * Update - Enhance webhook processing to enable retrieving orders using payment_intent metadata.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -368,9 +368,9 @@ class WC_Stripe_Express_Checkout_Helper {
 			return false;
 		}
 
-		// If the cart is not available we don't have any unsupported products in the cart, so we
+		// If the cart is not available or if the cart is empty we don't have any unsupported products in the cart, so we
 		// return true. This can happen e.g. when loading the cart or checkout blocks in Gutenberg.
-		if ( is_null( WC()->cart ) ) {
+		if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
 			return true;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -596,11 +596,11 @@ class WC_Stripe_Payment_Request {
 			return false;
 		}
 
-		// If the cart is not available we don't have any unsupported products in the cart, so we
+		// If the cart is not available or if the cart is empty we don't have any unsupported products in the cart, so we
 		// return true. This can happen e.g. when loading the cart or checkout blocks in Gutenberg.
-		if ( is_null( WC()->cart ) ) {
+		if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
 			return true;
-		}
+		} 
 
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -600,7 +600,7 @@ class WC_Stripe_Payment_Request {
 		// return true. This can happen e.g. when loading the cart or checkout blocks in Gutenberg.
 		if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
 			return true;
-		} 
+		}
 
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$_product = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );

--- a/readme.txt
+++ b/readme.txt
@@ -125,5 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
 * Tweak - Update links to plugin documentation and Stripe documentation.
+* Tweak - Add empty check for cart when checking for allowed products for express checkout.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #2406 

## Changes proposed in this Pull Request:
Added check for empty carts in `allowed_items_in_cart` function.
More context in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2406#issuecomment-2517283054

## Testing instructions
- Code review (as the reported bug is not reproducible)
- Test the ECE and PRB buttons on block and shortcode cart pages. Confirm that they are loaded and works correctly when they are supposed to.
