### PR TITLE
Add ACSS LPM feature flag

### DIFF
--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -182,6 +182,7 @@ class WC_Stripe_Settings_Controller {
 			'i18n_out_of_sync'          => $message,
 			'is_upe_checkout_enabled'   => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 			'is_ach_enabled'            => WC_Stripe_Feature_Flags::is_ach_lpm_enabled(),
+			'is_acss_enabled'           => WC_Stripe_Feature_Flags::is_acss_lpm_enabled(),
 			'is_bacs_enabled'           => WC_Stripe_Feature_Flags::is_bacs_lpm_enabled(),
 			'stripe_oauth_url'          => $oauth_url,
 			'stripe_test_oauth_url'     => $test_oauth_url,

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -8,6 +8,7 @@ class WC_Stripe_Feature_Flags {
 	const ECE_FEATURE_FLAG_NAME               = '_wcstripe_feature_ece';
 
 	const LPM_ACH_FEATURE_FLAG_NAME  = '_wcstripe_feature_lpm_ach';
+	const LPM_ACSS_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_acss';
 	const LPM_BACS_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_bacs';
 
 	/**
@@ -18,6 +19,16 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_ach_lpm_enabled() {
 		return 'yes' === get_option( self::LPM_ACH_FEATURE_FLAG_NAME, 'no' );
+	}
+
+	/**
+	 * Checks whether ACSS LPM (Local Payment Method) feature flag is enabled.
+	 * ACSS LPM is a feature that allows merchants to enable/disable the ACSS payment method.
+	 *
+	 * @return bool
+	 */
+	public static function is_acss_lpm_enabled() {
+		return 'yes' === get_option( self::LPM_ACSS_FEATURE_FLAG_NAME, 'no' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -422,6 +422,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// ACH LPM Feature flag.
 		$stripe_params['is_ach_enabled'] = WC_Stripe_Feature_Flags::is_ach_lpm_enabled();
 
+		// ACSS LPM Feature flag.
+		$stripe_params['is_acss_enabled'] = WC_Stripe_Feature_Flags::is_acss_lpm_enabled();
+
 		$cart_total = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
 		$currency   = get_woocommerce_currency();
 


### PR DESCRIPTION
Fixes #3781

## Changes proposed in this Pull Request:

Similar to #3745 and #3754, introduce a new `_wcstripe_feature_lpm_acss` feature flag for testing the ACSS / Canadian Pre-Authorized Debit LPM.

## Testing instructions

- Switch to this branch.

**Enable ACSS**

1. Enable the feature flag with `npm run wp option update _wcstripe_feature_lpm_acss 'yes'`.
2. Navigate to the Stripe gateway settings page and ensure `window.wc_stripe_settings_params.is_acss_enabled` evaluates to `'1'`.
3. Navigate to cart or checkout page and ensure `window.wc_stripe_upe_params.is_acss_enabled` evaluates to `'1'`.

**Disable ACSS**

1. Disable the feature flag with `npm run wp option delete _wcstripe_feature_lpm_acss`.
2. Navigate to the Stripe gateway settings page and ensure `window.wc_stripe_settings_params.is_acss_enabled` evaluates to `''`.
3. Navigate to cart or checkout page and ensure `window.wc_stripe_upe_params.is_acss_enabled` evaluates to `''`.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
