### PR TITLE
Make sure product exists before using it in ajax response

### DIFF
--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1469,7 +1469,7 @@ class WC_Stripe_Payment_Request {
 		$product      = wc_get_product( $product_id );
 
 		if ( ! $product ) {
-			throw new \Exception( 'There was an error adding this product to the cart.' );
+			throw new \Exception( __( 'There was an error adding this product to the cart.', 'woocommerce-gateway-stripe' ) );
 		}
 
 		$product_type = $product->get_type();

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1467,6 +1467,11 @@ class WC_Stripe_Payment_Request {
 		$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
 		$qty          = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
 		$product      = wc_get_product( $product_id );
+
+		if ( ! $product ) {
+			throw new \Exception( 'There was an error adding this product to the cart.' );
+		}
+
 		$product_type = $product->get_type();
 
 		// First empty the cart to prevent wrong calculation.


### PR DESCRIPTION
The `WC_Stripe_Payment_Request::ajax_add_to_cart()` function takes a product ID from the request body and passes it to [wc_get_product()](https://woocommerce.github.io/code-reference/files/woocommerce-includes-wc-product-functions.html#source-view.64). That function will return null if the product is not found, and false if the function call happened out of order (that is, before some prerequisite hooks have run).

Currently we're assuming that the product lookup succeeded, but if it doesn't then the `$product->get_type()` call on the following line raises a critical error like `Uncaught Error: Call to a member function get_type() on bool`.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
