### PR TITLE
Idempotency key for deferred intent UPE

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,7 +9,7 @@
 * Dev - Adds the payment method constants to the payment methods map file (frontend side).
 * Add - Adds a new notice for store admins when there are subscriptions without a payment method attached.
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
-* Fix - Prepare the redirect URL at the end of 'process_payment' method. 
+* Fix - Prepare the redirect URL at the end of 'process_payment' method.
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
 * Fix - Fix error when processing a subscription via Amazon Pay.
 * Fix - Make Amazon Pay compatible with upfront pre-orders.
@@ -21,6 +21,7 @@
 * Add - Bacs: Process Payment with Saved Bank Details
 * Tweak - Update payment method logos on the checkout page.
 * Update - Refactor unsupported deferred intent in the blocks checkout.
+* Add - Use idempotency keys when creating payment intents, to help prevent duplicate charges for a single order.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -128,7 +128,7 @@ class WC_Stripe_API {
 		$headers         = self::get_headers();
 		$idempotency_key = '';
 
-		if ( 'charges' === $api && 'POST' === $method ) {
+		if ( in_array( $api, [ 'charges', 'payment_intents' ], true ) && 'POST' === $method && ! empty( $request['metadata']['order_id'] ) ) {
 			$customer        = ! empty( $request['customer'] ) ? $request['customer'] : '';
 			$source          = ! empty( $request['source'] ) ? $request['source'] : $customer;
 			$idempotency_key = apply_filters( 'wc_stripe_idempotency_key', $request['metadata']['order_id'] . '-' . $source, $request );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -111,6 +111,32 @@ class WC_Stripe_API {
 	}
 
 	/**
+	 * Generates the idempotency key for the request.
+	 *
+	 * @param string $api The API endpoint.
+	 * @param string $method The HTTP method.
+	 * @param array  $request The request parameters.
+	 * @return string|null The idempotency key.
+	 */
+	public static function get_idempotency_key( $api, $method, $request ) {
+		if ( 'charges' === $api && 'POST' === $method ) {
+			$customer = ! empty( $request['customer'] ) ? $request['customer'] : '';
+			$source   = ! empty( $request['source'] ) ? $request['source'] : $customer;
+			return $request['metadata']['order_id'] . '-' . $source;
+		} elseif ( 'payment_intents' === $api && 'POST' === $method ) {
+			if ( empty( $request['metadata']['order_id'] ) ||
+				empty( $request['payment_method'] ) ||
+				empty( $request['metadata']['signature'] )
+			) {
+				return null;
+			}
+			return $request['metadata']['order_id'] . '-' . $request['payment_method'] . '-' . $request['metadata']['signature'];
+		}
+
+		return null;
+	}
+
+	/**
 	 * Send the request to Stripe's API
 	 *
 	 * @since 3.1.0
@@ -125,14 +151,10 @@ class WC_Stripe_API {
 	public static function request( $request, $api = 'charges', $method = 'POST', $with_headers = false ) {
 		WC_Stripe_Logger::log( "{$api} request: " . print_r( $request, true ) );
 
-		$headers         = self::get_headers();
-		$idempotency_key = '';
+		$headers = self::get_headers();
 
-		if ( in_array( $api, [ 'charges', 'payment_intents' ], true ) && 'POST' === $method && ! empty( $request['metadata']['order_id'] ) ) {
-			$customer        = ! empty( $request['customer'] ) ? $request['customer'] : '';
-			$source          = ! empty( $request['source'] ) ? $request['source'] : $customer;
-			$idempotency_key = apply_filters( 'wc_stripe_idempotency_key', $request['metadata']['order_id'] . '-' . $source, $request );
-
+		$idempotency_key = apply_filters( 'wc_stripe_idempotency_key', self::get_idempotency_key( $api, $method, $request ), $request );
+		if ( $idempotency_key ) {
 			$headers['Idempotency-Key'] = $idempotency_key;
 		}
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -124,13 +124,16 @@ class WC_Stripe_API {
 			$source   = ! empty( $request['source'] ) ? $request['source'] : $customer;
 			return $request['metadata']['order_id'] . '-' . $source;
 		} elseif ( 'payment_intents' === $api && 'POST' === $method ) {
-			if ( empty( $request['metadata']['order_id'] ) ||
-				empty( $request['payment_method'] ) ||
-				empty( $request['metadata']['signature'] )
-			) {
+			if ( empty( $request['metadata']['signature'] ) ||
+				empty( $request['payment_method'] ) ) {
 				return null;
 			}
-			return $request['metadata']['order_id'] . '-' . $request['payment_method'] . '-' . $request['metadata']['signature'];
+			// Order signature is derived from the order id, order key, customer id,
+			// order total and currency. We add the payment method ID to the idempotency key
+			// to allow orders to be retried with a different payment method, e.g. card was
+			// declined, and the shopper retried using Klarna.
+			// TODO: check if billing/shipping details need to be added.
+			return $request['metadata']['signature'] . '-' . $request['payment_method'];
 		}
 
 		return null;

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -124,16 +124,9 @@ class WC_Stripe_API {
 			$source   = ! empty( $request['source'] ) ? $request['source'] : $customer;
 			return $request['metadata']['order_id'] . '-' . $source;
 		} elseif ( 'payment_intents' === $api && 'POST' === $method ) {
-			if ( empty( $request['metadata']['signature'] ) ||
-				empty( $request['payment_method'] ) ) {
-				return null;
-			}
-			// Order signature is derived from the order id, order key, customer id,
-			// order total and currency. We add the payment method ID to the idempotency key
-			// to allow orders to be retried with a different payment method, e.g. card was
-			// declined, and the shopper retried using Klarna.
-			// TODO: check if billing/shipping details need to be added.
-			return $request['metadata']['signature'] . '-' . $request['payment_method'];
+			// https://docs.stripe.com/api/idempotent_requests suggests using
+			// v4 uuids for idempotency keys.
+			return wp_generate_uuid4();
 		}
 
 		return null;

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -372,7 +372,6 @@ class WC_Stripe_Intent_Controller {
 			'currency'             => strtolower( $currency ),
 			'payment_method_types' => $enabled_payment_methods,
 			'capture_method'       => $capture ? 'automatic' : 'manual',
-			'metadata'             => [ 'order_id' => $order_id ],
 		];
 
 		$request = $this->maybe_add_mandate_options( $request, $payment_method_type );

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -372,6 +372,7 @@ class WC_Stripe_Intent_Controller {
 			'currency'             => strtolower( $currency ),
 			'payment_method_types' => $enabled_payment_methods,
 			'capture_method'       => $capture ? 'automatic' : 'manual',
+			'metadata'             => [ 'order_id' => $order_id ],
 		];
 
 		$request = $this->maybe_add_mandate_options( $request, $payment_method_type );

--- a/readme.txt
+++ b/readme.txt
@@ -119,7 +119,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Adds the payment method constants to the payment methods map file (frontend side).
 * Add - Adds a new notice for store admins when there are subscriptions without a payment method attached.
 * Fix - Hides "pay" and "cancel" buttons on the order received page when an Amazon Pay order is pending, since it may take a while to be confirmed.
-* Fix - Prepare the redirect URL at the end of 'process_payment' method. 
+* Fix - Prepare the redirect URL at the end of 'process_payment' method.
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
 * Fix - Fix error when processing a subscription via Amazon Pay.
 * Fix - Make Amazon Pay compatible with upfront pre-orders.
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Bacs: Process Payment with Saved Bank Details
 * Tweak - Update payment method logos on the checkout page.
 * Update - Refactor unsupported deferred intent in the blocks checkout.
+* Add - Use idempotency keys when creating payment intents, to help prevent duplicate charges for a single order.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/blocks/retries.spec.js
+++ b/tests/e2e/tests/checkout/blocks/retries.spec.js
@@ -38,8 +38,6 @@ test.beforeEach( async ( { page } ) => {
 } );
 /**
  * When retrying payments, we will reuse a compatible payment intent, if the order already has one.
- * In addition, the payment method ID is included when generating the idempotency key
- * when creating a payment intent.
  *
  * This test verifies that the same payment method type can be used when retrying a payment, e.g.
  * chaging from one credit card to another.
@@ -68,8 +66,6 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
 
 /**
  * When retrying payments, we will reuse a compatible payment intent, if the order already has one.
- * In addition, the payment method ID is included when generating the idempotency key
- * when creating a payment intent.
  *
  * This test verifies that the same payment method type can be used when retrying the same payment,
  * after changing the billing details.
@@ -102,8 +98,6 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 } );
 
 /**
- * The idempotency key for creating a payment intent includes the payment method ID.
- *
  * This test verifies that a different payment method type can be used when retrying a payment
  * for the same order.
  */

--- a/tests/e2e/tests/checkout/blocks/retries.spec.js
+++ b/tests/e2e/tests/checkout/blocks/retries.spec.js
@@ -5,8 +5,8 @@ import { payments } from '../../../utils';
 const {
 	emptyCart,
 	setupCart,
-	setupShortcodeCheckout,
-	fillCreditCardDetailsShortcode,
+	setupBlocksCheckout,
+	fillCreditCardDetails,
 	handleCheckout3DSChallenge,
 	clickPlaceOrder,
 	handleCheckoutCashAppPay,
@@ -31,7 +31,7 @@ test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
 test.beforeEach( async ( { page } ) => {
 	await emptyCart( page );
 	await setupCart( page );
-	await setupShortcodeCheckout(
+	await setupBlocksCheckout(
 		page,
 		config.get( 'addresses.customer.billing' )
 	);
@@ -47,17 +47,16 @@ test.beforeEach( async ( { page } ) => {
 test( 'customer can retry payment, with a different card @smoke', async ( {
 	page,
 } ) => {
-	await fillCreditCardDetailsShortcode(
-		page,
-		config.get( 'cards.declined' )
-	);
+	await fillCreditCardDetails( page, config.get( 'cards.declined' ) );
 	await clickPlaceOrder( page );
 
 	// Expect the order to fail
-	await expect( page.locator( '.woocommerce-error' ) ).toBeVisible();
+	await expect(
+		page.locator( '.wc-block-store-notice.is-error' )
+	).toBeVisible();
 
-	// Change to a working card, and retry the payment.
-	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
+	// Change to a working card
+	await fillCreditCardDetails( page, config.get( 'cards.basic' ) );
 	await clickPlaceOrder( page );
 	await page.waitForURL( '**/order-received/**' );
 
@@ -78,14 +77,14 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
 test( 'customer can retry payment, with changed billing details @smoke', async ( {
 	page,
 } ) => {
-	await fillCreditCardDetailsShortcode( page, config.get( 'cards.3ds' ) );
+	await fillCreditCardDetails( page, config.get( 'cards.3ds' ) );
 	await clickPlaceOrder( page );
 
 	// Fail the 3DS challenge
 	await handleCheckout3DSChallenge( page, 'fail' );
 
 	// Change billing details
-	await page.fill( '#billing_postcode', '12345' );
+	await page.getByLabel( 'ZIP Code' ).fill( '12345' );
 
 	// Retry the payment
 	await clickPlaceOrder( page );
@@ -111,17 +110,16 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 test( 'customer can retry payment, using a different payment method @smoke', async ( {
 	page,
 } ) => {
-	await fillCreditCardDetailsShortcode(
-		page,
-		config.get( 'cards.declined' )
-	);
+	await fillCreditCardDetails( page, config.get( 'cards.declined' ) );
 	await clickPlaceOrder( page );
 
 	// Expect the order to fail
-	await expect( page.locator( '.woocommerce-error' ) ).toBeVisible();
+	await expect(
+		page.locator( '.wc-block-store-notice.is-error' )
+	).toBeVisible();
 
 	// Change to Cash App Pay
-	await handleCheckoutCashAppPay( page );
+	await handleCheckoutCashAppPay( page, '.wcstripe-payment-element' );
 
 	// Expect the order to succeed
 	await page.waitForURL( '**/order-received/**' );

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -7,6 +7,7 @@ const {
 	setupCart,
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
+	handleCheckout3DSChallenge,
 } = payments;
 
 test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
@@ -25,7 +26,17 @@ test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
 	await expect( page.getByLabel( 'Cash App Pay' ) ).toBeChecked();
 } );
 
-test( 'customer can retry payment @smoke', async ( { page } ) => {
+/**
+ * When retrying payments, we will reuse a compatible payment intent, if the order already has one.
+ * In addition, the payment method ID is included when generating the idempotency key
+ * when creating a payment intent.
+ *
+ * This test verifies that the same payment method type can be used when retrying a payment, e.g.
+ * chaging from one credit card to another.
+ */
+test( 'customer can retry payment, with a different card @smoke', async ( {
+	page,
+} ) => {
 	await emptyCart( page );
 	await setupCart( page );
 	await setupShortcodeCheckout(
@@ -56,6 +67,57 @@ test( 'customer can retry payment @smoke', async ( { page } ) => {
 	);
 } );
 
+/**
+ * When retrying payments, we will reuse a compatible payment intent, if the order already has one.
+ * In addition, the payment method ID is included when generating the idempotency key
+ * when creating a payment intent.
+ *
+ * This test verifies that the same payment method type can be used when retrying the same payment,
+ * after changing the billing details.
+ */
+test( 'customer can retry payment, with changed billing details @smoke', async ( {
+	page,
+} ) => {
+	await emptyCart( page );
+	await setupCart( page );
+	await setupShortcodeCheckout(
+		page,
+		config.get( 'addresses.customer.billing' )
+	);
+	await fillCreditCardDetailsShortcode( page, config.get( 'cards.3ds' ) );
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+
+	// Fail the 3DS challenge
+	await handleCheckout3DSChallenge( page, 'fail' );
+
+	// Change billing details
+	await page.fill( '#billing_postcode', '12345' );
+
+	// Retry the payment
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+
+	// Complete the 3DS challenge
+	await handleCheckout3DSChallenge( page );
+
+	// Expect the order to succeed
+	await page.waitForURL( '**/order-received/**' );
+
+	// Expect the order to succeed
+	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+		'Order received'
+	);
+} );
+
+/**
+ * The idempotency key for creating a payment intent includes the payment method ID.
+ *
+ * This test verifies that a different payment method type can be used when retrying a payment
+ * for the same order.
+ */
 test( 'customer can retry payment, using a different payment method @smoke', async ( {
 	page,
 } ) => {

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -38,8 +38,6 @@ test.beforeEach( async ( { page } ) => {
 } );
 /**
  * When retrying payments, we will reuse a compatible payment intent, if the order already has one.
- * In addition, the payment method ID is included when generating the idempotency key
- * when creating a payment intent.
  *
  * This test verifies that the same payment method type can be used when retrying a payment, e.g.
  * chaging from one credit card to another.
@@ -69,8 +67,6 @@ test( 'customer can retry payment, with a different card @smoke', async ( {
 
 /**
  * When retrying payments, we will reuse a compatible payment intent, if the order already has one.
- * In addition, the payment method ID is included when generating the idempotency key
- * when creating a payment intent.
  *
  * This test verifies that the same payment method type can be used when retrying the same payment,
  * after changing the billing details.
@@ -103,8 +99,6 @@ test( 'customer can retry payment, with changed billing details @smoke', async (
 } );
 
 /**
- * The idempotency key for creating a payment intent includes the payment method ID.
- *
  * This test verifies that a different payment method type can be used when retrying a payment
  * for the same order.
  */

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import config from 'config';
+import { payments } from '../../../utils';
+
+const {
+	emptyCart,
+	setupCart,
+	setupShortcodeCheckout,
+	fillCreditCardDetailsShortcode,
+} = payments;
+
+test.beforeAll( 'enable Cash App Pay', async ( { browser } ) => {
+	const adminContext = await browser.newContext( {
+		storageState: process.env.ADMINSTATE,
+	} );
+	const page = await adminContext.newPage();
+
+	await page.goto(
+		'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods'
+	);
+	await page.getByLabel( 'Cash App Pay' ).check();
+	await page.click( 'text=Save changes' );
+
+	await expect( page.getByText( 'Settings saved.' ) ).toBeDefined();
+	await expect( page.getByLabel( 'Cash App Pay' ) ).toBeChecked();
+} );
+
+test( 'customer can retry payment @smoke', async ( { page } ) => {
+	await emptyCart( page );
+	await setupCart( page );
+	await setupShortcodeCheckout(
+		page,
+		config.get( 'addresses.customer.billing' )
+	);
+	await fillCreditCardDetailsShortcode(
+		page,
+		config.get( 'cards.declined' )
+	);
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+
+	// Expect the order to fail
+	await expect( page.locator( '.woocommerce-error' ) ).toBeVisible();
+
+	// Change to a working card
+	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+	await page.waitForURL( '**/order-received/**' );
+
+	// Expect the order to succeed
+	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+		'Order received'
+	);
+} );
+
+test( 'customer can retry payment, using a different payment method @smoke', async ( {
+	page,
+} ) => {
+	await emptyCart( page );
+	await setupCart( page );
+	await setupShortcodeCheckout(
+		page,
+		config.get( 'addresses.customer.billing' )
+	);
+	await fillCreditCardDetailsShortcode(
+		page,
+		config.get( 'cards.declined' )
+	);
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+
+	// Expect the order to fail
+	await expect( page.locator( '.woocommerce-error' ) ).toBeVisible();
+
+	// Change to Cash App Pay
+	await page.getByText( 'Cash App Pay' ).click();
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+
+	// Expect a modal to appear
+	const simulateScanButton = await page
+		.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
+		.first()
+		.frameLocator( 'iframe[title="QR Code Instructions"]' )
+		.getByRole( 'button', { name: 'Simulate scan' } );
+
+	const context = await page.context();
+	const [ paymentPage ] = await Promise.all( [
+		context.waitForEvent( 'page' ),
+		simulateScanButton.dispatchEvent( 'click' ),
+	] );
+
+	await paymentPage.waitForLoadState();
+	await paymentPage
+		.getByRole( 'link', { name: 'Authorize Test Payment' } )
+		.click();
+	await paymentPage.waitForURL( '**/order-received/**' );
+
+	// Expect the order to succeed
+	await expect( paymentPage.locator( 'h1.entry-title' ) ).toHaveText(
+		'Order received'
+	);
+} );

--- a/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/sca-card.spec.js
@@ -7,6 +7,7 @@ const {
 	setupCart,
 	setupShortcodeCheckout,
 	fillCreditCardDetailsShortcode,
+	handleCheckout3DSChallenge,
 } = payments;
 
 test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
@@ -19,23 +20,8 @@ test( 'customer can checkout with a SCA card @smoke', async ( { page } ) => {
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.3ds' ) );
 	await page.locator( 'text=Place order' ).dispatchEvent( 'click' );
 
-	// Wait until the SCA frame is available
-	while (
-		! page.frame( {
-			name: 'stripe-challenge-frame',
-		} )
-	) {
-		await page.waitForTimeout( 1000 );
-	}
-	// Not ideal, but the iframe body gets repalced after load, so a waitFor does not work here.
-	await page.waitForTimeout( 2000 );
-
-	await page
-		.frame( {
-			name: 'stripe-challenge-frame',
-		} )
-		.getByRole( 'button', { name: 'Complete' } )
-		.click();
+	// Complete the 3DS challenge
+	await handleCheckout3DSChallenge( page );
 
 	await page.waitForURL( '**/checkout/order-received/**' );
 

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -390,27 +390,91 @@ export const fillACHBankDetails = async ( page ) => {
 export async function handleCheckout3DSChallenge( page, action = 'authorize' ) {
 	const outerFrameLocator = page
 		.locator( 'iframe[name^="__privateStripeFrame"]' )
-		.first()
-		.contentFrame();
+		.contentFrame()
+		.first();
 	const innerFrameLocator = outerFrameLocator.frameLocator(
 		'iframe[name="stripe-challenge-frame"]'
 	);
 
 	// Wait for the challenge modal to be ready -- the inner frame is "visible"
 	// and the loading indicator is hidden.
-	await innerFrameLocator.owner().waitFor();
-	await outerFrameLocator
-		.locator( '.LightboxModalLoadingIndicator' )
-		.waitFor( { state: 'hidden' } );
+	await expect( innerFrameLocator.owner() ).toBeVisible();
+	await expect(
+		outerFrameLocator.locator( '.LightboxModalLoadingIndicator' )
+	).toBeHidden();
 
 	const buttonId =
 		action === 'authorize'
 			? '#test-source-authorize-3ds'
 			: '#test-source-fail-3ds';
-	await innerFrameLocator.locator( buttonId ).waitFor( { state: 'visible' } );
+	await expect( innerFrameLocator.locator( buttonId ) ).toBeVisible();
 	await innerFrameLocator.locator( buttonId ).click();
 
 	if ( action === 'fail' ) {
-		await innerFrameLocator.owner().waitFor( { state: 'detached' } );
+		await expect( innerFrameLocator.owner() ).toBeHidden();
 	}
+}
+
+/**
+ * This roundabout way of clicking the Place Order button is an
+ * attempt to reduce the flakiness.
+ * @param {Page} page Playwright page fixture.
+ */
+export async function clickPlaceOrder( page ) {
+	// Wait for the button to be enabled (i.e. clickable), to wait
+	// for any logic we are potentially depending on.
+	await expect(
+		page.getByRole( 'button', { name: 'Place order' } )
+	).toBeEnabled();
+
+	// Dispatch a click event, instead of clicking the button directly,
+	// to reduce "missed" clicks.
+	await page
+		.getByRole( 'button', { name: 'Place order' } )
+		.dispatchEvent( 'click' );
+}
+
+/**
+ * Handles the Cash App Pay payment on the checkout page.
+ * @param {Page} page Playwright page fixture.
+ */
+export async function handleCheckoutCashAppPay(
+	page,
+	paymentElementSelector = '#wc-stripe_cashapp-upe-form'
+) {
+	await page.getByText( 'Cash App Pay' ).click();
+	await expect(
+		page
+			.frameLocator(
+				`${ paymentElementSelector } iframe[name^="__privateStripeFrame"]`
+			)
+			.locator( '.__PrivateStripeElementLoader' )
+	).toBeHidden();
+	await expect(
+		page
+			.frameLocator(
+				`${ paymentElementSelector } iframe[name^="__privateStripeFrame"]`
+			)
+			.getByText( 'Cash App Pay selected.' )
+	).toBeVisible();
+	await clickPlaceOrder( page );
+
+	// Expect a modal to appear
+	const simulateScanButton = await page
+		.locator( 'iframe[name^="__privateStripeFrame"]' )
+		.contentFrame()
+		.first()
+		.frameLocator( 'iframe[title="QR Code Instructions"]' )
+		.getByRole( 'button', { name: 'Simulate scan' } );
+
+	const context = await page.context();
+	const [ paymentPage ] = await Promise.all( [
+		context.waitForEvent( 'page' ),
+		simulateScanButton.dispatchEvent( 'click' ),
+	] );
+
+	await paymentPage.waitForLoadState();
+	await paymentPage
+		.getByRole( 'link', { name: 'Authorize Test Payment' } )
+		.click();
 }

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -381,3 +381,36 @@ export const fillACHBankDetails = async ( page ) => {
 	// Click "Done" button.
 	await frame.getByTestId( 'done-button' ).click();
 };
+
+/**
+ * Handles the 3DS challenge on the checkout page.
+ * @param {Page} page Playwright page fixture.
+ * @param {string} action The action to take on the challenge modal.
+ */
+export async function handleCheckout3DSChallenge( page, action = 'authorize' ) {
+	const outerFrameLocator = page
+		.locator( 'iframe[name^="__privateStripeFrame"]' )
+		.first()
+		.contentFrame();
+	const innerFrameLocator = outerFrameLocator.frameLocator(
+		'iframe[name="stripe-challenge-frame"]'
+	);
+
+	// Wait for the challenge modal to be ready -- the inner frame is "visible"
+	// and the loading indicator is hidden.
+	await innerFrameLocator.owner().waitFor();
+	await outerFrameLocator
+		.locator( '.LightboxModalLoadingIndicator' )
+		.waitFor( { state: 'hidden' } );
+
+	const buttonId =
+		action === 'authorize'
+			? '#test-source-authorize-3ds'
+			: '#test-source-fail-3ds';
+	await innerFrameLocator.locator( buttonId ).waitFor( { state: 'visible' } );
+	await innerFrameLocator.locator( buttonId ).click();
+
+	if ( action === 'fail' ) {
+		await innerFrameLocator.owner().waitFor( { state: 'detached' } );
+	}
+}

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -293,7 +293,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 			'metadata'                      => [
 				'_stripe_metadata' => '123',
 				'order_id'         => $this->order->get_id(),
-				'signature'        => 'abc123',
+				'signature'        => $this->order->get_id() . ':abc123',
 			],
 			'order'                         => $this->order,
 			'payment_method'                => 'pm_mock',
@@ -305,7 +305,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		];
 
 		$test_request = function ( $preempt, $parsed_args, $url ) {
-			$this->assertEquals( $this->order->get_id() . '-pm_mock-abc123', $parsed_args['headers']['Idempotency-Key'] );
+			$this->assertEquals( $this->order->get_id() . ':abc123-pm_mock', $parsed_args['headers']['Idempotency-Key'] );
 
 			return [
 				'response' => 200,

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -293,6 +293,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 			'metadata'                      => [
 				'_stripe_metadata' => '123',
 				'order_id'         => $this->order->get_id(),
+				'signature'        => 'abc123',
 			],
 			'order'                         => $this->order,
 			'payment_method'                => 'pm_mock',
@@ -304,7 +305,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		];
 
 		$test_request = function ( $preempt, $parsed_args, $url ) {
-			$this->assertEquals( $this->order->get_id() . '-cus_mock', $parsed_args['headers']['Idempotency-Key'] );
+			$this->assertEquals( $this->order->get_id() . '-pm_mock-abc123', $parsed_args['headers']['Idempotency-Key'] );
 
 			return [
 				'response' => 200,

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -290,11 +290,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 					],
 				],
 			],
-			'metadata'                      => [
-				'_stripe_metadata' => '123',
-				'order_id'         => $this->order->get_id(),
-				'signature'        => $this->order->get_id() . ':abc123',
-			],
+			'metadata'                      => [ '_stripe_metadata' => '123' ],
 			'order'                         => $this->order,
 			'payment_method'                => 'pm_mock',
 			'shipping'                      => [],
@@ -305,7 +301,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		];
 
 		$test_request = function ( $preempt, $parsed_args, $url ) {
-			$this->assertEquals( $this->order->get_id() . ':abc123-pm_mock', $parsed_args['headers']['Idempotency-Key'] );
+			$this->assertNotEmpty( $parsed_args['headers']['Idempotency-Key'] );
 
 			return [
 				'response' => 200,

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -231,7 +231,10 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 					],
 				],
 			],
-			'metadata'                      => [ '_stripe_metadata' => '123' ],
+			'metadata'                      => [
+				'_stripe_metadata' => '123',
+				'order_id'         => $this->order->get_id(),
+			],
 			'order'                         => $this->order,
 			'payment_method'                => 'pm_mock',
 			'shipping'                      => [],

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -231,10 +231,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 					],
 				],
 			],
-			'metadata'                      => [
-				'_stripe_metadata' => '123',
-				'order_id'         => $this->order->get_id(),
-			],
+			'metadata'                      => [ '_stripe_metadata' => '123' ],
 			'order'                         => $this->order,
 			'payment_method'                => 'pm_mock',
 			'shipping'                      => [],

--- a/tests/phpunit/test-wc-stripe-intent-controller.php
+++ b/tests/phpunit/test-wc-stripe-intent-controller.php
@@ -218,7 +218,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	public function test_intent_creation_request_setup_future_usage() {
 		$payment_information = [
 			'amount'                        => 100,
-			'capture_method'                => 'automattic',
+			'capture_method'                => 'automatic',
 			'currency'                      => WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
 			'customer'                      => 'cus_mock',
 			'level3'                        => [
@@ -258,6 +258,53 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	private function check_setup_future_usage_off_session( $payment_information ) {
 		$test_request = function ( $preempt, $parsed_args, $url ) {
 			$this->assertEquals( 'off_session', $parsed_args['body']['setup_future_usage'] );
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( [] ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		$this->mock_controller->create_and_confirm_payment_intent( $payment_information );
+	}
+
+	/**
+	 * Test presence of idempotency key when sending the payment intent request.
+	 */
+	public function test_idempotency_key_for_create_and_confirm_payment_intent() {
+		$payment_information = [
+			'amount'                        => 100,
+			'capture_method'                => 'automatic',
+			'currency'                      => WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
+			'customer'                      => 'cus_mock',
+			'level3'                        => [
+				'line_items' => [
+					[
+						'product_code'        => 'ABC123',
+						'product_description' => 'Test Product',
+						'unit_cost'           => 100,
+						'quantity'            => 1,
+					],
+				],
+			],
+			'metadata'                      => [
+				'_stripe_metadata' => '123',
+				'order_id'         => $this->order->get_id(),
+			],
+			'order'                         => $this->order,
+			'payment_method'                => 'pm_mock',
+			'shipping'                      => [],
+			'selected_payment_type'         => WC_Stripe_Payment_Methods::CARD,
+			'payment_method_types'          => [ WC_Stripe_Payment_Methods::CARD ],
+			'is_using_saved_payment_method' => false,
+			'save_payment_method_to_store'  => true,
+		];
+
+		$test_request = function ( $preempt, $parsed_args, $url ) {
+			$this->assertEquals( $this->order->get_id() . '-cus_mock', $parsed_args['headers']['Idempotency-Key'] );
 
 			return [
 				'response' => 200,


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

We use idempotency keys when creating charges for legacy checkout, i.e. sending `POST` requests to the `charges` endpoint. This is to avoid creating multiple charges for the same request, from retries or poor network conditions.

We want that same behavior for the new checkout. This PR adds idempotency keys to deferred intent requests, which uses the `payment_intents` endpoint.

## Background

We've been receiving several reports of multiple charges for a single order. While hard to reproduce, these patterns emerge:
   - Pattern 1: After submitting the order, i.e. clicking "Place order", the shopper gets an error. They then resubmit the order, but later it turns out that their first attempt successfully created a payment intent and charge.
   - Pattern 2: No shopper retries involved, but multiple payment intents are created, with timestamps that are <1 minute apart. 
   - Pattern 3: Same as pattern 2, but for automated subscription renewals.

For Pattern 1, we have recently pushed code that checks if the order already has an existing payment intent before attempting to request a new one. 

For Patterns 2 and 3, I believe these are caused by network-related retries, and using an idempotency key should help with these.

https://docs.stripe.com/api/idempotent_requests
https://docs.stripe.com/payments/payment-intents#best-practices
Original PR for idempotency: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/503

## Testing instructions
1. Verify that you are able to complete simple purchases without any trouble.
2. Verify that the order's payment method and/or billing details can be changed without getting an idempotency error:
    - Enable other payments methods, like Klarna.
    - As a shopper, try to make a purchase with the generic decline card `4000000000000002`.
    - After receiving the expected "card declined" message, switch your payment method to Klarna.
    - Change your billing/shipping address.
    - Resubmit your order.
    - You should not get any idempotency-related errors.
3. Verify that subscription renewals are not negatively impacted.
    - As a shopper, purchase a subscription.
    - As the merchant, go to the wp-admin subscription page, and manually process a renewal.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
