### PR TITLE
Avoid resending Processing Order customer email when merchant wins dispute

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.
 * Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Fix - Correctly sets the dispute opened note when a dispute does not require any further action.
 * Add - Display Multibanco payment instruction details in Order Received page and Order Confirmation email.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.
 * Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Fix - Correctly sets the dispute opened note when a dispute does not require any further action.
 * Add - Display Multibanco payment instruction details in Order Received page and Order Confirmation email.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3603 

## Changes proposed in this Pull Request:
When the merchant wins a dispute, the order gets its pre-dispute status back. In some cases, the order goes back to `processing`, which causes the "Your order has been received" email to be sent to the customer again. We've received feedback that this causes confusion to the customer, who just lost a dispute and may not be very happy to begin with.

This PR adds logic to avoid resending the "Processing Order" email for the above-described scenario.

## Testing instructions
1. Make sure your webhooks are enabled and working.
2. Install the email logging plugin of your choice, e.g. Post SMTP Email Log
3. As a shopper, add a physical product to cart and go to checkout.
4. Use `4000000000000259` as the CC number, and complete the purchase.
5. Wait a couple of minutes, and verify in wp-admin Orders that the order dispute has kicked in, and the order status has been set to `on-hold`.
6. View your email logs. Notice a few emails have been sent, including one `Your <Store Name> order has been received` customer email.
7. In the Stripe dashboard, simulate winning a dispute:
    - Go to the Disputes dashboard (https://dashboard.stripe.com/test/disputes), and view the  dispute.
   - Click "Counter dispute"
   - Under "Why should you win this dispute?", choose "The purchase was made by the rightful account owner"
   - Under "Product or service details", choose "Physical product"
   - Click "Next"
   - Under "Supporting evidence", expand "+ Additional information" and type `winning_evidence` in the textbox.
   - Check "I understand..." and click "Submit"

<img width="400" alt="Screenshot 2024-12-20 at 2 23 32 PM" src="https://github.com/user-attachments/assets/2baaee0b-fe47-4335-a3ba-8257dfc795d7" />

8. Wait a couple of minutes, and verify in wp-admin Orders that the order dispute has been closed in the merchant favor, and the order status has been set back to `processing`.
9. View your email logs.
10. In `develop`, the `Your <Store Name> order has been received` email has been resent.
11. In this branch, the email was not resent.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
