### PR TITLE
Add ACH support for WC Subscriptions

### DIFF
--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -987,6 +987,14 @@ trait WC_Stripe_Subscriptions_Trait {
 							/* translators: 1) email address associated with the Stripe Link payment method */
 							$payment_method_to_display = sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
 							break 3;
+						case WC_Stripe_Payment_Methods::ACH:
+							$payment_method_to_display = sprintf(
+								/* translators: account type (checking, savings), last 4 digits of account. */
+								__( 'Via %1$s account ending in %2$s', 'woocommerce-gateway-stripe' ),
+								ucfirst( $source->us_bank_account->account_type ),
+								$source->us_bank_account->last4
+							);
+							break 3;
 					}
 				}
 			}

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -990,7 +990,7 @@ trait WC_Stripe_Subscriptions_Trait {
 						case WC_Stripe_Payment_Methods::ACH:
 							$payment_method_to_display = sprintf(
 								/* translators: account type (checking, savings), last 4 digits of account. */
-								__( 'Via %1$s account ending in %2$s', 'woocommerce-gateway-stripe' ),
+								__( 'Via %1$s Account ending in %2$s', 'woocommerce-gateway-stripe' ),
 								ucfirst( $source->us_bank_account->account_type ),
 								$source->us_bank_account->last4
 							);

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
@@ -29,6 +29,7 @@ class WC_Stripe_UPE_Payment_Method_ACH extends WC_Stripe_UPE_Payment_Method {
 		$this->supported_currencies = [ WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ];
 		$this->supported_countries  = [ 'US' ];
 		$this->supports[]           = 'tokenization';
+		$this->supports[]           = 'subscriptions';
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @extends WC_Stripe_UPE_Payment_Method
  */
 class WC_Stripe_UPE_Payment_Method_ACH extends WC_Stripe_UPE_Payment_Method {
+	use WC_Stripe_Subscriptions_Trait;
 
 	/**
 	 * Stripe's internal identifier for ACH Direct Debit.
@@ -30,6 +31,9 @@ class WC_Stripe_UPE_Payment_Method_ACH extends WC_Stripe_UPE_Payment_Method {
 		$this->supported_countries  = [ 'US' ];
 		$this->supports[]           = 'tokenization';
 		$this->supports[]           = 'subscriptions';
+
+		// Check if subscriptions are enabled and add support for them.
+		$this->maybe_init_subscriptions();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3829 

## Changes proposed in this Pull Request:

Add ACH support for WC Subscriptions.

## Testing instructions

Reproduce the following critical flows using ACH for payments:

- [Purchase subscription product](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#purchase-subscription-product)
- [Purchase free trial subscription](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#purchase-free-trial-subscription)
- [Renew subscription](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#renew-subscription)
- [Change default payment method](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#change-default-payment-method)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
