### PR TITLE
Fix webhook order retrieval by intent charges

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.1.1 - xxxx-xx-xx =
+* Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.
 
 = 9.1.0 - 2025-01-09 =
 * Fix - Fixes the new checkout experience not being enabled by default due to conflict with a migration.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1317,8 +1317,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// Try to retrieve from the charges array.
 		if ( ! empty( $intent->charges ) ) {
 			$charge   = $intent->charges[0] ?? [];
-			$order_id = $charge['metadata']['order_id'] ?? null;
-			return wc_get_order( $order_id );
+			$order_id = $charge->metadata->order_id ?? null;
+			return $order_id ? wc_get_order( $order_id ) : false;
 		}
 
 		// Fall back to finding the order via the intent ID.

--- a/readme.txt
+++ b/readme.txt
@@ -111,5 +111,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.1.1 - xxxx-xx-xx =
+* Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -433,20 +433,26 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order->save_meta_data();
 		$order->save();
 
-		$notification = (object) [
+		$notification = [
 			'type' => $event_type,
-			'data' => (object) [
-				'object' => (object) [
+			'data' => [
+				'object' => [
 					'id'                 => 'pi_mock',
-					'metadata'           => (object) [
-						'order_id' => $order->get_id(),
+					'charges'            => [
+						[
+							'metadata' => [
+								'order_id' => $order->get_id(),
+							],
+						],
 					],
-					'last_payment_error' => (object) [
+					'last_payment_error' => [
 						'message' => 'Your card was declined. You can call your bank for details.',
 					],
 				],
 			],
 		];
+
+		$notification = json_decode( wp_json_encode( $notification ) );
 
 		$this->mock_webhook_handler->process_payment_intent( $notification );
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://wordpress.org/support/topic/credit-card-form-not-working-after-last-plugin-update-to-9-1-0/

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When processing webhook events, we try to retrieve the event order in multiple ways by parsing the received payment intent object. On https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3689 I have included another way to search for the order ID (inspired by WooPayments), but the expected format there is incorrect. This PR fixes that by checking for an object instead of an array.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Code review should be enough. I have included additional safety checks, and on https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3704/commits/4b93b08d34f3ba77cfad183dc91a1873d2513179 I have updated our existing unit tests to parse events using the expected format from this change.

It is a bit hard to test this change because I couldn't find any real Stripe event with this format. But you can try to request the webhook endpoint on your store using the event body (/?wc-api=wc_stripe) using Postman or something similar, with a modified event retrieved from https://dashboard.stripe.com/test/events:

- Remove all order_id information from the event body
- Add a `charges` key like:
```
...
charges: [
  {
      metadata: {
        order_id: <your order ID>
      }
  }
]
...
```

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
