### PR TITLE
Allow to save card with account creation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Add - Bacs: Process Payment with Saved Bank Details
 * Tweak - Update payment method logos on the checkout page.
 * Update - Refactor unsupported deferred intent in the blocks checkout.
+* Fix - Allow to save card during checkout with account creation.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -639,9 +639,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			<?php
 			if ( $display_tokenization ) {
 				$this->tokenization_script();
-				if ( is_user_logged_in() ) {
-					$this->saved_payment_methods();
-				}
+				$this->saved_payment_methods();
 			}
 			?>
 
@@ -656,9 +654,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$methods_enabled_for_saved_payments = array_filter( $this->get_upe_enabled_payment_method_ids(), [ $this, 'is_enabled_for_saved_payments' ] );
 			if ( $this->is_saved_cards_enabled() && ! empty( $methods_enabled_for_saved_payments ) ) {
 				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
-				if ( is_user_logged_in() ) {
-					$this->save_payment_method_checkbox( $force_save_payment );
-				}
+				$this->save_payment_method_checkbox( $force_save_payment );
 			}
 
 			do_action( 'wc_stripe_payment_fields_' . $this->id, $this->id );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -712,7 +712,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		$id = 'wc-' . $this->id . '-new-payment-method';
 		?>
 		<fieldset <?php echo $force_checked ? 'style="display:none;"' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>>
-			<p class="form-row woocommerce-SavedPaymentMethods-saveNew">
+			<p class="form-row woocommerce-SavedPaymentMethods-saveNew" <?php echo ! is_user_logged_in() ? 'style="display:none;"' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?>>
 				<input id="<?php echo esc_attr( $id ); ?>" name="<?php echo esc_attr( $id ); ?>" type="checkbox" value="true" style="width:auto;" <?php echo $force_checked ? 'checked' : ''; /* phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped */ ?> />
 				<label for="<?php echo esc_attr( $id ); ?>" style="display:inline;">
 					<?php echo esc_html( apply_filters( 'wc_stripe_save_to_account_text', __( 'Save payment information to my account for future purchases.', 'woocommerce-gateway-stripe' ) ) ); ?>

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Bacs: Process Payment with Saved Bank Details
 * Tweak - Update payment method logos on the checkout page.
 * Update - Refactor unsupported deferred intent in the blocks checkout.
+* Fix - Allow to save card during checkout with account creation.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes [#2832](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2832#issuecomment-2527720270)

## Changes proposed in this Pull Request:
1. Included the saved token related HTML to the dom in [a21617f](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3901/commits/a21617f4f1997d5b71d8209ab9ecafce7f8e9c5b). Without this the [tokenization-form](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/client/legacy/js/frontend/tokenization-form.js) from WooCommerce Core does not get initialized. This block of code in core handles showing/hiding the save payment method checkbox with the change of the create account checkbox.
2. I have hidden the save payment method checkbox in [02cb679](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3901/commits/02cb679c828ff48e6f9a2a112c124825c7959f54) using the `style` property when the user is logged out.

## Testing instructions
- Enable account creation during checkout from **WooCommerce > Settings > Accounts & Privacy**.
- Enable `card` payment method in Stripe settings page.
- As a new shopper, add a product to your cart and go to the shortcode checkout page.
- select the `Create an account` checkbox.
- In `develop` branch, notice that the `Save payment information to my `account for future purchases` checkbox does not appear in the card element.
- In this branch, confirm that the save payment information checkbox appears when you select the `Create an account` checkbox.
- Choose to create an account and save the card. Confirm that the card is saved in this shopper's account.
- Confirm that the card does not get saved if you do not choose to save the card.
- Now login to the shop as a registered customer.
- Make sure you have a few saved cards, if not save a few cards in **My Account > Payment methods** page.
- Add a product to your cart and go to the shortcode checkout page.
- Confirm that the saved cards are listed in the card element and you can also choose to use a new card.