### PR TITLE
Blocks API: get billing details from order if not in request

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Fix Stripe customer creation when using the Blocks API for express checkout.
 * Dev - Adds new logs to identify why express payment methods are not being displayed.
 * Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.
 * Fix - Fixes processing of orders through the Pay for Order page when using ECE with Blocks (Store) API.

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -124,17 +124,7 @@ class WC_Stripe_Customer {
 	 * @return array
 	 */
 	protected function generate_customer_request( $args = [] ) {
-		$billing_email  = isset( $_POST['billing_email'] ) ? filter_var( wp_unslash( $_POST['billing_email'] ), FILTER_SANITIZE_EMAIL ) : '';
-		$user           = $this->get_user();
-		$address_fields = [
-			'line1'       => 'billing_address_1',
-			'line2'       => 'billing_address_2',
-			'postal_code' => 'billing_postcode',
-			'city'        => 'billing_city',
-			'state'       => 'billing_state',
-			'country'     => 'billing_country',
-		];
-
+		$user = $this->get_user();
 		if ( $user ) {
 			$billing_first_name = get_user_meta( $user->ID, 'billing_first_name', true );
 			$billing_last_name  = get_user_meta( $user->ID, 'billing_last_name', true );
@@ -162,8 +152,9 @@ class WC_Stripe_Customer {
 				$defaults['name'] = $billing_full_name;
 			}
 		} else {
-			$billing_first_name = isset( $_POST['billing_first_name'] ) ? filter_var( wp_unslash( $_POST['billing_first_name'] ), FILTER_SANITIZE_SPECIAL_CHARS ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
-			$billing_last_name  = isset( $_POST['billing_last_name'] ) ? filter_var( wp_unslash( $_POST['billing_last_name'] ), FILTER_SANITIZE_SPECIAL_CHARS ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+			$billing_email      = $this->get_billing_data_field( 'billing_email', $args );
+			$billing_first_name = $this->get_billing_data_field( 'billing_first_name', $args );
+			$billing_last_name  = $this->get_billing_data_field( 'billing_last_name', $args );
 
 			// translators: %1$s First name, %2$s Second name.
 			$description = sprintf( __( 'Name: %1$s %2$s, Guest', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name );
@@ -184,15 +175,84 @@ class WC_Stripe_Customer {
 		$defaults['preferred_locales'] = $this->get_customer_preferred_locale( $user );
 
 		// Add customer address default values.
+		$address_fields = [
+			'line1'       => 'billing_address_1',
+			'line2'       => 'billing_address_2',
+			'postal_code' => 'billing_postcode',
+			'city'        => 'billing_city',
+			'state'       => 'billing_state',
+			'country'     => 'billing_country',
+		];
 		foreach ( $address_fields as $key => $field ) {
 			if ( $user ) {
 				$defaults['address'][ $key ] = get_user_meta( $user->ID, $field, true );
 			} else {
-				$defaults['address'][ $key ] = isset( $_POST[ $field ] ) ? filter_var( wp_unslash( $_POST[ $field ] ), FILTER_SANITIZE_SPECIAL_CHARS ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+				$defaults['address'][ $key ] = $this->get_billing_data_field( $field, $args );
 			}
 		}
 
 		return wp_parse_args( $args, $defaults );
+	}
+
+	/**
+	 * Get value of billing data field, either from POST or order object.
+	 *
+	 * @param string $field Field name.
+	 * @param array  $args  Additional arguments (optional).
+	 *
+	 * @return string
+	 */
+	private function get_billing_data_field( $field, $args = [] ) {
+		$valid_fields = [
+			'billing_email',
+			'billing_first_name',
+			'billing_last_name',
+			'billing_address_1',
+			'billing_address_2',
+			'billing_postcode',
+			'billing_city',
+			'billing_state',
+			'billing_country',
+		];
+
+		// Restrict field parameter to list of known billing fields.
+		if ( ! in_array( $field, $valid_fields, true ) ) {
+			return '';
+		}
+
+		// Prioritize POST data, if available.
+		if ( isset( $_POST[ $field ] ) ) {
+			if ( 'billing_email' === $field ) {
+				return filter_var( wp_unslash( $_POST[ $field ] ), FILTER_SANITIZE_EMAIL ); // phpcs:ignore WordPress.Security.NonceVerification
+			}
+
+			return filter_var( wp_unslash( $_POST[ $field ] ), FILTER_SANITIZE_SPECIAL_CHARS ); // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( isset( $args['order'] ) && $args['order'] instanceof WC_Order ) {
+			switch ( $field ) {
+				case 'billing_email':
+					return $args['order']->get_billing_email();
+				case 'billing_first_name':
+					return $args['order']->get_billing_first_name();
+				case 'billing_last_name':
+					return $args['order']->get_billing_last_name();
+				case 'billing_address_1':
+					return $args['order']->get_billing_address_1();
+				case 'billing_address_2':
+					return $args['order']->get_billing_address_2();
+				case 'billing_postcode':
+					return $args['order']->get_billing_postcode();
+				case 'billing_city':
+					return $args['order']->get_billing_city();
+				case 'billing_state':
+					return $args['order']->get_billing_state();
+				case 'billing_country':
+					return $args['order']->get_billing_country();
+				default:
+					return '';
+			}
+		}
+
+		return '';
 	}
 
 	/**
@@ -328,7 +388,7 @@ class WC_Stripe_Customer {
 	 */
 	public function update_or_create_customer( $args = [], $is_retry = false ) {
 		if ( empty( $this->get_id() ) ) {
-			return $this->recreate_customer();
+			return $this->recreate_customer( $args );
 		} else {
 			return $this->update_customer( $args, true );
 		}
@@ -676,11 +736,13 @@ class WC_Stripe_Customer {
 	/**
 	 * Recreates the customer for this user.
 	 *
+	 * @param array $args Additional arguments for the request (optional).
+	 *
 	 * @return string ID of the new Customer object.
 	 */
-	private function recreate_customer() {
+	private function recreate_customer( $args = [] ) {
 		$this->delete_id_from_meta();
-		return $this->create_customer();
+		return $this->create_customer( $args );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -432,7 +432,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$order_id = absint( get_query_var( 'order-pay' ) );
 			$order    = wc_get_order( $order_id );
 
-			$stripe_params['orderId']    = $order_id;
+			$stripe_params['orderId'] = $order_id;
 
 			// Make billing country available for subscriptions as well, so country-restricted payment methods can be shown.
 			if ( is_a( $order, 'WC_Order' ) ) {
@@ -2317,7 +2317,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$user     = $this->get_user_from_order( $order );
 		$customer = new WC_Stripe_Customer( $user->ID );
 
-		return $customer->update_or_create_customer();
+		// Pass the order object so we can retrieve billing details
+		// in payment flows where it is not present in the request.
+		$args = [ 'order' => $order ];
+		return $customer->update_or_create_customer( $args );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Fix Stripe customer creation when using the Blocks API for express checkout.
 * Dev - Adds new logs to identify why express payment methods are not being displayed.
 * Fix - Fixes a fatal error when editing the shortcode checkout page with an empty cart on PHP 8.4.
 * Fix - Fixes processing of orders through the Pay for Order page when using ECE with Blocks (Store) API.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3777 

## Changes proposed in this Pull Request:
With express checkout's shift to Blocks API for processing the order, the billing details required for Stripe customer creation logic is no longer present in the request (`POST`) data.

This PR adds logic to retrieve the billing data from the order object, if it is available.

## Testing instructions
1. As a guest shopper, make any purchase using an express payment method, e.g. Google Pay.
    - In `develop`, you will see a `Undefined index: name` PHP notice in your logs.
    - In this branch, the PHP notice should be gone.
2. Go to the Stripe customers dashboard (https://dashboard.stripe.com/test/customers):
    - In `develop`, the customer's name is `Name: , Guest` (missing name) and the billing details are also missing.
    - In this branch, the customer's name is present, e.g. `Card Holder Name` if using Google Pay test account. Verify inside the customer's page that their billing details are complete.
3. Make another purchase using the same express payment method and card.
    - In `develop`, another nameless customer with no billing details gets created in Stripe.
    - In this branch, the existing Stripe customer gets retrieved and reused, as expected.
5. Regression check: as a guest shopper, purchase an item using a credit card, a different name and email address.
    - The Stripe customer should be created with complete billing details, and reused whenever possible. 


Note: I wanted to add some unit tests, but the testable methods involve calls to Stripe API. I'm somewhat hesitant to add code to enable us to inject an API library, but LMK if you feel strongly one way or another.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
