### PR TITLE
Fix missing recipient for Payment Auth Requested email

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Show default recipient for Payment Authentication Requested email.
 * Dev - Updates the GitHub caching action (`actions/cache`) to v4 due deprecation.
 * Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Fix - Correctly sets the dispute opened note when a dispute does not require any further action.

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -36,10 +36,11 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 		$this->template_plain = 'emails/plain/failed-renewal-authentication-requested.php';
 		$this->template_base  = plugin_dir_path( WC_STRIPE_MAIN_FILE ) . 'templates/';
 
-		$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
-
 		// We want all the parent's methods, with none of its properties, so call its parent's constructor, rather than my parent constructor.
 		WC_Email::__construct();
+
+		// Set after calling the parent constructor, so it is not overriden.
+		$this->recipient = $this->get_option( 'recipient', get_option( 'admin_email' ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Show default recipient for Payment Authentication Requested email.
 * Dev - Updates the GitHub caching action (`actions/cache`) to v4 due deprecation.
 * Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Fix - Correctly sets the dispute opened note when a dispute does not require any further action.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3294

## Changes proposed in this Pull Request:
When viewing/editing the `Payment Authentication Requested Email` template and we haven't set any custom recipients, the `Recipient(s)` field is empty, despite having the store admin as the default recipient. 

We want the behavior to be consistent with other email templates, like `New Order` and `Failed Order`, which display the default recipient in the `Recipient(s)` field.

We also want the display to be consistent with the emails table list, which correctly displays the default email recipient.

| Before | After |
|--------|-------|
| <img width="660" alt="Screenshot 2024-12-23 at 1 03 11 PM" src="https://github.com/user-attachments/assets/86b3e617-8519-4dc2-b023-e907caf6bf66" /> | <img width="660" alt="Screenshot 2024-12-23 at 1 01 58 PM" src="https://github.com/user-attachments/assets/dee88931-1483-418f-bc73-8c437da1ced6" /> |

The emails table list correctly displays the default email recipient:
<img width="800" alt="Screenshot 2024-12-23 at 12 45 43 PM" src="https://github.com/user-attachments/assets/605f2f11-7202-4e42-a400-45c09d6ad783" />


## Testing instructions
1. Go to WooCommerce > Settings > Emails > Payment Authentication Requested Email (Manage).
2. In `develop`, the `Recipient(s)` field is empty.
3. In this branch, the `Recipient(s)` field shows the default recipient: the store admin email.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
