### PR TITLE
Payment intent status constants on the frontend

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Dev - Introduces new payment intent status constants for the frontend.
 * Add - Add new payment processing flow using confirmation tokens.
 * Dev - Adds new logs to identify why express payment methods are not being displayed.
 * Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -7,7 +7,10 @@ import {
 	getRequiredFieldDataFromCheckoutForm,
 } from 'wcstripe/express-checkout/utils';
 import { getStripeServerData } from 'wcstripe/stripe-utils';
-import { PAYMENT_METHOD_CASHAPP } from 'wcstripe/stripe-utils/constants';
+import {
+	PAYMENT_INTENT_STATUS_REQUIRES_ACTION,
+	PAYMENT_METHOD_CASHAPP,
+} from 'wcstripe/stripe-utils/constants';
 
 /**
  * Handles generic connections to the server and Stripe.
@@ -189,7 +192,8 @@ export default class WCStripeAPI {
 			}
 
 			if (
-				response.data.status === 'requires_action' &&
+				response.data.status ===
+					PAYMENT_INTENT_STATUS_REQUIRES_ACTION &&
 				response.data.next_action.type === 'redirect_to_url'
 			) {
 				window.location.href =

--- a/client/blocks/payment-request/event-handlers.js
+++ b/client/blocks/payment-request/event-handlers.js
@@ -5,6 +5,10 @@ import {
 	createOrder,
 } from 'wcstripe/api/blocks';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
+import {
+	PAYMENT_INTENT_STATUS_REQUIRES_CAPTURE,
+	PAYMENT_INTENT_STATUS_SUCCEEDED,
+} from 'wcstripe/stripe-utils/constants';
 
 const shippingAddressChangeHandler = ( paymentRequestType ) => ( evt ) => {
 	const { shippingAddress } = evt;
@@ -105,11 +109,11 @@ const getIntentFromConfirmation = ( intent, intentType ) => {
 };
 
 const doesIntentRequireCapture = ( intent ) => {
-	return intent.status === 'requires_capture';
+	return intent.status === PAYMENT_INTENT_STATUS_REQUIRES_CAPTURE;
 };
 
 const didIntentSucceed = ( intent ) => {
-	return intent.status === 'succeeded';
+	return intent.status === PAYMENT_INTENT_STATUS_SUCCEEDED;
 };
 
 /**

--- a/client/blocks/three-d-secure/use-payment-intents.js
+++ b/client/blocks/three-d-secure/use-payment-intents.js
@@ -1,4 +1,8 @@
 import { useEffect } from '@wordpress/element';
+import {
+	PAYMENT_INTENT_STATUS_REQUIRES_CAPTURE,
+	PAYMENT_INTENT_STATUS_SUCCEEDED,
+} from 'wcstripe/stripe-utils/constants';
 
 /**
  * @typedef {import('@woocommerce/type-defs/registered-payment-method-props').EmitResponseProps} EmitResponseProps
@@ -45,8 +49,8 @@ const openIntentModal = ( {
 			const intent =
 				response[ isSetupIntent ? 'setupIntent' : 'paymentIntent' ];
 			if (
-				intent.status !== 'requires_capture' &&
-				intent.status !== 'succeeded'
+				intent.status !== PAYMENT_INTENT_STATUS_REQUIRES_CAPTURE &&
+				intent.status !== PAYMENT_INTENT_STATUS_SUCCEEDED
 			) {
 				return checkoutResponse;
 			}

--- a/client/classic/upe/legacy-support.js
+++ b/client/classic/upe/legacy-support.js
@@ -1,5 +1,9 @@
 import $ from 'jquery';
 import { getStripeServerData } from 'wcstripe/stripe-utils';
+import {
+	PAYMENT_INTENT_STATUS_REQUIRES_CAPTURE,
+	PAYMENT_INTENT_STATUS_SUCCEEDED,
+} from 'wcstripe/stripe-utils/constants';
 
 /**
  * Handles hashchange events when using PRBs.
@@ -40,8 +44,8 @@ export const legacyHashchangeHandler = ( api, showError ) => {
 			const intent =
 				response[ type === 'si' ? 'setupIntent' : 'paymentIntent' ];
 			if (
-				intent.status !== 'requires_capture' &&
-				intent.status !== 'succeeded'
+				intent.status !== PAYMENT_INTENT_STATUS_REQUIRES_CAPTURE &&
+				intent.status !== PAYMENT_INTENT_STATUS_SUCCEEDED
 			) {
 				return;
 			}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -15,6 +15,7 @@ import {
 } from '../../stripe-utils';
 import { getFontRulesFromPage } from '../../styles/upe';
 import {
+	PAYMENT_INTENT_STATUS_REQUIRES_ACTION,
 	PAYMENT_METHOD_BOLETO,
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_CASHAPP,
@@ -582,7 +583,7 @@ export const confirmWalletPayment = async ( api, jQueryForm ) => {
 
 		// Do not redirect to the order received page if the modal is closed without payment.
 		// Otherwise redirect to the order received page.
-		if ( intentObject.status !== 'requires_action' ) {
+		if ( intentObject.status !== PAYMENT_INTENT_STATUS_REQUIRES_ACTION ) {
 			if ( ! isChangingPayment ) {
 				window.location.href = returnURL;
 			}

--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -96,3 +96,16 @@ export const errorCodes = {
 	MISSING: 'missing',
 	PROCESSING_ERROR: 'processing_error',
 };
+
+/**
+ * Payment intent status constants
+ */
+export const PAYMENT_INTENT_STATUS_CANCELED = 'canceled';
+export const PAYMENT_INTENT_STATUS_PROCESSING = 'processing';
+export const PAYMENT_INTENT_STATUS_REQUIRES_CONFIRMATION =
+	'requires_confirmation';
+export const PAYMENT_INTENT_STATUS_REQUIRES_ACTION = 'requires_action';
+export const PAYMENT_INTENT_STATUS_REQUIRES_CAPTURE = 'requires_capture';
+export const PAYMENT_INTENT_STATUS_REQUIRES_PAYMENT_METHOD =
+	'requires_payment_method';
+export const PAYMENT_INTENT_STATUS_SUCCEEDED = 'succeeded';

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Dev - Introduces new payment intent status constants for the frontend.
 * Add - Add new payment processing flow using confirmation tokens.
 * Dev - Adds new logs to identify why express payment methods are not being displayed.
 * Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR improves our code by introducing a new type of payment intent status constants for the frontend side. This should make development safer (with all known possible values in one place), make it easier to track references and turn the code more strict.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review should be enough. Check if the frontend tests are still passing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
