### PR TITLE
Adding a new feature flag and setting to control SPE

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.3.0 - xxxx-xx-xx =
+* Add - Adds a new feature flag to handle the Single Payment Element feature.
 * Fix - Fixes a fatal error that might happen when a payment method ID cannot be retrieved during the processing of an order (new checkout experience).
 * Dev - Generates a code coverage report for PHP Unit tests as a comment on PRs.
 * Add - Adds Stripe specific information to the System Status Report data.

--- a/client/data/settings/__tests__/hooks.js
+++ b/client/data/settings/__tests__/hooks.js
@@ -22,6 +22,7 @@ import {
 	useAmazonPayLocations,
 	useAmazonPayButtonSize,
 	useSepaTokensForOtherMethods,
+	useIsSpeEnabled,
 } from '../hooks';
 import { STORE_NAME } from '../../constants';
 import {
@@ -338,6 +339,12 @@ describe( 'Settings hooks tests', () => {
 			storeKey: 'amazon_pay_button_locations',
 			testedValue: [ 'checkout', 'cart' ],
 			fallbackValue: [],
+		},
+		useIsSpeEnabledSettings: {
+			hook: useIsSpeEnabled,
+			storeKey: 'is_spe_enabled',
+			testedValue: true,
+			fallbackValue: false,
 		},
 	};
 

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -182,6 +182,7 @@ export const useIsShortAccountStatementEnabled = makeSettingsHook(
 );
 export const useDebugLog = makeSettingsHook( 'is_debug_log_enabled' );
 export const useIsUpeEnabled = makeSettingsHook( 'is_upe_enabled' );
+export const useIsSpeEnabled = makeSettingsHook( 'is_spe_enabled' );
 
 export const useIndividualPaymentMethodSettings = makeSettingsHook(
 	'individual_payment_method_settings',

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -7,19 +7,23 @@ import {
 	useIsUpeEnabled,
 	useGetSavingError,
 	useSettings,
+	useIsSpeEnabled,
 } from 'wcstripe/data';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useDebugLog: jest.fn(),
 	useIsUpeEnabled: jest.fn(),
+	useIsSpeEnabled: jest.fn(),
 	useGetSavingError: jest.fn(),
 	useSettings: jest.fn(),
 } ) );
 
 describe( 'AdvancedSettings', () => {
 	beforeEach( () => {
+		global.wc_stripe_settings_params = { is_spe_available: true };
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useIsUpeEnabled.mockReturnValue( [ true, jest.fn() ] );
+		useIsSpeEnabled.mockReturnValue( [ true, jest.fn() ] );
 		useGetSavingError.mockReturnValue( null );
 
 		// Set `isLoading` to false so `LoadableSettingsSection` can render.

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -20,10 +20,11 @@ jest.mock( 'wcstripe/data', () => ( {
 
 describe( 'AdvancedSettings', () => {
 	beforeEach( () => {
-		global.wc_stripe_settings_params = { is_spe_available: true };
+		global.wc_stripe_settings_params = { is_spe_available: false };
+
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useIsUpeEnabled.mockReturnValue( [ true, jest.fn() ] );
-		useIsSpeEnabled.mockReturnValue( [ true, jest.fn() ] );
+		useIsSpeEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useGetSavingError.mockReturnValue( null );
 
 		// Set `isLoading` to false so `LoadableSettingsSection` can render.
@@ -55,5 +56,23 @@ describe( 'AdvancedSettings', () => {
 		userEvent.click( debugModeCheckbox );
 
 		expect( setIsLoggingCheckedMock ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'should not display single payment element setting if the feature flag is disabled', () => {
+		render( <AdvancedSettings /> );
+
+		expect(
+			screen.queryByText( 'Single payment element' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should display single payment element setting if the feature flag is enabled', () => {
+		global.wc_stripe_settings_params = { is_spe_available: true };
+
+		render( <AdvancedSettings /> );
+
+		expect(
+			screen.queryByText( 'Single payment element' )
+		).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/advanced-settings-section/__tests__/single-payment-element-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/single-payment-element-feature.test.js
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import React, { useContext } from 'react';
+import userEvent from '@testing-library/user-event';
+import SinglePaymentElementFeature from 'wcstripe/settings/advanced-settings-section/single-payment-element-feature';
+import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
+
+jest.useFakeTimers();
+
+describe( 'Single Payment Element feature setting', () => {
+	it( 'should render', () => {
+		render( <SinglePaymentElementFeature /> );
+
+		expect(
+			screen.queryByText( 'Single payment element' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should be disabled when UPE is disabled', () => {
+		const UpdateUpeDisabledFlagMock = () => {
+			const { setIsUpeEnabled } = useContext( UpeToggleContext );
+			setTimeout( () => {
+				setIsUpeEnabled( false );
+			}, 1000 );
+			return null;
+		};
+
+		render(
+			<div>
+				<UpdateUpeDisabledFlagMock />
+				<SinglePaymentElementFeature />
+			</div>
+		);
+
+		const checkbox = screen.getByTestId(
+			'single-payment-element-checkbox'
+		);
+
+		userEvent.click( checkbox );
+
+		jest.runAllTimers();
+
+		expect( checkbox ).toBeDisabled();
+		expect( checkbox ).not.toBeChecked();
+	} );
+} );

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 import { __ } from '@wordpress/i18n';
 import React from 'react';
 import { Card } from '@wordpress/components';
@@ -21,6 +22,7 @@ const AdvancedSettingsDescription = () => (
 );
 
 const AdvancedSettings = () => {
+	const isSpeAvailable = wc_stripe_settings_params.is_spe_available; // eslint-disable-line camelcase
 	return (
 		<SettingsSection Description={ AdvancedSettingsDescription }>
 			<LoadableSettingsSection numLines={ 10 }>
@@ -28,7 +30,7 @@ const AdvancedSettings = () => {
 					<CardBody>
 						<DebugMode />
 						<ExperimentalFeatures />
-						<SinglePaymentElementFeature />
+						{ isSpeAvailable && <SinglePaymentElementFeature /> }
 					</CardBody>
 				</Card>
 			</LoadableSettingsSection>

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -7,6 +7,7 @@ import DebugMode from './debug-mode';
 import ExperimentalFeatures from './experimental-features';
 import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
 import SinglePaymentElementFeature from 'wcstripe/settings/advanced-settings-section/single-payment-element-feature';
+import { useIsUpeEnabled } from 'wcstripe/data';
 
 const AdvancedSettingsDescription = () => (
 	<>
@@ -21,13 +22,14 @@ const AdvancedSettingsDescription = () => (
 );
 
 const AdvancedSettings = () => {
+	const [ isUpeEnabled ] = useIsUpeEnabled();
 	return (
 		<SettingsSection Description={ AdvancedSettingsDescription }>
 			<LoadableSettingsSection numLines={ 10 }>
 				<Card>
 					<CardBody>
 						<DebugMode />
-						<SinglePaymentElementFeature />
+						{ isUpeEnabled && <SinglePaymentElementFeature /> }
 						<ExperimentalFeatures />
 					</CardBody>
 				</Card>

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -7,7 +7,6 @@ import DebugMode from './debug-mode';
 import ExperimentalFeatures from './experimental-features';
 import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
 import SinglePaymentElementFeature from 'wcstripe/settings/advanced-settings-section/single-payment-element-feature';
-import { useIsUpeEnabled } from 'wcstripe/data';
 
 const AdvancedSettingsDescription = () => (
 	<>
@@ -22,7 +21,6 @@ const AdvancedSettingsDescription = () => (
 );
 
 const AdvancedSettings = () => {
-	const [ isUpeEnabled ] = useIsUpeEnabled();
 	return (
 		<SettingsSection Description={ AdvancedSettingsDescription }>
 			<LoadableSettingsSection numLines={ 10 }>
@@ -30,7 +28,7 @@ const AdvancedSettings = () => {
 					<CardBody>
 						<DebugMode />
 						<ExperimentalFeatures />
-						{ isUpeEnabled && <SinglePaymentElementFeature /> }
+						<SinglePaymentElementFeature />
 					</CardBody>
 				</Card>
 			</LoadableSettingsSection>

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -6,6 +6,7 @@ import CardBody from '../card-body';
 import DebugMode from './debug-mode';
 import ExperimentalFeatures from './experimental-features';
 import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
+import SinglePaymentElementFeature from 'wcstripe/settings/advanced-settings-section/single-payment-element-feature';
 
 const AdvancedSettingsDescription = () => (
 	<>
@@ -26,6 +27,7 @@ const AdvancedSettings = () => {
 				<Card>
 					<CardBody>
 						<DebugMode />
+						<SinglePaymentElementFeature />
 						<ExperimentalFeatures />
 					</CardBody>
 				</Card>

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -29,8 +29,8 @@ const AdvancedSettings = () => {
 				<Card>
 					<CardBody>
 						<DebugMode />
-						{ isUpeEnabled && <SinglePaymentElementFeature /> }
 						<ExperimentalFeatures />
+						{ isUpeEnabled && <SinglePaymentElementFeature /> }
 					</CardBody>
 				</Card>
 			</LoadableSettingsSection>

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -16,7 +16,7 @@ const SinglePaymentElementFeature = () => {
 
 	return (
 		<>
-			<h4 tabIndex="-1">
+			<h4>
 				{ __( 'Single payment element', 'woocommerce-gateway-stripe' ) }
 			</h4>
 			<CheckboxControl
@@ -38,6 +38,7 @@ const SinglePaymentElementFeature = () => {
 				) }
 				checked={ isSpeEnabled }
 				onChange={ setIsSpeEnabled }
+				disabled={ ! isUpeEnabled }
 			/>
 		</>
 	);

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -1,39 +1,33 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
 import { CheckboxControl, ExternalLink } from '@wordpress/components';
-import { getQuery } from '@woocommerce/navigation';
-import React, { useEffect, useRef } from 'react';
-import { useIsSpeEnabled } from '../../data';
+import React, { useEffect } from 'react';
+import { useIsSpeEnabled, useIsUpeEnabled } from '../../data';
 
 const SinglePaymentElementFeature = () => {
 	const [ isSpeEnabled, setIsSpeEnabled ] = useIsSpeEnabled();
-	const headingRef = useRef( null );
+	const [ isUpeEnabled ] = useIsUpeEnabled();
 
 	useEffect( () => {
-		if ( ! headingRef.current ) {
-			return;
+		if ( ! isUpeEnabled ) {
+			setIsSpeEnabled( false );
 		}
-
-		const { highlight } = getQuery();
-		if ( highlight === 'enable-spe' ) {
-			headingRef.current.focus();
-		}
-	}, [] );
+	}, [ isUpeEnabled, setIsSpeEnabled ] );
 
 	return (
 		<>
-			<h4 ref={ headingRef } tabIndex="-1">
+			<h4 tabIndex="-1">
 				{ __( 'Single payment element', 'woocommerce-gateway-stripe' ) }
 			</h4>
 			<CheckboxControl
-				data-testid="legacy-checkout-experience-checkbox"
+				data-testid="single-payment-element-checkbox"
 				label={ __(
 					'Enable the single payment element feature',
 					'woocommerce-gateway-stripe'
 				) }
 				help={ createInterpolateElement(
 					__(
-						"By enabling this, your store checkout form will use Stripe's dynamic payment methods. <learnMoreLink>Learn more</learnMoreLink>.",
+						"By enabling this, your store checkout form will use Stripe's dynamic payment methods. Legacy checkout must be disabled. <learnMoreLink>Learn more</learnMoreLink>.",
 						'woocommerce-gateway-stripe'
 					),
 					{

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -1,0 +1,52 @@
+import { __ } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import { getQuery } from '@woocommerce/navigation';
+import React, { useEffect, useRef } from 'react';
+import { useIsSpeEnabled } from '../../data';
+
+const SinglePaymentElementFeature = () => {
+	const [ isSpeEnabled, setIsSpeEnabled ] = useIsSpeEnabled();
+	const headingRef = useRef( null );
+
+	useEffect( () => {
+		if ( ! headingRef.current ) {
+			return;
+		}
+
+		const { highlight } = getQuery();
+		if ( highlight === 'enable-spe' ) {
+			headingRef.current.focus();
+		}
+	}, [] );
+
+	return (
+		<>
+			<h4 ref={ headingRef } tabIndex="-1">
+				{ __( 'Single payment element', 'woocommerce-gateway-stripe' ) }
+			</h4>
+			<CheckboxControl
+				data-testid="legacy-checkout-experience-checkbox"
+				label={ __(
+					'Enable the single payment element feature',
+					'woocommerce-gateway-stripe'
+				) }
+				help={ createInterpolateElement(
+					__(
+						"By enabling this, your store checkout form will display unified payment buttons, using Stripe's dynamic payment methods. <learnMoreLink>Learn more</learnMoreLink>.",
+						'woocommerce-gateway-stripe'
+					),
+					{
+						learnMoreLink: (
+							<ExternalLink href="https://docs.stripe.com/connect/dynamic-payment-methods" />
+						),
+					}
+				) }
+				checked={ isSpeEnabled }
+				onChange={ setIsSpeEnabled }
+			/>
+		</>
+	);
+};
+
+export default SinglePaymentElementFeature;

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -33,7 +33,7 @@ const SinglePaymentElementFeature = () => {
 				) }
 				help={ createInterpolateElement(
 					__(
-						"By enabling this, your store checkout form will display unified payment buttons, using Stripe's dynamic payment methods. <learnMoreLink>Learn more</learnMoreLink>.",
+						"By enabling this, your store checkout form will use Stripe's dynamic payment methods. <learnMoreLink>Learn more</learnMoreLink>.",
 						'woocommerce-gateway-stripe'
 					),
 					{

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -83,6 +83,11 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						],
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'is_spe_enabled'                     => [
+						'description'       => __( 'If Single Payment Element should be enabled.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'boolean',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 					'is_amazon_pay_enabled'              => [
 						'description'       => __( 'If Amazon Pay should be enabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
@@ -275,6 +280,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > Advanced settings */
 				'is_debug_log_enabled'                     => 'yes' === $this->gateway->get_option( 'logging' ),
 				'is_upe_enabled'                           => $is_upe_enabled,
+				'is_spe_enabled'                           => 'yes' === $this->gateway->get_option( 'single_payment_element' ),
 			]
 		);
 	}
@@ -309,6 +315,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		/* Settings > Advanced settings */
 		$this->update_is_debug_log_enabled( $request );
 		$this->update_is_upe_enabled( $request );
+		$this->update_is_spe_enabled( $request );
 
 		return new WP_REST_Response( [], 200 );
 	}
@@ -579,6 +586,21 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			$value = $request->get_param( $request_key );
 			$this->gateway->update_validated_option( $attribute, $value );
 		}
+	}
+
+	/**
+	 * Updates the "Single Payment Element" enable/disable settings.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 */
+	private function update_is_spe_enabled( WP_REST_Request $request ) {
+		$is_spe_enabled = $request->get_param( 'is_spe_enabled' );
+
+		if ( null === $is_spe_enabled ) {
+			return;
+		}
+
+		$this->gateway->update_option( 'single_payment_element', $is_spe_enabled ? 'yes' : 'no' );
 	}
 
 	/**

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -244,6 +244,7 @@ class WC_Stripe_Settings_Controller {
 			'account_country'           => $this->account->get_account_country(),
 			'are_apms_deprecated'       => WC_Stripe_Feature_Flags::are_apms_deprecated(),
 			'is_amazon_pay_available'   => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
+			'is_spe_enabled'            => WC_Stripe_Feature_Flags::is_spe_enabled(),
 			'oauth_nonce'               => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
 		];
 		wp_localize_script(

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -244,7 +244,7 @@ class WC_Stripe_Settings_Controller {
 			'account_country'           => $this->account->get_account_country(),
 			'are_apms_deprecated'       => WC_Stripe_Feature_Flags::are_apms_deprecated(),
 			'is_amazon_pay_available'   => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
-			'is_spe_enabled'            => WC_Stripe_Feature_Flags::is_spe_enabled(),
+			'is_spe_available'          => WC_Stripe_Feature_Flags::is_spe_available(),
 			'oauth_nonce'               => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
 		];
 		wp_localize_script(

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -7,6 +7,7 @@ class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
 	const ECE_FEATURE_FLAG_NAME               = '_wcstripe_feature_ece';
 	const AMAZON_PAY_FEATURE_FLAG_NAME        = '_wcstripe_feature_amazon_pay';
+	const SPE_FEATURE_FLAG_NAME               = '_wcstripe_feature_spe';
 	const LPM_ACH_FEATURE_FLAG_NAME           = '_wcstripe_feature_lpm_ach';
 	const LPM_ACSS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_acss';
 	const LPM_BACS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_bacs';
@@ -135,5 +136,14 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function are_apms_deprecated() {
 		return ( new \DateTime() )->format( 'Y-m-d' ) > '2024-10-28' && ! self::is_upe_checkout_enabled();
+	}
+
+	/**
+	 * Whether the Single Payment Element (SPE) feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_spe_enabled() {
+		return 'yes' === self::get_option_with_default( self::SPE_FEATURE_FLAG_NAME );
 	}
 }

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -151,7 +151,7 @@ class WC_Stripe_Feature_Flags {
 	}
 
 	/**
-	 * Whether the Single Payment Element (SPE) feature is enabled.
+	 * Whether the Single Payment Element (SPE) feature flag is enabled.
 	 *
 	 * @return bool
 	 */

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -22,6 +22,7 @@ class WC_Stripe_Feature_Flags {
 		'_wcstripe_feature_upe'            => 'yes',
 		self::ECE_FEATURE_FLAG_NAME        => 'yes',
 		self::AMAZON_PAY_FEATURE_FLAG_NAME => 'no',
+		self::SPE_FEATURE_FLAG_NAME        => 'no',
 		self::LPM_ACH_FEATURE_FLAG_NAME    => 'no',
 		self::LPM_ACSS_FEATURE_FLAG_NAME   => 'no',
 		self::LPM_BACS_FEATURE_FLAG_NAME   => 'no',
@@ -143,7 +144,7 @@ class WC_Stripe_Feature_Flags {
 	 *
 	 * @return bool
 	 */
-	public static function is_spe_enabled() {
+	public static function is_spe_available() {
 		return 'yes' === self::get_option_with_default( self::SPE_FEATURE_FLAG_NAME );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.3.0 - xxxx-xx-xx =
+* Add - Adds a new feature flag to handle the Single Payment Element feature.
 * Fix - Fixes a fatal error that might happen when a payment method ID cannot be retrieved during the processing of an order (new checkout experience).
 * Dev - Generates a code coverage report for PHP Unit tests as a comment on PRs.
 * Add - Adds Stripe specific information to the System Status Report data.

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -357,6 +357,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			'is_test_mode_enabled'                  => [ 'is_test_mode_enabled', 'testmode' ],
 			'is_payment_request_enabled'            => [ 'is_payment_request_enabled', 'payment_request' ],
 			'is_amazon_pay_enabled'                 => [ 'is_amazon_pay_enabled', 'amazon_pay' ],
+			'is_spe_enabled'                        => [ 'is_spe_enabled', 'single_payment_element' ],
 			'is_manual_capture_enabled'             => [ 'is_manual_capture_enabled', 'capture', true ],
 			'is_saved_cards_enabled'                => [ 'is_saved_cards_enabled', 'saved_cards' ],
 			'is_separate_card_form_enabled'         => [ 'is_separate_card_form_enabled', 'inline_cc_form', true ],

--- a/tests/phpunit/test-class-wc-stripe-feature-flags.php
+++ b/tests/phpunit/test-class-wc-stripe-feature-flags.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * These tests make assertions against the class WC_Stripe_Feature_Flags
+ */
+
+/**
+ * Class WC_Stripe_Feature_Flags_Test
+ *
+ * @package WooCommerce_Stripe/Tests/WC_Stripe_Feature_Flags
+ */
+class WC_Stripe_Feature_Flags_Test extends WP_UnitTestCase {
+	/**
+	 * Test for `is_spe_available`.
+	 *
+	 * @param string $option_value The value of the feature flag option.
+	 * @param bool   $expected     The expected result.
+	 * @return void
+	 * @dataProvider provide_test_is_spe_available
+	 */
+	public function test_is_spe_available( $option_value, $expected ) {
+		update_option( WC_Stripe_Feature_Flags::SPE_FEATURE_FLAG_NAME, $option_value );
+		$this->assertSame( $expected, WC_Stripe_Feature_Flags::is_spe_available() );
+	}
+
+	/**
+	 * Provider for `test_is_spe_available`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_is_spe_available() {
+		return [
+			'available'     => [
+				'option value' => 'yes',
+				'expected'     => true,
+			],
+			'not available' => [
+				'option value' => 'no',
+				'expected'     => false,
+			],
+		];
+	}
+}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #3892

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR introduces a new feature flag (`_wcstripe_feature_spe`) to control the Single Payment Element availability. This flag controls the feature as a whole, and does not behave like an option.

When the flag is enabled, and the legacy checkout experience is disabled, you should be able to toggle the "Single payment element" feature in settings. When the flag is disabled, the option is not displayed.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/spe-feature-flag`)
- Connect your Stripe account
- Enable the new feature flag (`_wcstripe_feature_spe`). You can do it by either hardcoding the return value of `is_spe_available` to `true` or by running `npm run wp option update _wcstripe_feature_spe 'yes'`
- As a merchant, disable the legacy checkout experience in settings (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`)
- Confirm that you can see the new "Single payment element" setting:
<img width="757" alt="Screenshot 2025-02-27 at 10 40 54" src="https://github.com/user-attachments/assets/24315457-480e-401a-a35c-55e3a0f064a0" />

- Confirm that you can toggle it and that the value you set persists upon page refresh
- Disable the `_wcstripe_feature_spe` feature flag
- Confirm that the option is gone even when the legacy checkout experience is disabled

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
