### PR TITLE
Avoid setting session when PRB not shown

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Fix - Adds support for the Reunion country when checking out using the new checkout experience.
 * Add - Support zero-amount refunds.
 * Fix - A potential fix to prevent duplicate charges.
+* Fix - Improve product page caching when Express Payment buttons are not enabled.
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -128,7 +128,12 @@ class WC_Stripe_Express_Checkout_Element {
 	 * @return void
 	 */
 	public function set_session() {
-		if ( ! $this->express_checkout_helper->is_product() || ( isset( WC()->session ) && WC()->session->has_session() ) ) {
+		// Don't set session cookies on product pages to allow for caching when payment request
+		// buttons are disabled. But keep cookies if there is already an active WC session in place.
+		if (
+			! ( $this->express_checkout_helper->is_product() && $this->express_checkout_helper->should_show_express_checkout_button() )
+			|| ( isset( WC()->session ) && WC()->session->has_session() )
+		) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -187,7 +187,12 @@ class WC_Stripe_Payment_Request {
 	 * @return void
 	 */
 	public function set_session() {
-		if ( ! $this->is_product() || ( isset( WC()->session ) && WC()->session->has_session() ) ) {
+		// Don't set session cookies on product pages to allow for caching when payment request
+		// buttons are disabled. But keep cookies if there is already an active WC session in place.
+		if (
+			! ( $this->is_product() && $this->should_show_payment_request_button() )
+			|| ( isset( WC()->session ) && WC()->session->has_session() )
+		) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,5 +115,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Adds support for the Reunion country when checking out using the new checkout experience.
 * Add - Support zero-amount refunds.
 * Fix - A potential fix to prevent duplicate charges.
+* Fix - Improve product page caching when Express Payment buttons are not enabled.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #1248 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

Express checkout buttons (Apple Pay/ Google Pay) require a WC session cookie. However, setting a cookie with a unique value on page loads makes the page uncacheable. 
The session cookie doesn't need to be set on the product pages if the express checkout buttons are not enabled. This PR adds a check to only set the session cookie when the buttons are enabled on the product page, improving the cacheability.

This follows a similar fix in WooPayments: https://github.com/Automattic/woocommerce-payments/pull/4085
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Test that the cookie is set when Express checkout buttons are shown."**
1. As a merchant, enable GooglePay/ApplePay via the "Express checkouts" section in the settings page.
2. As a shopper, navigate to a product page. Make sure the cart is empty.
3. Make sure Google Pay or Apple Pay button are presented.
4. Open dev tools -> Applications -> Cookies -> [Select your site].
5. Remove the cookie with the name `wp_woocommerce_session_*`
6. Refresh the page. Make sure the cookie is set again.
7. Place an order using Google Pay or Apple Pay. The order should be placed without any errors.

![CleanShot 2025-01-17 at 09 29 28](https://github.com/user-attachments/assets/db77bfe7-ba13-45f5-89cd-3f41a01b5450)


**Test that the cookie is set when Express checkout buttons are not shown."**
1. As a merchant, disable GooglePay/ApplePay via the "Express checkouts" section in the settings page.
2. As a shopper, navigate to a product page. Make sure the cart is empty.
3. Make sure Google Pay or Apple Pay buttons are presented.
4. Open dev tools -> Applications -> Cookies -> [Select your site].
5. Remove the cookie with the name `wp_woocommerce_session_*`
6. Refresh the page. Make sure the cookie is **NOT** set this time.

**(Optional) Test PRBs in legacy checkout**
1. Turn on legacy checkout via WooCommerce -> Settings -> Payments -> Stripe -> Settings -> Advanced Settings.
2. Repeat the previous tests.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
