### PR TITLE
Fix warning notice related to subscriptions helper

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.3.0 - xxxx-xx-xx =
+* Fix - Improves the checking for existing customer attribute when retrieving a payment method that may be detached from a subscription.
 * Fix - Reverts the default value for the `capture_method` property to avoid breaking Amazon Pay when creating a payment intent.
 * Add - Adds a new feature flag to handle the Single Payment Element feature.
 * Dev - Moves the method to check if the subscriptions extension is enabled to a new helper class.

--- a/includes/compat/class-wc-stripe-subscriptions-helper.php
+++ b/includes/compat/class-wc-stripe-subscriptions-helper.php
@@ -48,7 +48,7 @@ class WC_Stripe_Subscriptions_Helper {
 			$source_id = $subscription->get_meta( '_stripe_source_id' );
 			if ( $source_id ) {
 				$payment_method = WC_Stripe_API::get_payment_method( $source_id );
-				if ( ! $payment_method->customer ) {
+				if ( ! isset( $payment_method->customer ) ) {
 					$detached_subscriptions[] = [
 						'id'                        => $subscription->get_id(),
 						'customer_id'               => $subscription->get_meta( '_stripe_customer_id' ),

--- a/includes/compat/class-wc-stripe-subscriptions-helper.php
+++ b/includes/compat/class-wc-stripe-subscriptions-helper.php
@@ -48,7 +48,7 @@ class WC_Stripe_Subscriptions_Helper {
 			$source_id = $subscription->get_meta( '_stripe_source_id' );
 			if ( $source_id ) {
 				$payment_method = WC_Stripe_API::get_payment_method( $source_id );
-				if ( ! isset( $payment_method->customer ) ) {
+				if ( empty( $payment_method->customer ) ) {
 					$detached_subscriptions[] = [
 						'id'                        => $subscription->get_id(),
 						'customer_id'               => $subscription->get_meta( '_stripe_customer_id' ),

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.3.0 - xxxx-xx-xx =
+* Fix - Improves the checking for existing customer attribute when retrieving a payment method that may be detached from a subscription.
 * Fix - Reverts the default value for the `capture_method` property to avoid breaking Amazon Pay when creating a payment intent.
 * Add - Adds a new feature flag to handle the Single Payment Element feature.
 * Dev - Moves the method to check if the subscriptions extension is enabled to a new helper class.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR just fixes an issue introduced in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3863 when for some reason the `customer` property does not exist in the payment method object.

<img width="1247" alt="Screenshot 2025-03-06 at 09 36 46" src="https://github.com/user-attachments/assets/25e980c1-61b0-4ac2-89ab-82dcad4f8cda" />

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review should be enough. The default behavior should not change. This just improves the condition checking.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
