### PR TITLE
Fix background in express checkout settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
 * Add - Add WooCommerce Pre-Orders support to Bacs.
+* Tweak - Fix background in express checkout settings.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/client/settings/payment-request-section/styles.scss
+++ b/client/settings/payment-request-section/styles.scss
@@ -6,7 +6,6 @@
 			display: flex;
 			margin: 0;
 			padding: 16px 24px 14px 24px;
-			background: #fff;
 			flex-wrap: wrap;
 			justify-content: flex-start;
 			align-items: center;

--- a/readme.txt
+++ b/readme.txt
@@ -143,5 +143,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add subscriptions support to Bacs.
 * Update - Add tracks events for payment method settings updates.
 * Add - Add WooCommerce Pre-Orders support to Bacs.
+* Tweak - Fix background in express checkout settings.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

- Remove redundant background color from `.express-checkout`.

### Screenshots

| Before | After |
| -- | -- |
| <img width="400" src="https://github.com/user-attachments/assets/24be7fe3-4d24-4437-a435-af23fd0f893c" /> | <img width="400" src="https://github.com/user-attachments/assets/fa215b19-03f1-49c1-afd6-110474f2e42e" /> |

## Testing instructions

1. Switch to this branch.
2. Run `npm run start`.
3. Navigate to the settings page and ensure the express checkout section border looks like the "After" screenshot.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
