### PR TITLE
Add currency restriction pill on Amazon Pay

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -43,6 +43,7 @@
 * Fix - Use the original shipping address for Amazon Pay pay for orders.
 * Tweak - Improve settings page load by delaying oauth URL generation.
 * Tweak - Update the Woo logo in the Configure connection modal
+* Add - Add currency restriction pill on Amazon Pay.
 
 = 9.1.1 - 2025-01-10 =
 * Fix - Fixes the webhook order retrieval by intent charges. The processed event is an object, not an array.

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -16,6 +16,7 @@ import {
 } from '../../data';
 import './styles.scss';
 import AmazonPayIcon from '../../payment-method-icons/amazon-pay';
+import PaymentMethodMissingCurrencyPill from '../../components/payment-method-missing-currency-pill';
 import {
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_LINK,
@@ -259,6 +260,13 @@ const PaymentRequestSection = () => {
 										'Amazon Pay',
 										'woocommerce-gateway-stripe'
 									) }
+									<PaymentMethodMissingCurrencyPill
+										id="amazon_pay"
+										label={ __(
+											'Amazon Pay',
+											'woocommerce-gateway-stripe'
+										) }
+									/>
 								</div>
 								<div className="express-checkout__description">
 									{

--- a/client/utils/use-payment-method-currencies.js
+++ b/client/utils/use-payment-method-currencies.js
@@ -5,6 +5,7 @@ import {
 	PAYMENT_METHOD_ALIPAY,
 	PAYMENT_METHOD_KLARNA,
 	PAYMENT_METHOD_WECHAT_PAY,
+	PAYMENT_METHOD_AMAZON_PAY,
 } from 'wcstripe/stripe-utils/constants';
 
 const accountCountry =
@@ -152,6 +153,7 @@ const getWechatPayCurrencies = () => {
 		'PT',
 		'ES',
 	];
+
 	if ( EuroSupportedCountries.includes( accountCountry ) ) {
 		upeCurrencies = [ 'EUR', 'CNY' ];
 	}
@@ -206,6 +208,15 @@ const getKlarnaCurrencies = () => {
 	);
 };
 
+const getAmazonPayCurrencies = () => {
+	switch ( accountCountry ) {
+		case 'US':
+			return [ 'USD' ];
+		default:
+			return [ 'USD' ];
+	}
+};
+
 export const usePaymentMethodCurrencies = ( paymentMethodId ) => {
 	const { isUpeEnabled } = useContext( UpeToggleContext );
 
@@ -216,6 +227,8 @@ export const usePaymentMethodCurrencies = ( paymentMethodId ) => {
 			return getWechatPayCurrencies();
 		case PAYMENT_METHOD_KLARNA:
 			return getKlarnaCurrencies();
+		case PAYMENT_METHOD_AMAZON_PAY:
+			return getAmazonPayCurrencies();
 		default:
 			return PaymentMethodsMap[ paymentMethodId ]?.currencies || [];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -153,5 +153,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Use the original shipping address for Amazon Pay pay for orders.
 * Tweak - Improve settings page load by delaying oauth URL generation.
 * Tweak - Update the Woo logo in the Configure connection modal
+* Add - Add currency restriction pill on Amazon Pay.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3834 

## Changes proposed in this Pull Request:
[With Amazon Pay being restricted to USD](https://docs.stripe.com/payments/amazon-pay), we need to either hide Amazon Pay in settings if store currency is not USD, or similar to other payment methods, display a "Requires currency" notice beside it. For consistency and future implementation, this PR chose to follow other payment methods, adding a currency restriction pill and rendering next to the payment method in the settings when the shop's currency is not supported.

<img width="698" alt="Screenshot 2025-02-06 at 9 08 14 PM" src="https://github.com/user-attachments/assets/b6525b54-a75c-4816-912f-d62005bf86b3" />


## Testing instructions
1. With the feature flag off -- this is the default -- verify that Amazon Pay is not available in Stripe settings or in any store page.
2. Turn the feature flag on, by setting the `_wcstripe_feature_amazon_pay` option to yes.
3. Verify that Amazon Pay is now available in Stripe settings.
4. Go to WC->Settings->General->Currency options
5. Set the currency to a non-USD currency
6. Go to WC->Settings->Payments->Stripe->Express checkouts section
7. See `Requires currency` pill next to Amazon Pay
8. Confirm Amazon Pay button doesn't show on the product, cart, checkout pages
9. Go back to WC->Settings->General->Currency options
10. Set the currency to USD
11. Go back to WC->Settings->Payments->Stripe->Express checkouts section
12. Should not see the `Requires currency` pill next to Amazon Pay
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [X] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
