### PR TITLE
Redirect to correct page when payment fails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1196,7 +1196,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
-		$this->process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method );
+		if ( isset( $_GET['redirect_on_error'] ) ) {
+			$redirect_on_error = wc_clean( wp_unslash( $_GET['redirect_on_error'] ) );
+		} else {
+			$redirect_on_error = wc_get_checkout_url();
+		}
+
+		$this->process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $redirect_on_error );
 	}
 
 	/**
@@ -1250,7 +1256,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @since 5.5.0
 	 * @version 5.5.0
 	 */
-	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method ) {
+	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $redirect_on_error = null ) {
 		$order = wc_get_order( $order_id );
 
 		if ( ! is_object( $order ) ) {
@@ -1276,7 +1282,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$order->update_status( 'failed', sprintf( __( 'UPE payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getMessage() ) );
 
 			wc_add_notice( $e->getMessage(), 'error' );
-			wp_safe_redirect( wc_get_checkout_url() );
+
+			if ( $redirect_on_error ) {
+				wp_safe_redirect( $redirect_on_error );
+			} else {
+				wp_safe_redirect( wc_get_checkout_url() );
+			}
 			exit;
 		}
 	}
@@ -2376,15 +2387,24 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return string
 	 */
 	private function get_return_url_for_redirect( $order, $save_payment_method ) {
+		$query_args = [
+			'order_id'            => $order->get_id(),
+			'wc_payment_method'   => self::ID,
+			'_wpnonce'            => wp_create_nonce( 'wc_stripe_process_redirect_order_nonce' ),
+			'save_payment_method' => $save_payment_method ? 'yes' : 'no',
+		];
+
+		// If the user was originally on the pay-for-order page, and something went wrong during
+		// processing of the UPE redirect payment, redirect the user back to the pay-for-order page.
+		if ( parent::is_valid_pay_for_order_endpoint() ) {
+			$query_args['redirect_on_error'] =
+				rawurlencode( wp_sanitize_redirect( esc_url_raw( $order->get_checkout_payment_url() ) ) );
+		}
+
 		return wp_sanitize_redirect(
 			esc_url_raw(
 				add_query_arg(
-					[
-						'order_id'            => $order->get_id(),
-						'wc_payment_method'   => self::ID,
-						'_wpnonce'            => wp_create_nonce( 'wc_stripe_process_redirect_order_nonce' ),
-						'save_payment_method' => $save_payment_method ? 'yes' : 'no',
-					],
+					$query_args,
 					$this->get_return_url( $order )
 				)
 			)

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -65,6 +65,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	const BLOCKS_APPEARANCE_TRANSIENT = 'wc_stripe_blocks_appearance';
 
 	/**
+	 * Flag indicating where to redirect after a redirect-based payment method fails.
+	 *
+	 * @type string
+	 */
+	const REDIRECT_ON_ERROR_PAY_FOR_ORDER = 'pay-for-order';
+
+	/**
 	 * Notices (array)
 	 *
 	 * @var array
@@ -1196,10 +1203,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
-		if ( isset( $_GET['redirect_on_error'] ) ) {
-			$redirect_on_error = wc_clean( wp_unslash( $_GET['redirect_on_error'] ) );
-		} else {
-			$redirect_on_error = wc_get_checkout_url();
+		$redirect_on_error = '';
+		if ( isset( $_GET['redirect_on_error'] ) && self::REDIRECT_ON_ERROR_PAY_FOR_ORDER === $_GET['redirect_on_error'] ) {
+			$redirect_on_error = self::REDIRECT_ON_ERROR_PAY_FOR_ORDER;
 		}
 
 		$this->process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $redirect_on_error );
@@ -1252,11 +1258,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @param int    $order_id The order ID being processed.
 	 * @param string $intent_id The Stripe setup/payment intent ID for the order payment.
 	 * @param bool   $save_payment_method Boolean representing whether payment method for order should be saved.
+	 * @param string $redirect_on_error String representing the URL to redirect to on error, e.g. 'pay-for-order'. Optional.
 	 *
 	 * @since 5.5.0
 	 * @version 5.5.0
 	 */
-	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $redirect_on_error = null ) {
+	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $redirect_on_error = '' ) {
 		$order = wc_get_order( $order_id );
 
 		if ( ! is_object( $order ) ) {
@@ -1283,11 +1290,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			wc_add_notice( $e->getMessage(), 'error' );
 
-			if ( $redirect_on_error ) {
-				wp_safe_redirect( $redirect_on_error );
+			$redirect_url = '';
+			if ( self::REDIRECT_ON_ERROR_PAY_FOR_ORDER === $redirect_on_error ) {
+				$redirect_url = $order->get_checkout_payment_url();
 			} else {
-				wp_safe_redirect( wc_get_checkout_url() );
+				$redirect_url = wc_get_checkout_url();
 			}
+			wp_safe_redirect( wp_sanitize_redirect( $redirect_url ) );
+
 			exit;
 		}
 	}
@@ -2397,8 +2407,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// If the user was originally on the pay-for-order page, and something went wrong during
 		// processing of the UPE redirect payment, redirect the user back to the pay-for-order page.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$query_args['redirect_on_error'] =
-				rawurlencode( wp_sanitize_redirect( esc_url_raw( $order->get_checkout_payment_url() ) ) );
+			$query_args['redirect_on_error'] = self::REDIRECT_ON_ERROR_PAY_FOR_ORDER;
 		}
 
 		return wp_sanitize_redirect(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -65,13 +65,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	const BLOCKS_APPEARANCE_TRANSIENT = 'wc_stripe_blocks_appearance';
 
 	/**
-	 * Flag indicating where to redirect after a redirect-based payment method fails.
-	 *
-	 * @type string
-	 */
-	const REDIRECT_ON_ERROR_PAY_FOR_ORDER = 'pay-for-order';
-
-	/**
 	 * Notices (array)
 	 *
 	 * @var array
@@ -1203,12 +1196,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
-		$redirect_on_error = '';
-		if ( isset( $_GET['redirect_on_error'] ) && self::REDIRECT_ON_ERROR_PAY_FOR_ORDER === $_GET['redirect_on_error'] ) {
-			$redirect_on_error = self::REDIRECT_ON_ERROR_PAY_FOR_ORDER;
-		}
-
-		$this->process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $redirect_on_error );
+		$this->process_upe_redirect_payment(
+			$order_id,
+			$intent_id,
+			$save_payment_method,
+			isset( $_GET['pay_for_order'] ) && 'yes' === $_GET['pay_for_order']
+		);
 	}
 
 	/**
@@ -1258,12 +1251,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @param int    $order_id The order ID being processed.
 	 * @param string $intent_id The Stripe setup/payment intent ID for the order payment.
 	 * @param bool   $save_payment_method Boolean representing whether payment method for order should be saved.
-	 * @param string $redirect_on_error String representing the URL to redirect to on error, e.g. 'pay-for-order'. Optional.
+	 * @param bool $is_pay_for_order True if processing payment from Pay for Order page. Optional.
 	 *
 	 * @since 5.5.0
 	 * @version 5.5.0
 	 */
-	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $redirect_on_error = '' ) {
+	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $is_pay_for_order = false ) {
 		$order = wc_get_order( $order_id );
 
 		if ( ! is_object( $order ) ) {
@@ -1291,7 +1284,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			wc_add_notice( $e->getMessage(), 'error' );
 
 			$redirect_url = '';
-			if ( self::REDIRECT_ON_ERROR_PAY_FOR_ORDER === $redirect_on_error ) {
+			if ( $is_pay_for_order ) {
 				$redirect_url = $order->get_checkout_payment_url();
 			} else {
 				$redirect_url = wc_get_checkout_url();
@@ -2397,23 +2390,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return string
 	 */
 	private function get_return_url_for_redirect( $order, $save_payment_method ) {
-		$query_args = [
-			'order_id'            => $order->get_id(),
-			'wc_payment_method'   => self::ID,
-			'_wpnonce'            => wp_create_nonce( 'wc_stripe_process_redirect_order_nonce' ),
-			'save_payment_method' => $save_payment_method ? 'yes' : 'no',
-		];
-
-		// If the user was originally on the pay-for-order page, and something went wrong during
-		// processing of the UPE redirect payment, redirect the user back to the pay-for-order page.
-		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$query_args['redirect_on_error'] = self::REDIRECT_ON_ERROR_PAY_FOR_ORDER;
-		}
-
 		return wp_sanitize_redirect(
 			esc_url_raw(
 				add_query_arg(
-					$query_args,
+					[
+						'order_id'            => $order->get_id(),
+						'wc_payment_method'   => self::ID,
+						'_wpnonce'            => wp_create_nonce( 'wc_stripe_process_redirect_order_nonce' ),
+						'save_payment_method' => $save_payment_method ? 'yes' : 'no',
+						'pay_for_order'       => parent::is_valid_pay_for_order_endpoint() ? 'yes' : 'no',
+					],
 					$this->get_return_url( $order )
 				)
 			)

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3066 

## Changes proposed in this Pull Request:
When on the Pay for Order page, and the redirect-based payment method fails, the shopper gets redirected to the Cart/Checkout page instead of back to Pay for Order.

This PR fixes that behavior by tracking where to return the shopper so they can easily resume the process.

## Testing instructions
1. Enable redirect-based payment methods such as Afterpay and Klarna.
2. In WooCommerce > Orders, manually create an order.
    - Under Billing Address, add the customer's name and an address that is compatible with the payment method you plan to use, e.g. US, UK, etc. for Afterpay.
    - Under Shipping Address, click "Copy billing address" or enter a name and address.
    - Add an item to the order, and click Create.
3. Open the Pay for Order page in an incognito window.
<img width="300" alt="Screenshot 2024-12-27 at 10 42 04 AM" src="https://github.com/user-attachments/assets/02e91aef-3785-498a-8eab-c2cfd4621e89" />


4. Initiate payment using a redirect-based payment method, e.g. Afterpay.
5. Click "Fail test payment" on the auth page, or "X" or "Cancel" on an intermediate page.
6. In `develop`, the shopper gets redirected to an empty Cart page.
7. In this branch, the shopper gets returned to the Pay for Order page.

| Before | After |
|--------|-------|
| <img width="800" alt="Screenshot 2024-12-27 at 11 13 44 AM" src="https://github.com/user-attachments/assets/cd164607-b5ae-4350-a8f8-d4ed50b06f48" /> | <img width="800" alt="Screenshot 2024-12-27 at 11 13 11 AM" src="https://github.com/user-attachments/assets/a2f36e5e-d3b7-4197-b8dc-5e976c8d4c2b" /> |

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
