### PR TITLE
Add a GitHub Action workflow to run QIT E2E Integration tests.

### DIFF
--- a/.github/workflows/qit-e2e-tests.yml
+++ b/.github/workflows/qit-e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run ${{ matrix.checkout }} E2E tests
         shell: bash
-        run: ./vendor/bin/qit run:e2e woocommerce-gateway-stripe ${{ matrix.checkout == 'Legacy' && 'legacy' || '' }} --source ./ --plugin woocommerce --plugin woocommerce-subscriptions --plugin woocommerce-paypal-payments:test:setup-tests --theme storefront --env_file .env
+        run: ./vendor/bin/qit run:e2e woocommerce-gateway-stripe ${{ matrix.checkout == 'Legacy' && 'legacy' || '' }} --source ./ --plugin woocommerce --plugin woocommerce-subscriptions --plugin woocommerce-paypal-payments:test:setup-tests --env_file .env
       
       - name: Set the path in an env var
         if: ${{ failure() }}

--- a/.github/workflows/qit-e2e-tests.yml
+++ b/.github/workflows/qit-e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Run ${{ matrix.checkout }} E2E tests
         shell: bash
-        run: ./vendor/bin/qit run:e2e woocommerce-gateway-stripe --source ./ --plugin woocommerce --plugin woocommerce-subscriptions --plugin woocommerce-paypal-payments:test:setup-tests --theme storefront --pw_options="${{ matrix.checkout == 'Legacy' && '--grep @legacy' || '--grep-invert @legacy' }}" --env_file .env
+        run: ./vendor/bin/qit run:e2e woocommerce-gateway-stripe ${{ matrix.checkout == 'Legacy' && 'legacy' || '' }} --source ./ --plugin woocommerce --plugin woocommerce-subscriptions --plugin woocommerce-paypal-payments:test:setup-tests --theme storefront --env_file .env
       
       - name: Set the path in an env var
         if: ${{ failure() }}

--- a/.github/workflows/qit-e2e-tests.yml
+++ b/.github/workflows/qit-e2e-tests.yml
@@ -1,0 +1,100 @@
+name: QIT E2E tests
+
+on:
+  pull_request
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        checkout: [ 'Default', 'Legacy' ]
+
+    name: ${{ matrix.checkout }} QIT E2E tests
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # PHP
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer
+          coverage: none
+
+      - name: Cache Composer deps
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: ./vendor
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+
+      - name: Install composer dependencies
+        if: ${{ steps.composer-cache.outputs.cache-hit == false }}
+        shell: bash
+        run: composer install --no-progress
+
+      - name: Add partner for QIT
+        run: ./vendor/bin/qit partner:add --user='${{ secrets.PARTNER_USER }}' --application_password='${{ secrets.PARTNER_SECRET }}'
+
+      # Node
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Cache Node deps
+        id: node-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ./node_modules
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}
+
+      - name: Install node dependencies
+        if: ${{ steps.node-cache.outputs.cache-hit == false }}
+        shell: bash
+        run: npm ci
+
+      # Build
+      - name: Build plugin package
+        shell: bash
+        run: |
+          npm run build
+
+      # E2E test environment
+      - name: Fill in .env
+        run: |
+          echo 'STRIPE_PUB_KEY="${{ secrets.E2E_STRIPE_PUBLISHABLE_KEY }}"' >> .env
+          echo 'STRIPE_SECRET_KEY="${{ secrets.E2E_STRIPE_SECRET_KEY }}"' >> .env
+          echo 'PAYPAL_MERCHANT_ID="${{ secrets.PAYPAL_MERCHANT_ID }}"' >> .env
+          echo 'PAYPAL_MERCHANT_EMAIL="${{ secrets.PAYPAL_MERCHANT_EMAIL }}"' >> .env
+          echo 'PAYPAL_CLIENT_ID="${{ secrets.PAYPAL_CLIENT_ID }}"' >> .env
+          echo 'PAYPAL_CLIENT_SECRET="${{ secrets.PAYPAL_CLIENT_SECRET }}"' >> .env
+          echo 'PAYPAL_CUSTOMER_EMAIL="${{ secrets.PAYPAL_CUSTOMER_EMAIL }}"' >> .env
+          echo 'PAYPAL_CUSTOMER_PASSWORD="${{ secrets.PAYPAL_CUSTOMER_PASSWORD }}"' >> .env
+
+      - name: Run ${{ matrix.checkout }} E2E tests
+        shell: bash
+        run: ./vendor/bin/qit run:e2e woocommerce-gateway-stripe --source ./ --plugin woocommerce --plugin woocommerce-subscriptions --plugin woocommerce-paypal-payments:test:setup-tests --theme storefront --pw_options="${{ matrix.checkout == 'Legacy' && '--grep @legacy' || '--grep-invert @legacy' }}" --env_file .env
+      
+      - name: Set the path in an env var
+        if: ${{ failure() }}
+        run: echo "E2E_REPORT_PATH=$(./vendor/bin/qit e2e-report --dir_only --local)/playwright" >> $GITHUB_ENV
+
+      - name: Upload ${{ matrix.checkout }} QIT E2E test results
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.checkout }}-qit-e2e-test-results
+          path: ${{ env.E2E_REPORT_PATH }}
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/qit-e2e-tests.yml
+++ b/.github/workflows/qit-e2e-tests.yml
@@ -41,9 +41,6 @@ jobs:
         shell: bash
         run: composer install --no-progress
 
-      - name: Add partner for QIT
-        run: ./vendor/bin/qit partner:add --user='${{ secrets.PARTNER_USER }}' --application_password='${{ secrets.PARTNER_SECRET }}'
-
       # Node
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -69,6 +66,13 @@ jobs:
         shell: bash
         run: |
           npm run build
+
+      # QIT CLI
+      - name: Install QIT via composer
+        run: composer require woocommerce/qit-cli --dev
+      
+      - name: Add partner for QIT
+        run: ./vendor/bin/qit partner:add --user='${{ secrets.PARTNER_USER }}' --application_password='${{ secrets.PARTNER_SECRET }}'
 
       # E2E test environment
       - name: Fill in .env

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Dev - Add a GitHub Action workflow to run QIT E2E Integrations tests.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Dev - Add a GitHub Action workflow to run QIT E2E Integrations tests.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3530 

## Changes proposed in this Pull Request:
This PR adds a GitHub Action workflow to run QIT E2E integration tests for each pull request. The tests are located in the [integration tests repository](https://github.com/woocommerce/woocommerce-gateway-integration-qit), and this action will trigger the test run on every pull request.

## Testing instructions
Make sure that QIT E2E tests GitHub action is running and passing on this PR.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
