### PR TITLE
Fix excessive emails when enabling the gateway

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@
 * Dev - Add a GitHub Action workflow to run QIT E2E Integrations tests.
 * Fix - Check billing interval and period to set in mandate options.
 * Fix - Check order currency on pay for order page to display supported payment methods.
+* Fix - Duplicate emails when enabling the gateway.
 
 = 9.0.0 - 2024-12-12 =
 * Fix - Fix 404 that happens when using ECE and 3D Secure auth is triggered.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -556,11 +556,11 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return $default;
 		}
 
-		if ( ! empty( $main_settings[ $key ] ) ) {
-			return $main_settings[ $key ];
+		if ( ! is_null( $default ) && '' === $main_settings[ $key ] ) {
+			return $default;
 		}
 
-		return $default;
+		return $main_settings[ $key ];
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -536,12 +536,31 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	/**
 	 * Returns the UPE Payment Method settings option.
 	 *
-	 * Overrides @see WC:Settings_API::get_option_key() to use the same option key as the main Stripe gateway.
-	 *
 	 * @return string
 	 */
 	public function get_option_key() {
-		return 'woocommerce_stripe_settings';
+		return 'woocommerce_stripe_' . $this->stripe_id . '_settings';
+	}
+
+	/**
+	 * Get option from the main Stripe gateway if it exists.
+	 *
+	 * @param string $key Option key.
+	 * @param mixed  $default Value when empty.
+	 * @return string The value specified for the option or a default value for the option.
+	 */
+	public function get_option( $key, $default = null ) {
+		$main_settings = WC_Stripe_Helper::get_stripe_settings();
+
+		if ( empty( $main_settings ) ) {
+			return $default;
+		}
+
+		if ( ! empty( $main_settings[ $key ] ) ) {
+			return $main_settings[ $key ];
+		}
+
+		return $default;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -142,5 +142,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add a GitHub Action workflow to run QIT E2E Integrations tests.
 * Fix - Check billing interval and period to set in mandate options.
 * Fix - Check order currency on pay for order page to display supported payment methods.
+* Fix - Duplicate emails when enabling the gateway.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3660 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
During payment gateway [initialization](https://github.com/woocommerce/woocommerce/blob/92c8f4168dd345da243461feb208bd88693bcf1c/plugins/woocommerce/includes/class-wc-payment-gateways.php#L139), WC core add hooks that will get triggered when the main gateway is enabled. Use of a centralized option_key for all 'child gateways' makes WC core issue separate email notifications for all of them. 
To sidestep this problem, with this change, we use separate `option_key` for each child gateway but still use the parent gateways settings when retrieving them.

Changes made:
- Update `get_option_key()` to return settings specific to the Stripe ID.
- Introduce `get_option()` method to fetch options from the main Stripe gateway.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->
**Test emails**
- In `WooCommerce` -> `Settings` -> `Payments`, toggle the Stripe gateway off and then back on. Make sure only a single email titled `Payment gateway "Stripe" enabled` is sent to the admin.

**Regression tests**
- Enable all payment methods, save settings, refresh the page, confirm the settings are accurate. Verify payment method availability in the blocks/classic checkout pages.
- Disable one specific PM and after save & refresh confirm the settings are accurate and checkout page is accurate.
- Customize a payment method to add a custom title/description. Confirm the settings are saved and reflects on the blocks/classic checkout page.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
