### PR TITLE
ECE: fix cart timeout issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 9.2.0 - xxxx-xx-xx =
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Fix - Clear cart first when using express checkout inside the product page.
-* Fix - Resolve the click event before adding the product to the cart for express checkout inside the product page, to avoid Stripe timeouts.
+* Fix - Avoid Stripe timeouts for the express checkout click event.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.
 * Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@
 
 = 9.2.0 - xxxx-xx-xx =
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
+* Fix - Clear cart first when using express checkout inside the product page.
+* Fix - Resolve the click event before adding the product to the cart for express checkout inside the product page, to avoid Stripe timeouts.
+* Fix - Switch booking products back to using non-Store API (legacy) add to cart.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.
 * Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,6 @@
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Fix - Clear cart first when using express checkout inside the product page.
 * Fix - Resolve the click event before adding the product to the cart for express checkout inside the product page, to avoid Stripe timeouts.
-* Fix - Switch booking products back to using non-Store API (legacy) add to cart.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.
 * Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -577,8 +577,6 @@ export default class WCStripeAPI {
 	/**
 	 * Empty the cart (legacy version, non-StoreAPI).
 	 *
-	 * @todo Remove this once WC 9.7.0 is the min. required version.
-	 *
 	 * @param {Object} params Parameters.
 	 * @param {number} params.bookingId Booking ID.
 	 * @return {Promise} Promise for the request to the server.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -575,6 +575,22 @@ export default class WCStripeAPI {
 	}
 
 	/**
+	 * Empty the cart (legacy version, non-StoreAPI).
+	 *
+	 * @todo Remove this once WC 9.7.0 is the min. required version.
+	 *
+	 * @param {Object} params Parameters.
+	 * @param {number} params.bookingId Booking ID.
+	 * @return {Promise} Promise for the request to the server.
+	 */
+	expressCheckoutEmptyCartLegacy( { bookingId = null } ) {
+		return this.request( getExpressCheckoutAjaxURL( 'clear_cart' ), {
+			security: getExpressCheckoutData( 'nonce' )?.clear_cart,
+			...( bookingId ? { booking_id: bookingId } : {} ),
+		} );
+	}
+
+	/**
 	 * Creates order based on Express Checkout ECE payment method.
 	 *
 	 * @param {Object} paymentData Order data.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -299,9 +299,22 @@ jQuery( function ( $ ) {
 				event.resolve( clickOptions );
 				onClickHandler( event );
 
+				// Call addToCart after event.resolve() so we don't hit the 1-second Stripe
+				// timeout for the click event. If addToCart fails, set a flag to prevent
+				// payment confirmation ('confirm' event) from being triggered.
 				if ( getExpressCheckoutData( 'is_product_page' ) ) {
-					// Add products to the cart if everything is right.
-					await wcStripeECE.addToCart();
+					wcStripeECE.cartError = true;
+					const response = await wcStripeECE.addToCart();
+					const isAddToCartSuccessful =
+						response && response?.items_count > 0;
+					const isLegacyAddToCartSuccessful =
+						response?.result === 'success';
+					if (
+						isAddToCartSuccessful ||
+						isLegacyAddToCartSuccessful
+					) {
+						wcStripeECE.cartError = false;
+					}
 				}
 			} );
 
@@ -318,6 +331,17 @@ jQuery( function ( $ ) {
 			);
 
 			eceButton.on( 'confirm', async ( event ) => {
+				if (
+					getExpressCheckoutData( 'is_product_page' ) &&
+					wcStripeECE.cartError
+				) {
+					const message = __(
+						'There was an error adding the product to the cart.',
+						'woocommerce-gateway-stripe'
+					);
+					return wcStripeECE.abortPayment( event, message );
+				}
+
 				const order = options.order ? options.order : 0;
 				const orderDetails = options.orderDetails ?? {};
 				return await onConfirmHandler( {

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -381,11 +381,18 @@ jQuery( function ( $ ) {
 					getExpressCheckoutData( 'is_product_page' ) &&
 					wcStripeECE.isAddToCartSuccessful === false
 				) {
-					const message = __(
-						'There was an error adding the product to the cart.',
-						'woocommerce-gateway-stripe'
+					// wait 1s for the item to be added to the cart before proceeding
+					await new Promise( ( resolve ) =>
+						setTimeout( resolve, 1000 )
 					);
-					return wcStripeECE.abortPayment( event, message );
+
+					if ( wcStripeECE.isAddToCartSuccessful === false ) {
+						const message = __(
+							'There was an error adding the product to the cart.',
+							'woocommerce-gateway-stripe'
+						);
+						return wcStripeECE.abortPayment( event, message );
+					}
 				}
 
 				const order = options.order ? options.order : 0;

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -524,7 +524,7 @@ jQuery( function ( $ ) {
 		 *
 		 * @return {Promise} Promise for the request to the server.
 		 */
-		addToCart: () => {
+		addToCart: async () => {
 			let productId = $( '.single_add_to_cart_button' ).val();
 
 			// Check if product is a variable product.
@@ -573,6 +573,10 @@ jQuery( function ( $ ) {
 			if ( useLegacyCartEndpoints ) {
 				return api.expressCheckoutAddToCartLegacy( data );
 			}
+
+			// Clear the cart, so items that are currently in it
+			//  do not interfere with computed totals.
+			await api.expressCheckoutEmptyCart();
 
 			return api.expressCheckoutAddToCart( data );
 		},

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -284,9 +284,6 @@ jQuery( function ( $ ) {
 						window.alert( wcStripeECEError );
 						return;
 					}
-
-					// Add products to the cart if everything is right.
-					await wcStripeECE.addToCart();
 				}
 
 				const clickOptions = {
@@ -299,8 +296,13 @@ jQuery( function ( $ ) {
 					shippingRates: options.shippingRates,
 				};
 
-				onClickHandler( event );
 				event.resolve( clickOptions );
+				onClickHandler( event );
+
+				if ( getExpressCheckoutData( 'is_product_page' ) ) {
+					// Add products to the cart if everything is right.
+					await wcStripeECE.addToCart();
+				}
 			} );
 
 			eceButton.on(

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -79,7 +79,9 @@ jQuery( function ( $ ) {
 	 * StoreAPI will support this form correctly only after WC 9.7.0.
 	 * See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3780#issuecomment-2632051359
 	 */
-	const useLegacyCartEndpoints = $( '.variations_form' ).length > 0;
+	const useLegacyCartEndpoints =
+		$( '.variations_form' ).length > 0 ||
+		$( '#wc-bookings-booking-form' ).length > 0;
 
 	const wcStripeECE = {
 		createButton: ( elements, options ) =>

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -80,9 +80,7 @@ jQuery( function ( $ ) {
 	 * StoreAPI will support this form correctly only after WC 9.7.0.
 	 * See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3780#issuecomment-2632051359
 	 */
-	const useLegacyCartEndpoints =
-		$( '.variations_form' ).length > 0 ||
-		$( '#wc-bookings-booking-form' ).length > 0;
+	const useLegacyCartEndpoints = $( '.variations_form' ).length > 0;
 
 	const resolveClickEvent = ( event, options ) => {
 		const clickOptions = {
@@ -835,9 +833,7 @@ jQuery( function ( $ ) {
 						response.displayItems;
 
 					// Empty the cart to avoid having 2 products in the cart when payment request is not used.
-					api.expressCheckoutEmptyCartLegacy( {
-						bookingId: response.bookingId,
-					} );
+					api.expressCheckoutEmptyCart( response.bookingId );
 
 					wcStripeECE.init();
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -151,7 +151,7 @@ jQuery( function ( $ ) {
 			// that the product was successfully added to the cart.
 			wcStripeECE.isAddToCartSuccessful = false;
 			const response = await addToCartPromise;
-			const isAddToCartSuccessful = response && response?.items_count > 0;
+			const isAddToCartSuccessful = response?.items_count > 0;
 			const isLegacyAddToCartSuccessful = response?.result === 'success';
 			if ( isAddToCartSuccessful || isLegacyAddToCartSuccessful ) {
 				wcStripeECE.isAddToCartSuccessful = true;
@@ -160,6 +160,7 @@ jQuery( function ( $ ) {
 			return;
 		}
 
+		wcStripeECE.isAddToCartSuccessful = true;
 		return resolveClickEvent( event, options );
 	};
 
@@ -167,7 +168,7 @@ jQuery( function ( $ ) {
 		event,
 		elements
 	) => {
-		if ( ! wcStripeECE.isAddToCartSuccessful ) {
+		if ( wcStripeECE.isAddToCartSuccessful === false ) {
 			// wait 1s for the item to be added to the cart before proceeding
 			await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
 		}
@@ -373,7 +374,7 @@ jQuery( function ( $ ) {
 			eceButton.on( 'confirm', async ( event ) => {
 				if (
 					getExpressCheckoutData( 'is_product_page' ) &&
-					! wcStripeECE.isAddToCartSuccessful
+					wcStripeECE.isAddToCartSuccessful === false
 				) {
 					const message = __(
 						'There was an error adding the product to the cart.',

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -149,18 +149,30 @@ jQuery( function ( $ ) {
 
 			// Wait for the addToCart operation to finish, checking
 			// that the product was successfully added to the cart.
-			wcStripeECE.addToCartError = true;
+			wcStripeECE.isAddToCartSuccessful = false;
 			const response = await addToCartPromise;
 			const isAddToCartSuccessful = response && response?.items_count > 0;
 			const isLegacyAddToCartSuccessful = response?.result === 'success';
 			if ( isAddToCartSuccessful || isLegacyAddToCartSuccessful ) {
-				wcStripeECE.addToCartError = false;
+				wcStripeECE.isAddToCartSuccessful = true;
 			}
 
 			return;
 		}
 
 		return resolveClickEvent( event, options );
+	};
+
+	const handleProductPageShippingAddressChange = async (
+		event,
+		elements
+	) => {
+		if ( ! wcStripeECE.isAddToCartSuccessful ) {
+			// wait 1s for the item to be added to the cart before proceeding
+			await new Promise( ( resolve ) => setTimeout( resolve, 1000 ) );
+		}
+
+		return shippingAddressChangeHandler( api, event, elements );
 	};
 
 	const wcStripeECE = {
@@ -338,11 +350,19 @@ jQuery( function ( $ ) {
 				return await handleProductPageECEButtonClick( event, options );
 			} );
 
-			eceButton.on(
-				'shippingaddresschange',
-				async ( event ) =>
-					await shippingAddressChangeHandler( api, event, elements )
-			);
+			eceButton.on( 'shippingaddresschange', async ( event ) => {
+				if ( getExpressCheckoutData( 'is_product_page' ) ) {
+					return await handleProductPageShippingAddressChange(
+						event,
+						elements
+					);
+				}
+				return await shippingAddressChangeHandler(
+					api,
+					event,
+					elements
+				);
+			} );
 
 			eceButton.on(
 				'shippingratechange',
@@ -353,7 +373,7 @@ jQuery( function ( $ ) {
 			eceButton.on( 'confirm', async ( event ) => {
 				if (
 					getExpressCheckoutData( 'is_product_page' ) &&
-					wcStripeECE.addToCartError
+					! wcStripeECE.isAddToCartSuccessful
 				) {
 					const message = __(
 						'There was an error adding the product to the cart.',

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -84,6 +84,87 @@ jQuery( function ( $ ) {
 		$( '.variations_form' ).length > 0 ||
 		$( '#wc-bookings-booking-form' ).length > 0;
 
+	const resolveClickEvent = ( event, options ) => {
+		const clickOptions = {
+			lineItems: useLegacyCartEndpoints
+				? normalizeLineItems( options.displayItems )
+				: options.displayItems,
+			emailRequired: true,
+			shippingAddressRequired: options.requestShipping,
+			phoneNumberRequired: options.requestPhone,
+			shippingRates: options.shippingRates,
+		};
+
+		return event.resolve( clickOptions );
+	};
+
+	const handleProductPageECEButtonClick = async ( event, options ) => {
+		const addToCartButton = document.querySelector(
+			'.single_add_to_cart_button'
+		);
+
+		// First check if product can be added to cart.
+		if ( addToCartButton.classList.contains( 'disabled' ) ) {
+			const defaultMessage = __(
+				'Please select your product options before proceeding.',
+				'woocommerce-gateway-stripe'
+			);
+			let message;
+			if (
+				addToCartButton.classList.contains(
+					'wc-variation-is-unavailable'
+				)
+			) {
+				message =
+					getAddToCartVariationParams( 'i18n_unavailable_text' ) ||
+					__(
+						'Sorry, this product is unavailable. Please choose a different combination.',
+						'woocommerce-gateway-stripe'
+					);
+			}
+
+			// eslint-disable-next-line no-alert
+			window.alert( message || defaultMessage );
+			return;
+		}
+
+		if ( wcStripeECEError ) {
+			// eslint-disable-next-line no-alert
+			window.alert( wcStripeECEError );
+			return;
+		}
+
+		// Stripe requires event.resolve() to be called within 1s of the click event.
+		// Here, we enforce a timeout for the addToCart operation. If the operation
+		// takes longer, we will call event.resolve() immediately,
+		// and wait for the addToCart operation to finish after.
+		const addToCartPromise = wcStripeECE.addToCart();
+		const timeout = new Promise( ( resolve ) =>
+			setTimeout( () => {
+				resolve( 'timeout' );
+			}, 700 )
+		);
+		const result = await Promise.race( [ addToCartPromise, timeout ] );
+		if ( result === 'timeout' ) {
+			// Immediately resolve the click event to avoid the 1s timeout.
+			resolveClickEvent( event, options );
+
+			// Wait for the addToCart operation to finish, checking
+			// that the product was successfully added to the cart.
+			wcStripeECE.addToCartError = true;
+			const response = await addToCartPromise;
+			const isAddToCartSuccessful = response && response?.items_count > 0;
+			const isLegacyAddToCartSuccessful = response?.result === 'success';
+			if ( isAddToCartSuccessful || isLegacyAddToCartSuccessful ) {
+				wcStripeECE.addToCartError = false;
+			}
+
+			return;
+		}
+
+		return resolveClickEvent( event, options );
+	};
+
 	const wcStripeECE = {
 		createButton: ( elements, options ) =>
 			elements.create( 'expressCheckout', options ),
@@ -251,74 +332,12 @@ jQuery( function ( $ ) {
 					);
 				}
 
-				if ( getExpressCheckoutData( 'is_product_page' ) ) {
-					const addToCartButton = $( '.single_add_to_cart_button' );
-
-					// First check if product can be added to cart.
-					if ( addToCartButton.is( '.disabled' ) ) {
-						if (
-							addToCartButton.is( '.wc-variation-is-unavailable' )
-						) {
-							// eslint-disable-next-line no-alert
-							window.alert(
-								// eslint-disable-next-line camelcase
-								getAddToCartVariationParams(
-									'i18n_unavailable_text'
-								) ||
-									__(
-										'Sorry, this product is unavailable. Please choose a different combination.',
-										'woocommerce-gateway-stripe'
-									)
-							);
-						} else {
-							// eslint-disable-next-line no-alert
-							window.alert(
-								__(
-									'Please select your product options before proceeding.',
-									'woocommerce-gateway-stripe'
-								)
-							);
-						}
-						return;
-					}
-
-					if ( wcStripeECEError ) {
-						// eslint-disable-next-line no-alert
-						window.alert( wcStripeECEError );
-						return;
-					}
+				if ( ! getExpressCheckoutData( 'is_product_page' ) ) {
+					onClickHandler( event );
+					return resolveClickEvent( event, options );
 				}
 
-				const clickOptions = {
-					lineItems: useLegacyCartEndpoints
-						? normalizeLineItems( options.displayItems )
-						: options.displayItems,
-					emailRequired: true,
-					shippingAddressRequired: options.requestShipping,
-					phoneNumberRequired: options.requestPhone,
-					shippingRates: options.shippingRates,
-				};
-
-				event.resolve( clickOptions );
-				onClickHandler( event );
-
-				// Call addToCart after event.resolve() so we don't hit the 1-second Stripe
-				// timeout for the click event. If addToCart fails, set a flag to prevent
-				// payment confirmation ('confirm' event) from being triggered.
-				if ( getExpressCheckoutData( 'is_product_page' ) ) {
-					wcStripeECE.cartError = true;
-					const response = await wcStripeECE.addToCart();
-					const isAddToCartSuccessful =
-						response && response?.items_count > 0;
-					const isLegacyAddToCartSuccessful =
-						response?.result === 'success';
-					if (
-						isAddToCartSuccessful ||
-						isLegacyAddToCartSuccessful
-					) {
-						wcStripeECE.cartError = false;
-					}
-				}
+				return await handleProductPageECEButtonClick( event, options );
 			} );
 
 			eceButton.on(
@@ -336,7 +355,7 @@ jQuery( function ( $ ) {
 			eceButton.on( 'confirm', async ( event ) => {
 				if (
 					getExpressCheckoutData( 'is_product_page' ) &&
-					wcStripeECE.cartError
+					wcStripeECE.addToCartError
 				) {
 					const message = __(
 						'There was an error adding the product to the cart.',
@@ -598,7 +617,9 @@ jQuery( function ( $ ) {
 
 			// Clear the cart, so items that are currently in it
 			//  do not interfere with computed totals.
-			await api.expressCheckoutEmptyCart();
+			// Use the non-StoreAPI method as it is faster; Stripe requires
+			// the click event to be resolved within 1 second.
+			await api.expressCheckoutEmptyCartLegacy( {} );
 
 			return api.expressCheckoutAddToCart( data );
 		},
@@ -814,7 +835,9 @@ jQuery( function ( $ ) {
 						response.displayItems;
 
 					// Empty the cart to avoid having 2 products in the cart when payment request is not used.
-					api.expressCheckoutEmptyCart( response.bookingId );
+					api.expressCheckoutEmptyCartLegacy( {
+						bookingId: response.bookingId,
+					} );
 
 					wcStripeECE.init();
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -591,12 +591,12 @@ jQuery( function ( $ ) {
 
 				return api.expressCheckoutAddToCartLegacy( data );
 			}
-			
-      // BlocksAPI partial support (lacking support for variations).
+
+			// BlocksAPI partial support (lacking support for variations).
 			data.id = productId;
 			data.variation = [];
-      
-      // Clear the cart, so items that are currently in it
+
+			// Clear the cart, so items that are currently in it
 			//  do not interfere with computed totals.
 			await api.expressCheckoutEmptyCart();
 

--- a/readme.txt
+++ b/readme.txt
@@ -113,7 +113,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 9.2.0 - xxxx-xx-xx =
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Fix - Clear cart first when using express checkout inside the product page.
-* Fix - Switch booking products back to using non-Store API (legacy) add to cart.
+* Fix - Avoid Stripe timeouts for the express checkout click event.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.
 * Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,9 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.2.0 - xxxx-xx-xx =
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
+* Fix - Clear cart first when using express checkout inside the product page.
+* Fix - Resolve the click event before adding the product to the cart for express checkout inside the product page, to avoid Stripe timeouts.
+* Fix - Switch booking products back to using non-Store API (legacy) add to cart.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.
 * Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.

--- a/readme.txt
+++ b/readme.txt
@@ -113,7 +113,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 9.2.0 - xxxx-xx-xx =
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Fix - Clear cart first when using express checkout inside the product page.
-* Fix - Resolve the click event before adding the product to the cart for express checkout inside the product page, to avoid Stripe timeouts.
 * Fix - Switch booking products back to using non-Store API (legacy) add to cart.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3861 

## Changes proposed in this Pull Request:

This PR fixes the following issues that prevent express payment from loading properly inside the product page:

   1. The payment modal fails to load because the button `click` event fails to resolve within 1 second (a Stripe rule), due to slow responses from add-to-cart API calls (see #3861)
        - To fix this issue, we added our own timeout to add-to-cart calls, and call `event.resolve()` when we hit it.
            - `event.resolve()` does not need any data from the cart response. 
        - We also added a `isAddToCartSuccessful` flag to prevent the shopper from confirming payment if the product was not added to the cart successfully, and to allow the `shippingaddresschange` event to wait for the item to be added to the cart.
            - We need the item to be in the cart for shipping details to be displayed correctly.
            - The `shippingaddresschange` event has 20s to resolve, so we can afford to wait for the cart for a bit.

   2. The payment modal total amount includes other products that are in the cart, instead of just the current product. In some cases, the cart contains an incompatible product (e.g. pre-order product), and this prevents the current product from being added to the cart and causes ECE to fail.
       - We fixed these issues by clearing the cart before adding the current product. This is similar to [actions performed by the legacy add-to-cart method](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/beb2828170ae9fc1de540fd9b9517cac0e82b71b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php#L92).
           - We are using the legacy/non-StoreAPI method to clear the cart, as it is faster, and we are under a time restriction. Compared to the StoreAPI method, it does not need to issue a `/cart` request, followed by multiple `/remove-item` requests.  

Screenshot: Inside the product page, the total amount should only include the current product.

| Before | After |
|--------|-------|
|<img width="800" alt="Screenshot 2025-02-10 at 3 38 15 PM" src="https://github.com/user-attachments/assets/7a53ac89-71a9-4e31-aeb6-006d5e593dcf" /> | <img width="800" alt="Screenshot 2025-02-10 at 3 38 59 PM" src="https://github.com/user-attachments/assets/d069e4d0-581c-4e84-9b8c-e7ae326118dd" /> |


Screen recording: when network is slow, and add-to-cart operation takes >1s, we can still avoid the Stripe `event.resolve()` 1s timeout for `click`


https://github.com/user-attachments/assets/c5f7dc37-14e2-430f-9a28-ce01a6eea294



## Testing instructions

**Testing timeouts due to slow add-to-cart**
1. Define your shipping zone with both Free shipping and a Flat rate fee.
2. Go to a product page.
3. Open Chrome Developer Tools and under Network, throttle to 3G.
    - In `develop`, the payment modal does not load and the browser console displays a timeout message from Stripe.
    - In this branch, the payment modal loads. Verify that the total amount is correct (when the modal loads completely), including shipping.


**Testing correct total amount**
1. Add a few different products to your cart.
2. Go to a product page, preferably for a product that is not yet in your cart.
3. Click Google Pay.
    - In `develop`, the payment modal will show the total amount of all the items in your cart.
    - In this branch, the payment modal will show only the total amount for the current product.


**Testing conflicting products in cart**
1. Install the Pre-Orders (https://github.com/woocommerce/woocommerce-pre-orders) extensions.
2. Create a pre-order product.
3. Add the pre-order product to cart.
4. Go to a product page and click Google Pay.
    - In `develop`, the payment modal will not load and you will see a console error about incompatible products in the cart.
    - In this branch, you should be able to finish your purchase without any problem.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
