### PR TITLE
Fix duplicate token retrieval by using the correct payment method ID

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@
 * Add - Add WooCommerce Pre-Orders support to Bacs.
 * Tweak - Fix background in express checkout settings.
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
+* Fix - Fix duplicate token retrieval for reusable payment methods other than card.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2455,7 +2455,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 
 		// Searches for an existing duplicate token to update.
-		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $payment_method_instance->get_id() );
+		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $payment_method_instance->id );
 
 		if ( $found_token ) {
 			// Update the token with the new payment method ID.
@@ -2613,7 +2613,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$customer->clear_cache();
 
 			// Check if a token with the same payment method details exist. If so, just updates the payment method ID and return.
-			$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $user->ID, $payment_method->get_id() );
+			$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $user->ID, $payment_method->id );
 
 			// If we have a token found, update it and return.
 			if ( $found_token ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2454,7 +2454,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		}
 
 		// Searches for an existing duplicate token to update.
-		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $this->id );
+		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $payment_method_instance->get_id() );
 
 		if ( $found_token ) {
 			// Update the token with the new payment method ID.
@@ -2612,7 +2612,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$customer->clear_cache();
 
 			// Check if a token with the same payment method details exist. If so, just updates the payment method ID and return.
-			$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $user->ID, $this->id );
+			$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $user->ID, $payment_method->get_id() );
 
 			// If we have a token found, update it and return.
 			if ( $found_token ) {

--- a/readme.txt
+++ b/readme.txt
@@ -150,5 +150,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add WooCommerce Pre-Orders support to Bacs.
 * Tweak - Fix background in express checkout settings.
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
+* Fix - Fix duplicate token retrieval for reusable payment methods other than card.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
This PR fixes an issue where duplicate payment tokens were being created for non-card payment methods due to an incorrect payment gateway ID being used. Previously, tokenization worked correctly only for card payments but failed for other reusable payment methods like ACH or ACSS ([in progress](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4013)).

## Changes proposed in this Pull Request:

- Ensure the correct payment gateway ID is used for token retrieval.
- Prevent duplicate payment methods from being saved in "My Account" and during checkout.

## Testing instructions

### Test 1: Reproducing the issue (on `develop`)

1. Switch to `develop`.
2. Add a product to the cart and proceed to checkout.
3. Select a **reusable** payment method other than card (e.g., ACH).
4. Enable "Save payment information to my account for future purchases.".
5. Complete the checkout.
6. Repeat steps 2–5.
7. Navigate to **My Account > Payment Methods** or return to checkout and observe that the payment method has been duplicated.
8. Delete the duplicated payment methods from **My Account**.
9. Add the payment methods again through **My Account** and observe that the duplication issue also happens from **My account.**

### Test 2: Verify the Fix (on this branch)

1. Switch to this branch.
2. Repeat the same steps as **Test 1** from checkout and from **My Account**.
3. Observe that the payment method is no longer duplicated.

### Test 3: Ensure No Regressions (Card payments)

1. Switch to this branch.
2. Add a product to the cart and proceed to checkout.
3. Select the card payment method and enable "Save payment information to my account for future purchases.".
4. Complete the checkout process.
5. Repeat steps 2–4.
6. Verify that the card payment method is stored correctly without duplication.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
