### PR TITLE
Check order currency on pay for order page to display supported payment methods

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 * Update - Prevent editing of orders awaiting payment capture.
 * Add - Introduce locking and unlocking in refund flow to prevent double refund due to race condition.
+* Fix - Check order currency on pay for order page to display supported payment methods.
 
 = 9.0.0 - 2024-12-12 =
 * Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -235,7 +235,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		$current_store_currency = $this->get_woocommerce_currency();
 		$currencies             = $this->get_supported_currencies();
 		if ( ! empty( $currencies ) ) {
-			if ( isset( $_GET['pay_for_order'] ) ) {
+			if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['key'] ) ) {
 				$order          = wc_get_order( $order_id ? $order_id : absint( get_query_var( 'order-pay' ) ) );
 				$order_currency = $order->get_currency();
 				if ( ! in_array( $order_currency, $currencies, true ) ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -230,11 +230,20 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return false;
 		}
 
-		// Check currency compatibility.
+		// Check currency compatibility. On the pay for order page, check the order currency.
+		// Otherwise, check the store currency.
 		$current_store_currency = $this->get_woocommerce_currency();
 		$currencies             = $this->get_supported_currencies();
-		if ( ! empty( $currencies ) && ! in_array( $current_store_currency, $currencies, true ) ) {
-			return false;
+		if ( ! empty( $currencies ) ) {
+			if ( isset( $_GET['pay_for_order'] ) ) {
+				$order          = wc_get_order( $order_id ? $order_id : absint( get_query_var( 'order-pay' ) ) );
+				$order_currency = $order->get_currency();
+				if ( ! in_array( $order_currency, $currencies, true ) ) {
+					return false;
+				}
+			} else if ( ! in_array( $current_store_currency, $currencies, true ) ) {
+				return false;
+			}
 		}
 
 		// For payment methods that only support domestic payments, check if the store currency matches the account's default currency.

--- a/readme.txt
+++ b/readme.txt
@@ -133,5 +133,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 * Update - Prevent editing of orders awaiting payment capture.
 * Add - Introduce locking and unlocking in refund flow to prevent double refund due to race condition.
+* Fix - Check order currency on pay for order page to display supported payment methods.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3478 

When the order currency is different than the store currency, some currency dependent payment methods fail to load on the pay for order page.

## Changes proposed in this Pull Request:
On the pay for order page, we are now checking the order currency instead of the store currency to detect if a payment method should be available on this page.

## Testing instructions
- Set your store currency to USD
- Go to **WooCommerce > Orders** and create a new order. Add a customer and a product to the order.
- Leave the order as pending-payment.
- Change your store's currency to Euro and enable SEPA.
- Go to the `Customer payment page →` for this order.
- In `develop` branch, you will see SEPA is listed as an available payment method but there are no payment elements (the Stripe payment element fails to load) and the console error.

<img width="1113" alt="371368464-b6a23657-230f-4aa4-aa1f-dd75bddd222d" src="https://github.com/user-attachments/assets/40ad3edd-154d-4baa-a677-4424f95696d4" />

<img width="1305" alt="371368553-8e7ed4e1-3f10-439d-8092-e330498584d3" src="https://github.com/user-attachments/assets/1f98ccbd-e3fd-4c3a-bb4a-58c92d7a8c41" />


- In this branch, SEPA should not be listed as an available option. Other USD based payment methods should be listed if enabled.