### PR TITLE
ECE: fix add-to-cart issue for bookings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 9.2.0 - xxxx-xx-xx =
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
+* Fix - Switch booking products back to using non-StoreAPI add-to-cart methods.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.
 * Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -577,8 +577,6 @@ export default class WCStripeAPI {
 	/**
 	 * Empty the cart (legacy version, non-StoreAPI).
 	 *
-	 * @todo Remove this once WC 9.7.0 is the min. required version.
-	 *
 	 * @param {Object} params Parameters.
 	 * @param {number} params.bookingId Booking ID.
 	 * @return {Promise} Promise for the request to the server.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -575,6 +575,22 @@ export default class WCStripeAPI {
 	}
 
 	/**
+	 * Empty the cart (legacy version, non-StoreAPI).
+	 *
+	 * @todo Remove this once WC 9.7.0 is the min. required version.
+	 *
+	 * @param {Object} params Parameters.
+	 * @param {number} params.bookingId Booking ID.
+	 * @return {Promise} Promise for the request to the server.
+	 */
+	expressCheckoutEmptyCartLegacy( { bookingId = null } ) {
+		return this.request( getExpressCheckoutAjaxURL( 'clear_cart' ), {
+			security: getExpressCheckoutData( 'nonce' )?.clear_cart,
+			...( bookingId ? { booking_id: bookingId } : {} ),
+		} );
+	}
+
+	/**
 	 * Creates order based on Express Checkout ECE payment method.
 	 *
 	 * @param {Object} paymentData Order data.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -784,9 +784,13 @@ jQuery( function ( $ ) {
 						response.displayItems;
 
 					// Empty the cart to avoid having 2 products in the cart when payment request is not used.
-					api.expressCheckoutEmptyCartLegacy( {
-						bookingId: response.bookingId,
-					} );
+					if ( useLegacyCartEndpoints ) {
+						api.expressCheckoutEmptyCartLegacy( {
+							bookingId: response.bookingId,
+						} );
+					} else {
+						api.expressCheckoutEmptyCart( response.bookingId );
+					}
 
 					wcStripeECE.init();
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -80,7 +80,9 @@ jQuery( function ( $ ) {
 	 * StoreAPI will support this form correctly only after WC 9.7.0.
 	 * See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3780#issuecomment-2632051359
 	 */
-	const useLegacyCartEndpoints = $( '.variations_form' ).length > 0;
+	const useLegacyCartEndpoints =
+		$( '.variations_form' ).length > 0 ||
+		$( '.wc-bookings-booking-form' ).length > 0;
 
 	const wcStripeECE = {
 		createButton: ( elements, options ) =>
@@ -782,7 +784,9 @@ jQuery( function ( $ ) {
 						response.displayItems;
 
 					// Empty the cart to avoid having 2 products in the cart when payment request is not used.
-					api.expressCheckoutEmptyCart( response.bookingId );
+					api.expressCheckoutEmptyCartLegacy( {
+						bookingId: response.bookingId,
+					} );
 
 					wcStripeECE.init();
 

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -79,6 +79,9 @@ jQuery( function ( $ ) {
 	 * @todo Using the legacy endpoint (non-StoreAPI) and data format when variations are present.
 	 * StoreAPI will support this form correctly only after WC 9.7.0.
 	 * See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3780#issuecomment-2632051359
+	 *
+	 * @todo Using the legacy endpoint (non-StoreAPI) for booking products. Can be
+	 * removed once booking product flows have been fully migrated to StoreAPI.
 	 */
 	const useLegacyCartEndpoints =
 		$( '.variations_form' ).length > 0 ||

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.2.0 - xxxx-xx-xx =
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
+* Fix - Switch booking products back to using non-StoreAPI add-to-cart methods.
 * Dev - Add new E2E tests for Link express checkout.
 * Add - Add Amazon Pay to block cart and block checkout.
 * Fix - Remove intentional delay when displaying tax-related notice for express checkout, causing click event to time out.


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes an issue where express checkout buttons do not load properly for booking products.

As a quick fix, we switched booking products back to the "legacy" add-to-cart method, pending investigation on how the flow can be properly updated to use the new StoreAPI add-to-cart method.

For bookings, switch to non-StoreAPI add-to-cart as a quick fix.
| Before | After |
|--------|-------|
|<img width="800" alt="Screenshot 2025-02-10 at 3 45 59 PM" src="https://github.com/user-attachments/assets/5922988b-ac92-43c5-9ea1-d179a2f99e08" /> | <img width="800" alt="Screenshot 2025-02-10 at 3 46 34 PM" src="https://github.com/user-attachments/assets/adec8d91-da20-4caa-8287-46c2c757de7e" /> |


## Testing instructions
1. Install the WC Bookings extension (https://github.com/woocommerce/woocommerce-bookings).
2. Create a booking product.
3. Visit the product page, then select a date and time for the booking.
    - In `develop`, the ECE buttons get stuck loading, and the browser console shows an error about a missing date.
    - In this branch, the buttons should successfully load, and clicking them should bring up the payment modal.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
