### PR TITLE
Display better error messages when payment intent creation fails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Improve error message displayed when payment method creation fails in classic checkout.
 * Fix - Only update order status for a Radar review closed event when the order was already captured.
 * Dev - Introduces a new class with payment intent statuses constants.
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Improve error message displayed when payment method creation fails in classic checkout.
 * Fix - Only update order status for a Radar review closed event when the order was already captured.
 * Dev - Introduces a new class with payment intent statuses constants.
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3605 

## Changes proposed in this Pull Request:
When payment intent creation fails, we end up displaying the error message straight from Stripe, which some merchants have described as "cryptic".

In this PR, we add some error handling to display friendlier error messages for more common errors from Stripe.

This PR expands on previous work done in #3588 to cover more Stripe error codes.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Change your store currency to `EUR` and enable SEPA Direct Debit as a payment method.
2. As a shopper, add a product to cart and go to **classic/shortcode** checkout.
3. Do not enter anything for first name and last name.
4. Try to complete the checkout using SEPA Direct Debit.
5. In `develop`, you will see the error message: `Missing required param: billing_details[name].`
6. In this branch, you will see the error message: `Billing Name is a required field.`

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
