### PR TITLE
Fix: allow to edit uncaptured orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Add - Support zero-amount refunds.
 * Fix - A potential fix to prevent duplicate charges.
 * Fix - Improve product page caching when Express Payment buttons are not enabled.
+* Fix - Allow editing uncaptured orders but show a warning about the possible failure scenario.
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -29,7 +29,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 		add_action( 'woocommerce_cancel_unpaid_order', [ $this, 'prevent_cancelling_orders_awaiting_action' ], 10, 2 );
 
-		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'show_warning_for_uncaptured_order' ] );
+		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'show_warning_for_uncaptured_orders' ] );
 	}
 
 	/**

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -51,7 +51,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		$order = wc_get_order( $order_id );
 		// Bail if payment method is not manual capture supporting stripe method.
 		if ( ! WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
-			return $editable;
+			return;
 		}
 
 		try {

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -56,7 +56,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 
 		try {
 			$intent = $this->get_intent_from_order( $order );
-			if ( $intent && 'requires_capture' === $intent->status ) {
+			if ( $intent && WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
 				$capture_notice = __( "Attempting to capture more than the authorized amount will fail with an error.", 'woocommerce-gateway-stripe' );
 				$capture_tooltip = __( "You may edit the order to have a total less than or equal to the original authorized amount.", 'woocommerce-gateway-stripe' );
 				echo esc_html( $capture_notice ) . wc_help_tip( $capture_tooltip );

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -28,8 +28,6 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_tracks_event_properties', [ $this, 'woocommerce_tracks_event_properties' ], 10, 2 );
 
 		add_action( 'woocommerce_cancel_unpaid_order', [ $this, 'prevent_cancelling_orders_awaiting_action' ], 10, 2 );
-
-		add_filter( 'wc_order_is_editable', [ $this, 'disable_edit_for_uncaptured_orders' ], 10, 2 );
 	}
 
 	/**
@@ -40,80 +38,6 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public static function get_instance() {
 		return self::$_this;
-	}
-
-	/**
-	 * Disables the ability to edit for orders with uncaptured payment.
-	 *
-	 * @param $editable boolean The current editability of the order.
-	 * @param $order WC_Order The order object.
-	 * @return boolean false if the order has uncaptured payment, true otherwise.
-	 */
-	public function disable_edit_for_uncaptured_orders( $editable, $order ) {
-		// Bail if payment method is not manual capture supporting stripe method.
-		if ( ! WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
-			return $editable;
-		}
-
-		try {
-			$intent = $this->get_intent_from_order( $order );
-
-			if ( $intent && 'requires_capture' === $intent->status ) {
-				$editable = false;
-
-				// add hooks to change text about the reason when order items cannot be edited
-				add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'maybe_attach_gettext_callback' ] );
-				add_action( 'woocommerce_order_item_add_action_buttons', [ $this, 'maybe_unattach_gettext_callback' ] );
-			}
-		} catch ( Exception $e ) {
-			WC_Stripe_Logger::log( 'Error getting intent from order: ' . $e->getMessage() );
-		}
-
-		return $editable;
-	}
-
-	/**
-	 * Only attach the gettext callback when on admin edit order screen.
-	 */
-	public function maybe_attach_gettext_callback() {
-
-		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-
-			if ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) {
-				// Hook to gettext callback to change the tooltip text
-				add_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10, 3 );
-			}
-		}
-	}
-
-	/**
-	 * Unattach the gettext callback.
-	 */
-	public function maybe_unattach_gettext_callback() {
-
-		if ( is_admin() && function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-
-			if ( is_object( $screen ) && in_array( $screen->id, [ 'woocommerce_page_wc-orders', 'edit-shop_order' ], true ) ) {
-				// Unhook gettext callback to prevent extra call impact
-				remove_filter( 'gettext', [ $this, 'change_order_item_editable_text_tooltip' ], 10 );
-			}
-		}
-	}
-
-	/**
-	* When order items are not editable due to the charge being authorized to capture the current amount,
-	* change the tooltip to explain the reason.
-	*/
-	public function change_order_item_editable_text_tooltip( $translated_text, $text, $domain ) {
-		switch ( $text ) {
-			case 'To edit this order change the status back to "Pending payment"':
-				$translated_text = __( 'This order is no longer editable because the charge has been authorized for this amount.', 'woocommerce-gateway-stripe' );
-				break;
-		}
-
-		return $translated_text;
 	}
 
 	/**

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -28,6 +28,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		add_filter( 'woocommerce_tracks_event_properties', [ $this, 'woocommerce_tracks_event_properties' ], 10, 2 );
 
 		add_action( 'woocommerce_cancel_unpaid_order', [ $this, 'prevent_cancelling_orders_awaiting_action' ], 10, 2 );
+
+		add_action( 'woocommerce_admin_order_totals_after_total', [ $this, 'show_warning_for_uncaptured_order' ] );
 	}
 
 	/**
@@ -38,6 +40,30 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public static function get_instance() {
 		return self::$_this;
+	}
+
+	/**
+	 * Shows a warning message about editing uncaptured orders.
+	 *
+	 * @param $order_id
+	 */
+	public function show_warning_for_uncaptured_orders( $order_id ) {
+		$order = wc_get_order( $order_id );
+		// Bail if payment method is not manual capture supporting stripe method.
+		if ( ! WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
+			return $editable;
+		}
+
+		try {
+			$intent = $this->get_intent_from_order( $order );
+			if ( $intent && 'requires_capture' === $intent->status ) {
+				$capture_notice = __( "Attempting to capture more than the authorized amount will fail with an error.", 'woocommerce-gateway-stripe' );
+				$capture_tooltip = __( "You may edit the order to have a total less than or equal to the original authorized amount.", 'woocommerce-gateway-stripe' );
+				echo esc_html( $capture_notice ) . wc_help_tip( $capture_tooltip );
+			}
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log( 'Error getting intent from order: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -57,8 +57,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		try {
 			$intent = $this->get_intent_from_order( $order );
 			if ( $intent && WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {
-				$capture_notice = __( "Attempting to capture more than the authorized amount will fail with an error.", 'woocommerce-gateway-stripe' );
-				$capture_tooltip = __( "You may edit the order to have a total less than or equal to the original authorized amount.", 'woocommerce-gateway-stripe' );
+				$capture_notice = __( 'Attempting to capture more than the authorized amount will fail with an error.', 'woocommerce-gateway-stripe' );
+				$capture_tooltip = __( 'You may edit the order to have a total less than or equal to the original authorized amount.', 'woocommerce-gateway-stripe' );
 				echo esc_html( $capture_notice ) . wc_help_tip( $capture_tooltip );
 			}
 		} catch ( Exception $e ) {

--- a/readme.txt
+++ b/readme.txt
@@ -121,5 +121,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - A potential fix to prevent duplicate charges.
 * Fix - Prevent empty settings screen when cancelling changes to the payment methods display order.
 * Fix - Improve product page caching when Express Payment buttons are not enabled.
+* Fix - Allow editing uncaptured orders but show a warning about the possible failure scenario.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-order-handler.php
+++ b/tests/phpunit/test-class-wc-stripe-order-handler.php
@@ -50,40 +50,4 @@ class WC_Stripe_Order_Handler_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $this->order_handler->prevent_cancelling_orders_awaiting_action( true, $order ) );
 	}
-
-	/**
-	 * Test for disable_edit_for_uncaptured_orders().
-	 */
-	public function test_disable_edit_for_uncaptured_orders() {
-		$order = WC_Helper_Order::create_order();
-		$order->set_payment_method( 'bacs' );
-		$order->save();
-
-		// Test when payment method is not stripe.
-		$this->assertTrue( $this->order_handler->disable_edit_for_uncaptured_orders( true, $order ) );
-		$this->assertFalse( $this->order_handler->disable_edit_for_uncaptured_orders( false, $order ) );
-
-		$order->set_payment_method( 'stripe' );
-		$order->save();
-
-		$this->order_handler
-			->expects( $this->any() )
-			->method( 'get_intent_from_order' )
-			->willReturnOnConsecutiveCalls(
-				(object) [
-					'intent_id' => 'pi_mock1',
-					'status'    => 'succeeded',
-				],
-				(object) [
-					'intent_id' => 'pi_mock2',
-					'status'    => 'requires_capture',
-				]
-			);
-
-		// Test when intent is succeeded.
-		$this->assertTrue( $this->order_handler->disable_edit_for_uncaptured_orders( true, $order ) );
-
-		// Test when intent is requires_capture.
-		$this->assertFalse( $this->order_handler->disable_edit_for_uncaptured_orders( true, $order ) );
-	}
 }


### PR DESCRIPTION
Fixes #3723 

When authorize and capture later is enabled and a charge is authorized for a particular order, we can not charge a higher amount for that order. The payment fails with an error in this case. In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3646 I disabled the edit for uncaptured orders. This took away the ability to partial capture as well. If a merchant updates the order total to the same or less amount, the payment succeeds and this is a common use-case for some merchants. So the order should be editable. (check [this comment](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3646#issuecomment-2583070113) and WooPayments reference)

## Changes proposed in this Pull Request:
- Made the uncaptured orders editable again.
- Showing a warning message on the order edit page about the failure scenario if the total is updated to be greater than the authorized amount. Borrowed the warning message from the WooPayments docs.

## Testing instructions
- Enable `Issue an authorization on checkout, and capture later` in the Stripe settings page.
- As a shopper, purchase a product using a card.
- As an admin go to the order edit page. Confirm from the order notes that the charge has been authorized, the order is now editable and there is a warning message about the uncaptured order.

<img width="987" alt="Screenshot 2025-01-21 at 6 12 20 PM" src="https://github.com/user-attachments/assets/2de2fbe4-52da-4973-bd56-365444b61fe9" />


- As a shopper purchase a product with another payment method (such as COD) and confirm that the warning is not displayed on the order edit page.
- Now disable `Issue an authorization on checkout, and capture later` in the Stripe settings page.
- As a shopper, purchase a product using a card.
- As an admin go to the order edit page and confirm that the warning message is not displayed.