### PR TITLE
Fix ECE error on classic cart/checkout for non-English stores

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.
 * Fix - Allow the saving of iDEAL tokens when SEPA is disabled.
-* Fix - Fixes the incompatibility notice in editor due missing style property when instantiating Stripe payment methods. 
+* Fix - Fixes the incompatibility notice in editor due missing style property when instantiating Stripe payment methods.
 * Dev - Updates the GitHub caching action (`actions/cache`) to v4 due deprecation.
 * Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Fix - Correctly sets the dispute opened note when a dispute does not require any further action.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -103,13 +103,9 @@ jQuery( function ( $ ) {
 				}
 
 				return options.displayItems
-					.filter(
-						( i ) =>
-							i.label ===
-							__( 'Shipping', 'woocommerce-gateway-stripe' )
-					)
+					.filter( ( i ) => i.key && i.key === 'total_shipping' )
 					.map( ( i ) => ( {
-						id: `rate-${ i.label }`,
+						id: `rate-shipping`,
 						amount: i.amount,
 						displayName: i.label,
 					} ) );

--- a/readme.txt
+++ b/readme.txt
@@ -111,10 +111,11 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.
 * Fix - Allow the saving of iDEAL tokens when SEPA is disabled.
-* Fix - Fixes the incompatibility notice in editor due missing style property when instantiating Stripe payment methods. 
+* Fix - Fixes the incompatibility notice in editor due missing style property when instantiating Stripe payment methods.
 * Dev - Updates the GitHub caching action (`actions/cache`) to v4 due deprecation.
 * Fix - Don't update canceled order status to on-hold when a dispute is opened.
 * Fix - Correctly sets the dispute opened note when a dispute does not require any further action.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3683 

## Changes proposed in this Pull Request:
On classic (shortcode) cart and checkout, when the store language is not English, ECE may crash on load and display an error about shipping rates.

This PR fixes that behavior by using `key` (static) instead of `label` (translated) when comparing items in the shipping rates logic.

## Testing instructions
1. Make sure ECE is enabled, and enable `Apple Pay/Google Pay` and `Link` as payment methods.
2. In WooCommerce > Settings > Shipping, define a shipping zone that covers your test address zone.
3. Create classic (shortcode) cart and checkout pages, if you don't have them yet.
4. Change your site language to "Français".
5. As a shopper, add a product to cart, and go to classic cart, or classic checkout.
6. Click the Apple Pay/Google Pay/Link button.
7. In `develop`, the ECE modal will not load and you will see this error in the browser console:
```
Unhandled Promise Rejection: IntegrationError: When `shippingAddressRequired` is true, you must specify `shippingRates`.
```
8. In this branch, you should be able to complete your purchase without any problem.
9. Verify that you are able to use ECE regardless of store language.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
