### PR TITLE
Add Clearpay/Afterpay transaction limits information

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Dev - Introduces new payment method name constants for the frontend.
 * Dev - Improves the missing intent params error log by appending the payment information array.
 * Tweak - Improve error message displayed when payment method creation fails in classic checkout.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Add the transaction limit information to the Afterpay/Clearpay method when listing payment methods.
 * Dev - Introduces new payment method name constants for the frontend.
 * Dev - Improves the missing intent params error log by appending the payment information array.
 * Tweak - Improve error message displayed when payment method creation fails in classic checkout.

--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -55,7 +55,7 @@ export default {
 		label: __( 'Affirm', 'woocommerce-gateway-stripe' ),
 		// translators: %s is the store currency.
 		description: __(
-			'Allow customers to pay over time with Affirm. Available to all customers paying in %s.',
+			'Allow customers to pay over time. Available to all customers paying in %s. Purchases from 50 %s to 30,000 %s are eligible for Affirm financing.',
 			'woocommerce-gateway-stripe'
 		),
 		Icon: icons.affirm,

--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -60,7 +60,6 @@ export default {
 		),
 		Icon: icons.affirm,
 		currencies: [ 'USD', 'CAD' ],
-		acceptsDomesticPaymentsOnly: true,
 		allows_manual_capture: true,
 	},
 	// Clearpay and Afterpay are the same payment method, but with different strings and icon.
@@ -73,11 +72,11 @@ export default {
 		description:
 			accountCountry === 'GB'
 				? __(
-						'Allow customers to pay over time with Clearpay.',
+						'Allow customers to pay over time with Clearpay. {{limitsLink}}Transaction limits vary by country{{/limitsLink}}.',
 						'woocommerce-gateway-stripe'
 				  )
 				: __(
-						'Allow customers to pay over time with Afterpay.',
+						'Allow customers to pay over time with Afterpay. {{limitsLink}}Transaction limits vary by country{{/limitsLink}}.',
 						'woocommerce-gateway-stripe'
 				  ),
 		Icon: accountCountry === 'GB' ? icons.clearpay : icons.afterpay,

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { Button } from '@wordpress/components';
 import { Icon as IconComponent, dragHandle } from '@wordpress/icons';
 import { Reorder } from 'framer-motion';
+import interpolateComponents from 'interpolate-components';
 import PaymentMethodsMap from '../../payment-methods-map';
 import PaymentMethodDescription from './payment-method-description';
 import CustomizePaymentMethod from './customize-payment-method';
@@ -18,6 +19,8 @@ import {
 import { useAccount } from 'wcstripe/data/account';
 import PaymentMethodFeesPill from 'wcstripe/components/payment-method-fees-pill';
 import {
+	PAYMENT_METHOD_AFFIRM,
+	PAYMENT_METHOD_AFTERPAY_CLEARPAY,
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_GIROPAY,
 	PAYMENT_METHOD_SOFORT,
@@ -173,17 +176,28 @@ const getFormattedPaymentMethodDescription = (
 	method,
 	accountDefaultCurrency
 ) => {
-	const { description, acceptsDomesticPaymentsOnly } = PaymentMethodsMap[
-		method
-	];
+	const { description } = PaymentMethodsMap[ method ];
 
-	if ( acceptsDomesticPaymentsOnly ) {
-		const args = [];
-		const argsCount = ( description.match( /%s/g ) || [] ).length;
-		for ( let i = 0; i < argsCount; i++ ) {
-			args.push( accountDefaultCurrency?.toUpperCase() );
-		}
-		return sprintf( description, ...args );
+	if ( method === PAYMENT_METHOD_AFFIRM ) {
+		const currency = accountDefaultCurrency?.toUpperCase();
+		return sprintf( description, currency, currency, currency );
+	}
+
+	if ( method === PAYMENT_METHOD_AFTERPAY_CLEARPAY ) {
+		/* eslint-disable jsx-a11y/anchor-has-content */
+		return interpolateComponents( {
+			mixedString: description,
+			components: {
+				limitsLink: (
+					<a
+						target="_blank"
+						rel="noreferrer"
+						href="https://docs.stripe.com/payments/afterpay-clearpay#collection-schedule"
+					/>
+				),
+			},
+		} );
+		/* eslint-enable jsx-a11y/anchor-has-content */
 	}
 
 	return description;

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -178,7 +178,12 @@ const getFormattedPaymentMethodDescription = (
 	];
 
 	if ( acceptsDomesticPaymentsOnly ) {
-		return sprintf( description, accountDefaultCurrency?.toUpperCase() );
+		const args = [];
+		const argsCount = ( description.match( /%s/g ) || [] ).length;
+		for ( let i = 0; i < argsCount; i++ ) {
+			args.push( accountDefaultCurrency?.toUpperCase() );
+		}
+		return sprintf( description, ...args );
 	}
 
 	return description;

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Add the transaction limit information to the Afterpay/Clearpay method when listing payment methods.
 * Dev - Introduces new payment method name constants for the frontend.
 * Dev - Improves the missing intent params error log by appending the payment information array.
 * Tweak - Improve error message displayed when payment method creation fails in classic checkout.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Dev - Introduces new payment method name constants for the frontend.
 * Dev - Improves the missing intent params error log by appending the payment information array.
 * Tweak - Improve error message displayed when payment method creation fails in classic checkout.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Clearpay/Afterpay has limits based on the Stripe account and the customer's country. You can check them [here](https://docs.stripe.com/payments/afterpay-clearpay#collection-schedule). This PR adds this information when listing the method along with the link.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout and build this branch on your test environment (`tweak/add-clearpay-afterpay-transaction-limit-info`)
- Go to the payment method listing page (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`)
- Confirm the new Clearpay/Afterpay method description and click the link to see if it goes to where it should (`https://docs.stripe.com/payments/afterpay-clearpay#collection-schedule`)
![Screenshot 2024-12-18 at 12 58 37](https://github.com/user-attachments/assets/bcf0215c-0bc8-4abb-a7c1-10d7bd1f2557)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
