### PR TITLE
Avoid account cache busting on page load

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -43,6 +43,7 @@
 * Fix - Use the original shipping address for Amazon Pay pay for orders.
 * Tweak - Improve settings page load by delaying oauth URL generation.
 * Tweak - Update the Woo logo in the Configure connection modal
+* Tweak - Improve settings page load by avoid account cache clearing on every page load.
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/client/settings/payment-settings/__tests__/account-details-section.test.js
+++ b/client/settings/payment-settings/__tests__/account-details-section.test.js
@@ -46,10 +46,17 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 const mockRefreshAccount = jest.fn();
+const mockCreateSuccessNotice = jest.fn();
 jest.mock( '@wordpress/data', () => ( {
-	useDispatch: () => ( {
-		refreshAccount: mockRefreshAccount,
-	} ),
+	useDispatch: ( store ) => {
+		if ( store === 'wc/stripe' ) {
+			return { refreshAccount: mockRefreshAccount };
+		}
+		if ( store === 'core/notices' ) {
+			return { createSuccessNotice: mockCreateSuccessNotice };
+		}
+		return {};
+	},
 	combineReducers: jest.fn(),
 	createReduxStore: jest.fn(),
 	register: jest.fn(),
@@ -193,6 +200,7 @@ describe( 'AccountDetailsSection', () => {
 				},
 			} );
 			mockRefreshAccount.mockClear();
+			mockCreateSuccessNotice.mockClear();
 		} );
 
 		it( 'should show refresh account option in dropdown menu', () => {

--- a/client/settings/payment-settings/__tests__/account-details-section.test.js
+++ b/client/settings/payment-settings/__tests__/account-details-section.test.js
@@ -45,6 +45,15 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	default: jest.fn(),
 } ) );
 
+// Mock the dispatch function
+const mockRefreshAccount = jest.fn();
+jest.mock( '@wordpress/data', () => ( {
+	...jest.requireActual( '@wordpress/data' ),
+	useDispatch: () => ( {
+		refreshAccount: mockRefreshAccount,
+	} ),
+} ) );
+
 describe( 'AccountDetailsSection', () => {
 	const setModalTypeMock = jest.fn();
 	beforeEach( () => {
@@ -164,5 +173,94 @@ describe( 'AccountDetailsSection', () => {
 
 		const stripeAccountId = screen.getByText( /acct_123/i );
 		expect( stripeAccountId ).toBeInTheDocument();
+	} );
+
+	describe( 'Refresh account functionality', () => {
+		beforeEach( () => {
+			useAccount.mockReturnValue( {
+				data: {
+					webhook_url: 'example.com',
+					account: {
+						id: 'acct_123',
+						email: 'test@example.com',
+						testmode: false,
+					},
+					configured_webhook_urls: {
+						live: 'example.com',
+						test: 'example.com',
+					},
+				},
+			} );
+			mockRefreshAccount.mockClear();
+		} );
+
+		it( 'should show refresh account option in dropdown menu', () => {
+			render(
+				<AccountDetailsSection setModalType={ setModalTypeMock } />
+			);
+
+			// Open the dropdown menu
+			const menuButton = screen.getByLabelText(
+				'Edit details or disconnect account'
+			);
+			userEvent.click( menuButton );
+
+			// Check if refresh option exists
+			const refreshButton = screen.getByRole( 'menuitem', {
+				name: /refresh account details/i,
+			} );
+			expect( refreshButton ).toBeInTheDocument();
+		} );
+
+		it( 'should call refreshAccount when refresh option is clicked', async () => {
+			render(
+				<AccountDetailsSection setModalType={ setModalTypeMock } />
+			);
+
+			// Open the dropdown menu
+			const menuButton = screen.getByLabelText(
+				'Edit details or disconnect account'
+			);
+			userEvent.click( menuButton );
+
+			// Click the refresh option
+			const refreshButton = screen.getByRole( 'menuitem', {
+				name: /refresh account details/i,
+			} );
+			userEvent.click( refreshButton );
+
+			expect( mockRefreshAccount ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'should show refresh option in both test and live modes', () => {
+			// Test mode
+			useTestMode.mockReturnValue( [ true, jest.fn() ] );
+			const { rerender } = render(
+				<AccountDetailsSection setModalType={ setModalTypeMock } />
+			);
+
+			const menuButton = screen.getByLabelText(
+				'Edit details or disconnect account'
+			);
+			userEvent.click( menuButton );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: /refresh account details/i,
+				} )
+			).toBeInTheDocument();
+
+			// Live mode
+			useTestMode.mockReturnValue( [ false, jest.fn() ] );
+			rerender(
+				<AccountDetailsSection setModalType={ setModalTypeMock } />
+			);
+
+			userEvent.click( menuButton );
+			expect(
+				screen.getByRole( 'menuitem', {
+					name: /refresh account details/i,
+				} )
+			).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/settings/payment-settings/__tests__/account-details-section.test.js
+++ b/client/settings/payment-settings/__tests__/account-details-section.test.js
@@ -45,13 +45,14 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	default: jest.fn(),
 } ) );
 
-// Mock the dispatch function
 const mockRefreshAccount = jest.fn();
 jest.mock( '@wordpress/data', () => ( {
-	...jest.requireActual( '@wordpress/data' ),
 	useDispatch: () => ( {
 		refreshAccount: mockRefreshAccount,
 	} ),
+	combineReducers: jest.fn(),
+	createReduxStore: jest.fn(),
+	register: jest.fn(),
 } ) );
 
 describe( 'AccountDetailsSection', () => {
@@ -230,37 +231,6 @@ describe( 'AccountDetailsSection', () => {
 			userEvent.click( refreshButton );
 
 			expect( mockRefreshAccount ).toHaveBeenCalledTimes( 1 );
-		} );
-
-		it( 'should show refresh option in both test and live modes', () => {
-			// Test mode
-			useTestMode.mockReturnValue( [ true, jest.fn() ] );
-			const { rerender } = render(
-				<AccountDetailsSection setModalType={ setModalTypeMock } />
-			);
-
-			const menuButton = screen.getByLabelText(
-				'Edit details or disconnect account'
-			);
-			userEvent.click( menuButton );
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: /refresh account details/i,
-				} )
-			).toBeInTheDocument();
-
-			// Live mode
-			useTestMode.mockReturnValue( [ false, jest.fn() ] );
-			rerender(
-				<AccountDetailsSection setModalType={ setModalTypeMock } />
-			);
-
-			userEvent.click( menuButton );
-			expect(
-				screen.getByRole( 'menuitem', {
-					name: /refresh account details/i,
-				} )
-			).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/settings/payment-settings/account-details-section.js
+++ b/client/settings/payment-settings/account-details-section.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
 import { React, useState } from 'react';
 import { Button, Card, CardHeader, DropdownMenu } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
@@ -35,6 +36,7 @@ const AccountSettingsDropdownMenu = ( {
 } ) => {
 	// @todo - deconstruct setModalType from useModalType custom hook
 	const [ isTestModeEnabled ] = useTestMode();
+	const { refreshAccount } = useDispatch( 'wc/stripe' );
 	const [
 		isConfirmationModalVisible,
 		setIsConfirmationModalVisible,
@@ -56,6 +58,13 @@ const AccountSettingsDropdownMenu = ( {
 						),
 						onClick: () =>
 							setModalType( isTestModeEnabled ? 'test' : 'live' ),
+					},
+					{
+						title: __(
+							'Refresh account details',
+							'woocommerce-gateway-stripe'
+						),
+						onClick: () => refreshAccount(),
 					},
 					{
 						title: __( 'Disconnect', 'woocommerce-gateway-stripe' ),

--- a/client/settings/payment-settings/account-details-section.js
+++ b/client/settings/payment-settings/account-details-section.js
@@ -37,10 +37,21 @@ const AccountSettingsDropdownMenu = ( {
 	// @todo - deconstruct setModalType from useModalType custom hook
 	const [ isTestModeEnabled ] = useTestMode();
 	const { refreshAccount } = useDispatch( 'wc/stripe' );
+	const { createSuccessNotice } = useDispatch( 'core/notices' );
 	const [
 		isConfirmationModalVisible,
 		setIsConfirmationModalVisible,
 	] = useState( false );
+
+	const handleRefreshAccount = async () => {
+		await refreshAccount();
+		createSuccessNotice(
+			__(
+				'Account details reloaded successfully.',
+				'woocommerce-gateway-stripe'
+			)
+		);
+	};
 
 	return (
 		<>
@@ -64,7 +75,7 @@ const AccountSettingsDropdownMenu = ( {
 							'Refresh account details',
 							'woocommerce-gateway-stripe'
 						),
-						onClick: () => refreshAccount(),
+						onClick: handleRefreshAccount,
 					},
 					{
 						title: __( 'Disconnect', 'woocommerce-gateway-stripe' ),

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -41,8 +41,6 @@ class WC_Stripe_Settings_Controller {
 		// Priority 5 so we can manipulate the registered gateways before they are shown.
 		add_action( 'woocommerce_admin_field_payment_gateways', [ $this, 'hide_gateways_on_settings_page' ], 5 );
 
-		add_action( 'admin_init', [ $this, 'maybe_update_account_data' ] );
-
 		add_action( 'update_option_woocommerce_gateway_order', [ $this, 'set_stripe_gateways_in_list' ] );
 	}
 
@@ -240,29 +238,5 @@ class WC_Stripe_Settings_Controller {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Updates the Stripe account data on the settings page.
-	 *
-	 * Some plugin settings (eg statement descriptions) require the latest update-to-date data from the Stripe Account to display
-	 * correctly. This function clears the account cache when the settings page is loaded to ensure the latest data is displayed.
-	 */
-	public function maybe_update_account_data() {
-
-		// Exit early if we're not on the payments settings page.
-		if ( ! isset( $_GET['page'], $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'checkout' !== $_GET['tab'] ) {
-			return;
-		}
-
-		if ( ! isset( $_GET['section'] ) || 'stripe' !== $_GET['section'] ) {
-			return;
-		}
-
-		if ( ! WC_Stripe::get_instance()->connect->is_connected() ) {
-			return [];
-		}
-
-		$this->account->clear_cache();
 	}
 }

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -267,6 +267,7 @@ class WC_Stripe_Account {
 		$request = [
 			// The list of events we listen to based on WC_Stripe_Webhook_Handler::process_webhook()
 			'enabled_events' => [
+				'account.updated',
 				'source.chargeable',
 				'source.canceled',
 				'charge.succeeded',

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -466,7 +466,7 @@ class WC_Stripe_Account {
 	 *
 	 * @return void
 	 */
-	public function reconfigure_webhooks_on_update() {
+	public function maybe_reconfigure_webhooks_on_update() {
 		$settings = WC_Stripe_Helper::get_stripe_settings();
 		$modes = [ 'live', 'test' ];
 

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -22,6 +22,31 @@ class WC_Stripe_Account {
 	const STATUS_RESTRICTED      = 'restricted';
 
 	/**
+	 * List of webhook events that this plugin listens to.
+	 * Based on WC_Stripe_Webhook_Handler::process_webhook()
+	 */
+	const WEBHOOK_EVENTS = [
+		'account.updated',
+		'source.chargeable',
+		'source.canceled',
+		'charge.succeeded',
+		'charge.failed',
+		'charge.captured',
+		'charge.dispute.created',
+		'charge.dispute.closed',
+		'charge.refunded',
+		'charge.refund.updated',
+		'review.opened',
+		'review.closed',
+		'payment_intent.succeeded',
+		'payment_intent.payment_failed',
+		'payment_intent.amount_capturable_updated',
+		'payment_intent.requires_action',
+		'setup_intent.succeeded',
+		'setup_intent.setup_failed',
+	];
+
+	/**
 	 * The Stripe connect instance.
 	 *
 	 * @var WC_Stripe_Connect
@@ -265,29 +290,9 @@ class WC_Stripe_Account {
 	 */
 	public function configure_webhooks( $mode = 'live', $secret_key = '' ) {
 		$request = [
-			// The list of events we listen to based on WC_Stripe_Webhook_Handler::process_webhook()
-			'enabled_events' => [
-				'account.updated',
-				'source.chargeable',
-				'source.canceled',
-				'charge.succeeded',
-				'charge.failed',
-				'charge.captured',
-				'charge.dispute.created',
-				'charge.dispute.closed',
-				'charge.refunded',
-				'charge.refund.updated',
-				'review.opened',
-				'review.closed',
-				'payment_intent.succeeded',
-				'payment_intent.payment_failed',
-				'payment_intent.amount_capturable_updated',
-				'payment_intent.requires_action',
-				'setup_intent.succeeded',
-				'setup_intent.setup_failed',
-			],
-			'url'            => WC_Stripe_Helper::get_webhook_url(),
-			'api_version'    => WC_Stripe_API::STRIPE_API_VERSION,
+			'enabled_events' => self::WEBHOOK_EVENTS,
+			'url'           => WC_Stripe_Helper::get_webhook_url(),
+			'api_version'   => WC_Stripe_API::STRIPE_API_VERSION,
 		];
 
 		// If a secret key is provided, use it to configure the webhooks.
@@ -417,14 +422,51 @@ class WC_Stripe_Account {
 	}
 
 	/**
+	 * Checks if the enabled events in an existing webhook differ from our desired events.
+	 *
+	 * @param object $existing_webhook The existing webhook object from Stripe.
+	 * @return bool True if events differ, false if they match.
+	 */
+	private function do_webhook_events_differ( $existing_webhook ) {
+		$desired_events = self::WEBHOOK_EVENTS;
+		sort( $desired_events );
+		$existing_events = $existing_webhook->enabled_events;
+		sort( $existing_events );
+
+		return $desired_events !== $existing_events;
+	}
+
+	/**
+	 * Gets the existing webhook for the site's URL.
+	 *
+	 * @return object|false The webhook object if found, false otherwise.
+	 */
+	private function get_existing_webhook() {
+		$webhooks = WC_Stripe_API::retrieve( 'webhook_endpoints' );
+
+		if ( is_wp_error( $webhooks ) || ! isset( $webhooks->data ) ) {
+			return false;
+		}
+
+		$webhook_url = WC_Stripe_Helper::get_webhook_url();
+
+		foreach ( $webhooks->data as $webhook ) {
+			if ( isset( $webhook->url ) && WC_Stripe_Helper::is_webhook_url( $webhook->url, $webhook_url ) ) {
+				return $webhook;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Reconfigures webhooks during plugin update.
 	 * This ensures webhooks are updated with any new events that may have been added.
+	 * Only reconfigures if there's an existing webhook and its events differ from desired events.
 	 *
 	 * @return void
 	 */
 	public function reconfigure_webhooks_on_update() {
-		WC_Stripe_Logger::log( 'Attempting to reconfigure webhooks after plugin update.' );
-
 		$settings = WC_Stripe_Helper::get_stripe_settings();
 		$modes = [ 'live', 'test' ];
 
@@ -433,15 +475,38 @@ class WC_Stripe_Account {
 			$secret_key = $settings[ $secret_key_setting ] ?? '';
 
 			if ( empty( $secret_key ) ) {
-				WC_Stripe_Logger::log( "Skipping webhook reconfiguration for {$mode} mode - no API key available." );
 				continue;
 			}
 
 			try {
+				// Set the API key for this mode
+				$previous_secret = WC_Stripe_API::get_secret_key();
+				WC_Stripe_API::set_secret_key( $secret_key );
+
+				// Check for existing webhook
+				$existing_webhook = $this->get_existing_webhook();
+
+				if ( ! $existing_webhook ) {
+					continue;
+				}
+
+				// Check if events differ
+				if ( ! $this->do_webhook_events_differ( $existing_webhook ) ) {
+					continue;
+				}
+
+				// Events differ, reconfigure webhook
+				WC_Stripe_Logger::log( "Webhook events need updating for {$mode} mode - reconfiguring." );
 				$this->configure_webhooks( $mode, $secret_key );
 				WC_Stripe_Logger::log( "Successfully reconfigured webhooks for {$mode} mode after plugin update." );
+
 			} catch ( Exception $e ) {
-				WC_Stripe_Logger::log( "Failed to reconfigure webhooks for {$mode} mode: " . $e->getMessage() );
+				WC_Stripe_Logger::log( "Failed to check/reconfigure webhooks for {$mode} mode: " . $e->getMessage() );
+			} finally {
+				// Restore the previous secret key if we changed it
+				if ( isset( $previous_secret ) ) {
+					WC_Stripe_API::set_secret_key( $previous_secret );
+				}
 			}
 		}
 	}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -415,4 +415,34 @@ class WC_Stripe_Account {
 			return false;
 		}
 	}
+
+	/**
+	 * Reconfigures webhooks during plugin update.
+	 * This ensures webhooks are updated with any new events that may have been added.
+	 *
+	 * @return void
+	 */
+	public function reconfigure_webhooks_on_update() {
+		WC_Stripe_Logger::log( 'Attempting to reconfigure webhooks after plugin update.' );
+
+		$settings = WC_Stripe_Helper::get_stripe_settings();
+		$modes = [ 'live', 'test' ];
+
+		foreach ( $modes as $mode ) {
+			$secret_key_setting = 'live' === $mode ? 'secret_key' : 'test_secret_key';
+			$secret_key = $settings[ $secret_key_setting ] ?? '';
+
+			if ( empty( $secret_key ) ) {
+				WC_Stripe_Logger::log( "Skipping webhook reconfiguration for {$mode} mode - no API key available." );
+				continue;
+			}
+
+			try {
+				$this->configure_webhooks( $mode, $secret_key );
+				WC_Stripe_Logger::log( "Successfully reconfigured webhooks for {$mode} mode after plugin update." );
+			} catch ( Exception $e ) {
+				WC_Stripe_Logger::log( "Failed to reconfigure webhooks for {$mode} mode: " . $e->getMessage() );
+			}
+		}
+	}
 }

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -441,7 +441,7 @@ class WC_Stripe_Account {
 	 *
 	 * @return object|false The webhook object if found, false otherwise.
 	 */
-	private function get_existing_webhook() {
+	public function get_existing_webhook() {
 		$webhooks = WC_Stripe_API::retrieve( 'webhook_endpoints' );
 
 		if ( is_wp_error( $webhooks ) || ! isset( $webhooks->data ) ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1203,6 +1203,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
+	 * Process webhook account updated event.
+	 * This is triggered when the account details are updated in Stripe's end.
+	 * We want to clear the cached account data to fetch fresh data on next request.
+	 *
+	 * @param object $notification The notification from Stripe
+	 */
+	public function process_account_updated( $notification ) {
+		WC_Stripe::get_instance()->account->clear_cache();
+		WC_Stripe_Logger::log( 'Cleared account cache after receiving account.updated webhook.' );
+	}
+
+	/**
 	 * Processes the incoming webhook.
 	 *
 	 * @since 4.0.0
@@ -1213,6 +1225,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$notification = json_decode( $request_body );
 
 		switch ( $notification->type ) {
+			case 'account.updated':
+				$this->process_account_updated( $notification );
+				break;
+
 			case 'source.chargeable':
 				$this->process_webhook_payment( $notification );
 				break;

--- a/readme.txt
+++ b/readme.txt
@@ -153,5 +153,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Use the original shipping address for Amazon Pay pay for orders.
 * Tweak - Improve settings page load by delaying oauth URL generation.
 * Tweak - Update the Woo logo in the Configure connection modal
+* Tweak - Improve settings page load by avoid account cache clearing on every page load.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -460,7 +460,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		WC_Helper_Stripe_Api::$expected_request_call_params = [];
 
 		// Run the update
-		$this->account->reconfigure_webhooks_on_update();
+		$this->account->maybe_reconfigure_webhooks_on_update();
 
 		// Verify no webhook configuration was attempted
 		$this->assertEmpty(
@@ -496,7 +496,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 			);
 
 		// Run the update
-		$this->account->reconfigure_webhooks_on_update();
+		$this->account->maybe_reconfigure_webhooks_on_update();
 	}
 
 	/**
@@ -522,6 +522,6 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 			->method( 'configure_webhooks' );
 
 		// Run the update
-		$this->account->reconfigure_webhooks_on_update();
+		$this->account->maybe_reconfigure_webhooks_on_update();
 	}
 }

--- a/tests/phpunit/test-class-wc-stripe-account.php
+++ b/tests/phpunit/test-class-wc-stripe-account.php
@@ -444,4 +444,84 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		delete_transient( WC_Stripe_Account::TEST_WEBHOOK_STATUS_OPTION );
 		delete_transient( WC_Stripe_Account::LIVE_WEBHOOK_STATUS_OPTION );
 	}
+
+	/**
+	 * Test webhook reconfiguration on update with no existing webhooks.
+	 */
+	public function test_reconfigure_webhooks_on_update_no_existing_webhooks() {
+		// Mock that no existing webhook is found
+		$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->setConstructorArgs( [ $this->mock_connect, 'WC_Helper_Stripe_Api' ] )
+			->setMethods( [ 'get_existing_webhook' ] )
+			->getMock();
+		$this->account->method( 'get_existing_webhook' )->willReturn( false );
+
+		// Set up expectations that no webhook configuration will be attempted
+		WC_Helper_Stripe_Api::$expected_request_call_params = [];
+
+		// Run the update
+		$this->account->reconfigure_webhooks_on_update();
+
+		// Verify no webhook configuration was attempted
+		$this->assertEmpty(
+			WC_Helper_Stripe_Api::$expected_request_call_params,
+			'Should not configure webhooks when no existing webhooks found'
+		);
+	}
+
+	/**
+	 * Test webhook reconfiguration on update with existing webhooks that need updating.
+	 */
+	public function test_reconfigure_webhooks_on_update_with_outdated_webhooks() {
+		// Mock an existing webhook with different events
+		$outdated_webhook = (object) [
+			'id' => 'we_123',
+			'url' => WC_Stripe_Helper::get_webhook_url(),
+			'enabled_events' => [ 'charge.succeeded', 'charge.failed' ],
+			'status' => 'enabled',
+		];
+
+		// Setup the account mock
+		$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->setConstructorArgs( [ $this->mock_connect, 'WC_Helper_Stripe_Api' ] )
+			->setMethods( [ 'get_existing_webhook', 'configure_webhooks' ] )
+			->getMock();
+
+		$this->account->method( 'get_existing_webhook' )->willReturn( $outdated_webhook );
+		$this->account->expects( $this->once() )
+			->method( 'configure_webhooks' )
+			->with(
+				$this->equalTo( 'test' ),
+				$this->equalTo( 'sk_test_key' )
+			);
+
+		// Run the update
+		$this->account->reconfigure_webhooks_on_update();
+	}
+
+	/**
+	 * Test webhook reconfiguration on update with existing webhooks that are up to date.
+	 */
+	public function test_reconfigure_webhooks_on_update_with_current_webhooks() {
+		// Mock an existing webhook with current events
+		$current_webhook = (object) [
+			'id' => 'we_123',
+			'url' => WC_Stripe_Helper::get_webhook_url(),
+			'enabled_events' => WC_Stripe_Account::WEBHOOK_EVENTS,
+			'status' => 'enabled',
+		];
+
+		// Setup the account mock
+		$this->account = $this->getMockBuilder( WC_Stripe_Account::class )
+			->setConstructorArgs( [ $this->mock_connect, 'WC_Helper_Stripe_Api' ] )
+			->setMethods( [ 'get_existing_webhook', 'configure_webhooks' ] )
+			->getMock();
+
+		$this->account->method( 'get_existing_webhook' )->willReturn( $current_webhook );
+		$this->account->expects( $this->never() )
+			->method( 'configure_webhooks' );
+
+		// Run the update
+		$this->account->reconfigure_webhooks_on_update();
+	}
 }

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -366,6 +366,10 @@ function woocommerce_gateway_stripe() {
 					add_woocommerce_inbox_variant();
 					$this->update_plugin_version();
 
+					// Add webhook reconfiguration
+					$account = self::get_instance()->account;
+					$account->reconfigure_webhooks_on_update();
+
 					// TODO: Remove this when we're reasonably sure most merchants have had their
 					// settings updated like this. ~80% of merchants is a good threshold.
 					// - @reykjalin

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -368,7 +368,7 @@ function woocommerce_gateway_stripe() {
 
 					// Add webhook reconfiguration
 					$account = self::get_instance()->account;
-					$account->reconfigure_webhooks_on_update();
+					$account->maybe_reconfigure_webhooks_on_update();
 
 					// TODO: Remove this when we're reasonably sure most merchants have had their
 					// settings updated like this. ~80% of merchants is a good threshold.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3692

## Changes proposed in this Pull Request:

When visiting the settings page, we clear the account cache, which forces an API request to Stripe to get a fresh copy of account data. This was added in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2833 to fix issues around statement descriptors. 

Fetching account data introduces a ~1s latency to the page load. This PR proposes the following changes to improve page load performance

1. Remove account refresh on page load (https://github.com/woocommerce/woocommerce-gateway-stripe/commit/e7a4662dd93ac1ce46edc2606034f225879342e5)
2. Listen to `account.updated` webhook event and clear the account cache if there's an update. This will force a new request on the next page refresh. (https://github.com/woocommerce/woocommerce-gateway-stripe/commit/e8cf0496d1656eb57a54b0e27c606c4bedfb1f5b)
3. Reconfigure webhook on plugin update (https://github.com/woocommerce/woocommerce-gateway-stripe/commit/e06cf600abe9a057a18cca77162e9390783be424)
4. Add a new menu item to manually refresh the account (https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3853/commits/46274f669be519d426c068f066d38aba55787b70)

3rd step is needed to enable `account.updated` event on existing webhooks. I am not certain if reconfiguring automatically on plugin update is the best way to do it. Another option is just to show a notice asking merchants to reconfigure manually. 
  
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
### Test page load speed improvement
1. On `develop` branch, go to settings page.
2. Open dev tools -> Network -> Doc 
3. Refresh the page and notice the timing for the `/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings` page
5. Switch to this branch and recheck the page load timing, it should be much faster on this branch.

### Test webhook
1. Make sure your local site is configured to receive webhooks from Stripe.
2. Go to Settings -> Account details -> Configure connection.
3. Click "Reconfigure webhooks" button.
4. Under "Customer bank statement" section in settings page, click on "Stripe account settings" link.
6. Update "Statement descriptor" or "Shortened descriptor" on Stripe.
7. Come back to the merchant site and refresh the page.
8. Updated info should be displayed under "Customer bank statement"

### Test webhook reconfiguration on plugin update
1. Manually bump the value in `wc_stripe_version` option in your db.
2. Go to WooCommerce -> Status -> Logs -> Stripe logs
3. Make sure there are following entries in the logs

### Test manual account refresh
1. Remove the webhook from the Stripe dashboard.
2. In Stripe, update "Statement descriptor" or "Shortened descriptor".
3. Come back to WC Stripe settings page and notice that the update statement descriptor is not yet reflected in the "Customer bank statement" section.
4. Click the "Refresh account details" menu item.
5. Notice that the "Customer bank statement" section gets updated with the latest data.

![CleanShot 2025-02-10 at 10 58 58](https://github.com/user-attachments/assets/1f088245-f127-40a9-b8b6-9c8cf7624767)


```
Successfully reconfigured webhooks for test mode after plugin update.
```

```
Successfully reconfigured webhooks for live mode after plugin update.
```
(Only available if you have live mode configured)
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
