### PR TITLE
Update PHPCS minimum WP version

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,16 +2,18 @@
 <ruleset name="WordPress Coding Standards">
 	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
 
-    <!-- Exclude paths -->
+	<!-- Exclude paths -->
+	<exclude-pattern>./build/*</exclude-pattern>
 	<exclude-pattern>./dist/*</exclude-pattern>
 	<exclude-pattern>./docker/*</exclude-pattern>
 	<exclude-pattern>./node_modules/*</exclude-pattern>
 	<exclude-pattern>./vendor/*</exclude-pattern>
+	<exclude-pattern>./release/*</exclude-pattern>
 	<exclude-pattern>*\.(?!php$)</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="5.6" />
-	<config name="testVersion" value="7.4" />
+	<config name="minimum_supported_wp_version" value="6.3" />
+	<config name="testVersion" value="7.4-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -13,7 +13,9 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="6.3" />
-	<config name="testVersion" value="7.4-" />
+	<config name="testVersion" value="7.4-" />	
+	<arg name="parallel" value="8" />	
+	<arg value="ps" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" >


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR updates the PHPCS configuration by setting a new minimum supported WordPress version and enabling parallel processing for improved performance.

## Testing instructions

1. Run `npm run lint:php-fix` locally.
2. Ensure there are no errors or warnings.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [ ] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Type

<!-- Choose only one -->

-   [ ] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
