### PR TITLE
Legacy: skip save logic when using saved payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 * Tweak - Update payment method logos on the checkout page.
 * Update - Refactor unsupported deferred intent in the blocks checkout.
 * Add - Add BLIK LPM feature flag.
+* Fix - Skip unnecessary save step when already using a saved payment method for legacy checkout.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -825,7 +825,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		$force_save_source_value = apply_filters( 'wc_stripe_force_save_source', false );
 
-		if ( $this->save_payment_method_requested() || $force_save_source_value ) {
+		// We want to save the payment method if requested or forced, AND if we are not
+		// already using a saved payment method.
+		if ( ( $this->save_payment_method_requested() || $force_save_source_value ) &&
+			! $this->is_using_saved_payment_method() ) {
 			$query_params['save_payment_method'] = true;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,5 +132,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Update payment method logos on the checkout page.
 * Update - Refactor unsupported deferred intent in the blocks checkout.
 * Add - Add BLIK LPM feature flag.
+* Fix - Skip unnecessary save step when already using a saved payment method for legacy checkout.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes an edge-case scenario where we can end up unintentionally detaching saved payment methods from customers, potentially causing subscription renewals to fail.

For legacy checkout, when the customer requests to save the payment method but fails the card's auth challenge, we detach the payment method from the customer. This PR adds a condition that they were not using an already-saved payment method to begin with.

Additionally, if the customer clears the auth, we can end up saving duplicate payment method entries in `wp_woocommerce_payment_tokens`, pointing to the same Stripe payment method. This could lead to customers trying to delete the duplicates, unknowingly it also detaches the remaining payment method.

## Background
We have received reports where subscriptions are failing to renew with the following error message from Stripe:

```
The provided PaymentMethod was previously used with a PaymentIntent without Customer attachment, shared with a connected account without Customer attachment, or was detached from a Customer. It may not be used again. To use a PaymentMethod multiple times, you must attach it to a Customer first.
```

@mattallan  has flagged the following in p1738544815105449/1738346084.934989-slack-C3NCP7ZJ6

> maybe customers are failing the 3DS auth check on an existing card and that's deleting their saved payment methods which is attached to a subscription

I have verified that this flow can lead to us detaching a payment method used by a subscription: 
  - store is on legacy checkout
  - during checkout, the customer is using the saved payment method, and at the same time, the "save payment method" flag is set (i.e. the checkbox is checked, or `wc_stripe_force_save_source` filter is used) 
  - the payment triggers a 3DS flow and the customer fails to complete the auth challenge

## Testing instructions
1. Enable legacy checkout for your store, and enable logging.
2. As a logged in shopper, go to My account > Payment methods and save the credit card `4000002500003155`.
    - Complete the 3DS authentication modal when it pops up.
3. Go to the Stripe dashboard (https://dashboard.stripe.com/customers), to your customer's page, and under the Payment Methods section, verify that your saved payment method is there.
4. As the same shopper, add a product to cart and go to shortcode checkout.
5. Select `Use a new payment method`, and check the `Save payment information to my account for future purchases.`.
9. With "save for future purchases" still checked, switch from `Use a new payment method` to your saved payment method, and place your order.
   - In `develop`, you will see `/detach` requests in the logs. You will also find the payment method gone from the Stripe dashboard customers page.
   - In this branch, there should be no `/detach` requests, and the payment method should still be attached to the customer.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)