### PR TITLE
Handling charge expiration webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
 *** Changelog ***
 
-= 9.0.0 - xxxx-xx-xx =
+= 9.1.0 - xxxx-xx-xx =
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.
+
+= 9.0.0 - xxxx-xx-xx =
 * Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -521,6 +521,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @since 4.1.5 Can handle any fail payments from any methods.
+	 * @since 9.0.0 Can handle payment expiration.
 	 * @param object $notification
 	 */
 	public function process_webhook_charge_failed( $notification ) {
@@ -536,7 +537,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$message = __( 'This payment failed to clear.', 'woocommerce-gateway-stripe' );
+		if ( 'charge.expired' === $notification->type ) {
+			$message = __( 'This payment has expired.', 'woocommerce-gateway-stripe' );
+		} else {
+			$message = __( 'This payment failed to clear.', 'woocommerce-gateway-stripe' );
+		}
 		if ( ! $order->get_meta( '_stripe_status_final', false ) ) {
 			$order->update_status( 'failed', $message );
 		} else {
@@ -1160,6 +1165,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 
 			case 'charge.failed':
+			case 'charge.expired':
 				$this->process_webhook_charge_failed( $notification );
 				break;
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.

--- a/readme.txt
+++ b/readme.txt
@@ -110,8 +110,10 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
-= 9.0.0 - xxxx-xx-xx =
+= 9.1.0 - xxxx-xx-xx =
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.
+
+= 9.0.0 - xxxx-xx-xx =
 * Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -21,10 +21,10 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * Mock card payment intent template.
 	 */
 	const MOCK_PAYMENT_INTENT = [
-		'id'                 => 'pi_mock',
-		'object'             => 'payment_intent',
-		'status'             => 'succeeded',
-		'charges'            => [
+		'id'      => 'pi_mock',
+		'object'  => 'payment_intent',
+		'status'  => 'succeeded',
+		'charges' => [
 			'total_count' => 1,
 			'data'        => [
 				[
@@ -96,7 +96,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
 
 		// No payment intent.
-		$order = WC_Helper_Order::create_order();
+		$order            = WC_Helper_Order::create_order();
 		$data['order_id'] = $order->get_id();
 
 		$this->expectExceptionMessage( "Missing required data. 'intent_id' is missing for the deferred 'payment_intent.succeeded' event." );
@@ -110,7 +110,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order     = WC_Helper_Order::create_order();
 		$intent_id = 'pi_mock_1234';
 		$data      = [
-			'order_id' => $order->get_id(),
+			'order_id'  => $order->get_id(),
 			'intent_id' => $intent_id,
 		];
 
@@ -134,7 +134,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_mismatch_intent_id_process_deferred_webhook() {
 		$order = WC_Helper_Order::create_order();
 		$data  = [
-			'order_id' => $order->get_id(),
+			'order_id'  => $order->get_id(),
 			'intent_id' => 'pi_wrong_id',
 		];
 
@@ -168,7 +168,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function test_process_of_successful_payment_intent_deferred_webhook() {
 		$order = WC_Helper_Order::create_order();
 		$data  = [
-			'order_id' => $order->get_id(),
+			'order_id'  => $order->get_id(),
 			'intent_id' => self::MOCK_PAYMENT_INTENT['id'],
 		];
 
@@ -197,5 +197,107 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			);
 
 		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data );
+	}
+
+	/**
+	 * Test for `process_webhook_charge_failed`.
+	 *
+	 * @param WC_Order|bool $order           The order.
+	 * @param array         $event           The event type.
+	 * @param string        $expected_status The expected order status.
+	 * @param string        $expected_note   The expected order note.
+	 * @return void
+	 * @dataProvider provide_test_process_webhook_charge_failed
+	 */
+	public function test_process_webhook_charge_failed( $order, $event, $expected_status, $expected_note ) {
+		$notification = (object) [
+			'type' => $event,
+			'data' => (object) [
+				'object' => (object) [
+					'id' => 1234,
+				],
+			],
+		];
+		if ( $order instanceof WC_Order ) {
+			$charge_id                      = $order->get_transaction_id();
+			$notification->data->object->id = $charge_id;
+		}
+
+		$this->mock_webhook_handler->process_webhook_charge_failed( $notification );
+
+		if ( $order instanceof WC_Order ) {
+			$order = wc_get_order( $order->get_id() );
+			$note  = wc_get_order_notes(
+				[
+					'order_id' => $order->get_id(),
+					'limit'    => 1,
+				]
+			)[0];
+
+			$this->assertEquals( $expected_status, $order->get_status() );
+			$this->assertSame( $expected_note, $note->content );
+		} else {
+			$this->assertFalse( $order );
+		}
+	}
+
+	/**
+	 * Provider for `test_process_webhook_charge_failed`.
+	 *
+	 * @return array
+	 * @throws WC_Data_Exception If the transaction ID cannot be set.
+	 */
+	public function provide_test_process_webhook_charge_failed() {
+		$order_on_hold_charge_id = 1;
+		$order_on_hold           = WC_Helper_Order::create_order();
+		$order_on_hold->set_status( 'on-hold' );
+		$order_on_hold->set_transaction_id( $order_on_hold_charge_id );
+		$order_on_hold->save();
+
+		$order_on_hold_status_final_charge_id = 2;
+		$order_on_hold_status_final           = WC_Helper_Order::create_order();
+		$order_on_hold_status_final->set_status( 'on-hold' );
+		$order_on_hold_status_final->set_transaction_id( $order_on_hold_status_final_charge_id );
+		$order_on_hold_status_final->update_meta_data( '_stripe_status_final', true );
+		$order_on_hold_status_final->save();
+
+		$order_failed_charge_id = 3;
+		$order_failed           = WC_Helper_Order::create_order();
+		$order_failed->set_status( 'failed' );
+		$order_failed->set_transaction_id( $order_failed_charge_id );
+		$order_failed->save();
+
+		return [
+			'order not found'      => [
+				'order'           => false,
+				'event'           => 'charge.failed',
+				'expected status' => 'on-hold',
+				'expected note'   => '',
+			],
+			'order already failed' => [
+				'order'           => $order_failed,
+				'event'           => 'charge.failed',
+				'expected status' => 'failed',
+				'expected note'   => 'Order status changed from Pending payment to Failed.',
+			],
+			'charge failed event, order already with the final status' => [
+				'order'           => $order_on_hold_status_final,
+				'event'           => 'charge.failed',
+				'expected status' => 'on-hold',
+				'expected note'   => 'This payment failed to clear.',
+			],
+			'charge failed event'  => [
+				'order'           => $order_on_hold,
+				'event'           => 'charge.failed',
+				'expected status' => 'failed',
+				'expected note'   => 'This payment failed to clear. Order status changed from On hold to Failed.',
+			],
+			'charge expired event' => [
+				'order'           => $order_on_hold,
+				'event'           => 'charge.expired',
+				'expected status' => 'failed',
+				'expected note'   => 'This payment has expired. Order status changed from On hold to Failed.',
+			],
+		];
 	}
 }

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -202,43 +202,55 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	/**
 	 * Test for `process_webhook_charge_failed`.
 	 *
-	 * @param WC_Order|bool $order           The order.
-	 * @param array         $event           The event type.
-	 * @param string        $expected_status The expected order status.
-	 * @param string        $expected_note   The expected order note.
+	 * @param string $order_status       The order status.
+	 * @param bool   $order_status_final Whether the order status is final.
+	 * @param string $charge_id          The charge ID.
+	 * @param array  $event              The event type.
+	 * @param string $expected_status    The expected order status.
+	 * @param string $expected_note      The expected order note.
 	 * @return void
 	 * @dataProvider provide_test_process_webhook_charge_failed
 	 */
-	public function test_process_webhook_charge_failed( $order, $event, $expected_status, $expected_note ) {
+	public function test_process_webhook_charge_failed(
+		$order_status,
+		$order_status_final,
+		$charge_id,
+		$event,
+		$expected_status,
+		$expected_note
+	) {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( $order_status );
+		$order->set_transaction_id( $charge_id );
+		if ( $order_status_final ) {
+			$order->update_meta_data( '_stripe_status_final', true );
+		}
+		$order->save();
+
 		$notification = (object) [
 			'type' => $event,
 			'data' => (object) [
 				'object' => (object) [
-					'id' => 1234,
+					'id' => 'ch_fQpkNKxmUrZ8t4CT7EHGS3Rg',
 				],
 			],
 		];
-		if ( $order instanceof WC_Order ) {
-			$charge_id                      = $order->get_transaction_id();
-			$notification->data->object->id = $charge_id;
-		}
 
 		$this->mock_webhook_handler->process_webhook_charge_failed( $notification );
 
-		if ( $order instanceof WC_Order ) {
-			$order_id = $order->get_id();
-			$order    = wc_get_order( $order_id );
-			$note     = wc_get_order_notes(
-				[
-					'order_id' => $order_id,
-					'limit'    => 1,
-				]
-			)[0];
+		if ( $charge_id ) { // Order not found charge ID.
+			$final_order = wc_get_order( $order->get_id() );
+			$this->assertEquals( $expected_status, $final_order->get_status() );
 
-			$this->assertEquals( $expected_status, $order->get_status() );
-			$this->assertSame( $expected_note, $note->content );
-		} else {
-			$this->assertFalse( $order );
+			if ( $expected_note ) {
+				$notes = wc_get_order_notes(
+					[
+						'order_id' => $final_order->get_id(),
+						'limit'    => 1,
+					]
+				);
+				$this->assertSame( $expected_note, $notes[0]->content );
+			}
 		}
 	}
 
@@ -246,58 +258,40 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * Provider for `test_process_webhook_charge_failed`.
 	 *
 	 * @return array
-	 * @throws WC_Data_Exception If the transaction ID cannot be set.
 	 */
 	public function provide_test_process_webhook_charge_failed() {
-		$order_on_hold_charge_id = 1;
-		$order_on_hold           = WC_Helper_Order::create_order();
-		$order_on_hold->set_status( 'on-hold' );
-		$order_on_hold->set_transaction_id( $order_on_hold_charge_id );
-		$order_on_hold->save();
-
-		$order_on_hold_status_final_charge_id = 2;
-		$order_on_hold_status_final           = WC_Helper_Order::create_order();
-		$order_on_hold_status_final->set_status( 'on-hold' );
-		$order_on_hold_status_final->set_transaction_id( $order_on_hold_status_final_charge_id );
-		$order_on_hold_status_final->update_meta_data( '_stripe_status_final', true );
-		$order_on_hold_status_final->save();
-
-		$order_failed_charge_id = 3;
-		$order_failed           = WC_Helper_Order::create_order();
-		$order_failed->set_status( 'failed' );
-		$order_failed->set_transaction_id( $order_failed_charge_id );
-		$order_failed->save();
-
 		return [
-			'order not found'      => [
-				'order'           => false,
-				'event'           => 'charge.failed',
-				'expected status' => 'on-hold',
-				'expected note'   => '',
-			],
 			'order already failed' => [
-				'order'           => $order_failed,
-				'event'           => 'charge.failed',
-				'expected status' => 'failed',
-				'expected note'   => 'Order status changed from Pending payment to Failed.',
+				'order status'       => 'failed',
+				'order status final' => false,
+				'charge id'          => 'ch_fQpkNKxmUrZ8t4CT7EHGS3Rg',
+				'event'              => 'charge.failed',
+				'expected status'    => 'failed',
+				'expected note'      => '',
 			],
 			'charge failed event, order already with the final status' => [
-				'order'           => $order_on_hold_status_final,
-				'event'           => 'charge.failed',
-				'expected status' => 'on-hold',
-				'expected note'   => 'This payment failed to clear.',
+				'order status'       => 'on-hold',
+				'order status final' => true,
+				'charge id'          => 'ch_fQpkNKxmUrZ8t4CT7EHGS3Rg',
+				'event'              => 'charge.failed',
+				'expected status'    => 'on-hold',
+				'expected note'      => 'This payment failed to clear.',
 			],
 			'charge failed event'  => [
-				'order'           => $order_on_hold,
-				'event'           => 'charge.failed',
-				'expected status' => 'failed',
-				'expected note'   => 'This payment failed to clear. Order status changed from On hold to Failed.',
+				'order status'       => 'on-hold',
+				'order status final' => false,
+				'charge id'          => 'ch_fQpkNKxmUrZ8t4CT7EHGS3Rg',
+				'event'              => 'charge.failed',
+				'expected status'    => 'failed',
+				'expected note'      => 'This payment failed to clear. Order status changed from On hold to Failed.',
 			],
 			'charge expired event' => [
-				'order'           => $order_on_hold,
-				'event'           => 'charge.expired',
-				'expected status' => 'failed',
-				'expected note'   => 'This payment has expired. Order status changed from On hold to Failed.',
+				'order status'       => 'on-hold',
+				'order status final' => false,
+				'charge id'          => 'ch_fQpkNKxmUrZ8t4CT7EHGS3Rg',
+				'event'              => 'charge.expired',
+				'expected status'    => 'failed',
+				'expected note'      => 'This payment has expired. Order status changed from On hold to Failed.',
 			],
 		];
 	}

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -226,10 +226,11 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler->process_webhook_charge_failed( $notification );
 
 		if ( $order instanceof WC_Order ) {
-			$order = wc_get_order( $order->get_id() );
-			$note  = wc_get_order_notes(
+			$order_id = $order->get_id();
+			$order    = wc_get_order( $order_id );
+			$note     = wc_get_order_notes(
 				[
-					'order_id' => $order->get_id(),
+					'order_id' => $order_id,
 					'limit'    => 1,
 				]
 			)[0];


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1378

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When setting up a store to authorize and capture later, the payment for an order may never be captured. When this happens, Stripe expires the transaction [after ~7 days](https://docs.stripe.com/payments/place-a-hold-on-a-payment-method).

Currently, we don't have any handlers for this event. Expired orders stay unchanged on the store side.

This PR adds a handler for them, updating the status to `failed` and including a note with the corresponding information.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/handling-charge-expiration-webhooks`)
- Connect your Stripe account
- Enable manual capture in `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` ("Issue an authorization on checkout, and capture later")
- As a shopper, add a product to your cart
- Complete the checkout
- As a merchant, confirm the the order was set to `on-hold`
- Trigger the charge expiration event:
-- Option 1: wait the payment to expire. 7 days for card and 60 minutes for Affirm. This requires the store to be publicly accessible
-- Option 2: copy the following event body sample:
<details>
<summary><b>Sample event</b></summary>

```json
{
  "object": {
    "id": "ch_3QRf2fGwEEw4tjx01Ufql8i8",
    "object": "charge",
    "amount": 5500,
    "amount_captured": 0,
    "amount_refunded": 5500,
    "application": "ca_BC3QunyBFJIQULdxege9Gyg8WjKI1vXD",
    "application_fee": null,
    "application_fee_amount": null,
    "balance_transaction": null,
    "billing_details": {
      "address": {
        "city": "Random City",
        "country": "NZ",
        "line1": "1600 Random Address",
        "line2": null,
        "postal_code": "3015",
        "state": "WGN"
      },
      "email": "wesley.rosa@a8c.com",
      "name": "Card Holder Name",
      "phone": "+1 650-555-5555"
    },
    "calculated_statement_descriptor": "USELESS-EATER.JURASSIC",
    "captured": false,
    "created": 1733166741,
    "currency": "usd",
    "customer": "cus_RFPozHGCKF7lO9",
    "description": "WooCommerce Stripe Dev - Order 147",
    "destination": null,
    "dispute": null,
    "disputed": false,
    "failure_balance_transaction": null,
    "failure_code": null,
    "failure_message": null,
    "fraud_details": {
    },
    "invoice": null,
    "livemode": false,
    "metadata": {
      "customer_email": "wesley.rosa@a8c.com",
      "customer_name": "Card Holder Name",
      "order_id": "147",
      "order_key": "wc_order_shjWSILrZUUAh",
      "payment_type": "single",
      "signature": "147:dc9a096f7ef2036df0946723c4eb81c1",
      "site_url": "http://localhost:8082"
    },
    "on_behalf_of": null,
    "order": null,
    "outcome": {
      "network_advice_code": null,
      "network_decline_code": null,
      "network_status": "approved_by_network",
      "reason": null,
      "risk_level": "normal",
      "risk_score": 32,
      "seller_message": "Payment complete.",
      "type": "authorized"
    },
    "paid": true,
    "payment_intent": "pi_3QRf2fGwEEw4tjx01A0gYgI8",
    "payment_method": "pm_1QMv10GwEEw4tjx06McQy2nY",
    "payment_method_details": {
      "card": {
        "amount_authorized": 5500,
        "authorization_code": null,
        "brand": "visa",
        "capture_before": 1733771541,
        "checks": {
          "address_line1_check": "pass",
          "address_postal_code_check": "pass",
          "cvc_check": null
        },
        "country": "US",
        "exp_month": 12,
        "exp_year": 2024,
        "extended_authorization": {
          "status": "disabled"
        },
        "fingerprint": "NGxtOcphGPgIzOko",
        "funding": "credit",
        "incremental_authorization": {
          "status": "unavailable"
        },
        "installments": null,
        "last4": "4242",
        "mandate": null,
        "multicapture": {
          "status": "unavailable"
        },
        "network": "visa",
        "network_token": {
          "used": false
        },
        "overcapture": {
          "maximum_amount_capturable": 5500,
          "status": "unavailable"
        },
        "three_d_secure": null,
        "wallet": null
      },
      "type": "card"
    },
    "radar_options": {
    },
    "receipt_email": null,
    "receipt_number": null,
    "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT1V3YjZHd0VFdzR0angwKJaC3boGMgYaoRVYO8o6LBafjNK0v2jtmwIcozIk41LVm33M2SidTTuH1MrL_YjIHv6g6Bgk35hC-XY5",
    "refunded": true,
    "review": null,
    "shipping": {
      "address": {
        "city": "Random City",
        "country": "NZ",
        "line1": "1600 Random Address",
        "line2": "",
        "postal_code": "3015",
        "state": "WGN"
      },
      "carrier": null,
      "name": "Card Holder Name",
      "phone": null,
      "tracking_number": null
    },
    "source": null,
    "source_transfer": null,
    "statement_descriptor": null,
    "statement_descriptor_suffix": null,
    "status": "succeeded",
    "transfer_data": null,
    "transfer_group": null
  },
  "previous_attributes": {
    "amount_refunded": 0,
    "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xT1V3YjZHd0VFdzR0angwKJaC3boGMgbEybNpVgY6LBZcFYNsXB29FB4pNUqr2NQBA7Gxab6MuD-JSipUrblK1LSLg2VlVdB4RIs5",
    "refunded": false
  }
}
```
</details>
(change `object.id` property to match your charge ID. You can grab it on your Stripe dashboard or on the order edit page)

--- Request the webhook endpoint on your store using the event body (`/?wc-api=wc_stripe`) using Postman or something similar
- Confirm the handler was called: order status should be changed to `failed` and the following note added:
"This payment has expired. Order status changed from On hold to Failed."

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
