### PR TITLE
Add ACH LPM feature flag

### DIFF
--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -181,6 +181,7 @@ class WC_Stripe_Settings_Controller {
 			'time'                      => time(),
 			'i18n_out_of_sync'          => $message,
 			'is_upe_checkout_enabled'   => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+			'is_ach_enabled'            => WC_Stripe_Feature_Flags::is_ach_lpm_enabled(),
 			'stripe_oauth_url'          => $oauth_url,
 			'stripe_test_oauth_url'     => $test_oauth_url,
 			'show_customization_notice' => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -7,6 +7,18 @@ class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
 	const ECE_FEATURE_FLAG_NAME = '_wcstripe_feature_ece';
 
+	const LPM_ACH_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_ach';
+
+	/**
+	 * Checks whether ACH LPM (Local Payment Method) feature flag is enabled.
+	 * ACH LPM is a feature that allows merchants to enable/disable the ACH payment method.
+	 *
+	 * @return bool
+	 */
+	public static function is_ach_lpm_enabled() {
+		return 'yes' === get_option( self::LPM_ACH_FEATURE_FLAG_NAME, 'no' );
+	}
+
 	/**
 	 * Checks whether Stripe ECE (Express Checkout Element) feature flag is enabled.
 	 * Express checkout buttons are rendered with either ECE or PRB depending on this feature flag.

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -5,7 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
-	const ECE_FEATURE_FLAG_NAME = '_wcstripe_feature_ece';
+	const ECE_FEATURE_FLAG_NAME               = '_wcstripe_feature_ece';
 
 	const LPM_ACH_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_ach';
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -413,6 +413,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// ECE feature flag
 		$stripe_params['isECEEnabled'] = WC_Stripe_Feature_Flags::is_stripe_ece_enabled();
 
+		// ACH LPM Feature flag.
+		$stripe_params['isACHEnabled'] = WC_Stripe_Feature_Flags::is_ach_lpm_enabled();
+
 		$cart_total = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
 		$currency   = get_woocommerce_currency();
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -414,7 +414,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['isECEEnabled'] = WC_Stripe_Feature_Flags::is_stripe_ece_enabled();
 
 		// ACH LPM Feature flag.
-		$stripe_params['isACHEnabled'] = WC_Stripe_Feature_Flags::is_ach_lpm_enabled();
+		$stripe_params['is_ach_enabled'] = WC_Stripe_Feature_Flags::is_ach_lpm_enabled();
 
 		$cart_total = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
 		$currency   = get_woocommerce_currency();


### PR DESCRIPTION
Closes #3744 

## Changes proposed in this Pull Request:

Add a feature flag for tests of the ACH implementation.

## Testing instructions

### Enable ACH

1. Run:
   ```bash
   npm run wp option update _wcstripe_feature_lpm_ach 'yes'
   ```
2. On the Stripe Gateway settings page, open the browser console and verify:
   ```bash
   window.wc_stripe_settings_params.is_ach_enabled === '1'
   ```
3. On the checkout page (with products in the cart), verify:
   ```bash
   window.wc_stripe_upe_params.is_ach_enabled === '1'
   ```

### Disable ACH

1. Run:
   ```bash
   npm run wp option update _wcstripe_feature_lpm_ach 'no'
   ```
2. On the Stripe Gateway settings page, verify:
   ```bash
   window.wc_stripe_settings_params.is_ach_enabled === ''
   ``` 
3. On the checkout page, verify:
   ```bash
   window.wc_stripe_upe_params.is_ach_enabled === ''
   ``` 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
