### PR TITLE
Add support for Reunion country

### DIFF
--- a/assets/js/stripe-payment-request.js
+++ b/assets/js/stripe-payment-request.js
@@ -436,6 +436,12 @@ jQuery( function( $ ) {
 				options.country = 'US';
 			}
 
+			// Reunion Island (RE) is a FR territory supported by Stripe.
+			// It's considered like FR by Stripe.
+			if ( 'RE' === options.country ) {
+				options.country = 'FR';
+			}
+
 			// Handle errors thrown by Stripe, so we don't break the product page
 			try {
 				var paymentRequest = stripe.paymentRequest( options );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Adds support for the Reunion country when checking out using the new checkout experience.
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -52,6 +52,12 @@ export const createPaymentRequestUsingCart = ( stripe, cart ) => {
 		options.country = 'US';
 	}
 
+	// Reunion Island (RE) is a FR territory supported by Stripe.
+	// It's considered like FR by Stripe.
+	if ( options.country === 'RE' ) {
+		options.country = 'FR';
+	}
+
 	return stripe.paymentRequest( options );
 };
 

--- a/readme.txt
+++ b/readme.txt
@@ -111,5 +111,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Adds support for the Reunion country when checking out using the new checkout experience.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3713

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When checking out using PRBs in Reunion (part of France), an error might be thrown:
```
IntegrationError: Invalid value for paymentRequest(): country should be one of the following strings: AE, AT, AU, BE, BG, BR, CA, CH, CI, CR, CY, CZ, DE, DK, DO, EE, ES, FI, FR, GB, GI, GR, GT, HK, HR, HU, ID, IE, IN, IT, JP, LI, LT, LU, LV, MT, MX, MY, NL, NO, NZ, PE, PH, PL, PT, RO, SE, SG, SI, SK, SN, TH, TT, US, UY. You specified: RE.
```
This PR fixes that by overwriting the country param as France when starting the PRB payment request.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

### Confirm the bug

- Checkout and build the `develop` branch
- Connect your Stripe account
- Disable ECE if it is enabled (you can hardcoded `is_stripe_ece_enabled` to `false`)
- Set your store country to Reunion in settings (`wp-admin/admin.php?page=wc-settings`)
- Enable express payment methods (Google Pay, Apple Pay)
- As a shopper, access the store from a public-facing URL
- Attempt to purchase any product
- Confirm that you receive the error:
![Screenshot 2025-01-15 at 10 14 29](https://github.com/user-attachments/assets/d93e593e-91d9-430c-ae98-1b576adec34f)

### Confirm the fix

- Checkout and build this branch now (`fix/add-support-for-reunion-country`)
- Repeat the steps above
- Confirm the error is not thrown anymore

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
