### PR TITLE
Fix: WC_Stripe_Webhook_Handler: Cannot use object of type stdClass as array

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Fix - Improve product page caching when Express Payment buttons are not enabled.
 * Fix - Allow editing uncaptured orders but show a warning about the possible failure scenario.
 * Fix - Error when changing subscription payment method to a 3D Secure card while using a custom checkout endpoint.
+* Fix - Fixes the webhook order retrieval by intent charges by adding an array check.
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1314,7 +1314,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		// Try to retrieve from the charges array.
-		if ( ! empty( $intent->charges ) ) {
+		if ( ! empty( $intent->charges ) && is_array( $intent->charges ) ) {
 			$charge   = $intent->charges[0] ?? [];
 			$order_id = $charge->metadata->order_id ?? null;
 			return $order_id ? wc_get_order( $order_id ) : false;

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Improve product page caching when Express Payment buttons are not enabled.
 * Fix - Allow editing uncaptured orders but show a warning about the possible failure scenario.
 * Fix - Error when changing subscription payment method to a 3D Secure card while using a custom checkout endpoint.
+* Fix - Fixes the webhook order retrieval by intent charges by adding an array check.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3721 

In one scenario when processing webhook events, we retrieve the order from the `charges` data. We consider the `intent->charges` to be an array. In any case, if `intent->charges` is not an array it causes a fatal error. 

Check [this comment](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3721#issuecomment-2589976646) (expand the `stripe webhook event data for payment_intent.succeeded` section) to find out a sample event where `charges` is not an array.

A related change was done in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3704.

## Changes proposed in this Pull Request:

- Added `is_array` check before accessing it as an array.

## Testing instructions
- Code review.
