### PR TITLE
Report test webhook errors in the live environment as warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Report test webhook errors in the production environment at debug level
 * Fix - Prevents duplicated credit cards to be added to the customer's account through the My Account page, the shortcode checkout and the block checkout.
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -111,8 +111,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			status_header( 200 );
 			exit;
 		} else {
-			WC_Stripe_Logger::error( 'Webhook failed validation. Reason: ' . $validation_result );
-			WC_Stripe_Logger::error( 'Webhook body: ' . print_r( $request_body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+			// Both live and test webhooks are sent to the production endpoint and we want to record
+			// failures in both cases, but test mode errors should be reported at a lower severity.
+			// @see https://docs.stripe.com/connect/webhooks
+			$is_live_event = $event->livemode ?? true; // This is independent of self::testmode.
+			$log_with_severity = function( string $message ) use ( $is_live_event ) {
+				$is_live_event
+					? WC_Stripe_Logger::error( $message )
+					: WC_Stripe_Logger::debug( $message );
+			};
+			$log_with_severity( 'Webhook failed validation. Reason: ' . $validation_result );
+			$log_with_severity( 'Webhook body: ' . print_r( $request_body, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 
 			WC_Stripe_Webhook_State::set_last_webhook_failure_at( time() );
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Report test webhook errors in the production environment at debug level
 * Fix - Prevents duplicated credit cards to be added to the customer's account through the My Account page, the shortcode checkout and the block checkout.
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.


### PR DESCRIPTION
Stripe sends both test and live webhooks to the live endpoint [(docs)](https://docs.stripe.com/connect/webhooks#:~:text=For%20Connect%20webhooks%2C%20only%20test,transactions%20under%20a%20production%20application.). However signature validation here does not account for this, so test mode events fail validation and get logged as errors. On WPCOM we have alerts that trigger on these errors, which for test events are spurious.

This patch changes the log severity level to `debug` for errors in test mode events.

A further improvement would be to change `validate_request` to account for test mode events, but this is a bigger change. It also doesn't solve the current problem -- test mode signatures would be successfully validated, but any other test mode errors would still get reported as production errors.

Testing
---

To test manually, we'll need the event ID of a test mode webhook sent to the live site. All test events are sent to the live site so any should work; I'm using `setup_intent.succeeded` because that was the event type that instigated this PR). There is a log of these at https://dashboard.stripe.com/test/events.

I then redirected stripe `setup_intent.succeeded` webhooks to a dev site using a stripe CLI command like this (change the event type and site domain as needed):

```
stripe listen --events setup_intent.succeeded --forward-to 'https://very-demure.example.com/?wc-api=wc_stripe'
```

We can resend an event with a command like this (use your own event ID):

```
stripe events resend evt_NNN
```

I think the event can also be resent from the stripe admin from the dot menu on an attempt log entry like this one:

<img width="1319" alt="Screenshot 2025-01-08 at 3 51 47 PM" src="https://github.com/user-attachments/assets/0e825899-9f5a-4834-afd5-2140d51132d4" />

If that worked the CLI should report something like this:

```
2025-01-02 14:36:54   --> setup_intent.succeeded [evt_NNN]
2025-01-02 14:36:55  <--  [204] POST https://very-demure.example.com/?wc-api=wc_stripe [evt_NNN]
```

Since this was a test mode event, it should fail validation and get logged at debug level.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
