### PR TITLE
Add minimum amounts to terminal API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
 * Fix - Prepare the redirect URL at the end of 'process_payment' method. 
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
+* Add - Include minimum amounts in the capture_terminal_payment endpoint when a capture fails.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -18,6 +18,39 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 	protected $rest_base = 'wc_stripe/orders';
 
 	/**
+	 * Minimum charge amounts by currency.
+	 * https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts
+	 *
+	 * @var array
+	 */
+	protected static $minimum_amounts = [
+		'USD' => 50,    // $0.50
+		'AED' => 200,   // 2.00 د.إ
+		'AUD' => 50,    // $0.50
+		'BGN' => 100,   // лв1.00
+		'BRL' => 50,    // R$0.50
+		'CAD' => 50,    // $0.50
+		'CHF' => 50,    // 0.50 Fr
+		'CZK' => 1500,  // 15.00Kč
+		'DKK' => 250,   // 2.50-kr
+		'EUR' => 50,    // €0.50
+		'GBP' => 30,    // £0.30
+		'HKD' => 400,   // $4.00
+		'HUF' => 17500, // 175.00 Ft
+		'INR' => 50,    // ₹0.50
+		'JPY' => 50,    // ¥50
+		'MXN' => 1000,  // $10
+		'MYR' => 200,   // RM 2
+		'NOK' => 300,   // 3.00-kr
+		'NZD' => 50,    // $0.50
+		'PLN' => 200,   // 2.00 zł
+		'RON' => 200,   // lei2.00
+		'SEK' => 300,   // 3.00-kr
+		'SGD' => 50,    // $0.50
+		'THB' => 1000,  // ฿10
+	];
+
+	/**
 	 * Stripe payment gateway.
 	 *
 	 * @var WC_Gateway_Stripe
@@ -153,6 +186,25 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 			$this->gateway->process_response( $charge, $order );
 			$result = WC_Stripe_Order_Handler::get_instance()->capture_payment( $order );
 
+			// Check for amount_too_small error
+			if ( ! empty( $result->error ) && 'amount_too_small' === $result->error->code ) {
+				$currency = strtoupper( $order->get_currency() );
+				$minimum_amount = isset( self::$minimum_amounts[ $currency ] ) ? self::$minimum_amounts[ $currency ] : null;
+
+				$message = wp_json_encode(
+					[
+						'minimum_amount'          => $minimum_amount,
+						'minimum_amount_currency' => $currency,
+					]
+				);
+
+				return new WP_Error(
+					'wc_stripe_capture_error_amount_too_small',
+					$message,
+					[ 'status' => 400 ]
+				);
+			}
+
 			// Check for failure to capture payment.
 			if ( empty( $result ) || empty( $result->status ) || WC_Stripe_Intent_Status::SUCCEEDED !== $result->status ) {
 				return new WP_Error(
@@ -177,6 +229,5 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 		} catch ( WC_Stripe_Exception $e ) {
 			return rest_ensure_response( new WP_Error( 'stripe_error', $e->getMessage() ) );
 		}
-
 	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -246,6 +246,15 @@ class WC_Stripe_API {
 			$api
 		);
 
+		// Check for amount_too_small error - if found, return immediately without retrying
+		if (
+			isset( $result->error ) &&
+			isset( $result->error->code ) &&
+			'amount_too_small' === $result->error->code
+		) {
+			return $result;
+		}
+
 		$is_level3_param_not_allowed = (
 			isset( $result->error )
 			&& isset( $result->error->code )

--- a/readme.txt
+++ b/readme.txt
@@ -116,5 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
 * Fix - Prepare the redirect URL at the end of 'process_payment' method. 
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
+* Add - Include minimum amounts in the capture_terminal_payment endpoint when a capture fails.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
@@ -252,26 +252,43 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}
 
-	/**
-	 * Test capture payment with amount too small error for USD.
-	 */
-	public function test_capture_payment_amount_too_small_usd() {
+	public function test_capture_payment_amount_too_small_supported_currency() {
 		wp_set_current_user( 1 );
 		$order = WC_Helper_Order::create_order();
 		$order->set_currency( 'USD' );
 		$order->save();
 
-		// Mock response from Stripe API with amount_too_small error
+		// Mock response from Stripe API for payment intent retrieval.
 		$test_request = function ( $preempt, $parsed_args, $url ) {
+			if ( strpos( $url, 'payment_intents' ) !== false && strpos( $url, 'capture' ) === false ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => wp_json_encode(
+						[
+							'id'      => 'pi_12345',
+							'object'  => 'payment_intent',
+							'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
+							'charges' => [
+								'data' => [
+									[
+										'id'     => 'ch_12345',
+										'status' => 'succeeded',
+									],
+								],
+							],
+						]
+					),
+				];
+			}
+
+			// Mock the capture request to return amount_too_small error
 			return [
 				'response' => 200,
 				'headers'  => [ 'Content-Type' => 'application/json' ],
 				'body'     => wp_json_encode(
 					[
-						'id'      => 'pi_12345',
-						'object'  => 'payment_intent',
-						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
-						'error'   => [
+						'error' => [
 							'code'    => 'amount_too_small',
 							'message' => 'Amount must be at least $0.50 USD',
 						],
@@ -289,145 +306,10 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
 		$this->assertEquals( 400, $response->get_status() );
 
-		// Verify the error message contains the correct minimum amount
+		// Decode the error message to verify minimum amount data
 		$error_data = json_decode( $response->get_data()['message'], true );
-		$this->assertEquals( 50, $error_data['minimum_amount'] ); // $0.50 in cents
+		$this->assertEquals( 50, $error_data['minimum_amount'] );
 		$this->assertEquals( 'USD', $error_data['minimum_amount_currency'] );
-
-		remove_filter( 'pre_http_request', $test_request, 10, 3 );
-	}
-
-	/**
-	 * Test capture payment with amount too small error for EUR.
-	 */
-	public function test_capture_payment_amount_too_small_eur() {
-		wp_set_current_user( 1 );
-		$order = WC_Helper_Order::create_order();
-		$order->set_currency( 'EUR' );
-		$order->save();
-
-		// Mock response from Stripe API with amount_too_small error
-		$test_request = function ( $preempt, $parsed_args, $url ) {
-			return [
-				'response' => 200,
-				'headers'  => [ 'Content-Type' => 'application/json' ],
-				'body'     => wp_json_encode(
-					[
-						'id'      => 'pi_12345',
-						'object'  => 'payment_intent',
-						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
-						'error'   => [
-							'code'    => 'amount_too_small',
-							'message' => 'Amount must be at least €0.50 EUR',
-						],
-					]
-				),
-			];
-		};
-		add_filter( 'pre_http_request', $test_request, 10, 3 );
-
-		$endpoint = self::ORDERS_REST_BASE . '/' . strval( $order->get_id() ) . '/capture_terminal_payment';
-		$request  = new WP_REST_Request( 'POST', $endpoint );
-		$request->set_param( 'payment_intent_id', 'pi_12345' );
-		$response = rest_do_request( $request );
-
-		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
-		$this->assertEquals( 400, $response->get_status() );
-
-		// Verify the error message contains the correct minimum amount
-		$error_data = json_decode( $response->get_data()['message'], true );
-		$this->assertEquals( 50, $error_data['minimum_amount'] ); // €0.50 in cents
-		$this->assertEquals( 'EUR', $error_data['minimum_amount_currency'] );
-
-		remove_filter( 'pre_http_request', $test_request, 10, 3 );
-	}
-
-	/**
-	 * Test capture payment with amount too small error for JPY (zero-decimal currency).
-	 */
-	public function test_capture_payment_amount_too_small_jpy() {
-		wp_set_current_user( 1 );
-		$order = WC_Helper_Order::create_order();
-		$order->set_currency( 'JPY' );
-		$order->save();
-
-		// Mock response from Stripe API with amount_too_small error
-		$test_request = function ( $preempt, $parsed_args, $url ) {
-			return [
-				'response' => 200,
-				'headers'  => [ 'Content-Type' => 'application/json' ],
-				'body'     => wp_json_encode(
-					[
-						'id'      => 'pi_12345',
-						'object'  => 'payment_intent',
-						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
-						'error'   => [
-							'code'    => 'amount_too_small',
-							'message' => 'Amount must be at least ¥50 JPY',
-						],
-					]
-				),
-			];
-		};
-		add_filter( 'pre_http_request', $test_request, 10, 3 );
-
-		$endpoint = self::ORDERS_REST_BASE . '/' . strval( $order->get_id() ) . '/capture_terminal_payment';
-		$request  = new WP_REST_Request( 'POST', $endpoint );
-		$request->set_param( 'payment_intent_id', 'pi_12345' );
-		$response = rest_do_request( $request );
-
-		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
-		$this->assertEquals( 400, $response->get_status() );
-
-		// Verify the error message contains the correct minimum amount
-		$error_data = json_decode( $response->get_data()['message'], true );
-		$this->assertEquals( 50, $error_data['minimum_amount'] ); // ¥50 (JPY is zero-decimal)
-		$this->assertEquals( 'JPY', $error_data['minimum_amount_currency'] );
-
-		remove_filter( 'pre_http_request', $test_request, 10, 3 );
-	}
-
-	/**
-	 * Test capture payment with amount too small error for unsupported currency.
-	 */
-	public function test_capture_payment_amount_too_small_unsupported_currency() {
-		wp_set_current_user( 1 );
-		$order = WC_Helper_Order::create_order();
-		$order->set_currency( 'XYZ' ); // Invalid currency
-		$order->save();
-
-		// Mock response from Stripe API with amount_too_small error
-		$test_request = function ( $preempt, $parsed_args, $url ) {
-			return [
-				'response' => 200,
-				'headers'  => [ 'Content-Type' => 'application/json' ],
-				'body'     => wp_json_encode(
-					[
-						'id'      => 'pi_12345',
-						'object'  => 'payment_intent',
-						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
-						'error'   => [
-							'code'    => 'amount_too_small',
-							'message' => 'Amount too small for XYZ currency',
-						],
-					]
-				),
-			];
-		};
-		add_filter( 'pre_http_request', $test_request, 10, 3 );
-
-		$endpoint = self::ORDERS_REST_BASE . '/' . strval( $order->get_id() ) . '/capture_terminal_payment';
-		$request  = new WP_REST_Request( 'POST', $endpoint );
-		$request->set_param( 'payment_intent_id', 'pi_12345' );
-		$response = rest_do_request( $request );
-
-		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
-		$this->assertEquals( 400, $response->get_status() );
-
-		// Verify the error message contains null for unsupported currency
-		$error_data = json_decode( $response->get_data()['message'], true );
-		$this->assertNull( $error_data['minimum_amount'] );
-		$this->assertEquals( 'XYZ', $error_data['minimum_amount_currency'] );
 
 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
@@ -251,4 +251,184 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 
 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}
+
+	/**
+	 * Test capture payment with amount too small error for USD.
+	 */
+	public function test_capture_payment_amount_too_small_usd() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'USD' );
+		$order->save();
+
+		// Mock response from Stripe API with amount_too_small error
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					[
+						'id'      => 'pi_12345',
+						'object'  => 'payment_intent',
+						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
+						'error'   => [
+							'code'    => 'amount_too_small',
+							'message' => 'Amount must be at least $0.50 USD',
+						],
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$endpoint = self::ORDERS_REST_BASE . '/' . strval( $order->get_id() ) . '/capture_terminal_payment';
+		$request  = new WP_REST_Request( 'POST', $endpoint );
+		$request->set_param( 'payment_intent_id', 'pi_12345' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Verify the error message contains the correct minimum amount
+		$error_data = json_decode( $response->get_data()['message'], true );
+		$this->assertEquals( 50, $error_data['minimum_amount'] ); // $0.50 in cents
+		$this->assertEquals( 'USD', $error_data['minimum_amount_currency'] );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
+
+	/**
+	 * Test capture payment with amount too small error for EUR.
+	 */
+	public function test_capture_payment_amount_too_small_eur() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'EUR' );
+		$order->save();
+
+		// Mock response from Stripe API with amount_too_small error
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					[
+						'id'      => 'pi_12345',
+						'object'  => 'payment_intent',
+						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
+						'error'   => [
+							'code'    => 'amount_too_small',
+							'message' => 'Amount must be at least €0.50 EUR',
+						],
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$endpoint = self::ORDERS_REST_BASE . '/' . strval( $order->get_id() ) . '/capture_terminal_payment';
+		$request  = new WP_REST_Request( 'POST', $endpoint );
+		$request->set_param( 'payment_intent_id', 'pi_12345' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Verify the error message contains the correct minimum amount
+		$error_data = json_decode( $response->get_data()['message'], true );
+		$this->assertEquals( 50, $error_data['minimum_amount'] ); // €0.50 in cents
+		$this->assertEquals( 'EUR', $error_data['minimum_amount_currency'] );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
+
+	/**
+	 * Test capture payment with amount too small error for JPY (zero-decimal currency).
+	 */
+	public function test_capture_payment_amount_too_small_jpy() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'JPY' );
+		$order->save();
+
+		// Mock response from Stripe API with amount_too_small error
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					[
+						'id'      => 'pi_12345',
+						'object'  => 'payment_intent',
+						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
+						'error'   => [
+							'code'    => 'amount_too_small',
+							'message' => 'Amount must be at least ¥50 JPY',
+						],
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$endpoint = self::ORDERS_REST_BASE . '/' . strval( $order->get_id() ) . '/capture_terminal_payment';
+		$request  = new WP_REST_Request( 'POST', $endpoint );
+		$request->set_param( 'payment_intent_id', 'pi_12345' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Verify the error message contains the correct minimum amount
+		$error_data = json_decode( $response->get_data()['message'], true );
+		$this->assertEquals( 50, $error_data['minimum_amount'] ); // ¥50 (JPY is zero-decimal)
+		$this->assertEquals( 'JPY', $error_data['minimum_amount_currency'] );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
+
+	/**
+	 * Test capture payment with amount too small error for unsupported currency.
+	 */
+	public function test_capture_payment_amount_too_small_unsupported_currency() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order();
+		$order->set_currency( 'XYZ' ); // Invalid currency
+		$order->save();
+
+		// Mock response from Stripe API with amount_too_small error
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => wp_json_encode(
+					[
+						'id'      => 'pi_12345',
+						'object'  => 'payment_intent',
+						'status'  => WC_Stripe_Intent_Status::REQUIRES_CAPTURE,
+						'error'   => [
+							'code'    => 'amount_too_small',
+							'message' => 'Amount too small for XYZ currency',
+						],
+					]
+				),
+			];
+		};
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$endpoint = self::ORDERS_REST_BASE . '/' . strval( $order->get_id() ) . '/capture_terminal_payment';
+		$request  = new WP_REST_Request( 'POST', $endpoint );
+		$request->set_param( 'payment_intent_id', 'pi_12345' );
+		$response = rest_do_request( $request );
+
+		$this->assertEquals( 'wc_stripe_capture_error_amount_too_small', $response->get_data()['code'] );
+		$this->assertEquals( 400, $response->get_status() );
+
+		// Verify the error message contains null for unsupported currency
+		$error_data = json_decode( $response->get_data()['message'], true );
+		$this->assertNull( $error_data['minimum_amount'] );
+		$this->assertEquals( 'XYZ', $error_data['minimum_amount_currency'] );
+
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3728

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

The changes in this PR expose [minimum amounts](https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts) in the `capture_terminal_payment` endpoint when a capture fails due to the amount being smaller than the minimum amount for the currency. The main goal here is to maintain parity in API response with WooPayments to simplify the handling of these endpoints in mobile apps. The actual minimum amount validation is done by Stripe, this just updates the error response on the capture endpoint.

I want to highlight the following potential failure points:
- Currency minimum amounts could change, leading to a discrepancy between the endpoint response and the actual minimum accepted by Stripe.
- It's possible that there are 3rd party integrations on this endpoint, which will break with this change.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

**Pre-requisites**
1. As a merchant, enable the capture later feature in the Settings
2. The [minimum capturable amount](https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts) for USD is $0.50, so I suggest having a product with a price below that limit.
3. (Optional) Install [Basic Auth](https://github.com/WP-API/Basic-Auth); I find it easier to make curl requests to my test site with the `--user username:password` flag instead of setting up separate API keys. 

**Capturing an authorization**

1. As a shopper, purchase an order above the minimum amount limit. For instance, you can add several items of a product that has a unit price below the minimum amount.
2. As a merchant, edit the recently purchased order so the order amount is below the limit. For instance, you can remove some items from the order.
3. Note down the Stripe payment intent id and the order id.
4. Make a POST request to the capture_terminal_payment endpoint, making sure to use the correct payment intent id and order id:

```
curl -X POST https://example.com/wp-json/wc/v3/wc_stripe/orders/ORDER_ID/capture_terminal_payment \
	-u admin:password \
        -H "Content-Type: application/json" 
	-d '{
    "payment_intent_id": "pi_123"
}'
```

5. Check that the response is similar to this one. Note the JSON-encoded error metadata in the message:

```
{
  "code": "wc_stripe_capture_error_amount_too_small",
  "message": "{&quot;minimum_amount&quot;:50,&quot;minimum_amount_currency&quot;:&quot;USD&quot;}",
  "data": {
    "status": 400
  }
}
```
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

### Additional context

WooPayments PR: https://github.com/Automattic/woocommerce-payments/pull/10351

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
