### PR TITLE
Avoid duplicate payment method hidden input elements in shortcode checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@
 * Add - Use idempotency keys when creating payment intents, to help prevent duplicate charges for a single order.
 * Fix - Allow to save card during checkout with account creation.
 * Add - Add BLIK LPM feature flag.
+* Fix - Avoid duplicate payment method element for classic checkout
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -304,6 +304,14 @@ export const generateCheckoutEventNames = () => {
 };
 
 export const appendPaymentMethodIdToForm = ( form, paymentMethodId ) => {
+	// If the element already exists, remove it first, to avoid duplicates.
+	// This can happen if the payment is retried, e.g. entering a new card
+	// after a previous card was declined.
+	const existingElement = form.querySelector( '#wc-stripe-payment-method' );
+	if ( existingElement ) {
+		existingElement.remove();
+	}
+
 	form.append(
 		`<input type="hidden" id="wc-stripe-payment-method" name="wc-stripe-payment-method" value="${ paymentMethodId }" />`
 	);

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -303,12 +303,18 @@ export const generateCheckoutEventNames = () => {
 		.join( ' ' );
 };
 
+/**
+ * Appends a payment method ID to the form.
+ *
+ * @param {Object} form The jQuery form object.
+ * @param {string} paymentMethodId The payment method ID to append to the form.
+ */
 export const appendPaymentMethodIdToForm = ( form, paymentMethodId ) => {
 	// If the element already exists, remove it first, to avoid duplicates.
 	// This can happen if the payment is retried, e.g. entering a new card
 	// after a previous card was declined.
-	const existingElement = form.querySelector( '#wc-stripe-payment-method' );
-	if ( existingElement ) {
+	const existingElement = form.find( 'input#wc-stripe-payment-method' );
+	if ( existingElement.length ) {
 		existingElement.remove();
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -134,5 +134,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Use idempotency keys when creating payment intents, to help prevent duplicate charges for a single order.
 * Fix - Allow to save card during checkout with account creation.
 * Add - Add BLIK LPM feature flag.
+* Fix - Avoid duplicate payment method element for classic checkout
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/shortcode/retries.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/retries.spec.js
@@ -123,3 +123,30 @@ test( 'customer can retry payment, using a different payment method @smoke', asy
 		'Order received'
 	);
 } );
+
+/**
+ * This test verifies that exactly one element with the id wc-stripe-payment-method is present in the form,
+ * after retrying a payment.
+ */
+test( 'No duplicate payment method elements are created when retrying payments', async ( {
+	page,
+} ) => {
+	await fillCreditCardDetailsShortcode(
+		page,
+		config.get( 'cards.declined' )
+	);
+	await clickPlaceOrder( page );
+
+	// Expect the order to fail
+	await expect( page.locator( '.woocommerce-error' ) ).toBeVisible();
+
+	// Fail again
+	await clickPlaceOrder( page );
+
+	// Expect the order to fail
+	await expect( page.locator( '.woocommerce-error' ) ).toBeVisible();
+
+	// Expect only one element with the id wc-stripe-payment-method
+	const paymentMethodInputs = await page.$$( '#wc-stripe-payment-method' );
+	expect( paymentMethodInputs ).toHaveLength( 1 );
+} );


### PR DESCRIPTION
Fixes an issue for shortcode checkout where payment retries create a duplicate `#wc-stripe-payment-method` element in the form.

## Changes proposed in this Pull Request:
Check for old payment method elements before appending the new one, to avoid HTML elements with the same ID

## Testing instructions
1. Make sure legacy checkout is disabled.
2. As a shopper, add a product to cart and go to shortcode/classic checkout.
3. Use the card number `4000000000000002` to get a decline.
4. After getting a decline error, use the card number `4000000000009995`.
    - This will result in another decline, but the issue exists even when the payment retry is successful. We force a second decline only so we can use DevTools and inspect the document.
5. Elements tab, and bring up search, e.g. CMD+F.
6. Search for `#wc-stripe-payment-method`.
   - In `develop`, you will see two matches.
   - In this branch, you should only see one.
---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
