### PR TITLE
Add subscriptions support to Bacs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@
 * Fix - Allow to save card during checkout with account creation.
 * Add - Add BLIK LPM feature flag.
 * Fix - ACSS: Handle errors and edge cases.
+* Add - Add subscriptions support to Bacs.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -6,6 +6,7 @@ import {
 	getPaymentMethodsConstants,
 	PAYMENT_METHOD_AFTERPAY,
 	PAYMENT_METHOD_AFTERPAY_CLEARPAY,
+	PAYMENT_METHOD_BACS,
 	PAYMENT_METHOD_CLEARPAY,
 	PAYMENT_METHOD_GIROPAY,
 	PAYMENT_METHOD_LINK,
@@ -102,6 +103,17 @@ Object.entries( paymentMethodsConfig )
 					! isRestrictedInAnyCountry ||
 					upeConfig.countries.includes( billingCountry );
 
+				// Disable Bacs for subscriptions with free trial.
+				const cartContainsSubscriptions = cartData.cart.cartItems.every(
+					( item ) => item.type === 'subscription'
+				);
+				if (
+					upeName === PAYMENT_METHOD_BACS &&
+					cartContainsSubscriptions &&
+					cartData.cartTotals.total_price === '0'
+				) {
+					return false;
+				}
 				return isAvailableInTheCountry && !! api.getStripe();
 			},
 			// see .wc-block-checkout__payment-method styles in blocks/style.scss

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -996,7 +996,7 @@ trait WC_Stripe_Subscriptions_Trait {
 							);
 							break 3;
 						case WC_Stripe_Payment_Methods::BACS_DEBIT:
-							/* translators: 1) email address associated with the Stripe Link payment method */
+							/* translators: 1) the Bacs Direct Debit payment method's last 4 numbers */
 							$payment_method_to_display = sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
 							break 3;
 					}

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -987,6 +987,10 @@ trait WC_Stripe_Subscriptions_Trait {
 							/* translators: 1) email address associated with the Stripe Link payment method */
 							$payment_method_to_display = sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
 							break 3;
+						case WC_Stripe_Payment_Methods::BACS_DEBIT:
+							/* translators: 1) email address associated with the Stripe Link payment method */
+							$payment_method_to_display = sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
+							break 3;
 					}
 				}
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -28,6 +28,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		$this->accept_only_domestic_payment = true;
 		$this->label                        = __( 'Bacs Direct Debit', 'woocommerce-gateway-stripe' );
 		$this->description                  = __( 'Bacs Direct Debit enables customers in the UK to pay by providing their bank account details.', 'woocommerce-gateway-stripe' );
+		$this->supports[]                   = 'subscriptions';
 
 		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
 		if ( ! is_wc_endpoint_url( 'add-payment-method' ) ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -34,6 +34,8 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		if ( ! is_wc_endpoint_url( 'add-payment-method' ) ) {
 			$this->supports[] = 'tokenization';
 		}
+
+		$this->hide_bacs_for_subscriptions_with_free_trials();
 	}
 
 	/**
@@ -85,5 +87,24 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		$token->set_user_id( $user_id );
 		$token->save();
 		return $token;
+	}
+
+	public function hide_bacs_for_subscriptions_with_free_trials() {
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			function ( $available_gateways ) {
+				global $post;
+				$is_checkout_shortcode_page          = wc_post_content_has_shortcode( 'woocommerce_checkout' ) || has_block( 'woocommerce/classic-shortcode', $post );
+				$is_update_order_review_ajax_request = defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['wc-ajax'] ) && 'update_order_review' === $_REQUEST['wc-ajax'];
+				if ( $is_checkout_shortcode_page || $is_update_order_review_ajax_request ) {
+					// Checking if the amount is zero allows us to process orders that include subscriptions with a free trial,
+					// as long as another product increases the total amount, ensuring compatibility with Bacs.
+					if ( WC_Subscriptions_Cart::cart_contains_free_trial() && (float) WC()->cart->total === 0.00 ) {
+						unset( $available_gateways['stripe_bacs_debit'] );
+					}
+				}
+				return $available_gateways;
+			}
+		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -31,13 +31,13 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		$this->label                        = __( 'Bacs Direct Debit', 'woocommerce-gateway-stripe' );
 		$this->description                  = __( 'Bacs Direct Debit enables customers in the UK to pay by providing their bank account details.', 'woocommerce-gateway-stripe' );
 
-		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
-		if ( ! is_wc_endpoint_url( 'add-payment-method' ) ) {
-			$this->supports[] = 'tokenization';
-		}
-
 		// Check if subscriptions are enabled and add support for them.
 		$this->maybe_init_subscriptions();
+
+		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
+		if ( is_wc_endpoint_url( 'add-payment-method' ) ) {
+			unset( $this->supports['tokenization'] );
+		}
 
 		$this->hide_bacs_for_subscriptions_with_free_trials();
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since x.x.x
  */
 class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Method {
+	use WC_Stripe_Subscriptions_Trait;
+
 	/**
 	 * The Stripe ID for the payment method.
 	 */
@@ -32,7 +34,8 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 
 		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
 		if ( ! is_wc_endpoint_url( 'add-payment-method' ) ) {
-			$this->supports[] = 'tokenization';
+			// Check if subscriptions are enabled and add support for them.
+			$this->maybe_init_subscriptions();
 		}
 
 		$this->hide_bacs_for_subscriptions_with_free_trials();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -30,13 +30,14 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		$this->accept_only_domestic_payment = true;
 		$this->label                        = __( 'Bacs Direct Debit', 'woocommerce-gateway-stripe' );
 		$this->description                  = __( 'Bacs Direct Debit enables customers in the UK to pay by providing their bank account details.', 'woocommerce-gateway-stripe' );
-		$this->supports[]                   = 'subscriptions';
 
 		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
 		if ( ! is_wc_endpoint_url( 'add-payment-method' ) ) {
-			// Check if subscriptions are enabled and add support for them.
-			$this->maybe_init_subscriptions();
+			$this->supports[] = 'tokenization';
 		}
+
+		// Check if subscriptions are enabled and add support for them.
+		$this->maybe_init_subscriptions();
 
 		$this->hide_bacs_for_subscriptions_with_free_trials();
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -135,5 +135,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Allow to save card during checkout with account creation.
 * Add - Add BLIK LPM feature flag.
 * Fix - ACSS: Handle errors and edge cases.
+* Add - Add subscriptions support to Bacs.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Closes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3798

## Changes proposed in this Pull Request:

The changes here are quite simple. The most important one is enabling Bacs support for subscriptions. By default, Bacs should work well for the subscription cases listed below, except for subscriptions with a free trial. For now, the Bacs payment method is being disabled for subscriptions with a free trial as it will be addressed separately. More info [here](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4006).

## Testing instructions

> [!IMPORTANT]  
> First, make sure that the business in your Stripe account is located in the UK ([link](https://dashboard.stripe.com/test/settings/account)) and that your default currency is GBP ([link](https://dashboard.stripe.com/settings/payouts)). Otherwise you won't be able to see Bacs as a payment option.

> [!IMPORTANT]  
> Update the store country to the UK and set the currency to GBP in the WooCommerce settings.

> [!IMPORTANT]  
> Also, make sure the Bacs feature is enabled. You can use the following to do that:
`wp option update _wcstripe_feature_lpm_bacs 'yes'`

Install the WooCommerce Subscriptions and test checking out using following subscription variatons.

- Simple subscription.
    - [x]  Virtual product.
    - [x]  Physical product.
- Variable subscription.
    - [x]  Virtual products.
    - [x]  Physical products.
- Simple subscription with:
  - [ ] Free Trial
    ```
    {
      "error": {
        "message": "Your account isn't configured to directly use SetupIntents to create Mandates for Bacs Direct Debits. See https://stripe.com/docs/payments/payment-methods/bacs-debit to learn more, or contact us through https://support.stripe.com/contact/.",
        "param": "deferred_intent.payment_method_types",
        "request_log_url": "https://dashboard.stripe.com/acct_1Ja916HJAl4h87JO/test/logs/req_D2rNbNMZcnr08C?t=1740691770",
        "type": "invalid_request_error"
      }
    }
    ```
  - [x] Sign Up Fee.
  - [x] Free trial with Sign Up Fee

It would be nice to test with shortcode checkout and the checkout block.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
