### PR TITLE
Forced Tokenization Support (Do not merge, requires Deposits#684)

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -20,6 +20,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 	use WC_Stripe_Subscriptions_Trait;
 	use WC_Stripe_Pre_Orders_Trait;
+	use WC_Stripe_Forced_Tokenization_Trait;
 
 	/**
 	 * The delay between retries.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -513,7 +513,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'signature' => $this->get_order_signature( $order ),
 		];
 
-		if ( $this->has_subscription( $order->get_id() ) ) {
+		if ( $this->has_subscription( $order->get_id() ) || $this->order_requires_order_payment_token( $order ) ) {
 			$metadata += [
 				'payment_type' => 'recurring',
 			];
@@ -1586,7 +1586,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		$request['payment_method_types'] = [ WC_Stripe_Payment_Methods::CARD ];
 
-		if ( $this->has_subscription( $order->get_id() ) ) {
+		if ( $this->has_subscription( $order->get_id() ) || $this->order_requires_order_payment_token( $order ) ) {
 			// If this is a failed subscription order payment, the intent should be
 			// prepared for future usage.
 			$request['setup_future_usage'] = 'off_session';

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -402,6 +402,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				return $this->process_pre_order( $order_id );
 			}
 
+			if ( $this->order_requires_order_payment_token( $order ) ) {
+				return $this->process_order_saving_order_token( $order_id );
+			}
+
 			// Check whether there is an existing intent.
 			$intent = $this->get_intent_from_order( $order );
 			if ( isset( $intent->object ) && 'setup_intent' === $intent->object ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -104,6 +104,9 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		// Check if pre-orders are enabled and add support for them.
 		$this->maybe_init_pre_orders();
 
+		// Check if forced tokenization is enabled and add support for it.
+		$this->maybe_init_forced_tokenization();
+
 		// Get setting values.
 		$this->title                = $this->get_validated_option( 'title' );
 		$this->description          = $this->get_validated_option( 'description' );

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -402,10 +402,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 				return $this->process_pre_order( $order_id );
 			}
 
-			if ( $this->order_requires_order_payment_token( $order ) ) {
-				return $this->process_order_saving_order_token( $order_id );
-			}
-
 			// Check whether there is an existing intent.
 			$intent = $this->get_intent_from_order( $order );
 			if ( isset( $intent->object ) && 'setup_intent' === $intent->object ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -260,6 +260,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		$this->elements_form();
 
+		/** Documented in includes/payment-methods/class-wc-stripe-upe-payment-gateway.php */
 		if ( apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) { // wpcs: csrf ok.
 
 			$this->save_payment_method_checkbox();

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -375,6 +375,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		// https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95 .
 		// See https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271 and
 		// https://github.com/woocommerce/woocommerce/wiki/Payment-Token-API .
+		/** Documented in includes/payment-methods/class-wc-stripe-upe-payment-gateway.php */
 		return apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $saved_cards, FILTER_VALIDATE_BOOLEAN ) );
 	}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1030,7 +1030,7 @@ class WC_Stripe_Intent_Controller {
 
 		// If the customer is saving the payment method to the store or has a subscription, we should set the setup_future_usage to off_session.
 		// Only exception is when using a confirmation token. For confirmations tokens, the setup_future_usage is set within the payment method.
-		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || ! empty( $payment_information['has_subscription'] ) ) ) {
+		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || ! empty( $payment_information['has_subscription'] ) || $payment_information['has_forced_tokenization'] ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -1,0 +1,142 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Trait for Forced Tokenization compatibility.
+ *
+ * @since x.x.x
+ */
+trait WC_Stripe_Forced_Tokenization_Trait {
+
+	/**
+	 * Stores a flag to indicate if the forced tokenization integration hooks have been attached.
+	 *
+	 * The callbacks attached as part of maybe_init_forced_tokenization() only need to be attached once to avoid duplication.
+	 *
+	 * @var bool False by default, true once the callbacks have been attached.
+	 */
+	private static $has_attached_forced_tokenization_integration_hooks = false;
+
+	/**
+	 * Initialize pre-orders hook.
+	 *
+	 * @since x.x.x
+	 */
+	public function maybe_init_forced_tokenization() {
+		if ( ! $this->is_forced_tokenization_enabled() ) {
+			return;
+		}
+
+		$this->supports[] = 'forced-tokenization'; // @phpstan-ignore-line (supports is defined in the classes that use this trait)
+
+		add_action( 'wc_checkout_tokenization_' . $this->id . '_charge_order_token', [ $this, 'process_order_tokenization_payment' ], 10, 2 ); // @phpstan-ignore-line (id is defined in the classes that use this trait)
+
+		/**
+		 * The callbacks attached below only need to be attached once. We don't need each gateway instance to have its own callback.
+		 * Therefore we only attach them once on the main `stripe` gateway and store a flag to indicate that they have been attached.
+		 */
+		if ( self::$has_attached_forced_tokenization_integration_hooks || WC_Gateway_Stripe::ID !== $this->id ) { // @phpstan-ignore-line (id is defined in the classes that use this trait)
+			return;
+		}
+
+		add_filter( 'wc_stripe_display_save_payment_method_checkbox', [ $this, 'hide_save_payment_for_forced_tokenization' ] );
+
+		self::$has_attached_forced_tokenization_integration_hooks = true;
+	}
+
+	/**
+	 * Checks if forced tokenization is supported on this site.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	public function is_forced_tokenization_enabled() {
+		return class_exists( 'WC_Checkout_Tokenization' );
+	}
+
+	/**
+	 * Whether the current cart require a payment token stored against the order.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param  int $order_id
+	 * @return bool
+	 */
+	public function cart_requires_order_payment_token() {
+		return $this->is_forced_tokenization_enabled() && WC_Checkout_Tokenization::cart_requires_order_payment_token();
+	}
+
+	/**
+	 * Whether the current order requires a payment token be stored against the order.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int|\WC_Order $order_id The order ID or order object.
+	 * @return bool True if the order requires a payment token stored against the order, false otherwise.
+	 */
+	public function order_requires_order_payment_token( $order_id ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return false;
+		}
+
+		return $this->is_forced_tokenization_enabled() && WC_Checkout_Tokenization::order_requires_order_payment_token( $order );
+	}
+
+	/**
+	 * Whether the current cart requires the user to save a payment method.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool True if the cart requires the user to save a payment method, false otherwise.
+	 */
+	public function cart_requires_user_payment_method() {
+		return $this->is_forced_tokenization_enabled() && WC_Checkout_Tokenization::cart_requires_user_payment_method();
+	}
+
+	/**
+	 * Whether the current order requires the user to save a payment method.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int|\WC_Order $order_id The order ID or order object.
+	 * @return bool True if the order requires the user to save a payment method, false otherwise.
+	 */
+	public function order_requires_user_payment_method( $order_id ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return false;
+		}
+
+		return $this->is_forced_tokenization_enabled() && WC_Checkout_Tokenization::order_requires_user_payment_method( $order );
+	}
+
+	/**
+	 * Hide the save payment method checkbox when forced tokenization is enabled.
+	 *
+	 * Hides the save payment checkbox when a payment token is required for the
+	 * user or the order.
+	 *
+	 * Runs on the filter `wc_stripe_display_save_payment_method_checkbox`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param bool $display_save_option Whether to display the save payment method checkbox.
+	 * @return bool Modified value of $display_save_option.
+	 */
+	public function hide_save_payment_for_forced_tokenization( $display_save_option ) {
+		if ( ! $display_save_option ) {
+			// No further checking required.
+			return $display_save_option;
+		}
+
+		if ( $this->cart_requires_order_payment_token() || $this->cart_requires_user_payment_method() ) {
+			$display_save_option = false;
+		}
+
+		return $display_save_option;
+	}
+}

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -43,7 +43,27 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 
 		add_filter( 'wc_stripe_display_save_payment_method_checkbox', [ $this, 'hide_save_payment_for_forced_tokenization' ] );
 
+		add_filter( 'pre_wc_checkout_tokenization_get_order_payment_token', [ $this, 'get_order_payment_token' ], 10, 2 );
+
 		self::$has_attached_forced_tokenization_integration_hooks = true;
+	}
+
+	public function get_order_payment_token( $token, $top_most_order ) {
+		if ( $top_most_order->payment_method !== $this->id ) {
+			return $token;
+		}
+
+		$intent = $this->get_intent_from_order( $top_most_order );
+
+		$token = array(
+			'gateway' => $this->id,
+			'token'   => $intent->id,
+			'data'    => array(
+				'intent' => $intent,
+			),
+		);
+
+		return $token;
 	}
 
 	/**

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -68,6 +68,21 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 
 		$intent = $this->get_intent_from_order( $top_most_order );
 
+		if (
+			! $intent ||
+			! isset( $intent->setup_future_usage ) ||
+			! 'off_session' === $intent->setup_future_usage
+		) {
+			/*
+			 * The token is not valid for off-session payments.
+			 *
+			 * As the forced tokenization feature requires the token to
+			 * be available for re-use, do not consider the token to
+			 * be set.
+			 */
+			return $token;
+		}
+
 		$token = [
 			'gateway' => $this->id,
 			'token'   => $intent->id,

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -51,7 +51,7 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 	}
 
 	public function get_order_payment_token( $token, $top_most_order ) {
-		if ( $top_most_order->payment_method !== $this->id ) {
+		if ( $top_most_order->get_payment_method() !== $this->id ) {
 			return $token;
 		}
 

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -162,7 +162,14 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 		return $display_save_option;
 	}
 
-	public function process_order_saving_order_token( $order_id ) {
+	/**
+	 * Process a payment and store a reusable token against the order.
+	 *
+	 * @param WC_Order $order Order object.
+	 * @param bool     $retry Whether this is a retry.
+	 * @param mixed    $error Previous error.
+	 */
+	public function process_order_saving_order_token( $order_id, $retry = true, $error = false ) {
 		try {
 			$order = wc_get_order( $order_id );
 			if ( ! $order ) {
@@ -222,19 +229,25 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 				$order->add_order_note( $order_note );
 			}
 		}
-
 	}
 
+	/**
+	 * Process a scheduled payment for an order with forced tokenization.
+	 *
+	 * Runs on the "wc_checkout_tokenization_{$this->id}_charge_order_token" action.
+	 *
+	 * @param WC_Order $order Scheduled order.
+	 */
 	public function charge_order_token( $order ) {
 		return $this->process_order_token_payment( $order );
 	}
 
 	/**
-	 * Process a scheduled deposit payment.
+	 * Process a scheduled payment.
 	 *
-	 * @param mixed $order          Scheduled deposit order.
-	 * @param mixed $retry          Whether to retry the payment.
-	 * @param mixed $previous_error Previous error.
+	 * @param WC_Order $order          Scheduled deposit order.
+	 * @param bool     $retry          Whether to retry the payment.
+	 * @param mixed    $previous_error Previous error.
 	 */
 	public function process_order_token_payment( $order, $retry = true, $previous_error = false ) {
 		$amount         = $order->get_total();
@@ -246,11 +259,6 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 			// Get source from order
 			$prepared_source = $this->prepare_order_source( $top_most_order );
 			$source_object   = $prepared_source->source_object;
-
-			// Check for an existing intent, which is associated with the order.
-			// if ( $this->has_authentication_already_failed( $order ) ) {
-			// 	return;
-			// }
 
 			$this->check_source( $prepared_source );
 			$this->save_source_to_order( $order, $prepared_source );

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -55,13 +55,13 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 
 		$intent = $this->get_intent_from_order( $top_most_order );
 
-		$token = array(
+		$token = [
 			'gateway' => $this->id,
 			'token'   => $intent->id,
-			'data'    => array(
+			'data'    => [
 				'intent' => $intent,
-			),
-		);
+			],
+		];
 
 		return $token;
 	}
@@ -224,108 +224,181 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 	}
 
 	public function charge_order_token( $order ) {
+		return $this->process_order_token_payment( $order );
+	}
+
+	/**
+	 * Process a scheduled deposit payment.
+	 *
+	 * @param mixed $order          Scheduled deposit order.
+	 * @param mixed $retry          Whether to retry the payment.
+	 * @param mixed $previous_error Previous error.
+	 */
+	public function process_order_token_payment( $order, $retry = true, $previous_error = false ) {
+		$amount         = $order->get_total();
 		$top_most_order = WC_Checkout_Tokenization::get_top_most_order( $order );
 
-		$intent = $this->get_intent_from_order( $top_most_order );
-		if ( isset( $intent->object ) && 'setup_intent' === $intent->object ) {
-			$intent = false; // This function can only deal with *payment* intents
-		}
+		try {
+			$order_id = $order->get_id();
 
-		$stripe_customer_id = null;
-		if ( $intent && ! empty( $intent->customer ) ) {
-			$stripe_customer_id = $intent->customer;
-		}
+			// Get source from order
+			$prepared_source = $this->prepare_order_source( $top_most_order );
+			$source_object   = $prepared_source->source_object;
 
-		$prepared_source = $this->prepare_order_source( $top_most_order );
+			// Check for an existing intent, which is associated with the order.
+			// if ( $this->has_authentication_already_failed( $order ) ) {
+			// 	return;
+			// }
 
-		$this->maybe_disallow_prepaid_card( $prepared_source->source_object );
-		$this->check_source( $prepared_source );
+			$this->check_source( $prepared_source );
+			$this->save_source_to_order( $order, $prepared_source );
 
-		$this->save_source_to_order( $order, $prepared_source );
-
-		// Update the saved payment method to have the latest billing details.
-		if ( $prepared_source->source && $this->is_using_saved_payment_method() ) {
-			$this->update_saved_payment_method( $prepared_source->source, $order );
-		}
-
-		if ( 0 >= $order->get_total() ) {
-			return $this->complete_free_order( $order, $prepared_source, $force_save_source );
-		}
-
-		// This will throw exception if not valid.
-		$this->validate_minimum_order_amount( $order );
-
-		WC_Stripe_Logger::log( "Info: Begin processing payment for order $order_id for the amount of {$order->get_total()}" );
-
-		if ( $intent ) {
-			$intent = $this->update_existing_intent( $intent, $top_most_order, $prepared_source );
-		} else {
-			$intent = $this->create_intent( $top_most_order, $prepared_source );
-		}
-
-		// Confirm the intent after locking the order to make sure webhooks will not interfere.
-		if ( empty( $intent->error ) ) {
-			$this->lock_order_payment( $order, $intent );
-			$intent = $this->confirm_intent( $intent, $order, $prepared_source );
-		}
-
-		$force_save_source_value = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $prepared_source->source );
-
-		if ( ! empty( $intent->error ) ) {
-			$this->maybe_remove_non_existent_customer( $intent->error, $order );
-
-			// We want to retry.
-			if ( $this->is_retryable_error( $intent->error ) ) {
-				return $this->retry_after_error( $intent, $order, $retry, $force_save_source, $previous_error, $use_order_source );
+			if ( ! $prepared_source->customer ) {
+				throw new WC_Stripe_Exception(
+					'Failed to process payment for order ' . $order->get_id() . '. Stripe customer id is missing in the order',
+					__( 'Customer not found', 'woocommerce-gateway-stripe' )
+				);
 			}
 
-			$this->unlock_order_payment( $order );
-			$this->throw_localized_message( $intent, $order );
-		}
+			WC_Stripe_Logger::log( "Info: Begin processing scheduled payment for order {$order_id} for the amount of {$amount}" );
 
-		if ( WC_Stripe_Intent_Status::SUCCEEDED === $intent->status && ! $this->is_using_saved_payment_method() && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
-			$this->save_payment_method( $prepared_source->source_object );
-		}
+			/*
+			 * If we're doing a retry and source is chargeable, we need to pass
+			 * a different idempotency key and retry for success.
+			 */
+			if ( is_object( $source_object ) && empty( $source_object->error ) && $this->need_update_idempotency_key( $source_object, $previous_error ) ) {
+				add_filter( 'wc_stripe_idempotency_key', [ $this, 'change_idempotency_key' ], 10, 2 );
+			}
 
-		if ( ! empty( $intent ) ) {
-			// Use the last charge within the intent to proceed.
-			$response = $this->get_latest_charge_from_intent( $intent );
+			if ( ( $this->is_no_such_source_error( $previous_error ) || $this->is_no_linked_source_error( $previous_error ) ) && apply_filters( 'wc_stripe_use_default_customer_source', true ) ) {
+				// Passing empty source will charge customer default.
+				$prepared_source->source = '';
+			}
 
-			// If the intent requires a 3DS flow, redirect to it.
-			if ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $intent->status ) {
-				$this->unlock_order_payment( $order );
+			// If the payment gateway is SEPA, use the charges API.
+			// TODO: Remove when SEPA is migrated to payment intents.
+			if ( 'stripe_sepa' === $this->id ) {
+				$request            = $this->generate_payment_request( $order, $prepared_source );
+				$request['capture'] = 'true';
+				$request['amount']  = WC_Stripe_Helper::get_stripe_amount( $amount, $request['currency'] );
+				$response           = WC_Stripe_API::request( $request );
 
-				// If the order requires some action from the customer, add meta to the order to prevent it from being cancelled by WooCommerce's hold stock settings.
-				WC_Stripe_Helper::set_payment_awaiting_action( $order );
+				$is_authentication_required = false;
+			} else {
+				$this->lock_order_payment( $order );
+				$response                   = $this->create_and_confirm_intent_for_off_session( $order, $prepared_source, $amount );
+				$is_authentication_required = $this->is_authentication_required_for_payment( $response );
+			}
 
-				if ( is_wc_endpoint_url( 'order-pay' ) ) {
-					$redirect_url = add_query_arg( 'wc-stripe-confirmation', 1, $order->get_checkout_payment_url( false ) );
+			// It's only a failed payment if it's an error and it's not of the type 'authentication_required'.
+			// If it's 'authentication_required', then we should email the user and ask them to authenticate.
+			if ( ! empty( $response->error ) && ! $is_authentication_required ) {
+				// We want to retry.
+				if ( $this->is_retryable_error( $response->error ) ) {
+					if ( $retry ) {
+						// Don't do anymore retries after this.
+						if ( 5 <= $this->retry_interval ) { // @phpstan-ignore-line (retry_interval is defined in classes using this class)
+							return $this->process_order_token_payment( $order, false, $response->error );
+						}
 
-					return [
-						'result'   => 'success',
-						'redirect' => wp_sanitize_redirect( esc_url_raw( $redirect_url ) ),
-					];
-				} else {
-					/**
-					 * This URL contains only a hash, which will be sent to `checkout.js` where it will be set like this:
-					 * `window.location = result.redirect`
-					 * Once this redirect is sent to JS, the `onHashChange` function will execute `handleCardPayment`.
-					 */
+						sleep( $this->retry_interval );
 
-					return [
-						'result'                => 'success',
-						'redirect'              => $this->get_return_url( $order ),
-						'payment_intent_secret' => $intent->client_secret,
-						'save_payment_method'   => $this->save_payment_method_requested(),
-					];
+						$this->retry_interval++;
+
+						return $this->process_order_token_payment( $order, true, $response->error );
+					} else {
+						$localized_message = sprintf(
+							/* translators: 1) error message from Stripe; 2) request log URL */
+							__( 'Sorry, we are unable to process the payment at this time. Reason: %1$s %2$s', 'woocommerce-gateway-stripe' ),
+							$response->error->message,
+							isset( $response->error->request_log_url ) ? make_clickable( $response->error->request_log_url ) : ''
+						);
+						$order->add_order_note( $localized_message );
+						throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
+					}
 				}
+
+				$localized_messages = WC_Stripe_Helper::get_localized_messages();
+
+				if ( 'card_error' === $response->error->type ) {
+					$localized_message = isset( $localized_messages[ $response->error->code ] ) ? $localized_messages[ $response->error->code ] : $response->error->message;
+				} elseif ( 'payment_intent_mandate_invalid' === $response->error->type ) {
+					$localized_message = __(
+						'The mandate used for this scheduled payment is invalid. You may need to bring the customer back to your store and ask them to resubmit their payment information.',
+						'woocommerce-gateway-stripe'
+					);
+				} else {
+					$localized_message = isset( $localized_messages[ $response->error->type ] ) ? $localized_messages[ $response->error->type ] : $response->error->message;
+				}
+
+				if ( isset( $response->error->request_log_url ) ) {
+					$localized_message .= ' ' . make_clickable( $response->error->request_log_url );
+				}
+
+				$order->add_order_note( $localized_message );
+
+				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 			}
+		} catch ( WC_Stripe_Exception $e ) {
+			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+
+			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
+
+			/* translators: error message */
+			$order->update_status( 'failed' );
+			$this->unlock_order_payment( $order );
+
+			return;
 		}
 
-		// Process valid response.
-		$this->process_response( $response, $order );
+		try {
 
+			// Either the charge was successfully captured, or it requires further authentication.
+			if ( $is_authentication_required ) {
+				do_action( 'wc_gateway_stripe_process_payment_authentication_required', $order, $response );
 
+				$error_message = __( 'This transaction requires authentication.', 'woocommerce-gateway-stripe' );
+				$order->add_order_note( $error_message );
 
+				$charge = $this->get_latest_charge_from_intent( $response->error->payment_intent );
+				$id     = $charge->id;
+
+				$order->set_transaction_id( $id );
+				/* translators: %s is the charge Id */
+				$order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
+				if ( is_callable( [ $order, 'save' ] ) ) {
+					$order->save();
+				}
+			} elseif ( $this->must_authorize_off_session( $response ) ) {
+				$charge_attempt_at = $response->processing->card->customer_notification->completes_at;
+				$attempt_date      = wp_date( get_option( 'date_format', 'F j, Y' ), $charge_attempt_at, wp_timezone() );
+				$attempt_time      = wp_date( get_option( 'time_format', 'g:i a' ), $charge_attempt_at, wp_timezone() );
+
+				$message = sprintf(
+					/* translators: 1) a date in the format yyyy-mm-dd, e.g. 2021-09-21; 2) time in the 24-hour format HH:mm, e.g. 23:04 */
+					__( 'The customer must authorize this payment via the pre-debit notification sent to them by their card issuing bank, before %1$s at %2$s, when the charge will be attempted.', 'woocommerce-gateway-stripe' ),
+					$attempt_date,
+					$attempt_time
+				);
+				$order->add_order_note( $message );
+				$order->update_status( 'pending' );
+				if ( is_callable( [ $order, 'save' ] ) ) {
+					$order->save();
+				}
+			} else {
+				// The charge was successfully captured
+				do_action( 'wc_gateway_stripe_process_payment', $response, $order );
+
+				// Use the last charge within the intent or the full response body in case of SEPA.
+				$latest_charge = $this->get_latest_charge_from_intent( $response );
+				$this->process_response( ( ! empty( $latest_charge ) ) ? $latest_charge : $response, $order );
+			}
+		} catch ( WC_Stripe_Exception $e ) {
+			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+
+			do_action( 'wc_gateway_stripe_process_payment_error', $e, $order );
+		}
+
+		$this->unlock_order_payment( $order );
 	}
 }

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -45,6 +45,8 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 
 		add_filter( 'pre_wc_checkout_tokenization_get_order_payment_token', [ $this, 'get_order_payment_token' ], 10, 2 );
 
+		add_action( 'wc_checkout_tokenization_delete_order_payment_token', [ $this, 'delete_order_payment_token' ], 10, 2 );
+
 		self::$has_attached_forced_tokenization_integration_hooks = true;
 	}
 
@@ -400,5 +402,33 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 		}
 
 		$this->unlock_order_payment( $order );
+	}
+
+	/**
+	 * Delete the Stripe token data from the order.
+	 *
+	 * Detach the payment method from the customer as the order is now
+	 * completed and the payment method is no longer required.
+	 *
+	 * The payment method is invalidated via the API rather than deleting
+	 * the meta data to allow for future references in refunds and other
+	 * operations.
+	 *
+	 * @see https://docs.stripe.com/api/payment_methods/detach
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Order $order The order object the token is stored against.
+	 */
+	public function delete_order_payment_token( $order ) {
+		// API request to detach the payment method from the customer.
+		$payment_method_id = $order->get_meta( '_stripe_source_id' ); // Payment method is stored as source ID.
+		$customer_id       = $order->get_meta( '_stripe_customer_id' );
+
+		if ( ! $payment_method_id || ! $customer_id ) {
+			return;
+		}
+
+		WC_Stripe_API::detach_payment_method_from_customer( $customer_id, $payment_method_id );
 	}
 }

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -87,7 +87,7 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 	 * @return bool
 	 */
 	public function is_forced_tokenization_enabled() {
-		return class_exists( 'WC_Checkout_Tokenization' );
+		return WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && class_exists( 'WC_Checkout_Tokenization' );
 	}
 
 	/**

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -82,12 +82,17 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 	/**
 	 * Checks if forced tokenization is supported on this site.
 	 *
+	 * Forced tokenization is only supported under the following circumstances:
+	 * - The gateway supports tokenization.
+	 * - UPE Checkout is enabled (not supported for legacy checkouts)
+	 * - The WC_Checkout_Tokenization class exists.
+	 *
 	 * @since x.x.x
 	 *
 	 * @return bool
 	 */
 	public function is_forced_tokenization_enabled() {
-		return WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && class_exists( 'WC_Checkout_Tokenization' );
+		return $this->supports( 'tokenization' ) && WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && class_exists( 'WC_Checkout_Tokenization' );
 	}
 
 	/**

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -50,6 +50,17 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 		self::$has_attached_forced_tokenization_integration_hooks = true;
 	}
 
+	/**
+	 * Filter the order payment token to include the source and intent.
+	 *
+	 * Runs on the `pre_wc_checkout_tokenization_get_order_payment_token` filter.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $token The order payment token.
+	 * @param WC_Order $top_most_order The top most order in the chain.
+	 * @return array The modified order payment token.
+	 */
 	public function get_order_payment_token( $token, $top_most_order ) {
 		if ( $top_most_order->get_payment_method() !== $this->id ) {
 			return $token;

--- a/includes/compat/trait-wc-stripe-forced-tokenization.php
+++ b/includes/compat/trait-wc-stripe-forced-tokenization.php
@@ -31,7 +31,7 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 
 		$this->supports[] = 'forced-tokenization'; // @phpstan-ignore-line (supports is defined in the classes that use this trait)
 
-		add_action( 'wc_checkout_tokenization_' . $this->id . '_charge_order_token', [ $this, 'process_order_tokenization_payment' ], 10, 2 ); // @phpstan-ignore-line (id is defined in the classes that use this trait)
+		add_action( 'wc_checkout_tokenization_' . $this->id . '_charge_order_token', [ $this, 'charge_order_token' ], 10, 2 ); // @phpstan-ignore-line (id is defined in the classes that use this trait)
 
 		/**
 		 * The callbacks attached below only need to be attached once. We don't need each gateway instance to have its own callback.
@@ -158,5 +158,174 @@ trait WC_Stripe_Forced_Tokenization_Trait {
 		}
 
 		return $display_save_option;
+	}
+
+	public function process_order_saving_order_token( $order_id ) {
+		try {
+			$order = wc_get_order( $order_id );
+			if ( ! $order ) {
+				return false;
+			}
+
+			$future_payments = function( $request ) {
+				$request['setup_future_usage'] = 'off_session';
+				return $request;
+			};
+
+			add_filter( 'wc_stripe_generate_create_intent_request', $future_payments );
+
+			$source   = $this->prepare_order_source( $order ); // @phpstan-ignore-line (prepare_order_source is defined in the classes that use this trait)
+			$response = $this->create_and_confirm_intent_for_off_session( $order, $source ); // @phpstan-ignore-line (create_and_confirm_intent_for_off_session is defined in the classes that use this trait)
+
+			add_filter( 'wc_stripe_generate_create_intent_request', $future_payments );
+
+			$is_authentication_required = $this->is_authentication_required_for_payment( $response ); // @phpstan-ignore-line (is_authentication_required_for_payment is defined in the classes that use this trait)
+
+			if ( ! empty( $response->error ) && ! $is_authentication_required ) {
+				if ( ! $retry ) {
+					throw new Exception( $response->error->message );
+				}
+				$this->remove_order_source_before_retry( $order );
+				// $this->process_pre_order_release_payment( $order, false );
+			} elseif ( $is_authentication_required ) {
+				$charge = $this->get_latest_charge_from_intent( $response->error->payment_intent );
+				$id     = $charge->id;
+
+				$order->set_transaction_id( $id );
+				/* translators: %s is the charge Id */
+				$order->update_status( 'failed', sprintf( __( 'Stripe charge awaiting authentication by user: %s.', 'woocommerce-gateway-stripe' ), $id ) );
+				if ( is_callable( [ $order, 'save' ] ) ) {
+					$order->save();
+				}
+
+				WC_Emails::instance();
+
+				do_action( 'wc_gateway_stripe_process_payment_authentication_required', $order );
+
+				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
+			} else {
+				// Successful
+				$this->process_response( $this->get_latest_charge_from_intent( $response ), $order ); // @phpstan-ignore-line (process_response is defined in the classes that use this trait)
+			}
+		} catch ( Exception $e ) {
+			$error_message = is_callable( [ $e, 'getLocalizedMessage' ] ) ? $e->getLocalizedMessage() : $e->getMessage();
+			/* translators: error message */
+			$order_note = sprintf( __( 'Stripe Transaction Failed (%s)', 'woocommerce-gateway-stripe' ), $error_message );
+
+			// Mark order as failed if not already set,
+			// otherwise, make sure we add the order note so we can detect when someone fails to check out multiple times
+			if ( ! $order->has_status( 'failed' ) ) {
+				$order->update_status( 'failed', $order_note );
+			} else {
+				$order->add_order_note( $order_note );
+			}
+		}
+
+	}
+
+	public function charge_order_token( $order ) {
+		$top_most_order = WC_Checkout_Tokenization::get_top_most_order( $order );
+
+		$intent = $this->get_intent_from_order( $top_most_order );
+		if ( isset( $intent->object ) && 'setup_intent' === $intent->object ) {
+			$intent = false; // This function can only deal with *payment* intents
+		}
+
+		$stripe_customer_id = null;
+		if ( $intent && ! empty( $intent->customer ) ) {
+			$stripe_customer_id = $intent->customer;
+		}
+
+		$prepared_source = $this->prepare_order_source( $top_most_order );
+
+		$this->maybe_disallow_prepaid_card( $prepared_source->source_object );
+		$this->check_source( $prepared_source );
+
+		$this->save_source_to_order( $order, $prepared_source );
+
+		// Update the saved payment method to have the latest billing details.
+		if ( $prepared_source->source && $this->is_using_saved_payment_method() ) {
+			$this->update_saved_payment_method( $prepared_source->source, $order );
+		}
+
+		if ( 0 >= $order->get_total() ) {
+			return $this->complete_free_order( $order, $prepared_source, $force_save_source );
+		}
+
+		// This will throw exception if not valid.
+		$this->validate_minimum_order_amount( $order );
+
+		WC_Stripe_Logger::log( "Info: Begin processing payment for order $order_id for the amount of {$order->get_total()}" );
+
+		if ( $intent ) {
+			$intent = $this->update_existing_intent( $intent, $top_most_order, $prepared_source );
+		} else {
+			$intent = $this->create_intent( $top_most_order, $prepared_source );
+		}
+
+		// Confirm the intent after locking the order to make sure webhooks will not interfere.
+		if ( empty( $intent->error ) ) {
+			$this->lock_order_payment( $order, $intent );
+			$intent = $this->confirm_intent( $intent, $order, $prepared_source );
+		}
+
+		$force_save_source_value = apply_filters( 'wc_stripe_force_save_source', $force_save_source, $prepared_source->source );
+
+		if ( ! empty( $intent->error ) ) {
+			$this->maybe_remove_non_existent_customer( $intent->error, $order );
+
+			// We want to retry.
+			if ( $this->is_retryable_error( $intent->error ) ) {
+				return $this->retry_after_error( $intent, $order, $retry, $force_save_source, $previous_error, $use_order_source );
+			}
+
+			$this->unlock_order_payment( $order );
+			$this->throw_localized_message( $intent, $order );
+		}
+
+		if ( WC_Stripe_Intent_Status::SUCCEEDED === $intent->status && ! $this->is_using_saved_payment_method() && ( $this->save_payment_method_requested() || $force_save_source_value ) ) {
+			$this->save_payment_method( $prepared_source->source_object );
+		}
+
+		if ( ! empty( $intent ) ) {
+			// Use the last charge within the intent to proceed.
+			$response = $this->get_latest_charge_from_intent( $intent );
+
+			// If the intent requires a 3DS flow, redirect to it.
+			if ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $intent->status ) {
+				$this->unlock_order_payment( $order );
+
+				// If the order requires some action from the customer, add meta to the order to prevent it from being cancelled by WooCommerce's hold stock settings.
+				WC_Stripe_Helper::set_payment_awaiting_action( $order );
+
+				if ( is_wc_endpoint_url( 'order-pay' ) ) {
+					$redirect_url = add_query_arg( 'wc-stripe-confirmation', 1, $order->get_checkout_payment_url( false ) );
+
+					return [
+						'result'   => 'success',
+						'redirect' => wp_sanitize_redirect( esc_url_raw( $redirect_url ) ),
+					];
+				} else {
+					/**
+					 * This URL contains only a hash, which will be sent to `checkout.js` where it will be set like this:
+					 * `window.location = result.redirect`
+					 * Once this redirect is sent to JS, the `onHashChange` function will execute `handleCardPayment`.
+					 */
+
+					return [
+						'result'                => 'success',
+						'redirect'              => $this->get_return_url( $order ),
+						'payment_intent_secret' => $intent->client_secret,
+						'save_payment_method'   => $this->save_payment_method_requested(),
+					];
+				}
+			}
+		}
+
+		// Process valid response.
+		$this->process_response( $response, $order );
+
+
+
 	}
 }

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -261,6 +261,7 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 
 		$this->form();
 
+		/** Documented in includes/payment-methods/class-wc-stripe-upe-payment-gateway.php */
 		if ( apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) && ! is_add_payment_method_page() && ! isset( $_GET['change_payment_method'] ) ) {
 			$this->save_payment_method_checkbox();
 		}

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -91,6 +91,9 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 		// Check if pre-orders are enabled and add support for them.
 		$this->maybe_init_pre_orders();
 
+		// Check if forced tokenization is enabled.
+		$this->maybe_init_forced_tokenization();
+
 		$main_settings              = WC_Stripe_Helper::get_stripe_settings();
 		$this->title                = $this->get_option( 'title' );
 		$this->description          = $this->get_option( 'description' );

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -10,6 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Express_Checkout_Helper {
 
 	use WC_Stripe_Pre_Orders_Trait;
+	use WC_Stripe_Forced_Tokenization_Trait;
 
 	/**
 	 * Stripe settings.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Payment_Request {
 
 	use WC_Stripe_Pre_Orders_Trait;
+	use WC_Stripe_Forced_Tokenization_Trait;
 
 	/**
 	 * Enabled.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -236,6 +236,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Check if pre-orders are enabled and add support for them.
 		$this->maybe_init_pre_orders();
 
+		// Check if forced tokenization is enabled and add support for it.
+		$this->maybe_init_forced_tokenization();
+
 		$this->title                         = $this->payment_methods['card']->get_title();
 		$this->description                   = $this->payment_methods['card']->get_description();
 		$this->enabled                       = $this->get_option( 'enabled' );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -802,6 +802,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			<?php
 			$methods_enabled_for_saved_payments = array_filter( $this->get_upe_enabled_payment_method_ids(), [ $this, 'is_enabled_for_saved_payments' ] );
 			if ( $this->is_saved_cards_enabled() && ! empty( $methods_enabled_for_saved_payments ) ) {
+				/** Documented in includes/payment-methods/class-wc-stripe-upe-payment-gateway.php */
 				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
 				$this->save_payment_method_checkbox( $force_save_payment );
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2594,6 +2594,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return true;
 		}
 
+		// Saved when required by forced tokenization (user payment method) feature.
+		if ( $this->order_requires_user_payment_method( $order_id ) ) {
+			return true;
+		}
+
 		// Unless it's paying for a subscription, don't save it when saving payment methods is disabled.
 		if ( ! $this->is_saved_cards_enabled() ) {
 			return false;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3007,7 +3007,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	private function should_upe_payment_method_show_save_option( $payment_method ) {
 		if ( $payment_method->is_reusable() ) {
 			// If a subscription in the cart, it will be saved by default so no need to show the option.
-			return $this->is_saved_cards_enabled() && ! $this->is_subscription_item_in_cart() && ! $this->is_pre_order_charged_upon_release_in_cart();
+			$display_option = $this->is_saved_cards_enabled() && ! $this->is_subscription_item_in_cart() && ! $this->is_pre_order_charged_upon_release_in_cart();
+
+			/**
+			 * Filters whether the save payment checkbox should be displayed for the payment method.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param bool $result Whether the save payment checkbox should be displayed for the payment method.
+			 */
+			$display_option = apply_filters( 'wc_stripe_display_save_payment_method_checkbox', filter_var( $display_option, FILTER_VALIDATE_BOOLEAN ) );
+			return $display_option;
 		}
 
 		return false;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2416,6 +2416,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			'payment_type'                  => 'single', // single | recurring.
 			'save_payment_method_to_store'  => $save_payment_method_to_store,
 			'capture_method'                => $capture_method,
+			'has_forced_tokenization'       => $this->order_requires_order_payment_token( $order ),
 		];
 
 		if ( WC_Stripe_Payment_Methods::ACH === $selected_payment_type ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
@@ -37,6 +37,9 @@ class WC_Stripe_UPE_Payment_Method_ACH extends WC_Stripe_UPE_Payment_Method {
 
 		// Add support for pre-orders.
 		$this->maybe_init_pre_orders();
+
+		// Check if forced tokenization is enabled.
+		$this->maybe_init_forced_tokenization();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -38,6 +38,9 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		// Add support for pre-orders.
 		$this->maybe_init_pre_orders();
 
+		// Check if forced tokenization is enabled.
+		$this->maybe_init_forced_tokenization();
+
 		$this->maybe_hide_bacs_payment_gateway();
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
@@ -35,6 +35,9 @@ class WC_Stripe_UPE_Payment_Method_Bancontact extends WC_Stripe_UPE_Payment_Meth
 
 		// Add support for pre-orders.
 		$this->maybe_init_pre_orders();
+
+		// Check if forced tokenization is enabled.
+		$this->maybe_init_forced_tokenization();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
@@ -35,6 +35,9 @@ class WC_Stripe_UPE_Payment_Method_Ideal extends WC_Stripe_UPE_Payment_Method {
 
 		// Add support for pre-orders.
 		$this->maybe_init_pre_orders();
+
+		// Check if forced tokenization is enabled.
+		$this->maybe_init_forced_tokenization();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
@@ -36,6 +36,9 @@ class WC_Stripe_UPE_Payment_Method_Sepa extends WC_Stripe_UPE_Payment_Method {
 
 		// Add support for pre-orders.
 		$this->maybe_init_pre_orders();
+
+		// Check if forced tokenization is enabled.
+		$this->maybe_init_forced_tokenization();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
@@ -32,5 +32,8 @@ class WC_Stripe_UPE_Payment_Method_Sofort extends WC_Stripe_UPE_Payment_Method {
 
 		// Add support for pre-orders.
 		$this->maybe_init_pre_orders();
+
+		// Check if forced tokenization is enabled.
+		$this->maybe_init_forced_tokenization();
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -626,6 +626,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			</fieldset>
 			<?php
 			if ( $this->should_show_save_option() ) {
+				/** Documented in includes/payment-methods/class-wc-stripe-upe-payment-gateway.php */
 				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
 				if ( is_user_logged_in() ) {
 					$this->save_payment_method_checkbox( $force_save_payment );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -18,6 +18,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 
 	use WC_Stripe_Subscriptions_Utilities_Trait;
 	use WC_Stripe_Pre_Orders_Trait;
+	use WC_Stripe_Forced_Tokenization_Trait;
 
 	/**
 	 * Stripe key name

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -302,6 +302,11 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return $this->is_reusable() || WC_Stripe_Payment_Methods::BLIK === $this->stripe_id;
 		}
 
+		// If cart or order contains a product that requires a payment token, enable payment method if it's reusable.
+		if ( $this->cart_requires_order_payment_token() || ( ! empty( $order_id ) && $this->order_requires_order_payment_token( $order_id ) ) ) {
+			return $this->is_reusable();
+		}
+
 		// Note: this $this->is_automatic_capture_enabled() call will be handled by $this->__call() and fall through to the UPE gateway class.
 		if ( $this->requires_automatic_capture() && ! $this->is_automatic_capture_enabled() ) {
 			return false;

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -203,6 +203,7 @@ function woocommerce_gateway_stripe() {
 				require_once __DIR__ . '/includes/class-wc-stripe-payment-method-configurations.php';
 				include_once __DIR__ . '/includes/class-wc-stripe-api.php';
 				include_once __DIR__ . '/includes/class-wc-stripe-mode.php';
+				require_once __DIR__ . '/includes/compat/trait-wc-stripe-forced-tokenization.php';
 				require_once __DIR__ . '/includes/compat/class-wc-stripe-subscriptions-helper.php';
 				require_once __DIR__ . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';
 				require_once __DIR__ . '/includes/compat/trait-wc-stripe-subscriptions.php';


### PR DESCRIPTION
Related to https://github.com/woocommerce/woocommerce-deposits/issues/375 out of a discussion on peIGPw-A6-p2#comment-1021

## Changes proposed in this Pull Request:

This introduces support for a generic `forced_tokenization` feature that will allow gateways to implement a generic approach for extensions to use in the event they require either order tokens or user accounts and payment methods. 

The goal is that Gateways will need to adapt once and future extensions requiring such features will use the generic API to opt-in to the feature. This will reduce the need for implementations in each gateway for each extension requiring the feature. 

At the moment their is custom support for subscriptions and pre-orders in the Stripe gateway, this code is to avoid needing to add snowflake code for Deposits too. 

This makes use of the polyfill in https://github.com/woocommerce/woocommerce-deposits/pull/684 that is intended to eventually go in to WooCommerce Core to save payment intents against orders/user payment methods as required by the gateway.

Per peIGPw-A6-p2#comment-1202 there is no support for legacy gateways for this feature.

## Testing instructions

1. Enable the deposits extension
2. Checkout the branch in https://github.com/woocommerce/woocommerce-deposits/pull/684
3. Configure a product with a payment plan
   1. Four payments, 25% each
   2. One day apart
   3. Price the product to be at least four times the stripe minimum allowed amount
4. Configure ngrok or similar to ensure that the Stripe webhooks can hit your server
5. While logged out (eg in a private browser window), purchase the product
6. Connect to the database, view the `..wc_orders` table
7. Modify the `date_created_gmt` date for the first of the scheduled orders to be a past time
8. Wait for the cron job and action schedular tasks to run -- this can take a while as the cron task only runs hourly
9. Once these tasks have run, ensure that the scheduled order is marked as complete rather than pending payment


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
