### PR TITLE
Fix 404 when using ECE and 3D Secure

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
@@ -16,7 +17,7 @@
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -290,7 +290,8 @@ export default class WCStripeAPI {
 	 *
 	 * @param {string} redirectUrl The redirect URL, returned from the server.
 	 * @param {string} paymentMethodToSave The ID of a Payment Method if it should be saved (optional).
-	 * @return {string|true} A redirect URL on success, or `true` if no confirmation is needed.
+	 * @return {Object|true} An object containing the redirect URL on success and a flag indicating
+	 *   if the page is the Pay for order page, or `true` if no confirmation is needed.
 	 */
 	confirmIntent( redirectUrl, paymentMethodToSave ) {
 		const partials = redirectUrl.match(

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -384,9 +384,12 @@ describe( 'Express checkout event handlers', () => {
 				result: 'success',
 				redirect: 'https://example.com/redirect',
 			} );
-			api.confirmIntent.mockResolvedValue(
-				'https://example.com/confirmation_redirect'
-			);
+			api.confirmIntent.mockReturnValue( {
+				request: Promise.resolve(
+					'https://example.com/confirmation_redirect'
+				),
+				isOrderPage: false,
+			} );
 
 			await onConfirmHandler(
 				api,
@@ -415,9 +418,12 @@ describe( 'Express checkout event handlers', () => {
 				result: 'success',
 				redirect: 'https://example.com/redirect',
 			} );
-			api.confirmIntent.mockRejectedValue(
-				new Error( 'Intent confirmation error' )
-			);
+			api.confirmIntent.mockReturnValue( {
+				request: Promise.reject(
+					new Error( 'Intent confirmation error' )
+				),
+				isOrderPage: false,
+			} );
 
 			await onConfirmHandler(
 				api,
@@ -513,9 +519,12 @@ describe( 'Express checkout event handlers', () => {
 				result: 'success',
 				redirect: 'https://example.com/redirect',
 			} );
-			api.confirmIntent.mockResolvedValue(
-				'https://example.com/confirmation_redirect'
-			);
+			api.confirmIntent.mockReturnValue( {
+				request: Promise.resolve(
+					'https://example.com/confirmation_redirect'
+				),
+				isOrderPage: false,
+			} );
 
 			await onConfirmHandler(
 				api,
@@ -545,9 +554,12 @@ describe( 'Express checkout event handlers', () => {
 				result: 'success',
 				redirect: 'https://example.com/redirect',
 			} );
-			api.confirmIntent.mockRejectedValue(
-				new Error( 'Intent confirmation error' )
-			);
+			api.confirmIntent.mockReturnValue( {
+				request: Promise.reject(
+					new Error( 'Intent confirmation error' )
+				),
+				isOrderPage: false,
+			} );
 
 			await onConfirmHandler(
 				api,

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -103,7 +103,8 @@ export const onConfirmHandler = async (
 		if ( confirmationRequest === true ) {
 			completePayment( orderResponse.redirect );
 		} else {
-			const redirectUrl = await confirmationRequest;
+			const { request } = confirmationRequest;
+			const redirectUrl = await request;
 
 			completePayment( redirectUrl );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
@@ -126,7 +127,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3642 

## Changes proposed in this Pull Request:
This PR fixes a 404 that happens when 3D Secure is triggered while using ECE.

[WCStripeAPI's confirmIntent](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/3519dd775bc2b6b574bdd3001ebdb438b60b9697/client/api/index.js#L295) returns the redirect URL wrapped in an object, instead of directly. In this PR, we update some lines to reflect that.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Go to your Stripe dashboard's Radar Rules (https://dashboard.stripe.com/test/settings/radar/rules) and under **Authentication rules**, add a rule to request 3D Secure authentication if the amount is greater than 10 USD, for example. 
<img width="300" alt="Screenshot 2024-12-06 at 2 19 11 PM" src="https://github.com/user-attachments/assets/6443f840-0e33-46e2-a13c-c45a36d0a938">


2. As a shopper, purchase a product costing more than 10 USD, via Google Pay.
3. In `develop`: Notice the payment fails and you are redirected to a 404 page.
4. In this branch: the payment should succeed.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
