### PR TITLE
Fix fatal error when editing the shortcode checkout page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.
 * Add - Adds a new filter to allow changing the user attributed to an order when paying for it through the Order Pay page.
 * Fix - Fixes an error with the fingerprint property setting when using the legacy checkout.
 * Fix - Fixes order attribution data for the Express Checkout Element when using the Blocks API to process.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -626,7 +626,7 @@ class WC_Stripe_Express_Checkout_Helper {
 			! $this->is_pay_for_order_page() &&
 			(
 				( is_product() && ! $this->product_needs_shipping( $this->get_product() ) ) ||
-				( ( is_cart() || is_checkout() ) && ! WC()->cart->needs_shipping() )
+				( ( is_cart() || is_checkout() ) && ( ! WC()->cart || ! WC()->cart->needs_shipping() ) )
 			) &&
 			wc_tax_enabled() &&
 			in_array( get_option( 'woocommerce_tax_based_on' ), [ 'billing', 'shipping' ], true )

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.
 * Add - Adds a new filter to allow changing the user attributed to an order when paying for it through the Order Pay page.
 * Fix - Fixes an error with the fingerprint property setting when using the legacy checkout.
 * Fix - Fixes order attribution data for the Express Checkout Element when using the Blocks API to process.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3757

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR fixes a fatal error thrown when editing the shortcode checkout page on PHP 8.4 with an empty cart:
```
PHP Fatal error: Uncaught Error: Call to a member function needs_shipping() on null in */wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-express-checkout-helper.php:629
```

The fix consists on checking the existence of the cart object before calling the `needs_shipping` method.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review should be enough. If you want to test it:

- Checkout and build this branch on your test environment (`fix/fatal-error-editing-shortcode-checkout`)
- Make sure you are running your store on PHP 8.4
- As a merchant, edit your shortcode checkout page (create one before if you don't have it)
- Confirm no fatal errors are thrown

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
