### PR TITLE
Fix fatal error with PRB buttons

### DIFF
--- a/.github/workflows/php-code-coverage.yml
+++ b/.github/workflows/php-code-coverage.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   pull-requests: write
-  contents: read
 
 jobs:
   test:

--- a/.github/workflows/php-code-coverage.yml
+++ b/.github/workflows/php-code-coverage.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   test:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.3.0 - xxxx-xx-xx =
+* Fix - Fixes a possible fatal error when a product added to the cart cannot be found (with Payment Request Buttons).
 * Dev - Adds a new README.md file to the plugin with specific development-focused instructions.
 * Add - Implements the Single Payment Element feature for the new checkout experience on the block checkout page.
 * Dev - Additional replacements for payment method constant values on the backend.

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1467,35 +1467,45 @@ class WC_Stripe_Payment_Request {
 			define( 'WOOCOMMERCE_CART', true );
 		}
 
-		WC()->shipping->reset_shipping();
+		try {
+			WC()->shipping->reset_shipping();
 
-		$product_id   = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
-		$qty          = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
-		$product      = wc_get_product( $product_id );
-		$product_type = $product->get_type();
+			$product_id = isset( $_POST['product_id'] ) ? absint( $_POST['product_id'] ) : 0;
+			$qty        = ! isset( $_POST['qty'] ) ? 1 : absint( $_POST['qty'] );
+			$product    = wc_get_product( $product_id );
 
-		// First empty the cart to prevent wrong calculation.
-		WC()->cart->empty_cart();
+			if ( ! is_a( $product, 'WC_Product' ) ) {
+				/* translators: 1) The product Id */
+				throw new Exception( sprintf( __( 'Product with the ID (%1$s) cannot be found.', 'woocommerce-gateway-stripe' ), $product_id ) );
+			}
 
-		if ( ( 'variable' === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
-			$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
+			$product_type = $product->get_type();
 
-			$data_store   = WC_Data_Store::load( 'product' );
-			$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+			// First empty the cart to prevent wrong calculation.
+			WC()->cart->empty_cart();
 
-			WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
-		} elseif ( in_array( $product_type, $this->supported_product_types(), true ) ) {
-			WC()->cart->add_to_cart( $product->get_id(), $qty );
+			if ( ( 'variable' === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
+				$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
+
+				$data_store   = WC_Data_Store::load( 'product' );
+				$variation_id = $data_store->find_matching_product_variation( $product, $attributes );
+
+				WC()->cart->add_to_cart( $product->get_id(), $qty, $variation_id, $attributes );
+			} elseif ( in_array( $product_type, $this->supported_product_types(), true ) ) {
+				WC()->cart->add_to_cart( $product->get_id(), $qty );
+			}
+
+			WC()->cart->calculate_totals();
+
+			$data           = [];
+			$data          += $this->build_display_items();
+			$data['result'] = 'success';
+
+			// @phpstan-ignore-next-line (return statement is added)
+			wp_send_json( $data );
+		} catch ( Exception $e ) {
+			wp_send_json( [ 'error' => wp_strip_all_tags( $e->getMessage() ) ] );
 		}
-
-		WC()->cart->calculate_totals();
-
-		$data           = [];
-		$data          += $this->build_display_items();
-		$data['result'] = 'success';
-
-		// @phpstan-ignore-next-line (return statement is added)
-		wp_send_json( $data );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.3.0 - xxxx-xx-xx =
+* Fix - Fixes a possible fatal error when a product added to the cart cannot be found (with Payment Request Buttons).
 * Dev - Adds a new README.md file to the plugin with specific development-focused instructions.
 * Add - Implements the Single Payment Element feature for the new checkout experience on the block checkout page.
 * Dev - Additional replacements for payment method constant values on the backend.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR fixes a possible fatal error happening when a product cannot be found, related to PRBs' add to cart ajax endpoint. This error was caught with Grafana:
```
PHP Fatal error: Uncaught Error: Call to a member function get_type() on bool in /wordpress/plugins/woocommerce-gateway-stripe/9.2.0/includes/payment-methods/class-wc-stripe-payment-request.php:1475 Stack trace: #0 /wordpress/core/6.7.2/wp-includes/class-wp-hook.php(324): WC_Stripe_Payment_Request->ajax_add_to_cart('') #1 /wordpress/core/6.7.2/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array) #2 /wordpress/core/6.7.2/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #3 /wordpress/plugins/woocommerce/9.7.1/includes/class-wc-ajax.php(98): do_action('wc_ajax_wc_stri...') #4 /wordpress/core/6.7.2/wp-includes/class-wp-hook.php(324): WC_AJAX::do_wc_ajax('') #5 /wordpress/core/6.7.2/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(false, Array) #6 /wordpress/core/6.7.2/wp-includes/plugin.php(517): WP_Hook->do_action(Array) #7 /wordpress/core/6.7.2/wp-includes/template-loader.php(13): do_action('template_redire...') #8 /wordpress/core/6.7.2/wp-blog-header.php(19): require_once('/wordpress/core...') #9 /wordpress/core/6.7.2/index.php(17): require('/wordpress/core...') #10 {main} thrown in /wordpress/plugins/woocommerce-gateway-stripe/9.2.0/includes/payment-methods/class-wc-stripe-payment-request.php on line 1475
``` 

On a regular store setup, this error should not happen since we deprecated PRBs in favor of express payment methods. But this change should at least make the code safer.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review should be enough. Check if the tests are still passing.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
