### PR TITLE
Prevent editing of orders awaiting payment capture

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.0.0 - xxxx-xx-xx =
+* Update - Prevent editing of orders awaiting payment capture.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
@@ -16,7 +17,7 @@
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -28,6 +28,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_tracks_event_properties', [ $this, 'woocommerce_tracks_event_properties' ], 10, 2 );
 
 		add_action( 'woocommerce_cancel_unpaid_order', [ $this, 'prevent_cancelling_orders_awaiting_action' ], 10, 2 );
+
+		add_filter( 'wc_order_is_editable', [ $this, 'prevent_editing_orders_awaiting_payment_capture' ], 10, 2 );
 	}
 
 	/**
@@ -439,6 +441,28 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		return $cancel_order;
+	}
+
+	/**
+	 * Hooks into wc_order_is_editable filter to prevent editing of orders that are
+	 * awaiting payment capture.
+	 *
+	 * This is necessary because any changes to the order total does
+	 * not update the pre-authorized amount on the Stripe side, and later attempts to
+	 * capture payment for the new total will fail.
+	 */
+	public function prevent_editing_orders_awaiting_payment_capture( $is_editable, $order ) {
+		// Bail if payment method is not stripe.
+		if ( substr( (string) $order->get_payment_method(), 0, 6 ) !== 'stripe' ) {
+			return $is_editable;
+		}
+
+		$intent = $this->get_intent_from_order( $order );
+		if ( isset( $intent->status ) && 'requires_capture' === $intent->status ) {
+			return false;
+		}
+
+		return $is_editable;
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.0.0 - xxxx-xx-xx =
+* Update - Prevent editing of orders awaiting payment capture.
 * Fix - Set correct payment method when using Link and a card that is 3D Secure authenticated.
 * Fix - Fix total calculation for custom product types when using the Payment Request Button.
 * Fix - Fix order attribution metadata not included in PRBs or Express Checkout Element.
@@ -126,7 +127,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Return 'is_live' as true in account summary response when test mode is disabled in gateway settings and charge is enabled in Stripe account.
 * Fix - Prevents notices being displayed on WordPress 6.7 due to loading translations too early (only shown on stores with WP_DEBUG enabled).
 * Fix - Prevent showing the shipping options on express checkout modal for virtual product variations.
-* Fix - Do not assume payment is using a saved card when retrying a failed payment. 
+* Fix - Do not assume payment is using a saved card when retrying a failed payment.
 * Tweak - Update links to plugin documentation and Stripe documentation.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 

--- a/tests/phpunit/test-class-wc-stripe-order-handler.php
+++ b/tests/phpunit/test-class-wc-stripe-order-handler.php
@@ -50,4 +50,40 @@ class WC_Stripe_Order_Handler_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $this->order_handler->prevent_cancelling_orders_awaiting_action( true, $order ) );
 	}
+
+	/**
+	 * Test for prevent_editing_orders_awaiting_payment_capture().
+	 */
+	public function test_prevent_editing_orders_awaiting_payment_capture() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'bacs' );
+		$order->save();
+
+		// Test when payment method is not stripe.
+		$this->assertTrue( $this->order_handler->prevent_editing_orders_awaiting_payment_capture( true, $order ) );
+		$this->assertFalse( $this->order_handler->prevent_editing_orders_awaiting_payment_capture( false, $order ) );
+
+		$order->set_payment_method( 'stripe' );
+		$order->save();
+
+		$this->order_handler
+			->expects( $this->any() )
+			->method( 'get_intent_from_order' )
+			->willReturnOnConsecutiveCalls(
+				(object) [
+					'intent_id' => 'pi_mock1',
+					'status'    => 'succeeded',
+				],
+				(object) [
+					'intent_id' => 'pi_mock2',
+					'status'    => 'requires_capture',
+				]
+			);
+
+		// Test when intent is succeeded.
+		$this->assertTrue( $this->order_handler->prevent_editing_orders_awaiting_payment_capture( true, $order ) );
+
+		// Test when intent is requires_capture.
+		$this->assertFalse( $this->order_handler->prevent_editing_orders_awaiting_payment_capture( true, $order ) );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1231 

## Changes proposed in this Pull Request:
This PR adds changes to prevent the editing, i.e. adding/updating of line items, of orders that are awaiting payment capture. 

Reason: The authorized amount in Stripe does not get updated with the order total. Attempting to capture payment when the order total is not the same as the authorized amount results in failure.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Go to Stripe > Settings and enable `Issue an authorization on checkout, and capture later`.
2. As a shopper, complete a purchase.
3. View the order in wp-admin, and verify that the order is not editable (see screenshot).

<img width="500" alt="Screenshot 2024-12-10 at 9 44 42 PM" src="https://github.com/user-attachments/assets/b4c56620-158f-4cbc-abb6-555f51ad51e5">


### Known issue

The tooltip beside the message `This order is no longer editable.` displays inaccurate instructions. For our case, setting the order back to `Pending payment` will not make the order editable -- it will remain uneditable as long as the order is awaiting payment capture.

Unfortunately, WC core does not currently offer an easy way to customize this tooltip message. Suggestions to mitigate are welcome.

<img width="317" alt="Screenshot 2024-12-10 at 10 53 02 PM" src="https://github.com/user-attachments/assets/289c1d63-08fb-4ae3-8d60-9813c5be450d">


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
