### PR TITLE
Prevent editing uncaptured order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 9.1.0 - xxxx-xx-xx =
+* Update - Prevent editing of orders awaiting payment capture.
+
 = 9.0.0 - xxxx-xx-xx =
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -106,7 +106,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	public static function change_order_item_editable_text_tooltip( $translated_text, $text, $domain ) {
 		switch ( $text ) {
 			case 'To edit this order change the status back to "Pending payment"':
-				$translated_text = __( 'This order is no longer editable because the charge has been authorized.', 'woocommerce-subscriptions' );
+				$translated_text = __( 'This order is no longer editable because the charge has been authorized.', 'woocommerce-gateway-stripe' );
 				break;
 		}
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -75,7 +75,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 
-			if ( true || ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
+			if ( ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
 				// Hook to gettext callback to change the tooltip text
 				add_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10, 3 );
 			}
@@ -87,12 +87,10 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function maybe_unattach_gettext_callback() {
 
-		wc_get_logger()->debug( 'maybe_unattach_gettext_callback' );
-
 		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 
-			if ( true || ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
+			if ( ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
 				// Unhook gettext callback to prevent extra call impact
 				remove_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10 );
 			}
@@ -106,7 +104,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	public function change_order_item_editable_text_tooltip( $translated_text, $text, $domain ) {
 		switch ( $text ) {
 			case 'To edit this order change the status back to "Pending payment"':
-				$translated_text = __( 'This order is no longer editable because the charge has been authorized.', 'woocommerce-gateway-stripe' );
+				$translated_text = __( 'This order is no longer editable because the charge has been authorized for this amount.', 'woocommerce-gateway-stripe' );
 				break;
 		}
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -80,7 +80,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 
-			if ( ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
+			if ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) {
 				// Hook to gettext callback to change the tooltip text
 				add_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10, 3 );
 			}
@@ -95,7 +95,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 
-			if ( ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
+			if ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) {
 				// Unhook gettext callback to prevent extra call impact
 				remove_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10 );
 			}

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -88,7 +88,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * unattach the gettext callback.
+	 * Unattach the gettext callback.
 	 */
 	public function maybe_unattach_gettext_callback() {
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -68,7 +68,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Only attach the gettext callback when on admin edit order screen
+	 * Only attach the gettext callback when on admin edit order screen.
 	 */
 	public function maybe_attach_gettext_callback() {
 
@@ -83,7 +83,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * unattach the gettext callback
+	 * unattach the gettext callback.
 	 */
 	public function maybe_unattach_gettext_callback() {
 
@@ -101,7 +101,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 	/**
 	* When order items are not editable due to the charge being authorized to capture the current amount,
-	* change the tooltip to explain the reason
+	* change the tooltip to explain the reason.
 	*/
 	public function change_order_item_editable_text_tooltip( $translated_text, $text, $domain ) {
 		switch ( $text ) {

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -55,12 +55,62 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 			if ( $intent && 'requires_capture' === $intent->status ) {
 				$editable = false;
+
+				// add hooks to change text about the reason when order items cannot be edited
+				add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'maybe_attach_gettext_callback' ] );
+				add_action( 'woocommerce_order_item_add_action_buttons', [ $this, 'maybe_unattach_gettext_callback' ] );
 			}
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::log( 'Error getting intent from order: ' . $e->getMessage() );
 		}
 
 		return $editable;
+	}
+
+	/**
+	 * Only attach the gettext callback when on admin edit order screen
+	 */
+	public static function maybe_attach_gettext_callback() {
+
+		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+
+			if ( true || ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
+				// Hook to gettext callback to change the tooltip text
+				add_filter( 'gettext', array( __CLASS__, 'change_order_item_editable_text_tooltip' ), 10, 3 );
+			}
+		}
+	}
+
+	/**
+	 * unattach the gettext callback
+	 */
+	public static function maybe_unattach_gettext_callback() {
+
+		wc_get_logger()->debug( 'maybe_unattach_gettext_callback' );
+
+		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+
+			if ( true || ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
+				// Unhook gettext callback to prevent extra call impact
+				remove_filter( 'gettext', array( __CLASS__, 'change_order_item_editable_text_tooltip' ), 10 );
+			}
+		}
+	}
+
+	/**
+	* When order items are not editable due to the charge being authorized to capture the current amount,
+	* change the tooltip to explain the reason
+	*/
+	public static function change_order_item_editable_text_tooltip( $translated_text, $text, $domain ) {
+		switch ( $text ) {
+			case 'To edit this order change the status back to "Pending payment"':
+				$translated_text = __( 'This order is no longer editable because the charge has been authorized.', 'woocommerce-subscriptions' );
+				break;
+		}
+
+		return $translated_text;
 	}
 
 	/**

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -70,14 +70,14 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Only attach the gettext callback when on admin edit order screen
 	 */
-	public static function maybe_attach_gettext_callback() {
+	public function maybe_attach_gettext_callback() {
 
 		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
 			$screen = get_current_screen();
 
 			if ( true || ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
 				// Hook to gettext callback to change the tooltip text
-				add_filter( 'gettext', array( __CLASS__, 'change_order_item_editable_text_tooltip' ), 10, 3 );
+				add_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10, 3 );
 			}
 		}
 	}
@@ -85,7 +85,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * unattach the gettext callback
 	 */
-	public static function maybe_unattach_gettext_callback() {
+	public function maybe_unattach_gettext_callback() {
 
 		wc_get_logger()->debug( 'maybe_unattach_gettext_callback' );
 
@@ -94,7 +94,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 			if ( true || ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) ) {
 				// Unhook gettext callback to prevent extra call impact
-				remove_filter( 'gettext', array( __CLASS__, 'change_order_item_editable_text_tooltip' ), 10 );
+				remove_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10 );
 			}
 		}
 	}
@@ -103,7 +103,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	* When order items are not editable due to the charge being authorized to capture the current amount,
 	* change the tooltip to explain the reason
 	*/
-	public static function change_order_item_editable_text_tooltip( $translated_text, $text, $domain ) {
+	public function change_order_item_editable_text_tooltip( $translated_text, $text, $domain ) {
 		switch ( $text ) {
 			case 'To edit this order change the status back to "Pending payment"':
 				$translated_text = __( 'This order is no longer editable because the charge has been authorized.', 'woocommerce-gateway-stripe' );

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -50,6 +50,11 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return boolean false if the order has uncaptured payment, true otherwise.
 	 */
 	public function disable_edit_for_uncaptured_orders( $editable, $order ) {
+		// Bail if payment method is not manual capture supporting stripe method.
+		if ( ! WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
+			return $editable;
+		}
+
 		try {
 			$intent = $this->get_intent_from_order( $order );
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -28,6 +28,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_tracks_event_properties', [ $this, 'woocommerce_tracks_event_properties' ], 10, 2 );
 
 		add_action( 'woocommerce_cancel_unpaid_order', [ $this, 'prevent_cancelling_orders_awaiting_action' ], 10, 2 );
+
+		add_filter( 'wc_order_is_editable', [ $this, 'disable_edit_for_uncaptured_orders' ], 10, 2 );
 	}
 
 	/**
@@ -38,6 +40,27 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public static function get_instance() {
 		return self::$_this;
+	}
+
+	/**
+	 * Disables the ability to edit for orders with uncaptured payment.
+	 *
+	 * @param $editable boolean The current editability of the order.
+	 * @param $order WC_Order The order object.
+	 * @return boolean false if the order has uncaptured payment, true otherwise.
+	 */
+	public function disable_edit_for_uncaptured_orders( $editable, $order ) {
+		try {
+			$intent = $this->get_intent_from_order( $order );
+
+			if ( $intent && 'requires_capture' === $intent->status ) {
+				$editable = false;
+			}
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log( 'Error getting intent from order: ' . $e->getMessage() );
+		}
+
+		return $editable;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,9 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
+= 9.1.0 - xxxx-xx-xx =
+* Update - Prevent editing of orders awaiting payment capture.
+
 = 9.0.0 - xxxx-xx-xx =
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
 * Add - Pre-fill user email and phone number for Link in the Payment Element.


### PR DESCRIPTION
Fixes #916 

The original issue #916 describes a bug that occurs when a charge has been authorized, and the merchant attempts to increase the price of the order before capturing the payment. The order fails when the merchant changes the order status to `processing` after updating the price. Because in Stripe it is not possible to capture a charge for more than the authorized amount. Despite the order failure, the customer receives a order processing email.
 
Though the bug description focuses on the wrong email sent to the customer, my understanding is we should not allow the merchants to update the amount in the corresponding order if the amount has already been authorized (as we know it is definitely going to fail)

## Changes proposed in this Pull Request:
- Not allowing to update the order if the intent has `requires_capture` status (indicating the charge has been authorized)

## Testing instructions

- Enable `Issue an authorization on checkout, and capture later` in the Stripe settings page.
- As a shopper, purchase a product with a card.
- As an admin, go to the order edit page.
- Confirm that the order items are not editable. You can not increase/decrease the number of items, add/remove coupons, update price/tax etc. (anything that would change the total amount)
- You should see `This order is no longer editable` message and the tooltip should explain the reason.