### PR TITLE
Use correct key for 'quantity' in add-item API call

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 9.2.0 - xxxx-xx-xx =
 * Add - Adds a new notice for store admins when there are subscriptions without a payment method attached.
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
+* Fix - Fix the quantity parameter for the express checkout add-to-cart API call.
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Fix - Clear cart first when using express checkout inside the product page.
 * Fix - Avoid Stripe timeouts for the express checkout click event.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -524,9 +524,17 @@ export default class WCStripeAPI {
 	 * @return {Promise} Promise for the request to the server.
 	 */
 	expressCheckoutAddToCart( productData ) {
+		// Rename qty to quantity to match StoreAPI expected parameter.
+		const { qty, ...rest } = productData;
+		const quantity = qty ?? 1;
+		const blocksApiProductData = {
+			...rest,
+			quantity,
+		};
+
 		const data = applyFilters(
 			'wcstripe.express-checkout.cart-add-item',
-			productData
+			blocksApiProductData
 		);
 		return this.postToBlocksAPI( '/wc/store/v1/cart/add-item', data );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -113,6 +113,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 9.2.0 - xxxx-xx-xx =
 * Add - Adds a new notice for store admins when there are subscriptions without a payment method attached.
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
+* Fix - Fix the quantity parameter for the express checkout add-to-cart API call.
 * Dev - Replaces part of the StoreAPI call code for the cart endpoints to use the newly introduced filter.
 * Fix - Clear cart first when using express checkout inside the product page.
 * Fix - Avoid Stripe timeouts for the express checkout click event.


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Fixes an issue where the incorrect quantity is added to the cart, when using express checkout inside the product page.

Issue: StoreAPI is expecting `quantity`, but we are sending `qty`.

## Testing instructions
1. As a shopper, go to a product page.
2. Change the quantity from 1 to 2.
3. Click Google Pay.
    - In `develop`, the total amount only reflects the price for 1. Peeking at the `add-item` request, you will see the API response `quantity` as 1 (the request payload `qty` is 2).
    - In this branch, the total amount should properly reflect the requested product quantity. Peeking at the `add-item` request, you should see the response `quantity` as 2.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
