### PR TITLE
Display Multibanco details in Order Received page and Order Confirmation email

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Add - Display Multibanco payment instruction details in Order Received page and Order Confirmation email.
 * Tweak - Add the transaction limit information to the Afterpay/Clearpay method when listing payment methods.
 * Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Fix - Handles additional fields when checking out using ECE on the block checkout.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -937,6 +937,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		switch ( $notification->type ) {
 			case 'payment_intent.requires_action':
+				do_action( 'wc_gateway_stripe_process_payment_intent_requires_action', $order, $notification->data->object );
+
 				if ( $is_voucher_payment ) {
 					$order->update_status( 'on-hold', __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
 					wc_reduce_stock_levels( $order_id );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
@@ -85,8 +85,6 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 			esc_html_e( 'Reference:', 'woocommerce-gateway-stripe' ) . "\n\n";
 			echo esc_html( $data['reference'] ) . "\n\n";
-			esc_html_e( 'Voucher URL:', 'woocommerce-gateway-stripe' ) . "\n\n";
-			echo esc_html( $data['hosted_voucher_url'] ) . "\n\n";
 		} else {
 			?>
 			<h3><?php esc_html_e( 'MULTIBANCO ORDER INFORMATION', 'woocommerce-gateway-stripe' ); ?></h3>

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
@@ -29,6 +29,104 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 		);
 
 		add_filter( 'wc_stripe_allowed_payment_processing_statuses', [ $this, 'add_allowed_payment_processing_statuses' ], 10, 2 );
+
+		add_action( 'wc_gateway_stripe_process_payment_intent_requires_action', [ $this, 'save_instructions' ], 10, 2 );
+		add_action( 'woocommerce_thankyou_stripe_multibanco', [ $this, 'thankyou_page' ] );
+		add_action( 'woocommerce_email_before_order_table', [ $this, 'email_instructions' ], 10, 3 );
+	}
+
+	/**
+	 * Output for the order received page.
+	 *
+	 * @param int $order_id
+	 */
+	public function thankyou_page( $order_id ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return;
+		}
+
+		$this->get_instructions( $order );
+	}
+
+	/**
+	 * Add content to the WC emails.
+	 *
+	 * @param WC_Order $order
+	 * @param bool     $sent_to_admin
+	 * @param bool     $plain_text
+	 */
+	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
+		$payment_method = $order->get_payment_method();
+		if ( ! $sent_to_admin && 'stripe_multibanco' === $payment_method && $order->has_status( 'on-hold' ) ) {
+			$this->get_instructions( $order, $plain_text );
+		}
+	}
+
+	/**
+	 * Gets Multibanco payment instructions for the customer.
+	 *
+	 * @param WC_Order $order
+	 */
+	public function get_instructions( $order, $plain_text = false ) {
+		$data = $order->get_meta( '_stripe_multibanco' );
+		if ( ! $data ) {
+			return;
+		}
+
+		if ( $plain_text ) {
+			esc_html_e( 'MULTIBANCO ORDER INFORMATION', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+			esc_html_e( 'Amount:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo wp_kses_post( $data['amount'] ) . "\n\n";
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+			esc_html_e( 'Entity:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo esc_html( $data['entity'] ) . "\n\n";
+			echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+			esc_html_e( 'Reference:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo esc_html( $data['reference'] ) . "\n\n";
+			esc_html_e( 'Voucher URL:', 'woocommerce-gateway-stripe' ) . "\n\n";
+			echo esc_html( $data['hosted_voucher_url'] ) . "\n\n";
+		} else {
+			?>
+			<h3><?php esc_html_e( 'MULTIBANCO ORDER INFORMATION', 'woocommerce-gateway-stripe' ); ?></h3>
+			<ul class="woocommerce-order-overview woocommerce-thankyou-order-details order_details">
+				<li class="woocommerce-order-overview__order order">
+					<?php esc_html_e( 'Amount:', 'woocommerce-gateway-stripe' ); ?>
+					<strong><?php echo wp_kses_post( $data['amount'] ); ?></strong>
+				</li>
+				<li class="woocommerce-order-overview__order order">
+					<?php esc_html_e( 'Entity:', 'woocommerce-gateway-stripe' ); ?>
+					<strong><?php echo esc_html( $data['entity'] ); ?></strong>
+				</li>
+				<li class="woocommerce-order-overview__order order">
+					<?php esc_html_e( 'Reference:', 'woocommerce-gateway-stripe' ); ?>
+					<strong><?php echo esc_html( $data['reference'] ); ?></strong>
+				</li>
+			</ul>
+			<?php
+		}
+	}
+
+
+	/**
+	 * Saves Multibanco information to the order meta for later use.
+	 *
+	 * @param object $order
+	 * @param object $payment_intent. The PaymentIntent object.
+	 */
+	public function save_instructions( $order, $payment_intent ) {
+		if ( empty( $payment_intent->next_action->multibanco_display_details ) ) {
+			return;
+		}
+
+		$data = [
+			'amount'    => $order->get_formatted_order_total(),
+			'entity'    => $payment_intent->next_action->multibanco_display_details->entity,
+			'reference' => $payment_intent->next_action->multibanco_display_details->reference,
+		];
+
+		$order->update_meta_data( '_stripe_multibanco', $data );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
@@ -67,6 +67,7 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 	 * Gets Multibanco payment instructions for the customer.
 	 *
 	 * @param WC_Order $order
+	 * @param bool     $plain_text
 	 */
 	public function get_instructions( $order, $plain_text = false ) {
 		$data = $order->get_meta( '_stripe_multibanco' );

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Add - Display Multibanco payment instruction details in Order Received page and Order Confirmation email.
 * Tweak - Add the transaction limit information to the Afterpay/Clearpay method when listing payment methods.
 * Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Fix - Handles additional fields when checking out using ECE on the block checkout.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3625 

## Changes proposed in this Pull Request:
Display Multibanco payment instruction details in the Order Received/Thank You page, and in the Order Confirmation email for added convenience to the shopper. This feature was present in the legacy checkout.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Make sure your webhooks are enabled and working.
2. Set your shop currency to `EUR` and enable Multibanco as a payment method.
3. Install your email logging plugin of choice, e.g. Post SMTP Email Log
4. As a shopper, purchase something using Multibanco.
5. Verify that the Order Received/Thank You page displays the Multibanco payment instruction details.
6. Using your email logging plugin, verify that the order confirmation email contains the Multibanco payment instruction details.


| Before | After |
|--------|-------|
|<img width="600" alt="Screenshot 2024-12-17 at 10 59 23 AM" src="https://github.com/user-attachments/assets/ed36e1fd-3d71-4695-84a5-fe2ea42c7321" /> | <img width="600" alt="Screenshot 2024-12-17 at 10 59 07 AM" src="https://github.com/user-attachments/assets/5ddb61cf-9794-454a-8788-6fcae073516b" /> |
| <img width="624" alt="Screenshot 2024-12-17 at 11 02 24 AM" src="https://github.com/user-attachments/assets/a56eda1f-a951-44bb-822e-9abac42219d9" />| <img width="624" alt="Screenshot 2024-12-17 at 11 52 47 AM" src="https://github.com/user-attachments/assets/5e6fbb68-1d44-4d92-8112-ab23716a2f52" /> |



---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
