### PR TITLE
Add ACH support for WC Pre-Orders

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
@@ -30,7 +30,7 @@ class WC_Stripe_UPE_Payment_Method_ACH extends WC_Stripe_UPE_Payment_Method {
 		$this->supported_currencies = [ WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ];
 		$this->supported_countries  = [ 'US' ];
 		$this->supports[]           = 'tokenization';
-    $this->supports[]           = 'subscriptions';
+		$this->supports[]           = 'subscriptions';
 
 		// Check if subscriptions are enabled and add support for them.
 		$this->maybe_init_subscriptions();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
@@ -36,7 +36,7 @@ class WC_Stripe_UPE_Payment_Method_ACH extends WC_Stripe_UPE_Payment_Method {
 		$this->maybe_init_subscriptions();
 
 		// Add support for pre-orders.
-		$this->maybe_init_pre_orders();		
+		$this->maybe_init_pre_orders();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
@@ -29,6 +29,9 @@ class WC_Stripe_UPE_Payment_Method_ACH extends WC_Stripe_UPE_Payment_Method {
 		$this->supported_currencies = [ WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ];
 		$this->supported_countries  = [ 'US' ];
 		$this->supports[]           = 'tokenization';
+
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3809 

## Changes proposed in this Pull Request:

Add ACH support for WC Pre-Orders.

## Testing instructions

### Pre-Order (Charge Up Front)
1. Create a product, enable Pre-Orders, set When to Charge to Upfront.
2. On the storefront, purchase this product with ACH and use a customer account.
3. Verify the order in WooCommerce → Orders (payment captured immediately).
4. In WooCommerce → Pre-Orders, release the product and confirm no additional charge occurs.

### Pre-Order (Charge Upon Release)
1. Create a product, enable Pre-Orders, set When to Charge to Upon Release.
2. On the storefront, purchase this product with ACH and use a customer account (no immediate charge).
3. Verify the order in WooCommerce → Orders (should show a pre-order status).
4. In WooCommerce → Pre-Orders, release the product and confirm the customer is charged via ACH at release.

In both scenarios, please check the order notes and status logs for any anomalies.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
