### PR TITLE
Add support for Bacs to handle Pre-Orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,7 +32,7 @@
 * Fix - ACSS: Handle errors and edge cases.
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
-* Add - Add WooCommerce Pre-Orders support to Bacs
+* Add - Add WooCommerce Pre-Orders support to Bacs.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@
 * Fix - ACSS: Handle errors and edge cases.
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
+* Add - Add WooCommerce Pre-Orders support to Bacs
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -104,8 +104,8 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 			'woocommerce_available_payment_gateways',
 			function ( $available_gateways ) {
 				if (
-				$this->should_hide_bacs_for_pre_orders_charge_upon_release() ||
-				$this->should_hide_bacs_for_subscriptions_with_free_trials()
+					$this->should_hide_bacs_for_pre_orders_charge_upon_release() ||
+					$this->should_hide_bacs_for_subscriptions_with_free_trials()
 				) {
 					unset( $available_gateways['stripe_bacs_debit'] );
 				}
@@ -115,7 +115,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 	}
 
 	/**
-	 * Determines whether the Bacs payment gateway should be hidden for pre-orders  that are charged upon release.
+	 * Determines whether the Bacs payment gateway should be hidden for pre-orders that are charged upon release.
 	 *
 	 * WooCommerce Pre-Orders allows merchants to choose when to charge customers.
 	 * If a product is set to be charged upon release, Bacs can't be used for now as setup intents are not supported for Bacs.
@@ -133,7 +133,6 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		}
 		return false;
 	}
-
 
 	/**
 	 * Determines whether the Bacs payment gateway should be hidden for subscriptions with free trials.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -34,10 +34,15 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		// Check if subscriptions are enabled and add support for them.
 		$this->maybe_init_subscriptions();
 
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
+
 		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
 		if ( is_wc_endpoint_url( 'add-payment-method' ) ) {
 			unset( $this->supports['tokenization'] );
 		}
+
+		$this->hide_bacs_for_pre_orders_charge_upon_release();
 
 		$this->hide_bacs_for_subscriptions_with_free_trials();
 	}
@@ -93,6 +98,38 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		return $token;
 	}
 
+	/**
+	 * Hides the Bacs payment method for pre-orders that are charged upon release.
+	 *
+	 * This function removes the "stripe_bacs_debit" payment gateway from the available payment methods
+	 * if the cart contains a pre-order product that is charged upon release. This ensures that customers
+	 * do not select Bacs for pre-orders that are not charged upfront.
+	 *
+	 * @return void
+	 */
+	public function hide_bacs_for_pre_orders_charge_upon_release() {
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			function ( $available_gateways ) {
+				if ( is_checkout() && WC_Pre_Orders_Cart::cart_contains_pre_order() ) {
+					$product_id = reset( WC()->cart->get_cart() )['product_id'];
+					if ( WC_Pre_Orders_Product::product_is_charged_upon_release( $product_id ) ) {
+						unset( $available_gateways['stripe_bacs_debit'] );
+					}
+				}
+				return $available_gateways;
+			}
+		);
+	}
+
+	/**
+	 * Hides the Bacs payment method for subscriptions with free trials.
+	 *
+	 * This function removes the "stripe_bacs_debit" payment gateway from the available payment methods
+	 * if the cart contains a subscription with a free trial and the total cart amount is zero.
+	 *
+	 * @return void
+	 */
 	public function hide_bacs_for_subscriptions_with_free_trials() {
 		add_filter(
 			'woocommerce_available_payment_gateways',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -113,7 +113,8 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 			function ( $available_gateways ) {
 				if ( is_checkout() && class_exists( 'WC_Pre_Orders_Cart' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() ) {
 					// Iteration is unnecessary since only one pre-order product can be in the cart.
-					$product_id = reset( WC()->cart->get_cart() )['product_id'];
+					$cart = WC()->cart->get_cart();
+					$product_id = reset( $cart )['product_id'];
 					if ( WC_Pre_Orders_Product::product_is_charged_upon_release( $product_id ) ) {
 						unset( $available_gateways['stripe_bacs_debit'] );
 					}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -42,9 +42,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 			unset( $this->supports['tokenization'] );
 		}
 
-		$this->hide_bacs_for_pre_orders_charge_upon_release();
-
-		$this->hide_bacs_for_subscriptions_with_free_trials();
+		$this->maybe_hide_bacs_payment_gateway();
 	}
 
 	/**
@@ -99,25 +97,17 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 	}
 
 	/**
-	 * Hides the Bacs payment method for pre-orders that are charged upon release.
-	 *
-	 * This function removes the "stripe_bacs_debit" payment gateway from the available payment methods
-	 * if the cart contains a pre-order product that is charged upon release. This ensures that customers
-	 * do not select Bacs for pre-orders that are not charged upfront.
-	 *
-	 * @return void
+	 * Conditionally hides the Bacs payment gateway for specific scenarios.
 	 */
-	public function hide_bacs_for_pre_orders_charge_upon_release() {
+	public function maybe_hide_bacs_payment_gateway() {
 		add_filter(
 			'woocommerce_available_payment_gateways',
 			function ( $available_gateways ) {
-				if ( is_checkout() && class_exists( 'WC_Pre_Orders_Cart' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() ) {
-					// Iteration is unnecessary since only one pre-order product can be in the cart.
-					$cart = WC()->cart->get_cart();
-					$product_id = reset( $cart )['product_id'];
-					if ( WC_Pre_Orders_Product::product_is_charged_upon_release( $product_id ) ) {
-						unset( $available_gateways['stripe_bacs_debit'] );
-					}
+				if (
+				$this->should_hide_bacs_for_pre_orders_charge_upon_release() ||
+				$this->should_hide_bacs_for_subscriptions_with_free_trials()
+				) {
+					unset( $available_gateways['stripe_bacs_debit'] );
 				}
 				return $available_gateways;
 			}
@@ -125,29 +115,45 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 	}
 
 	/**
-	 * Hides the Bacs payment method for subscriptions with free trials.
+	 * Determines whether the Bacs payment gateway should be hidden for pre-orders  that are charged upon release.
 	 *
-	 * This function removes the "stripe_bacs_debit" payment gateway from the available payment methods
-	 * if the cart contains a subscription with a free trial and the total cart amount is zero.
+	 * WooCommerce Pre-Orders allows merchants to choose when to charge customers.
+	 * If a product is set to be charged upon release, Bacs can't be used for now as setup intents are not supported for Bacs.
 	 *
-	 * @return void
+	 * @return bool True if Bacs should be hidden, false otherwise.
 	 */
-	public function hide_bacs_for_subscriptions_with_free_trials() {
-		add_filter(
-			'woocommerce_available_payment_gateways',
-			function ( $available_gateways ) {
-				global $post;
-				$is_checkout_shortcode_page          = wc_post_content_has_shortcode( 'woocommerce_checkout' ) || has_block( 'woocommerce/classic-shortcode', $post );
-				$is_update_order_review_ajax_request = defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['wc-ajax'] ) && 'update_order_review' === $_REQUEST['wc-ajax'];
-				if ( $is_checkout_shortcode_page || $is_update_order_review_ajax_request ) {
-					// Checking if the amount is zero allows us to process orders that include subscriptions with a free trial,
-					// as long as another product increases the total amount, ensuring compatibility with Bacs.
-					if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_free_trial() && (float) WC()->cart->total === 0.00 ) {
-						unset( $available_gateways['stripe_bacs_debit'] );
-					}
-				}
-				return $available_gateways;
+	public function should_hide_bacs_for_pre_orders_charge_upon_release() {
+		if ( is_checkout() && class_exists( 'WC_Pre_Orders_Cart' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() ) {
+			$cart = WC()->cart->get_cart();
+			// Iteration is unnecessary since only one pre-order product can be in the cart.
+			$product_id = reset( $cart )['product_id'];
+			if ( class_exists( 'WC_Pre_Orders_Product' ) && WC_Pre_Orders_Product::product_is_charged_upon_release( $product_id ) ) {
+				return true;
 			}
-		);
+		}
+		return false;
+	}
+
+
+	/**
+	 * Determines whether the Bacs payment gateway should be hidden for subscriptions with free trials.
+	 *
+	 * If the cart contains a subscription with a free trial and the cart total amount is zero,
+	 * Bacs can't be used for now as setup intents are not supported for Bacs.
+	 *
+	 * @return bool True if Bacs should be hidden, false otherwise.
+	 */
+	public function should_hide_bacs_for_subscriptions_with_free_trials() {
+		global $post;
+		$is_checkout_shortcode_page          = wc_post_content_has_shortcode( 'woocommerce_checkout' ) || has_block( 'woocommerce/classic-shortcode', $post );
+		$is_update_order_review_ajax_request = defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['wc-ajax'] ) && 'update_order_review' === $_REQUEST['wc-ajax'];
+		if ( $is_checkout_shortcode_page || $is_update_order_review_ajax_request ) {
+			// Checking if the amount is zero allows us to process orders that include subscriptions with a free trial,
+			// as long as another product increases the total amount, ensuring compatibility with Bacs.
+			if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_free_trial() && (float) WC()->cart->total === 0.00 ) {
+				return true;
+			}
+		}
+		return false;
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -111,7 +111,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		add_filter(
 			'woocommerce_available_payment_gateways',
 			function ( $available_gateways ) {
-				if ( is_checkout() && WC_Pre_Orders_Cart::cart_contains_pre_order() ) {
+				if ( is_checkout() && class_exists( 'WC_Pre_Orders_Cart' ) && WC_Pre_Orders_Cart::cart_contains_pre_order() ) {
 					// Iteration is unnecessary since only one pre-order product can be in the cart.
 					$product_id = reset( WC()->cart->get_cart() )['product_id'];
 					if ( WC_Pre_Orders_Product::product_is_charged_upon_release( $product_id ) ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -112,6 +112,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 			'woocommerce_available_payment_gateways',
 			function ( $available_gateways ) {
 				if ( is_checkout() && WC_Pre_Orders_Cart::cart_contains_pre_order() ) {
+					// Iteration is unnecessary since only one pre-order product can be in the cart.
 					$product_id = reset( WC()->cart->get_cart() )['product_id'];
 					if ( WC_Pre_Orders_Product::product_is_charged_upon_release( $product_id ) ) {
 						unset( $available_gateways['stripe_bacs_debit'] );

--- a/readme.txt
+++ b/readme.txt
@@ -142,6 +142,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - ACSS: Handle errors and edge cases.
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
-* Add - Add WooCommerce Pre-Orders support to Bacs
+* Add - Add WooCommerce Pre-Orders support to Bacs.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -142,5 +142,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - ACSS: Handle errors and edge cases.
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
+* Add - Add WooCommerce Pre-Orders support to Bacs
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3803

## Changes proposed in this Pull Request:

- Added support for pre-orders by initializing the `maybe_init_pre_orders` method in the constructor.

- Introduced the `hide_bacs_for_pre_orders_charge_upon_release` method to remove the Bacs payment option for pre-orders that are charged upon release. This prevents customers from selecting Bacs for pre-orders that are not charged upfront, as Bacs does not support delayed charges. The limitation is similar to [the one affecting subscriptions with free trials](https://github.com/woocommerce/woocommerce-gateway-stripe/issues/3798#issuecomment-2695488273).

## Testing instructions

> [!IMPORTANT]  
> First, make sure that the business in your Stripe account is located in the UK ([link](https://dashboard.stripe.com/test/settings/account)) and that your default currency is GBP ([link](https://dashboard.stripe.com/settings/payouts)). Otherwise you won't be able to see Bacs as a payment option.

> [!IMPORTANT]  
> Update the store country to the UK and set the currency to GBP in the WooCommerce settings.

> [!IMPORTANT]  
> Also, make sure the Bacs feature is enabled. You can use the following to do that:
`wp option update _wcstripe_feature_lpm_bacs 'yes'`. Also, you can enable Bacs using the dev tools extension.

- Switch to this branch.
- Install the WooCommerce Pre-Order extension

### Test Pre-Orders that charge upon release

- Create a simple product.
- Enable pre-orders for the product.
- Define a future availability date.
- **Set "When to Charge" to "Upfront"**
- Add the product to cart.
- Checkout with Bacs without issues.

### Test Pre-Orders that charge upon release
- Create a simple product.
- Enable pre-orders for the product.
- Define a future availability date.
- **Set "When to Charge" to "Upon release"**
- Add the product to cart and Bacs should not be available as payment option on the checkout form.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
