### PR TITLE
Use hardcoded names outside module

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -1,11 +1,5 @@
 /* global wc_stripe_params, Stripe */
 
-import {
-	PAYMENT_METHOD_BOLETO,
-	PAYMENT_METHOD_OXXO,
-	PAYMENT_METHOD_SEPA,
-} from 'wcstripe/stripe-utils/constants';
-
 jQuery( function($ ) {
 	'use strict';
 
@@ -544,7 +538,7 @@ jQuery( function($ ) {
 			if ( wc_stripe_form.isSepaChosen() ) {
 				extra_details.currency = $( '#stripe-sepa_debit-payment-data' ).data( 'currency' );
 				extra_details.mandate  = { notification_method: wc_stripe_params.sepa_mandate_notification };
-				extra_details.type     = PAYMENT_METHOD_SEPA;
+				extra_details.type     = 'sepa_debit';
 
 				return stripe.createSource( iban, extra_details ).then( wc_stripe_form.sourceResponse );
 			}
@@ -701,7 +695,7 @@ jQuery( function($ ) {
 		 * After the customer closes the modal proceeds with checkout normally
 		 */
 		handleBoleto: function () {
-			wc_stripe_form.executeCheckout( PAYMENT_METHOD_BOLETO, function ( checkout_response ) {
+			wc_stripe_form.executeCheckout( 'boleto', function ( checkout_response ) {
 				stripe.confirmBoletoPayment(
 					checkout_response.client_secret,
 					checkout_response.confirm_payment_data
@@ -785,7 +779,7 @@ jQuery( function($ ) {
 		 * After the customer closes the modal proceeds with checkout normally
 		 */
 		handleOxxo: function () {
-			wc_stripe_form.executeCheckout( PAYMENT_METHOD_OXXO, function ( checkout_response ) {
+			wc_stripe_form.executeCheckout( 'oxxo', function ( checkout_response ) {
 				stripe.confirmOxxoPayment(
 					checkout_response.client_secret,
 					checkout_response.confirm_payment_data

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 9.1.1 - xxxx-xx-xx =
 * Fix - Payment request button fails to display when the legacy checkout experience is enabled.
+* Fix - Resolves the payment element loading issue in the legacy checkout experience.
 
 = 9.1.0 - 2025-01-09 =
 * Fix - Fixes the new checkout experience not being enabled by default due to conflict with a migration.

--- a/readme.txt
+++ b/readme.txt
@@ -112,5 +112,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.1.1 - xxxx-xx-xx =
 * Fix - Payment request button fails to display when the legacy checkout experience is enabled.
+* Fix - Resolves the payment element loading issue in the legacy checkout experience.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:
The `assets` folder is not built as a module. So any `import` in `assets/js/` folder fails with the error `Cannot use import statement outside a module`. 

Here I have got rid of the import statement and used the hardcoded payment method names in the `stripe.js` file.

## Testing instructions
- Enable the legacy checkout experience.
- Enable card payment method.
- As a shopper, add a product to your cart and go to the checkout page.
- In `develop` branch, notice that the card element fails to load.
- In this branch the card element should load properly.
