### PR TITLE
Don't update canceled order to on-hold in the dispute created event

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Tweak - Add the transaction limit information to the Afterpay/Clearpay method when listing payment methods.
 * Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Fix - Handles additional fields when checking out using ECE on the block checkout.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -351,7 +351,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			'</a>'
 		);
 
-		if ( ! $order->get_meta( '_stripe_status_final', false ) ) {
+		if ( ! $order->has_status( 'cancelled' ) && ! $order->get_meta( '_stripe_status_final', false ) ) {
 			$order->update_status( 'on-hold', $message );
 		} else {
 			$order->add_order_note( $message );

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Tweak - Add the transaction limit information to the Afterpay/Clearpay method when listing payment methods.
 * Tweak - Add transaction threshold information to Affirm when listing payment methods.
 * Fix - Handles additional fields when checking out using ECE on the block checkout.

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -306,11 +306,11 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @return void
 	 * @dataProvider provide_test_process_webhook_dispute
 	 */
-	public function test_process_webhook_dispute( $order_status_final, $dispute_status, $expected_status, $expected_note ) {
+	public function test_process_webhook_dispute( $order_status, $order_status_final, $dispute_status, $expected_status, $expected_note ) {
 		$charge_id = 'ch_fQpkNKxmUrZ8t4CT7EHGS3Rg';
 
 		$order = WC_Helper_Order::create_order();
-		$order->set_status( 'processing' );
+		$order->set_status( $order_status );
 		$order->set_transaction_id( $charge_id );
 		if ( $order_status_final ) {
 			$order->update_meta_data( '_stripe_status_final', true );
@@ -351,18 +351,28 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function provide_test_process_webhook_dispute() {
 		return [
 			'response needed, order status not final'     => [
+				'order status'       => 'processing',
 				'order status final' => false,
 				'dispute status'     => 'needs_response',
 				'expected status'    => 'on-hold',
 				'expected note'      => '/A dispute was created for this order. Response is needed./',
 			],
+			'response needed, order status not final, status is cancelled' => [
+				'order status'       => 'cancelled',
+				'order status final' => false,
+				'dispute status'     => 'needs_response',
+				'expected status'    => 'cancelled',
+				'expected note'      => '/A dispute was created for this order. Response is needed./',
+			],
 			'response needed, order status final'         => [
+				'order status'       => 'processing',
 				'order status final' => true,
 				'dispute status'     => 'needs_response',
 				'expected status'    => 'processing',
 				'expected note'      => '/A dispute was created for this order. Response is needed./',
 			],
 			'response not needed, order status not final' => [
+				'order status'       => 'processing',
 				'order status final' => false,
 				'dispute status'     => 'lost',
 				'expected status'    => 'on-hold',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #2598

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Currently, when an order is canceled but then a dispute is opened for it, we change the order status to `on-hold.` This does not make sense in this case. If the order is canceled, its lifetime has ended.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Since this is a bit hard to test, code review should be enough. But if you want to try testing the flow:

- Checkout and build this branch on your test environment (`fix/don-t-update-canceled-order-to-on-hold-in-the-dispute-event`)
- Connect your Stripe account
- Configure webhooks
- As a shopper, add a product to your cart
- Go to the checkout page
- Use any regular card to complete the purchase
- As a merchant, cancel the newly created order
- Copy the sample dispute opened event body below
<details>
<summary><b>Sample event</b></summary>

```json
{
  "object": {
    "id": "dp_1QXkGcGwEEw4tjx0ElVhWtCa",
    "object": "dispute",
    "amount": 1100,
    "balance_transaction": "txn_1QXkGdGwEEw4tjx0E923VfyN",
    "balance_transactions": [
      {
        "id": "txn_1QXkGdGwEEw4tjx0E923VfyN",
        "object": "balance_transaction",
        "amount": -1100,
        "available_on": 1735171200,
        "created": 1734616794,
        "currency": "usd",
        "description": "Chargeback withdrawal for ch_3QXkGbGwEEw4tjx01pt9gIJe",
        "exchange_rate": null,
        "fee": 1500,
        "fee_details": [
          {
            "amount": 1500,
            "application": null,
            "currency": "usd",
            "description": "Dispute fee",
            "type": "stripe_fee"
          }
        ],
        "net": -2600,
        "reporting_category": "dispute",
        "source": "dp_1QXkGcGwEEw4tjx0ElVhWtCa",
        "status": "pending",
        "type": "adjustment"
      }
    ],
    "charge": "ch_3QXkGbGwEEw4tjx01pt9gIJe",
    "created": 1734616794,
    "currency": "usd",
    "enhanced_eligibility_types": [
    ],
    "evidence": {
      "access_activity_log": null,
      "billing_address": "1600 Amphitheatre Parkway\n\nMountain View, CA, 94043, US",
      "cancellation_policy": null,
      "cancellation_policy_disclosure": null,
      "cancellation_rebuttal": null,
      "customer_communication": null,
      "customer_email_address": "admin@example.com",
      "customer_name": "Card Holder Name",
      "customer_purchase_ip": null,
      "customer_signature": null,
      "duplicate_charge_documentation": null,
      "duplicate_charge_explanation": null,
      "duplicate_charge_id": null,
      "enhanced_evidence": {
      },
      "product_description": null,
      "receipt": null,
      "refund_policy": null,
      "refund_policy_disclosure": null,
      "refund_refusal_explanation": null,
      "service_date": null,
      "service_documentation": null,
      "shipping_address": "1600 Amphitheatre Parkway\n\nMountain View, CA, 94043, US",
      "shipping_carrier": null,
      "shipping_date": null,
      "shipping_documentation": null,
      "shipping_tracking_number": null,
      "uncategorized_file": null,
      "uncategorized_text": null
    },
    "evidence_details": {
      "due_by": 1735430399,
      "enhanced_eligibility": {
      },
      "has_evidence": false,
      "past_due": false,
      "submission_count": 0
    },
    "is_charge_refundable": false,
    "livemode": false,
    "metadata": {
    },
    "payment_intent": "pi_3QXkGbGwEEw4tjx01PkubTsY",
    "payment_method_details": {
      "card": {
        "brand": "visa",
        "case_type": "chargeback",
        "network_reason_code": "83"
      },
      "type": "card"
    },
    "reason": "fraudulent",
    "status": "lost"
  }
}
```
</details>
(change `object.charge` property to match your charge ID. You can grab it on your Stripe dashboard or the order edit page)
- Request the webhook endpoint on your store using the event body (`/?wc-api=wc_stripe`) using Postman or something similar

- Confirm the order status it not changed to on-hold, only the note is added

\* Unit tests will be added after https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3671 is merged

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
