### PR TITLE
ECE: fix account creation on checkout for subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
-* Fix - Allow account creation on checkout for subscriptions if enabled in settings.
+* Fix - Allow account creation on checkout, if enabled, when purchasing subscriptions using ECE.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Allow account creation on checkout for subscriptions if enabled in settings.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
@@ -16,7 +17,7 @@
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -50,16 +50,12 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return bool
 	 */
 	public function is_authentication_required() {
-		// If guest checkout is disabled and account creation upon checkout is not possible, authentication is required.
-		if ( 'no' === get_option( 'woocommerce_enable_guest_checkout', 'yes' ) && ! $this->is_account_creation_possible() ) {
-			return true;
-		}
-		// If cart contains subscription and account creation upon checkout is not posible, authentication is required.
-		if ( $this->has_subscription_product() && ! $this->is_account_creation_possible() ) {
-			return true;
+		if ( 'yes' === get_option( 'woocommerce_enable_guest_checkout', 'yes' ) ) {
+			return false;
 		}
 
-		return false;
+		// If guest checkout is disabled and account creation upon checkout is not possible, authentication is required.
+		return 'no' === get_option( 'woocommerce_enable_guest_checkout', 'yes' ) && ! $this->is_account_creation_possible();
 	}
 
 	/**
@@ -70,8 +66,14 @@ class WC_Stripe_Express_Checkout_Helper {
 	public function is_account_creation_possible() {
 		// If automatically generate username/password are disabled, we can not include any of those fields,
 		// during express checkout. So account creation is not possible.
+
+		$is_checkout_signup_allowed =
+			'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' ) ||
+			( $this->has_subscription_product() &&
+				'yes' === get_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'no' ) );
+
 		return (
-			'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' ) &&
+			$is_checkout_signup_allowed &&
 			'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) &&
 			'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' )
 		);

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -50,6 +50,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return bool
 	 */
 	public function is_authentication_required() {
+		// If guest checkout is enabled, authentication is not required.
 		if ( 'yes' === get_option( 'woocommerce_enable_guest_checkout', 'yes' ) ) {
 			return false;
 		}
@@ -64,19 +65,18 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return bool
 	 */
 	public function is_account_creation_possible() {
-		// If automatically generate username/password are disabled, we can not include any of those fields,
-		// during express checkout. So account creation is not possible.
-
-		$is_checkout_signup_allowed =
+		// Check if account creation is allowed on checkout.
+		$is_signup_on_checkout_allowed =
 			'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' ) ||
 			( $this->has_subscription_product() &&
 				'yes' === get_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'no' ) );
 
-		return (
-			$is_checkout_signup_allowed &&
+		// Account creation is not possible for express checkout if we cannot automatically generate the username and password.
+		$username_password_generation_enabled =
 			'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) &&
-			'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' )
-		);
+			'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' );
+
+		return $is_signup_on_checkout_allowed && $username_password_generation_enabled;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
-* Fix - Allow account creation on checkout for subscriptions if enabled in settings.
+* Fix - Allow account creation on checkout, if enabled, when purchasing subscriptions using ECE.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Fix - Allow account creation on checkout for subscriptions if enabled in settings.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
@@ -126,7 +127,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 

--- a/tests/phpunit/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/test-wc-stripe-express-checkout-helper.php
@@ -192,4 +192,79 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		$checkout_data        = $wc_stripe_ece_helper->get_checkout_data();
 		$this->assertEmpty( $checkout_data['default_shipping_option'] );
 	}
+
+	/**
+	 * Test for is_authentication_required().
+	 */
+	public function test_is_authentication_required() {
+		$wc_stripe_ece_helper_mock = $this->createPartialMock(
+			WC_Stripe_Express_Checkout_Helper::class,
+			[
+				'is_account_creation_possible',
+			]
+		);
+		$wc_stripe_ece_helper_mock->expects( $this->any() )
+			->method( 'is_account_creation_possible' )
+			->willReturnOnConsecutiveCalls( true, false );
+
+		// Guest checkout is enabled.
+		update_option( 'woocommerce_enable_guest_checkout', 'yes' );
+		$this->assertFalse( $wc_stripe_ece_helper_mock->is_authentication_required() );
+
+		// Guest checkout is disabled, and account creation is possible.
+		update_option( 'woocommerce_enable_guest_checkout', 'no' );
+		$this->assertFalse( $wc_stripe_ece_helper_mock->is_authentication_required() );
+
+		// Guest checkout is disabled, and account creation is not possible.
+		update_option( 'woocommerce_enable_guest_checkout', 'no' );
+		$this->assertTrue( $wc_stripe_ece_helper_mock->is_authentication_required() );
+	}
+
+	/**
+	 * Test for is_account_creation_possible().
+	 */
+	public function test_is_account_creation_possible() {
+		$wc_stripe_ece_helper_mock = $this->createPartialMock(
+			WC_Stripe_Express_Checkout_Helper::class,
+			[
+				'has_subscription_product',
+			]
+		);
+		$wc_stripe_ece_helper_mock->expects( $this->any() )
+			->method( 'has_subscription_product' )
+			->willReturn( false );
+
+		// Account creation on checkout is enabled.
+		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'yes' );
+		$this->assertTrue( $wc_stripe_ece_helper_mock->is_account_creation_possible() );
+
+		// Account creation on checkout is disabled.
+		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' );
+		$this->assertFalse( $wc_stripe_ece_helper_mock->is_account_creation_possible() );
+
+		// Account creation on checkout is enabled for subscriptions, but no subscription in cart.
+		update_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'yes' );
+		$this->assertFalse( $wc_stripe_ece_helper_mock->is_account_creation_possible() );
+
+		//. Tests for when a subscription product is in the cart.
+		$wc_stripe_ece_helper_mock2 = $this->createPartialMock(
+			WC_Stripe_Express_Checkout_Helper::class,
+			[
+				'has_subscription_product',
+			]
+		);
+		$wc_stripe_ece_helper_mock2->expects( $this->any() )
+			->method( 'has_subscription_product' )
+			->willReturn( true );
+
+		// Account creation on checkout is disabled.
+		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' );
+		update_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'no' );
+		$this->assertFalse( $wc_stripe_ece_helper_mock2->is_account_creation_possible() );
+
+		// Account creation on checkout is enabled for subscriptions, with subscription in cart.
+		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' );
+		update_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'yes' );
+		$this->assertTrue( $wc_stripe_ece_helper_mock2->is_account_creation_possible() );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3639

## Changes proposed in this Pull Request:
When `Allow subscription customers to create an account during checkout` is enabled, subscription shoppers are not required to be registered and logged in prior to purchase. Instead, a user account gets created, and the shopper gets logged in, on checkout success. This is already the behavior when paying for subscriptions via card and other non-express payment methods.

This PR fixes the behavior for ECE, by adding a check for the specific setting for subscriptions: `woocommerce_enable_signup_from_checkout_for_subscriptions`.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. You will need a Google Pay test account with an email address that is not yet signed up for your WooCommerce store. (A quick way for me is to modify the wp_users table if my Google Pay email has already been used.) 
2. As the merchant:
    - Make sure ECE is enabled, and `Apple Pay/Google Pay` is enabled as a payment method.
    - Add a subscription product, if your store does not already have one.
    - Go to **WooCommerce > Settings > Accounts & Privacy** and under **Account creation**, disable `During checkout`, but enable `Allow subscription customers to create an account during checkout`.

<img width="800" alt="Screenshot 2024-12-10 at 12 02 19 PM" src="https://github.com/user-attachments/assets/3d9beb4a-d894-4b97-abdb-494465a503dd">


3. As a logged out shopper, try to purchase a subscription using Google Pay.
4. In `develop`, you will get a Javascript popup requiring you to sign in first.
5. In this branch, you should be allowed to finish the purchase.
6. Upon successful purchase, go to **My Account** and notice a user account has been created and your user is logged in.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
