### PR TITLE
Fix Legacy E2E tests

### DIFF
--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -128,15 +128,21 @@ export async function fillCreditCardDetailsShortcode( page, card ) {
  */
 export async function fillCreditCardDetailsLegacy( page, card ) {
 	await page
-		.frameLocator( '#wc-stripe-card-number-element iframe' )
+		.frameLocator(
+			'#wc-stripe-card-number-element iframe[name^="__privateStripeFrame"]'
+		)
 		.locator( 'input[name="cardnumber"]' )
 		.fill( card.number );
 	await page
-		.frameLocator( '#wc-stripe-card-expiry-element iframe' )
+		.frameLocator(
+			'#wc-stripe-card-expiry-element iframe[name^="__privateStripeFrame"]'
+		)
 		.locator( 'input[name="exp-date"]' )
 		.fill( card.expires.month + card.expires.year );
 	await page
-		.frameLocator( '#wc-stripe-card-code-element iframe' )
+		.frameLocator(
+			'#wc-stripe-card-code-element iframe[name^="__privateStripeFrame"]'
+		)
 		.locator( 'input[name="cvc"]' )
 		.fill( card.cvc );
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes the failing legacy checkout tests... the problem is that the selector `#wc-stripe-card-expiry-element iframe'` resolves to 2 possible iframes; the solution is to use the more specific selector: `#wc-stripe-card-expiry-element iframe[name^="__privateStripeFrame"]'`

NOTE: We already fixed this for some other tests a few months ago... the randomness of this happening seems to indicate some A/B testing from Stripe in their payment modal html layout; that would explain why the tests worked before. In any case, using the more specific selector makes sense.

![Screenshot 2025-02-06 at 19 17 52](https://github.com/user-attachments/assets/b2e3cea6-6ac7-425d-97b1-738e3024b1f5)

![Screenshot 2025-02-06 at 19 18 42](https://github.com/user-attachments/assets/192c91fe-2a72-4244-99b1-85eaeb7b5d1e)

## Testing instructions

Check that all tests/checks pass.

_Alternatively, you can test them locally:_
1. Run: `npm run test:e2e-setup`
2. Run: `npm run test:e2e-legacy`
3. Check that all test pass.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
