### PR TITLE
Enable ACH feature flag by default

### DIFF
--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -22,7 +22,7 @@ class WC_Stripe_Feature_Flags {
 		'_wcstripe_feature_upe'            => 'yes',
 		self::ECE_FEATURE_FLAG_NAME        => 'yes',
 		self::AMAZON_PAY_FEATURE_FLAG_NAME => 'no',
-		self::LPM_ACH_FEATURE_FLAG_NAME    => 'no',
+		self::LPM_ACH_FEATURE_FLAG_NAME    => 'yes',
 		self::LPM_ACSS_FEATURE_FLAG_NAME   => 'no',
 		self::LPM_BACS_FEATURE_FLAG_NAME   => 'no',
 	];


### PR DESCRIPTION
Closes #4011 

## Changes proposed in this Pull Request:

Enable ACH feature flag by default.

## Testing instructions

1. Delete the `_wcstripe_feature_lpm_ach` option from your local environment.  
2. Ensure that the following criteria are met:  
   - The store is registered as a **US Merchant**.  
   - The store currency is set to **USD**.  
3. Navigate to the **Plugin Settings** (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`) page.  
4. Verify that **ACH** appears as an available payment option in the settings.  

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
