### PR TITLE
Bump mariadb version to fix dev and e2e docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "host.docker.internal:host-gateway"
   db:
     container_name: woocommerce_stripe_mysql
-    image: mariadb:10.5.8
+    image: mariadb:latest
     ports:
       - "5678:3306"
     env_file:

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -31,7 +31,7 @@ for arg in "$@"; do
 	fi
 done
 
-if [[ *"wordpress" == "$(docker-compose -p wcstripe-e2e ps --services --filter "status=running" | grep wordpress)" ]]; then
+if [[ *"wordpress" == "$(docker compose -p wcstripe-e2e ps --services --filter "status=running" | grep wordpress)" ]]; then
 	error "Docker E2E containers are not running, please start them with 'npm run test:e2e-up' or 'npm run test:e2e-setup' and try again."
 	exit 1
 fi

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -36,7 +36,7 @@ fi
 step "Starting E2E docker containers"
 CWD="$CWD" E2E_ROOT="$E2E_ROOT" redirect_output docker compose -p wcstripe-e2e -f "$E2E_ROOT"/env/docker-compose.yml up --build --force-recreate -d wordpress
 
-step "Configuring Wordpress"
+step "Configuring WordPress"
 # Wait for containers to be started up before setup.
 # The db being accessible means that the db container started and the WP has been downloaded and the plugin linked
 set +e

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -58,10 +58,10 @@ redirect_output cli wp core install \
 	--skip-email
 
 if [[ -n "$WP_VERSION" && "$WP_VERSION" != "latest" ]]; then
-	echo " - Installing Wordpress ${WP_VERSION}..."
+	echo " - Installing WordPress ${WP_VERSION}..."
 	redirect_output cli wp core update --version="$WP_VERSION" --force --quiet
 else
-	echo " - Updating Wordpress to the latest version"
+	echo " - Updating WordPress to the latest version"
 	redirect_output cli wp core update --quiet
 fi
 
@@ -74,7 +74,7 @@ redirect_output cli wp config set WP_DEBUG false --raw
 echo " - Updating permalink structure"
 redirect_output cli wp rewrite structure '/%postname%/'
 
-echo " - Installing Wordpress Importer"
+echo " - Installing WordPress Importer"
 redirect_output cli wp plugin install wordpress-importer --activate
 
 echo " - Disable emails to avoid spamming"

--- a/tests/e2e/env/docker-compose.yml
+++ b/tests/e2e/env/docker-compose.yml
@@ -1,7 +1,7 @@
 volumes:
   # Kludge for not having the ./docker directory bound recursively
   dockerdirectory:
-    
+
 services:
   wordpress:
     build: .
@@ -24,7 +24,7 @@ services:
       - "host.docker.internal:host-gateway"
   db:
     container_name: wcstripe-e2e-mysql
-    image: mariadb:10.5.8
+    image: mariadb:latest
     ports:
       - "6789:3306"
     env_file:


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:
Our Github workflow e2e runs have been failing, stuck at `Waiting for containers...`. For example, [this run](https://github.com/woocommerce/woocommerce-gateway-stripe/actions/runs/12362715060/job/34502600836).

When performing a fresh local dev docker setup, it also gets stuck with `Waiting until the service is ready...`.

This is due to a `mariadb` error: `mysqlcheck: Got error: 2026: TLS/SSL error: SSL is required, but the server does not support it when trying to connect`. Using an updated `mariadb` fixes this.

This PR also updates an instance of `docker-compose` (v1) to `docker compose` (v2), as the latest Ubuntu is already on v2. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Github workflow e2e tests setup succeeds -- it does not get stuck at `Waiting for containers...`.
2. Fresh local dev setup succeeds:
   - `npm run down`
   - `docker system prune -a -f`
   - `npm run up`


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
