### PR TITLE
Fix prb not loading in legacy checkout experience

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.1 - xxxx-xx-xx =
+* Fix - Payment request button fails to display when the legacy checkout experience is enabled.
 
 = 9.1.0 - 2025-01-09 =
 * Fix - Fixes the new checkout experience not being enabled by default due to conflict with a migration.

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -178,7 +178,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return array
 	 */
 	public function get_payment_method_data() {
-		$js_params = WC_Stripe_Feature_Flags::is_stripe_ece_enabled()
+		$js_params = WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_stripe_ece_enabled()
 			? $this->get_express_checkout_javascript_params()
 			: $this->get_payment_request_javascript_params();
 		// We need to call array_merge_recursive so the blocks 'button' setting doesn't overwrite

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -85,7 +85,7 @@ class WC_Stripe_Payment_Request {
 		add_action( 'woocommerce_stripe_updated', [ $this, 'migrate_button_size' ] );
 
 		// Check if ECE feature flag is enabled.
-		if ( WC_Stripe_Feature_Flags::is_stripe_ece_enabled() ) {
+		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_stripe_ece_enabled() ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,5 +111,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.1 - xxxx-xx-xx =
+* Fix - Payment request button fails to display when the legacy checkout experience is enabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3645 

## Changes proposed in this Pull Request:
In the constructor of `includes/payment-methods/class-wc-stripe-payment-request.php` we are bailing early if ECE feature flag is enabled (which is now enabled by default for everyone). But ECE is available for new checkout experience only. Due to this early bailing, neither ECE nor PRB are being registered when the legacy checkout experience is enabled.

Now we are bailing early from PRB only if ECE and the new checkout experience both are enabled.

## Testing instructions
#### New checkout experience. 
- Enable the ECE feature flag. Confirm that on the checkout page, the ECE buttons are loaded and checkout with ECE is successful.
- Disable the ECE feature flag. Confirm that on the checkout page, the PRB buttons are loaded and checkout with PRB is successful.

#### Legacy checkout experience. 
- Enable the ECE feature flag (because it is enabled by default now). Confirm that on the checkout page, the PRB buttons are loaded and checkout with PRB is successful.

