### PR TITLE
Amazon Pay ECE: add payment flow using confirmation tokens

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Add new payment processing flow using confirmation tokens.
 * Dev - Adds new logs to identify why express payment methods are not being displayed.
 * Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.
 * Fix - Fixes processing of orders through the Pay for Order page when using ECE with Blocks (Store) API.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -513,13 +513,15 @@ export default class WCStripeAPI {
 	 * Pays for an order based on the Express Checkout payment method.
 	 *
 	 * @param {number} order The order ID.
+	 * @param {Object} orderDetails Order details, including order key and billing email.
 	 * @param {Object} paymentData Order data.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutECEPayForOrder( order, paymentData ) {
-		return this.postToBlocksAPI( `/wc/store/v1/checkout/${ order }`, {
-			...paymentData,
-		} );
+	expressCheckoutECEPayForOrder( order, orderDetails, paymentData ) {
+		const billingEmail = orderDetails.billingEmail ?? '';
+		const key = orderDetails.orderKey ?? '';
+		const url = `/wc/store/v1/checkout/${ order }?key=${ key }&billing_email=${ billingEmail }`;
+		return this.postToBlocksAPI( url, paymentData );
 	}
 
 	/**

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -530,6 +530,7 @@ export default class WCStripeAPI {
 	 * @return {Promise} The promise for the request to the server.
 	 */
 	postToBlocksAPI( path, data ) {
+		console.log( 'data', data );
 		return apiFetch( {
 			method: 'POST',
 			path,

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -530,7 +530,6 @@ export default class WCStripeAPI {
 	 * @return {Promise} The promise for the request to the server.
 	 */
 	postToBlocksAPI( path, data ) {
-		console.log( 'data', data );
 		return apiFetch( {
 			method: 'POST',
 			path,

--- a/client/blocks/express-checkout/express-checkout-container.js
+++ b/client/blocks/express-checkout/express-checkout-container.js
@@ -5,13 +5,17 @@ import {
 	getExpressCheckoutButtonAppearance,
 	getExpressCheckoutData,
 	getPaymentMethodTypesForExpressMethod,
+	isManualPaymentMethodCreation,
 } from 'wcstripe/express-checkout/utils';
 
 export const ExpressCheckoutContainer = ( props ) => {
 	const { stripe, billing, expressPaymentMethod } = props;
+
 	const options = {
 		mode: 'payment',
-		paymentMethodCreation: 'manual',
+		...( isManualPaymentMethodCreation( expressPaymentMethod ) && {
+			paymentMethodCreation: 'manual',
+		} ),
 		amount: billing.cartTotal.value,
 		currency: billing.currency.code.toLowerCase(),
 		paymentMethodTypes: getPaymentMethodTypesForExpressMethod(

--- a/client/blocks/express-checkout/express-checkout-container.js
+++ b/client/blocks/express-checkout/express-checkout-container.js
@@ -10,7 +10,6 @@ import {
 
 export const ExpressCheckoutContainer = ( props ) => {
 	const { stripe, billing, expressPaymentMethod } = props;
-
 	const options = {
 		mode: 'payment',
 		...( isManualPaymentMethodCreation( expressPaymentMethod ) && {

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -117,14 +117,14 @@ export const useExpressCheckout = ( {
 	);
 
 	const onConfirm = async ( event ) => {
-		return await onConfirmHandler(
+		return await onConfirmHandler( {
 			api,
 			stripe,
 			elements,
 			completePayment,
 			abortPayment,
-			event
-		);
+			event,
+		} );
 	};
 
 	return {

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -77,7 +77,7 @@ jQuery( function ( $ ) {
 			wcStripeECE.getButtonSeparator().hide();
 		},
 
-		renderButton: ( expressPaymentType, eceButton ) => {
+		renderButton: ( eceButton, expressPaymentType ) => {
 			if ( $( '#wc-stripe-express-checkout-element' ).length ) {
 				const containerName = `wc-stripe-express-checkout-element-${ expressPaymentType }`;
 				$( '#wc-stripe-express-checkout-element' ).append(
@@ -128,6 +128,10 @@ jQuery( function ( $ ) {
 
 			const shippingRates = getShippingRates();
 
+			// For each supported express payment type, create their own
+			// express checkout element. This is necessary as some express payment types
+			// may require different options or configurations, e.g. Amazon Pay
+			// does not support paymentMethodCreation: 'manual'.
 			const expressPaymentTypes = [ 'applePay', 'googlePay', 'link' ];
 			expressPaymentTypes.forEach( ( expressPaymentType ) => {
 				wcStripeECE.createExpressCheckoutElement( expressPaymentType, {
@@ -173,7 +177,7 @@ jQuery( function ( $ ) {
 				},
 			} );
 
-			wcStripeECE.renderButton( expressPaymentType, eceButton );
+			wcStripeECE.renderButton( eceButton, expressPaymentType );
 
 			eceButton.on( 'loaderror', () => {
 				wcStripeECEError = __(

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -234,15 +234,15 @@ jQuery( function ( $ ) {
 
 			eceButton.on( 'confirm', async ( event ) => {
 				const order = options.order ? options.order : 0;
-				return await onConfirmHandler(
+				return await onConfirmHandler( {
 					api,
-					api.getStripe(),
+					stripe: api.getStripe(),
 					elements,
-					wcStripeECE.completePayment,
-					wcStripeECE.abortPayment,
+					completePayment: wcStripeECE.completePayment,
+					abortPayment: wcStripeECE.abortPayment,
 					event,
-					order
-				);
+					order,
+				} );
 			} );
 
 			eceButton.on( 'cancel', () => {

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -273,6 +273,7 @@ jQuery( function ( $ ) {
 
 			eceButton.on( 'confirm', async ( event ) => {
 				const order = options.order ? options.order : 0;
+				const orderDetails = options.orderDetails ?? {};
 				return await onConfirmHandler( {
 					api,
 					stripe: api.getStripe(),
@@ -281,6 +282,7 @@ jQuery( function ( $ ) {
 					abortPayment: wcStripeECE.abortPayment,
 					event,
 					order,
+					orderDetails,
 				} );
 			} );
 
@@ -313,11 +315,29 @@ jQuery( function ( $ ) {
 		 */
 		init: () => {
 			if ( getExpressCheckoutData( 'is_pay_for_order' ) ) {
+				if (
+					typeof wcStripeExpressCheckoutPayForOrderParams ===
+					'undefined'
+				) {
+					return;
+				}
+
 				const {
 					total: { amount: total },
 					displayItems,
 					order,
+					orderDetails,
 				} = wcStripeExpressCheckoutPayForOrderParams;
+
+				// When paying as guest, the order key and billing email are required by the
+				// Blocks API Pay for Order endpoint, which ECE uses.
+				// These fields are both present when the user is logged in.
+				if (
+					! orderDetails?.orderKey ||
+					! orderDetails?.billingEmail
+				) {
+					return;
+				}
 
 				wcStripeECE.startExpressCheckout( {
 					mode: 'payment',
@@ -328,6 +348,7 @@ jQuery( function ( $ ) {
 					locale: getExpressCheckoutData( 'stripe' )?.locale ?? 'en',
 					displayItems,
 					order,
+					orderDetails,
 				} );
 			} else if ( getExpressCheckoutData( 'is_product_page' ) ) {
 				wcStripeECE.startExpressCheckout( {

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -10,8 +10,9 @@ import {
 	getExpressCheckoutButtonAppearance,
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
-	getExpressPaymentMethodTypes,
 	normalizeLineItems,
+	isManualPaymentMethodCreation,
+	getPaymentMethodTypesForExpressMethod,
 } from 'wcstripe/express-checkout/utils';
 import {
 	onAbortPaymentHandler,
@@ -76,9 +77,22 @@ jQuery( function ( $ ) {
 			wcStripeECE.getButtonSeparator().hide();
 		},
 
-		renderButton: ( eceButton ) => {
+		renderButton: ( expressPaymentType, eceButton ) => {
 			if ( $( '#wc-stripe-express-checkout-element' ).length ) {
-				eceButton.mount( '#wc-stripe-express-checkout-element' );
+				const containerName = `wc-stripe-express-checkout-element-${ expressPaymentType }`;
+				$( '#wc-stripe-express-checkout-element' ).append(
+					`<div id="${ containerName }"></div>`
+				);
+
+				eceButton.mount( `#${ containerName }` );
+
+				// If the express payment type, e.g. Apple Pay, is not available,
+				// remove the container.
+				eceButton.on( 'ready', ( { availablePaymentMethods } ) => {
+					if ( ! availablePaymentMethods ) {
+						$( `#${ containerName }` ).remove();
+					}
+				} );
 			}
 		},
 
@@ -93,7 +107,7 @@ jQuery( function ( $ ) {
 		 *
 		 * @param {Object} options ECE options.
 		 */
-		startExpressCheckoutElement: ( options ) => {
+		startExpressCheckout: ( options ) => {
 			const getShippingRates = () => {
 				if ( ! options.requestShipping ) {
 					return [];
@@ -114,12 +128,22 @@ jQuery( function ( $ ) {
 
 			const shippingRates = getShippingRates();
 
+			const expressPaymentTypes = [ 'applePay', 'googlePay', 'link' ];
+			expressPaymentTypes.forEach( ( expressPaymentType ) => {
+				wcStripeECE.createExpressCheckoutElement( expressPaymentType, {
+					...options,
+					shippingRates,
+				} );
+			} );
+		},
+
+		createExpressCheckoutElement: ( expressPaymentType, options ) => {
 			// This is a bit of a hack, but we need some way to get the shipping information before rendering the button, and
 			// since we don't have any address information at this point it seems best to rely on what came with the cart response.
 			// Relying on what's provided in the cart response seems safest since it should always include a valid shipping
 			// rate if one is required and available.
 			// If no shipping rate is found we can't render the button so we just exit.
-			if ( options.requestShipping && ! shippingRates ) {
+			if ( options.requestShipping && ! options.shippingRates ) {
 				return;
 			}
 
@@ -127,18 +151,29 @@ jQuery( function ( $ ) {
 				mode: options.mode ? options.mode : 'payment',
 				amount: options.total,
 				currency: options.currency,
-				paymentMethodCreation: 'manual',
+				...( isManualPaymentMethodCreation( expressPaymentType ) && {
+					paymentMethodCreation: 'manual',
+				} ),
 				appearance: getExpressCheckoutButtonAppearance(),
 				locale: getExpressCheckoutData( 'stripe' )?.locale ?? 'en',
-				paymentMethodTypes: getExpressPaymentMethodTypes(),
+				paymentMethodTypes: getPaymentMethodTypesForExpressMethod(
+					expressPaymentType
+				),
 			} );
 
-			const eceButton = wcStripeECE.createButton(
-				elements,
-				getExpressCheckoutButtonStyleSettings()
-			);
+			const eceButton = wcStripeECE.createButton( elements, {
+				...getExpressCheckoutButtonStyleSettings(),
+				paymentMethods: {
+					amazonPay: 'never',
+					googlePay:
+						expressPaymentType === 'googlePay' ? 'always' : 'never',
+					applePay:
+						expressPaymentType === 'applePay' ? 'always' : 'never',
+					link: expressPaymentType === 'link' ? 'auto' : 'never',
+				},
+			} );
 
-			wcStripeECE.renderButton( eceButton );
+			wcStripeECE.renderButton( expressPaymentType, eceButton );
 
 			eceButton.on( 'loaderror', () => {
 				wcStripeECEError = __(
@@ -213,7 +248,7 @@ jQuery( function ( $ ) {
 					emailRequired: true,
 					shippingAddressRequired: options.requestShipping,
 					phoneNumberRequired: options.requestPhone,
-					shippingRates,
+					shippingRates: options.shippingRates,
 				};
 
 				onClickHandler( event );
@@ -280,7 +315,7 @@ jQuery( function ( $ ) {
 					order,
 				} = wcStripeExpressCheckoutPayForOrderParams;
 
-				wcStripeECE.startExpressCheckoutElement( {
+				wcStripeECE.startExpressCheckout( {
 					mode: 'payment',
 					total,
 					currency: getExpressCheckoutData( 'checkout' )
@@ -291,7 +326,7 @@ jQuery( function ( $ ) {
 					order,
 				} );
 			} else if ( getExpressCheckoutData( 'is_product_page' ) ) {
-				wcStripeECE.startExpressCheckoutElement( {
+				wcStripeECE.startExpressCheckout( {
 					mode: 'payment',
 					total: getExpressCheckoutData( 'product' )?.total.amount,
 					currency: getExpressCheckoutData( 'product' )?.currency,
@@ -307,7 +342,7 @@ jQuery( function ( $ ) {
 			} else {
 				// Cart and Checkout page specific initialization.
 				api.expressCheckoutGetCartDetails().then( ( cart ) => {
-					wcStripeECE.startExpressCheckoutElement( {
+					wcStripeECE.startExpressCheckout( {
 						mode: 'payment',
 						total: cart.order_data.total.amount,
 						currency: getExpressCheckoutData( 'checkout' )

--- a/client/entrypoints/express-checkout/styles.scss
+++ b/client/entrypoints/express-checkout/styles.scss
@@ -4,4 +4,8 @@
 
 #wc-stripe-express-checkout-element {
 	margin-bottom: 12px;
+	display: flex;
+	gap: 10px;
+	flex-wrap: wrap;
+	justify-content: center;
 }

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -271,14 +271,14 @@ describe( 'Express checkout event handlers', () => {
 				error: { message: 'Submit error' },
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
-				event
-			);
+				event,
+			} );
 
 			expect( elements.submit ).toHaveBeenCalled();
 			expect( abortPayment ).toHaveBeenCalledWith(
@@ -294,14 +294,14 @@ describe( 'Express checkout event handlers', () => {
 				error: { message: 'Payment method error' },
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
-				event
-			);
+				event,
+			} );
 
 			expect( elements.submit ).toHaveBeenCalled();
 			expect( stripe.createPaymentMethod ).toHaveBeenCalledWith( {
@@ -331,16 +331,19 @@ describe( 'Express checkout event handlers', () => {
 				},
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
-				event
-			);
+				event,
+			} );
 
-			const expectedOrderData = normalizeOrderData( event, 'pm_123' );
+			const expectedOrderData = normalizeOrderData( {
+				event,
+				paymentMethodId: 'pm_123',
+			} );
 			expect( api.expressCheckoutECECreateOrder ).toHaveBeenCalledWith(
 				expectedOrderData
 			);
@@ -365,14 +368,14 @@ describe( 'Express checkout event handlers', () => {
 			} );
 			api.confirmIntent.mockReturnValue( true );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
-				event
-			);
+				event,
+			} );
 
 			expect( api.confirmIntent ).toHaveBeenCalledWith(
 				'https://example.com/redirect'
@@ -400,14 +403,14 @@ describe( 'Express checkout event handlers', () => {
 				),
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
-				event
-			);
+				event,
+			} );
 
 			expect( api.confirmIntent ).toHaveBeenCalledWith(
 				'https://example.com/redirect'
@@ -435,14 +438,14 @@ describe( 'Express checkout event handlers', () => {
 				),
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
-				event
-			);
+				event,
+			} );
 
 			expect( api.confirmIntent ).toHaveBeenCalledWith(
 				'https://example.com/redirect'
@@ -472,17 +475,17 @@ describe( 'Express checkout event handlers', () => {
 				},
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
 				event,
-				order
-			);
+				order,
+			} );
 
-			const expectedOrderData = normalizeOrderData( event, 'pm_123' );
+			const expectedOrderData = normalizeOrderData( { event, paymentMethodId: 'pm_123' } );
 			expect( api.expressCheckoutECEPayForOrder ).toHaveBeenCalledWith(
 				123,
 				expectedOrderData
@@ -508,15 +511,15 @@ describe( 'Express checkout event handlers', () => {
 			} );
 			api.confirmIntent.mockReturnValue( true );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
 				event,
-				order
-			);
+				order,
+			} );
 
 			expect( api.confirmIntent ).toHaveBeenCalledWith(
 				'https://example.com/redirect'
@@ -544,15 +547,15 @@ describe( 'Express checkout event handlers', () => {
 				),
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
 				event,
-				order
-			);
+				order,
+			} );
 
 			expect( api.confirmIntent ).toHaveBeenCalledWith(
 				'https://example.com/redirect'
@@ -580,15 +583,15 @@ describe( 'Express checkout event handlers', () => {
 				),
 			} );
 
-			await onConfirmHandler(
+			await onConfirmHandler( {
 				api,
 				stripe,
 				elements,
 				completePayment,
 				abortPayment,
 				event,
-				order
-			);
+				order,
+			} );
 
 			expect( api.confirmIntent ).toHaveBeenCalledWith(
 				'https://example.com/redirect'

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -491,6 +491,7 @@ describe( 'Express checkout event handlers', () => {
 			} );
 			expect( api.expressCheckoutECEPayForOrder ).toHaveBeenCalledWith(
 				123,
+				{},
 				expectedOrderData
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -485,7 +485,10 @@ describe( 'Express checkout event handlers', () => {
 				order,
 			} );
 
-			const expectedOrderData = normalizeOrderData( { event, paymentMethodId: 'pm_123' } );
+			const expectedOrderData = normalizeOrderData( {
+				event,
+				paymentMethodId: 'pm_123',
+			} );
 			expect( api.expressCheckoutECEPayForOrder ).toHaveBeenCalledWith(
 				123,
 				expectedOrderData

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -1,11 +1,19 @@
 import { __ } from '@wordpress/i18n';
 import {
+<<<<<<< HEAD
 	getErrorMessageFromNotice,
 	normalizeOrderData,
+=======
+>>>>>>> dc53ad3e (Add payment flow using confirmation tokens)
 	normalizeShippingAddress,
 	normalizeLineItems,
 	getExpressCheckoutData,
+	isManualPaymentMethodCreation,
 } from './utils';
+import {
+	handleConfirmationTokenFlow,
+	handleManualPaymentMethodFlow,
+} from './payment-flow';
 import {
 	trackExpressCheckoutButtonClick,
 	trackExpressCheckoutButtonLoad,
@@ -52,91 +60,19 @@ export const shippingRateChangeHandler = async ( api, event, elements ) => {
 	}
 };
 
-export const onConfirmHandler = async (
-	api,
-	stripe,
-	elements,
-	completePayment,
-	abortPayment,
-	event,
-	order = 0 // Order ID for the pay for order flow.
-) => {
+export const onConfirmHandlerForBlocksAPI = async ( params ) => {
+	const { abortPayment, elements, event } = params;
+
 	const submitResponse = await elements.submit();
 	if ( submitResponse?.error ) {
 		return abortPayment( event, submitResponse?.error?.message );
 	}
 
-	const { paymentMethod, error } = await stripe.createPaymentMethod( {
-		elements,
-	} );
-
-	if ( error ) {
-		return abortPayment( event, error.message );
+	if ( ! isManualPaymentMethodCreation( event.expressPaymentType ) ) {
+		return handleConfirmationTokenFlow( params );
 	}
 
-	try {
-		// Kick off checkout processing step.
-		let orderResponse;
-		if ( ! order ) {
-			orderResponse = await api.expressCheckoutECECreateOrder(
-				normalizeOrderData( event, paymentMethod.id )
-			);
-		} else {
-			orderResponse = await api.expressCheckoutECEPayForOrder(
-				order,
-				normalizeOrderData( event, paymentMethod.id )
-			);
-		}
-
-		if ( orderResponse.payment_result?.payment_status !== 'success' ) {
-			return abortPayment(
-				event,
-				getErrorMessageFromNotice(
-					orderResponse.payment_result?.payment_details.find(
-						( detail ) => detail.key === 'errorMessage'
-					)?.value
-				),
-				true
-			);
-		}
-
-		const confirmationRequest = api.confirmIntent(
-			orderResponse.payment_result.redirect_url
-		);
-
-		// `true` means there is no intent to confirm.
-		if ( confirmationRequest === true ) {
-			completePayment( orderResponse.payment_result.redirect_url );
-		} else {
-			const { request } = confirmationRequest;
-			const redirectUrl = await request;
-
-			completePayment( redirectUrl );
-		}
-	} catch ( e ) {
-		let errorMessage;
-		if ( e.message ) {
-			errorMessage = e.message;
-		} else {
-			const paymentDetailsErrorMessage = e.payment_result?.payment_details.find(
-				( detail ) => detail.key === 'errorMessage'
-			)?.value;
-			if ( paymentDetailsErrorMessage ) {
-				errorMessage = paymentDetailsErrorMessage;
-			}
-		}
-		if ( ! errorMessage ) {
-			errorMessage = __(
-				'There was a problem processing the order.',
-				'woocommerce-gateway-stripe'
-			);
-		}
-		return abortPayment(
-			event,
-			getErrorMessageFromNotice( errorMessage ),
-			true
-		);
-	}
+	return handleManualPaymentMethodFlow( params );
 };
 
 export const onReadyHandler = function ( { availablePaymentMethods } ) {

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -1,9 +1,4 @@
 import {
-<<<<<<< HEAD
-	getErrorMessageFromNotice,
-	normalizeOrderData,
-=======
->>>>>>> dc53ad3e (Add payment flow using confirmation tokens)
 	normalizeShippingAddress,
 	normalizeLineItems,
 	getExpressCheckoutData,
@@ -59,7 +54,7 @@ export const shippingRateChangeHandler = async ( api, event, elements ) => {
 	}
 };
 
-export const onConfirmHandlerForBlocksAPI = async ( params ) => {
+export const onConfirmHandler = async ( params ) => {
 	const { abortPayment, elements, event } = params;
 
 	const submitResponse = await elements.submit();

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import {
 <<<<<<< HEAD
 	getErrorMessageFromNotice,

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -1,8 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import {
-	getErrorMessageFromNotice,
-	normalizeOrderData,
-} from './utils';
+import { getErrorMessageFromNotice, normalizeOrderData } from './utils';
 
 const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 	let errorMessage;
@@ -52,7 +49,7 @@ export const handleManualPaymentMethodFlow = async ( {
 			api,
 			event,
 			paymentMethodId: paymentMethod.id,
-			order
+			order,
 		} );
 
 		if ( result !== 'success' ) {

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -34,6 +34,7 @@ export const handleManualPaymentMethodFlow = async ( {
 	abortPayment,
 	event,
 	order = 0,
+	orderDetails = {},
 } ) => {
 	const { paymentMethod, error } = await stripe.createPaymentMethod( {
 		elements,
@@ -50,6 +51,7 @@ export const handleManualPaymentMethodFlow = async ( {
 			event,
 			paymentMethodId: paymentMethod.id,
 			order,
+			orderDetails,
 		} );
 
 		if ( result !== 'success' ) {
@@ -84,6 +86,7 @@ export const handleConfirmationTokenFlow = async ( {
 	abortPayment,
 	event,
 	order = 0,
+	orderDetails = {},
 } ) => {
 	// Create a ConfirmationToken that we can use later to create and confirm the payment intent.
 	const { error, confirmationToken } = await stripe.createConfirmationToken( {
@@ -109,6 +112,7 @@ export const handleConfirmationTokenFlow = async ( {
 			event,
 			confirmationTokenId: confirmationToken.id,
 			order,
+			orderDetails,
 		} );
 
 		if ( result !== 'success' ) {
@@ -141,11 +145,13 @@ const processOrder = async ( {
 	paymentMethodId,
 	confirmationTokenId,
 	order = 0,
+	orderDetails = {},
 } ) => {
 	let orderResponse;
 	if ( order ) {
 		orderResponse = await api.expressCheckoutECEPayForOrder(
 			order,
+			orderDetails,
 			normalizeOrderData( {
 				event,
 				paymentMethodId,

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -1,0 +1,175 @@
+import { __ } from '@wordpress/i18n';
+import {
+	getErrorMessageFromNotice,
+	normalizeOrderData,
+} from './utils';
+
+const handlePaymentFlowException = ( event, exception, abortPayment ) => {
+	let errorMessage;
+	if ( exception.message ) {
+		errorMessage = exception.message;
+	} else {
+		const paymentDetailsErrorMessage = exception.payment_result?.payment_details.find(
+			( detail ) => detail.key === 'errorMessage'
+		)?.value;
+		if ( paymentDetailsErrorMessage ) {
+			errorMessage = paymentDetailsErrorMessage;
+		}
+	}
+	if ( ! errorMessage ) {
+		errorMessage = __(
+			'There was a problem processing the order.',
+			'woocommerce-gateway-stripe'
+		);
+	}
+	return abortPayment(
+		event,
+		getErrorMessageFromNotice( errorMessage ),
+		true
+	);
+};
+
+export const handleManualPaymentMethodFlow = async ( {
+	api,
+	stripe,
+	elements,
+	completePayment,
+	abortPayment,
+	event,
+	order = 0,
+} ) => {
+	const { paymentMethod, error } = await stripe.createPaymentMethod( {
+		elements,
+	} );
+
+	if ( error ) {
+		return abortPayment( event, error.message );
+	}
+
+	try {
+		// Kick off checkout processing step.
+		const { result, errorMessage, redirect } = await processOrder( {
+			api,
+			event,
+			paymentMethodId: paymentMethod.id,
+			order
+		} );
+
+		if ( result !== 'success' ) {
+			return abortPayment(
+				event,
+				getErrorMessageFromNotice( errorMessage ),
+				true
+			);
+		}
+
+		const confirmationRequest = api.confirmIntent( redirect );
+
+		// `true` means there is no intent to confirm.
+		if ( confirmationRequest === true ) {
+			completePayment( redirect );
+		} else {
+			const { request } = confirmationRequest;
+			const redirectUrl = await request;
+
+			completePayment( redirectUrl );
+		}
+	} catch ( e ) {
+		return handlePaymentFlowException( event, e, abortPayment );
+	}
+};
+
+export const handleConfirmationTokenFlow = async ( {
+	api,
+	stripe,
+	elements,
+	completePayment,
+	abortPayment,
+	event,
+	order = 0,
+} ) => {
+	// Create a ConfirmationToken that we can use later to create and confirm the payment intent.
+	const { error, confirmationToken } = await stripe.createConfirmationToken( {
+		elements,
+		params: {
+			// Required by Amazon Pay, but is not used by express checkout
+			// as it uses a payment modal instead of redirection.
+			return_url: window.location.href,
+		},
+	} );
+
+	if ( error ) {
+		return abortPayment(
+			event,
+			getErrorMessageFromNotice( error.message ),
+			true
+		);
+	}
+
+	try {
+		const { result, errorMessage, redirect } = await processOrder( {
+			api,
+			event,
+			confirmationTokenId: confirmationToken.id,
+			order,
+		} );
+
+		if ( result !== 'success' ) {
+			return abortPayment(
+				event,
+				getErrorMessageFromNotice( errorMessage ),
+				true
+			);
+		}
+
+		const confirmationRequest = api.confirmIntent( redirect );
+
+		// `true` means there is no intent to confirm.
+		if ( confirmationRequest === true ) {
+			completePayment( redirect );
+		} else {
+			const { request } = confirmationRequest;
+			const redirectUrl = await request;
+
+			completePayment( redirectUrl );
+		}
+	} catch ( e ) {
+		return handlePaymentFlowException( event, e, abortPayment );
+	}
+};
+
+const processOrder = async ( {
+	api,
+	event,
+	paymentMethodId,
+	confirmationTokenId,
+	order = 0,
+} ) => {
+	let orderResponse;
+	if ( order ) {
+		orderResponse = await api.expressCheckoutECEPayForOrder(
+			order,
+			normalizeOrderData( {
+				event,
+				paymentMethodId,
+				confirmationTokenId,
+			} )
+		);
+	} else {
+		orderResponse = await api.expressCheckoutECECreateOrder(
+			normalizeOrderData( {
+				event,
+				paymentMethodId,
+				confirmationTokenId,
+			} )
+		);
+	}
+
+	return {
+		result: orderResponse?.payment_result?.payment_status,
+		errorMessage: orderResponse?.payment_result?.payment_details?.find(
+			( detail ) => detail.key === 'errorMessage'
+		)?.value,
+		redirect: orderResponse?.payment_result?.redirect_url,
+	};
+};

--- a/client/express-checkout/utils/__tests__/normalize.test.js
+++ b/client/express-checkout/utils/__tests__/normalize.test.js
@@ -190,6 +190,10 @@ describe( 'Express checkout normalization', () => {
 						value: 'pm_123456',
 					},
 					{
+						key: 'wc-stripe-confirmation-token',
+						value: '',
+					},
+					{
 						key: 'express_payment_type',
 						value: 'express',
 					},
@@ -214,9 +218,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
-				expectedNormalizedData
-			);
+			expect(
+				normalizeOrderData( { event, paymentMethodId } )
+			).toEqual( expectedNormalizedData );
 		} );
 
 		test( 'should normalize order data with missing optional event fields', () => {
@@ -249,6 +253,10 @@ describe( 'Express checkout normalization', () => {
 						value: 'pm_123456',
 					},
 					{
+						key: 'wc-stripe-confirmation-token',
+						value: '',
+					},
+					{
 						key: 'express_payment_type',
 						value: undefined,
 					},
@@ -273,9 +281,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
-				expectedNormalizedData
-			);
+			expect(
+				normalizeOrderData( { event, paymentMethodId } )
+			).toEqual( expectedNormalizedData );
 		} );
 
 		test( 'should normalize order data with minimum required fields', () => {
@@ -312,6 +320,10 @@ describe( 'Express checkout normalization', () => {
 						value: 'pm_123456',
 					},
 					{
+						key: 'wc-stripe-confirmation-token',
+						value: '',
+					},
+					{
 						key: 'express_payment_type',
 						value: undefined,
 					},
@@ -336,9 +348,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
-				expectedNormalizedData
-			);
+			expect(
+				normalizeOrderData( { event, paymentMethodId } )
+			).toEqual( expectedNormalizedData );
 		} );
 	} );
 

--- a/client/express-checkout/utils/__tests__/normalize.test.js
+++ b/client/express-checkout/utils/__tests__/normalize.test.js
@@ -130,7 +130,7 @@ describe( 'Express checkout normalization', () => {
 	} );
 
 	describe( 'normalizeOrderData', () => {
-		test( 'should normalize order data with complete event and paymentMethodId', () => {
+		test( 'should normalize order data with complete event and paymentMethodId/confirmationTokenId', () => {
 			const event = {
 				billingDetails: {
 					name: 'John Doe',
@@ -221,6 +221,37 @@ describe( 'Express checkout normalization', () => {
 			expect(
 				normalizeOrderData( { event, paymentMethodId } )
 			).toEqual( expectedNormalizedData );
+
+			const confirmationTokenId = 'ctoken_123456';
+			const expectedNormalizedDataWithConfirmationToken = {
+				...expectedNormalizedData,
+				payment_data: [
+					{
+						key: 'payment_method',
+						value: 'stripe',
+					},
+					{
+						key: 'wc-stripe-payment-method',
+						value: '',
+					},
+					{
+						key: 'wc-stripe-confirmation-token',
+						value: 'ctoken_123456',
+					},
+					{
+						key: 'express_payment_type',
+						value: 'express',
+					},
+					{
+						key: 'wc-stripe-is-deferred-intent',
+						value: true,
+					},
+				],
+			};
+
+			expect(
+				normalizeOrderData( { event, confirmationTokenId } )
+			).toEqual( expectedNormalizedDataWithConfirmationToken );
 		} );
 
 		test( 'should normalize order data with missing optional event fields', () => {

--- a/client/express-checkout/utils/__tests__/normalize.test.js
+++ b/client/express-checkout/utils/__tests__/normalize.test.js
@@ -218,9 +218,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect(
-				normalizeOrderData( { event, paymentMethodId } )
-			).toEqual( expectedNormalizedData );
+			expect( normalizeOrderData( { event, paymentMethodId } ) ).toEqual(
+				expectedNormalizedData
+			);
 
 			const confirmationTokenId = 'ctoken_123456';
 			const expectedNormalizedDataWithConfirmationToken = {
@@ -312,9 +312,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect(
-				normalizeOrderData( { event, paymentMethodId } )
-			).toEqual( expectedNormalizedData );
+			expect( normalizeOrderData( { event, paymentMethodId } ) ).toEqual(
+				expectedNormalizedData
+			);
 		} );
 
 		test( 'should normalize order data with minimum required fields', () => {
@@ -379,9 +379,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect(
-				normalizeOrderData( { event, paymentMethodId } )
-			).toEqual( expectedNormalizedData );
+			expect( normalizeOrderData( { event, paymentMethodId } ) ).toEqual(
+				expectedNormalizedData
+			);
 		} );
 	} );
 

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -1,7 +1,10 @@
 import ReactDOM from 'react-dom';
 import { ExpressCheckoutElement, Elements } from '@stripe/react-stripe-js';
 import { memoize } from 'lodash';
-import { getPaymentMethodTypesForExpressMethod } from 'wcstripe/express-checkout/utils';
+import {
+	getPaymentMethodTypesForExpressMethod,
+	isManualPaymentMethodCreation,
+} from 'wcstripe/express-checkout/utils';
 import { PAYMENT_METHOD_LINK } from 'wcstripe/stripe-utils/constants';
 
 export const checkPaymentMethodIsAvailable = memoize(
@@ -21,7 +24,9 @@ export const checkPaymentMethodIsAvailable = memoize(
 				stripe={ api.loadStripe() }
 				options={ {
 					mode: 'payment',
-					paymentMethodCreation: 'manual',
+					...( isManualPaymentMethodCreation( paymentMethod ) && {
+						paymentMethodCreation: 'manual',
+					} ),
 					amount: Number( cart.cartTotals.total_price ),
 					currency: cart.cartTotals.currency_code.toLowerCase(),
 					paymentMethodTypes: getPaymentMethodTypesForExpressMethod(

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -373,3 +373,17 @@ export const expressCheckoutNoticeDelay = async () => {
 		setTimeout( resolve, EXPRESS_CHECKOUT_NOTICE_DELAY )
 	);
 };
+
+export const isManualPaymentMethodCreation = ( expressPaymentType ) => {
+	if ( expressPaymentType === 'amazon_pay' ) {
+		return false;
+	}
+
+	// WEOOOW WEEEEOOOOW WEEEEOOOOW! 🚨🚨🚨
+	// TODO: Remove before merge! For testing only!
+	if ( expressPaymentType === 'google_pay' ) {
+		return false;
+	}
+
+	return true;
+};

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -338,6 +338,12 @@ export const expressCheckoutNoticeDelay = async () => {
 	);
 };
 
+/**
+ * Determine if the express payment type should use manual payment method creation.
+ *
+ * @param {string} expressPaymentType The express payment type, e.g 'googlePay' or 'google_pay'
+ * @return {boolean} True if manual payment method creation should be used, false otherwise.
+ */
 export const isManualPaymentMethodCreation = ( expressPaymentType ) => {
 	if ( [ 'amazonPay', 'amazon_pay' ].includes( expressPaymentType ) ) {
 		return false;

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -1,7 +1,6 @@
 /* global wc_stripe_express_checkout_params */
 import jQuery from 'jquery';
-import { isLinkEnabled, getPaymentMethodTypes } from 'wcstripe/stripe-utils';
-import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
+import { isLinkEnabled } from 'wcstripe/stripe-utils';
 import { EXPRESS_CHECKOUT_NOTICE_DELAY } from 'wcstripe/data/constants';
 import {
 	PAYMENT_METHOD_CARD,
@@ -260,29 +259,6 @@ const getRequiredFieldDataFromShortcodeCheckoutForm = ( data ) => {
 };
 
 /**
- * Get array of payment method types to use with intent. Filtering out the method types not part of Express Checkout.
- *
- * @see https://docs.stripe.com/elements/express-checkout-element/accept-a-payment#enable-payment-methods - lists the method types
- * supported and which ones are required by each Express Checkout method.
- *
- * @param {string} paymentMethodType Payment method type Stripe ID.
- * @return {Array} Array of payment method types to use with intent, for Express Checkout.
- */
-export const getExpressPaymentMethodTypes = ( paymentMethodType = null ) => {
-	const expressPaymentMethodTypes = getPaymentMethodTypes(
-		paymentMethodType
-	).filter( ( type ) =>
-		[ 'paypal', 'amazon_pay', PAYMENT_METHOD_CARD ].includes( type )
-	);
-
-	if ( isLinkEnabled() ) {
-		expressPaymentMethodTypes.push( PAYMENT_METHOD_LINK );
-	}
-
-	return expressPaymentMethodTypes;
-};
-
-/**
  * Fetches the payment method types required to process a payment for an Express method.
  *
  * @see https://docs.stripe.com/elements/express-checkout-element/accept-a-payment#enable-payment-methods - lists the method types
@@ -292,23 +268,11 @@ export const getExpressPaymentMethodTypes = ( paymentMethodType = null ) => {
  * @return {Array} Array of payment method types necessary to process a payment for an Express method.
  */
 export const getPaymentMethodTypesForExpressMethod = ( paymentMethodType ) => {
-	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;
-	const paymentMethodTypes = [];
-
-	if ( ! paymentMethodsConfig ) {
-		return paymentMethodTypes;
-	}
-
-	// All express payment methods require 'card' payments. Add it if it's enabled.
-	if ( paymentMethodsConfig?.card !== undefined ) {
-		paymentMethodTypes.push( PAYMENT_METHOD_CARD );
-	}
+	// Google Pay, Apple Pay and Link use the 'card' payment method.
+	const paymentMethodTypes = [ PAYMENT_METHOD_CARD ];
 
 	// Add 'link' payment method type if enabled and requested.
-	if (
-		paymentMethodType === PAYMENT_METHOD_LINK &&
-		isLinkEnabled( paymentMethodsConfig )
-	) {
+	if ( paymentMethodType === PAYMENT_METHOD_LINK && isLinkEnabled() ) {
 		paymentMethodTypes.push( PAYMENT_METHOD_LINK );
 	}
 
@@ -375,13 +339,7 @@ export const expressCheckoutNoticeDelay = async () => {
 };
 
 export const isManualPaymentMethodCreation = ( expressPaymentType ) => {
-	if ( expressPaymentType === 'amazon_pay' ) {
-		return false;
-	}
-
-	// WEOOOW WEEEEOOOOW WEEEEOOOOW! 🚨🚨🚨
-	// TODO: Remove before merge! For testing only!
-	if ( expressPaymentType === 'google_pay' ) {
+	if ( [ 'amazonPay', 'amazon_pay' ].includes( expressPaymentType ) ) {
 		return false;
 	}
 

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -349,5 +349,11 @@ export const isManualPaymentMethodCreation = ( expressPaymentType ) => {
 		return false;
 	}
 
+	// TODO: Uncomment me to test Google Pay on confirmation token flow.
+	// Remove me before merging to production.
+	// if ( [ 'googlePay', 'google_pay' ].includes( expressPaymentType ) ) {
+	// 	return false;
+	// }
+
 	return true;
 };

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -349,11 +349,5 @@ export const isManualPaymentMethodCreation = ( expressPaymentType ) => {
 		return false;
 	}
 
-	// TODO: Uncomment me to test Google Pay on confirmation token flow.
-	// Remove me before merging to production.
-	// if ( [ 'googlePay', 'google_pay' ].includes( expressPaymentType ) ) {
-	// 	return false;
-	// }
-
 	return true;
 };

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -26,15 +26,15 @@ export const normalizeLineItems = ( displayItems ) => {
  *
  * @param {Object} params
  * @param {Object} params.event Stripe's event object.
- * @param {string|null} params.paymentMethodId Payment method ID from Stripe, if using manual payment method flow.
- * @param {string|null} params.confirmationTokenId Confirmation token ID from Stripe, if using confirmation token flow.*
+ * @param {string} params.paymentMethodId Payment method ID from Stripe, if using manual payment method flow.
+ * @param {string} params.confirmationTokenId Confirmation token ID from Stripe, if using confirmation token flow.*
  *
  * @return {Object} Order object in the format WooCommerce expects.
  */
 export const normalizeOrderData = ( {
 	event,
-	paymentMethodId,
-	confirmationTokenId,
+	paymentMethodId = '',
+	confirmationTokenId = '',
 } ) => {
 	const name = event?.billingDetails?.name;
 	const email = event?.billingDetails?.email ?? '';
@@ -75,7 +75,7 @@ export const normalizeOrderData = ( {
 			postcode: shipping?.address?.postal_code ?? '',
 			method: [ event?.shippingRate?.id ?? null ],
 		},
-		customer_note: event.order_comments,
+		customer_note: event?.order_comments,
 		payment_method: 'stripe',
 		payment_data: buildBlocksAPIPaymentData( {
 			expressPaymentType: event?.expressPaymentType,
@@ -129,8 +129,8 @@ export const normalizeShippingAddress = ( shippingAddress ) => {
  */
 const buildBlocksAPIPaymentData = ( {
 	expressPaymentType,
-	paymentMethodId,
-	confirmationTokenId,
+	paymentMethodId = '',
+	confirmationTokenId = '',
 } ) => {
 	return [
 		{

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -24,12 +24,18 @@ export const normalizeLineItems = ( displayItems ) => {
 /**
  * Normalize order data from Stripe's object to the expected format for WC (when using the Blocks API).
  *
- * @param {Object} event Stripe's event object.
- * @param {string} paymentMethodId Stripe's payment method id.
+ * @param {Object} params
+ * @param {Object} params.event Stripe's event object.
+ * @param {string|null} params.paymentMethodId Payment method ID from Stripe, if using manual payment method flow.
+ * @param {string|null} params.confirmationTokenId Confirmation token ID from Stripe, if using confirmation token flow.*
  *
  * @return {Object} Order object in the format WooCommerce expects.
  */
-export const normalizeOrderData = ( event, paymentMethodId ) => {
+export const normalizeOrderData = ( {
+	event,
+	paymentMethodId,
+	confirmationTokenId,
+} ) => {
 	const name = event?.billingDetails?.name;
 	const email = event?.billingDetails?.email ?? '';
 	const billing = event?.billingDetails?.address ?? {};
@@ -71,10 +77,11 @@ export const normalizeOrderData = ( event, paymentMethodId ) => {
 		},
 		customer_note: event.order_comments,
 		payment_method: 'stripe',
-		payment_data: buildBlocksAPIPaymentData(
-			event?.expressPaymentType,
-			paymentMethodId
-		),
+		payment_data: buildBlocksAPIPaymentData( {
+			expressPaymentType: event?.expressPaymentType,
+			paymentMethodId,
+			confirmationTokenId,
+		} ),
 		extensions: applyFilters(
 			'wcstripe.express-checkout.cart-place-order-extension-data',
 			{}
@@ -113,11 +120,18 @@ export const normalizeShippingAddress = ( shippingAddress ) => {
 /**
  * Builds the payment data for the Blocks API.
  *
- * @param {string} expressPaymentType The express payment type.
- * @param {string} paymentMethodId The payment method ID.
+ * @param {Object} params
+ * @param {string} params.expressPaymentType The express payment type.
+ * @param {string} params.paymentMethodId The payment method ID.
+ * @param {string} params.confirmationTokenId The confirmation token ID.
+ *
  * @return {Array} The payment data.
  */
-const buildBlocksAPIPaymentData = ( expressPaymentType, paymentMethodId ) => {
+const buildBlocksAPIPaymentData = ( {
+	expressPaymentType,
+	paymentMethodId,
+	confirmationTokenId,
+} ) => {
 	return [
 		{
 			key: 'payment_method',
@@ -126,6 +140,10 @@ const buildBlocksAPIPaymentData = ( expressPaymentType, paymentMethodId ) => {
 		{
 			key: 'wc-stripe-payment-method',
 			value: paymentMethodId,
+		},
+		{
+			key: 'wc-stripe-confirmation-token',
+			value: confirmationTokenId,
 		},
 		{
 			key: 'express_payment_type',

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -696,7 +696,6 @@ class WC_Stripe_Intent_Controller {
 		// Throws a WC_Stripe_Exception if required information is missing.
 		$required_params = [
 			'amount',
-			'capture_method',
 			'currency',
 			'customer',
 			'level3',
@@ -710,7 +709,9 @@ class WC_Stripe_Intent_Controller {
 
 		// The payment method is not required if we're using the confirmation token flow.
 		if ( empty( $payment_information['confirmation_token'] ) ) {
-			$required_params[]  = 'payment_method';
+			$required_params[] = 'payment_method';
+			$required_params[] = 'capture_method';
+
 			$non_empty_params[] = 'payment_method';
 		}
 
@@ -816,8 +817,6 @@ class WC_Stripe_Intent_Controller {
 	public function update_and_confirm_payment_intent( $payment_intent, $payment_information ) {
 		// Throws a WC_Stripe_Exception if required information is missing.
 		$required_params = [
-			'capture_method',
-			'payment_method',
 			'shipping',
 			'selected_payment_type',
 			'payment_method_types',
@@ -825,6 +824,12 @@ class WC_Stripe_Intent_Controller {
 			'order',
 			'save_payment_method_to_store',
 		];
+
+		// The payment method is not required if we're using the confirmation token flow.
+		if ( empty( $payment_information['confirmation_token'] ) ) {
+			$required_params[] = 'payment_method';
+			$required_params[] = 'capture_method';
+		}
 
 		$instance_params = [ 'order' => 'WC_Order' ];
 
@@ -920,8 +925,7 @@ class WC_Stripe_Intent_Controller {
 		$payment_method_types  = $payment_information['payment_method_types'];
 
 		$request = [
-			'capture_method' => $payment_information['capture_method'],
-			'shipping'       => $payment_information['shipping'],
+			'shipping' => $payment_information['shipping'],
 		];
 
 		$is_using_confirmation_token = ! empty( $payment_information['confirmation_token'] );
@@ -929,6 +933,8 @@ class WC_Stripe_Intent_Controller {
 			$request['confirmation_token'] = $payment_information['confirmation_token'];
 		} else {
 			$request['payment_method'] = $payment_information['payment_method'];
+			$request['capture_method'] = $payment_information['capture_method'];
+
 		}
 
 		// For Stripe Link & SEPA with deferred intent UPE, we must create mandate to acknowledge that terms have been shown to customer.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -243,9 +243,9 @@ class WC_Stripe_Intent_Controller {
 			// 4. Generate the setup intent
 			$setup_intent = WC_Stripe_API::request(
 				[
-					'customer'       => $customer->get_id(),
-					'confirm'        => 'true',
-					'payment_method' => $source_id,
+					'customer'             => $customer->get_id(),
+					'confirm'              => 'true',
+					'payment_method'       => $source_id,
 					'payment_method_types' => [ $source_object->type ],
 				],
 				'setup_intents'
@@ -702,12 +702,17 @@ class WC_Stripe_Intent_Controller {
 			'level3',
 			'metadata',
 			'order',
-			'payment_method',
 			'save_payment_method_to_store',
 			'shipping',
 		];
 
-		$non_empty_params = [ 'payment_method' ];
+		$non_empty_params = [];
+
+		// The payment method is not required if we're using the confirmation token flow.
+		if ( empty( $payment_information['confirmation_token'] ) ) {
+			$required_params[]  = 'payment_method';
+			$non_empty_params[] = 'payment_method';
+		}
 
 		$instance_params = [ 'order' => 'WC_Order' ];
 
@@ -916,12 +921,19 @@ class WC_Stripe_Intent_Controller {
 
 		$request = [
 			'capture_method' => $payment_information['capture_method'],
-			'payment_method' => $payment_information['payment_method'],
 			'shipping'       => $payment_information['shipping'],
 		];
 
+		$is_using_confirmation_token = ! empty( $payment_information['confirmation_token'] );
+		if ( $is_using_confirmation_token ) {
+			$request['confirmation_token'] = $payment_information['confirmation_token'];
+		} else {
+			$request['payment_method'] = $payment_information['payment_method'];
+		}
+
 		// For Stripe Link & SEPA with deferred intent UPE, we must create mandate to acknowledge that terms have been shown to customer.
-		if ( $this->is_mandate_data_required( $selected_payment_type ) ) {
+		// TODO "You cannot provide both a confirmation_token and mandate_data because they both contain payment method information."
+		if ( ! $is_using_confirmation_token && $this->is_mandate_data_required( $selected_payment_type ) ) {
 			$request = $this->add_mandate_data( $request );
 		}
 
@@ -1121,7 +1133,7 @@ class WC_Stripe_Intent_Controller {
 
 			// Check if the subscription has the delayed update all flag and attempt to update all subscriptions after the intent has been confirmed. If successful, display the "updated all subscriptions" notice.
 			if ( WC_Subscriptions_Change_Payment_Gateway::will_subscription_update_all_payment_methods( $subscription ) && WC_Subscriptions_Change_Payment_Gateway::update_all_payment_methods_from_subscription( $subscription, $token->get_gateway_id() ) ) {
-				$notice  = __( 'Payment method updated for all your current subscriptions.', 'woocommerce-gateway-stripe' );
+				$notice = __( 'Payment method updated for all your current subscriptions.', 'woocommerce-gateway-stripe' );
 			}
 
 			wc_add_notice( $notice );

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -932,7 +932,6 @@ class WC_Stripe_Intent_Controller {
 		}
 
 		// For Stripe Link & SEPA with deferred intent UPE, we must create mandate to acknowledge that terms have been shown to customer.
-		// TODO "You cannot provide both a confirmation_token and mandate_data because they both contain payment method information."
 		if ( ! $is_using_confirmation_token && $this->is_mandate_data_required( $selected_payment_type ) ) {
 			$request = $this->add_mandate_data( $request );
 		}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -287,6 +287,10 @@ class WC_Stripe_Express_Checkout_Element {
 		}
 
 		$data['order']          = $order->get_id();
+		$data['orderDetails']   = [
+			'orderKey'     => $order->get_order_key(),
+			'billingEmail' => $order->get_billing_email(),
+		];
 		$data['displayItems']   = $items;
 		$data['needs_shipping'] = false; // This should be already entered/prepared.
 		$data['total']          = [

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -398,7 +398,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['createAndConfirmSetupIntentNonce'] = wp_create_nonce( 'wc_stripe_create_and_confirm_setup_intent_nonce' );
 		$stripe_params['updateFailedOrderNonce']           = wp_create_nonce( 'wc_stripe_update_failed_order_nonce' );
 		$stripe_params['paymentMethodsConfig']             = $this->get_enabled_payment_method_config();
-		$stripe_params['genericErrorMessage']              = __( 'GENERIC: There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-gateway-stripe' );
+		$stripe_params['genericErrorMessage']              = __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-gateway-stripe' );
 		$stripe_params['accountDescriptor']                = $this->statement_descriptor;
 		$stripe_params['addPaymentReturnURL']              = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']             = $enabled_billing_fields;
@@ -429,7 +429,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$order_id = absint( get_query_var( 'order-pay' ) );
 			$order    = wc_get_order( $order_id );
 
-			$stripe_params['orderId']    = $order_id;
+			$stripe_params['orderId'] = $order_id;
 
 			// Make billing country available for subscriptions as well, so country-restricted payment methods can be shown.
 			if ( is_a( $order, 'WC_Order' ) ) {
@@ -783,13 +783,20 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	private function process_payment_with_deferred_intent( int $order_id ) {
 		if ( ! empty( $_POST['wc-stripe-confirmation-token'] ) ) {
-			return $this->process_payment_using_confirmation_token( $order_id );
+			return $this->process_payment_with_confirmation_token( $order_id );
 		}
 
-		return $this->process_payment_using_manual_payment_method( $order_id );
+		return $this->process_payment_with_payment_method( $order_id );
 	}
 
-	private function process_payment_using_manual_payment_method( int $order_id ) {
+	/**
+	 * Process the payment for an order that has a payment method attached.
+	 *
+	 * @param int $order_id ID of order to be processed.
+	 *
+	 * @return array An array with the result of the payment processing, and a redirect URL on success.
+	 */
+	private function process_payment_with_payment_method( int $order_id ) {
 		if ( $this->is_changing_payment_method_for_subscription() ) {
 			return $this->process_change_subscription_payment_with_deferred_intent( $order_id );
 		}
@@ -938,7 +945,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 	}
 
-	private function process_payment_using_confirmation_token( int $order_id ) {
+	/**
+	 * Process the payment for an order that has a confirmation token attached.
+	 *
+	 * @param int $order_id ID of order to be processed.
+	 *
+	 * @return array An array with the result of the payment processing, and a redirect URL on success.
+	 */
+	private function process_payment_with_confirmation_token( int $order_id ) {
 		$order = wc_get_order( $order_id );
 
 		try {
@@ -972,6 +986,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 	}
 
+	/**
+	 * Handle errors that occur during the payment processing.
+	 *
+	 * @param WC_Stripe_Exception $e    The exception that was thrown.
+	 * @param WC_Order            $order The order that was being processed.
+	 *
+	 * @return array
+	 */
 	private function handle_process_payment_error( WC_Stripe_Exception $e, $order ) {
 		$error_message = sprintf(
 			/* translators: localized exception message */
@@ -1568,9 +1590,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function is_prepaid_card( $payment_method ) {
 		return (
-		$payment_method
-		&& ( WC_Stripe_Payment_Methods::CARD === $payment_method->type )
-		&& 'prepaid' === $payment_method->card->funding
+			$payment_method
+			&& ( WC_Stripe_Payment_Methods::CARD === $payment_method->type )
+			&& 'prepaid' === $payment_method->card->funding
 		);
 	}
 
@@ -1684,7 +1706,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$payment_method    = $this->payment_methods[ $payment_method_type ];
 		$payment_method_id = $payment_method instanceof WC_Stripe_UPE_Payment_Method_CC ? $this->id : $payment_method->id;
 		$is_stripe_link    = WC_Stripe_Payment_Methods::LINK === $payment_method_type ||
-		( isset( $stripe_payment_method->type ) && WC_Stripe_Payment_Methods::LINK === $stripe_payment_method->type );
+			( isset( $stripe_payment_method->type ) && WC_Stripe_Payment_Methods::LINK === $stripe_payment_method->type );
 
 		// Stripe Link uses the main gateway to process payments, however Link payments should use the title of the Link payment method.
 		if ( $is_stripe_link && isset( $this->payment_methods[ WC_Stripe_Payment_Methods::LINK ] ) ) {
@@ -1737,7 +1759,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$method_status        = isset( $stripe_capabilities[ $capability_id ] ) ? $stripe_capabilities[ $capability_id ] : 'inactive';
 			$subtext_messages     = $method->get_subtext_messages( $method_status );
 			$aria_label           = sprintf(
-			/* translators: $1%s payment method ID, $2%s "enabled" or "disabled" */
+				/* translators: $1%s payment method ID, $2%s "enabled" or "disabled" */
 				esc_attr__( 'The &quot;%1$s&quot; payment method is currently %2$s', 'woocommerce-gateway-stripe' ),
 				$method_id,
 				$method_enabled_label
@@ -1758,8 +1780,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 							' . ( 'enabled' === $method_enabled ? __( 'Yes', 'woocommerce-gateway-stripe' ) : __( 'No', 'woocommerce-gateway-stripe' ) ) . '
 							</span>
 						</a>'
-					. ( ! $is_automatic_capture_enabled && $method->requires_automatic_capture() ? '<span class="tips dashicons dashicons-warning" style="margin-top: 1px; margin-right: -25px; margin-left: 5px; color: red" data-tip="' . $manual_capture_tip . '" />' : '' ) .
-				'</td>
+						. ( ! $is_automatic_capture_enabled && $method->requires_automatic_capture() ? '<span class="tips dashicons dashicons-warning" style="margin-top: 1px; margin-right: -25px; margin-left: 5px; color: red" data-tip="' . $manual_capture_tip . '" />' : '' ) .
+					'</td>
 					<td class="description wc-stripe-upe-method-selection__description" width="">' . $method->get_description() . '</td>
 				</tr>';
 		}
@@ -1954,7 +1976,19 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return stdClass
 	 */
 	private function process_payment_intent_for_order( WC_Order $order, array $payment_information, $retry = true ) {
-		// TODO amazon-pay-ece
+		// Check if order already has a successful payment intent
+		$existing_intent = $this->get_intent_from_order( $order );
+		if ( $existing_intent && isset( $existing_intent->id ) && 'pi_' === substr( $existing_intent->id, 0, 3 ) ) {
+			// Fetch the latest intent data from Stripe
+			$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
+
+			// If the intent is already successful, return it to prevent duplicate charges
+			if ( isset( $intent->status ) && in_array( $intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
+				return $intent;
+			}
+		}
+
+		// Check if the order has a payment intent that is compatible with the current payment method types.
 		$payment_intent = $this->get_existing_compatible_payment_intent( $order, $payment_information['payment_method_types'] );
 
 		// If the payment intent is not compatible, we need to create a new one. Throws an exception on error.
@@ -1979,7 +2013,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			if ( ! $this->is_retryable_error( $payment_intent->error ) || ! $retry ) {
 				throw new WC_Stripe_Exception(
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					print_r( $payment_intent, true ),
 					$payment_intent->error->message
 				);
@@ -2112,14 +2146,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		];
 
 		if ( ! empty( $payment_method_id ) ) {
-			$payment_method_details = WC_Stripe_API::get_payment_method( $payment_method_id );
-
+			$payment_method_details                              = WC_Stripe_API::get_payment_method( $payment_method_id );
 			$payment_information['payment_method']               = $payment_method_id;
 			$payment_information['payment_method_details']       = $payment_method_details;
 			$payment_information['payment_type']                 = 'single'; // single | recurring.
 			$payment_information['save_payment_method_to_store'] = $save_payment_method_to_store;
-
-			$payment_information['payment_method_options'] = $this->get_payment_method_options(
+			$payment_information['payment_method_options']       = $this->get_payment_method_options(
 				$order,
 				$selected_payment_type,
 				$payment_method_details
@@ -2128,7 +2160,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$confirmation_token_id                               = sanitize_text_field( wp_unslash( $_POST['wc-stripe-confirmation-token'] ?? '' ) );
 			$payment_information['confirmation_token']           = $confirmation_token_id;
 			$payment_information['payment_type']                 = 'single'; // single | recurring.
-			$payment_information['save_payment_method_to_store'] = false; // TODO amazon-pay-ece: What should this be?
+			$payment_information['save_payment_method_to_store'] = false;
 		}
 
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.
@@ -2258,7 +2290,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return string
 	 */
 	private function get_selected_payment_method_type_from_request() {
-		// TODO amazon-pay-ece: $_POST['payment_method'] is 'stripe' for Amazon Pay.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( ! isset( $_POST['payment_method'] ) ) {
 			return '';
@@ -2272,6 +2303,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		return substr( $payment_method_type, 0, 7 ) === 'stripe_' ? substr( $payment_method_type, 7 ) : 'card';
 	}
 
+	/**
+	 * Gets the express payment type, e.g. google_pay, apple_pay, from the request,
+	 *   if applicable.
+	 *
+	 * @return string|null
+	 */
 	private function get_express_payment_type_from_request() {
 		if ( ! isset( $_POST['express_payment_type'] ) ) {
 			return null;
@@ -2566,23 +2603,23 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return $this->get_upe_enabled_at_checkout_payment_method_ids( $order_id );
 		}
 
-		// TODO: check if this will support Link in the Payment Element
-		if ( WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID === $express_payment_type ) {
-			return [
-				WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
-				WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
-			];
-		} elseif ( 'google_pay' === $express_payment_type || 'apple_pay' === $express_payment_type ) {
-			return [
-				WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
-			];
-		} elseif ( 'amazon_pay' === $express_payment_type ) {
-			return [
-				'amazon_pay',
-			];
+		// Check if this is for an express payment
+		if ( ! empty( $express_payment_type ) ) {
+			switch ( $express_payment_type ) {
+				case 'link':
+					return [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID, WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID ];
+				case 'google_pay':
+				case 'apple_pay':
+					return [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID ];
+				case 'amazon_pay':
+					return [ 'amazon_pay' ];
+				default:
+					return [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID ];
+			}
 		}
 
-		// If the "card" type was selected and Link is enabled, include Link in the types.
+		// If the "card" type was selected and Link is enabled, include Link in the types,
+		// to support paying with cards stored in Link.
 		if (
 			WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID === $selected_payment_type &&
 			in_array(
@@ -2596,6 +2633,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 			];
 		}
+
+		// Otherwise, return the selected payment method type.
+		return [ $selected_payment_type ];
 	}
 
 	/**
@@ -2626,7 +2666,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$token_gateway_type = $payment_method->get_retrievable_type();
 
 		if ( WC_Stripe_Payment_Methods::CARD === $token_gateway_type ||
-		WC_Stripe_Payment_Methods::LINK === $token_gateway_type ) {
+			WC_Stripe_Payment_Methods::LINK === $token_gateway_type ) {
 			return $this->id;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2629,7 +2629,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Check if this is for an express payment
 		if ( ! empty( $express_payment_type ) ) {
 			switch ( $express_payment_type ) {
-				case 'link':
+				case WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID:
 					return [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID, WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID ];
 				case 'google_pay':
 				case 'apple_pay':

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2165,11 +2165,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_information['confirmation_token']           = $confirmation_token_id;
 			$payment_information['payment_type']                 = 'single'; // single | recurring.
 			$payment_information['save_payment_method_to_store'] = false;
-			$payment_information['payment_method_options']       = [
-				$selected_payment_type => [
-					'capture_method' => $capture_method,
-				],
-			];
+
+			// When using confirmation tokens with manual capture, we need to
+			// set the capture_method parameter under payment method options.
+			if ( 'manual' === $capture_method ) {
+				$payment_information['payment_method_options'] = [
+					$selected_payment_type => [
+						'capture_method' => 'manual',
+					],
+				];
+			} else {
+				$payment_information['capture_method'] = $capture_method;
+			}
 		}
 
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2131,7 +2131,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'amount'                        => $amount,
 			'currency'                      => $currency,
 			'customer'                      => $this->get_customer_id_for_order( $order ),
-			'capture_method'                => $capture_method,
 			'is_using_saved_payment_method' => $is_using_saved_payment_method,
 			'level3'                        => $this->get_level3_data_from_order( $order ),
 			'metadata'                      => $this->get_metadata_from_order( $order ),
@@ -2157,11 +2156,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$order,
 				$payment_method_details
 			);
+			$payment_information['capture_method']               = $capture_method;
 		} else {
 			$confirmation_token_id                               = sanitize_text_field( wp_unslash( $_POST['wc-stripe-confirmation-token'] ?? '' ) );
 			$payment_information['confirmation_token']           = $confirmation_token_id;
 			$payment_information['payment_type']                 = 'single'; // single | recurring.
 			$payment_information['save_payment_method_to_store'] = false;
+			$payment_information['payment_method_options']       = [
+				$selected_payment_type => [
+					'capture_method' => $capture_method,
+				],
+			];
 		}
 
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2153,8 +2153,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_information['payment_type']                 = 'single'; // single | recurring.
 			$payment_information['save_payment_method_to_store'] = $save_payment_method_to_store;
 			$payment_information['payment_method_options']       = $this->get_payment_method_options(
-				$order,
 				$selected_payment_type,
+				$order,
 				$payment_method_details
 			);
 		} else {
@@ -2173,7 +2173,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		return $payment_information;
 	}
 
-	private function get_payment_method_options( $order, $selected_payment_type, $payment_method_details ) {
+	/**
+	 * Returns the payment method options for the selected payment type.
+	 *
+	 * @param string   $selected_payment_type  The selected payment type, e.g. 'klarna'
+	 * @param WC_Order $order                  The WC Order we are processing a payment for.
+	 * @param stdClass $payment_method_details The payment method details.
+	 */
+	private function get_payment_method_options( $selected_payment_type, $order, $payment_method_details ) {
 		$payment_method_options = [];
 
 		// Specify the client in payment_method_options (currently, Checkout only supports a client value of "web")

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -398,7 +398,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['createAndConfirmSetupIntentNonce'] = wp_create_nonce( 'wc_stripe_create_and_confirm_setup_intent_nonce' );
 		$stripe_params['updateFailedOrderNonce']           = wp_create_nonce( 'wc_stripe_update_failed_order_nonce' );
 		$stripe_params['paymentMethodsConfig']             = $this->get_enabled_payment_method_config();
-		$stripe_params['genericErrorMessage']              = __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-gateway-stripe' );
+		$stripe_params['genericErrorMessage']              = __( 'GENERIC: There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-gateway-stripe' );
 		$stripe_params['accountDescriptor']                = $this->statement_descriptor;
 		$stripe_params['addPaymentReturnURL']              = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']             = $enabled_billing_fields;
@@ -782,6 +782,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return array An array with the result of the payment processing, and a redirect URL on success.
 	 */
 	private function process_payment_with_deferred_intent( int $order_id ) {
+		if ( ! empty( $_POST['wc-stripe-confirmation-token'] ) ) {
+			return $this->process_payment_using_confirmation_token( $order_id );
+		}
+
+		return $this->process_payment_using_manual_payment_method( $order_id );
+	}
+
+	private function process_payment_using_manual_payment_method( int $order_id ) {
 		if ( $this->is_changing_payment_method_for_subscription() ) {
 			return $this->process_change_subscription_payment_with_deferred_intent( $order_id );
 		}
@@ -884,7 +892,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$wallet_and_voucher_methods        = array_merge( WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS );
 				$contains_wallet_or_voucher_method = isset( $payment_intent->payment_method_types ) && count( array_intersect( $wallet_and_voucher_methods, $payment_intent->payment_method_types ) ) !== 0;
 				$contains_redirect_next_action     = isset( $payment_intent->next_action->type ) && in_array( $payment_intent->next_action->type, [ 'redirect_to_url', 'alipay_handle_redirect' ], true )
-					&& ! empty( $payment_intent->next_action->{$payment_intent->next_action->type}->url );
+				&& ! empty( $payment_intent->next_action->{$payment_intent->next_action->type}->url );
 				if ( ! $contains_wallet_or_voucher_method && ! $contains_redirect_next_action ) {
 					// Return the payment method used to process the payment so the block checkout can save the payment method.
 					$response_args['payment_method'] = $payment_information['payment_method'];
@@ -926,29 +934,67 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$response_args
 			);
 		} catch ( WC_Stripe_Exception $e ) {
-			$shopper_error_message = sprintf(
-				/* translators: localized exception message */
-				__( 'There was an error processing the payment: %s', 'woocommerce-gateway-stripe' ),
-				$e->getLocalizedMessage()
-			);
+			$this->handle_process_payment_error( $e, $order );
+		}
+	}
 
-			wc_add_notice( $shopper_error_message, 'error' );
+	private function process_payment_using_confirmation_token( int $order_id ) {
+		$order = wc_get_order( $order_id );
 
-			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+		try {
+			$payment_information = $this->prepare_payment_information_from_request( $order );
 
-			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
+			$this->set_customer_id_for_order( $order, $payment_information['customer'] );
 
-			$order->update_status(
-				'failed',
-				/* translators: localized exception message */
-				sprintf( __( 'Payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getLocalizedMessage() )
-			);
+			if ( $this->is_payment_needed( $order->get_id() ) ) {
+				$payment_intent = $this->process_payment_intent_for_order( $order, $payment_information );
+			} else {
+				// TODO: add confirmation token support, if possible.
+				$payment_intent = $this->process_setup_intent_for_order( $order, $payment_information );
+			}
+
+			$payment_method_id = $payment_intent->payment_method;
+			$this->set_payment_method_id_for_order( $order, $payment_method_id );
+
+			$selected_payment_type = $payment_information['selected_payment_type'];
+
+			// TODO: We want to set the payment method title to 'Amazon Pay', if applicable.
+			$this->set_payment_method_title_for_order( $order, $selected_payment_type );
+
+			$return_url = $this->get_return_url( $order );
 
 			return [
-				'result'   => 'failure',
-				'redirect' => '',
+				'result'   => 'success',
+				'redirect' => $return_url,
 			];
+		} catch ( WC_Stripe_Exception $e ) {
+			$this->handle_process_payment_error( $e, $order );
 		}
+	}
+
+	private function handle_process_payment_error( WC_Stripe_Exception $e, $order ) {
+		$error_message = sprintf(
+			/* translators: localized exception message */
+			__( 'There was an error processing the payment: %s', 'woocommerce-gateway-stripe' ),
+			$e->getLocalizedMessage()
+		);
+
+		wc_add_notice( $error_message, 'error' );
+
+		WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+
+		do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
+
+		$order->update_status(
+			'failed',
+			/* translators: localized exception message */
+			sprintf( __( 'Payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getLocalizedMessage() )
+		);
+
+		return [
+			'result'   => 'failure',
+			'redirect' => '',
+		];
 	}
 
 	/**
@@ -1522,9 +1568,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function is_prepaid_card( $payment_method ) {
 		return (
-			$payment_method
-			&& ( WC_Stripe_Payment_Methods::CARD === $payment_method->type )
-			&& 'prepaid' === $payment_method->card->funding
+		$payment_method
+		&& ( WC_Stripe_Payment_Methods::CARD === $payment_method->type )
+		&& 'prepaid' === $payment_method->card->funding
 		);
 	}
 
@@ -1638,7 +1684,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$payment_method    = $this->payment_methods[ $payment_method_type ];
 		$payment_method_id = $payment_method instanceof WC_Stripe_UPE_Payment_Method_CC ? $this->id : $payment_method->id;
 		$is_stripe_link    = WC_Stripe_Payment_Methods::LINK === $payment_method_type ||
-			( isset( $stripe_payment_method->type ) && WC_Stripe_Payment_Methods::LINK === $stripe_payment_method->type );
+		( isset( $stripe_payment_method->type ) && WC_Stripe_Payment_Methods::LINK === $stripe_payment_method->type );
 
 		// Stripe Link uses the main gateway to process payments, however Link payments should use the title of the Link payment method.
 		if ( $is_stripe_link && isset( $this->payment_methods[ WC_Stripe_Payment_Methods::LINK ] ) ) {
@@ -1691,7 +1737,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$method_status        = isset( $stripe_capabilities[ $capability_id ] ) ? $stripe_capabilities[ $capability_id ] : 'inactive';
 			$subtext_messages     = $method->get_subtext_messages( $method_status );
 			$aria_label           = sprintf(
-				/* translators: $1%s payment method ID, $2%s "enabled" or "disabled" */
+			/* translators: $1%s payment method ID, $2%s "enabled" or "disabled" */
 				esc_attr__( 'The &quot;%1$s&quot; payment method is currently %2$s', 'woocommerce-gateway-stripe' ),
 				$method_id,
 				$method_enabled_label
@@ -1712,8 +1758,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 							' . ( 'enabled' === $method_enabled ? __( 'Yes', 'woocommerce-gateway-stripe' ) : __( 'No', 'woocommerce-gateway-stripe' ) ) . '
 							</span>
 						</a>'
-						. ( ! $is_automatic_capture_enabled && $method->requires_automatic_capture() ? '<span class="tips dashicons dashicons-warning" style="margin-top: 1px; margin-right: -25px; margin-left: 5px; color: red" data-tip="' . $manual_capture_tip . '" />' : '' ) .
-					'</td>
+					. ( ! $is_automatic_capture_enabled && $method->requires_automatic_capture() ? '<span class="tips dashicons dashicons-warning" style="margin-top: 1px; margin-right: -25px; margin-left: 5px; color: red" data-tip="' . $manual_capture_tip . '" />' : '' ) .
+				'</td>
 					<td class="description wc-stripe-upe-method-selection__description" width="">' . $method->get_description() . '</td>
 				</tr>';
 		}
@@ -1908,19 +1954,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return stdClass
 	 */
 	private function process_payment_intent_for_order( WC_Order $order, array $payment_information, $retry = true ) {
-		// Check if order already has a successful payment intent
-		$existing_intent = $this->get_intent_from_order( $order );
-		if ( $existing_intent && isset( $existing_intent->id ) && 'pi_' === substr( $existing_intent->id, 0, 3 ) ) {
-			// Fetch the latest intent data from Stripe
-			$intent = $this->stripe_request( 'payment_intents/' . $existing_intent->id );
-
-			// If the intent is already successful, return it to prevent duplicate charges
-			if ( isset( $intent->status ) && in_array( $intent->status, self::SUCCESSFUL_INTENT_STATUS, true ) ) {
-				return $intent;
-			}
-		}
-
-		// Check if the order has a payment intent that is compatible with the current payment method types.
+		// TODO amazon-pay-ece
 		$payment_intent = $this->get_existing_compatible_payment_intent( $order, $payment_information['payment_method_types'] );
 
 		// If the payment intent is not compatible, we need to create a new one. Throws an exception on error.
@@ -1945,7 +1979,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			if ( ! $this->is_retryable_error( $payment_intent->error ) || ! $retry ) {
 				throw new WC_Stripe_Exception(
-					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					print_r( $payment_intent, true ),
 					$payment_intent->error->message
 				);
@@ -2052,9 +2086,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_method_id = sanitize_text_field( wp_unslash( $_POST['wc-stripe-payment-method'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}
 
-		$payment_method_details = WC_Stripe_API::get_payment_method( $payment_method_id );
-
-		$payment_method_types = $this->get_payment_method_types_for_intent_creation( $selected_payment_type, $order->get_id() );
+		$payment_method_types = $this->get_payment_method_types_for_intent_creation(
+			$selected_payment_type,
+			$order->get_id(),
+			$this->get_express_payment_type_from_request()
+		);
 
 		$payment_information = [
 			'amount'                        => $amount,
@@ -2066,10 +2102,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'metadata'                      => $this->get_metadata_from_order( $order ),
 			'order'                         => $order,
 			'payment_initiated_by'          => 'initiated_by_customer', // initiated_by_merchant | initiated_by_customer.
-			'payment_method'                => $payment_method_id,
-			'payment_method_details'        => $payment_method_details,
-			'payment_type'                  => 'single', // single | recurring.
-			'save_payment_method_to_store'  => $save_payment_method_to_store,
 			'selected_payment_type'         => $selected_payment_type,
 			'payment_method_types'          => $payment_method_types,
 			'shipping'                      => $shipping_details,
@@ -2079,12 +2111,36 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'has_subscription'              => $this->has_subscription( $order->get_id() ),
 		];
 
+		if ( ! empty( $payment_method_id ) ) {
+			$payment_method_details = WC_Stripe_API::get_payment_method( $payment_method_id );
+
+			$payment_information['payment_method']               = $payment_method_id;
+			$payment_information['payment_method_details']       = $payment_method_details;
+			$payment_information['payment_type']                 = 'single'; // single | recurring.
+			$payment_information['save_payment_method_to_store'] = $save_payment_method_to_store;
+
+			$payment_information['payment_method_options'] = $this->get_payment_method_options(
+				$order,
+				$selected_payment_type,
+				$payment_method_details
+			);
+		} else {
+			$confirmation_token_id                               = sanitize_text_field( wp_unslash( $_POST['wc-stripe-confirmation-token'] ?? '' ) );
+			$payment_information['confirmation_token']           = $confirmation_token_id;
+			$payment_information['payment_type']                 = 'single'; // single | recurring.
+			$payment_information['save_payment_method_to_store'] = false; // TODO amazon-pay-ece: What should this be?
+		}
+
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.
 		$is_short_statement_descriptor_enabled = 'yes' === $this->get_option( 'is_short_statement_descriptor_enabled', 'no' );
 		if ( WC_Stripe_Payment_Methods::CARD === $selected_payment_type && $is_short_statement_descriptor_enabled ) {
 			$payment_information['statement_descriptor_suffix'] = WC_Stripe_Helper::get_dynamic_statement_descriptor_suffix( $order );
 		}
 
+		return $payment_information;
+	}
+
+	private function get_payment_method_options( $order, $selected_payment_type, $payment_method_details ) {
 		$payment_method_options = [];
 
 		// Specify the client in payment_method_options (currently, Checkout only supports a client value of "web")
@@ -2119,9 +2175,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			];
 		}
 
-		$payment_information['payment_method_options'] = $payment_method_options;
-
-		return $payment_information;
+		return $payment_method_options;
 	}
 
 	/**
@@ -2204,6 +2258,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return string
 	 */
 	private function get_selected_payment_method_type_from_request() {
+		// TODO amazon-pay-ece: $_POST['payment_method'] is 'stripe' for Amazon Pay.
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( ! isset( $_POST['payment_method'] ) ) {
 			return '';
@@ -2215,6 +2270,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 
 		return substr( $payment_method_type, 0, 7 ) === 'stripe_' ? substr( $payment_method_type, 7 ) : 'card';
+	}
+
+	private function get_express_payment_type_from_request() {
+		if ( ! isset( $_POST['express_payment_type'] ) ) {
+			return null;
+		}
+
+		return sanitize_text_field( wp_unslash( $_POST['express_payment_type'] ) );
 	}
 
 	/**
@@ -2489,13 +2552,34 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 *
 	 * @param string $selected_payment_type The payment type the shopper selected, if any.
 	 * @param int    $order_id              ID of the WC order we're handling.
+	 * @param string|void $express_payment_type  The express payment type, if any.
 	 *
 	 * @return array
 	 */
-	private function get_payment_method_types_for_intent_creation( string $selected_payment_type, int $order_id ): array {
+	private function get_payment_method_types_for_intent_creation(
+		string $selected_payment_type,
+		int $order_id,
+		$express_payment_type = ''
+	): array {
 		// If the shopper didn't select a payment type, return all the enabled ones.
 		if ( '' === $selected_payment_type ) {
 			return $this->get_upe_enabled_at_checkout_payment_method_ids( $order_id );
+		}
+
+		// TODO: check if this will support Link in the Payment Element
+		if ( WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID === $express_payment_type ) {
+			return [
+				WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+				WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
+			];
+		} elseif ( 'google_pay' === $express_payment_type || 'apple_pay' === $express_payment_type ) {
+			return [
+				WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+			];
+		} elseif ( 'amazon_pay' === $express_payment_type ) {
+			return [
+				'amazon_pay',
+			];
 		}
 
 		// If the "card" type was selected and Link is enabled, include Link in the types.
@@ -2512,9 +2596,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 			];
 		}
-
-		// Otherwise, return the selected payment method type.
-		return [ $selected_payment_type ];
 	}
 
 	/**
@@ -2545,7 +2626,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$token_gateway_type = $payment_method->get_retrievable_type();
 
 		if ( WC_Stripe_Payment_Methods::CARD === $token_gateway_type ||
-			WC_Stripe_Payment_Methods::LINK === $token_gateway_type ) {
+		WC_Stripe_Payment_Methods::LINK === $token_gateway_type ) {
 			return $this->id;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -899,7 +899,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$wallet_and_voucher_methods        = array_merge( WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS );
 				$contains_wallet_or_voucher_method = isset( $payment_intent->payment_method_types ) && count( array_intersect( $wallet_and_voucher_methods, $payment_intent->payment_method_types ) ) !== 0;
 				$contains_redirect_next_action     = isset( $payment_intent->next_action->type ) && in_array( $payment_intent->next_action->type, [ 'redirect_to_url', 'alipay_handle_redirect' ], true )
-				&& ! empty( $payment_intent->next_action->{$payment_intent->next_action->type}->url );
+					&& ! empty( $payment_intent->next_action->{$payment_intent->next_action->type}->url );
 				if ( ! $contains_wallet_or_voucher_method && ! $contains_redirect_next_action ) {
 					// Return the payment method used to process the payment so the block checkout can save the payment method.
 					$response_args['payment_method'] = $payment_information['payment_method'];
@@ -941,7 +941,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$response_args
 			);
 		} catch ( WC_Stripe_Exception $e ) {
-			$this->handle_process_payment_error( $e, $order );
+			return $this->handle_process_payment_error( $e, $order );
 		}
 	}
 
@@ -982,7 +982,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				'redirect' => $return_url,
 			];
 		} catch ( WC_Stripe_Exception $e ) {
-			$this->handle_process_payment_error( $e, $order );
+			return $this->handle_process_payment_error( $e, $order );
 		}
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -958,6 +958,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		try {
 			$payment_information = $this->prepare_payment_information_from_request( $order );
 
+			$this->validate_selected_payment_method_type( $payment_information, $order->get_billing_country() );
+
 			$this->set_customer_id_for_order( $order, $payment_information['customer'] );
 
 			if ( $this->is_payment_needed( $order->get_id() ) ) {
@@ -972,7 +974,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			$selected_payment_type = $payment_information['selected_payment_type'];
 
-			// TODO: We want to set the payment method title to 'Amazon Pay', if applicable.
 			$this->set_payment_method_title_for_order( $order, $selected_payment_type );
 
 			$return_url = $this->get_return_url( $order );

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Add new payment processing flow using confirmation tokens.
 * Dev - Adds new logs to identify why express payment methods are not being displayed.
 * Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.
 * Fix - Fixes processing of orders through the Pay for Order page when using ECE with Blocks (Store) API.

--- a/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/test-class-wc-stripe-upe-payment-gateway.php
@@ -358,8 +358,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test basic checkout process_payment flow with deferred intent.
+	 *
+	 * @dataProvider provide_process_payment_deferred_intent_returns_valid_response
 	 */
-	public function test_process_payment_deferred_intent_returns_valid_response() {
+	public function test_process_payment_deferred_intent_returns_valid_response( $post_vars ) {
 		$customer_id = 'cus_mock';
 		$order       = WC_Helper_Order::create_order();
 		$currency    = $order->get_currency();
@@ -382,11 +384,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		);
 
 		// Set the appropriate POST flag to trigger a deferred intent request.
-		$_POST = [
-			'payment_method'               => 'stripe',
-			'wc-stripe-payment-method'     => 'pm_mock',
-			'wc-stripe-is-deferred-intent' => '1',
-		];
+		$_POST = $post_vars;
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
@@ -406,6 +404,30 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( self::MOCK_RETURN_URL, $response['redirect'] );
+	}
+
+	/**
+	 * Provider for `test_process_payment_deferred_intent_returns_valid_response`.
+	 */
+	public function provide_process_payment_deferred_intent_returns_valid_response() {
+		return [
+			'with-payment-method'     => [
+				[
+					'payment_method'               => 'stripe',
+					'wc-stripe-payment-method'     => 'pm_mock',
+					'wc-stripe-confirmation-token' => '',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+			'with-confirmation-token' => [
+				[
+					'payment_method'               => 'stripe',
+					'wc-stripe-payment-method'     => '',
+					'wc-stripe-confirmation-token' => 'ctoken_mock',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+		];
 	}
 
 	/**
@@ -589,8 +611,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 	/**
 	 * Exception handling of the process_payment flow with deferred intent.
+	 *
+	 * @dataProvider provide_process_payment_deferred_intent_handles_exception
 	 */
-	public function test_process_payment_deferred_intent_handles_exception() {
+	public function test_process_payment_deferred_intent_handles_exception( $post_vars ) {
 		$payment_intent_id = 'pi_mock';
 		$customer_id       = 'cus_mock';
 		$order             = WC_Helper_Order::create_order();
@@ -609,11 +633,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			],
 		];
 
-		$_POST = [
-			'payment_method'               => 'stripe',
-			'wc-stripe-payment-method'     => 'pm_mock',
-			'wc-stripe-is-deferred-intent' => '1',
-		];
+		$_POST = $post_vars;
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->once() )
@@ -637,7 +657,34 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'failed', $processed_order->get_status() );
 	}
 
-	public function test_process_payment_deferred_intent_bails_with_empty_payment_type() {
+	/**
+	 * Provider for `test_process_payment_deferred_intent_handles_exception`.
+	 */
+	public function provide_process_payment_deferred_intent_handles_exception() {
+		return [
+			'with-payment-method'     => [
+				[
+					'payment_method'               => 'stripe',
+					'wc-stripe-payment-method'     => 'pm_mock',
+					'wc-stripe-confirmation-token' => '',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+			'with-confirmation-token' => [
+				[
+					'payment_method'               => 'stripe',
+					'wc-stripe-payment-method'     => '',
+					'wc-stripe-confirmation-token' => 'ctoken_mock',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_process_payment_deferred_intent_bails_with_empty_payment_type
+	 */
+	public function test_process_payment_deferred_intent_bails_with_empty_payment_type( $post_vars ) {
 		$payment_intent_id = 'pi_mock';
 		$customer_id       = 'cus_mock';
 		$order             = WC_Helper_Order::create_order();
@@ -656,11 +703,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			],
 		];
 
-		$_POST = [
-			'payment_method'               => '',
-			'wc-stripe-payment-method'     => 'pm_mock',
-			'wc-stripe-is-deferred-intent' => '1',
-		];
+		$_POST = $post_vars;
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->never() )
@@ -683,7 +726,34 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'failed', $processed_order->get_status() );
 	}
 
-	public function test_process_payment_deferred_intent_bails_with_invalid_payment_type() {
+	/**
+	 * Provider for `test_process_payment_deferred_intent_bails_with_empty_payment_type`.
+	 */
+	public function provide_process_payment_deferred_intent_bails_with_empty_payment_type() {
+		return [
+			'with-payment-method'     => [
+				[
+					'payment_method'               => '',
+					'wc-stripe-payment-method'     => 'pm_mock',
+					'wc-stripe-confirmation-token' => '',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+			'with-confirmation-token' => [
+				[
+					'payment_method'               => '',
+					'wc-stripe-payment-method'     => '',
+					'wc-stripe-confirmation-token' => 'ctoken_mock',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider provide_process_payment_deferred_intent_bails_with_invalid_payment_type
+	 */
+	public function test_process_payment_deferred_intent_bails_with_invalid_payment_type( $post_vars ) {
 		$payment_intent_id = 'pi_mock';
 		$customer_id       = 'cus_mock';
 		$order             = WC_Helper_Order::create_order();
@@ -702,11 +772,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			],
 		];
 
-		$_POST = [
-			'payment_method'               => 'some_invalid_type',
-			'wc-stripe-payment-method'     => 'pm_mock',
-			'wc-stripe-is-deferred-intent' => '1',
-		];
+		$_POST = $post_vars;
 
 		$this->mock_gateway->intent_controller
 			->expects( $this->never() )
@@ -727,6 +793,30 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$processed_order = wc_get_order( $order_id );
 		$this->assertEquals( 'failed', $processed_order->get_status() );
+	}
+
+	/**
+	 * Provider for `test_process_payment_deferred_intent_bails_with_invalid_payment_type`.
+	 */
+	public function provide_process_payment_deferred_intent_bails_with_invalid_payment_type() {
+		return [
+			'with-payment-method'     => [
+				[
+					'payment_method'               => 'some_invalid_type',
+					'wc-stripe-payment-method'     => 'pm_mock',
+					'wc-stripe-confirmation-token' => '',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+			'with-confirmation-token' => [
+				[
+					'payment_method'               => 'some_invalid_type',
+					'wc-stripe-payment-method'     => '',
+					'wc-stripe-confirmation-token' => 'ctoken_mock',
+					'wc-stripe-is-deferred-intent' => '1',
+				],
+			],
+		];
 	}
 
 	/**
@@ -1026,7 +1116,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			'captured'               => true,
 			'status'                 => 'succeeded',
 			'payment_method_details' => [
-				'type'       => WC_Stripe_Payment_Methods::BANCONTACT,
+				'type'                                => WC_Stripe_Payment_Methods::BANCONTACT,
 				WC_Stripe_Payment_Methods::BANCONTACT => [
 					'generated_sepa_debit' => $generated_payment_method_id,
 				],
@@ -2283,11 +2373,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// Create a mock failed payment intent that would be attached to the order
 		$mock_failed_intent = (object) wp_parse_args(
 			[
-				'id'                  => 'pi_mock_failed',
-				'payment_method'      => 'pm_mock',
-				'status'              => WC_Stripe_Intent_Status::CANCELED,
+				'id'                   => 'pi_mock_failed',
+				'payment_method'       => 'pm_mock',
+				'status'               => WC_Stripe_Intent_Status::CANCELED,
 				'payment_method_types' => [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID ],
-				'charges'             => (object) [
+				'charges'              => (object) [
 					'data' => [],
 				],
 			],
@@ -2297,11 +2387,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// Create a mock successful payment intent that will be created
 		$mock_success_intent = (object) wp_parse_args(
 			[
-				'id'                  => 'pi_mock_new',
-				'payment_method'      => 'pm_mock',
-				'status'              => WC_Stripe_Intent_Status::SUCCEEDED,
+				'id'                   => 'pi_mock_new',
+				'payment_method'       => 'pm_mock',
+				'status'               => WC_Stripe_Intent_Status::SUCCEEDED,
 				'payment_method_types' => [ WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID ],
-				'charges'             => (object) [
+				'charges'              => (object) [
 					'data' => [
 						(object) [
 							'id'       => 'ch_mock',


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3737 

## Changes proposed in this Pull Request:
To set the stage for Amazon Pay, we need to introduce a payment flow that uses confirmation tokens instead of manually created payment methods.

Since Amazon Pay does not support `paymentMethodCreation: manual`, we cannot use the same payment element to create all express checkout buttons.

This PR makes the following changes:
- We add a "confirmation token" branch to deferred intent payment processing
- For product page, classic cart, classic checkout and Pay-for-Order pages, we split the express checkout payment types: creating one payment element for each type.
   - This is already our approach for block cart and block checkout. 
   - As we are splitting the express payment types (and as such, we have to mount them in children divs under the main div), the width/layout for the express payment buttons have slightly changed. See comments for the before and after.

## Testing instructions
1. Purchase items using ECE on the different pages that we display them: product page, classic/block checkout, classic/block cart, and Pay-for-Order page. Purchases should behave as expected.
    - As all of our express payment types are set to use manual payment method creation, this is a regression check. Everything should behave the same way as before. 
2. Purchase products using non-express payment methods, e.g. credit card, Klarna. Purchases should behave as expected. 
3. To test the newly-added confirmation tokens flow, uncomment https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3741/files#r1927748266, which will set Google Pay to use the new flow. Do not forget to rebuild your source afterwards.
4. With Google Pay set to use confirmation tokens, purchase items using Google Pay on the different pages where we display them.
6. In wp-admin, check that the orders get set to "Processing" or "Completed". With confirmation tokens, you may have to wait a few minutes (around 3-5 mins) for it. 
7. Test confirmation token flow + manual capture:
    - In Stripe Settings > Transaction Preferences, turn on "capture later".
    - Verify that you can purchase items without any problem.
    - Similar to automatic capture, it may take a few minutes for the order status to change from "Pending payment" to "On hold".
    - Change the status to "Processing" to capture the payment.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
