### PR TITLE
Fix fatal PHP error

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -150,7 +150,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		if ( WC_Stripe_Feature_Flags::is_bacs_lpm_enabled() ) {
 			// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			self::$UPE_AVAILABLE_METHODS[] = WC_Stripe_UPE_Payment_Method_Bacs::class;
+			$this->UPE_AVAILABLE_METHODS[] = WC_Stripe_UPE_Payment_Method_Bacs::class;
 		}
 
 		foreach ( self::UPE_AVAILABLE_METHODS as $payment_method_class ) {


### PR DESCRIPTION
Fixes a fatal PHP error introduced in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3727

```
  | <b>Fatal error</b>:  Uncaught Error: Access to undeclared static property WC_Stripe_UPE_Payment_Gateway::$UPE_AVAILABLE_METHODS in /Users/asumaran/Developer/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php:153
  | Stack trace:
  | #0 /Users/asumaran/Developer/woocommerce-gateway-stripe/woocommerce-gateway-stripe.php(755): WC_Stripe_UPE_Payment_Gateway-&gt;__construct()
  | #1 /Users/asumaran/Developer/woocommerce-gateway-stripe/includes/class-wc-stripe-order-handler.php(243): WC_Stripe-&gt;get_main_stripe_gateway()
  | #2 /Users/asumaran/valet/wcstripe/wp-includes/class-wp-hook.php(324): WC_Stripe_Order_Handler-&gt;maybe_process_redirect_order(Object(WP))
  | #3 /Users/asumaran/valet/wcstripe/wp-includes/class-wp-hook.php(348): WP_Hook-&gt;apply_filters(NULL, Array)
  | #4 /Users/asumaran/valet/wcstripe/wp-includes/plugin.php(565): WP_Hook-&gt;do_action(Array)
  | #5 /Users/asumaran/valet/wcstripe/wp-includes/class-wp.php(830): do_action_ref_array('wp', Array)
  | #6 /Users/asumaran/valet/wcstripe/wp-includes/functions.php(1336): WP-&gt;main('')
  | #7 /Users/asumaran/valet/wcstripe/wp-blog-header.php(16): wp()
  | #8 /Users/asumaran/valet/wcstripe/index.php(17): require('/Users/asumaran...')
  | #9 /Users/asumaran/.composer/vendor/laravel/valet/server.php(111): require('/Users/asumaran...')
  | #10 {main}
  | thrown in <b>/Users/asumaran/Developer/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php</b> on line <b>153</b><br />


```