### PR TITLE
Amazon Pay ECE: allow continue on loaderror for other express types

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Prevent an express checkout element's load errors from affecting other express checkout elements.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -93,6 +93,10 @@ jQuery( function ( $ ) {
 						$( `#${ containerName }` ).remove();
 					}
 				} );
+
+				eceButton.on( 'loaderror', () => {
+					$( `#${ containerName }` ).remove();
+				} );
 			}
 		},
 
@@ -184,13 +188,6 @@ jQuery( function ( $ ) {
 			} );
 
 			wcStripeECE.renderButton( eceButton, expressPaymentType );
-
-			eceButton.on( 'loaderror', () => {
-				wcStripeECEError = __(
-					'The cart is incompatible with express checkout.',
-					'woocommerce-gateway-stripe'
-				);
-			} );
 
 			eceButton.on( 'click', async function ( event ) {
 				// If login is required for checkout, display redirect confirmation dialog.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Prevent an express checkout element's load errors from affecting other express checkout elements.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.


### PR DESCRIPTION
Fixes an issue where other express payment types, e.g. Google Pay, do not work properly when Amazon Pay fails to load due to compatibility reasons.

## Changes proposed in this Pull Request:
In #3741, we have moved to using one element per express payment type. In this PR, we allow other express payment types to keep working even when another express payment type fails to load.

For example, if Amazon Pay fails to load, e.g. due to currency incompatibility, we still want shoppers to be able to use other express payment types if they themselves have no issues.

## Testing instructions
1. Turn the feature flag on, by setting the `_wcstripe_feature_amazon_pay` option to `yes`.
2. Enable Google Pay/Apple Pay, Link and Amazon Pay in your Stripe extension settings.
3. With store currency as `usd`, verify that Google Pay/Apple Pay, Link and Amazon Pay are available in the product page.
4. With store currency as `eur`, verify that Amazon Pay is no longer available after a refresh.
5. Click on one of the other express payment buttons, e.g. Google Pay.
    - In `develop`, you will see a window alert saying the cart is not compatible with express checkout.
    - In this branch, you should have no problems using any of the other express types to make a purchase.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
