### PR TITLE
Copy updates for the SPE setting

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.3.0 - xxxx-xx-xx =
+* Tweak - Updates the Single Payment Element setting copy. Now it is labeled "Smart Checkout".
 * Dev - Adds a new README.md file to the plugin with specific development-focused instructions.
 * Add - Implements the Single Payment Element feature for the new checkout experience on the block checkout page.
 * Dev - Additional replacements for payment method constant values on the backend.

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -62,7 +62,7 @@ describe( 'AdvancedSettings', () => {
 		render( <AdvancedSettings /> );
 
 		expect(
-			screen.queryByText( 'Single payment element' )
+			screen.queryByText( 'Enable Smart Checkout (Recommended)' )
 		).not.toBeInTheDocument();
 	} );
 
@@ -72,7 +72,7 @@ describe( 'AdvancedSettings', () => {
 		render( <AdvancedSettings /> );
 
 		expect(
-			screen.queryByText( 'Single payment element' )
+			screen.queryByText( 'Enable Smart Checkout (Recommended)' )
 		).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/advanced-settings-section/__tests__/single-payment-element-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/single-payment-element-feature.test.js
@@ -11,7 +11,7 @@ describe( 'Single Payment Element feature setting', () => {
 		render( <SinglePaymentElementFeature /> );
 
 		expect(
-			screen.queryByText( 'Single payment element' )
+			screen.queryByText( 'Enable Smart Checkout (Recommended)' )
 		).toBeInTheDocument();
 	} );
 

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -17,22 +17,25 @@ const SinglePaymentElementFeature = () => {
 	return (
 		<>
 			<h4>
-				{ __( 'Single payment element', 'woocommerce-gateway-stripe' ) }
+				{ __(
+					'Enable Smart Checkout (Recommended)',
+					'woocommerce-gateway-stripe'
+				) }
 			</h4>
 			<CheckboxControl
 				data-testid="single-payment-element-checkbox"
 				label={ __(
-					'Enable the single payment element feature',
+					'Enable Smart Checkout to display payment methods',
 					'woocommerce-gateway-stripe'
 				) }
 				help={ createInterpolateElement(
 					__(
-						"By enabling this, your store checkout form will use Stripe's dynamic payment methods. Legacy checkout must be disabled. <learnMoreLink>Learn more</learnMoreLink>.",
+						"Automatically display the most relevant payment methods for each customer with Stripe's AI-driven Dynamic Payment Methods to optimize your checkout for conversions. <learnMoreLink>Learn more</learnMoreLink>.",
 						'woocommerce-gateway-stripe'
 					),
 					{
 						learnMoreLink: (
-							<ExternalLink href="https://docs.stripe.com/connect/dynamic-payment-methods" />
+							<ExternalLink href="https://woocommerce.com/document/stripe/setup-and-configuration/settings-guide/#advanced-settings" />
 						),
 					}
 				) }

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.3.0 - xxxx-xx-xx =
+* Tweak - Updates the Single Payment Element setting copy. Now it is labeled "Smart Checkout".
 * Dev - Adds a new README.md file to the plugin with specific development-focused instructions.
 * Add - Implements the Single Payment Element feature for the new checkout experience on the block checkout page.
 * Dev - Additional replacements for payment method constant values on the backend.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #4028
Figma: 0fiyiUe18lGU6kGyQNmXxE-fi?node-id=275-8546
Discussion: peNR48-1bj-p2

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR updates the copy for the new Single Payment Element setting, now labeled "Smart Checkout" for merchants. The goal is to make it easier for users to understand how it works, and to avoid confusion with other features.

It changes the title, the label, description, and destination URL for the "Learn more" link (now pointing to `https://woocommerce.com/document/stripe/setup-and-configuration/settings-guide/#advanced-settings`).

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`tweak/copy-updates-for-the-spe-setting`)
- Connect your Stripe account
- Enable the SPE feature flag (`_wcstripe_feature_spe`). You can do it by either hardcoding the return value of `is_spe_available` to `true` or by running `npm run wp option update _wcstripe_feature_spe 'yes'`
- As a merchant, disable the legacy checkout experience in settings (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`)
- Confirm you can see the new version for the SPE setting:
<img width="1054" alt="Screenshot 2025-03-12 at 09 30 35" src="https://github.com/user-attachments/assets/89beb83e-d55d-4922-a6e9-a34d65a013eb" />

- Confirm the link is sending you to `https://woocommerce.com/document/stripe/setup-and-configuration/settings-guide/#advanced-settings`

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
