### PR TITLE
Fix Bacs Shortcode Tokenization

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -38,11 +38,6 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		// Add support for pre-orders.
 		$this->maybe_init_pre_orders();
 
-		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
-		if ( is_wc_endpoint_url( 'add-payment-method' ) ) {
-			$this->supports = array_values( array_diff( $this->supports, [ 'tokenization' ] ) );
-		}
-
 		$this->maybe_hide_bacs_payment_gateway();
 	}
 
@@ -106,13 +101,27 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 			function ( $available_gateways ) {
 				if (
 					$this->should_hide_bacs_for_pre_orders_charge_upon_release() ||
-					$this->should_hide_bacs_for_subscriptions_with_free_trials()
+					$this->should_hide_bacs_for_subscriptions_with_free_trials() ||
+					$this->should_hide_bacs_on_add_payment_page()
 				) {
 					unset( $available_gateways['stripe_bacs_debit'] );
 				}
 				return $available_gateways;
 			}
 		);
+	}
+
+	/**
+	 * Determines whether the Bacs payment gateway should be hidden on the "Add Payment Method" page.
+	 *
+	 * @return bool True if the Bacs payment gateway should be hidden, false otherwise.
+	 */
+	public function should_hide_bacs_on_add_payment_page() {
+		if ( is_wc_endpoint_url( 'add-payment-method' ) ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -40,7 +40,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 
 		// Remove Bacs from the “Add Payment Method” page for now, as its implementation will be handled later.
 		if ( is_wc_endpoint_url( 'add-payment-method' ) ) {
-			unset( $this->supports['tokenization'] );
+			$this->supports = array_values( array_diff( $this->supports, [ 'tokenization' ] ) );
 		}
 
 		$this->maybe_hide_bacs_payment_gateway();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -30,6 +30,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 		$this->accept_only_domestic_payment = true;
 		$this->label                        = __( 'Bacs Direct Debit', 'woocommerce-gateway-stripe' );
 		$this->description                  = __( 'Bacs Direct Debit enables customers in the UK to pay by providing their bank account details.', 'woocommerce-gateway-stripe' );
+		$this->supports[]                   = 'tokenization';
 
 		// Check if subscriptions are enabled and add support for them.
 		$this->maybe_init_subscriptions();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -102,7 +102,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 				if (
 					$this->should_hide_bacs_for_pre_orders_charge_upon_release() ||
 					$this->should_hide_bacs_for_subscriptions_with_free_trials() ||
-					$this->should_hide_bacs_on_add_payment_page()
+					$this->should_hide_bacs_on_add_payment_method_page()
 				) {
 					unset( $available_gateways['stripe_bacs_debit'] );
 				}
@@ -116,7 +116,7 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 	 *
 	 * @return bool True if the Bacs payment gateway should be hidden, false otherwise.
 	 */
-	public function should_hide_bacs_on_add_payment_page() {
+	public function should_hide_bacs_on_add_payment_method_page() {
 		if ( is_wc_endpoint_url( 'add-payment-method' ) ) {
 			return true;
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -144,10 +144,8 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 	 * @return bool True if Bacs should be hidden, false otherwise.
 	 */
 	public function should_hide_bacs_for_subscriptions_with_free_trials() {
-		global $post;
-		$is_checkout_shortcode_page          = wc_post_content_has_shortcode( 'woocommerce_checkout' ) || has_block( 'woocommerce/classic-shortcode', $post );
 		$is_update_order_review_ajax_request = defined( 'DOING_AJAX' ) && DOING_AJAX && isset( $_REQUEST['wc-ajax'] ) && 'update_order_review' === $_REQUEST['wc-ajax'];
-		if ( $is_checkout_shortcode_page || $is_update_order_review_ajax_request ) {
+		if ( is_checkout() || $is_update_order_review_ajax_request ) {
 			// Checking if the amount is zero allows us to process orders that include subscriptions with a free trial,
 			// as long as another product increases the total amount, ensuring compatibility with Bacs.
 			if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_free_trial() && (float) WC()->cart->total === 0.00 ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

While testing Bacs direct debit saved payment methods, I found that my saved method was not displaying on the shortcode checkout. It was displaying on blocks checkout, My Account page, and in the Stripe customer dashboard though. I confirmed the issue was that the payment method was not marked as support `tokenization`. This PR adds that support and confirms that the removal of that support for the "Add New Payment Method" on the My Account page is still applied (i.e. shoppers can't add a Bacs payment method from the My Account page).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

My biggest concerns with this PR that I'd like to confirm through testing is that all the scenarios that Bacs should be hidden (My Account > Add New, Subscription with free trial, Pre-Order with delayed charges) are still hidden properly.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

> [!IMPORTANT]  
> First, make sure that the business in your Stripe account is located in the UK ([link](https://dashboard.stripe.com/test/settings/account)) and that your default currency is GBP ([link](https://dashboard.stripe.com/settings/payouts)). Otherwise you won't be able to see Bacs as a payment option.

> [!IMPORTANT]  
> Update the store country to the UK and set the currency to GBP in the WooCommerce settings.

**Checkout with saved payment method**
- Switch to this branch.
- As a logged in shopper, add a product to the cart.
- Visit the shortcode checkout page.
- Enter a valid UK address.
- Confirm Bacs Direct Debit is an available payment method.
- Enter Bacs data, checking the "Save payment information..." box.
- Complete the order.
- Visit My Account page and confirm payment method was saved.
- Attempt another checkout with the same shopper.
- Confirm that the newly saved payment method is availabe on the shortcode checkout page.

**Not able to save method from My Account**
- As a logged in shopper visit the My Account page.
- Click on Payment Methods then click "Add payment method".
- Confirm that Bacs Direct Debit is not an option from this page.

Some other things to test for regressions:
- A subscription checkout
- A free trial subscription checkout
- A pre-order checkout
- A delayed payment pre-order checkout
- Confirm saved payment methods still work on blocks checkout.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
This is just fixing a feature that hasn't been released yet and should be considered as part of the overall changelog entry for the feature being released.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
