### PR TITLE
Adding admin notices for detached subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Adds a new notice for store admins when there are subscriptions without a payment method attached.
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -391,44 +391,31 @@ class WC_Stripe_Admin_Notices {
 	 */
 	public function subscriptions_check_environment() {
 		$detached_messages = '';
-		$subscriptions     = wcs_get_subscriptions(
-			[
-				'subscriptions_per_page' => -1,
-				'orderby'                => 'date',
-				'order'                  => 'DESC',
-				'subscription_status'    => [ 'active', 'on-hold', 'pending-cancel' ],
-			]
-		);
+		$subscriptions     = $this->get_detached_subscriptions();
 		foreach ( $subscriptions as $subscription ) {
-			$source_id = $subscription->get_meta( '_stripe_source_id' );
-			if ( $source_id ) {
-				$payment_method = WC_Stripe_API::get_payment_method( $source_id );
-				if ( ! $payment_method->customer ) {
-					$customer_payment_method_link = sprintf(
-						'<a href="%s">%s</a>',
-						esc_url( $subscription->get_change_payment_method_url() ),
-						esc_html(
-							/* translators: this is a text for a link pointing to the customer's payment method page */
-							__( 'this link &rarr;', 'woocommerce-gateway-stripe' )
-						)
-					);
-					$customer_stripe_page = sprintf(
-						'<a href="%s">%s</a>',
-						esc_url( 'https://dashboard.stripe.com/customers/' . $subscription->get_meta( '_stripe_customer_id' ) ),
-						esc_html(
-							/* translators: this is a text for a link pointing to the customer's page on Stripe */
-							__( 'here &rarr;', 'woocommerce-gateway-stripe' )
-						)
-					);
-					$detached_messages .= sprintf(
-					/* translators: %1$s is the subscription ID. %2$s is a customer payment method page. %3$s is the customer's page on Stripe */
-						__( 'Subscription #%1$s\'s payment method is missing, <strong>preventing renewals</strong>. Share %2$s with the customer to update it or manually set the <strong>Stripe Payment Method ID</strong> meta field in the subscriptions details "Billing" section to another from %3$s.', 'woocommerce-gateway-stripe' ),
-						$subscription->get_id(),
-						$customer_payment_method_link,
-						$customer_stripe_page
-					);
-				}
-			}
+			$customer_payment_method_link = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $subscription->get_change_payment_method_url() ),
+				esc_html(
+					/* translators: this is a text for a link pointing to the customer's payment method page */
+					__( 'this link &rarr;', 'woocommerce-gateway-stripe' )
+				)
+			);
+			$customer_stripe_page = sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( 'https://dashboard.stripe.com/customers/' . $subscription->get_meta( '_stripe_customer_id' ) ),
+				esc_html(
+					/* translators: this is a text for a link pointing to the customer's page on Stripe */
+					__( 'here &rarr;', 'woocommerce-gateway-stripe' )
+				)
+			);
+			$detached_messages .= sprintf(
+			/* translators: %1$s is the subscription ID. %2$s is a customer payment method page. %3$s is the customer's page on Stripe */
+				__( 'Subscription #%1$s\'s payment method is missing, <strong>preventing renewals</strong>. Share %2$s with the customer to update it or manually set the <strong>Stripe Payment Method ID</strong> meta field in the subscriptions details "Billing" section to another from %3$s.', 'woocommerce-gateway-stripe' ),
+				$subscription->get_id(),
+				$customer_payment_method_link,
+				$customer_stripe_page
+			);
 		}
 		$show_notice = get_option( 'wc_stripe_show_subscriptions_notice' );
 		if ( ! empty( $detached_messages ) && 'no' !== $show_notice ) {
@@ -527,6 +514,33 @@ class WC_Stripe_Admin_Notices {
 		if ( empty( $previous_version ) || version_compare( $previous_version, '4.3.0', 'ge' ) ) {
 			update_option( 'wc_stripe_show_sca_notice', 'no' );
 		}
+	}
+
+	/**
+	 * Returns a list of subscriptions without a payment method attached.
+	 *
+	 * @return array
+	 */
+	private function get_detached_subscriptions() {
+		$detached_subscriptions = [];
+		$subscriptions          = wcs_get_subscriptions(
+			[
+				'subscriptions_per_page' => -1,
+				'orderby'                => 'date',
+				'order'                  => 'DESC',
+				'subscription_status'    => [ 'active', 'on-hold', 'pending-cancel' ],
+			]
+		);
+		foreach ( $subscriptions as $subscription ) {
+			$source_id = $subscription->get_meta( '_stripe_source_id' );
+			if ( $source_id ) {
+				$payment_method = WC_Stripe_API::get_payment_method( $source_id );
+				if ( ! $payment_method->customer ) {
+					$detached_subscriptions[] = $subscription;
+				}
+			}
+		}
+		return $detached_subscriptions;
 	}
 }
 

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -58,6 +58,11 @@ class WC_Stripe_Admin_Notices {
 		// All other payment methods.
 		$this->payment_methods_check_environment();
 
+		// Subscription related checks.
+		if ( class_exists( 'WC_Subscriptions' ) && class_exists( 'WC_Subscription' ) && version_compare( WC_Subscriptions::$version, '2.2.0', '>=' ) ) {
+			$this->subscriptions_check_environment();
+		}
+
 		foreach ( (array) $this->notices as $notice_key => $notice ) {
 			echo '<div class="' . esc_attr( $notice['class'] ) . '" style="position:relative;">';
 
@@ -380,6 +385,59 @@ class WC_Stripe_Admin_Notices {
 	}
 
 	/**
+	 * Environment check for subscriptions.
+	 *
+	 * @return void
+	 */
+	public function subscriptions_check_environment() {
+		$detached_messages = '';
+		$subscriptions     = wcs_get_subscriptions(
+			[
+				'subscriptions_per_page' => -1,
+				'orderby'                => 'date',
+				'order'                  => 'DESC',
+				'subscription_status'    => [ 'active', 'on-hold', 'pending-cancel' ],
+			]
+		);
+		foreach ( $subscriptions as $subscription ) {
+			$source_id = $subscription->get_meta( '_stripe_source_id' );
+			if ( $source_id ) {
+				$payment_method           = WC_Stripe_API::get_payment_method( $source_id );
+				$payment_method->customer = null;
+				if ( ! $payment_method->customer ) {
+					$customer_payment_method_link = sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( $subscription->get_change_payment_method_url() ),
+						esc_html(
+							/* translators: this is a text for a link pointing to the customer's payment method page */
+							__( 'this link &rarr;', 'woocommerce-gateway-stripe' )
+						)
+					);
+					$customer_stripe_page = sprintf(
+						'<a href="%s">%s</a>',
+						esc_url( 'https://dashboard.stripe.com/customers/' . $subscription->get_meta( '_stripe_customer_id' ) ),
+						esc_html(
+							/* translators: this is a text for a link pointing to the customer's page on Stripe */
+							__( 'here &rarr;', 'woocommerce-gateway-stripe' )
+						)
+					);
+					$detached_messages .= sprintf(
+					/* translators: %1$s is the subscription ID. %2$s is a customer payment method page. %3$s is the customer's page on Stripe */
+						__( 'Subscription #%1$s\'s payment method is missing, <strong>preventing renewals</strong>. Share %2$s with the customer to update it or manually set the <strong>Stripe Payment Method ID</strong> meta field in the subscriptions details "Billing" section to another from %3$s.', 'woocommerce-gateway-stripe' ),
+						$subscription->get_id(),
+						$customer_payment_method_link,
+						$customer_stripe_page
+					);
+				}
+			}
+		}
+		$show_notice = get_option( 'wc_stripe_show_subscriptions_notice' );
+		if ( ! empty( $detached_messages ) && 'no' !== $show_notice ) {
+			$this->add_admin_notice( 'subscriptions', 'notice notice-error', $detached_messages, true );
+		}
+	}
+
+	/**
 	 * Hides any admin notices.
 	 *
 	 * @since 4.0.0
@@ -421,8 +479,6 @@ class WC_Stripe_Admin_Notices {
 					break;
 				case 'sofort':
 					update_option( 'wc_stripe_show_sofort_notice', 'no' );
-					break;
-				case 'sofort':
 					update_option( 'wc_stripe_show_sofort_upe_notice', 'no' );
 					break;
 				case 'sca':
@@ -436,6 +492,9 @@ class WC_Stripe_Admin_Notices {
 					break;
 				case 'upe_payment_methods':
 					update_option( 'wc_stripe_show_upe_payment_methods_notice', 'no' );
+					break;
+				case 'subscriptions':
+					update_option( 'wc_stripe_show_subscriptions_notice', 'no' );
 					break;
 			}
 		}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -17,6 +17,13 @@ class WC_Stripe_Admin_Notices {
 	private const DETACHED_SUBSCRIPTIONS_TRANSIENT_KEY = 'wcstripe_detached_subscriptions';
 
 	/**
+	 * Stripe customer page base URL.
+	 *
+	 * @var string
+	 */
+	private const STRIPE_CUSTOMER_PAGE_BASE_URL = 'https://dashboard.stripe.com/customers/';
+
+	/**
 	 * Notices (array)
 	 *
 	 * @var array
@@ -410,7 +417,7 @@ class WC_Stripe_Admin_Notices {
 			);
 			$customer_stripe_page = sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( 'https://dashboard.stripe.com/customers/' . $subscription['customer_id'] ),
+				esc_url( self::STRIPE_CUSTOMER_PAGE_BASE_URL . $subscription['customer_id'] ),
 				esc_html(
 					/* translators: this is a text for a link pointing to the customer's page on Stripe */
 					__( 'here &rarr;', 'woocommerce-gateway-stripe' )

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -10,6 +10,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Admin_Notices {
 	/**
+	 * Transient key for detached subscriptions.
+	 *
+	 * @var string
+	 */
+	private const DETACHED_SUBSCRIPTIONS_TRANSIENT_KEY = 'wcstripe_detached_subscriptions';
+
+	/**
 	 * Notices (array)
 	 *
 	 * @var array
@@ -395,7 +402,7 @@ class WC_Stripe_Admin_Notices {
 		foreach ( $subscriptions as $subscription ) {
 			$customer_payment_method_link = sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( $subscription->get_change_payment_method_url() ),
+				esc_url( $subscription['change_payment_method_url'] ),
 				esc_html(
 					/* translators: this is a text for a link pointing to the customer's payment method page */
 					__( 'this link &rarr;', 'woocommerce-gateway-stripe' )
@@ -403,7 +410,7 @@ class WC_Stripe_Admin_Notices {
 			);
 			$customer_stripe_page = sprintf(
 				'<a href="%s">%s</a>',
-				esc_url( 'https://dashboard.stripe.com/customers/' . $subscription->get_meta( '_stripe_customer_id' ) ),
+				esc_url( 'https://dashboard.stripe.com/customers/' . $subscription['customer_id'] ),
 				esc_html(
 					/* translators: this is a text for a link pointing to the customer's page on Stripe */
 					__( 'here &rarr;', 'woocommerce-gateway-stripe' )
@@ -412,7 +419,7 @@ class WC_Stripe_Admin_Notices {
 			$detached_messages .= sprintf(
 			/* translators: %1$s is the subscription ID. %2$s is a customer payment method page. %3$s is the customer's page on Stripe */
 				__( 'Subscription #%1$s\'s payment method is missing, <strong>preventing renewals</strong>. Share %2$s with the customer to update it or manually set the <strong>Stripe Payment Method ID</strong> meta field in the subscriptions details "Billing" section to another from %3$s.', 'woocommerce-gateway-stripe' ),
-				$subscription->get_id(),
+				$subscription['id'],
 				$customer_payment_method_link,
 				$customer_stripe_page
 			);
@@ -522,6 +529,12 @@ class WC_Stripe_Admin_Notices {
 	 * @return array
 	 */
 	private function get_detached_subscriptions() {
+		// Check if we have a cached result.
+		$cached_subscriptions = get_transient( self::DETACHED_SUBSCRIPTIONS_TRANSIENT_KEY );
+		if ( ! empty( $cached_subscriptions ) ) {
+			return $cached_subscriptions;
+		}
+
 		$detached_subscriptions = [];
 		$subscriptions          = wcs_get_subscriptions(
 			[
@@ -536,10 +549,18 @@ class WC_Stripe_Admin_Notices {
 			if ( $source_id ) {
 				$payment_method = WC_Stripe_API::get_payment_method( $source_id );
 				if ( ! $payment_method->customer ) {
-					$detached_subscriptions[] = $subscription;
+					$detached_subscriptions[] = [
+						'id'                        => $subscription->get_id(),
+						'customer_id'               => $subscription->get_meta( '_stripe_customer_id' ),
+						'change_payment_method_url' => $subscription->get_change_payment_method_url(),
+					];
 				}
 			}
 		}
+
+		// Cache the result for a day.
+		set_transient( self::DETACHED_SUBSCRIPTIONS_TRANSIENT_KEY, $detached_subscriptions, DAY_IN_SECONDS );
+
 		return $detached_subscriptions;
 	}
 }

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -402,8 +402,7 @@ class WC_Stripe_Admin_Notices {
 		foreach ( $subscriptions as $subscription ) {
 			$source_id = $subscription->get_meta( '_stripe_source_id' );
 			if ( $source_id ) {
-				$payment_method           = WC_Stripe_API::get_payment_method( $source_id );
-				$payment_method->customer = null;
+				$payment_method = WC_Stripe_API::get_payment_method( $source_id );
 				if ( ! $payment_method->customer ) {
 					$customer_payment_method_link = sprintf(
 						'<a href="%s">%s</a>',

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.2.0 - xxxx-xx-xx =
+* Add - Adds a new notice for store admins when there are subscriptions without a payment method attached.
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.

--- a/tests/phpunit/helpers/class-wc-subscriptions-helper.php
+++ b/tests/phpunit/helpers/class-wc-subscriptions-helper.php
@@ -18,6 +18,19 @@ function wcs_get_subscriptions_for_order( $order ) {
 }
 
 /**
+ * A function to mock wcs_get_subscriptions.
+ *
+ * @return array
+ */
+function wcs_get_subscriptions() {
+	if ( ! WC_Subscriptions_Helpers::$wcs_get_subscriptions ) {
+		return [];
+	}
+
+	return (array) WC_Subscriptions_Helpers::$wcs_get_subscriptions;
+}
+
+/**
  * A helper class for setting up mocks for WC_Subscriptions functions.
  */
 class WC_Subscriptions_Helpers {
@@ -28,4 +41,11 @@ class WC_Subscriptions_Helpers {
 	 * @var array
 	 */
 	public static $wcs_get_subscriptions_for_order = null;
+
+	/**
+	 * Mock for wcs_get_subscriptions.
+	 *
+	 * @var array
+	 */
+	public static $wcs_get_subscriptions = null;
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See: p1739145321956079-slack-C7U3Y3VMY

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR adds new admin notices to alert merchants when subscriptions payment methods are detached, preventing renewals from happening. This should help them be more proactive in identifying and fixing this kind of issue.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

- Checkout and build this branch on your test environment (`add/admin-notices-for-detached-subscriptions`)
- Connect your Stripe account
- Install the subscriptions extension
- Create a subscription product
- As a shopper, purchase the subscription
- As a merchant, access the Stripe dashboard and delete the payment methods bound to the shopper account above
- Confirm that you can see the new notice in wp-admin:
<img width="1539" alt="Screenshot 2025-02-11 at 13 27 39" src="https://github.com/user-attachments/assets/6f4635f9-e886-4f4f-8d5d-966a8c7aed6c" />

(you can also just set `$payment_method->customer` to `null` in the `subscriptions_check_environment` method)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
