### PR TITLE
Fix setup_future_usage for subscriptions and confirmation tokens

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
 * Fix - Prepare the redirect URL at the end of 'process_payment' method. 
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
+* Fix - Fix error when processing a subscription via Amazon Pay.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -990,7 +990,9 @@ class WC_Stripe_Intent_Controller {
 			$request['return_url'] = $payment_information['return_url'];
 		}
 
-		if ( $payment_information['save_payment_method_to_store'] || ! empty( $payment_information['has_subscription'] ) ) {
+		// If the customer is saving the payment method to the store or has a subscription, we should set the setup_future_usage to off_session.
+		// Only exception is when using a confirmation token. For confirmations tokens, the setup_future_usage is set within the payment method.
+		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || ! empty( $payment_information['has_subscription'] ) ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2241,6 +2241,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			} else {
 				$payment_information['capture_method'] = $capture_method;
 			}
+
+			// When using confirmation tokens for subscriptions, we need to set the setup_future_usage parameter under payment method options.
+			if ( $payment_information['has_subscription'] ) {
+				$payment_information['payment_method_options'][ $selected_payment_type ]['setup_future_usage'] = 'off_session';
+			}
 		}
 
 		// Use the dynamic + short statement descriptor if enabled and it's a card payment.

--- a/readme.txt
+++ b/readme.txt
@@ -116,5 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
 * Fix - Prepare the redirect URL at the end of 'process_payment' method. 
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
+* Fix - Fix error when processing a subscription via Amazon Pay.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3876 and https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3859

## Changes proposed in this Pull Request:
This fixes the payment processing error when trying to purchase a subscription using Amazon Pay.
Confirmation tokens used in Amazon Pay payment flow requires `setup_future_usage` parameter to be set within the `payment_method_options` of the payment method being used. See https://docs.stripe.com/payments/payment-element/migration-ct#conditional-options


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Turn the Amazon Pay feature flag on, by setting the `_wcstripe_feature_amazon_pay` option to yes. OR return `true` [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/beb2828170ae9fc1de540fd9b9517cac0e82b71b/includes/class-wc-stripe-feature-flags.php/#L40-L43)
2. As a shopper, add a subscription product to the cart.
3. Choose Amazon Pay from the checkout page and go through the off-site checkout process.
4. You should see the order confirmation page.
5. Following error should not be displayed

```
The provided setup_future_usage (off_session) does not match the setup_future_usage from the provided confirmation_token (null). Try confirming with a Payment Intent that is configured to use the same parameters as the ConfirmationToken
```

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Added changelog entry **in both** `changelog.txt` and `readme.txt` (or does not apply)
-   [ ] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
