### PR TITLE
Amazon Pay ECE: add feature flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.
 * Tweak - Use WC Core's rate limiter on "Add payment method" page.
 * Add - New Amazon Pay payment method in the Stripe Express Checkout Element for the classic, shortcode (classic) checkout, product, and cart pages.

--- a/client/settings/payment-request-section/__tests__/index.test.js
+++ b/client/settings/payment-request-section/__tests__/index.test.js
@@ -42,6 +42,7 @@ describe( 'PaymentRequestSection', () => {
 		global.wc_stripe_settings_params = {
 			...globalValues,
 			is_ece_enabled: true,
+			is_amazon_pay_available: true,
 		};
 	} );
 
@@ -121,6 +122,19 @@ describe( 'PaymentRequestSection', () => {
 		global.wc_stripe_settings_params = {
 			...globalValues,
 			is_ece_enabled: false,
+			is_amazon_pay_available: true,
+		};
+
+		render( <PaymentRequestSection /> );
+
+		expect( screen.queryByText( 'Amazon Pay' ) ).toBeNull();
+	} );
+
+	it( 'hide Amazon Pay if feature flag is off', () => {
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			is_ece_enabled: true,
+			is_amazon_pay_available: false,
 		};
 
 		render( <PaymentRequestSection /> );

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -76,6 +76,8 @@ const PaymentRequestSection = () => {
 	);
 
 	const isECEEnabled = wc_stripe_settings_params.is_ece_enabled; // eslint-disable-line camelcase
+	const isAmazonPayAvailable =
+		wc_stripe_settings_params.is_amazon_pay_available; // eslint-disable-line camelcase
 
 	return (
 		<Card className="express-checkouts">
@@ -236,7 +238,7 @@ const PaymentRequestSection = () => {
 							</div>
 						</li>
 					) }
-					{ isECEEnabled && (
+					{ isAmazonPayAvailable && isECEEnabled && (
 						<li className="express-checkout has-icon-border">
 							<div className="express-checkout__checkbox">
 								<CheckboxControl

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -1,4 +1,4 @@
-/* global wc_stripe_upe_params, wc */
+/* global wc_stripe_upe_params, wc, wc_stripe_express_checkout_params */
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { getAppearance } from '../styles/upe';
@@ -233,13 +233,11 @@ export const isLinkEnabled = ( paymentMethodsConfig ) => {
 /**
  * Check whether Amazon Pay is enabled.
  *
- * @param {Object} paymentMethodsConfig Checkout payment methods configuration settings object.
  * @return {boolean} True, if enabled; false otherwise.
  */
-export const isAmazonPayEnabled = ( paymentMethodsConfig ) => {
-	paymentMethodsConfig =
-		paymentMethodsConfig || getStripeServerData()?.paymentMethodsConfig;
-	return paymentMethodsConfig?.amazonPay !== undefined;
+export const isAmazonPayEnabled = () => {
+	// eslint-disable-next-line camelcase, no-undef
+	return !! wc_stripe_express_checkout_params?.stripe?.is_amazon_pay_enabled;
 };
 
 /**

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -192,6 +192,7 @@ class WC_Stripe_Settings_Controller {
 			'account_country'           => $this->account->get_account_country(),
 			'are_apms_deprecated'       => WC_Stripe_Feature_Flags::are_apms_deprecated(),
 			'is_ece_enabled'            => WC_Stripe_Feature_Flags::is_stripe_ece_enabled(),
+			'is_amazon_pay_available'   => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
 	const ECE_FEATURE_FLAG_NAME               = '_wcstripe_feature_ece';
+	const AMAZON_PAY_FEATURE_FLAG_NAME        = '_wcstripe_feature_amazon_pay';
 
 	const LPM_ACH_FEATURE_FLAG_NAME  = '_wcstripe_feature_lpm_ach';
 	const LPM_ACSS_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_acss';
@@ -29,6 +30,15 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_acss_lpm_enabled() {
 		return 'yes' === get_option( self::LPM_ACSS_FEATURE_FLAG_NAME, 'no' );
+	}
+
+	/**
+	 * Feature flag to control Amazon Pay feature availability.
+	 *
+	 * @return bool
+	 */
+	public static function is_amazon_pay_available() {
+		return 'yes' === get_option( self::AMAZON_PAY_FEATURE_FLAG_NAME, 'no' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -190,6 +190,7 @@ class WC_Stripe_Express_Checkout_Element {
 				'locale'                      => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
 				'is_link_enabled'             => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
 				'is_express_checkout_enabled' => $this->express_checkout_helper->is_express_checkout_enabled(),
+				'is_amazon_pay_enabled'       => $this->express_checkout_helper->is_amazon_pay_enabled(),
 			],
 			'nonce'                  => [
 				'payment'                   => wp_create_nonce( 'wc-stripe-express-checkout' ),

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -226,10 +226,10 @@ class WC_Stripe_Express_Checkout_Helper {
 			}
 		}
 
-		$data     = [];
-		$items    = [];
-		$price    = $this->get_product_price( $product );
-		$currency = get_woocommerce_currency();
+		$data      = [];
+		$items     = [];
+		$price     = $this->get_product_price( $product );
+		$currency  = get_woocommerce_currency();
 		$total_tax = 0;
 
 		$items[] = [
@@ -259,8 +259,8 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		$data['displayItems'] = $items;
 		$data['total']        = [
-			'label'  => apply_filters( 'wc_stripe_payment_request_total_label', $this->total_label ),
-			'amount' => WC_Stripe_Helper::get_stripe_amount( $price + $total_tax, $currency ),
+			'label'   => apply_filters( 'wc_stripe_payment_request_total_label', $this->total_label ),
+			'amount'  => WC_Stripe_Helper::get_stripe_amount( $price + $total_tax, $currency ),
 			'pending' => true,
 		];
 
@@ -1160,12 +1160,12 @@ class WC_Stripe_Express_Checkout_Helper {
 	public function get_button_settings() {
 		$button_type = $this->get_button_type();
 		return [
-			'type'         => $button_type,
-			'theme'        => $this->get_button_theme(),
-			'height'       => $this->get_button_height(),
-			'radius'       => $this->get_button_radius(),
+			'type'   => $button_type,
+			'theme'  => $this->get_button_theme(),
+			'height' => $this->get_button_height(),
+			'radius' => $this->get_button_radius(),
 			// Default format is en_US.
-			'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
+			'locale' => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
 		];
 	}
 
@@ -1320,7 +1320,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		$message      = __( 'To complete your transaction with **the selected payment method**, you must log in or create an account with our site.', 'woocommerce-gateway-stripe' );
 		$redirect_url = add_query_arg(
 			[
-				'_wpnonce'                               => wp_create_nonce( 'wc-stripe-set-redirect-url' ),
+				'_wpnonce'                                => wp_create_nonce( 'wc-stripe-set-redirect-url' ),
 				'wc_stripe_express_checkout_redirect_url' => rawurlencode( home_url( add_query_arg( [] ) ) ), // Current URL to redirect to after login.
 			],
 			home_url()
@@ -1362,6 +1362,16 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_express_checkout_enabled() {
 		return isset( $this->stripe_settings['payment_request'] ) && 'yes' === $this->stripe_settings['payment_request'];
+	}
+
+	/**
+	 * Returns whether Amazon Pay is enabled.
+	 *
+	 * @return boolean
+	 */
+	public function is_amazon_pay_enabled() {
+		return WC_Stripe_Feature_Flags::is_amazon_pay_available() &&
+			isset( $this->stripe_settings['amazon_pay'] ) && 'yes' === $this->stripe_settings['amazon_pay'];
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.
 * Tweak - Use WC Core's rate limiter on "Add payment method" page.
 * Add - New Amazon Pay payment method in the Stripe Express Checkout Element for the classic, shortcode (classic) checkout, product, and cart pages.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -294,7 +294,7 @@ function woocommerce_gateway_stripe() {
 					if ( isset( $_GET['area'] ) && 'payment_requests' === $_GET['area'] ) {
 						require_once __DIR__ . '/includes/admin/class-wc-stripe-payment-requests-controller.php';
 						new WC_Stripe_Payment_Requests_Controller();
-					} else if ( isset( $_GET['area'] ) && 'amazon_pay' === $_GET['area'] ) {
+					} elseif ( isset( $_GET['area'] ) && 'amazon_pay' === $_GET['area'] && WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
 						require_once dirname( __FILE__ ) . '/includes/admin/class-wc-stripe-amazon-pay-controller.php';
 						new WC_Stripe_Amazon_Pay_Controller();
 					} else {


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3822 

## Changes proposed in this Pull Request:

- Adds a feature flag to control the release of Amazon Pay express checkout.
- Hooks `isAmazonPayEnabled` logic to correct setting

## Testing instructions
1. With the feature flag off -- this is the default -- verify that Amazon Pay is not available in Stripe settings or in any store page.
2. Turn the feature flag on, by setting the `_wcstripe_feature_amazon_pay` option to `yes`.
3. Verify that Amazon Pay is now available in Stripe settings.
5. With Amazon Pay enabled and the store currency set to `usd`, verify that Amazon Pay shows up in the product page.
    - Issue that prevented other express payment from working when Amazon Pay fails to load, e.g. due to currency being set to anything but `usd`, will be fixed in #3825 
7. Turn the feature flag off again, by deleting the `_wcstripe_feature_amazon_pay` option.
8. Verify that Amazon Pay is no longer available in the product page after a refresh.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
