### PR TITLE
Fix an issue preventing the new checkout experience to be enabled by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
-* Fix - Fixes the new checkout experience not being enabled by default due to filter in settings.
+* Fix - Fixes the new checkout experience not being enabled by default due to conflict with a migration.
 * Fix - Prevents duplicated credit cards to be added to the customer's account through the My Account page, the shortcode checkout and the block checkout.
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Fixes the new checkout experience not being enabled by default due to filter in settings.
 * Fix - Prevents duplicated credit cards to be added to the customer's account through the My Account page, the shortcode checkout and the block checkout.
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -267,7 +267,7 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 			),
 			'type'        => 'checkbox',
 			'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),
-			'default'     => 'yes',
+			'default'     => 'no',
 			'desc_tip'    => true,
 		],
 	];

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -267,7 +267,7 @@ if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 			),
 			'type'        => 'checkbox',
 			'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),
-			'default'     => 'no',
+			'default'     => 'yes',
 			'desc_tip'    => true,
 		],
 	];

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
-* Fix - Fixes the new checkout experience not being enabled by default due to filter in settings.
+* Fix - Fixes the new checkout experience not being enabled by default due to conflict with a migration.
 * Fix - Prevents duplicated credit cards to be added to the customer's account through the My Account page, the shortcode checkout and the block checkout.
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.0 - xxxx-xx-xx =
+* Fix - Fixes the new checkout experience not being enabled by default due to filter in settings.
 * Fix - Prevents duplicated credit cards to be added to the customer's account through the My Account page, the shortcode checkout and the block checkout.
 * Fix - Return to the correct page when redirect-based payment method fails.
 * Fix - Show default recipient for Payment Authentication Requested email.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -267,7 +267,8 @@ function woocommerce_gateway_stripe() {
 				require_once dirname( __FILE__ ) . '/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php';
 				require_once dirname( __FILE__ ) . '/includes/class-wc-stripe-account.php';
 				new Allowed_Payment_Request_Button_Types_Update();
-				new Migrate_Payment_Request_Data_To_Express_Checkout_Data();
+				// TODO: Temporary disabling the migration as it has a conflict with the new UPE checkout.
+				// new Migrate_Payment_Request_Data_To_Express_Checkout_Data();
 
 				$this->api                           = new WC_Stripe_Connect_API();
 				$this->connect                       = new WC_Stripe_Connect( $this->api );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes p1736431656256189-slack-C05GDK92WGM?thread_ts=1736138325.638449&cid=C05GDK92WGM

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

This was fully tested by me already on both localhost and on a JN website. So, code review should be enough.

If you want to repeat the tests:

- Create a new test environment (from scratch, Docker or JN for example)
- Use the code from this branch on it (`fix/new-checkout-not-enabled-by-default`)
- Confirm that, after connecting your Stripe account, the "Legacy checkout experience" is disabled

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
