### PR TITLE
Prevent unnecessary call to get intent on order edit page

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - A potential fix to prevent duplicate charges.
 * Fix - Improve product page caching when Express Payment buttons are not enabled.
 * Fix - Allow editing uncaptured orders but show a warning about the possible failure scenario.
+* Fix - Fetch the payment intent status on order edit page only for unpaid orders if manual capture is enabled.
 * Fix - Error when changing subscription payment method to a 3D Secure card while using a custom checkout endpoint.
 * Fix - Fixes the webhook order retrieval by intent charges by adding an array check.
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -54,6 +54,13 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
+		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+
+		// Bail if the order is already captured or if manual capture is disabled.
+		if ( 'yes' === $order->get_meta( '_stripe_charge_captured', true ) || $gateway->is_automatic_capture_enabled() ) {
+			return;
+		}
+
 		try {
 			$intent = $this->get_intent_from_order( $order );
 			if ( $intent && WC_Stripe_Intent_Status::REQUIRES_CAPTURE === $intent->status ) {

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent empty settings screen when cancelling changes to the payment methods display order.
 * Fix - Improve product page caching when Express Payment buttons are not enabled.
 * Fix - Allow editing uncaptured orders but show a warning about the possible failure scenario.
+* Fix - Fetch the payment intent status on order edit page only for unpaid orders if manual capture is enabled.
 * Fix - Error when changing subscription payment method to a 3D Secure card while using a custom checkout endpoint.
 * Fix - Fixes the webhook order retrieval by intent charges by adding an array check.
 


### PR DESCRIPTION
Fixes #3770 

## Changes proposed in this Pull Request:
On the edit order page, for uncaptured orders, we show a warning message `Attempting to capture more than the authorized amount will fail with an error.`.  
This is only displayed when the intent has `requires_capture` status and to find this status we make an API request to get the intent data. However, if the order has already been captured, we should not make the API call and bail early as the order is uneditable at this point. The same goes for when manual capture is disabled.
In this PR, I have added an early bailing condition for these 2 scenarios.


## Testing instructions
- Code review should be enough.
- Use query monitor on the edit order page for different scenarios if you would like to do functional tests.
- Enable `Issue an authorization on checkout, and capture later` in the Stripe settings page.
    - Purchase a product with a card. Go to the order edit page as an admin and confirm that there is a GET request for `payment_intents`. 
    - Capture the previous order. Go to the order edit page as an admin and confirm that there is no GET request for `payment_intents`.
    - Purchase a product with COD. Go to the order edit page as an admin and confirm that there is no GET request for `payment_intents`.
- Disable `Issue an authorization on checkout, and capture later` in the Stripe settings page.
    - Purchase a product with a card, other APMs and COD. Go to the order edit page as an admin and confirm that there are no GET requests for `payment_intents`.