### PR TITLE
Avoid saving failed cards when subscribing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Prevents the saving of payment methods when subscribing with a failed method.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -281,13 +281,20 @@ trait WC_Stripe_Subscriptions_Trait {
 			// Create a setup intent, or update an existing one associated with the order.
 			$payment_intent = $this->process_setup_intent_for_order( $subscription, $payment_information );
 
-			// Handle saving the payment method in the store.
-			if ( $payment_information['save_payment_method_to_store'] && $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type() ) {
-				$this->handle_saving_payment_method(
-					$subscription,
-					$payment_information['payment_method_details'],
-					$selected_payment_type
-				);
+			$intent_successful_or_requiring_action = in_array(
+				$payment_intent->status,
+				array_merge( self::SUCCESSFUL_INTENT_STATUS, [ 'requires_confirmation', 'requires_action' ] ),
+				true
+			);
+			if ( $intent_successful_or_requiring_action ) {
+				// Handle saving the payment method in the store.
+				if ( $payment_information['save_payment_method_to_store'] && $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type() ) {
+					$this->handle_saving_payment_method(
+						$subscription,
+						$payment_information['payment_method_details'],
+						$selected_payment_type
+					);
+				}
 			}
 
 			$redirect           = $this->get_return_url( $subscription );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -844,7 +844,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			// Handle saving the payment method in the store.
 			// It's already attached to the Stripe customer at this point.
-			if ( $payment_information['save_payment_method_to_store'] && $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type() ) {
+			$intent_success_or_requiring_action = in_array(
+				$payment_intent->status,
+				array_merge( self::SUCCESSFUL_INTENT_STATUS, [ 'requires_confirmation', 'requires_action' ] ),
+				true
+			);
+			if ( $payment_information['save_payment_method_to_store']
+				&& $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type()
+				&& $intent_success_or_requiring_action ) {
 				$this->handle_saving_payment_method(
 					$order,
 					$payment_method_details,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1467,7 +1467,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Check if the cart contains a pre-order product. Ignore the cart if we're on the Pay for Order page.
 		if ( $this->is_pre_order_item_in_cart() && ! $is_pay_for_order_page ) {
-			$pre_order_product = $this->get_pre_order_product_from_cart();
+			$pre_order_product  = $this->get_pre_order_product_from_cart();
 
 			// Only one pre-order product is allowed per cart,
 			// so we can return if it's charged upfront.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -844,28 +844,30 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			// Handle saving the payment method in the store.
 			// It's already attached to the Stripe customer at this point.
-			$intent_success_or_requiring_action = in_array(
+			// Don't save the payment method if the intent was not successful
+			$intent_successful_or_requiring_action = in_array(
 				$payment_intent->status,
 				array_merge( self::SUCCESSFUL_INTENT_STATUS, [ 'requires_confirmation', 'requires_action' ] ),
 				true
 			);
-			if ( $payment_information['save_payment_method_to_store']
-				&& $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type()
-				&& $intent_success_or_requiring_action ) {
-				$this->handle_saving_payment_method(
-					$order,
-					$payment_method_details,
-					$selected_payment_type
-				);
-			} elseif ( $is_using_saved_payment_method ) {
-				$this->maybe_update_source_on_subscription_order(
-					$order,
-					(object) [
-						'payment_method' => $payment_information['payment_method'],
-						'customer'       => $payment_information['customer'],
-					],
-					$this->get_upe_gateway_id_for_order( $upe_payment_method )
-				);
+			if ( $intent_successful_or_requiring_action ) {
+				if ( $payment_information['save_payment_method_to_store']
+					&& $upe_payment_method && $upe_payment_method->get_id() === $upe_payment_method->get_retrievable_type() ) {
+					$this->handle_saving_payment_method(
+						$order,
+						$payment_method_details,
+						$selected_payment_type
+					);
+				} elseif ( $is_using_saved_payment_method ) {
+					$this->maybe_update_source_on_subscription_order(
+						$order,
+						(object) [
+							'payment_method' => $payment_information['payment_method'],
+							'customer'       => $payment_information['customer'],
+						],
+						$this->get_upe_gateway_id_for_order( $upe_payment_method )
+					);
+				}
 			}
 
 			// Set the selected UPE payment method type title in the WC order.
@@ -1465,7 +1467,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Check if the cart contains a pre-order product. Ignore the cart if we're on the Pay for Order page.
 		if ( $this->is_pre_order_item_in_cart() && ! $is_pay_for_order_page ) {
-			$pre_order_product  = $this->get_pre_order_product_from_cart();
+			$pre_order_product = $this->get_pre_order_product_from_cart();
 
 			// Only one pre-order product is allowed per cart,
 			// so we can return if it's charged upfront.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Prevents the saving of payment methods when subscribing with a failed method.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2281

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR blocks the saving of payment methods when subscribing if the method used has failed. For this, I am checking the payment intent status and not calling the method saving handler if it is not successful.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
