### PR TITLE
Improve the dispute created message

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Correctly sets the dispute opened note when a dispute does not require any further action.
 * Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Fix - Handles additional fields when checking out using ECE on the block checkout.
 * Dev - Introduces new payment method name constants for the frontend.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -344,12 +344,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		$this->set_stripe_order_status_before_hold( $order, $order->get_status() );
 
-		$message = sprintf(
-		/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			__( 'A dispute was created for this order. Response is needed. Please go to your %1$sStripe Dashboard%2$s to review this dispute.', 'woocommerce-gateway-stripe' ),
-			'<a href="' . esc_url( $this->get_transaction_url( $order ) ) . '" title="Stripe Dashboard" target="_blank">',
-			'</a>'
-		);
+		$needs_response = in_array( $notification->data->object->status, [ 'needs_response', 'warning_needs_response' ], true );
+		if ( $needs_response ) {
+			$message = sprintf(
+			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
+				__( 'A dispute was created for this order. Response is needed. Please go to your %1$sStripe Dashboard%2$s to review this dispute.', 'woocommerce-gateway-stripe' ),
+				'<a href="' . esc_url( $this->get_transaction_url( $order ) ) . '" title="Stripe Dashboard" target="_blank">',
+				'</a>'
+			);
+		} else {
+			$message = __( 'A dispute was created for this order. It was closed as lost or accepted.', 'woocommerce-gateway-stripe' );
+		}
 
 		if ( ! $order->get_meta( '_stripe_status_final', false ) ) {
 			$order->update_status( 'on-hold', $message );
@@ -597,7 +602,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund( $notification ) {
 		$refund_object = $this->get_refund_object( $notification );
-		$order = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
@@ -612,11 +617,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id = $order->get_id();
 
 		if ( 'stripe' === substr( (string) $order->get_payment_method(), 0, 6 ) ) {
-			$charge        = $order->get_transaction_id();
-			$captured      = $order->get_meta( '_stripe_charge_captured' );
-			$refund_id     = $order->get_meta( '_stripe_refund_id' );
-			$currency      = $order->get_currency();
-			$raw_amount    = $refund_object->amount;
+			$charge     = $order->get_transaction_id();
+			$captured   = $order->get_meta( '_stripe_charge_captured' );
+			$refund_id  = $order->get_meta( '_stripe_refund_id' );
+			$currency   = $order->get_currency();
+			$raw_amount = $refund_object->amount;
 
 			if ( ! in_array( strtolower( $currency ), WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
 				$raw_amount /= 100;

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -602,7 +602,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund( $notification ) {
 		$refund_object = $this->get_refund_object( $notification );
-		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+		$order = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
@@ -617,11 +617,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id = $order->get_id();
 
 		if ( 'stripe' === substr( (string) $order->get_payment_method(), 0, 6 ) ) {
-			$charge     = $order->get_transaction_id();
-			$captured   = $order->get_meta( '_stripe_charge_captured' );
-			$refund_id  = $order->get_meta( '_stripe_refund_id' );
-			$currency   = $order->get_currency();
-			$raw_amount = $refund_object->amount;
+			$charge        = $order->get_transaction_id();
+			$captured      = $order->get_meta( '_stripe_charge_captured' );
+			$refund_id     = $order->get_meta( '_stripe_refund_id' );
+			$currency      = $order->get_currency();
+			$raw_amount    = $refund_object->amount;
 
 			if ( ! in_array( strtolower( $currency ), WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
 				$raw_amount /= 100;

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -353,7 +353,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				'</a>'
 			);
 		} else {
-			$message = __( 'A dispute was created for this order. It was closed as lost or accepted.', 'woocommerce-gateway-stripe' );
+			$message = __( 'A dispute was created for this order.', 'woocommerce-gateway-stripe' );
 		}
 
 		if ( ! $order->get_meta( '_stripe_status_final', false ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Correctly sets the dispute opened note when a dispute does not require any further action.
 * Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Fix - Handles additional fields when checking out using ECE on the block checkout.
 * Dev - Introduces new payment method name constants for the frontend.

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -21,10 +21,10 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * Mock card payment intent template.
 	 */
 	const MOCK_PAYMENT_INTENT = [
-		'id'                 => 'pi_mock',
-		'object'             => 'payment_intent',
-		'status'             => WC_Stripe_Intent_Status::SUCCEEDED,
-		'charges'            => [
+		'id'      => 'pi_mock',
+		'object'  => 'payment_intent',
+		'status'  => WC_Stripe_Intent_Status::SUCCEEDED,
+		'charges' => [
 			'total_count' => 1,
 			'data'        => [
 				[
@@ -292,6 +292,81 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				'event'              => 'charge.expired',
 				'expected status'    => 'failed',
 				'expected note'      => 'This payment has expired. Order status changed from On hold to Failed.',
+			],
+		];
+	}
+
+	/**
+	 * Test for `process_webhook_dispute`.
+	 *
+	 * @param bool $order_status_final Whether the order status is final.
+	 * @param string $dispute_status   The dispute status.
+	 * @param string $expected_status  The expected order status.
+	 * @param string $expected_note    The expected order note.
+	 * @return void
+	 * @dataProvider provide_test_process_webhook_dispute
+	 */
+	public function test_process_webhook_dispute( $order_status_final, $dispute_status, $expected_status, $expected_note ) {
+		$charge_id = 'ch_fQpkNKxmUrZ8t4CT7EHGS3Rg';
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'processing' );
+		$order->set_transaction_id( $charge_id );
+		if ( $order_status_final ) {
+			$order->update_meta_data( '_stripe_status_final', true );
+		}
+		$order->save();
+
+		$notification = (object) [
+			'type' => 'charge.dispute.created',
+			'data' => (object) [
+				'object' => (object) [
+					'charge' => $charge_id,
+					'status' => $dispute_status,
+				],
+			],
+		];
+
+		$this->mock_webhook_handler->process_webhook_dispute( $notification );
+
+		$final_order = wc_get_order( $order->get_id() );
+
+		$notes = wc_get_order_notes(
+			[
+				'order_id' => $final_order->get_id(),
+				'limit'    => 1,
+			]
+		);
+
+		$this->assertSame( $expected_status, $final_order->get_status() );
+		$this->assertSame( $expected_note, $notes[0]->content );
+
+	}
+
+	/**
+	 * Provider for `test_process_webhook_dispute`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_process_webhook_dispute() {
+		return [
+			'response needed, order status not final'     => [
+				'order status final' => false,
+				'dispute status'     => 'needs_response',
+				'expected status'    => 'on-hold',
+				'expected note'      => 'A dispute was created for this order. Response is needed. Please go to your <a href="https://dashboard.stripe.com/payments/ch_fQpkNKxmUrZ8t4CT7EHGS3Rg" title="Stripe Dashboard" target="_blank">Stripe Dashboard</a> to review this dispute. Order status changed from Processing to On hold.',
+			],
+			'response needed, order status final'         => [
+				'order status final' => true,
+				'dispute status'     => 'needs_response',
+				'expected status'    => 'processing',
+				'expected note'      => 'A dispute was created for this order. Response is needed. Please go to your <a href="https://dashboard.stripe.com/payments/ch_fQpkNKxmUrZ8t4CT7EHGS3Rg" title="Stripe Dashboard" target="_blank">Stripe Dashboard</a> to review this dispute.',
+			],
+			'response not needed, order status not final' => [
+				'order status final' => false,
+				'dispute status'     => 'lost',
+				'expected status'    => 'on-hold',
+				'expected note'      => 'A dispute was created for this order. It was closed as lost or accepted. Order status changed from Processing to On hold.',
 			],
 		];
 	}

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -339,7 +339,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $expected_status, $final_order->get_status() );
-		$this->assertSame( $expected_note, $notes[0]->content );
+		$this->assertMatchesRegularExpression( $expected_note, $notes[0]->content );
 
 	}
 
@@ -354,19 +354,19 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				'order status final' => false,
 				'dispute status'     => 'needs_response',
 				'expected status'    => 'on-hold',
-				'expected note'      => 'A dispute was created for this order. Response is needed. Please go to your <a href="https://dashboard.stripe.com/payments/ch_fQpkNKxmUrZ8t4CT7EHGS3Rg" title="Stripe Dashboard" target="_blank">Stripe Dashboard</a> to review this dispute. Order status changed from Processing to On hold.',
+				'expected note'      => '/A dispute was created for this order. Response is needed./',
 			],
 			'response needed, order status final'         => [
 				'order status final' => true,
 				'dispute status'     => 'needs_response',
 				'expected status'    => 'processing',
-				'expected note'      => 'A dispute was created for this order. Response is needed. Please go to your <a href="https://dashboard.stripe.com/payments/ch_fQpkNKxmUrZ8t4CT7EHGS3Rg" title="Stripe Dashboard" target="_blank">Stripe Dashboard</a> to review this dispute.',
+				'expected note'      => '/A dispute was created for this order. Response is needed./',
 			],
 			'response not needed, order status not final' => [
 				'order status final' => false,
 				'dispute status'     => 'lost',
 				'expected status'    => 'on-hold',
-				'expected note'      => 'A dispute was created for this order. It was closed as lost or accepted. Order status changed from Processing to On hold.',
+				'expected note'      => '/A dispute was created for this order. It was closed as lost or accepted. Order status changed from Processing to On hold./',
 			],
 		];
 	}

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -366,7 +366,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				'order status final' => false,
 				'dispute status'     => 'lost',
 				'expected status'    => 'on-hold',
-				'expected note'      => '/A dispute was created for this order. It was closed as lost or accepted. Order status changed from Processing to On hold./',
+				'expected note'      => '/A dispute was created for this order. Order status changed from Processing to On hold./',
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1233

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Most times, when a dispute is open, no actions are needed. It is either already lost or won. The current note we add to the order implies that an action is always required. This PR fixes that by checking the dispute status and setting the note accordingly.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Since this is a bit hard to test, code review should be enough. But if you want to try testing the flow:

- Checkout and build this branch on your test environment (`fix/improve-dispute-created-message`)
- Connect your Stripe account
- Configure webhooks
- As a shopper, add a product to your cart
- Go to the checkout page
- Use any regular card to complete the purchase
- Copy the sample dispute opened event body below
<details>
<summary><b>Sample event</b></summary>

```json
{
  "object": {
    "id": "dp_1QXkGcGwEEw4tjx0ElVhWtCa",
    "object": "dispute",
    "amount": 1100,
    "balance_transaction": "txn_1QXkGdGwEEw4tjx0E923VfyN",
    "balance_transactions": [
      {
        "id": "txn_1QXkGdGwEEw4tjx0E923VfyN",
        "object": "balance_transaction",
        "amount": -1100,
        "available_on": 1735171200,
        "created": 1734616794,
        "currency": "usd",
        "description": "Chargeback withdrawal for ch_3QXkGbGwEEw4tjx01pt9gIJe",
        "exchange_rate": null,
        "fee": 1500,
        "fee_details": [
          {
            "amount": 1500,
            "application": null,
            "currency": "usd",
            "description": "Dispute fee",
            "type": "stripe_fee"
          }
        ],
        "net": -2600,
        "reporting_category": "dispute",
        "source": "dp_1QXkGcGwEEw4tjx0ElVhWtCa",
        "status": "pending",
        "type": "adjustment"
      }
    ],
    "charge": "ch_3QXkGbGwEEw4tjx01pt9gIJe",
    "created": 1734616794,
    "currency": "usd",
    "enhanced_eligibility_types": [
    ],
    "evidence": {
      "access_activity_log": null,
      "billing_address": "1600 Amphitheatre Parkway\n\nMountain View, CA, 94043, US",
      "cancellation_policy": null,
      "cancellation_policy_disclosure": null,
      "cancellation_rebuttal": null,
      "customer_communication": null,
      "customer_email_address": "admin@example.com",
      "customer_name": "Card Holder Name",
      "customer_purchase_ip": null,
      "customer_signature": null,
      "duplicate_charge_documentation": null,
      "duplicate_charge_explanation": null,
      "duplicate_charge_id": null,
      "enhanced_evidence": {
      },
      "product_description": null,
      "receipt": null,
      "refund_policy": null,
      "refund_policy_disclosure": null,
      "refund_refusal_explanation": null,
      "service_date": null,
      "service_documentation": null,
      "shipping_address": "1600 Amphitheatre Parkway\n\nMountain View, CA, 94043, US",
      "shipping_carrier": null,
      "shipping_date": null,
      "shipping_documentation": null,
      "shipping_tracking_number": null,
      "uncategorized_file": null,
      "uncategorized_text": null
    },
    "evidence_details": {
      "due_by": 1735430399,
      "enhanced_eligibility": {
      },
      "has_evidence": false,
      "past_due": false,
      "submission_count": 0
    },
    "is_charge_refundable": false,
    "livemode": false,
    "metadata": {
    },
    "payment_intent": "pi_3QXkGbGwEEw4tjx01PkubTsY",
    "payment_method_details": {
      "card": {
        "brand": "visa",
        "case_type": "chargeback",
        "network_reason_code": "83"
      },
      "type": "card"
    },
    "reason": "fraudulent",
    "status": "lost"
  }
}
```
</details>
(change `object.charge` property to match your charge ID. You can grab it on your Stripe dashboard or the order edit page)
- Request the webhook endpoint on your store using the event body (`/?wc-api=wc_stripe`) using Postman or something similar

- Confirm the order gets updated with the correct note:
"A dispute was created for this order. It was closed as lost or accepted."

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
