### PR TITLE
Fix insufficient funds error message on the legacy shortcode checkout

### DIFF
--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -890,7 +890,7 @@ jQuery( function($ ) {
 			}
 
 			// Correctly sets the insufficient funds message.
-			if ( 'card_declined' === result.error.code && 'insufficient_funds' === result.error.decline_code ) {
+			if ( 'card_declined' === result.error.code && 'insufficient_funds' === result.error?.decline_code ) {
 				message = wc_stripe_params.insufficient_funds;
 			}
 

--- a/assets/js/stripe.js
+++ b/assets/js/stripe.js
@@ -885,8 +885,13 @@ jQuery( function($ ) {
 				message = wc_stripe_params.invalid_request_error;
 			}
 
-			if ( wc_stripe_params.hasOwnProperty(result.error.code) ) {
+			if ( wc_stripe_params.hasOwnProperty( result.error.code ) ) {
 				message = wc_stripe_params[ result.error.code ];
+			}
+
+			// Correctly sets the insufficient funds message.
+			if ( 'card_declined' === result.error.code && 'insufficient_funds' === result.error.decline_code ) {
+				message = wc_stripe_params.insufficient_funds;
 			}
 
 			wc_stripe_form.reset();

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Fixes incorrect error message for card failures due insufficient funds on the shortcode checkout page (legacy).
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -265,6 +265,7 @@ class WC_Stripe_Helper {
 				'tax_id_invalid'                        => __( 'Invalid Tax Id, please try again with a valid tax id', 'woocommerce-gateway-stripe' ),
 				'invalid_wallet_type'                   => __( 'Invalid wallet payment type, please try again or use an alternative method.', 'woocommerce-gateway-stripe' ),
 				'payment_intent_authentication_failure' => __( 'We are unable to authenticate your payment method. Please choose a different payment method and try again.', 'woocommerce-gateway-stripe' ),
+				'insufficient_funds'                    => __( 'Your card has insufficient funds.', 'woocommerce-gateway-stripe' ),
 			]
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -111,5 +111,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Fixes incorrect error message for card failures due insufficient funds on the shortcode checkout page (legacy).
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3715

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

When checking out with a card with insufficient funds, there's no indication of the issue. This was observed on the legacy version of the shortcode checkout.

This PR fixes the bug by checking for the specific error code contained in the `decline_code` property of the error object.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`fix/fix-insufficient-funds-error-message`)
- Connect your Stripe account
- Enable the legacy checkout experience
- Create a page for the shortcode checkout
- As a shopper, add any product to your cart
- Go to the shortcode checkout page
- Attempt to complete the payment using the card `4000008260003178`
- Click the button to complete the payment
- Confirm that you receive the correct error message onscreen:
<img width="409" alt="Screenshot 2025-01-15 at 14 01 16" src="https://github.com/user-attachments/assets/ca4e896f-2b08-4eaf-99ce-06e75d04c2d9" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
