### PR TITLE
Map feature flags into a standard array for easier maintenance

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Fix - Make Amazon Pay compatible with upfront pre-orders.
 * Add - Include minimum amounts in the capture_terminal_payment endpoint when a capture fails.
 * Dev - Fix changelog action
+* Tweak - Map feature flags into a standard array for easier maintenance.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -29,7 +29,7 @@ class WC_Stripe_Feature_Flags {
 	/**
 	 * Retrieve all defined feature flags with their default values.
 	 *
-	 * @return array array( 'flag_name' => 'yes' or 'no', ...)
+	 * @return array
 	 */
 	public static function get_all_feature_flags_with_defaults() {
 		return self::$feature_flags;

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -7,10 +7,44 @@ class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
 	const ECE_FEATURE_FLAG_NAME               = '_wcstripe_feature_ece';
 	const AMAZON_PAY_FEATURE_FLAG_NAME        = '_wcstripe_feature_amazon_pay';
+	const LPM_ACH_FEATURE_FLAG_NAME           = '_wcstripe_feature_lpm_ach';
+	const LPM_ACSS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_acss';
+	const LPM_BACS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_bacs';
 
-	const LPM_ACH_FEATURE_FLAG_NAME  = '_wcstripe_feature_lpm_ach';
-	const LPM_ACSS_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_acss';
-	const LPM_BACS_FEATURE_FLAG_NAME = '_wcstripe_feature_lpm_bacs';
+	/**
+	 * Map of feature flag option names => their default "yes"/"no" value.
+	 * This single source of truth makes it easier to maintain our dev tools.
+	 *
+	 * @var array
+	 */
+	protected static $feature_flags = [
+		'_wcstripe_feature_upe'            => 'yes',
+		self::ECE_FEATURE_FLAG_NAME        => 'yes',
+		self::AMAZON_PAY_FEATURE_FLAG_NAME => 'no',
+		self::LPM_ACH_FEATURE_FLAG_NAME    => 'no',
+		self::LPM_ACSS_FEATURE_FLAG_NAME   => 'no',
+		self::LPM_BACS_FEATURE_FLAG_NAME   => 'no',
+	];
+
+	/**
+	 * Retrieve all defined feature flags with their default values.
+	 *
+	 * @return array array( 'flag_name' => 'yes' or 'no', ...)
+	 */
+	public static function get_all_feature_flags_with_defaults() {
+		return self::$feature_flags;
+	}
+
+	/**
+	 * Retrieve the default value for a specific feature flag.
+	 *
+	 * @param string $flag
+	 * @return string
+	 */
+	public static function get_option_with_default( $flag ) {
+		$default = isset( self::$feature_flags[ $flag ] ) ? self::$feature_flags[ $flag ] : 'no';
+		return get_option( $flag, $default );
+	}
 
 	/**
 	 * Checks whether ACH LPM (Local Payment Method) feature flag is enabled.
@@ -19,7 +53,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_ach_lpm_enabled() {
-		return 'yes' === get_option( self::LPM_ACH_FEATURE_FLAG_NAME, 'no' );
+		return 'yes' === self::get_option_with_default( self::LPM_ACH_FEATURE_FLAG_NAME );
 	}
 
 	/**
@@ -29,7 +63,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_acss_lpm_enabled() {
-		return 'yes' === get_option( self::LPM_ACSS_FEATURE_FLAG_NAME, 'no' );
+		return 'yes' === self::get_option_with_default( self::LPM_ACSS_FEATURE_FLAG_NAME );
 	}
 
 	/**
@@ -38,7 +72,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_amazon_pay_available() {
-		return 'yes' === get_option( self::AMAZON_PAY_FEATURE_FLAG_NAME, 'no' );
+		return 'yes' === self::get_option_with_default( self::AMAZON_PAY_FEATURE_FLAG_NAME );
 	}
 
 	/**
@@ -48,7 +82,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_bacs_lpm_enabled(): bool {
-		return 'yes' === get_option( self::LPM_BACS_FEATURE_FLAG_NAME, 'no' );
+		return 'yes' === self::get_option_with_default( self::LPM_BACS_FEATURE_FLAG_NAME );
 	}
 
 	/**
@@ -58,7 +92,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_stripe_ece_enabled() {
-		return 'yes' === get_option( self::ECE_FEATURE_FLAG_NAME, 'yes' );
+		return 'yes' === self::get_option_with_default( self::ECE_FEATURE_FLAG_NAME );
 	}
 
 	/**
@@ -68,7 +102,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_upe_preview_enabled() {
-		return 'yes' === get_option( '_wcstripe_feature_upe', 'yes' );
+		return 'yes' === self::get_option_with_default( '_wcstripe_feature_upe' );
 	}
 
 	/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -28,6 +28,7 @@ class WC_Stripe_Feature_Flags {
 
 	/**
 	 * Retrieve all defined feature flags with their default values.
+	 * Note: This method is intended for use in the dev tools.
 	 *
 	 * @return array
 	 */

--- a/readme.txt
+++ b/readme.txt
@@ -122,5 +122,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Make Amazon Pay compatible with upfront pre-orders.
 * Add - Include minimum amounts in the capture_terminal_payment endpoint when a capture fails.
 * Dev - Fix changelog action
+* Tweak - Map feature flags into a standard array for easier maintenance.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Adds a mapping of feature flags and their default values. This single source of truth makes it easier to maintain our dev tools.

## Testing instructions

N/A

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
