### PR TITLE
Correctly handle IPP failed orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Correctly handles IPP failed payments webhook calls by extracting the order ID from the payment intent metadata.
 * Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -615,7 +615,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund( $notification ) {
 		$refund_object = $this->get_refund_object( $notification );
-		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+		$order = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
@@ -630,11 +630,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id = $order->get_id();
 
 		if ( 'stripe' === substr( (string) $order->get_payment_method(), 0, 6 ) ) {
-			$charge     = $order->get_transaction_id();
-			$captured   = $order->get_meta( '_stripe_charge_captured' );
-			$refund_id  = $order->get_meta( '_stripe_refund_id' );
-			$currency   = $order->get_currency();
-			$raw_amount = $refund_object->amount;
+			$charge        = $order->get_transaction_id();
+			$captured      = $order->get_meta( '_stripe_charge_captured' );
+			$refund_id     = $order->get_meta( '_stripe_refund_id' );
+			$currency      = $order->get_currency();
+			$raw_amount    = $refund_object->amount;
 
 			if ( ! in_array( strtolower( $currency ), WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
 				$raw_amount /= 100;

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -925,7 +925,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @param stdClass $notification The webhook notification from Stripe.
 	 */
-	public function process_payment_intent_success( $notification ) {
+	public function process_payment_intent( $notification ) {
 		$intent = $notification->data->object;
 		$order  = $this->get_order_from_intent( $intent );
 
@@ -1226,7 +1226,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			case 'payment_intent.payment_failed':
 			case 'payment_intent.amount_capturable_updated':
 			case 'payment_intent.requires_action':
-				$this->process_payment_intent_success( $notification );
+				$this->process_payment_intent( $notification );
 				break;
 
 			case 'setup_intent.succeeded':

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1001,7 +1001,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					break;
 				}
 
-				$error_message = $intent->last_payment_error ? $intent->last_payment_error->message : '';
+				$error_message = $intent->last_payment_error->message ?? '';
 
 				/* translators: 1) The error message that was received from Stripe. */
 				$message = sprintf( __( 'Stripe SCA authentication failed. Reason: %s', 'woocommerce-gateway-stripe' ), $error_message );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -615,7 +615,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund( $notification ) {
 		$refund_object = $this->get_refund_object( $notification );
-		$order = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
@@ -630,11 +630,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order_id = $order->get_id();
 
 		if ( 'stripe' === substr( (string) $order->get_payment_method(), 0, 6 ) ) {
-			$charge        = $order->get_transaction_id();
-			$captured      = $order->get_meta( '_stripe_charge_captured' );
-			$refund_id     = $order->get_meta( '_stripe_refund_id' );
-			$currency      = $order->get_currency();
-			$raw_amount    = $refund_object->amount;
+			$charge     = $order->get_transaction_id();
+			$captured   = $order->get_meta( '_stripe_charge_captured' );
+			$refund_id  = $order->get_meta( '_stripe_refund_id' );
+			$currency   = $order->get_currency();
+			$raw_amount = $refund_object->amount;
 
 			if ( ! in_array( strtolower( $currency ), WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
 				$raw_amount /= 100;
@@ -1244,29 +1244,44 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	private function get_order_from_intent( $intent ) {
 		// Attempt to get the order from the intent metadata.
-		if ( isset( $intent->metadata->signature ) ) {
-			$signature = wc_clean( $intent->metadata->signature );
-			$data      = explode( ':', $signature );
+		if ( isset( $intent->metadata ) ) {
+			// Try to retrieve from the signature
+			if ( isset( $intent->metadata->signature ) ) {
+				$signature = wc_clean( $intent->metadata->signature );
+				$data      = explode( ':', $signature );
 
-			// Verify we received the order ID and signature (hash).
-			$order = isset( $data[0], $data[1] ) ? wc_get_order( absint( $data[0] ) ) : false;
+				// Verify we received the order ID and signature (hash).
+				$order = isset( $data[0], $data[1] ) ? wc_get_order( absint( $data[0] ) ) : false;
 
-			if ( $order ) {
-				$intent_id = WC_Stripe_Helper::get_intent_id_from_order( $order );
+				if ( $order ) {
+					$intent_id = WC_Stripe_Helper::get_intent_id_from_order( $order );
 
-				// Return the order if the intent ID matches.
-				if ( $intent->id === $intent_id ) {
-					return $order;
-				}
+					// Return the order if the intent ID matches.
+					if ( $intent->id === $intent_id ) {
+						return $order;
+					}
 
-				/**
-				 * If the order has no intent ID stored, we may have failed to store it during the initial payment request.
-				 * Confirm that the signature matches the order, otherwise fall back to finding the order via the intent ID.
-				 */
-				if ( empty( $intent_id ) && $this->get_order_signature( $order ) === $signature ) {
-					return $order;
+					/**
+					 * If the order has no intent ID stored, we may have failed to store it during the initial payment request.
+					 * Confirm that the signature matches the order, otherwise fall back to finding the order via the intent ID.
+					 */
+					if ( empty( $intent_id ) && $this->get_order_signature( $order ) === $signature ) {
+						return $order;
+					}
 				}
 			}
+
+			// Try to retrieve from the metadata order ID.
+			if ( isset( $intent->metadata->order_id ) ) {
+				return wc_get_order( absint( $intent->metadata->order_id ) );
+			}
+		}
+
+		// Try to retrieve from the charges array.
+		if ( ! empty( $intent->charges ) ) {
+			$charge   = $intent->charges[0] ?? [];
+			$order_id = $charge['metadata']['order_id'] ?? null;
+			return wc_get_order( $order_id );
 		}
 
 		// Fall back to finding the order via the intent ID.

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -23,6 +23,7 @@ class WC_Stripe_Payment_Methods {
 	const SEPA_DEBIT        = 'sepa_debit';
 	const SOFORT            = 'sofort';
 	const WECHAT_PAY        = 'wechat_pay';
+	const CARD_PRESENT      = 'card_present';
 
 	/**
 	 * Payment methods that are considered as voucher payment methods.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Correctly handles IPP failed payments webhook calls by extracting the order ID from the payment intent metadata.
 * Fix - Fix ECE crash in classic cart and checkout pages for non-English language sites.
 * Fix - Correctly handles UK postcodes redacted by Apple Pay.
 * Tweak - Avoid re-sending Processing Order customer email when merchant wins dispute.

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -391,11 +391,35 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @param bool $order_status_final Whether the order status is final.
 	 * @param string $expected_status The expected order status.
 	 * @param string $expected_note The expected order note.
+	 * @param int $expected_process_payment_calls The expected number of calls to process_payment.
+	 * @param int $expected_process_payment_intent_incomplete_calls The expected number of calls to process_payment_intent_incomplete.
 	 * @return void
 	 * @dataProvider provide_test_process_payment_intent
 	 * @throws WC_Data_Exception When order status is invalid.
 	 */
-	public function test_process_payment_intent( $event_type, $order_status, $order_locked, $payment_type, $order_status_final, $expected_status, $expected_note ) {
+	public function test_process_payment_intent(
+		$event_type,
+		$order_status,
+		$order_locked,
+		$payment_type,
+		$order_status_final,
+		$expected_status,
+		$expected_note,
+		$expected_process_payment_calls,
+		$expected_process_payment_intent_incomplete_calls
+	) {
+		$mock_action_process_payment = new MockAction();
+		add_action(
+			'wc_gateway_stripe_process_payment',
+			[ &$mock_action_process_payment, 'action' ]
+		);
+
+		$mock_action_process_payment_intent_incomplete = new MockAction();
+		add_action(
+			'wc_gateway_stripe_process_payment_intent_incomplete',
+			[ &$mock_action_process_payment_intent_incomplete, 'action' ]
+		);
+
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( $order_status );
 		if ( $order_locked ) {
@@ -405,10 +429,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			$order->update_meta_data( '_stripe_status_final', true );
 		}
 		$order->update_meta_data( '_stripe_upe_payment_type', $payment_type );
-		if ( in_array( $payment_type, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS, true )
-			|| in_array( $payment_type, WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, true ) ) {
-			$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
-		}
+		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 		$order->save_meta_data();
 		$order->save();
 
@@ -441,6 +462,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			);
 			$this->assertMatchesRegularExpression( $expected_note, $notes[0]->content );
 		}
+
+		$this->assertEquals( $expected_process_payment_calls, $mock_action_process_payment->get_call_count() );
+		$this->assertEquals( $expected_process_payment_intent_incomplete_calls, $mock_action_process_payment_intent_incomplete->get_call_count() );
 	}
 
 	/**
@@ -451,76 +475,92 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	public function provide_test_process_payment_intent() {
 		return [
 			'invalid status'                              => [
-				'event_type'         => 'payment_intent.succeeded',
-				'order_status'       => 'cancelled',
-				'order locked'       => false,
-				'payment type'       => WC_Stripe_Payment_Methods::CARD,
-				'order_status_final' => false,
-				'expected_status'    => 'cancelled',
-				'expected_note'      => '',
+				'event type'                     => 'payment_intent.succeeded',
+				'order status'                   => 'cancelled',
+				'order locked'                   => false,
+				'payment type'                   => WC_Stripe_Payment_Methods::CARD,
+				'order status final'             => false,
+				'expected status'                => 'cancelled',
+				'expected note'                  => '',
+				'expected process payment calls' => 0,
+				'expected process payment intent incomplete calls' => 0,
 			],
 			'order is locked'                             => [
-				'event_type'         => 'payment_intent.succeeded',
-				'order_status'       => 'pending',
-				'order locked'       => true,
-				'payment type'       => WC_Stripe_Payment_Methods::CARD,
-				'order_status_final' => false,
-				'expected_status'    => 'pending',
-				'expected_note'      => '',
+				'event type'                     => 'payment_intent.succeeded',
+				'order status'                   => 'pending',
+				'order locked'                   => true,
+				'payment type'                   => WC_Stripe_Payment_Methods::CARD,
+				'order status final'             => false,
+				'expected status'                => 'pending',
+				'expected note'                  => '',
+				'expected process payment calls' => 0,
+				'expected process payment intent incomplete calls' => 0,
 			],
 			'success, payment_intent.requires_action, voucher payment' => [
-				'event_type'         => 'payment_intent.requires_action',
-				'order_status'       => 'pending',
-				'order locked'       => false,
-				'payment type'       => WC_Stripe_Payment_Methods::BOLETO,
-				'order_status_final' => false,
-				'expected_status'    => 'on-hold',
-				'expected_note'      => '/Awaiting payment. Order status changed from Pending payment to On hold./',
+				'event type'                     => 'payment_intent.requires_action',
+				'order status'                   => 'pending',
+				'order locked'                   => false,
+				'payment type'                   => WC_Stripe_Payment_Methods::BOLETO,
+				'order status final'             => false,
+				'expected status'                => 'on-hold',
+				'expected note'                  => '/Awaiting payment. Order status changed from Pending payment to On hold./',
+				'expected process payment calls' => 0,
+				'expected process payment intent incomplete calls' => 0,
 			],
 			'success, payment_intent.succeeded, voucher payment' => [
-				'event_type'         => 'payment_intent.succeeded',
-				'order_status'       => 'pending',
-				'order locked'       => false,
-				'payment type'       => WC_Stripe_Payment_Methods::BOLETO,
-				'order_status_final' => false,
-				'expected_status'    => 'pending',
-				'expected_note'      => '',
+				'event type'                     => 'payment_intent.succeeded',
+				'order status'                   => 'pending',
+				'order locked'                   => false,
+				'payment type'                   => WC_Stripe_Payment_Methods::BOLETO,
+				'order status final'             => false,
+				'expected status'                => 'pending',
+				'expected note'                  => '',
+				'expected process payment calls' => 1,
+				'expected process payment intent incomplete calls' => 0,
 			],
 			'success, payment_intent.amount_capturable_updated, async payment, awaiting action' => [
-				'event_type'         => 'payment_intent.amount_capturable_updated',
-				'order_status'       => 'pending',
-				'order locked'       => false,
-				'payment type'       => WC_Stripe_Payment_Methods::CARD,
-				'order_status_final' => false,
-				'expected_status'    => 'pending',
-				'expected_note'      => '',
+				'event type'                     => 'payment_intent.amount_capturable_updated',
+				'order status'                   => 'pending',
+				'order locked'                   => false,
+				'payment type'                   => WC_Stripe_Payment_Methods::CARD,
+				'order status final'             => false,
+				'expected status'                => 'pending',
+				'expected note'                  => '',
+				'expected process payment calls' => 0,
+				'expected process payment intent incomplete calls' => 1,
 			],
 			'success, payment_intent.payment_failed, voucher payment' => [
-				'event_type'         => 'payment_intent.payment_failed',
-				'order_status'       => 'pending',
-				'order locked'       => false,
-				'payment type'       => WC_Stripe_Payment_Methods::BOLETO,
-				'order_status_final' => false,
-				'expected_status'    => 'failed',
-				'expected_note'      => '/Payment not completed in time Order status changed from Pending payment to Failed./',
+				'event type'                     => 'payment_intent.payment_failed',
+				'order status'                   => 'pending',
+				'order locked'                   => false,
+				'payment type'                   => WC_Stripe_Payment_Methods::BOLETO,
+				'order status final'             => false,
+				'expected status'                => 'failed',
+				'expected note'                  => '/Payment not completed in time Order status changed from Pending payment to Failed./',
+				'expected process payment calls' => 0,
+				'expected process payment intent incomplete calls' => 0,
 			],
 			'success, payment_intent.payment_failed, IPP' => [
-				'event_type'         => 'payment_intent.payment_failed',
-				'order_status'       => 'pending',
-				'order locked'       => false,
-				'payment type'       => WC_Stripe_Payment_Methods::CARD_PRESENT,
-				'order_status_final' => false,
-				'expected_status'    => 'failed',
-				'expected_note'      => '/Stripe SCA authentication failed. Reason: Your card was declined. You can call your bank for details. Order status changed from Pending payment to Failed./',
+				'event type'                     => 'payment_intent.payment_failed',
+				'order status'                   => 'pending',
+				'order locked'                   => false,
+				'payment type'                   => WC_Stripe_Payment_Methods::CARD_PRESENT,
+				'order status final'             => false,
+				'expected status'                => 'failed',
+				'expected note'                  => '/Stripe SCA authentication failed. Reason: Your card was declined. You can call your bank for details. Order status changed from Pending payment to Failed./',
+				'expected process payment calls' => 0,
+				'expected process payment intent incomplete calls' => 0,
 			],
 			'success, payment_intent.payment_failed, IPP, status final' => [
-				'event_type'         => 'payment_intent.payment_failed',
-				'order_status'       => 'pending',
-				'order locked'       => false,
-				'payment type'       => WC_Stripe_Payment_Methods::CARD_PRESENT,
-				'order_status_final' => true,
-				'expected_status'    => 'pending',
-				'expected_note'      => '/Stripe SCA authentication failed. Reason: Your card was declined. You can call your bank for details./',
+				'event type'                     => 'payment_intent.payment_failed',
+				'order status'                   => 'pending',
+				'order locked'                   => false,
+				'payment type'                   => WC_Stripe_Payment_Methods::CARD_PRESENT,
+				'order status final'             => true,
+				'expected status'                => 'pending',
+				'expected note'                  => '/Stripe SCA authentication failed. Reason: Your card was declined. You can call your bank for details./',
+				'expected process payment calls' => 0,
+				'expected process payment intent incomplete calls' => 0,
 			],
 		];
 	}

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -380,4 +380,148 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Test for `process_payment_intent`.
+	 *
+	 * @param string $event_type The event type.
+	 * @param string $order_status The order status.
+	 * @param bool $order_locked Whether the order is locked.
+	 * @param string $payment_type The payment method.
+	 * @param bool $order_status_final Whether the order status is final.
+	 * @param string $expected_status The expected order status.
+	 * @param string $expected_note The expected order note.
+	 * @return void
+	 * @dataProvider provide_test_process_payment_intent
+	 * @throws WC_Data_Exception When order status is invalid.
+	 */
+	public function test_process_payment_intent( $event_type, $order_status, $order_locked, $payment_type, $order_status_final, $expected_status, $expected_note ) {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( $order_status );
+		if ( $order_locked ) {
+			$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) );
+		}
+		if ( $order_status_final ) {
+			$order->update_meta_data( '_stripe_status_final', true );
+		}
+		$order->update_meta_data( '_stripe_upe_payment_type', $payment_type );
+		if ( in_array( $payment_type, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS, true )
+			|| in_array( $payment_type, WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, true ) ) {
+			$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
+		}
+		$order->save_meta_data();
+		$order->save();
+
+		$notification = (object) [
+			'type' => $event_type,
+			'data' => (object) [
+				'object' => (object) [
+					'id'                 => 'pi_mock',
+					'metadata'           => (object) [
+						'order_id' => $order->get_id(),
+					],
+					'last_payment_error' => (object) [
+						'message' => 'Your card was declined. You can call your bank for details.',
+					],
+				],
+			],
+		];
+
+		$this->mock_webhook_handler->process_payment_intent( $notification );
+
+		$final_order = wc_get_order( $order->get_id() );
+
+		$this->assertSame( $expected_status, $final_order->get_status() );
+		if ( ! empty( $expected_note ) ) {
+			$notes = wc_get_order_notes(
+				[
+					'order_id' => $final_order->get_id(),
+					'limit'    => 1,
+				]
+			);
+			$this->assertMatchesRegularExpression( $expected_note, $notes[0]->content );
+		}
+	}
+
+	/**
+	 * Provider for `test_process_payment_intent`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_process_payment_intent() {
+		return [
+			'invalid status'                              => [
+				'event_type'         => 'payment_intent.succeeded',
+				'order_status'       => 'cancelled',
+				'order locked'       => false,
+				'payment type'       => WC_Stripe_Payment_Methods::CARD,
+				'order_status_final' => false,
+				'expected_status'    => 'cancelled',
+				'expected_note'      => '',
+			],
+			'order is locked'                             => [
+				'event_type'         => 'payment_intent.succeeded',
+				'order_status'       => 'pending',
+				'order locked'       => true,
+				'payment type'       => WC_Stripe_Payment_Methods::CARD,
+				'order_status_final' => false,
+				'expected_status'    => 'pending',
+				'expected_note'      => '',
+			],
+			'success, payment_intent.requires_action, voucher payment' => [
+				'event_type'         => 'payment_intent.requires_action',
+				'order_status'       => 'pending',
+				'order locked'       => false,
+				'payment type'       => WC_Stripe_Payment_Methods::BOLETO,
+				'order_status_final' => false,
+				'expected_status'    => 'on-hold',
+				'expected_note'      => '/Awaiting payment. Order status changed from Pending payment to On hold./',
+			],
+			'success, payment_intent.succeeded, voucher payment' => [
+				'event_type'         => 'payment_intent.succeeded',
+				'order_status'       => 'pending',
+				'order locked'       => false,
+				'payment type'       => WC_Stripe_Payment_Methods::BOLETO,
+				'order_status_final' => false,
+				'expected_status'    => 'pending',
+				'expected_note'      => '',
+			],
+			'success, payment_intent.amount_capturable_updated, async payment, awaiting action' => [
+				'event_type'         => 'payment_intent.amount_capturable_updated',
+				'order_status'       => 'pending',
+				'order locked'       => false,
+				'payment type'       => WC_Stripe_Payment_Methods::CARD,
+				'order_status_final' => false,
+				'expected_status'    => 'pending',
+				'expected_note'      => '',
+			],
+			'success, payment_intent.payment_failed, voucher payment' => [
+				'event_type'         => 'payment_intent.payment_failed',
+				'order_status'       => 'pending',
+				'order locked'       => false,
+				'payment type'       => WC_Stripe_Payment_Methods::BOLETO,
+				'order_status_final' => false,
+				'expected_status'    => 'failed',
+				'expected_note'      => '/Payment not completed in time Order status changed from Pending payment to Failed./',
+			],
+			'success, payment_intent.payment_failed, IPP' => [
+				'event_type'         => 'payment_intent.payment_failed',
+				'order_status'       => 'pending',
+				'order locked'       => false,
+				'payment type'       => WC_Stripe_Payment_Methods::CARD_PRESENT,
+				'order_status_final' => false,
+				'expected_status'    => 'failed',
+				'expected_note'      => '/Stripe SCA authentication failed. Reason: Your card was declined. You can call your bank for details. Order status changed from Pending payment to Failed./',
+			],
+			'success, payment_intent.payment_failed, IPP, status final' => [
+				'event_type'         => 'payment_intent.payment_failed',
+				'order_status'       => 'pending',
+				'order locked'       => false,
+				'payment type'       => WC_Stripe_Payment_Methods::CARD_PRESENT,
+				'order_status_final' => true,
+				'expected_status'    => 'pending',
+				'expected_note'      => '/Stripe SCA authentication failed. Reason: Your card was declined. You can call your bank for details./',
+			],
+		];
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3631

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When we perform In-Person Payments and the payment fails, Stripe sends a `payment_intent.payment_failed` webhook event (as expected), but the body is a bit different: we may not have the `signature` property. Because of it, our webhook handler class fails to retrieve the associated order, skipping the whole failure processing code.

This PR fixes the issue by adding two more ways of extracting the order ID from the webhook event body: from the `order_id` property inside the `metadata` property, and the `charges` array.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Create public-facing test store (JN website recommended)
- Connect your test Stripe account. It must have completed the onboarding process
- Setup webhook calls
- Create a test product
- Follow [this guide](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3631#issuecomment-2566200203) to set up an Android emulator with the Woo app and IPP-enabled. Point it to your store
- Create the new order following the above and try to collect payments using the simulated card reader. [Add any custom amounts that can trigger failures](https://docs.stripe.com/terminal/references/testing#physical-test-cards)
- Confirm that the order is marked as `failed` and a note is added:
```
Stripe SCA authentication failed. Reason: Your card was declined. You can call your bank for details. In testmode, using a physical test card with designated amount ending values produce specific decline responses. See https://stripe.com/docs/terminal/references/testing#physical-test-cards for details. Order status changed from Pending payment to Failed.
```

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

cc @Mayisha @staskus 