### PR TITLE
Check billing interval and period to set in mandate options

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 * Update - Prevent editing of orders awaiting payment capture.
 * Add - Introduce locking and unlocking in refund flow to prevent double refund due to race condition.
+* Fix - Check billing interval and period to set in mandate options.
 * Fix - Check order currency on pay for order page to display supported payment methods.
 
 = 9.0.0 - 2024-12-12 =

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -868,7 +868,8 @@ trait WC_Stripe_Subscriptions_Trait {
 			return [];
 		}
 
-		if ( 1 === count( $subscriptions ) || $cart_contain_switches ) {
+		$has_interval = $sub_billing_period && $sub_billing_interval > 0;
+		if ( $has_interval && ( 1 === count( $subscriptions ) || $cart_contain_switches ) ) {
 			$mandate_options['amount_type']    = 'fixed';
 			$mandate_options['interval']       = $sub_billing_period;
 			$mandate_options['interval_count'] = $sub_billing_interval;

--- a/readme.txt
+++ b/readme.txt
@@ -137,6 +137,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add empty check for cart when checking for allowed products for express checkout.
 * Update - Prevent editing of orders awaiting payment capture.
 * Add - Introduce locking and unlocking in refund flow to prevent double refund due to race condition.
+* Fix - Check billing interval and period to set in mandate options.
 * Fix - Check order currency on pay for order page to display supported payment methods.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3634 

In the issue, it is reported that subscription purchases and renewals failed due to empty values in the `interval` and `interval_count` args in the `mandate_options`. We could not reproduce the bug. One possibility is this might be related to a bigger issue with the HPOS data synchronizer causing object metadata to be wiped/deleted (see https://github.com/woocommerce/woocommerce/issues/53307).


## Changes proposed in this Pull Request:
- Checking if the subscription has billing interval and billing period data. If these are not present we fallback to the else block to use `interval: sporadic`.


## Testing instructions
As the originally reported bug is not reproducible, test subscription and renewal flow to ensure there are no regressions.
**Single subscription**
- As a shopper, add a subscription product to your cart and complete the checkout with a card.
    - Check the logs and confirm that `interval` and `interval_count` are correctly set in the `mandate_options`.
- Renew this subscription as an admin from the subscription edit page.
    - Check the logs and confirm that `interval` and `interval_count` are correctly set in the `mandate_options`.
- Renew this subscription as the shopper from 'My Account > Subscriptions' page.
    - Check the logs and confirm that `interval` and `interval_count` are correctly set in the `mandate_options`.

**Multiple Subscriptions**
- As a shopper, add two subscription products to your cart having different billing intervals and complete the checkout with a card.
    - Check the logs and confirm that `interval: sporadic` is set in the `mandate_options` with no `interval_count`.
- Renew one of the subscriptions as an admin from the corresponding subscription edit page.
    - Check the logs and confirm that `interval` and `interval_count` are correctly set in the `mandate_options`.
- Renew one of the subscriptions as the shopper from 'My Account > Subscriptions' page.
    - Check the logs and confirm that `interval` and `interval_count` are correctly set in the `mandate_options`.