### PR TITLE
Fix issue where payment methods do not refresh after address changes.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Add - Include minimum amounts in the capture_terminal_payment endpoint when a capture fails.
 * Dev - Fix changelog action
 * Dev - Fix QIT Tests GitHub workflow.
+* Fix - Fix issue where payment methods do not refresh after address changes.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -92,14 +92,7 @@ const expressCheckoutElement = ( expressPaymentMethod, api ) => {
 			return false;
 		}
 
-		return new Promise( ( resolve ) => {
-			checkPaymentMethodIsAvailable(
-				expressPaymentMethod,
-				api,
-				cart,
-				resolve
-			);
-		} );
+		return checkPaymentMethodIsAvailable( expressPaymentMethod, api, cart );
 	};
 
 	const supports = {

--- a/client/express-checkout/utils/check-payment-method-availability.js
+++ b/client/express-checkout/utils/check-payment-method-availability.js
@@ -13,71 +13,75 @@ import {
 } from 'wcstripe/stripe-utils/constants';
 
 export const checkPaymentMethodIsAvailable = memoize(
-	( paymentMethod, api, cart, resolve ) => {
-		// Create the DIV container on the fly
-		const containerEl = document.createElement( 'div' );
+	( paymentMethod, api, cart ) => {
+		return new Promise( ( resolve ) => {
+			// Create the DIV container on the fly
+			const containerEl = document.createElement( 'div' );
 
-		// Ensure the element is hidden and doesn’t interfere with the page layout.
-		containerEl.style.display = 'none';
+			// Ensure the element is hidden and doesn’t interfere with the page layout.
+			containerEl.style.display = 'none';
 
-		document.querySelector( 'body' ).appendChild( containerEl );
+			document.querySelector( 'body' ).appendChild( containerEl );
 
-		const root = ReactDOM.createRoot( containerEl );
+			const root = ReactDOM.createRoot( containerEl );
 
-		root.render(
-			<Elements
-				stripe={ api.loadStripe() }
-				options={ {
-					mode: 'payment',
-					...( isManualPaymentMethodCreation( paymentMethod ) && {
-						paymentMethodCreation: 'manual',
-					} ),
-					amount: Number( cart.cartTotals.total_price ),
-					currency: cart.cartTotals.currency_code.toLowerCase(),
-					paymentMethodTypes: getPaymentMethodTypesForExpressMethod(
-						paymentMethod
-					),
-				} }
-			>
-				<ExpressCheckoutElement
-					onLoadError={ () => resolve( false ) }
+			root.render(
+				<Elements
+					stripe={ api.loadStripe() }
 					options={ {
-						paymentMethods: {
-							amazonPay:
-								paymentMethod ===
-								EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY
-									? 'auto'
-									: 'never',
-							applePay:
-								paymentMethod ===
-								EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY
-									? 'always'
-									: 'never',
-							googlePay:
-								paymentMethod ===
-								EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY
-									? 'always'
-									: 'never',
-							link:
-								paymentMethod ===
-								EXPRESS_PAYMENT_METHOD_SETTING_LINK
-									? 'auto'
-									: 'never',
-							paypal: 'never',
-						},
+						mode: 'payment',
+						...( isManualPaymentMethodCreation( paymentMethod ) && {
+							paymentMethodCreation: 'manual',
+						} ),
+						amount: Number( cart.cartTotals.total_price ),
+						currency: cart.cartTotals.currency_code.toLowerCase(),
+						paymentMethodTypes: getPaymentMethodTypesForExpressMethod(
+							paymentMethod
+						),
 					} }
-					onReady={ ( event ) => {
-						let canMakePayment = false;
-						if ( event.availablePaymentMethods ) {
-							canMakePayment =
-								event.availablePaymentMethods[ paymentMethod ];
-						}
-						resolve( canMakePayment );
-						root.unmount();
-						containerEl.remove();
-					} }
-				/>
-			</Elements>
-		);
+				>
+					<ExpressCheckoutElement
+						onLoadError={ () => resolve( false ) }
+						options={ {
+							paymentMethods: {
+								amazonPay:
+									paymentMethod ===
+									EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY
+										? 'auto'
+										: 'never',
+								applePay:
+									paymentMethod ===
+									EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY
+										? 'always'
+										: 'never',
+								googlePay:
+									paymentMethod ===
+									EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY
+										? 'always'
+										: 'never',
+								link:
+									paymentMethod ===
+									EXPRESS_PAYMENT_METHOD_SETTING_LINK
+										? 'auto'
+										: 'never',
+								paypal: 'never',
+							},
+						} }
+						onReady={ ( event ) => {
+							let canMakePayment = false;
+							if ( event.availablePaymentMethods ) {
+								canMakePayment =
+									event.availablePaymentMethods[
+										paymentMethod
+									];
+							}
+							resolve( canMakePayment );
+							root.unmount();
+							containerEl.remove();
+						} }
+					/>
+				</Elements>
+			);
+		} );
 	}
 );

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -188,7 +188,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 
 			// Check for amount_too_small error
 			if ( ! empty( $result->error ) && 'amount_too_small' === $result->error->code ) {
-				$currency = strtoupper( $order->get_currency() );
+				$currency       = strtoupper( $order->get_currency() );
 				$minimum_amount = isset( self::$minimum_amounts[ $currency ] ) ? self::$minimum_amounts[ $currency ] : null;
 
 				$message = wp_json_encode(

--- a/readme.txt
+++ b/readme.txt
@@ -123,5 +123,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Include minimum amounts in the capture_terminal_payment endpoint when a capture fails.
 * Dev - Fix changelog action
 * Dev - Fix QIT Tests GitHub workflow.
+* Fix - Fix issue where payment methods do not refresh after address changes.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
This is a port of a [fix on WooPayments](https://github.com/Automattic/woocommerce-payments/pull/9927/) made by @timur27. So all credits to him.

We need to apply the same fix here on WC Stripe as @ricardo was running into the same bug.

## Testing instructions

- Enable ACSS.
- Enable ECE.
- Add a product and go to the blocks-based checkout page.
- Enter a US address.
- ACSS/Bacs payment method should hide.
- Enter a Canadian address.
- ACSS should show.
- Ensure Express Checkouts continues to work.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
