### PR TITLE
Additional fields on the ECE block checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Handles additional fields when checking out using ECE on the block checkout.
 * Fix - Only update order status for a Radar review closed event when the order was already captured.
 * Dev - Introduces a new class with payment intent statuses constants.
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.

--- a/client/blocks/normalize.js
+++ b/client/blocks/normalize.js
@@ -29,7 +29,7 @@ const normalizeOrderData = ( paymentMethodEvent, paymentRequestType ) => {
 	const name =
 		paymentMethod.billing_details.name ?? paymentMethodEvent.payerName;
 
-	let data = {
+	const data = {
 		_wpnonce: getBlocksConfiguration()?.nonce?.checkout,
 		billing_first_name:
 			name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
@@ -82,58 +82,7 @@ const normalizeOrderData = ( paymentMethodEvent, paymentRequestType ) => {
 		data.shipping_postcode = shipping?.postalCode;
 	}
 
-	data = getRequiredFieldDataFromCheckoutForm( data );
-
 	return { ...data, ...extractOrderAttributionData() };
-};
-
-/**
- * Get required field values from the checkout form if they are filled and add to the order data.
- *
- * @param {Object} data Order data.
- *
- * @return {Object} Order data with required field values.
- */
-const getRequiredFieldDataFromCheckoutForm = ( data ) => {
-	const requiredFields = document.querySelectorAll(
-		'form.checkout .validate-required'
-	);
-
-	if ( requiredFields.length ) {
-		requiredFields.forEach( function ( fieldWrapper ) {
-			const field = fieldWrapper.querySelector( ':input' );
-			const name = field.getAttribute( 'name' );
-
-			let value = '';
-			if ( field.getAttribute( 'type' ) === 'checkbox' ) {
-				value = field.checked;
-			} else {
-				value = field.value;
-			}
-
-			if ( value && name ) {
-				if ( ! data[ name ] ) {
-					data[ name ] = value;
-				}
-
-				// if shipping same as billing is selected, copy the billing field to shipping field.
-				const shipToDiffAddress = document.querySelector(
-					'#ship-to-different-address input'
-				).checked;
-				if ( ! shipToDiffAddress ) {
-					const shippingFieldName = name.replace(
-						'billing_',
-						'shipping_'
-					);
-					if ( ! data[ shippingFieldName ] && data[ name ] ) {
-						data[ shippingFieldName ] = data[ name ];
-					}
-				}
-			}
-		} );
-	}
-
-	return data;
 };
 
 /**

--- a/client/blocks/normalize.js
+++ b/client/blocks/normalize.js
@@ -29,7 +29,7 @@ const normalizeOrderData = ( paymentMethodEvent, paymentRequestType ) => {
 	const name =
 		paymentMethod.billing_details.name ?? paymentMethodEvent.payerName;
 
-	const data = {
+	let data = {
 		_wpnonce: getBlocksConfiguration()?.nonce?.checkout,
 		billing_first_name:
 			name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
@@ -82,7 +82,58 @@ const normalizeOrderData = ( paymentMethodEvent, paymentRequestType ) => {
 		data.shipping_postcode = shipping?.postalCode;
 	}
 
+	data = getRequiredFieldDataFromCheckoutForm( data );
+
 	return { ...data, ...extractOrderAttributionData() };
+};
+
+/**
+ * Get required field values from the checkout form if they are filled and add to the order data.
+ *
+ * @param {Object} data Order data.
+ *
+ * @return {Object} Order data with required field values.
+ */
+const getRequiredFieldDataFromCheckoutForm = ( data ) => {
+	const requiredFields = document.querySelectorAll(
+		'form.checkout .validate-required'
+	);
+
+	if ( requiredFields.length ) {
+		requiredFields.forEach( function ( fieldWrapper ) {
+			const field = fieldWrapper.querySelector( ':input' );
+			const name = field.getAttribute( 'name' );
+
+			let value = '';
+			if ( field.getAttribute( 'type' ) === 'checkbox' ) {
+				value = field.checked;
+			} else {
+				value = field.value;
+			}
+
+			if ( value && name ) {
+				if ( ! data[ name ] ) {
+					data[ name ] = value;
+				}
+
+				// if shipping same as billing is selected, copy the billing field to shipping field.
+				const shipToDiffAddress = document.querySelector(
+					'#ship-to-different-address input'
+				).checked;
+				if ( ! shipToDiffAddress ) {
+					const shippingFieldName = name.replace(
+						'billing_',
+						'shipping_'
+					);
+					if ( ! data[ shippingFieldName ] && data[ name ] ) {
+						data[ shippingFieldName ] = data[ name ];
+					}
+				}
+			}
+		} );
+	}
+
+	return data;
 };
 
 /**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -10,6 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Domain\Services\CheckoutFields;
+
 /**
  * WC_Stripe_Express_Checkout_Element class.
  */
@@ -366,6 +369,16 @@ class WC_Stripe_Express_Checkout_Element {
 		} elseif ( 'google_pay' === $express_checkout_type ) {
 			$order->set_payment_method_title( 'Google Pay (Stripe)' );
 			$order->save();
+		}
+
+		// Save custom checkout fields to the order.
+		$checkout_fields = Package::container()->get( CheckoutFields::class );
+		$field_names     = array_keys( $checkout_fields->get_additional_fields() );
+		foreach ( $field_names as $name ) {
+			if ( isset( $_POST[ $name ] ) ) {
+				$order->update_meta_data( $name, wc_clean( wp_unslash( $_POST[ $name ] ) ) );
+				$order->save_meta_data();
+			}
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Handles additional fields when checking out using ECE on the block checkout.
 * Fix - Only update order status for a Radar review closed event when the order was already captured.
 * Dev - Introduces a new class with payment intent statuses constants.
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3431

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Currently, custom checkout fields added with the action `woocommerce_register_additional_checkout_field` are ignored when checking out using an Express Checkout Element within the block checkout.

This PR correctly handles them by checking all the registered fields and persisting each one in the order as metas.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`fix/additional-fields-on-ece-block-checkout`)
- Enable ECE. You can do it by hardcoding `is_stripe_ece_enabled` to `true`
- Enable express payment methods in settings (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`)
- Add a custom field to the block checkout. You can add this snippet to `woocommerce-gateway-stripe.php`, for example ([ref](https://www.codesmade.com/add-field-in-checkout-woocommerce-block/)):
```php
add_action(
	'woocommerce_init',
	function() {
		woocommerce_register_additional_checkout_field(
			array(
				'id'            => 'namespace/delivery-date-id',
				'label'         => 'Delivery Date',
				'optionalLabel' => 'Delivery Date (optional)',
				'location'      => 'address',
				'required'      => true,
				'attributes'    => array(
					'autocomplete'     => 'delivery-date-id',
					'aria-describedby' => 'some-element',
					'aria-label'       => 'custom aria label',
					'pattern'          => '[A-Z0-9]{5}', // A 5-character string of capital letters and numbers.
					'title'            => 'Title to show on hover',
					'data-custom'      => 'custom data',
				),
			),
		);
	}
);
```
- Access the store by a public-facing URL as a shopper
- Add a physical product to your cart
- Go to the block checkout
- Fill the custom checkout field you just added
- Complete the purchase using any express method
- Access your database (PHPMyAdmin, MySQL Workbench or Adminer plugin) and confirm the field was saved as a meta (`wp_wc_orders_meta`):
![Screenshot 2024-12-17 at 12 47 47](https://github.com/user-attachments/assets/960cc15d-86fd-4658-b0f2-1e1311846254)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
