### PR TITLE
Introducing payment intent status constants

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Dev - Introduces a new class with payment intent statuses constants.
 * Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1130,7 +1130,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				if ( ! empty( $intent->error ) ) {
 					$response         = $intent;
 					$intent_cancelled = true;
-				} elseif ( 'requires_capture' === $intent->status ) {
+				} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 					$result           = WC_Stripe_API::request(
 						[],
 						'payment_intents/' . $intent->id . '/cancel'
@@ -1554,7 +1554,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return object                   Either an error or the updated intent.
 	 */
 	public function confirm_intent( $intent, $order, $prepared_source ) {
-		if ( 'requires_confirmation' !== $intent->status ) {
+		if ( WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION !== $intent->status ) {
 			return $intent;
 		}
 
@@ -1575,9 +1575,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		// Save a note about the status of the intent.
 		$order_id = $order->get_id();
-		if ( 'succeeded' === $confirmed_intent->status ) {
+		if ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $confirmed_intent->status ) {
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
-		} elseif ( 'requires_action' === $confirmed_intent->status ) {
+		} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $confirmed_intent->status ) {
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id requires authentication for order $order_id" );
 		}
 
@@ -1746,7 +1746,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		if ( is_wp_error( $setup_intent ) ) {
 			WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
-		} elseif ( 'requires_action' === $setup_intent->status ) {
+		} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
 			$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
 			$order->save();
 

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1130,7 +1130,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				if ( ! empty( $intent->error ) ) {
 					$response         = $intent;
 					$intent_cancelled = true;
-				} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
+				} elseif ( WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 					$result           = WC_Stripe_API::request(
 						[],
 						'payment_intents/' . $intent->id . '/cancel'
@@ -1554,7 +1554,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return object                   Either an error or the updated intent.
 	 */
 	public function confirm_intent( $intent, $order, $prepared_source ) {
-		if ( WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION !== $intent->status ) {
+		if ( WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION !== $intent->status ) {
 			return $intent;
 		}
 
@@ -1575,9 +1575,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		// Save a note about the status of the intent.
 		$order_id = $order->get_id();
-		if ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $confirmed_intent->status ) {
+		if ( WC_Stripe_Intent_Status::SUCCEEDED === $confirmed_intent->status ) {
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
-		} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $confirmed_intent->status ) {
+		} elseif ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $confirmed_intent->status ) {
 			WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id requires authentication for order $order_id" );
 		}
 
@@ -1746,7 +1746,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		if ( is_wp_error( $setup_intent ) ) {
 			WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
-		} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
+		} elseif ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
 			$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
 			$order->save();
 

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -139,7 +139,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 			}
 
 			// Ensure that intent can be captured.
-			if ( ! in_array( $intent->status, [ 'processing', 'requires_capture' ], true ) ) {
+			if ( ! in_array( $intent->status, [ WC_Stripe_Payment_Intent_Status::PROCESSING, WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE ], true ) ) {
 				return new WP_Error( 'wc_stripe_payment_uncapturable', __( 'The payment cannot be captured', 'woocommerce-gateway-stripe' ), [ 'status' => 409 ] );
 			}
 
@@ -154,7 +154,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 			$result = WC_Stripe_Order_Handler::get_instance()->capture_payment( $order );
 
 			// Check for failure to capture payment.
-			if ( empty( $result ) || empty( $result->status ) || 'succeeded' !== $result->status ) {
+			if ( empty( $result ) || empty( $result->status ) || WC_Stripe_Payment_Intent_Status::SUCCEEDED !== $result->status ) {
 				return new WP_Error(
 					'wc_stripe_capture_error',
 					sprintf(

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -139,7 +139,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 			}
 
 			// Ensure that intent can be captured.
-			if ( ! in_array( $intent->status, [ WC_Stripe_Payment_Intent_Status::PROCESSING, WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE ], true ) ) {
+			if ( ! in_array( $intent->status, [ WC_Stripe_Intent_Status::PROCESSING, WC_Stripe_Intent_Status::REQUIRES_CAPTURE ], true ) ) {
 				return new WP_Error( 'wc_stripe_payment_uncapturable', __( 'The payment cannot be captured', 'woocommerce-gateway-stripe' ), [ 'status' => 409 ] );
 			}
 
@@ -154,7 +154,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 			$result = WC_Stripe_Order_Handler::get_instance()->capture_payment( $order );
 
 			// Check for failure to capture payment.
-			if ( empty( $result ) || empty( $result->status ) || WC_Stripe_Payment_Intent_Status::SUCCEEDED !== $result->status ) {
+			if ( empty( $result ) || empty( $result->status ) || WC_Stripe_Intent_Status::SUCCEEDED !== $result->status ) {
 				return new WP_Error(
 					'wc_stripe_capture_error',
 					sprintf(

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -83,7 +83,7 @@ class WC_Stripe_Settings_Controller {
 		try {
 			$intent = $this->get_gateway()->get_intent_from_order( $order );
 
-			if ( $intent && 'requires_capture' === $intent->status ) {
+			if ( $intent && WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 				$no_refunds_button  = __( 'Refunding unavailable', 'woocommerce-gateway-stripe' );
 				$no_refunds_tooltip = __( 'Refunding via Stripe is unavailable because funds have not been captured for this order. Process order to take payment, or cancel to remove the pre-authorization.', 'woocommerce-gateway-stripe' );
 				echo '<style>.button.refund-items { display: none; }</style>';

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -83,7 +83,7 @@ class WC_Stripe_Settings_Controller {
 		try {
 			$intent = $this->get_gateway()->get_intent_from_order( $order );
 
-			if ( $intent && WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
+			if ( $intent && WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 				$no_refunds_button  = __( 'Refunding unavailable', 'woocommerce-gateway-stripe' );
 				$no_refunds_tooltip = __( 'Refunding via Stripe is unavailable because funds have not been captured for this order. Process order to take payment, or cancel to remove the pre-authorization.', 'woocommerce-gateway-stripe' );
 				echo '<style>.button.refund-items { display: none; }</style>';

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -888,7 +888,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'setup_intent' === $intent->object && WC_Stripe_Payment_Intent_Status::SUCCESSFUL_STATUSES === $intent->status ) {
+		if ( 'setup_intent' === $intent->object && WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status ) {
 			WC()->cart->empty_cart();
 			if ( $this->has_pre_order( $order ) ) {
 				$this->mark_order_as_pre_ordered( $order );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -463,7 +463,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				$this->throw_localized_message( $intent, $order );
 			}
 
-			if ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status && ! $this->is_using_saved_payment_method() && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
+			if ( WC_Stripe_Intent_Status::SUCCEEDED === $intent->status && ! $this->is_using_saved_payment_method() && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
 				$this->save_payment_method( $prepared_source->source_object );
 			}
 
@@ -472,7 +472,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				$response = $this->get_latest_charge_from_intent( $intent );
 
 				// If the intent requires a 3DS flow, redirect to it.
-				if ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $intent->status ) {
+				if ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $intent->status ) {
 					$this->unlock_order_payment( $order );
 
 					// If the order requires some action from the customer, add meta to the order to prevent it from being cancelled by WooCommerce's hold stock settings.
@@ -705,7 +705,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			);
 		}
 
-		if ( WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status && isset( $intent->last_payment_error )
+		if ( WC_Stripe_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status && isset( $intent->last_payment_error )
 			&& 'authentication_required' === $intent->last_payment_error->code ) {
 			$level3_data = $this->get_level3_data_from_order( $order );
 			$intent      = WC_Stripe_API::request_with_level3_data(
@@ -888,17 +888,17 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'setup_intent' === $intent->object && WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status ) {
+		if ( 'setup_intent' === $intent->object && WC_Stripe_Intent_Status::SUCCEEDED === $intent->status ) {
 			WC()->cart->empty_cart();
 			if ( $this->has_pre_order( $order ) ) {
 				$this->mark_order_as_pre_ordered( $order );
 			} else {
 				$order->payment_complete();
 			}
-		} elseif ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status || WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
+		} elseif ( WC_Stripe_Intent_Status::SUCCEEDED === $intent->status || WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 			// Proceed with the payment completion.
 			$this->handle_intent_verification_success( $order, $intent );
-		} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status ) {
+		} elseif ( WC_Stripe_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status ) {
 			// `requires_payment_method` means that SCA got denied for the current payment method.
 			$this->handle_intent_verification_failure( $order, $intent );
 		}

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -463,7 +463,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				$this->throw_localized_message( $intent, $order );
 			}
 
-			if ( 'succeeded' === $intent->status && ! $this->is_using_saved_payment_method() && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
+			if ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status && ! $this->is_using_saved_payment_method() && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
 				$this->save_payment_method( $prepared_source->source_object );
 			}
 
@@ -472,7 +472,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				$response = $this->get_latest_charge_from_intent( $intent );
 
 				// If the intent requires a 3DS flow, redirect to it.
-				if ( 'requires_action' === $intent->status ) {
+				if ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $intent->status ) {
 					$this->unlock_order_payment( $order );
 
 					// If the order requires some action from the customer, add meta to the order to prevent it from being cancelled by WooCommerce's hold stock settings.
@@ -705,7 +705,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			);
 		}
 
-		if ( 'requires_payment_method' === $intent->status && isset( $intent->last_payment_error )
+		if ( WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status && isset( $intent->last_payment_error )
 			&& 'authentication_required' === $intent->last_payment_error->code ) {
 			$level3_data = $this->get_level3_data_from_order( $order );
 			$intent      = WC_Stripe_API::request_with_level3_data(
@@ -888,17 +888,17 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( 'setup_intent' === $intent->object && 'succeeded' === $intent->status ) {
+		if ( 'setup_intent' === $intent->object && WC_Stripe_Payment_Intent_Status::SUCCESSFUL_STATUSES === $intent->status ) {
 			WC()->cart->empty_cart();
 			if ( $this->has_pre_order( $order ) ) {
 				$this->mark_order_as_pre_ordered( $order );
 			} else {
 				$order->payment_complete();
 			}
-		} elseif ( 'succeeded' === $intent->status || 'requires_capture' === $intent->status ) {
+		} elseif ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status || WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 			// Proceed with the payment completion.
 			$this->handle_intent_verification_success( $order, $intent );
-		} elseif ( 'requires_payment_method' === $intent->status ) {
+		} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status ) {
 			// `requires_payment_method` means that SCA got denied for the current payment method.
 			$this->handle_intent_verification_failure( $order, $intent );
 		}

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -259,14 +259,14 @@ class WC_Stripe_Intent_Controller {
 			}
 
 			// 5. Respond.
-			if ( 'requires_action' === $setup_intent->status ) {
+			if ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
 				$response = [
-					'status'        => 'requires_action',
+					'status'        => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
 					'client_secret' => $setup_intent->client_secret,
 				];
-			} elseif ( 'requires_payment_method' === $setup_intent->status
-				|| 'requires_confirmation' === $setup_intent->status
-				|| 'canceled' === $setup_intent->status ) {
+			} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $setup_intent->status
+				|| WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION === $setup_intent->status
+				|| WC_Stripe_Payment_Intent_Status::CANCELED === $setup_intent->status ) {
 				// These statuses should not be possible, as such we return an error.
 				$response = [
 					'status' => 'error',
@@ -1041,7 +1041,7 @@ class WC_Stripe_Intent_Controller {
 
 			$setup_intent = $this->create_and_confirm_setup_intent( $payment_information );
 
-			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, [ 'succeeded', 'processing', 'requires_action', 'requires_confirmation' ], true ) ) {
+			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, [ WC_Stripe_Payment_Intent_Status::SUCCEEDED, WC_Stripe_Payment_Intent_Status::PROCESSING, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION, WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION ], true ) ) {
 				throw new WC_Stripe_Exception( 'Response from Stripe: ' . print_r( $setup_intent, true ), __( 'There was an error adding this payment method. Please refresh the page and try again', 'woocommerce-gateway-stripe' ) );
 			}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -259,14 +259,14 @@ class WC_Stripe_Intent_Controller {
 			}
 
 			// 5. Respond.
-			if ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
+			if ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
 				$response = [
-					'status'        => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
+					'status'        => WC_Stripe_Intent_Status::REQUIRES_ACTION,
 					'client_secret' => $setup_intent->client_secret,
 				];
-			} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $setup_intent->status
-				|| WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION === $setup_intent->status
-				|| WC_Stripe_Payment_Intent_Status::CANCELED === $setup_intent->status ) {
+			} elseif ( WC_Stripe_Intent_Status::REQUIRES_PAYMENT_METHOD === $setup_intent->status
+				|| WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION === $setup_intent->status
+				|| WC_Stripe_Intent_Status::CANCELED === $setup_intent->status ) {
 				// These statuses should not be possible, as such we return an error.
 				$response = [
 					'status' => 'error',
@@ -1041,7 +1041,7 @@ class WC_Stripe_Intent_Controller {
 
 			$setup_intent = $this->create_and_confirm_setup_intent( $payment_information );
 
-			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, WC_Stripe_Payment_Intent_Status::SUCCESSFUL_SETUP_INTENT_STATUSES, true ) ) {
+			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, WC_Stripe_Intent_Status::SUCCESSFUL_SETUP_INTENT_STATUSES, true ) ) {
 				throw new WC_Stripe_Exception( 'Response from Stripe: ' . print_r( $setup_intent, true ), __( 'There was an error adding this payment method. Please refresh the page and try again', 'woocommerce-gateway-stripe' ) );
 			}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1041,7 +1041,7 @@ class WC_Stripe_Intent_Controller {
 
 			$setup_intent = $this->create_and_confirm_setup_intent( $payment_information );
 
-			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, [ WC_Stripe_Payment_Intent_Status::SUCCEEDED, WC_Stripe_Payment_Intent_Status::PROCESSING, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION, WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION ], true ) ) {
+			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, WC_Stripe_Payment_Intent_Status::VALID_SUCCESSFUL_SETUP_INTENT_STATUSES, true ) ) {
 				throw new WC_Stripe_Exception( 'Response from Stripe: ' . print_r( $setup_intent, true ), __( 'There was an error adding this payment method. Please refresh the page and try again', 'woocommerce-gateway-stripe' ) );
 			}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1041,7 +1041,7 @@ class WC_Stripe_Intent_Controller {
 
 			$setup_intent = $this->create_and_confirm_setup_intent( $payment_information );
 
-			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, WC_Stripe_Payment_Intent_Status::VALID_SUCCESSFUL_SETUP_INTENT_STATUSES, true ) ) {
+			if ( empty( $setup_intent->status ) || ! in_array( $setup_intent->status, WC_Stripe_Payment_Intent_Status::SUCCESSFUL_SETUP_INTENT_STATUSES, true ) ) {
 				throw new WC_Stripe_Exception( 'Response from Stripe: ' . print_r( $setup_intent, true ), __( 'There was an error adding this payment method. Please refresh the page and try again', 'woocommerce-gateway-stripe' ) );
 			}
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -268,7 +268,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 					if ( ! empty( $intent->error ) ) {
 						/* translators: error message */
 						$order->add_order_note( sprintf( __( 'Unable to capture charge! %s', 'woocommerce-gateway-stripe' ), $intent->error->message ) );
-					} elseif ( 'requires_capture' === $intent->status ) {
+					} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 						$level3_data = $this->get_level3_data_from_order( $order );
 						$result      = WC_Stripe_API::request_with_level3_data(
 							[
@@ -287,7 +287,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 							$is_stripe_captured = true;
 							$result             = $this->get_latest_charge_from_intent( $result );
 						}
-					} elseif ( 'succeeded' === $intent->status ) {
+					} elseif ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status ) {
 						$is_stripe_captured = true;
 					}
 				} else {

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -268,7 +268,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 					if ( ! empty( $intent->error ) ) {
 						/* translators: error message */
 						$order->add_order_note( sprintf( __( 'Unable to capture charge! %s', 'woocommerce-gateway-stripe' ), $intent->error->message ) );
-					} elseif ( WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
+					} elseif ( WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 						$level3_data = $this->get_level3_data_from_order( $order );
 						$result      = WC_Stripe_API::request_with_level3_data(
 							[
@@ -287,7 +287,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 							$is_stripe_captured = true;
 							$result             = $this->get_latest_charge_from_intent( $result );
 						}
-					} elseif ( WC_Stripe_Payment_Intent_Status::SUCCEEDED === $intent->status ) {
+					} elseif ( WC_Stripe_Intent_Status::SUCCEEDED === $intent->status ) {
 						$is_stripe_captured = true;
 					}
 				} else {

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -294,7 +294,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			$new_payment_method = $this->get_upe_gateway_id_for_order( $upe_payment_method );
 
 			// If the payment intent requires confirmation or action, redirect the customer to confirm the intent.
-			if ( in_array( $payment_intent->status, [ 'requires_confirmation', 'requires_action' ], true ) ) {
+			if ( in_array( $payment_intent->status, [ WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION ], true ) ) {
 				// Because we're filtering woocommerce_subscriptions_update_payment_via_pay_shortcode, we need to manually set this delayed update all flag here.
 				if ( isset( $_POST['update_all_subscriptions_payment_method'] ) && wc_clean( wp_unslash( $_POST['update_all_subscriptions_payment_method'] ) ) ) {
 					$subscription->update_meta_data( '_delayed_update_payment_method_all', $new_payment_method );
@@ -1030,7 +1030,7 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		if (
 			! $existing_intent
-			|| 'requires_payment_method' !== $existing_intent->status
+			|| WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD !== $existing_intent->status
 			|| empty( $existing_intent->last_payment_error )
 			|| 'authentication_required' !== $existing_intent->last_payment_error->code
 		) {
@@ -1118,7 +1118,7 @@ trait WC_Stripe_Subscriptions_Trait {
 	 */
 	protected function must_authorize_off_session( $payment_intent ) {
 		return ! empty( $payment_intent->status )
-			&& 'processing' === $payment_intent->status
+			&& WC_Stripe_Payment_Intent_Status::PROCESSING === $payment_intent->status
 			&& ! empty( $payment_intent->processing->card->customer_notification->completes_at );
 	}
 

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -294,7 +294,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			$new_payment_method = $this->get_upe_gateway_id_for_order( $upe_payment_method );
 
 			// If the payment intent requires confirmation or action, redirect the customer to confirm the intent.
-			if ( in_array( $payment_intent->status, WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION_OR_ACTION_STATUSES, true ) ) {
+			if ( in_array( $payment_intent->status, WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION_OR_ACTION_STATUSES, true ) ) {
 				// Because we're filtering woocommerce_subscriptions_update_payment_via_pay_shortcode, we need to manually set this delayed update all flag here.
 				if ( isset( $_POST['update_all_subscriptions_payment_method'] ) && wc_clean( wp_unslash( $_POST['update_all_subscriptions_payment_method'] ) ) ) {
 					$subscription->update_meta_data( '_delayed_update_payment_method_all', $new_payment_method );
@@ -1030,7 +1030,7 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		if (
 			! $existing_intent
-			|| WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD !== $existing_intent->status
+			|| WC_Stripe_Intent_Status::REQUIRES_PAYMENT_METHOD !== $existing_intent->status
 			|| empty( $existing_intent->last_payment_error )
 			|| 'authentication_required' !== $existing_intent->last_payment_error->code
 		) {
@@ -1118,7 +1118,7 @@ trait WC_Stripe_Subscriptions_Trait {
 	 */
 	protected function must_authorize_off_session( $payment_intent ) {
 		return ! empty( $payment_intent->status )
-			&& WC_Stripe_Payment_Intent_Status::PROCESSING === $payment_intent->status
+			&& WC_Stripe_Intent_Status::PROCESSING === $payment_intent->status
 			&& ! empty( $payment_intent->processing->card->customer_notification->completes_at );
 	}
 

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -294,7 +294,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			$new_payment_method = $this->get_upe_gateway_id_for_order( $upe_payment_method );
 
 			// If the payment intent requires confirmation or action, redirect the customer to confirm the intent.
-			if ( in_array( $payment_intent->status, [ WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION ], true ) ) {
+			if ( in_array( $payment_intent->status, WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION_OR_ACTION_STATUSES, true ) ) {
 				// Because we're filtering woocommerce_subscriptions_update_payment_via_pay_shortcode, we need to manually set this delayed update all flag here.
 				if ( isset( $_POST['update_all_subscriptions_payment_method'] ) && wc_clean( wp_unslash( $_POST['update_all_subscriptions_payment_method'] ) ) ) {
 					$subscription->update_meta_data( '_delayed_update_payment_method_all', $new_payment_method );

--- a/includes/constants/class-wc-stripe-currency-code.php
+++ b/includes/constants/class-wc-stripe-currency-code.php
@@ -1,5 +1,12 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class WC_Stripe_Currency_Code
+ */
 class WC_Stripe_Currency_Code {
 
 	// Source: https://docs.stripe.com/currencies

--- a/includes/constants/class-wc-stripe-intent-status.php
+++ b/includes/constants/class-wc-stripe-intent-status.php
@@ -6,6 +6,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Class WC_Stripe_Intent_Status
+ *
+ * For a documentation on the possible intent statuses, please refer to the following link:
+ * https://docs.stripe.com/api/payment_intents/object#payment_intent_object-status
  */
 class WC_Stripe_Intent_Status {
 	/**

--- a/includes/constants/class-wc-stripe-intent-status.php
+++ b/includes/constants/class-wc-stripe-intent-status.php
@@ -5,9 +5,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class WC_Stripe_Payment_Intent_Status
+ * Class WC_Stripe_Intent_Status
  */
-class WC_Stripe_Payment_Intent_Status {
+class WC_Stripe_Intent_Status {
 	/**
 	 * Payment intent status that indicates the payment was canceled.
 	 *

--- a/includes/constants/class-wc-stripe-payment-intent-status.php
+++ b/includes/constants/class-wc-stripe-payment-intent-status.php
@@ -63,4 +63,14 @@ class WC_Stripe_Payment_Intent_Status {
 	 * @var array
 	 */
 	const SUCCESSFUL_STATUSES = [ self::SUCCEEDED, self::REQUIRES_CAPTURE, self::PROCESSING ];
+
+	/**
+	 * Grouping of statuses that require confirmation or action.
+	 */
+	const REQUIRES_CONFIRMATION_OR_ACTION_STATUSES = [ self::REQUIRES_CONFIRMATION, self::REQUIRES_ACTION ];
+
+	/**
+	 * Grouping of statuses that are considered successful when setting up intents.
+	 */
+	const VALID_SUCCESSFUL_SETUP_INTENT_STATUSES = [ self::SUCCEEDED, self::PROCESSING, self::REQUIRES_ACTION, self::REQUIRES_CONFIRMATION ];
 }

--- a/includes/constants/class-wc-stripe-payment-intent-status.php
+++ b/includes/constants/class-wc-stripe-payment-intent-status.php
@@ -1,0 +1,66 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class WC_Stripe_Payment_Intent_Status
+ */
+class WC_Stripe_Payment_Intent_Status {
+	/**
+	 * Payment intent status that indicates the payment was canceled.
+	 *
+	 * @var string
+	 */
+	const CANCELED = 'canceled';
+
+	/**
+	 * Payment intent status that indicates the payment is processing.
+	 *
+	 * @var string
+	 */
+	const PROCESSING = 'processing';
+
+	/**
+	 * Payment intent status that indicates the payment requires confirmation.
+	 *
+	 * @var string
+	 */
+	const REQUIRES_CONFIRMATION = 'requires_confirmation';
+
+	/**
+	 * Payment intent status that indicates the payment requires action.
+	 *
+	 * @var string
+	 */
+	const REQUIRES_ACTION = 'requires_action';
+
+	/**
+	 * Payment intent status that indicates the payment requires capture.
+	 *
+	 * @var string
+	 */
+	const REQUIRES_CAPTURE = 'requires_capture';
+
+	/**
+	 * Payment intent status that indicates the payment requires payment method.
+	 *
+	 * @var string
+	 */
+	const REQUIRES_PAYMENT_METHOD = 'requires_payment_method';
+
+	/**
+	 * Payment intent status that indicates the payment was successful.
+	 *
+	 * @var string
+	 */
+	const SUCCEEDED = 'succeeded';
+
+	/**
+	 * Stripe intents that are treated as successfully created.
+	 *
+	 * @var array
+	 */
+	const SUCCESSFUL_STATUSES = [ self::SUCCEEDED, self::REQUIRES_CAPTURE, self::PROCESSING ];
+}

--- a/includes/constants/class-wc-stripe-payment-intent-status.php
+++ b/includes/constants/class-wc-stripe-payment-intent-status.php
@@ -72,5 +72,5 @@ class WC_Stripe_Payment_Intent_Status {
 	/**
 	 * Grouping of statuses that are considered successful when setting up intents.
 	 */
-	const VALID_SUCCESSFUL_SETUP_INTENT_STATUSES = [ self::SUCCEEDED, self::PROCESSING, self::REQUIRES_ACTION, self::REQUIRES_CONFIRMATION ];
+	const SUCCESSFUL_SETUP_INTENT_STATUSES = [ self::SUCCEEDED, self::PROCESSING, self::REQUIRES_ACTION, self::REQUIRES_CONFIRMATION ];
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -42,6 +42,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	];
 
 	/**
+	 * Stripe intents that are treated as successfully created.
+	 *
+	 * @type array
+	 *
+	 * @deprecated 9.1.0
+	 */
+	const SUCCESSFUL_INTENT_STATUS = [ 'succeeded', 'requires_capture', 'processing' ];
+
+	/**
 	 * Transient name for appearance settings.
 	 *
 	 * @type string

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -42,13 +42,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	];
 
 	/**
-	 * Stripe intents that are treated as successfully created.
-	 *
-	 * @type array
-	 */
-	const SUCCESSFUL_INTENT_STATUS = [ 'succeeded', 'requires_capture', 'processing' ];
-
-	/**
 	 * Transient name for appearance settings.
 	 *
 	 * @type string
@@ -870,7 +863,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$return_url = $this->get_return_url( $order );
 
 			// Updates the redirect URL and add extra meta data to the order if the payment intent requires confirmation or action.
-			if ( in_array( $payment_intent->status, [ 'requires_confirmation', 'requires_action' ], true ) ) {
+			if ( in_array( $payment_intent->status, [ WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION ], true ) ) {
 				$redirect                          = $this->get_redirect_url( $return_url, $payment_intent, $payment_information, $order, $payment_needed );
 				$wallet_and_voucher_methods        = array_merge( WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS );
 				$contains_wallet_or_voucher_method = isset( $payment_intent->payment_method_types ) && count( array_intersect( $wallet_and_voucher_methods, $payment_intent->payment_method_types ) ) !== 0;
@@ -889,21 +882,21 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$order->save();
 			} else {
 				$redirect = $return_url;
-			}
 
-			if ( $payment_needed && ! in_array( $payment_intent->status, [ 'requires_confirmation', 'requires_action' ], true ) ) {
-				// Use the last charge within the intent to proceed.
-				$charge = $this->get_latest_charge_from_intent( $payment_intent );
+				if ( $payment_needed ) {
+					// Use the last charge within the intent to proceed.
+					$charge = $this->get_latest_charge_from_intent( $payment_intent );
 
-				// Only process the response if it contains a charge object. Intents with no charge require further action like 3DS and will be processed later.
-				if ( $charge ) {
-					$this->process_response( $charge, $order );
-				}
-			} elseif ( in_array( $payment_intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
-				if ( ! $this->has_pre_order( $order ) ) {
-					$order->payment_complete();
-				} elseif ( $this->maybe_process_pre_orders( $order ) ) {
-					$this->mark_order_as_pre_ordered( $order );
+					// Only process the response if it contains a charge object. Intents with no charge require further action like 3DS and will be processed later.
+					if ( $charge ) {
+						$this->process_response( $charge, $order );
+					}
+				} elseif ( in_array( $payment_intent->status, WC_Stripe_Payment_Intent_Status::SUCCESSFUL_STATUSES, true ) ) {
+					if ( ! $this->has_pre_order( $order ) ) {
+						$order->payment_complete();
+					} elseif ( $this->maybe_process_pre_orders( $order ) ) {
+						$this->mark_order_as_pre_ordered( $order );
+					}
 				}
 			}
 
@@ -1053,7 +1046,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$this->throw_localized_message( $intent, $order );
 			}
 
-			if ( 'requires_action' === $intent->status || 'requires_confirmation' === $intent->status ) {
+			if ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $intent->status || WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION === $intent->status ) {
 				if ( isset( $intent->next_action->type ) && 'redirect_to_url' === $intent->next_action->type && ! empty( $intent->next_action->redirect_to_url->url ) ) {
 					return [
 						'result'   => 'success',
@@ -2413,17 +2406,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 
 		// Check if the status of the intent still allows update.
-		if ( in_array( $intent->status, [ 'canceled', 'succeeded' ], true ) ) {
+		if ( in_array( $intent->status, [ WC_Stripe_Payment_Intent_Status::CANCELED, WC_Stripe_Payment_Intent_Status::SUCCEEDED ], true ) ) {
 			return null;
 		}
 
 		// If the intent requires confirmation to show voucher on checkout (i.e. Boleto or oxxo or multibanco ) or requires action (i.e. need to show a 3DS confirmation card or handle the UPE redirect), don't reuse the intent
-		if ( in_array( $intent->status, [ 'requires_confirmation', 'requires_action' ], true ) ) {
+		if ( in_array( $intent->status, [ WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION ], true ) ) {
 			return null;
 		}
 
 		// Cash App Pay intents with a "requires payment method" status cannot be reused. See https://docs.stripe.com/payments/cash-app-pay/accept-a-payment?web-or-mobile=web&payments-ui-type=direct-api#failed-payments
-		if ( in_array( WC_Stripe_Payment_Methods::CASHAPP_PAY, $intent->payment_method_types ) && 'requires_payment_method' === $intent->status ) {
+		if ( in_array( WC_Stripe_Payment_Methods::CASHAPP_PAY, $intent->payment_method_types ) && WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status ) {
 			return null;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -863,7 +863,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$return_url = $this->get_return_url( $order );
 
 			// Updates the redirect URL and add extra meta data to the order if the payment intent requires confirmation or action.
-			if ( in_array( $payment_intent->status, [ WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION ], true ) ) {
+			if ( in_array( $payment_intent->status, WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION_OR_ACTION_STATUSES, true ) ) {
 				$redirect                          = $this->get_redirect_url( $return_url, $payment_intent, $payment_information, $order, $payment_needed );
 				$wallet_and_voucher_methods        = array_merge( WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS );
 				$contains_wallet_or_voucher_method = isset( $payment_intent->payment_method_types ) && count( array_intersect( $wallet_and_voucher_methods, $payment_intent->payment_method_types ) ) !== 0;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -863,7 +863,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$return_url = $this->get_return_url( $order );
 
 			// Updates the redirect URL and add extra meta data to the order if the payment intent requires confirmation or action.
-			if ( in_array( $payment_intent->status, WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION_OR_ACTION_STATUSES, true ) ) {
+			if ( in_array( $payment_intent->status, WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION_OR_ACTION_STATUSES, true ) ) {
 				$redirect                          = $this->get_redirect_url( $return_url, $payment_intent, $payment_information, $order, $payment_needed );
 				$wallet_and_voucher_methods        = array_merge( WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS );
 				$contains_wallet_or_voucher_method = isset( $payment_intent->payment_method_types ) && count( array_intersect( $wallet_and_voucher_methods, $payment_intent->payment_method_types ) ) !== 0;
@@ -891,7 +891,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					if ( $charge ) {
 						$this->process_response( $charge, $order );
 					}
-				} elseif ( in_array( $payment_intent->status, WC_Stripe_Payment_Intent_Status::SUCCESSFUL_STATUSES, true ) ) {
+				} elseif ( in_array( $payment_intent->status, WC_Stripe_Intent_Status::SUCCESSFUL_STATUSES, true ) ) {
 					if ( ! $this->has_pre_order( $order ) ) {
 						$order->payment_complete();
 					} elseif ( $this->maybe_process_pre_orders( $order ) ) {
@@ -1046,7 +1046,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$this->throw_localized_message( $intent, $order );
 			}
 
-			if ( WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION === $intent->status || WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION === $intent->status ) {
+			if ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $intent->status || WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION === $intent->status ) {
 				if ( isset( $intent->next_action->type ) && 'redirect_to_url' === $intent->next_action->type && ! empty( $intent->next_action->redirect_to_url->url ) ) {
 					return [
 						'result'   => 'success',
@@ -2406,17 +2406,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 
 		// Check if the status of the intent still allows update.
-		if ( in_array( $intent->status, [ WC_Stripe_Payment_Intent_Status::CANCELED, WC_Stripe_Payment_Intent_Status::SUCCEEDED ], true ) ) {
+		if ( in_array( $intent->status, [ WC_Stripe_Intent_Status::CANCELED, WC_Stripe_Intent_Status::SUCCEEDED ], true ) ) {
 			return null;
 		}
 
 		// If the intent requires confirmation to show voucher on checkout (i.e. Boleto or oxxo or multibanco ) or requires action (i.e. need to show a 3DS confirmation card or handle the UPE redirect), don't reuse the intent
-		if ( in_array( $intent->status, [ WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION ], true ) ) {
+		if ( in_array( $intent->status, [ WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Intent_Status::REQUIRES_ACTION ], true ) ) {
 			return null;
 		}
 
 		// Cash App Pay intents with a "requires payment method" status cannot be reused. See https://docs.stripe.com/payments/cash-app-pay/accept-a-payment?web-or-mobile=web&payments-ui-type=direct-api#failed-payments
-		if ( in_array( WC_Stripe_Payment_Methods::CASHAPP_PAY, $intent->payment_method_types ) && WC_Stripe_Payment_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status ) {
+		if ( in_array( WC_Stripe_Payment_Methods::CASHAPP_PAY, $intent->payment_method_types ) && WC_Stripe_Intent_Status::REQUIRES_PAYMENT_METHOD === $intent->status ) {
 			return null;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Dev - Introduces a new class with payment intent statuses constants.
 * Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
@@ -117,7 +117,7 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 					[
 						'id'      => 'pi_12345',
 						'object'  => 'payment_intent',
-						'status'  => WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE,
+						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
 						'charges' => [
 							'data' => [
 								[
@@ -173,7 +173,7 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 					[
 						'id'     => 'pi_12345',
 						'object' => 'payment_intent',
-						'status' => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
+						'status' => WC_Stripe_Intent_Status::SUCCEEDED,
 					]
 				),
 			];
@@ -223,7 +223,7 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 					[
 						'id'      => 'pi_12345',
 						'object'  => 'payment_intent',
-						'status'  => WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE,
+						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
 						'charges' => [
 							'data' => [
 								[

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
@@ -117,7 +117,7 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 					[
 						'id'      => 'pi_12345',
 						'object'  => 'payment_intent',
-						'status'  => 'requires_capture',
+						'status'  => WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE,
 						'charges' => [
 							'data' => [
 								[
@@ -173,7 +173,7 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 					[
 						'id'     => 'pi_12345',
 						'object' => 'payment_intent',
-						'status' => 'succeeded',
+						'status' => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
 					]
 				),
 			];
@@ -223,7 +223,7 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 					[
 						'id'      => 'pi_12345',
 						'object'  => 'payment_intent',
-						'status'  => 'requires_capture',
+						'status'  => WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE,
 						'charges' => [
 							'data' => [
 								[

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -90,7 +90,7 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 
 		$intent = (object) [
 			'id'     => 'pi_123',
-			'status' => 'requires_capture',
+			'status' => WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE,
 		];
 
 		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -90,7 +90,7 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 
 		$intent = (object) [
 			'id'     => 'pi_123',
-			'status' => WC_Stripe_Payment_Intent_Status::REQUIRES_CAPTURE,
+			'status' => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
 		];
 
 		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -62,7 +62,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	const MOCK_CARD_PAYMENT_INTENT_TEMPLATE = [
 		'id'                 => 'pi_mock',
 		'object'             => 'payment_intent',
-		'status'             => 'succeeded',
+		'status'             => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
 		'last_payment_error' => [],
 		'client_secret'      => 'cs_mock',
 		'charges'            => [
@@ -105,7 +105,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	const MOCK_CARD_SETUP_INTENT_TEMPLATE = [
 		'object'           => 'setup_intent',
-		'status'           => 'succeeded',
+		'status'           => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
 		'client_secret'    => 'cs_mock',
 		'last_setup_error' => [],
 	];
@@ -417,7 +417,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$mock_intent = (object) wp_parse_args(
 			[
-				'status'         => 'requires_action',
+				'status'         => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
 				'data'           => [
 					(object) [
 						'id'       => $order_id,
@@ -488,7 +488,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$mock_intent = (object) wp_parse_args(
 			[
-				'status'               => 'requires_action',
+				'status'               => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
 				'object'               => 'payment_intent',
 				'data'                 => [
 					(object) [
@@ -1337,7 +1337,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				'id'             => $payment_intent_id,
 				'amount'         => $amount,
 				'payment_method' => $payment_method_id,
-				'status'         => 'requires_action',
+				'status'         => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
 				'charges'        => (object) [
 					'data' => [
 						(object) [
@@ -2142,7 +2142,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 						],
 					],
 				],
-				'status'               => 'requires_action',
+				'status'               => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
 			],
 			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
 		);

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -62,7 +62,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	const MOCK_CARD_PAYMENT_INTENT_TEMPLATE = [
 		'id'                 => 'pi_mock',
 		'object'             => 'payment_intent',
-		'status'             => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
+		'status'             => WC_Stripe_Intent_Status::SUCCEEDED,
 		'last_payment_error' => [],
 		'client_secret'      => 'cs_mock',
 		'charges'            => [
@@ -105,7 +105,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	const MOCK_CARD_SETUP_INTENT_TEMPLATE = [
 		'object'           => 'setup_intent',
-		'status'           => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
+		'status'           => WC_Stripe_Intent_Status::SUCCEEDED,
 		'client_secret'    => 'cs_mock',
 		'last_setup_error' => [],
 	];
@@ -417,7 +417,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$mock_intent = (object) wp_parse_args(
 			[
-				'status'         => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
+				'status'         => WC_Stripe_Intent_Status::REQUIRES_ACTION,
 				'data'           => [
 					(object) [
 						'id'       => $order_id,
@@ -488,7 +488,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$mock_intent = (object) wp_parse_args(
 			[
-				'status'               => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
+				'status'               => WC_Stripe_Intent_Status::REQUIRES_ACTION,
 				'object'               => 'payment_intent',
 				'data'                 => [
 					(object) [
@@ -1337,7 +1337,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 				'id'             => $payment_intent_id,
 				'amount'         => $amount,
 				'payment_method' => $payment_method_id,
-				'status'         => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
+				'status'         => WC_Stripe_Intent_Status::REQUIRES_ACTION,
 				'charges'        => (object) [
 					'data' => [
 						(object) [
@@ -2142,7 +2142,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 						],
 					],
 				],
-				'status'               => WC_Stripe_Payment_Intent_Status::REQUIRES_ACTION,
+				'status'               => WC_Stripe_Intent_Status::REQUIRES_ACTION,
 			],
 			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
 		);

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -135,7 +135,7 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 
 			// Respond with a successfull intent for confirmations.
 			if ( $url !== $intents_api_endpoint ) {
-				$response['body'] = str_replace( WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::SUCCEEDED, $response['body'] );
+				$response['body'] = str_replace( WC_Stripe_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Intent_Status::SUCCEEDED, $response['body'] );
 				return $response;
 			}
 

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -135,7 +135,7 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 
 			// Respond with a successfull intent for confirmations.
 			if ( $url !== $intents_api_endpoint ) {
-				$response['body'] = str_replace( 'requires_confirmation', 'succeeded', $response['body'] );
+				$response['body'] = str_replace( WC_Stripe_Payment_Intent_Status::REQUIRES_CONFIRMATION, WC_Stripe_Payment_Intent_Status::SUCCEEDED, $response['body'] );
 				return $response;
 			}
 

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -23,7 +23,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	const MOCK_PAYMENT_INTENT = [
 		'id'                 => 'pi_mock',
 		'object'             => 'payment_intent',
-		'status'             => 'succeeded',
+		'status'             => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
 		'charges'            => [
 			'total_count' => 1,
 			'data'        => [

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -23,7 +23,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	const MOCK_PAYMENT_INTENT = [
 		'id'                 => 'pi_mock',
 		'object'             => 'payment_intent',
-		'status'             => WC_Stripe_Payment_Intent_Status::SUCCEEDED,
+		'status'             => WC_Stripe_Intent_Status::SUCCEEDED,
 		'charges'            => [
 			'total_count' => 1,
 			'data'        => [

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -215,6 +215,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-stripe.php';
 				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-currency-code.php';
 				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-payment-methods.php';
+				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-payment-intent-status.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php';

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -215,7 +215,7 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-stripe.php';
 				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-currency-code.php';
 				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-payment-methods.php';
-				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-payment-intent-status.php';
+				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-intent-status.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method.php';
 				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php';


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This is another simple refactor PR introducing a new constant class to replace all references to payment intent status names. This is useful to centralize information, make it easier to reference the statuses, and later build specific logic for groups of statuses.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review should be enough. Check if the tests are still passing. No behavior should change with this PR.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
