### PR TITLE
Fix E2E run/up check

### DIFF
--- a/tests/e2e/bin/down.sh
+++ b/tests/e2e/bin/down.sh
@@ -4,4 +4,4 @@ set -e
 . ./tests/e2e/bin/common.sh
 
 step "Stopping E2E docker containers"
-CWD="$CWD" redirect_output docker-compose -p wcstripe-e2e down
+CWD="$CWD" redirect_output docker compose -p wcstripe-e2e down

--- a/tests/e2e/bin/run-tests.sh
+++ b/tests/e2e/bin/run-tests.sh
@@ -31,16 +31,10 @@ for arg in "$@"; do
 	fi
 done
 
-if [[ *"wordpress" == "$(docker compose -p wcstripe-e2e ps --services --filter "status=running" | grep wordpress)" ]]; then
+if [[ "wordpress" != "$(docker compose -p wcstripe-e2e ps --services --filter "status=running" | grep wordpress)" ]]; then
 	error "Docker E2E containers are not running, please start them with 'npm run test:e2e-up' or 'npm run test:e2e-setup' and try again."
 	exit 1
 fi
-
-set -e
-
-. ./tests/e2e/bin/common.sh
-
-cd "$CWD"
 
 TEST_ENV="$TEST_ENV DOCKER=true E2E_ROOT=${E2E_ROOT} BASE_URL='http://localhost:8088'"
 TEST_ENV="$TEST_ENV ADMIN_USER='admin' ADMIN_PASSWORD='admin'"

--- a/tests/e2e/bin/up.sh
+++ b/tests/e2e/bin/up.sh
@@ -4,4 +4,4 @@ set -e
 . ./tests/e2e/bin/common.sh
 
 step "Starting E2E docker containers"
-CWD="$CWD" redirect_output docker-compose -f "$E2E_ROOT/env/docker-compose.yml" up -d
+CWD="$CWD" redirect_output docker-compose -p wcstripe-e2e -f "$E2E_ROOT/env/docker-compose.yml" up -d

--- a/tests/e2e/bin/up.sh
+++ b/tests/e2e/bin/up.sh
@@ -4,4 +4,4 @@ set -e
 . ./tests/e2e/bin/common.sh
 
 step "Starting E2E docker containers"
-CWD="$CWD" redirect_output docker-compose -p wcstripe-e2e -f "$E2E_ROOT/env/docker-compose.yml" up -d
+CWD="$CWD" redirect_output docker compose -p wcstripe-e2e -f "$E2E_ROOT/env/docker-compose.yml" up -d


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes the check when running `npm run test:e2e`; it now correctly exits with an error if the containers are not running:

![Screenshot 2025-02-26 at 19 35 12](https://github.com/user-attachments/assets/bff63a18-a475-4d12-b694-73f7fc857355)

It also sets the project-name for `npm run test:e2e-up` to avoid orphaned containers when running `npm run test:e2e-down` 

## Testing instructions

1. Checkout the develop develop
2. Make sure the E2E containers are stopped
3. Run `npm run test:e2e-setup`
    ![Screenshot 2025-02-26 at 20 00 31](https://github.com/user-attachments/assets/24a19514-fe6a-4189-8898-9dddbd3b53de)
4. Run `npm run test:e2e-up`, and check that the project name used is `env`
    ![Screenshot 2025-02-26 at 20 01 38](https://github.com/user-attachments/assets/1c2856b8-aa7f-47b6-99a1-05c33246fd5e)
5. Run `npm run test:e2e-down` and verify it has no effect.
6. Checkout this branch
7. Re-run `npm run test:e2e-setup` and check that the descriptive error message is displayed:
    ![Screenshot 2025-02-26 at 20 03 00](https://github.com/user-attachments/assets/1c66c688-f447-4e08-b999-5054a233af26)
8. Manually delete the `env` containers created during step 4.
9. Re-run `npm run test:e2e-up`, and check that the correct project name is used:
    ![Screenshot 2025-02-26 at 20 05 25](https://github.com/user-attachments/assets/26fd02b7-ecd4-4a73-a53e-53cbf5a0a26f)
10. Re-run  `npm run test:e2e-down`, and verify that the containers are correctly removed.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
