### PR TITLE
Potential fix for duplicate charges

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - A potential fix to prevent duplicate charges.
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1910,7 +1910,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
 
 				// If the intent is already successful, return it to prevent duplicate charges
-				if ( in_array( $intent->status, [ WC_Stripe_Intent_Status::SUCCEEDED, WC_Stripe_Intent_Status::REQUIRES_CAPTURE, WC_Stripe_Intent_Status::PROCESSING ], true ) ) {
+				if ( in_array( $intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
 					return $intent;
 				}
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1904,12 +1904,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Check if order already has a successful payment intent
 		$existing_intent = $this->get_intent_from_order( $order );
 		if ( $existing_intent && isset( $existing_intent->id ) ) {
-			// Fetch the latest intent data from Stripe
-			$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
+			$is_payment_intent = 'pi_' === substr( $existing_intent->id, 0, 3 );
+			if ( $is_payment_intent ) {
+				// Fetch the latest intent data from Stripe
+				$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
 
-			// If the intent is already successful, return it to prevent duplicate charges
-			if ( in_array( $intent->status, [ WC_Stripe_Intent_Status::SUCCEEDED, WC_Stripe_Intent_Status::REQUIRES_CAPTURE, WC_Stripe_Intent_Status::PROCESSING ], true ) ) {
-				return $intent;
+				// If the intent is already successful, return it to prevent duplicate charges
+				if ( in_array( $intent->status, [ WC_Stripe_Intent_Status::SUCCEEDED, WC_Stripe_Intent_Status::REQUIRES_CAPTURE, WC_Stripe_Intent_Status::PROCESSING ], true ) ) {
+					return $intent;
+				}
 			}
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1903,16 +1903,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	private function process_payment_intent_for_order( WC_Order $order, array $payment_information, $retry = true ) {
 		// Check if order already has a successful payment intent
 		$existing_intent = $this->get_intent_from_order( $order );
-		if ( $existing_intent && isset( $existing_intent->id ) ) {
-			$is_payment_intent = 'pi_' === substr( $existing_intent->id, 0, 3 );
-			if ( $is_payment_intent ) {
-				// Fetch the latest intent data from Stripe
-				$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
+		if ( $existing_intent && isset( $existing_intent->id ) && 'pi_' === substr( $existing_intent->id, 0, 3 ) ) {
+			// Fetch the latest intent data from Stripe
+			$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
 
-				// If the intent is already successful, return it to prevent duplicate charges
-				if ( in_array( $intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
-					return $intent;
-				}
+			// If the intent is already successful, return it to prevent duplicate charges
+			if ( isset( $intent->status ) && in_array( $intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
+				return $intent;
 			}
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1901,6 +1901,19 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return stdClass
 	 */
 	private function process_payment_intent_for_order( WC_Order $order, array $payment_information, $retry = true ) {
+		// Check if order already has a successful payment intent
+		$existing_intent = $this->get_intent_from_order( $order );
+		if ( $existing_intent && isset( $existing_intent->id ) ) {
+			// Fetch the latest intent data from Stripe
+			$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
+
+			// If the intent is already successful, return it to prevent duplicate charges
+			if ( in_array( $intent->status, [ WC_Stripe_Intent_Status::SUCCEEDED, WC_Stripe_Intent_Status::REQUIRES_CAPTURE, WC_Stripe_Intent_Status::PROCESSING ], true ) ) {
+				return $intent;
+			}
+		}
+
+		// Check if the order has a payment intent that is compatible with the current payment method types.
 		$payment_intent = $this->get_existing_compatible_payment_intent( $order, $payment_information['payment_method_types'] );
 
 		// If the payment intent is not compatible, we need to create a new one. Throws an exception on error.

--- a/readme.txt
+++ b/readme.txt
@@ -111,5 +111,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - A potential fix to prevent duplicate charges.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -2148,6 +2148,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
 		);
 
+		$mock_payment_method = (object) self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
+
 		// Set the appropriate POST flag to trigger a deferred intent request.
 		$_POST = [
 			'payment_method'               => 'stripe',
@@ -2161,9 +2163,21 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->willReturn( $mock_intent );
 
 		$this->mock_gateway
-			->expects( $this->once() )
+			->expects( $this->exactly( 2 ) )
 			->method( 'get_intent_from_order' )
 			->willReturn( $mock_intent );
+
+		$this->mock_gateway
+			->expects( $this->exactly( 2 ) )
+			->method( 'stripe_request' )
+			->withConsecutive(
+				[ 'payment_methods/pm_mock' ],
+				[ 'payment_intents/' . $mock_intent->id ]
+			)
+			->willReturnOnConsecutiveCalls(
+				$mock_payment_method,
+				$mock_intent
+			);
 
 		$this->mock_gateway
 			->expects( $this->once() )
@@ -2174,6 +2188,176 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertMatchesRegularExpression( "/#wc-stripe-confirm-pi:{$order_id}:{$mock_intent->client_secret}/", $response['redirect'] );
+	}
+
+
+	/**
+	 * Test that a successful payment intent is reused instead of creating a new one.
+	 * This prevents duplicate charges when the shopper retries a payment after
+	 * a successful charge but failed order completion.
+	 *
+	 * @return void
+	 * @throws Exception If test fails.
+	 */
+	public function test_process_payment_reuses_successful_payment_intent() {
+		$customer_id = 'cus_mock';
+		$order       = WC_Helper_Order::create_order();
+		$order_id    = $order->get_id();
+
+		$mock_intent = (object) wp_parse_args(
+			[
+				'payment_method'       => 'pm_mock',
+				'payment_method_types' => [ WC_Stripe_Payment_Methods::CARD ],
+				'charges'              => (object) [
+					'data' => [
+						(object) [
+							'id'       => $order_id,
+							'captured' => 'yes',
+							'status'   => 'succeeded',
+						],
+					],
+				],
+				'status'               => WC_Stripe_Intent_Status::SUCCEEDED,
+			],
+			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
+		);
+
+		$mock_payment_method = (object) self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
+
+		// Set the appropriate POST flag to trigger a deferred intent request.
+		$_POST = [
+			'payment_method'               => 'stripe',
+			'wc-stripe-payment-method'     => 'pm_mock',
+			'wc-stripe-is-deferred-intent' => '1',
+		];
+
+		// Mock that we find an existing successful intent on the order
+		$this->mock_gateway
+			->expects( $this->exactly( 1 ) )
+			->method( 'get_intent_from_order' )
+			->willReturn( $mock_intent );
+
+		// Mock both the payment method retrieval and payment intent retrieval
+		$this->mock_gateway
+			->expects( $this->exactly( 2 ) )
+			->method( 'stripe_request' )
+			->withConsecutive(
+				[ 'payment_methods/pm_mock' ],
+				[ "payment_intents/{$mock_intent->id}", null, null, 'POST' ]
+			)
+			->willReturnOnConsecutiveCalls(
+				$mock_payment_method,
+				$mock_intent
+			);
+
+		// We should never try to create a new intent since we have a successful one
+		$this->mock_gateway->intent_controller
+			->expects( $this->never() )
+			->method( 'create_and_confirm_payment_intent' );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( $customer_id );
+
+		$response = $this->mock_gateway->process_payment( $order_id );
+
+		// Verify the response indicates success
+		$this->assertEquals( 'success', $response['result'] );
+	}
+
+	/**
+	 * Test that a failed payment intent is not reused and a new one is created instead.
+	 *
+	 * @return void
+	 * @throws Exception If test fails.
+	 */
+	public function test_process_payment_creates_new_intent_when_existing_intent_failed() {
+		$customer_id = 'cus_mock';
+		$order       = WC_Helper_Order::create_order();
+		$order_id    = $order->get_id();
+
+		$mock_payment_method = (object) self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
+
+		// Create a mock failed payment intent that would be attached to the order
+		$mock_failed_intent = (object) wp_parse_args(
+			[
+				'id'                  => 'pi_mock_failed',
+				'payment_method'      => 'pm_mock',
+				'status'              => WC_Stripe_Intent_Status::CANCELED,
+				'payment_method_types' => [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID ],
+				'charges'             => (object) [
+					'data' => [],
+				],
+			],
+			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
+		);
+
+		// Create a mock successful payment intent that will be created
+		$mock_success_intent = (object) wp_parse_args(
+			[
+				'id'                  => 'pi_mock_new',
+				'payment_method'      => 'pm_mock',
+				'status'              => WC_Stripe_Intent_Status::SUCCEEDED,
+				'payment_method_types' => [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID ],
+				'charges'             => (object) [
+					'data' => [
+						(object) [
+							'id'       => 'ch_mock',
+							'captured' => true,
+							'status'   => 'succeeded',
+						],
+					],
+				],
+			],
+			self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE
+		);
+
+		// Set the appropriate POST flag to trigger a deferred intent request
+		$_POST = [
+			'payment_method'               => 'stripe',
+			'wc-stripe-payment-method'     => 'pm_mock',
+			'wc-stripe-is-deferred-intent' => '1',
+		];
+
+		// Save the failed intent ID to the order
+		$order->update_meta_data( '_stripe_intent_id', $mock_failed_intent->id );
+		$order->save();
+
+		// Mock that we find an existing failed intent on the order
+		$this->mock_gateway
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_intent_from_order' )
+			->willReturn( $mock_failed_intent );
+
+		// Mock both the payment method retrieval and payment intent retrieval
+		$this->mock_gateway
+			->expects( $this->exactly( 2 ) )
+			->method( 'stripe_request' )
+			->withConsecutive(
+				[ 'payment_methods/pm_mock' ],
+				[ "payment_intents/{$mock_failed_intent->id}", null, null, 'POST' ]
+			)
+			->willReturnOnConsecutiveCalls(
+				$mock_payment_method,
+				$mock_failed_intent
+			);
+
+		// We should create a new intent since the existing one failed
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->willReturn( $mock_success_intent );
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( $customer_id );
+
+		$response = $this->mock_gateway->process_payment( $order_id );
+
+		// Verify the response indicates success
+		$this->assertEquals( 'success', $response['result'] );
 	}
 
 	/**

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -2206,6 +2206,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$mock_intent = (object) wp_parse_args(
 			[
+				'id'                   => 'pi_mock',
 				'payment_method'       => 'pm_mock',
 				'payment_method_types' => [ WC_Stripe_Payment_Methods::CARD ],
 				'charges'              => (object) [


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3638

## Changes proposed in this Pull Request:

This PR addresses an edge case that could lead to multiple charges on the same order. During the `process_payment` function, if the process halts or times out after creating and confirming the payment intent on Stripe but before completing the order on the merchant's site, a warning will be displayed, allowing the shopper to retry. If the shopper chooses to ignore the warning and retries, this can result in a duplicate charge. This PR prevents such duplicates by checking whether the associated payment intent is successful. If it is, the payment intent is reused instead of creating a new one.

It's unclear whether this is exactly what happened in #3638, but checking for an existing successful charge should prevent at least one of the paths that could lead to duplicate charges.

WooPayments has a similar check. In addition, it shows a banner in the order summary screen when a duplicate charge attempt is detected. I haven't replicated it here, but that's an improvement we can make to this PR.

![CleanShot 2025-01-14 at 16 58 57](https://github.com/user-attachments/assets/28bc0c67-ed11-4b4e-9286-aeba9eeedb9b)
  

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Simulate duplicate charges**
1. Switch to the `develop` branch.
2. Add the following line [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/c7e54366f6f4dffabcca43eb8e40caee63cef49b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L1966) just before the `return`.
```
exit('simulate_duplicate_charge');
```
3. As a shopper, add a product to the cart and try to complete the order.
4. Notice that the order fails with the following error notice.
![CleanShot 2025-01-14 at 14 26 04](https://github.com/user-attachments/assets/e8306074-ff0b-44c5-a424-cd4cbd319f42)
5. In a separate tab, go to the WC admin area and notice that there's an order with the "Pending payment" status. Note down the order id.
6. Look up the charge in Stripe dashboard and notice that there's a successful charge for the order.
7. Remove the line introduced in step 2. 
8. Retry the order by clicking "Place order" button again.
9. Notice that the order notes in the admin area contains two intent IDs and one charge ID.
10. On the Stripe dashboard, notice that the order was charged twice
![CleanShot 2025-01-14 at 14 33 53](https://github.com/user-attachments/assets/4f5e30fc-d289-4427-8563-b33a2ef883d4)

**Test the fix**
1. Switch to this branch.
2. Repeat the steps from the above test.
3. There should not be two separate charges for the same order in the Stripe dashboard.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
