### PR TITLE
Amazon Pay ECE: update settings to use new payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -43,6 +43,7 @@
 * Add - Add Amazon Pay payment method class.
 * Fix - Prevent potential duplicate renewal charges by ensuring subscription integration hooks are only attached once per Gateway ID
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
+* Update - Enable/disable Amazon Pay by adding/removing it from the enabled payment methods list.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/client/data/settings/__tests__/hooks.js
+++ b/client/data/settings/__tests__/hooks.js
@@ -29,6 +29,7 @@ import {
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_EPS,
 	PAYMENT_METHOD_GIROPAY,
+	PAYMENT_METHOD_AMAZON_PAY,
 } from 'wcstripe/stripe-utils/constants';
 
 jest.mock( '@wordpress/data' );
@@ -322,12 +323,6 @@ describe( 'Settings hooks tests', () => {
 			testedValue: [ 'checkout', 'cart' ],
 			fallbackValue: [],
 		},
-		useAmazonPayEnabledSettings: {
-			hook: useAmazonPayEnabledSettings,
-			storeKey: 'is_amazon_pay_enabled',
-			testedValue: true,
-			fallbackValue: false,
-		},
 		useAmazonPayButtonSize: {
 			hook: useAmazonPayButtonSize,
 			storeKey: 'amazon_pay_button_size',
@@ -399,4 +394,84 @@ describe( 'Settings hooks tests', () => {
 			} );
 		}
 	);
+
+	describe( 'useAmazonPayEnabledSettings()', () => {
+		test( 'returns true when PAYMENT_METHOD_AMAZON_PAY is in enabled_payment_method_ids', () => {
+			selectors = {
+				getSettings: jest.fn( () => ( {
+					enabled_payment_method_ids: [ PAYMENT_METHOD_AMAZON_PAY ],
+				} ) ),
+			};
+
+			const { result } = renderHook( useAmazonPayEnabledSettings );
+			const [ value ] = result.current;
+
+			expect( value ).toBeTruthy();
+		} );
+
+		test( 'returns false when PAYMENT_METHOD_AMAZON_PAY is not in enabled_payment_method_ids', () => {
+			selectors = {
+				getSettings: jest.fn( () => ( {
+					enabled_payment_method_ids: [ PAYMENT_METHOD_CARD ],
+				} ) ),
+			};
+
+			const { result } = renderHook( useAmazonPayEnabledSettings );
+			const [ value ] = result.current;
+
+			expect( value ).toBeFalsy();
+		} );
+
+		test( 'updates enabled_payment_method_ids when enabling Amazon Pay', () => {
+			actions = {
+				updateSettingsValues: jest.fn(),
+			};
+
+			selectors = {
+				getSettings: jest.fn( () => ( {
+					enabled_payment_method_ids: [ PAYMENT_METHOD_CARD ],
+				} ) ),
+			};
+
+			const { result } = renderHook( useAmazonPayEnabledSettings );
+			const [ , action ] = result.current;
+
+			act( () => {
+				action( true );
+			} );
+
+			expect( actions.updateSettingsValues ).toHaveBeenCalledWith( {
+				enabled_payment_method_ids: [
+					PAYMENT_METHOD_CARD,
+					PAYMENT_METHOD_AMAZON_PAY,
+				],
+			} );
+		} );
+
+		test( 'updates enabled_payment_method_ids when disabling Amazon Pay', () => {
+			actions = {
+				updateSettingsValues: jest.fn(),
+			};
+
+			selectors = {
+				getSettings: jest.fn( () => ( {
+					enabled_payment_method_ids: [
+						PAYMENT_METHOD_CARD,
+						PAYMENT_METHOD_AMAZON_PAY,
+					],
+				} ) ),
+			};
+
+			const { result } = renderHook( useAmazonPayEnabledSettings );
+			const [ , action ] = result.current;
+
+			act( () => {
+				action( false );
+			} );
+
+			expect( actions.updateSettingsValues ).toHaveBeenCalledWith( {
+				enabled_payment_method_ids: [ PAYMENT_METHOD_CARD ],
+			} );
+		} );
+	} );
 } );

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -1,6 +1,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useCallback } from 'react';
 import { STORE_NAME } from '../constants';
+import { PAYMENT_METHOD_AMAZON_PAY } from 'wcstripe/stripe-utils/constants';
 
 const EMPTY_ARR = [];
 
@@ -156,9 +157,32 @@ export const usePaymentRequestLocations = makeSettingsHook(
 	'payment_request_button_locations',
 	EMPTY_ARR
 );
-export const useAmazonPayEnabledSettings = makeSettingsHook(
-	'is_amazon_pay_enabled'
-);
+export const useAmazonPayEnabledSettings = () => {
+	const [
+		enabledMethodIds,
+		updateEnabledMethodIds,
+	] = useEnabledPaymentMethodIds();
+	const isAmazonPayEnabled = enabledMethodIds.includes(
+		PAYMENT_METHOD_AMAZON_PAY
+	);
+
+	const updateIsAmazonPayEnabled = ( isEnabled ) => {
+		if ( isEnabled ) {
+			updateEnabledMethodIds( [
+				...enabledMethodIds,
+				PAYMENT_METHOD_AMAZON_PAY,
+			] );
+		} else {
+			updateEnabledMethodIds( [
+				...enabledMethodIds.filter(
+					( id ) => id !== PAYMENT_METHOD_AMAZON_PAY
+				),
+			] );
+		}
+	};
+
+	return [ isAmazonPayEnabled, updateIsAmazonPayEnabled ];
+};
 export const useAmazonPayButtonSize = makeSettingsHook(
 	'amazon_pay_button_size',
 	''

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -88,11 +88,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'is_amazon_pay_enabled'              => [
-						'description'       => __( 'If Amazon Pay should be enabled.', 'woocommerce-gateway-stripe' ),
-						'type'              => 'boolean',
-						'validate_callback' => 'rest_validate_request_arg',
-					],
 					'amazon_pay_button_size'             => [
 						'description'       => __( 'Express checkout button sizes.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
@@ -266,7 +261,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'individual_payment_method_settings'       => $is_upe_enabled ? WC_Stripe_Helper::get_upe_individual_payment_method_settings( $this->gateway ) : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),
 
 				/* Settings > Express checkouts */
-				'is_amazon_pay_enabled'                    => 'yes' === $this->gateway->get_option( 'amazon_pay' ),
 				'amazon_pay_button_size'                   => $this->gateway->get_validated_option( 'amazon_pay_button_size' ),
 				'amazon_pay_button_locations'              => $this->gateway->get_validated_option( 'amazon_pay_button_locations' ),
 				'is_payment_request_enabled'               => 'yes' === $this->gateway->get_option( 'payment_request' ),
@@ -307,7 +301,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		/* Settings > Express checkouts */
 		$this->update_is_payment_request_enabled( $request );
 		$this->update_payment_request_settings( $request );
-		$this->update_is_amazon_pay_enabled( $request );
 		$this->update_amazon_pay_settings( $request );
 
 		/* Settings > Payments & transactions */
@@ -393,21 +386,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		$this->gateway->update_option( 'testmode', $is_test_mode_enabled ? 'yes' : 'no' );
-	}
-
-	/**
-	 * Updates the "Amazon Pay" enable/disable settings.
-	 *
-	 * @param WP_REST_Request $request Request object.
-	 */
-	private function update_is_amazon_pay_enabled( WP_REST_Request $request ) {
-		$is_amazon_pay_enabled = $request->get_param( 'is_amazon_pay_enabled' );
-
-		if ( null === $is_amazon_pay_enabled ) {
-			return;
-		}
-
-		$this->gateway->update_option( 'amazon_pay', $is_amazon_pay_enabled ? 'yes' : 'no' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -190,7 +190,7 @@ class WC_Stripe_Express_Checkout_Element {
 				'locale'                      => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
 				'is_link_enabled'             => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
 				'is_express_checkout_enabled' => $this->express_checkout_helper->is_express_checkout_enabled(),
-				'is_amazon_pay_enabled'       => $this->express_checkout_helper->is_amazon_pay_enabled(),
+				'is_amazon_pay_enabled'       => WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled(),
 				'is_payment_request_enabled'  => $this->express_checkout_helper->is_payment_request_enabled(),
 			],
 			'nonce'                  => [

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1359,7 +1359,9 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return boolean
 	 */
 	public function is_express_checkout_enabled() {
-		return $this->is_payment_request_enabled() || $this->is_amazon_pay_enabled() || WC_Stripe_UPE_Payment_Method_Link::is_link_enabled();
+		return $this->is_payment_request_enabled() ||
+			WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled() ||
+			WC_Stripe_UPE_Payment_Method_Link::is_link_enabled();
 	}
 
 	/**
@@ -1369,16 +1371,6 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_payment_request_enabled() {
 		return isset( $this->stripe_settings['payment_request'] ) && 'yes' === $this->stripe_settings['payment_request'];
-	}
-
-	/**
-	 * Returns whether Amazon Pay is enabled.
-	 *
-	 * @return boolean
-	 */
-	public function is_amazon_pay_enabled() {
-		return WC_Stripe_Feature_Flags::is_amazon_pay_available() &&
-			isset( $this->stripe_settings['amazon_pay'] ) && 'yes' === $this->stripe_settings['amazon_pay'];
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -450,7 +450,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['cartContainsSubscription']         = $this->is_subscription_item_in_cart();
 		$stripe_params['accountCountry']                   = WC_Stripe::get_instance()->account->get_account_country();
 		$stripe_params['isPaymentRequestEnabled']          = $express_checkout_helper->is_payment_request_enabled();
-		$stripe_params['isAmazonPayEnabled']               = $express_checkout_helper->is_amazon_pay_enabled();
+		$stripe_params['isAmazonPayEnabled']               = WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled();
 		$stripe_params['isLinkEnabled']                    = WC_Stripe_UPE_Payment_Method_Link::is_link_enabled();
 
 		// Add appearance settings.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
@@ -27,6 +27,40 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 	}
 
 	/**
+	 * Return if Amazon Pay is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_amazon_pay_enabled() {
+		// Amazon Pay is disabled if feature flag is disabled.
+		if ( ! WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
+			return false;
+		}
+
+		// Amazon Pay is disabled if UPE is disabled.
+		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+			return false;
+		}
+
+		$upe_enabled_method_ids = WC_Stripe_Helper::get_settings( null, 'upe_checkout_experience_accepted_payments' );
+
+		return is_array( $upe_enabled_method_ids ) && in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );
+	}
+
+	/**
+	 * Returns whether the payment method is available.
+	 *
+	 * Amazon Pay is rendered as an express checkout method only, for now.
+	 * We return false here so that it isn't considered available by WooCommerce
+	 * and rendered as a standard payment method at checkout.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return false;
+	}
+
+	/**
 	 * Returns whether the payment method requires automatic capture.
 	 *
 	 * @return bool

--- a/readme.txt
+++ b/readme.txt
@@ -153,5 +153,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add Amazon Pay payment method class.
 * Fix - Prevent potential duplicate renewal charges by ensuring subscription integration hooks are only attached once per Gateway ID
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
+* Update - Enable/disable Amazon Pay by adding/removing it from the enabled payment methods list.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -361,7 +361,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			'is_stripe_enabled'                     => [ 'is_stripe_enabled', 'enabled' ],
 			'is_test_mode_enabled'                  => [ 'is_test_mode_enabled', 'testmode' ],
 			'is_payment_request_enabled'            => [ 'is_payment_request_enabled', 'payment_request' ],
-			'is_amazon_pay_enabled'                 => [ 'is_amazon_pay_enabled', 'amazon_pay' ],
 			'is_spe_enabled'                        => [ 'is_spe_enabled', 'single_payment_element' ],
 			'is_manual_capture_enabled'             => [ 'is_manual_capture_enabled', 'capture', true ],
 			'is_saved_cards_enabled'                => [ 'is_saved_cards_enabled', 'saved_cards' ],


### PR DESCRIPTION
Part of #3859

## Changes proposed in this Pull Request:
As part of supporting subscriptions and payment tokens for Amazon Pay, we introduced Amazon Pay's own payment method class, i.e. `WC_Stripe_UPE_Payment_Method_Amazon_Pay`, in #4015.

In order for the new payment method to be available to use, it needs to be present in the list of enabled payment methods. This PR updates how we enable and disable Amazon Pay as a payment method, from using a boolean flag to adding and removing it from said list.

## Testing instructions

1. With the Amazon Pay feature flag off (default), verify that you do not see Amazon Pay in wp-admin or in the store.
2. Turn on the Amazon Pay feature flag `_wcstripe_feature_amazon_pay` using Stripe dev tools, or by adding it to `wp_options` with a value of `yes`
3. Enable Amazon Pay as a payment method, in the wp-admin Stripe settings page.
4. Verify that you are able to see Amazon Pay in the express checkout section for product, cart (classic and block), and checkout (classic and block) pages.
5. Verify that you do NOT see Amazon Pay as a standard payment method in classic checkout.
6. Disable Amazon Pay as a payment method, in the wp-admin Stripe settings page.
7. Verify that you are no longer able to see Amazon Pay in the product, cart (classic and block), and checkout (classic and block) pages.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
