### PR TITLE
Make confirmation tokens compatible with upfront pre-orders

### DIFF
--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -16,6 +16,9 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: 'Collect changelog data from PR description'
         run: |
           DO_NOT_REQUIRE_CHANGELOG=$(grep -E -o '.{0,3} This Pull Request does not require a changelog entry' <<< "${{ github.event.pull_request.description }}" | awk '{print substr($0,2,1)}')

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -16,9 +16,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: 'Collect changelog data from PR description'
         run: |
           DO_NOT_REQUIRE_CHANGELOG=$(grep -E -o '.{0,3} This Pull Request does not require a changelog entry' <<< "${{ github.event.pull_request.description }}" | awk '{print substr($0,2,1)}')

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Fix - Prepare the redirect URL at the end of 'process_payment' method. 
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
 * Fix - Fix error when processing a subscription via Amazon Pay.
+* Fix - Make Amazon Pay compatible with upfront pre-orders.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1012,7 +1012,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			$this->set_customer_id_for_order( $order, $payment_information['customer'] );
 
-			if ( $this->is_payment_needed( $order->get_id() ) ) {
+			$payment_needed = $this->is_payment_needed( $order->get_id() );
+
+			if ( $payment_needed ) {
 				$payment_intent = $this->process_payment_intent_for_order( $order, $payment_information );
 			} else {
 				// TODO: add confirmation token support, if possible.
@@ -1028,6 +1030,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$payment_method = $this->stripe_request( 'payment_methods/' . $payment_method_id );
 
 			$this->set_payment_method_title_for_order( $order, $selected_payment_type, $payment_method );
+
+			if ( $payment_needed ) {
+				// Use the last charge within the intent to proceed.
+				$charge = $this->get_latest_charge_from_intent( $payment_intent );
+
+				if ( $charge ) {
+					$this->process_response( $charge, $order );
+				}
+			}
 
 			$return_url = $this->get_return_url( $order );
 

--- a/readme.txt
+++ b/readme.txt
@@ -118,5 +118,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prepare the redirect URL at the end of 'process_payment' method. 
 * Fix - Fix uncaught error in block editor when the new checkout experience is enabled.
 * Fix - Fix error when processing a subscription via Amazon Pay.
+* Fix - Make Amazon Pay compatible with upfront pre-orders.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3876

## Changes proposed in this Pull Request:

This PR fixes Pre-orders with upfront charge compatibility when using Amazon Pay.
Note that the original issue mentioned in #3876 was fixed in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3904. This PR is a continuation of that to ensure general compatibility of upfront pre-orders with Amazon Pay.

Prior to this PR, when purchasing a upfront pre-order using Amazon Pay, the order was not treated as a pre-order, instead the order remained in the `pending-payment` status with pre-order specific meta fields absent from the order.

This PR fixes it by calling `process_response` at the end of the confirmation token flow. Note that calling `$order->payment_complete` is enough to fix this issue for pre-orders but, I think calling `process_response` is the better approach as it also handles a few other things like setting some stripe meta fields, stock level handling etc.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Pre-requisites
1. Turn the Amazon Pay feature flag on, by setting the `_wcstripe_feature_amazon_pay` option to yes. OR return `true` [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/beb2828170ae9fc1de540fd9b9517cac0e82b71b/includes/class-wc-stripe-feature-flags.php/#L40-L43)

### Test upfront pre-order subscriptions 

1. Goto Woocommerce > products > Create a Subscription Product ( or Variable Subscription product )
2. Navigate the pre-order tab and enable pre-order
3. Add pre-order availability date
4. Select when to charge > upfront product
5. Go to the shop page and check out with Amazon Pay.
6. Make sure the resulting pre-order meets the acceptance criteria in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3876

### Test upfront pre-order simple products.
1. Goto WooCommerce > Products > Create a simple product.
2. Follow steps 2 to 5 from previous test.
3. Goto WooCommerce > Orders. Make sure the pre-order is created with `Pre-ordered` status.
4. Go to WooCommerce > Pre-orders. Make sure the pre-order has the active status.
5. Complete the pre-order via the Actions -> Complete section.
6. The order should now have the processing or complete status.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- You can optionally choose to enter a changelog entry by checking the box and supplying data. -->

-   [x] Automatically create a changelog entry from the details below.

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Details</summary>

#### Type

<!-- Choose only one -->

-   [x] Fix - Fixes an existing bug
-   [ ] Add - Adds functionality
-   [ ] Update - Update existing functionality
-   [ ] Dev - Development related task
-   [ ] Tweak - A minor adjustment to the codebase

#### Message <!-- Add a changelog message here -->

</details>

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fix upfront pre-orders when using Amazon Pay.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
