### PR TITLE
Improve webhook status related messages on the settings page.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.
 * Fix - Allow account creation on checkout, if enabled, when purchasing subscriptions using ECE.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
+* Tweak - Improve webhook status related messages on the settings page.
 * Update - Prevent editing of orders awaiting payment capture.
 * Add - Introduce locking and unlocking in refund flow to prevent double refund due to race condition.
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -159,8 +159,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		wc_get_logger()->debug( 'Number of webhooks: ' . $number_of_duplicate_webhooks );
-
 		return $number_of_duplicate_webhooks > 1;
 	}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -117,6 +117,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Webhook_State::set_last_webhook_failure_at( time() );
 			WC_Stripe_Webhook_State::set_last_error_reason( $validation_result );
 
+			if ( WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH === $validation_result ) {
+				// Return a 400 HTTP status code to notify Stripe about a misconfigured webhook when the signature does not match.
+				// @see https://docs.stripe.com/webhooks#disable
+				status_header( 400 );
+				exit;
+			}
+
 			// A webhook endpoint must return a 2xx HTTP status code to prevent future webhook
 			// delivery failures.
 			// @see https://docs.stripe.com/webhooks#acknowledge-events-immediately
@@ -135,7 +142,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
 	 */
 	public function validate_request( $request_headers, $request_body ) {
-		if ( empty( $request_headers ) ) {
+		if ( true || empty( $request_headers ) ) {
 			return WC_Stripe_Webhook_State::VALIDATION_FAILED_EMPTY_HEADERS;
 		}
 		if ( empty( $request_body ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -118,7 +118,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 			if ( WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH === $validation_result && $this->has_duplicate_webhooks_setup() ) {
 				WC_Stripe_Webhook_State::set_last_error_reason( WC_Stripe_Webhook_State::VALIDATION_FAILED_DUPLICATE_WEBHOOKS );
-			
+
 				// Return a 400 HTTP status code to notify Stripe about a misconfigured webhook when the signature does not match.
 				// @see https://docs.stripe.com/webhooks#disable
 				status_header( 400 );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -115,14 +115,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			WC_Stripe_Logger::error( 'Webhook body: ' . print_r( $request_body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 
 			WC_Stripe_Webhook_State::set_last_webhook_failure_at( time() );
-			WC_Stripe_Webhook_State::set_last_error_reason( $validation_result );
 
-			if ( WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH === $validation_result ) {
+			if ( WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH === $validation_result && $this->has_duplicate_webhooks_setup() ) {
+				WC_Stripe_Webhook_State::set_last_error_reason( WC_Stripe_Webhook_State::VALIDATION_FAILED_DUPLICATE_WEBHOOKS );
+			
 				// Return a 400 HTTP status code to notify Stripe about a misconfigured webhook when the signature does not match.
 				// @see https://docs.stripe.com/webhooks#disable
 				status_header( 400 );
 				exit;
 			}
+
+			WC_Stripe_Webhook_State::set_last_error_reason( $validation_result );
 
 			// A webhook endpoint must return a 2xx HTTP status code to prevent future webhook
 			// delivery failures.
@@ -130,6 +133,35 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			status_header( 204 );
 			exit;
 		}
+	}
+
+	/**
+	 * Check if the Stripe account has duplicate webhooks setup for this site.
+	 *
+	 * @since 9.1.0
+	 */
+	public function has_duplicate_webhooks_setup() {
+		$webhook_url = WC_Stripe_Helper::get_webhook_url();
+		$webhooks    = WC_Stripe_API::retrieve( 'webhook_endpoints' );
+
+		if ( is_wp_error( $webhooks ) || ! isset( $webhooks->data ) || empty( $webhooks->data ) ) {
+			return false;
+		}
+
+		$number_of_duplicate_webhooks = count( $webhooks );
+		foreach ( $webhooks->data as $webhook ) {
+			if ( ! isset( $webhook->url ) ) {
+				continue;
+			}
+
+			if ( $webhook->url === $webhook_url ) {
+				$number_of_duplicate_webhooks++;
+			}
+		}
+
+		wc_get_logger()->debug( 'Number of webhooks: ' . $number_of_duplicate_webhooks );
+
+		return $number_of_duplicate_webhooks > 1;
 	}
 
 	/**
@@ -142,7 +174,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @return string The validation result (e.g. self::VALIDATION_SUCCEEDED )
 	 */
 	public function validate_request( $request_headers, $request_body ) {
-		if ( true || empty( $request_headers ) ) {
+		if ( empty( $request_headers ) ) {
 			return WC_Stripe_Webhook_State::VALIDATION_FAILED_EMPTY_HEADERS;
 		}
 		if ( empty( $request_body ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -148,18 +148,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return false;
 		}
 
-		$number_of_duplicate_webhooks = count( $webhooks );
+		$number_of_webhooks = 0;
 		foreach ( $webhooks->data as $webhook ) {
 			if ( ! isset( $webhook->url ) ) {
 				continue;
 			}
 
 			if ( $webhook->url === $webhook_url ) {
-				$number_of_duplicate_webhooks++;
+				$number_of_webhooks++;
 			}
 		}
 
-		return $number_of_duplicate_webhooks > 1;
+		return $number_of_webhooks > 1;
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -184,7 +184,7 @@ class WC_Stripe_Webhook_State {
 		}
 
 		if ( self::VALIDATION_FAILED_DUPLICATE_WEBHOOKS == $last_error ) {
-			return( __( 'Multiple webhooks are created for this site. Please remove the duplicate webhooks or re-configure the webhooks', 'woocommerce-gateway-stripe' ) );
+			return( __( 'Multiple webhooks exist for this site. Please remove the duplicate webhooks or re-configure the webhooks', 'woocommerce-gateway-stripe' ) );
 		}
 
 		if ( self::VALIDATION_FAILED_TIMESTAMP_MISMATCH == $last_error ) {

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -27,6 +27,7 @@ class WC_Stripe_Webhook_State {
 	const VALIDATION_FAILED_EMPTY_SECRET       = 'empty_secret';
 	const VALIDATION_FAILED_USER_AGENT_INVALID = 'user_agent_invalid';
 	const VALIDATION_FAILED_SIGNATURE_INVALID  = 'signature_invalid';
+	const VALIDATION_FAILED_DUPLICATE_WEBHOOKS  = 'duplicate_webhooks';
 	const VALIDATION_FAILED_TIMESTAMP_MISMATCH = 'timestamp_out_of_range';
 	const VALIDATION_FAILED_SIGNATURE_MISMATCH = 'signature_mismatch';
 
@@ -170,7 +171,7 @@ class WC_Stripe_Webhook_State {
 		}
 
 		if ( self::VALIDATION_FAILED_EMPTY_SECRET === $last_error ) {
-			return( __( 'The webhook secret is not set in the store', 'woocommerce-gateway-stripe' ) );
+			return( __( 'The webhook secret is not set in the store. Please configure the webhooks', 'woocommerce-gateway-stripe' ) );
 		}
 
 		// Legacy failure reason. Removed in 8.6.0.
@@ -180,6 +181,10 @@ class WC_Stripe_Webhook_State {
 
 		if ( self::VALIDATION_FAILED_SIGNATURE_INVALID == $last_error ) {
 			return( __( 'The webhook signature was missing or was incorrectly formatted', 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( self::VALIDATION_FAILED_DUPLICATE_WEBHOOKS == $last_error ) {
+			return( __( 'Multiple webhooks are created for this site. Please remove the duplicate webhooks or re-configure the webhooks', 'woocommerce-gateway-stripe' ) );
 		}
 
 		if ( self::VALIDATION_FAILED_TIMESTAMP_MISMATCH == $last_error ) {

--- a/readme.txt
+++ b/readme.txt
@@ -130,6 +130,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Correctly handles charge expired webhook events, setting the order status to failed and adding a note.
 * Fix - Allow account creation on checkout, if enabled, when purchasing subscriptions using ECE.
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
+* Tweak - Improve webhook status related messages on the settings page.
 * Update - Prevent editing of orders awaiting payment capture.
 * Add - Introduce locking and unlocking in refund flow to prevent double refund due to race condition.
 

--- a/tests/phpunit/test-wc-stripe-webhook-state.php
+++ b/tests/phpunit/test-wc-stripe-webhook-state.php
@@ -248,7 +248,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 
 		$this->set_valid_request_data();
 		$this->process_webhook();
-		$this->assertEquals( 'The webhook secret is not set in the store', WC_Stripe_Webhook_State::get_last_error_reason() );
+		$this->assertEquals( 'The webhook secret is not set in the store. Please configure the webhooks', WC_Stripe_Webhook_State::get_last_error_reason() );
 	}
 
 	// Test failure reason: invalid signature.


### PR DESCRIPTION
Fixes #3342

## Changes proposed in this Pull Request:
- Checking if the Stripe dashboard has multiple/duplicate webhook set up for the store when a webhook validation fails for signature mismatch. 
    - Returning status code 400 to Stripe (only if there are duplicate webhooks). [Stripe will disable](https://docs.stripe.com/webhooks#disable) the duplicate webhooks if not 2xx codes are received for a few days.
    - Improved the warning when signature validation fails due to multiple webhook set up for the same site.
- Improved the warning when webhook secret is not set.

## Testing instructions
- Make sure your site is publicly accessible (use ngrok or a JN site).
- As an admin, go to the Stripe settings page and configure the webhooks.
- Go to the Stripe dashboard and manually create 2/3 webhooks.
- As a shopper, purchase a product to trigger a webhook event.
- Check the logs and notice one or more logs for webhook validation failure.
- Go to the Stripe dashboard and check the latest event. Confirm that the webhook configured from the settings page has received a response of 200 status code. The other manually created webhooks should receive a response of 400 status code.
- Reconfigure the webhook from the settings page and confirm that the webhook related warning is gone. Check the Stripe dashboard and confirm that the manually created webhooks have been deleted.
- Check the issue #3342 and suggest if there is anything else to improve.