### PR TITLE
Improving missing intent params log

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Dev - Improves the missing intent params error log by appending the payment information array.
 * Tweak - Display email address for Link saved payment methods.
 * Fix - Only update order status for a Radar review closed event when the order was already captured.
 * Dev - Introduces a new class with payment intent statuses constants.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -875,11 +875,14 @@ class WC_Stripe_Intent_Controller {
 
 		// Bail out if we're missing required information.
 		if ( ! empty( $missing_params ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+			$calling_method = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 2 )[1]['function'] ?? '';
 			throw new WC_Stripe_Exception(
 				sprintf(
-					'The information for creating and confirming the intent is missing the following data: %s. Payment information received: %s.',
+					'The information for creating and confirming the intent is missing the following data: %s. Payment information received: %s. Calling method: %s',
 					implode( ', ', $missing_params ),
-					wp_json_encode( $payment_information )
+					wp_json_encode( $payment_information ),
+					$calling_method
 				),
 				$shopper_error_message
 			);

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -877,8 +877,9 @@ class WC_Stripe_Intent_Controller {
 		if ( ! empty( $missing_params ) ) {
 			throw new WC_Stripe_Exception(
 				sprintf(
-					'The information for creating and confirming the intent is missing the following data: %s.',
-					implode( ', ', $missing_params )
+					'The information for creating and confirming the intent is missing the following data: %s. Payment information received: %s.',
+					implode( ', ', $missing_params ),
+					wp_json_encode( $payment_information )
 				),
 				$shopper_error_message
 			);

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Dev - Improves the missing intent params error log by appending the payment information array.
 * Tweak - Display email address for Link saved payment methods.
 * Fix - Only update order status for a Radar review closed event when the order was already captured.
 * Dev - Introduces a new class with payment intent statuses constants.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3467

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR improves the logging of the missing payment intent params error by appending the payment information array and the calling method. This is intended to make it easier to debug when such cases happen.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout and build this branch on your test environment (`dev/improving-missing-intent-params-log`)
- Connect your Stripe account
- Add the following line to `includes/class-wc-stripe-intent-controller.php#714`
```php
		unset( $payment_information['payment_method'] );
```
- As a shopper, add a product to your cart
- Go to the checkout page and try to complete the purchase
- You should see an error:
![Screenshot 2024-12-17 at 18 57 02](https://github.com/user-attachments/assets/86a79896-1f3f-4be1-a248-af9ad5d5ed62)
- Go to your store log page (`wp-admin/admin.php?page=wc-status&tab=logs`) and open the latest Stripe log file (`woocommerce-gateway-stripe`)
- Confirm that you can see the new information added to the message:
![Screenshot 2024-12-17 at 18 54 37](https://github.com/user-attachments/assets/b91fefc1-62b2-46b4-8f55-6fe6ca779f7e)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
