### PR TITLE
Display Link email in Payment Methods page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Tweak - Display email address for Link saved payment methods.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
@@ -14,7 +15,7 @@
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 = 8.9.0 - 2024-11-14 =

--- a/includes/class-wc-stripe-link-payment-token.php
+++ b/includes/class-wc-stripe-link-payment-token.php
@@ -40,7 +40,7 @@ class WC_Payment_Token_Link extends WC_Payment_Token {
 	public function get_display_name( $deprecated = '' ) {
 		$display = sprintf(
 			/* translators: customer email */
-			__( 'Stripe Link email %s', 'woocommerce-gateway-stripe' ),
+			__( 'Stripe Link (%s)', 'woocommerce-gateway-stripe' ),
 			$this->get_email()
 		);
 

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -392,7 +392,11 @@ class WC_Stripe_Payment_Tokens {
 				$item['method']['brand'] = esc_html__( 'Cash App Pay', 'woocommerce-gateway-stripe' );
 				break;
 			case WC_Stripe_Payment_Methods::LINK:
-				$item['method']['brand'] = esc_html__( 'Stripe Link', 'woocommerce-gateway-stripe' );
+				$item['method']['brand'] = sprintf(
+					/* translators: customer email */
+					__( 'Stripe Link (%s)', 'woocommerce-gateway-stripe' ),
+					$payment_token->get_email()
+				);
 				break;
 		}
 

--- a/includes/class-wc-stripe-payment-tokens.php
+++ b/includes/class-wc-stripe-payment-tokens.php
@@ -394,8 +394,8 @@ class WC_Stripe_Payment_Tokens {
 			case WC_Stripe_Payment_Methods::LINK:
 				$item['method']['brand'] = sprintf(
 					/* translators: customer email */
-					__( 'Stripe Link (%s)', 'woocommerce-gateway-stripe' ),
-					$payment_token->get_email()
+					esc_html__( 'Stripe Link (%s)', 'woocommerce-gateway-stripe' ),
+					esc_html( $payment_token->get_email() )
 				);
 				break;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Tweak - Display email address for Link saved payment methods.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.
 * Remove - Remove Link autofill modal feature.
@@ -124,7 +125,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:
- In My Account > Payment Methods, display the Link email address for added context, the same way we display it in the Subscriptions and checkout pages.
- Tweak the checkout page display text, for consistency with Subscriptions and Payment Methods pages.

| Before | After |
|--------|-------|
| <img width="400" alt="Screenshot 2024-12-06 at 11 27 42 AM" src="https://github.com/user-attachments/assets/4223cd45-6d3c-48d3-82ec-0f3effb722cd"> | <img width="400" alt="Screenshot 2024-12-06 at 11 27 56 AM" src="https://github.com/user-attachments/assets/0d45873a-2cdc-44cf-8c2a-5fab9821128c"> |


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
