### PR TITLE
Amazon Pay ECE: add to block cart and checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
-* Tweak - Process ECE cart requests using the Blocks (Store) API. 
+* Add - Add Amazon Pay to block cart and block checkout.
+* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,10 +2,9 @@
 
 = 9.2.0 - xxxx-xx-xx =
 * Add - Add Amazon Pay to block cart and block checkout.
-* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Dev - Introduces new payment method constants for the express methods: Google Pay, Apple Pay, Link, and Amazon Pay.
 * Fix - Prevent an express checkout element's load errors from affecting other express checkout elements.
-* Tweak - Process ECE cart requests using the Blocks (Store) API. 
+* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.

--- a/client/blocks/__tests__/index.test.js
+++ b/client/blocks/__tests__/index.test.js
@@ -1,0 +1,109 @@
+import { render } from '@testing-library/react';
+import {
+	expressCheckoutElementAmazonPay,
+	expressCheckoutElementApplePay,
+	expressCheckoutElementGooglePay,
+	expressCheckoutElementStripeLink,
+} from 'wcstripe/blocks/express-checkout';
+import { PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT } from 'wcstripe/blocks/express-checkout/constants';
+import {
+	AmazonPayPreview,
+	ApplePayPreview,
+	GooglePayPreview,
+	StripeLinkPreview,
+} from 'wcstripe/blocks/express-checkout/express-button-previews';
+import { loadStripe } from 'wcstripe/blocks/load-stripe';
+import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
+import { checkPaymentMethodIsAvailable } from 'wcstripe/express-checkout/utils/check-payment-method-availability';
+import { ExpressCheckoutContainer } from 'wcstripe/blocks/express-checkout/express-checkout-container';
+
+jest.mock( 'wcstripe/blocks/load-stripe' );
+jest.mock( 'wcstripe/blocks/utils' );
+jest.mock(
+	'wcstripe/express-checkout/utils/check-payment-method-availability'
+);
+
+// Mock the express button previews
+jest.mock( 'wcstripe/blocks/express-checkout/express-button-previews', () => ( {
+	AmazonPayPreview: jest.fn( () => <div /> ),
+	ApplePayPreview: jest.fn( () => <div /> ),
+	GooglePayPreview: jest.fn( () => <div /> ),
+	StripeLinkPreview: jest.fn( () => <div /> ),
+} ) );
+
+// Mock the ExpressCheckoutContainer component
+jest.mock( '../express-checkout/express-checkout-container', () => ( {
+	ExpressCheckoutContainer: jest.fn( () => <div /> ),
+} ) );
+
+describe( 'expressCheckoutElement', () => {
+	const api = {};
+
+	beforeEach( () => {
+		loadStripe.mockReturnValue( Promise.resolve( {} ) );
+		getBlocksConfiguration.mockReturnValue( {
+			shouldShowExpressCheckoutButton: true,
+			supports: [],
+			isAdmin: false,
+		} );
+		checkPaymentMethodIsAvailable.mockImplementation(
+			( _method, _api, _cart, resolve ) => {
+				resolve( true );
+			}
+		);
+	} );
+
+	const testCases = [
+		{
+			fn: expressCheckoutElementAmazonPay,
+			paymentMethod: 'amazonPay',
+			editorElement: AmazonPayPreview,
+			title: 'WooCommerce Stripe - Amazon Pay',
+		},
+		{
+			fn: expressCheckoutElementApplePay,
+			paymentMethod: 'applePay',
+			editorElement: ApplePayPreview,
+			title: 'WooCommerce Stripe - Apple Pay',
+		},
+		{
+			fn: expressCheckoutElementGooglePay,
+			paymentMethod: 'googlePay',
+			editorElement: GooglePayPreview,
+			title: 'WooCommerce Stripe - Google Pay',
+		},
+		{
+			fn: expressCheckoutElementStripeLink,
+			paymentMethod: 'link',
+			editorElement: StripeLinkPreview,
+			title: 'WooCommerce Stripe - Link by Stripe',
+		},
+	];
+
+	testCases.forEach( ( { fn, paymentMethod, editorElement, title } ) => {
+		it( `should return the correct config for ${ paymentMethod }`, async () => {
+			const config = fn( api );
+
+			expect( config.name ).toBe(
+				`${ PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT }_${ paymentMethod }`
+			);
+			expect( config.title ).toBe( title );
+
+			render( config.content );
+			expect( ExpressCheckoutContainer ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					expressPaymentMethod: paymentMethod,
+				} ),
+				{}
+			);
+
+			render( config.edit );
+			expect( editorElement ).toHaveBeenCalledTimes( 1 );
+
+			expect( config.paymentMethodId ).toBe(
+				PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT
+			);
+			expect( config.gatewayId ).toBe( 'stripe' );
+		} );
+	} );
+} );

--- a/client/blocks/__tests__/index.test.js
+++ b/client/blocks/__tests__/index.test.js
@@ -16,6 +16,12 @@ import { loadStripe } from 'wcstripe/blocks/load-stripe';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
 import { checkPaymentMethodIsAvailable } from 'wcstripe/express-checkout/utils/check-payment-method-availability';
 import { ExpressCheckoutContainer } from 'wcstripe/blocks/express-checkout/express-checkout-container';
+import {
+	EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
+	EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
+	EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
+	EXPRESS_PAYMENT_METHOD_SETTING_LINK,
+} from 'wcstripe/stripe-utils/constants';
 
 jest.mock( 'wcstripe/blocks/load-stripe' );
 jest.mock( 'wcstripe/blocks/utils' );
@@ -56,25 +62,25 @@ describe( 'expressCheckoutElement', () => {
 	const testCases = [
 		{
 			fn: expressCheckoutElementAmazonPay,
-			paymentMethod: 'amazonPay',
+			paymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 			editorElement: AmazonPayPreview,
 			title: 'WooCommerce Stripe - Amazon Pay',
 		},
 		{
 			fn: expressCheckoutElementApplePay,
-			paymentMethod: 'applePay',
+			paymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
 			editorElement: ApplePayPreview,
 			title: 'WooCommerce Stripe - Apple Pay',
 		},
 		{
 			fn: expressCheckoutElementGooglePay,
-			paymentMethod: 'googlePay',
+			paymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
 			editorElement: GooglePayPreview,
 			title: 'WooCommerce Stripe - Google Pay',
 		},
 		{
 			fn: expressCheckoutElementStripeLink,
-			paymentMethod: 'link',
+			paymentMethod: EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			editorElement: StripeLinkPreview,
 			title: 'WooCommerce Stripe - Link by Stripe',
 		},

--- a/client/blocks/express-checkout/express-button-previews/index.js
+++ b/client/blocks/express-checkout/express-button-previews/index.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
-import googlePayIcon from '../../../payment-method-icons/google-pay/icon-white.svg';
+import amazonPayIcon from '../../../payment-method-icons/amazon-pay/icon.svg';
 import applePayIcon from '../../../payment-method-icons/apple-pay/icon-white.svg';
+import googlePayIcon from '../../../payment-method-icons/google-pay/icon-white.svg';
 import stripeLinkIcon from '../../../payment-method-icons/link/icon-black.svg';
 import './style.scss';
 
@@ -24,14 +25,14 @@ const PaymentButtonPreview = ( { icon, className } ) => (
 );
 
 /**
- * GooglePayPreview Component
+ * AmazonPayPreview Component
  *
  * @return {JSX.Element} The rendered component.
  */
-export const GooglePayPreview = () => (
+export const AmazonPayPreview = () => (
 	<PaymentButtonPreview
-		icon={ googlePayIcon }
-		className="wc-stripe-google-pay-preview"
+		icon={ amazonPayIcon }
+		className="wc-stripe-amazon-pay-preview"
 	/>
 );
 
@@ -44,6 +45,18 @@ export const ApplePayPreview = () => (
 	<PaymentButtonPreview
 		icon={ applePayIcon }
 		className="wc-stripe-apple-pay-preview"
+	/>
+);
+
+/**
+ * GooglePayPreview Component
+ *
+ * @return {JSX.Element} The rendered component.
+ */
+export const GooglePayPreview = () => (
+	<PaymentButtonPreview
+		icon={ googlePayIcon }
+		className="wc-stripe-google-pay-preview"
 	/>
 );
 

--- a/client/blocks/express-checkout/express-button-previews/style.scss
+++ b/client/blocks/express-checkout/express-button-previews/style.scss
@@ -12,6 +12,13 @@
 		cursor: pointer;
 		filter: opacity(0.7);
 	}
+	/* Amazon Pay Overrides */
+	&.wc-stripe-amazon-pay-preview {
+		background-color: #ffd814;
+		img {
+			height: 40px;
+		}
+	}
 	/* Stripe Link Overrides */
 	&.wc-stripe-link-preview {
 		background-color: #00d66f;

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -3,6 +3,7 @@
 import { PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT } from './constants';
 import { ExpressCheckoutContainer } from './express-checkout-container';
 import {
+	AmazonPayPreview,
 	ApplePayPreview,
 	GooglePayPreview,
 	StripeLinkPreview,
@@ -114,8 +115,38 @@ const expressCheckoutElementsStripeLink = ( api ) => ( {
 	supports,
 } );
 
+const expressCheckoutElementsAmazonPay = ( api ) => ( {
+	name: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT + '_amazonPay',
+	title: 'WooCommerce Stripe - Amazon Pay',
+	content: (
+		<ExpressCheckoutContainer
+			api={ api }
+			stripe={ stripePromise }
+			expressPaymentMethod="amazonPay"
+		/>
+	),
+	edit: <AmazonPayPreview />,
+	canMakePayment: ( { cart } ) => {
+		if ( ! getBlocksConfiguration()?.shouldShowExpressCheckoutButton ) {
+			return false;
+		}
+
+		// eslint-disable-next-line camelcase
+		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
+			return false;
+		}
+
+		return new Promise( ( resolve ) => {
+			checkPaymentMethodIsAvailable( 'amazonPay', api, cart, resolve );
+		} );
+	},
+	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
+	supports,
+} );
+
 export {
-	expressCheckoutElementsGooglePay,
+	expressCheckoutElementsAmazonPay,
 	expressCheckoutElementsApplePay,
+	expressCheckoutElementsGooglePay,
 	expressCheckoutElementsStripeLink,
 };

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -12,9 +12,10 @@ import { loadStripe } from 'wcstripe/blocks/load-stripe';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
 import { checkPaymentMethodIsAvailable } from 'wcstripe/express-checkout/utils/check-payment-method-availability';
 import {
+	EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
-	PAYMENT_METHOD_LINK,
+	EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 } from 'wcstripe/stripe-utils/constants';
 
 /** @typedef {import('react')} React */
@@ -29,13 +30,13 @@ const stripePromise = loadStripe();
  */
 const getTitle = ( expressPaymentMethod ) => {
 	switch ( expressPaymentMethod ) {
-		case 'amazonPay':
+		case EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY:
 			return 'WooCommerce Stripe - Amazon Pay';
 		case EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY:
 			return 'WooCommerce Stripe - Apple Pay';
 		case EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY:
 			return 'WooCommerce Stripe - Google Pay';
-		case PAYMENT_METHOD_LINK:
+		case EXPRESS_PAYMENT_METHOD_SETTING_LINK:
 			return 'WooCommerce Stripe - Link by Stripe';
 		default:
 			return '';
@@ -50,13 +51,13 @@ const getTitle = ( expressPaymentMethod ) => {
  */
 const getEditorElement = ( expressPaymentMethod ) => {
 	switch ( expressPaymentMethod ) {
-		case 'amazonPay':
+		case EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY:
 			return <AmazonPayPreview />;
 		case EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY:
 			return <ApplePayPreview />;
 		case EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY:
 			return <GooglePayPreview />;
-		case PAYMENT_METHOD_LINK:
+		case EXPRESS_PAYMENT_METHOD_SETTING_LINK:
 			return <StripeLinkPreview />;
 		default:
 			return null;
@@ -121,13 +122,13 @@ const expressCheckoutElement = ( expressPaymentMethod, api ) => {
 };
 
 const expressCheckoutElementAmazonPay = ( api ) =>
-	expressCheckoutElement( 'amazonPay', api );
+	expressCheckoutElement( EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY, api );
 const expressCheckoutElementApplePay = ( api ) =>
 	expressCheckoutElement( EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY, api );
 const expressCheckoutElementGooglePay = ( api ) =>
 	expressCheckoutElement( EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY, api );
 const expressCheckoutElementStripeLink = ( api ) =>
-	expressCheckoutElement( PAYMENT_METHOD_LINK, api );
+	expressCheckoutElement( EXPRESS_PAYMENT_METHOD_SETTING_LINK, api );
 
 export {
 	expressCheckoutElementAmazonPay,

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -11,88 +11,72 @@ import {
 import { loadStripe } from 'wcstripe/blocks/load-stripe';
 import { getBlocksConfiguration } from 'wcstripe/blocks/utils';
 import { checkPaymentMethodIsAvailable } from 'wcstripe/express-checkout/utils/check-payment-method-availability';
-import { PAYMENT_METHOD_LINK } from 'wcstripe/stripe-utils/constants';
+
+/** @typedef {import('react')} React */
 
 const stripePromise = loadStripe();
 
-const supports = {
-	features: getBlocksConfiguration()?.supports ?? [],
+/**
+ * Get the title for the express payment method.
+ *
+ * @param {string} expressPaymentMethod
+ * @return {string} The title.
+ */
+const getTitle = ( expressPaymentMethod ) => {
+	switch ( expressPaymentMethod ) {
+		case 'amazonPay':
+			return 'WooCommerce Stripe - Amazon Pay';
+		case 'applePay':
+			return 'WooCommerce Stripe - Apple Pay';
+		case 'googlePay':
+			return 'WooCommerce Stripe - Google Pay';
+		case 'link':
+			return 'WooCommerce Stripe - Link by Stripe';
+		default:
+			return '';
+	}
 };
-if ( getBlocksConfiguration().isAdmin ?? false ) {
-	supports.style = getBlocksConfiguration()?.style ?? [];
-}
 
-const expressCheckoutElementsGooglePay = ( api ) => ( {
-	name: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT + '_googlePay',
-	title: 'WooCommerce Stripe - Google Pay',
-	content: (
+/**
+ * Get the editor element for the express payment method.
+ *
+ * @param {string} expressPaymentMethod
+ * @return {React.ReactNode} The React element for the editor.
+ */
+const getEditorElement = ( expressPaymentMethod ) => {
+	switch ( expressPaymentMethod ) {
+		case 'amazonPay':
+			return <AmazonPayPreview />;
+		case 'applePay':
+			return <ApplePayPreview />;
+		case 'googlePay':
+			return <GooglePayPreview />;
+		case 'link':
+			return <StripeLinkPreview />;
+		default:
+			return null;
+	}
+};
+
+/**
+ *
+ * @param {string} expressPaymentMethod
+ * @param {Object} api The Stripe API object.
+ * @return {Object} The express payment method configuration.
+ */
+const expressCheckoutElement = ( expressPaymentMethod, api ) => {
+	const name =
+		PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT + '_' + expressPaymentMethod;
+	const title = getTitle( expressPaymentMethod );
+	const content = (
 		<ExpressCheckoutContainer
 			api={ api }
 			stripe={ stripePromise }
-			expressPaymentMethod="googlePay"
+			expressPaymentMethod={ expressPaymentMethod }
 		/>
-	),
-	edit: <GooglePayPreview />,
-	canMakePayment: ( { cart } ) => {
-		if ( ! getBlocksConfiguration()?.shouldShowExpressCheckoutButton ) {
-			return false;
-		}
-
-		// eslint-disable-next-line camelcase
-		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
-			return false;
-		}
-
-		return new Promise( ( resolve ) => {
-			checkPaymentMethodIsAvailable( 'googlePay', api, cart, resolve );
-		} );
-	},
-	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
-	gatewayId: 'stripe',
-	supports,
-} );
-
-const expressCheckoutElementsApplePay = ( api ) => ( {
-	name: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT + '_applePay',
-	title: 'WooCommerce Stripe - Apple Pay',
-	content: (
-		<ExpressCheckoutContainer
-			api={ api }
-			stripe={ stripePromise }
-			expressPaymentMethod="applePay"
-		/>
-	),
-	edit: <ApplePayPreview />,
-	canMakePayment: ( { cart } ) => {
-		if ( ! getBlocksConfiguration()?.shouldShowExpressCheckoutButton ) {
-			return false;
-		}
-
-		// eslint-disable-next-line camelcase
-		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
-			return false;
-		}
-
-		return new Promise( ( resolve ) => {
-			checkPaymentMethodIsAvailable( 'applePay', api, cart, resolve );
-		} );
-	},
-	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
-	gatewayId: 'stripe',
-	supports,
-} );
-
-const expressCheckoutElementsStripeLink = ( api ) => ( {
-	name: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT + '_link',
-	content: (
-		<ExpressCheckoutContainer
-			api={ api }
-			stripe={ stripePromise }
-			expressPaymentMethod="link"
-		/>
-	),
-	edit: <StripeLinkPreview />,
-	canMakePayment: ( { cart } ) => {
+	);
+	const edit = getEditorElement( expressPaymentMethod );
+	const canMakePayment = ( { cart } ) => {
 		if ( ! getBlocksConfiguration()?.shouldShowExpressCheckoutButton ) {
 			return false;
 		}
@@ -104,49 +88,45 @@ const expressCheckoutElementsStripeLink = ( api ) => ( {
 
 		return new Promise( ( resolve ) => {
 			checkPaymentMethodIsAvailable(
-				PAYMENT_METHOD_LINK,
+				expressPaymentMethod,
 				api,
 				cart,
 				resolve
 			);
 		} );
-	},
-	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
-	supports,
-} );
+	};
 
-const expressCheckoutElementsAmazonPay = ( api ) => ( {
-	name: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT + '_amazonPay',
-	title: 'WooCommerce Stripe - Amazon Pay',
-	content: (
-		<ExpressCheckoutContainer
-			api={ api }
-			stripe={ stripePromise }
-			expressPaymentMethod="amazonPay"
-		/>
-	),
-	edit: <AmazonPayPreview />,
-	canMakePayment: ( { cart } ) => {
-		if ( ! getBlocksConfiguration()?.shouldShowExpressCheckoutButton ) {
-			return false;
-		}
+	const supports = {
+		features: getBlocksConfiguration()?.supports ?? [],
+		...( getBlocksConfiguration()?.isAdmin && {
+			style: getBlocksConfiguration()?.style ?? [],
+		} ),
+	};
 
-		// eslint-disable-next-line camelcase
-		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
-			return false;
-		}
+	return {
+		name,
+		title,
+		content,
+		edit,
+		canMakePayment,
+		paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
+		gatewayId: 'stripe',
+		supports,
+	};
+};
 
-		return new Promise( ( resolve ) => {
-			checkPaymentMethodIsAvailable( 'amazonPay', api, cart, resolve );
-		} );
-	},
-	paymentMethodId: PAYMENT_METHOD_EXPRESS_CHECKOUT_ELEMENT,
-	supports,
-} );
+const expressCheckoutElementAmazonPay = ( api ) =>
+	expressCheckoutElement( 'amazonPay', api );
+const expressCheckoutElementApplePay = ( api ) =>
+	expressCheckoutElement( 'applePay', api );
+const expressCheckoutElementGooglePay = ( api ) =>
+	expressCheckoutElement( 'googlePay', api );
+const expressCheckoutElementStripeLink = ( api ) =>
+	expressCheckoutElement( 'link', api );
 
 export {
-	expressCheckoutElementsAmazonPay,
-	expressCheckoutElementsApplePay,
-	expressCheckoutElementsGooglePay,
-	expressCheckoutElementsStripeLink,
+	expressCheckoutElementAmazonPay,
+	expressCheckoutElementApplePay,
+	expressCheckoutElementGooglePay,
+	expressCheckoutElementStripeLink,
 };

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -16,10 +16,10 @@ import { SavedTokenHandler } from './saved-token-handler';
 import { updateTokenLabelsWhenLoaded } from './token-label-updater.js';
 import paymentRequestPaymentMethod from 'wcstripe/blocks/payment-request';
 import {
-	expressCheckoutElementsAmazonPay,
-	expressCheckoutElementsApplePay,
-	expressCheckoutElementsGooglePay,
-	expressCheckoutElementsStripeLink,
+	expressCheckoutElementAmazonPay,
+	expressCheckoutElementApplePay,
+	expressCheckoutElementGooglePay,
+	expressCheckoutElementStripeLink,
 } from 'wcstripe/blocks/express-checkout';
 import WCStripeAPI from 'wcstripe/api';
 import {
@@ -111,10 +111,10 @@ Object.entries( paymentMethodsConfig )
 
 if ( getBlocksConfiguration()?.isECEEnabled ) {
 	// Register Express Checkout Element.
-	registerExpressPaymentMethod( expressCheckoutElementsAmazonPay( api ) );
-	registerExpressPaymentMethod( expressCheckoutElementsApplePay( api ) );
-	registerExpressPaymentMethod( expressCheckoutElementsGooglePay( api ) );
-	registerExpressPaymentMethod( expressCheckoutElementsStripeLink( api ) );
+	registerExpressPaymentMethod( expressCheckoutElementAmazonPay( api ) );
+	registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
+	registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
+	registerExpressPaymentMethod( expressCheckoutElementStripeLink( api ) );
 } else {
 	// Register Stripe Payment Request.
 	registerExpressPaymentMethod( paymentRequestPaymentMethod );

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -16,8 +16,9 @@ import { SavedTokenHandler } from './saved-token-handler';
 import { updateTokenLabelsWhenLoaded } from './token-label-updater.js';
 import paymentRequestPaymentMethod from 'wcstripe/blocks/payment-request';
 import {
-	expressCheckoutElementsGooglePay,
+	expressCheckoutElementsAmazonPay,
 	expressCheckoutElementsApplePay,
+	expressCheckoutElementsGooglePay,
 	expressCheckoutElementsStripeLink,
 } from 'wcstripe/blocks/express-checkout';
 import WCStripeAPI from 'wcstripe/api';
@@ -110,8 +111,9 @@ Object.entries( paymentMethodsConfig )
 
 if ( getBlocksConfiguration()?.isECEEnabled ) {
 	// Register Express Checkout Element.
-	registerExpressPaymentMethod( expressCheckoutElementsGooglePay( api ) );
+	registerExpressPaymentMethod( expressCheckoutElementsAmazonPay( api ) );
 	registerExpressPaymentMethod( expressCheckoutElementsApplePay( api ) );
+	registerExpressPaymentMethod( expressCheckoutElementsGooglePay( api ) );
 	registerExpressPaymentMethod( expressCheckoutElementsStripeLink( api ) );
 } else {
 	// Register Stripe Payment Request.

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -110,8 +110,12 @@ Object.entries( paymentMethodsConfig )
 	} );
 
 if ( getBlocksConfiguration()?.isECEEnabled ) {
-	// Register Express Checkout Element.
-	registerExpressPaymentMethod( expressCheckoutElementAmazonPay( api ) );
+	// Register Express Checkout Elements.
+
+	// Hide behind feature flag so the editor does not show the button.
+	if ( getBlocksConfiguration()?.isAmazonPayAvailable ) {
+		registerExpressPaymentMethod( expressCheckoutElementAmazonPay( api ) );
+	}
 	registerExpressPaymentMethod( expressCheckoutElementApplePay( api ) );
 	registerExpressPaymentMethod( expressCheckoutElementGooglePay( api ) );
 	registerExpressPaymentMethod( expressCheckoutElementStripeLink( api ) );

--- a/client/express-checkout/tracking.js
+++ b/client/express-checkout/tracking.js
@@ -4,8 +4,9 @@ import { recordEvent } from 'wcstripe/tracking';
 // Track the button click event.
 export const trackExpressCheckoutButtonClick = ( paymentMethod, source ) => {
 	const expressPaymentTypeEvents = {
-		google_pay: 'gpay_button_click',
+		amazon_pay: 'amazonpay_button_click',
 		apple_pay: 'applepay_button_click',
+		google_pay: 'gpay_button_click',
 		link: 'link_button_click',
 	};
 
@@ -21,8 +22,9 @@ export const trackExpressCheckoutButtonClick = ( paymentMethod, source ) => {
 export const trackExpressCheckoutButtonLoad = debounce(
 	( { paymentMethods, source } ) => {
 		const expressPaymentTypeEvents = {
-			googlePay: 'gpay_button_load',
+			amazonPay: 'amazonpay_button_load',
 			applePay: 'applepay_button_load',
+			googlePay: 'gpay_button_load',
 			link: 'link_button_load',
 		};
 

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -38,7 +38,10 @@ export const checkPaymentMethodIsAvailable = memoize(
 					onLoadError={ () => resolve( false ) }
 					options={ {
 						paymentMethods: {
-							amazonPay: 'never',
+							amazonPay:
+								paymentMethod === 'amazonPay'
+									? 'auto'
+									: 'never',
 							applePay:
 								paymentMethod === 'applePay'
 									? 'always'

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -6,6 +6,7 @@ import {
 	isManualPaymentMethodCreation,
 } from 'wcstripe/express-checkout/utils';
 import {
+	EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_LINK,
@@ -43,7 +44,8 @@ export const checkPaymentMethodIsAvailable = memoize(
 					options={ {
 						paymentMethods: {
 							amazonPay:
-								paymentMethod === 'amazonPay'
+								paymentMethod ===
+								EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY
 									? 'auto'
 									: 'never',
 							applePay:

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -135,11 +135,11 @@ export const getExpressCheckoutButtonStyleSettings = () => {
 
 	return {
 		paymentMethods: {
+			amazonPay: 'auto',
 			applePay: 'always',
 			googlePay: 'always',
 			link: 'auto',
 			paypal: 'never',
-			amazonPay: 'never',
 		},
 		layout: { overflow: 'never' },
 		buttonTheme: {

--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -116,7 +116,7 @@ export const PAYMENT_INTENT_STATUS_SUCCEEDED = 'succeeded';
 /**
  * Express payment methods setting constants
  */
-export const EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY = 'googlePay';
-export const EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY = 'applePay';
-export const EXPRESS_PAYMENT_METHOD_SETTING_LINK = 'link';
 export const EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY = 'amazonPay';
+export const EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY = 'applePay';
+export const EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY = 'googlePay';
+export const EXPRESS_PAYMENT_METHOD_SETTING_LINK = 'link';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -437,6 +437,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// ECE feature flag
 		$stripe_params['isECEEnabled'] = WC_Stripe_Feature_Flags::is_stripe_ece_enabled();
 
+		// Amazon Pay feature flag.
+		$stripe_params['isAmazonPayAvailable'] = WC_Stripe_Feature_Flags::is_amazon_pay_available();
+
 		// ACH LPM Feature flag.
 		$stripe_params['is_ach_enabled'] = WC_Stripe_Feature_Flags::is_ach_lpm_enabled();
 
@@ -2197,7 +2200,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$order,
 				$payment_method_details
 			);
-			$payment_information['capture_method']           = $capture_method;
+			$payment_information['capture_method']               = $capture_method;
 		} else {
 			$confirmation_token_id                               = sanitize_text_field( wp_unslash( $_POST['wc-stripe-confirmation-token'] ?? '' ) );
 			$payment_information['confirmation_token']           = $confirmation_token_id;

--- a/readme.txt
+++ b/readme.txt
@@ -112,10 +112,9 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.2.0 - xxxx-xx-xx =
 * Add - Add Amazon Pay to block cart and block checkout.
-* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Dev - Introduces new payment method constants for the express methods: Google Pay, Apple Pay, Link, and Amazon Pay.
 * Fix - Prevent an express checkout element's load errors from affecting other express checkout elements.
-* Tweak - Process ECE cart requests using the Blocks (Store) API. 
+* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,8 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
-* Tweak - Process ECE cart requests using the Blocks (Store) API. 
+* Add - Add Amazon Pay to block cart and block checkout.
+* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.


### PR DESCRIPTION
Fixes #3732 

## Changes proposed in this Pull Request:
Adds Amazon Pay express checkout to block cart and block checkout.

| Block cart | Block checkout |
|------------|----------------|
| <img width="861" alt="Screenshot 2025-02-04 at 1 28 19 PM" src="https://github.com/user-attachments/assets/5ad68f49-47d4-450f-a89b-351d67d9ff60" /> | <img width="861" alt="Screenshot 2025-02-04 at 1 30 17 PM" src="https://github.com/user-attachments/assets/4ff0b8f8-6577-4bc9-a084-877ec20f4832" /> |

## Testing instructions
1. Turn on the feature flag by setting the `_wcstripe_feature_amazon_pay` option to `yes`.
2. In wp-admin Stripe settings, enable Amazon Pay as a payment method.
3. As a shopper, add an item to your cart.
4. Complete the purchase using Amazon Pay, inside the block cart or block checkout page.
5. Verify in wp-admin that the order details are correct, and that the status is `Completed` or `Processing`.
    - It may take a while (3-5 minutes) for charges to clear. Status will be `Pending payment` until then.
6. View block cart or block checkout inside the wp-admin block editor. Verify that the Amazon Pay button is present.
7. Disable Amazon Pay as a payment method, or turn off the feature flag.
8. Verify that Amazon Pay is no longer available inside block cart and checkout.
9. For wp-admin block editor: 
    - With the feature flag on and Amazon Pay disabled, the button will still be visible inside the editor. This is a known ECE issue and is documented in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3437.
    - With the feature flag off, the Amazon Pay button should no longer be visible inside the editor.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
