### PR TITLE
Add Bacs LPM feature flag

### DIFF
--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -182,6 +182,7 @@ class WC_Stripe_Settings_Controller {
 			'i18n_out_of_sync'          => $message,
 			'is_upe_checkout_enabled'   => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			'is_ach_enabled'            => WC_Stripe_Feature_Flags::is_ach_lpm_enabled(),
+			'is_bacs_enabled'           => WC_Stripe_Feature_Flags::is_bacs_lpm_enabled(),
 			'stripe_oauth_url'          => $oauth_url,
 			'stripe_test_oauth_url'     => $test_oauth_url,
 			'show_customization_notice' => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -7,7 +7,8 @@ class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
 	const ECE_FEATURE_FLAG_NAME               = '_wcstripe_feature_ece';
 
-	const LPM_ACH_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_ach';
+	const LPM_ACH_FEATURE_FLAG_NAME  = '_wcstripe_feature_lpm_ach';
+	const LPM_BACS_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_bacs';
 
 	/**
 	 * Checks whether ACH LPM (Local Payment Method) feature flag is enabled.
@@ -17,6 +18,16 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_ach_lpm_enabled() {
 		return 'yes' === get_option( self::LPM_ACH_FEATURE_FLAG_NAME, 'no' );
+	}
+
+	/**
+	 * Checks whether Bacs LPM (Local Payment Method) feature flag is enabled.
+	 * Alows the merchant to enable/disable Bacs payment method.
+	 *
+	 * @return bool
+	 */
+	public static function is_bacs_lpm_enabled(): bool {
+		return 'yes' === get_option( self::LPM_BACS_FEATURE_FLAG_NAME, 'no' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -416,6 +416,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// ACH LPM Feature flag.
 		$stripe_params['is_ach_enabled'] = WC_Stripe_Feature_Flags::is_ach_lpm_enabled();
 
+		// Bacs LPM Feature flag.
+		$stripe_params['is_bacs_enabled'] = WC_Stripe_Feature_Flags::is_bacs_lpm_enabled();
+
 		$cart_total = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
 		$currency   = get_woocommerce_currency();
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Closes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3750

## Changes proposed in this Pull Request:

Introduces the `_wcstripe_feature_lpm_bacs` flag to toggle the Bacs local payment method. It will be used in the next PR to control whether the payment method is shown or hidden.

## Testing instructions

### Enable Bacs

- Switch to this branch `as-bacs-feature-flag`. 
- On the root path of your WP install run `wp option update _wcstripe_feature_lpm_bacs 'yes'` (prepend with `npm run` if you are using Docker)
- Go to the Stripe Gateway settings page, then run in the browser console. `window.wc_stripe_settings_params.is_bacs_enabled === '1'`, it should be `true`
- Go to the Checkout Page then run. `window.wc_stripe_upe_params.is_bacs_enabled === '1'`, it should be `true`.

### Disable Bacs

- On the root path of your WP install run `wp option update _wcstripe_feature_lpm_bacs 'no'`
- Go to the Stripe Gateway settings page, then run in the browser console. `window.wc_stripe_settings_params.is_bacs_enabled === ''`, it should be `true`
- Go to the Checkout Page then run. `window. wc_stripe_upe_params.is_bacs_enabled === ''`, it should be `true`.

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
