### PR TITLE
Enabling Blocks API for ECE by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Enables the use of Blocks API for Express Checkout Element orders by default.
 * Fix - Fixes order attribution data for the Express Checkout Element when using the Blocks API to process.
 * Tweak - Process ECE orders using the Blocks API.
 * Fix - Fixes incorrect error message for card failures due insufficient funds on the shortcode checkout page (legacy).

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -519,34 +519,6 @@ export default class WCStripeAPI {
 	 * @return {Promise} Promise for the request to the server.
 	 */
 	expressCheckoutECECreateOrder( paymentData ) {
-		return this.request( getExpressCheckoutAjaxURL( 'create_order' ), {
-			_wpnonce: getExpressCheckoutData( 'nonce' )?.checkout,
-			...getRequiredFieldDataFromCheckoutForm( paymentData ),
-		} );
-	}
-
-	/**
-	 * Pays for an order based on the Express Checkout payment method.
-	 *
-	 * @param {number} order The order ID.
-	 * @param {Object} paymentData Order data.
-	 * @return {Promise} Promise for the request to the server.
-	 */
-	expressCheckoutECEPayForOrder( order, paymentData ) {
-		return this.request( getExpressCheckoutAjaxURL( 'pay_for_order' ), {
-			_wpnonce: getExpressCheckoutData( 'nonce' )?.pay_for_order,
-			order,
-			...paymentData,
-		} );
-	}
-
-	/**
-	 * Creates order based on Express Checkout ECE payment method.
-	 *
-	 * @param {Object} paymentData Order data.
-	 * @return {Promise} Promise for the request to the server.
-	 */
-	expressCheckoutECECreateOrderForBlocksAPI( paymentData ) {
 		return this.postToBlocksAPI( '/wc/store/v1/checkout', {
 			...getRequiredFieldDataFromCheckoutForm( paymentData ),
 		} );
@@ -559,7 +531,7 @@ export default class WCStripeAPI {
 	 * @param {Object} paymentData Order data.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutECEPayForOrderForBlocksAPI( order, paymentData ) {
+	expressCheckoutECEPayForOrder( order, paymentData ) {
 		return this.postToBlocksAPI( `/wc/store/v1/checkout/${ order }`, {
 			...paymentData,
 		} );

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -7,7 +7,6 @@ import {
 	onClickHandler,
 	onCompletePaymentHandler,
 	onConfirmHandler,
-	onConfirmHandlerForBlocksAPI,
 } from 'wcstripe/express-checkout/event-handler';
 import {
 	displayExpressCheckoutNotice,
@@ -118,16 +117,6 @@ export const useExpressCheckout = ( {
 	);
 
 	const onConfirm = async ( event ) => {
-		if ( getExpressCheckoutData( 'use_blocks_api' ) ) {
-			return await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event
-			);
-		}
 		return await onConfirmHandler(
 			api,
 			stripe,

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -19,7 +19,6 @@ import {
 	onClickHandler,
 	onCompletePaymentHandler,
 	onConfirmHandler,
-	onConfirmHandlerForBlocksAPI,
 	onReadyHandler,
 	shippingAddressChangeHandler,
 	shippingRateChangeHandler,
@@ -235,17 +234,6 @@ jQuery( function ( $ ) {
 
 			eceButton.on( 'confirm', async ( event ) => {
 				const order = options.order ? options.order : 0;
-				if ( getExpressCheckoutData( 'use_blocks_api' ) ) {
-					return await onConfirmHandlerForBlocksAPI(
-						api,
-						api.getStripe(),
-						elements,
-						wcStripeECE.completePayment,
-						wcStripeECE.abortPayment,
-						event,
-						order
-					);
-				}
 				return await onConfirmHandler(
 					api,
 					api.getStripe(),

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -6,12 +6,9 @@ import {
 	normalizeShippingAddress,
 	normalizeOrderData,
 	normalizePayForOrderData,
-	normalizeOrderDataForBlocksAPI,
-	normalizePayForOrderDataForBlocksAPI,
 } from '../utils';
 import {
 	onConfirmHandler,
-	onConfirmHandlerForBlocksAPI,
 	shippingAddressChangeHandler,
 	shippingRateChangeHandler,
 } from 'wcstripe/express-checkout/event-handler';
@@ -324,8 +321,15 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				result: 'error',
-				messages: 'Order creation error',
+				payment_result: {
+					payment_status: 'error',
+					payment_details: [
+						{
+							key: 'errorMessage',
+							value: 'Order creation error',
+						},
+					],
+				},
 			} );
 
 			await onConfirmHandler(
@@ -355,8 +359,10 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				result: 'success',
-				redirect: 'https://example.com/redirect',
+				payment_result: {
+					payment_status: 'success',
+					redirect_url: 'https://example.com/redirect',
+				},
 			} );
 			api.confirmIntent.mockReturnValue( true );
 
@@ -384,14 +390,15 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				result: 'success',
-				redirect: 'https://example.com/redirect',
+				payment_result: {
+					payment_status: 'success',
+					redirect_url: 'https://example.com/redirect',
+				},
 			} );
 			api.confirmIntent.mockReturnValue( {
 				request: Promise.resolve(
 					'https://example.com/confirmation_redirect'
 				),
-				isOrderPage: false,
 			} );
 
 			await onConfirmHandler(
@@ -418,14 +425,15 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				result: 'success',
-				redirect: 'https://example.com/redirect',
+				payment_result: {
+					payment_status: 'success',
+					redirect_url: 'https://example.com/redirect',
+				},
 			} );
 			api.confirmIntent.mockReturnValue( {
 				request: Promise.reject(
 					new Error( 'Intent confirmation error' )
 				),
-				isOrderPage: false,
 			} );
 
 			await onConfirmHandler(
@@ -442,7 +450,8 @@ describe( 'Express checkout event handlers', () => {
 			);
 			expect( abortPayment ).toHaveBeenCalledWith(
 				event,
-				'Intent confirmation error'
+				'Intent confirmation error',
+				true
 			);
 			expect( completePayment ).not.toHaveBeenCalled();
 		} );
@@ -453,8 +462,15 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				result: 'error',
-				messages: 'Order creation error',
+				payment_result: {
+					payment_status: 'error',
+					payment_details: [
+						{
+							key: 'errorMessage',
+							value: 'Order creation error',
+						},
+					],
+				},
 			} );
 
 			await onConfirmHandler(
@@ -489,8 +505,10 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				result: 'success',
-				redirect: 'https://example.com/redirect',
+				payment_result: {
+					payment_status: 'success',
+					redirect_url: 'https://example.com/redirect',
+				},
 			} );
 			api.confirmIntent.mockReturnValue( true );
 
@@ -519,14 +537,15 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				result: 'success',
-				redirect: 'https://example.com/redirect',
+				payment_result: {
+					payment_status: 'success',
+					redirect_url: 'https://example.com/redirect',
+				},
 			} );
 			api.confirmIntent.mockReturnValue( {
 				request: Promise.resolve(
 					'https://example.com/confirmation_redirect'
 				),
-				isOrderPage: false,
 			} );
 
 			await onConfirmHandler(
@@ -554,417 +573,18 @@ describe( 'Express checkout event handlers', () => {
 				paymentMethod: { id: 'pm_123' },
 			} );
 			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				result: 'success',
-				redirect: 'https://example.com/redirect',
+				payment_result: {
+					payment_status: 'success',
+					redirect_url: 'https://example.com/redirect',
+				},
 			} );
 			api.confirmIntent.mockReturnValue( {
 				request: Promise.reject(
 					new Error( 'Intent confirmation error' )
 				),
-				isOrderPage: false,
 			} );
 
 			await onConfirmHandler(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order
-			);
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Intent confirmation error'
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-	} );
-
-	describe( 'onConfirmHandlerForBlocksAPI', () => {
-		let api;
-		let stripe;
-		let elements;
-		let completePayment;
-		let abortPayment;
-		let event;
-		let order;
-
-		beforeEach( () => {
-			api = {
-				expressCheckoutECECreateOrderForBlocksAPI: jest.fn(),
-				expressCheckoutECEPayForOrderForBlocksAPI: jest.fn(),
-				confirmIntent: jest.fn(),
-			};
-			stripe = {
-				createPaymentMethod: jest.fn(),
-			};
-			elements = {
-				submit: jest.fn(),
-			};
-			completePayment = jest.fn();
-			abortPayment = jest.fn();
-			event = {
-				billingDetails: {
-					name: 'John Doe',
-					email: 'john.doe@example.com',
-					address: {
-						organization: 'Some Company',
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-					phone: '(123) 456-7890',
-				},
-				shippingAddress: {
-					name: 'John Doe',
-					organization: 'Some Company',
-					address: {
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-				},
-				shippingRate: { id: 'rate_1' },
-				expressPaymentType: 'express',
-			};
-			order = 123;
-		} );
-
-		afterEach( () => {
-			jest.clearAllMocks();
-		} );
-
-		test( 'should abort payment if elements.submit fails', async () => {
-			elements.submit.mockResolvedValue( {
-				error: { message: 'Submit error' },
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event
-			);
-
-			expect( elements.submit ).toHaveBeenCalled();
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Submit error'
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment if stripe.createPaymentMethod fails', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				error: { message: 'Payment method error' },
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event
-			);
-
-			expect( elements.submit ).toHaveBeenCalled();
-			expect( stripe.createPaymentMethod ).toHaveBeenCalledWith( {
-				elements,
-			} );
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Payment method error'
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment if expressCheckoutECECreateOrder fails', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECECreateOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'error',
-					payment_details: [
-						{
-							key: 'errorMessage',
-							value: 'Order creation error',
-						},
-					],
-				},
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event
-			);
-
-			const expectedOrderData = normalizeOrderDataForBlocksAPI(
-				event,
-				'pm_123'
-			);
-			expect(
-				api.expressCheckoutECECreateOrderForBlocksAPI
-			).toHaveBeenCalledWith( expectedOrderData );
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Order creation error',
-				true
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should complete payment if confirmationRequest is true', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECECreateOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( true );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event
-			);
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should complete payment if confirmationRequest returns a redirect URL', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECECreateOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.resolve(
-					'https://example.com/confirmation_redirect'
-				),
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event
-			);
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/confirmation_redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment if confirmIntent throws an error', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECECreateOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.reject(
-					new Error( 'Intent confirmation error' )
-				),
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event
-			);
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Intent confirmation error',
-				true
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment if expressCheckoutECEPayForOrder fails', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'error',
-					payment_details: [
-						{
-							key: 'errorMessage',
-							value: 'Order creation error',
-						},
-					],
-				},
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order
-			);
-
-			const expectedOrderData = normalizePayForOrderDataForBlocksAPI(
-				event,
-				'pm_123'
-			);
-			expect(
-				api.expressCheckoutECEPayForOrderForBlocksAPI
-			).toHaveBeenCalledWith( 123, expectedOrderData );
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Order creation error',
-				true
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should complete payment (pay for order) if confirmationRequest is true', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( true );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order
-			);
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should complete payment (pay for order) if confirmationRequest returns a redirect URL', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.resolve(
-					'https://example.com/confirmation_redirect'
-				),
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order
-			);
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/confirmation_redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment (pay for order) if confirmIntent throws an error', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrderForBlocksAPI.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.reject(
-					new Error( 'Intent confirmation error' )
-				),
-			} );
-
-			await onConfirmHandlerForBlocksAPI(
 				api,
 				stripe,
 				elements,

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -6,8 +6,6 @@ import {
 	normalizeShippingAddress,
 	normalizeLineItems,
 	getExpressCheckoutData,
-	normalizeOrderDataForBlocksAPI,
-	normalizePayForOrderDataForBlocksAPI,
 } from './utils';
 import {
 	trackExpressCheckoutButtonClick,
@@ -88,75 +86,6 @@ export const onConfirmHandler = async (
 			orderResponse = await api.expressCheckoutECEPayForOrder(
 				order,
 				normalizePayForOrderData( event, paymentMethod.id )
-			);
-		}
-
-		if ( orderResponse.result !== 'success' ) {
-			return abortPayment(
-				event,
-				getErrorMessageFromNotice( orderResponse.messages ),
-				true
-			);
-		}
-
-		const confirmationRequest = api.confirmIntent( orderResponse.redirect );
-
-		// `true` means there is no intent to confirm.
-		if ( confirmationRequest === true ) {
-			completePayment( orderResponse.redirect );
-		} else {
-			const { request } = confirmationRequest;
-			const redirectUrl = await request;
-
-			completePayment( redirectUrl );
-		}
-	} catch ( e ) {
-		let errorMessage;
-		if ( e.message ) {
-			errorMessage = e.message;
-		} else {
-			errorMessage = __(
-				'There was a problem processing the order.',
-				'woocommerce-gateway-stripe'
-			);
-		}
-		return abortPayment( event, errorMessage );
-	}
-};
-
-export const onConfirmHandlerForBlocksAPI = async (
-	api,
-	stripe,
-	elements,
-	completePayment,
-	abortPayment,
-	event,
-	order = 0 // Order ID for the pay for order flow.
-) => {
-	const submitResponse = await elements.submit();
-	if ( submitResponse?.error ) {
-		return abortPayment( event, submitResponse?.error?.message );
-	}
-
-	const { paymentMethod, error } = await stripe.createPaymentMethod( {
-		elements,
-	} );
-
-	if ( error ) {
-		return abortPayment( event, error.message );
-	}
-
-	try {
-		// Kick off checkout processing step.
-		let orderResponse;
-		if ( ! order ) {
-			orderResponse = await api.expressCheckoutECECreateOrderForBlocksAPI(
-				normalizeOrderDataForBlocksAPI( event, paymentMethod.id )
-			);
-		} else {
-			orderResponse = await api.expressCheckoutECEPayForOrderForBlocksAPI(
-				order,
-				normalizePayForOrderDataForBlocksAPI( event, paymentMethod.id )
 			);
 		}
 

--- a/client/express-checkout/utils/__tests__/normalize.test.js
+++ b/client/express-checkout/utils/__tests__/normalize.test.js
@@ -4,9 +4,7 @@
 import {
 	normalizeLineItems,
 	normalizeOrderData,
-	normalizeOrderDataForBlocksAPI,
 	normalizePayForOrderData,
-	normalizePayForOrderDataForBlocksAPI,
 	normalizeShippingAddress,
 } from '../normalize';
 
@@ -168,223 +166,6 @@ describe( 'Express checkout normalization', () => {
 			const paymentMethodId = 'pm_123456';
 
 			const expectedNormalizedData = {
-				billing_first_name: 'John',
-				billing_last_name: 'Doe',
-				billing_company: 'Some Company',
-				billing_email: 'john.doe@example.com',
-				billing_phone: '1234567890',
-				billing_country: 'US',
-				billing_address_1: '123 Main St',
-				billing_address_2: 'Apt 4B',
-				billing_city: 'New York',
-				billing_state: 'NY',
-				billing_postcode: '10001',
-				shipping_first_name: 'John',
-				shipping_last_name: 'Doe',
-				shipping_company: 'Some Company',
-				shipping_phone: '1234567890',
-				shipping_country: 'US',
-				shipping_address_1: '123 Main St',
-				shipping_address_2: 'Apt 4B',
-				shipping_city: 'New York',
-				shipping_state: 'NY',
-				shipping_postcode: '10001',
-				shipping_method: [ 'rate_1' ],
-				order_comments: '',
-				payment_method: 'stripe',
-				ship_to_different_address: 1,
-				terms: 1,
-				'wc-stripe-is-deferred-intent': true,
-				'wc-stripe-payment-method': paymentMethodId,
-				express_checkout_type: 'express',
-				express_payment_type: 'express',
-			};
-
-			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
-				expectedNormalizedData
-			);
-		} );
-
-		test( 'should normalize order data with missing optional event fields', () => {
-			const event = {};
-			const paymentMethodId = 'pm_123456';
-
-			const expectedNormalizedData = {
-				billing_first_name: '',
-				billing_last_name: '-',
-				billing_company: '',
-				billing_email: '',
-				billing_phone: '',
-				billing_country: '',
-				billing_address_1: '',
-				billing_address_2: '',
-				billing_city: '',
-				billing_state: '',
-				billing_postcode: '',
-				shipping_first_name: '',
-				shipping_last_name: '',
-				shipping_company: '',
-				shipping_phone: '',
-				shipping_country: '',
-				shipping_address_1: '',
-				shipping_address_2: '',
-				shipping_city: '',
-				shipping_state: '',
-				shipping_postcode: '',
-				shipping_method: [ null ],
-				order_comments: '',
-				payment_method: 'stripe',
-				ship_to_different_address: 1,
-				terms: 1,
-				'wc-stripe-is-deferred-intent': true,
-				'wc-stripe-payment-method': paymentMethodId,
-				express_payment_type: undefined,
-			};
-
-			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
-				expectedNormalizedData
-			);
-		} );
-
-		test( 'should normalize order data with minimum required fields', () => {
-			const event = {
-				billingDetails: {
-					name: 'John',
-				},
-			};
-			const paymentMethodId = 'pm_123456';
-
-			const expectedNormalizedData = {
-				billing_first_name: 'John',
-				billing_last_name: '',
-				billing_company: '',
-				billing_email: '',
-				billing_phone: '',
-				billing_country: '',
-				billing_address_1: '',
-				billing_address_2: '',
-				billing_city: '',
-				billing_state: '',
-				express_checkout_type: undefined,
-				express_payment_type: undefined,
-				billing_postcode: '',
-				shipping_first_name: '',
-				shipping_last_name: '',
-				shipping_company: '',
-				shipping_phone: '',
-				shipping_country: '',
-				shipping_address_1: '',
-				shipping_address_2: '',
-				shipping_city: '',
-				shipping_state: '',
-				shipping_postcode: '',
-				shipping_method: [ null ],
-				order_comments: '',
-				payment_method: 'stripe',
-				ship_to_different_address: 1,
-				terms: 1,
-				'wc-stripe-is-deferred-intent': true,
-				'wc-stripe-payment-method': paymentMethodId,
-			};
-
-			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
-				expectedNormalizedData
-			);
-		} );
-	} );
-
-	describe( 'normalizePayForOrderData', () => {
-		test( 'should normalize pay for order data with complete event and paymentMethodId', () => {
-			const event = {
-				billingDetails: {
-					name: 'John Doe',
-					email: 'john.doe@example.com',
-					address: {
-						organization: 'Some Company',
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-					phone: '(123) 456-7890',
-				},
-				shippingAddress: {
-					name: 'John Doe',
-					organization: 'Some Company',
-					address: {
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-				},
-				shippingRate: { id: 'rate_1' },
-				expressPaymentType: 'express',
-			};
-
-			expect( normalizePayForOrderData( event, 'pm_123456' ) ).toEqual( {
-				payment_method: 'stripe',
-				'wc-stripe-is-deferred-intent': true,
-				'wc-stripe-payment-method': 'pm_123456',
-				express_payment_type: 'express',
-			} );
-		} );
-
-		test( 'should normalize pay for order data with empty event and empty payment method', () => {
-			const event = {};
-			const paymentMethodId = '';
-
-			expect(
-				normalizePayForOrderData( event, paymentMethodId )
-			).toEqual( {
-				payment_method: 'stripe',
-				'wc-stripe-is-deferred-intent': true,
-				'wc-stripe-payment-method': '',
-				express_payment_type: undefined,
-			} );
-		} );
-	} );
-
-	describe( 'normalizeOrderDataForBlocksAPI', () => {
-		test( 'should normalize order data with complete event and paymentMethodId', () => {
-			const event = {
-				billingDetails: {
-					name: 'John Doe',
-					email: 'john.doe@example.com',
-					address: {
-						organization: 'Some Company',
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-					phone: '(123) 456-7890',
-				},
-				shippingAddress: {
-					name: 'John Doe',
-					organization: 'Some Company',
-					address: {
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-				},
-				shippingRate: { id: 'rate_1' },
-				expressPaymentType: 'express',
-			};
-
-			const paymentMethodId = 'pm_123456';
-
-			const expectedNormalizedData = {
 				billing_address: {
 					address_1: '123 Main St',
 					address_2: 'Apt 4B',
@@ -434,9 +215,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect(
-				normalizeOrderDataForBlocksAPI( event, paymentMethodId )
-			).toEqual( expectedNormalizedData );
+			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
+				expectedNormalizedData
+			);
 		} );
 
 		test( 'should normalize order data with missing optional event fields', () => {
@@ -493,9 +274,9 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect(
-				normalizeOrderDataForBlocksAPI( event, paymentMethodId )
-			).toEqual( expectedNormalizedData );
+			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
+				expectedNormalizedData
+			);
 		} );
 
 		test( 'should normalize order data with minimum required fields', () => {
@@ -556,13 +337,13 @@ describe( 'Express checkout normalization', () => {
 				},
 			};
 
-			expect(
-				normalizeOrderDataForBlocksAPI( event, paymentMethodId )
-			).toEqual( expectedNormalizedData );
+			expect( normalizeOrderData( event, paymentMethodId ) ).toEqual(
+				expectedNormalizedData
+			);
 		} );
 	} );
 
-	describe( 'normalizePayForOrderDataForBlocksAPI', () => {
+	describe( 'normalizePayForOrderData', () => {
 		test( 'should normalize pay for order data with complete event and paymentMethodId', () => {
 			const event = {
 				billingDetails: {
@@ -595,9 +376,7 @@ describe( 'Express checkout normalization', () => {
 				expressPaymentType: 'express',
 			};
 
-			expect(
-				normalizePayForOrderDataForBlocksAPI( event, 'pm_123456' )
-			).toEqual( {
+			expect( normalizePayForOrderData( event, 'pm_123456' ) ).toEqual( {
 				payment_data: [
 					{
 						key: 'payment_method',
@@ -625,7 +404,7 @@ describe( 'Express checkout normalization', () => {
 			const paymentMethodId = '';
 
 			expect(
-				normalizePayForOrderDataForBlocksAPI( event, paymentMethodId )
+				normalizePayForOrderData( event, paymentMethodId )
 			).toEqual( {
 				payment_data: [
 					{

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -1,5 +1,4 @@
 import { applyFilters } from '@wordpress/hooks';
-import { extractOrderAttributionData } from 'wcstripe/blocks/utils';
 
 /**
  * Normalizes incoming cart total items for use as a displayItems with the Stripe api.
@@ -23,63 +22,6 @@ export const normalizeLineItems = ( displayItems ) => {
 };
 
 /**
- * Normalize order data from Stripe's object to the expected format for WC.
- *
- * @param {Object} event Stripe's event object.
- * @param {string} paymentMethodId Stripe's payment method id.
- *
- * @return {Object} Order object in the format WooCommerce expects.
- */
-export const normalizeOrderData = ( event, paymentMethodId ) => {
-	const name = event?.billingDetails?.name;
-	const email = event?.billingDetails?.email ?? '';
-	const billing = event?.billingDetails?.address ?? {};
-	const shipping = event?.shippingAddress ?? {};
-
-	const phone =
-		event?.billingDetails?.phone?.replace( /[() -]/g, '' ) ??
-		event?.payerPhone?.replace( /[() -]/g, '' ) ??
-		'';
-
-	return {
-		billing_first_name:
-			name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
-		billing_last_name: name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '-',
-		billing_company: billing?.organization ?? '',
-		billing_email: email ?? event?.payerEmail ?? '',
-		billing_phone: phone,
-		billing_country: billing?.country ?? '',
-		billing_address_1: billing?.line1 ?? '',
-		billing_address_2: billing?.line2 ?? '',
-		billing_city: billing?.city ?? '',
-		billing_state: billing?.state ?? '',
-		billing_postcode: billing?.postal_code ?? '',
-		shipping_first_name:
-			shipping?.name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
-		shipping_last_name:
-			shipping?.name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',
-		shipping_company: shipping?.organization ?? '',
-		shipping_phone: phone,
-		shipping_country: shipping?.address?.country ?? '',
-		shipping_address_1: shipping?.address?.line1 ?? '',
-		shipping_address_2: shipping?.address?.line2 ?? '',
-		shipping_city: shipping?.address?.city ?? '',
-		shipping_state: shipping?.address?.state ?? '',
-		shipping_postcode: shipping?.address?.postal_code ?? '',
-		shipping_method: [ event?.shippingRate?.id ?? null ],
-		order_comments: '',
-		payment_method: 'stripe',
-		ship_to_different_address: 1,
-		terms: 1,
-		'wc-stripe-payment-method': paymentMethodId,
-		express_checkout_type: event?.expressPaymentType,
-		express_payment_type: event?.expressPaymentType,
-		'wc-stripe-is-deferred-intent': true,
-		...extractOrderAttributionData(),
-	};
-};
-
-/**
  * Normalize order data from Stripe's object to the expected format for WC (when using the Blocks API).
  *
  * @param {Object} event Stripe's event object.
@@ -87,7 +29,7 @@ export const normalizeOrderData = ( event, paymentMethodId ) => {
  *
  * @return {Object} Order object in the format WooCommerce expects.
  */
-export const normalizeOrderDataForBlocksAPI = ( event, paymentMethodId ) => {
+export const normalizeOrderData = ( event, paymentMethodId ) => {
 	const name = event?.billingDetails?.name;
 	const email = event?.billingDetails?.email ?? '';
 	const billing = event?.billingDetails?.address ?? {};
@@ -141,23 +83,6 @@ export const normalizeOrderDataForBlocksAPI = ( event, paymentMethodId ) => {
 };
 
 /**
- * Normalize Pay for Order data from Stripe's object to the expected format for WC.
- *
- * @param {Object} event Stripe's event object.
- * @param {string} paymentMethodId Stripe's payment method id.
- *
- * @return {Object} Order object in the format WooCommerce expects.
- */
-export const normalizePayForOrderData = ( event, paymentMethodId ) => {
-	return {
-		payment_method: 'stripe',
-		'wc-stripe-is-deferred-intent': true, // Set the deferred intent flag, so the deferred intent flow is used.
-		'wc-stripe-payment-method': paymentMethodId,
-		express_payment_type: event?.expressPaymentType,
-	};
-};
-
-/**
  * Normalize Pay for Order data from Stripe's object to the expected format for WC (when using Blocks API).
  *
  * @param {Object} event Stripe's event object.
@@ -165,10 +90,7 @@ export const normalizePayForOrderData = ( event, paymentMethodId ) => {
  *
  * @return {Object} Order object in the format WooCommerce expects.
  */
-export const normalizePayForOrderDataForBlocksAPI = (
-	event,
-	paymentMethodId
-) => {
+export const normalizePayForOrderData = ( event, paymentMethodId ) => {
 	return {
 		payment_method: 'stripe',
 		payment_data: buildBlocksAPIPaymentData(

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -299,8 +299,11 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 
 	/**
 	 * Create order. Security is handled by WC.
+	 *
+	 * @deprecated 9.2.0 Payment is processed using the Blocks API by default.
 	 */
 	public function ajax_create_order() {
+		_deprecated_function( __METHOD__, '9.2.0' );
 		try {
 			if ( WC()->cart->is_empty() ) {
 				wp_send_json_error( __( 'Empty cart', 'woocommerce-gateway-stripe' ) );

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -350,8 +350,11 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 
 	/**
 	 * Processes the Pay for Order AJAX request from the Express Checkout.
+	 *
+	 * @deprecated 9.2.0 Payment is processed using the Blocks API by default.
 	 */
 	public function ajax_pay_for_order() {
+		_deprecated_function( __METHOD__, '9.2.0' );
 		check_ajax_referer( 'wc-stripe-pay-for-order' );
 
 		if (

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -214,7 +214,6 @@ class WC_Stripe_Express_Checkout_Element {
 			'product'                => $this->express_checkout_helper->get_product_data(),
 			'is_cart_page'           => is_cart(),
 			'taxes_based_on_billing' => wc_tax_enabled() && get_option( 'woocommerce_tax_based_on' ) === 'billing',
-			'use_blocks_api'         => $this->express_checkout_helper->use_blocks_api(),
 		];
 	}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1355,15 +1355,6 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
-	 * Returns whether Stripe express checkout element should use the Blocks API.
-	 *
-	 * @return boolean
-	 */
-	public function use_blocks_api() {
-		return isset( $this->stripe_settings['express_checkout_use_blocks_api'] ) && 'yes' === $this->stripe_settings['express_checkout_use_blocks_api'];
-	}
-
-	/**
 	 * Restores the shipping methods previously chosen for each recurring cart after shipping was reset and recalculated
 	 * during the express checkout get_shipping_options flow.
 	 *

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1355,6 +1355,18 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
+	 * Returns whether Stripe express checkout element should use the Blocks API.
+	 *
+	 * @return boolean
+	 *
+	 * @deprecated 9.2.0 Feature flag enable by default.
+	 */
+	public function use_blocks_api() {
+		_deprecated_function( __METHOD__, '9.2.0' );
+		return isset( $this->stripe_settings['express_checkout_use_blocks_api'] ) && 'yes' === $this->stripe_settings['express_checkout_use_blocks_api'];
+	}
+
+	/**
 	 * Restores the shipping methods previously chosen for each recurring cart after shipping was reset and recalculated
 	 * during the express checkout get_shipping_options flow.
 	 *

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Enables the use of Blocks API for Express Checkout Element orders by default.
 * Fix - Fixes order attribution data for the Express Checkout Element when using the Blocks API to process.
 * Tweak - Process ECE orders using the Blocks API.
 * Fix - Fixes incorrect error message for card failures due insufficient funds on the shortcode checkout page (legacy).

--- a/tests/phpunit/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/test-wc-stripe-express-checkout-helper.php
@@ -21,7 +21,6 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		$stripe_settings['testmode']                        = 'yes';
 		$stripe_settings['test_publishable_key']            = 'pk_test_key';
 		$stripe_settings['test_secret_key']                 = 'sk_test_key';
-		$stripe_settings['express_checkout_use_blocks_api'] = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}
 
@@ -311,15 +310,5 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'expected'    => '12345',
 			],
 		];
-	}
-
-	/**
-	 * Test for `use_blocks_api`.
-	 *
-	 * @return void
-	 */
-	public function test_use_blocks_api() {
-		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
-		$this->assertTrue( $wc_stripe_ece_helper->use_blocks_api() );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR enables the use of the Blocks API (introduced in ) by default when processing Express Checkout Element orders by removing all references to the feature flag and the conditionals.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/enable-blocks-api-for-ece-by-default`)
- Connect your Stripe account
- Enable express payment methods (Google Pay, Apple Pay, Link)
- As a shopper, access the store by a public-facing address
- Add any product to your cart
- Confirm you can complete the order using any express payment method

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
