### PR TITLE
ECE: remove intentional delay causing timeout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,10 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.
 * Dev - Introduces new payment method constants for the express methods: Google Pay, Apple Pay, Link, and Amazon Pay.
 * Fix - Prevent an express checkout element's load errors from affecting other express checkout elements.
-* Tweak - Process ECE cart requests using the Blocks (Store) API. 
+* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -10,7 +10,6 @@ import {
 } from 'wcstripe/express-checkout/event-handler';
 import {
 	displayExpressCheckoutNotice,
-	expressCheckoutNoticeDelay,
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
 	normalizeLineItems,
@@ -100,8 +99,6 @@ export const useExpressCheckout = ( {
 					'info',
 					[ 'ece-taxes-info' ]
 				);
-				// Wait for the notice to be displayed before proceeding.
-				await expressCheckoutNoticeDelay();
 			}
 
 			// Global click event handler to ECE.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -6,7 +6,6 @@ import WCStripeAPI from '../../api';
 import {
 	displayExpressCheckoutNotice,
 	displayLoginConfirmation,
-	expressCheckoutNoticeDelay,
 	getExpressCheckoutButtonAppearance,
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
@@ -233,8 +232,6 @@ jQuery( function ( $ ) {
 						'info',
 						[ 'ece-taxes-info' ]
 					);
-					// Wait for the notice to be displayed before proceeding.
-					await expressCheckoutNoticeDelay();
 				}
 
 				if ( getExpressCheckoutData( 'is_product_page' ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -111,9 +111,10 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.
 * Dev - Introduces new payment method constants for the express methods: Google Pay, Apple Pay, Link, and Amazon Pay.
 * Fix - Prevent an express checkout element's load errors from affecting other express checkout elements.
-* Tweak - Process ECE cart requests using the Blocks (Store) API. 
+* Tweak - Process ECE cart requests using the Blocks (Store) API.
 * Add - Adds a new setting to toggle saving of Bancontact and iDEAL methods as SEPA Debit.
 * Add - Wrap Amazon Pay in feature flag.
 * Fix - Allow the saving of Bancontact tokens when SEPA is disabled.


### PR DESCRIPTION
Fixes #3838

## Changes proposed in this Pull Request:
When taxes are based on customer billing address and the shopper is using express checkout, we cannot display the final tax amount accurately inside the payment modal, as we do not get the customer's billing address until the payment sheet is returned.

In #3550, we decided to display a notice to inform shoppers of this limitation. We also added a slight intentional delay (700ms), at the time the longest possible that will not go over Stripe's 1-second limit for the click event to resolve.

With recent changes in how ECE orders are processed, we are now hitting this limit and causing ECE to bail and get stuck, at least inside the product page. 

In this PR, we remove any intentional delays we've added, to avoid cases like this.

Subsequently, in a future PR, we need to move the notice to where the merchant or shopper can have ample time to read it, without affecting Stripe timeouts. One idea is to advise the merchant of the tax limitations inside the tax settings page -- similar to the way core advises them when their tax setup is inconsistent -- and they can then decide for themselves where and whether to display a notice to their shoppers.

## Testing instructions

1. Set up taxes for your store:
     - Go to **WooCommerce > Settings > Tax > Tax options**.
     - For `Prices entered with tax`, select `No, I will enter prices exclusive of tax`.
     - For `Calculate tax based on`, select `Customer billing address`.
2. As a shopper, go to a product page. 
3. Click Google Pay.
    - In `develop`, the page gets stuck with the pinwheel animation, and the payment modal never loads.
    - In this branch, the payment modal should load.
---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
