### PR TITLE
Fix legacy checkout settings overwrite issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@
 * Fix - ACSS: Handle errors and edge cases.
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
+* Fix - Fix issue where Legacy Checkout settings get overwritten with old value.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -522,15 +522,12 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$settings = WC_Stripe_Helper::get_stripe_settings();
-
 		// If the new UPE is enabled, we need to remove the flag to ensure legacy SEPA tokens are updated flag.
 		if ( $is_upe_enabled && ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			delete_option( 'woocommerce_stripe_subscriptions_legacy_sepa_tokens_updated' );
 		}
 
-		$settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = $is_upe_enabled ? 'yes' : 'disabled';
-		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+		$this->gateway->update_option( WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME, $is_upe_enabled ? 'yes' : 'disabled' );
 
 		// including the class again because otherwise it's not present.
 		if ( WC_Stripe_Inbox_Notes::are_inbox_notes_supported() ) {

--- a/readme.txt
+++ b/readme.txt
@@ -142,5 +142,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - ACSS: Handle errors and edge cases.
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
+* Fix - Fix issue where Legacy Checkout settings get overwritten with old value.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes issue flagged in p1741286062119479-slack-C055WHLA98D

Also fixes failing e2e legacy tests.

## Changes proposed in this Pull Request:
To update the `Enable the legacy checkout experience` in settings, we need to call `WC_Settings_API::update_option` instead of manually updating it. This is so later calls to the function does not overwrite new values, due to in-memory settings still holding the old value.

Calling `WC_Settings_API::update_option()` updates in-memory settings as well as the database.

## Testing instructions
1. Go to Stripe > Settings > Advanced settings, and toggle `Enable the legacy checkout experience`, and save. 
   - In `develop`, the form reloads and the checkbox reverts to its old state.
      - For example, if you enable and save, after the reload, the checkbox is unchecked. If you peek at `upe_checkout_experience_enabled` inside `woocommerce_stripe_settings` in the `wp_options` table, you will see a `yes` instead of the expected `disabled`.
   - In this branch, the setting should stick.
2. Failing e2e legacy tests should be green again.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)