### PR TITLE
Lint fixes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.
 * Fix - Correctly handles IPP failed payments webhook calls by extracting the order ID from the payment intent metadata.
+* Dev - Fix lint issues raised by WordPress code standards.
 * Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1408,7 +1408,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$currency    = $order->get_currency();
 
 		$stripe_line_items = array_map(
-			function( $item ) use ( $currency ) {
+			function ( $item ) use ( $currency ) {
 				if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
 					$product_id = $item->get_variation_id()
 						? $item->get_variation_id()

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -439,7 +439,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		$this->gateway->update_option( 'logging', $is_debug_log_enabled ? 'yes' : 'no' );
-
 	}
 
 	/**

--- a/includes/admin/stripe-eps-settings.php
+++ b/includes/admin/stripe-eps-settings.php
@@ -1,4 +1,6 @@
 <?php
+// This file is the body of WC_Gateway_Stripe_Eps::init_form_fields().
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -39,7 +41,7 @@ return apply_filters(
 			'title'       => __( 'Webhook Endpoints', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 			/* translators: webhook URL */
-			'description' => $this->display_admin_settings_webhook_description(),
+			'description' => $this->display_admin_settings_webhook_description(), // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 		],
 	]
 );

--- a/includes/admin/stripe-p24-settings.php
+++ b/includes/admin/stripe-p24-settings.php
@@ -1,4 +1,6 @@
 <?php
+// This file is the body of WC_Gateway_Stripe_P24::init_form_fields().
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -39,7 +41,7 @@ return apply_filters(
 			'title'       => __( 'Webhook Endpoints', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 			/* translators: webhook URL */
-			'description' => $this->display_admin_settings_webhook_description(),
+			'description' => $this->display_admin_settings_webhook_description(), // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 		],
 	]
 );

--- a/includes/admin/stripe-sepa-settings.php
+++ b/includes/admin/stripe-sepa-settings.php
@@ -1,4 +1,6 @@
 <?php
+// This file is the body of WC_Gateway_Stripe_Sepa::init_form_fields().
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -43,7 +45,7 @@ return apply_filters(
 			'title'       => __( 'Webhook Endpoints', 'woocommerce-gateway-stripe' ),
 			'type'        => 'title',
 			/* translators: webhook URL */
-			'description' => $this->display_admin_settings_webhook_description(),
+			'description' => $this->display_admin_settings_webhook_description(), // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 		],
 	]
 );

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1101,7 +1101,7 @@ class WC_Stripe_Intent_Controller {
 				throw new WC_Stripe_Exception( 'subscription_not_found', __( "We're not able to process this subscription change payment request payment. Please try again later.", 'woocommerce-gateway-stripe' ) );
 			}
 
-			$setup_intent_id = isset( $_POST['intent_id'] ) ? wc_clean( wp_unslash( $_POST['intent_id'] ) ) : null;
+			$setup_intent_id = ( isset( $_POST['intent_id'] ) && is_string( $_POST['intent_id'] ) ) ? sanitize_text_field( wp_unslash( $_POST['intent_id'] ) ) : null;
 
 			if ( empty( $setup_intent_id ) ) {
 				throw new WC_Stripe_Exception( 'intent_not_found', __( "We're not able to process this subscription change payment request payment. Please try again later.", 'woocommerce-gateway-stripe' ) );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1200,7 +1200,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
 		$this->process_response( $charge, $order );
-
 	}
 
 	/**

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -90,16 +90,19 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	 */
 	private function get_subscription_to_migrate( $subscription_id ) {
 		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( '---- Skipping migration of subscription #%d. The Legacy experience is enabled.', $subscription_id ) );
 		}
 
 		if ( ! class_exists( 'WC_Subscriptions' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( '---- Skipping migration of subscription #%d. The WooCommerce Subscriptions extension is not active.', $subscription_id ) );
 		}
 
 		$subscription = wcs_get_subscription( $subscription_id );
 
 		if ( ! $subscription ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( '---- Skipping migration of subscription #%d. Subscription not found.', $subscription_id ) );
 		}
 
@@ -121,6 +124,7 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 
 		// Bail out if the subscription is already using a pm_.
 		if ( 0 !== strpos( $source_id, 'src_' ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( 'The subscription is not using a Stripe Source for renewals.', $subscription->get_id() ) );
 		}
 
@@ -129,11 +133,13 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 
 		// Bail out, if the source object isn't expected to be migrated. eg Card sources are not migrated.
 		if ( isset( $source_object->type ) && 'card' === $source_object->type ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( 'Skipping migration of Source for subscription #%d. Source is a card.', $subscription->get_id() ) );
 		}
 
 		// Bail out if the src_ hasn't been migrated to pm_ yet.
 		if ( ! isset( $source_object->metadata->migrated_payment_method ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( 'The Source has not been migrated to PaymentMethods on the Stripe account.', $subscription->get_id() ) );
 		}
 
@@ -153,6 +159,7 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	private function set_subscription_updated_payment_gateway_id( WC_Subscription $subscription ) {
 		// The subscription is not using the legacy SEPA gateway ID.
 		if ( WC_Gateway_Stripe_Sepa::ID !== $subscription->get_payment_method() ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( '---- Skipping migration of subscription #%d. Subscription is not using the legacy SEPA payment method.', $subscription->get_id() ) );
 		}
 

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -204,21 +204,7 @@ class WC_Stripe_Payment_Tokens {
 							$token->save();
 							$tokens[ $token->get_id() ] = $token;
 						} else {
-							if ( ! isset( $stored_tokens[ $source->id ] ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
-								$token = new WC_Stripe_Payment_Token_CC();
-								$token->set_token( $source->id );
-								$token->set_gateway_id( WC_Gateway_Stripe::ID );
-								$token->set_card_type( strtolower( $source->brand ) );
-								$token->set_last4( $source->last4 );
-								$token->set_expiry_month( $source->exp_month );
-								$token->set_expiry_year( $source->exp_year );
-								$token->set_user_id( $customer_id );
-								$token->set_fingerprint( $source->fingerprint );
-								$token->save();
-								$tokens[ $token->get_id() ] = $token;
-							} else {
-								unset( $stored_tokens[ $source->id ] );
-							}
+							unset( $stored_tokens[ $source->id ] );
 						}
 					}
 				}

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -192,6 +192,17 @@ class WC_Stripe_Payment_Tokens {
 							} else {
 								unset( $stored_tokens[ $source->id ] );
 							}
+						} elseif ( ! isset( $stored_tokens[ $source->id ] ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
+							$token = new WC_Payment_Token_CC();
+							$token->set_token( $source->id );
+							$token->set_gateway_id( WC_Gateway_Stripe::ID );
+							$token->set_card_type( strtolower( $source->brand ) );
+							$token->set_last4( $source->last4 );
+							$token->set_expiry_month( $source->exp_month );
+							$token->set_expiry_year( $source->exp_year );
+							$token->set_user_id( $customer_id );
+							$token->save();
+							$tokens[ $token->get_id() ] = $token;
 						} else {
 							if ( ! isset( $stored_tokens[ $source->id ] ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
 								$token = new WC_Stripe_Payment_Token_CC();
@@ -446,10 +457,8 @@ class WC_Stripe_Payment_Tokens {
 				}
 
 				$stripe_customer->detach_payment_method( $token->get_token() );
-			} else {
-				if ( WC_Gateway_Stripe::ID === $token->get_gateway_id() || WC_Gateway_Stripe_Sepa::ID === $token->get_gateway_id() ) {
-					$stripe_customer->delete_source( $token->get_token() );
-				}
+			} elseif ( WC_Gateway_Stripe::ID === $token->get_gateway_id() || WC_Gateway_Stripe_Sepa::ID === $token->get_gateway_id() ) {
+				$stripe_customer->delete_source( $token->get_token() );
 			}
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
@@ -471,10 +480,8 @@ class WC_Stripe_Payment_Tokens {
 				if ( WC_Stripe_UPE_Payment_Gateway::ID === $token->get_gateway_id() ) {
 					$stripe_customer->set_default_payment_method( $token->get_token() );
 				}
-			} else {
-				if ( WC_Gateway_Stripe::ID === $token->get_gateway_id() || WC_Gateway_Stripe_Sepa::ID === $token->get_gateway_id() ) {
-					$stripe_customer->set_default_source( $token->get_token() );
-				}
+			} elseif ( WC_Gateway_Stripe::ID === $token->get_gateway_id() || WC_Gateway_Stripe_Sepa::ID === $token->get_gateway_id() ) {
+				$stripe_customer->set_default_source( $token->get_token() );
 			}
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );

--- a/readme.txt
+++ b/readme.txt
@@ -115,6 +115,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.
 * Fix - Correctly handles IPP failed payments webhook calls by extracting the order ID from the payment intent metadata.
+* Dev - Fix lint issues raised by WordPress code standards.
 * Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -188,84 +188,85 @@ function woocommerce_gateway_stripe() {
 			 */
 			public function init() {
 				if ( is_admin() ) {
-					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-privacy.php';
+					require_once __DIR__ . '/includes/admin/class-wc-stripe-privacy.php';
 				}
 
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-feature-flags.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-upe-compatibility.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-co-branded-cc-compatibility.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-exception.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-logger.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-helper.php';
-				include_once dirname( __FILE__ ) . '/includes/class-wc-stripe-api.php';
-				include_once dirname( __FILE__ ) . '/includes/class-wc-stripe-mode.php';
-				require_once dirname( __FILE__ ) . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';
-				require_once dirname( __FILE__ ) . '/includes/compat/trait-wc-stripe-subscriptions.php';
-				require_once dirname( __FILE__ ) . '/includes/compat/trait-wc-stripe-pre-orders.php';
-				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php';
-				require_once dirname( __FILE__ ) . '/includes/abstracts/abstract-wc-stripe-payment-gateway.php';
-				require_once dirname( __FILE__ ) . '/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-action-scheduler-service.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-state.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-webhook-handler.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-tokens/trait-wc-stripe-fingerprint.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-tokens/interface-wc-stripe-payment-method-comparison.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-tokens/class-wc-stripe-cc-payment-token.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-tokens/class-wc-stripe-sepa-payment-token.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-tokens/class-wc-stripe-link-payment-token.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-tokens/class-wc-stripe-cash-app-payment-token.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-apple-pay-registration.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-gateway-stripe.php';
-				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-currency-code.php';
-				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-payment-methods.php';
-				require_once dirname( __FILE__ ) . '/includes/constants/class-wc-stripe-intent-status.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-alipay.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-eps.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-p24.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-upe-payment-method-wechat-pay.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-bancontact.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-sofort.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-giropay.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-eps.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-ideal.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-p24.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-alipay.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-sepa.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-multibanco.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-boleto.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-gateway-stripe-oxxo.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-payment-request.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-express-checkout-element.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-express-checkout-helper.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php';
-				require_once dirname( __FILE__ ) . '/includes/compat/class-wc-stripe-woo-compat-utils.php';
-				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect.php';
-				require_once dirname( __FILE__ ) . '/includes/connect/class-wc-stripe-connect-api.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-order-handler.php';
-				require_once dirname( __FILE__ ) . '/includes/payment-tokens/class-wc-stripe-payment-tokens.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-customer.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-intent-controller.php';
-				require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-inbox-notes.php';
-				require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
-				require_once dirname( __FILE__ ) . '/includes/migrations/class-allowed-payment-request-button-types-update.php';
-				require_once dirname( __FILE__ ) . '/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php';
-				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-account.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-feature-flags.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-upe-compatibility.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-co-branded-cc-compatibility.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-exception.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-logger.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-helper.php';
+				include_once __DIR__ . '/includes/class-wc-stripe-api.php';
+				include_once __DIR__ . '/includes/class-wc-stripe-mode.php';
+				require_once __DIR__ . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';
+				require_once __DIR__ . '/includes/compat/trait-wc-stripe-subscriptions.php';
+				require_once __DIR__ . '/includes/compat/trait-wc-stripe-pre-orders.php';
+				require_once __DIR__ . '/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php';
+				require_once __DIR__ . '/includes/abstracts/abstract-wc-stripe-payment-gateway.php';
+				require_once __DIR__ . '/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-action-scheduler-service.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-webhook-state.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-webhook-handler.php';
+				require_once __DIR__ . '/includes/payment-tokens/trait-wc-stripe-fingerprint.php';
+				require_once __DIR__ . '/includes/payment-tokens/interface-wc-stripe-payment-method-comparison.php';
+				require_once __DIR__ . '/includes/payment-tokens/class-wc-stripe-cc-payment-token.php';
+				require_once __DIR__ . '/includes/payment-tokens/class-wc-stripe-sepa-payment-token.php';
+				require_once __DIR__ . '/includes/payment-tokens/class-wc-stripe-link-payment-token.php';
+				require_once __DIR__ . '/includes/payment-tokens/class-wc-stripe-cash-app-payment-token.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-apple-pay-registration.php';
+				require_once __DIR__ . '/includes/class-wc-gateway-stripe.php';
+				require_once __DIR__ . '/includes/constants/class-wc-stripe-currency-code.php';
+				require_once __DIR__ . '/includes/constants/class-wc-stripe-payment-methods.php';
+				require_once __DIR__ . '/includes/constants/class-wc-stripe-intent-status.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-alipay.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-giropay.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-eps.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-p24.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-upe-payment-method-wechat-pay.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-bancontact.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-sofort.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-giropay.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-eps.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-ideal.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-p24.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-alipay.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-sepa.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-multibanco.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-boleto.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-gateway-stripe-oxxo.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-payment-request.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-express-checkout-element.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-express-checkout-helper.php';
+				require_once __DIR__ . '/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php';
+				require_once __DIR__ . '/includes/compat/class-wc-stripe-woo-compat-utils.php';
+				require_once __DIR__ . '/includes/connect/class-wc-stripe-connect.php';
+				require_once __DIR__ . '/includes/connect/class-wc-stripe-connect-api.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-order-handler.php';
+				require_once __DIR__ . '/includes/payment-tokens/class-wc-stripe-payment-tokens.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-customer.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-intent-controller.php';
+				require_once __DIR__ . '/includes/admin/class-wc-stripe-inbox-notes.php';
+				require_once __DIR__ . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
+				require_once __DIR__ . '/includes/migrations/class-allowed-payment-request-button-types-update.php';
+				require_once __DIR__ . '/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php';
+				require_once __DIR__ . '/includes/class-wc-stripe-account.php';
+
 				new Allowed_Payment_Request_Button_Types_Update();
 				new Migrate_Payment_Request_Data_To_Express_Checkout_Data();
 
@@ -284,24 +285,24 @@ function woocommerce_gateway_stripe() {
 				$intent_controller->init_hooks();
 
 				if ( is_admin() ) {
-					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-admin-notices.php';
-					require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-settings-controller.php';
+					require_once __DIR__ . '/includes/admin/class-wc-stripe-admin-notices.php';
+					require_once __DIR__ . '/includes/admin/class-wc-stripe-settings-controller.php';
 
 					if ( isset( $_GET['area'] ) && 'payment_requests' === $_GET['area'] ) {
-						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
+						require_once __DIR__ . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();
 					} else {
 						new WC_Stripe_Settings_Controller( $this->account );
 					}
 
 					if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
+						require_once __DIR__ . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
 						new WC_Stripe_Payment_Gateways_Controller();
 					}
 				}
 
 				// REMOVE IN THE FUTURE.
-				require_once dirname( __FILE__ ) . '/includes/deprecated/class-wc-stripe-apple-pay.php';
+				require_once __DIR__ . '/includes/deprecated/class-wc-stripe-apple-pay.php';
 
 				add_filter( 'woocommerce_payment_gateways', [ $this, 'add_gateways' ] );
 				add_filter( 'pre_update_option_woocommerce_stripe_settings', [ $this, 'gateway_settings_update' ], 10, 2 );
@@ -786,7 +787,7 @@ function woocommerce_gateway_stripe() {
 				if ( ! class_exists( 'WCS_Background_Repairer' ) ) {
 					return;
 				}
-				require_once dirname( __FILE__ ) . '/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php';
+				require_once __DIR__ . '/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php';
 
 				$logger  = wc_get_logger();
 				$updater = new WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens( $logger );
@@ -796,7 +797,7 @@ function woocommerce_gateway_stripe() {
 			}
 
 			public function load_plugin_textdomain() {
-				load_plugin_textdomain( 'woocommerce-gateway-stripe', false, plugin_basename( dirname( __FILE__ ) ) . '/languages' );
+				load_plugin_textdomain( 'woocommerce-gateway-stripe', false, plugin_basename( __DIR__ ) . '/languages' );
 			}
 		}
 
@@ -859,7 +860,7 @@ add_action( 'woocommerce_blocks_loaded', 'woocommerce_gateway_stripe_woocommerce
 
 function woocommerce_gateway_stripe_woocommerce_block_support() {
 	if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ) {
-		require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-blocks-support.php';
+		require_once __DIR__ . '/includes/class-wc-stripe-blocks-support.php';
 		// priority is important here because this ensures this integration is
 		// registered before the WooCommerce Blocks built-in Stripe registration.
 		// Blocks code has a check in place to only register if 'stripe' is not


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Fixing some lint issues raised by the WordPress code standards. Ideally these would be enforced in a pre-commit hook, but existing issues need to be fixed first.

Some notes:
- Escaping variables in exception messages is [awkward](https://github.com/WordPress/WordPress-Coding-Standards/issues/2374) because we don't know what context it will be rendered in. Here I've ignored the warning.
- `wc_clean` is just `sanitize_text_field` [when applied to a string](https://github.com/woocommerce/woocommerce/blob/04c63f02fee90a7ff2a9a20874ce20205379eeb7/plugins/woocommerce/includes/wc-formatting-functions.php#L394), but is not detected as a sanitizing function by the linter. It is possible for the values in `$_POST` to be [something other than a string (TIL)](https://www.php.net/manual/en/reserved.variables.post.php#87650), but internally `sanitize_text_field` [assumes it's been passed a string](https://developer.wordpress.org/reference/functions/sanitize_text_field/) (not enforced). For errors about unsanitized input that look like

```
isset( $_POST['foo'] ) ? wc_clean( $_POST['foo'] ) : null
```

I've replaced this with

```
( isset( $_POST['foo'] ) && is_string( $_POST['foo'] ) ) ? sanitize_text_field( $_POST['foo'] ) : null
```

## Testing instructions

I think reading the code and making sure unit tests pass is good enough; this should change any behavior.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
