### PR TITLE
Temporarily disabling Store API integration for express checkouts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.3.0 - xxxx-xx-xx =
+* Fix - Temporarily disables the Store API integration for ECE due incompatibility issues with the Order Status Manager extension.
 * Dev - Adds a new README.md file to the plugin with specific development-focused instructions.
 * Add - Implements the Single Payment Element feature for the new checkout experience on the block checkout page.
 * Dev - Additional replacements for payment method constant values on the backend.

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -611,6 +611,19 @@ export default class WCStripeAPI {
 	}
 
 	/**
+	 * Creates order based on Express Checkout ECE payment method (legacy version, non-StoreAPI).
+	 *
+	 * @param {Object} paymentData Order data.
+	 * @return {Promise} Promise for the request to the server.
+	 */
+	expressCheckoutECECreateOrderLegacy( paymentData ) {
+		return this.request( getExpressCheckoutAjaxURL( 'create_order' ), {
+			_wpnonce: getExpressCheckoutData( 'nonce' )?.checkout,
+			...getRequiredFieldDataFromCheckoutForm( paymentData ),
+		} );
+	}
+
+	/**
 	 * Pays for an order based on the Express Checkout payment method.
 	 *
 	 * @param {number} order The order ID.
@@ -625,6 +638,21 @@ export default class WCStripeAPI {
 		const key = orderDetails.orderKey ?? '';
 		const url = `/wc/store/v1/checkout/${ order }?key=${ key }&billing_email=${ billingEmail }`;
 		return this.postToBlocksAPI( url, paymentData );
+	}
+
+	/**
+	 * Pays for an order based on the Express Checkout payment method (legacy version, non-StoreAPI).
+	 *
+	 * @param {number} order The order ID.
+	 * @param {Object} paymentData Order data.
+	 * @return {Promise} Promise for the request to the server.
+	 */
+	expressCheckoutECEPayForOrderLegacy( order, paymentData ) {
+		return this.request( getExpressCheckoutAjaxURL( 'pay_for_order' ), {
+			_wpnonce: getExpressCheckoutData( 'nonce' )?.pay_for_order,
+			order,
+			...paymentData,
+		} );
 	}
 
 	/**

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -82,10 +82,10 @@ jQuery( function ( $ ) {
 	 *
 	 * @todo Using the legacy endpoint (non-StoreAPI) for booking products. Can be
 	 * removed once booking product flows have been fully migrated to StoreAPI.
+	 *
+	 * @todo Disabling the StoreAPI temporarily due incompatibility with old version of the Order Status Manager plugin.
 	 */
-	const useLegacyCartEndpoints =
-		$( '.variations_form' ).length > 0 ||
-		$( '.wc-bookings-booking-form' ).length > 0;
+	const useLegacyCartEndpoints = true;
 
 	const resolveClickEvent = ( event, options ) => {
 		const clickOptions = {

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -12,6 +12,9 @@ import {
 	shippingRateChangeHandler,
 } from 'wcstripe/express-checkout/event-handler';
 
+// @todo Disabling the StoreAPI temporarily due incompatibility with old version of the Order Status Manager plugin.
+const useLegacyCartEndpoints = true;
+
 describe( 'Express checkout event handlers', () => {
 	describe( 'shippingAddressChangeHandler', () => {
 		let api;
@@ -206,406 +209,406 @@ describe( 'Express checkout event handlers', () => {
 		} );
 	} );
 
-	describe( 'onConfirmHandler', () => {
-		let api;
-		let stripe;
-		let elements;
-		let completePayment;
-		let abortPayment;
-		let event;
-		let order;
+	if ( ! useLegacyCartEndpoints ) {
+		describe( 'onConfirmHandler', () => {
+			let api;
+			let stripe;
+			let elements;
+			let completePayment;
+			let abortPayment;
+			let event;
+			let order;
 
-		beforeEach( () => {
-			api = {
-				expressCheckoutECECreateOrder: jest.fn(),
-				expressCheckoutECEPayForOrder: jest.fn(),
-				confirmIntent: jest.fn(),
-			};
-			stripe = {
-				createPaymentMethod: jest.fn(),
-			};
-			elements = {
-				submit: jest.fn(),
-			};
-			completePayment = jest.fn();
-			abortPayment = jest.fn();
-			event = {
-				billingDetails: {
-					name: 'John Doe',
-					email: 'john.doe@example.com',
-					address: {
+			beforeEach( () => {
+				api = {
+					expressCheckoutECECreateOrder: jest.fn(),
+					expressCheckoutECEPayForOrder: jest.fn(),
+					confirmIntent: jest.fn(),
+				};
+				stripe = {
+					createPaymentMethod: jest.fn(),
+				};
+				elements = {
+					submit: jest.fn(),
+				};
+				completePayment = jest.fn();
+				abortPayment = jest.fn();
+				event = {
+					billingDetails: {
+						name: 'John Doe',
+						email: 'john.doe@example.com',
+						address: {
+							organization: 'Some Company',
+							country: 'US',
+							line1: '123 Main St',
+							line2: 'Apt 4B',
+							city: 'New York',
+							state: 'NY',
+							postal_code: '10001',
+						},
+						phone: '(123) 456-7890',
+					},
+					shippingAddress: {
+						name: 'John Doe',
 						organization: 'Some Company',
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-					phone: '(123) 456-7890',
-				},
-				shippingAddress: {
-					name: 'John Doe',
-					organization: 'Some Company',
-					address: {
-						country: 'US',
-						line1: '123 Main St',
-						line2: 'Apt 4B',
-						city: 'New York',
-						state: 'NY',
-						postal_code: '10001',
-					},
-				},
-				shippingRate: { id: 'rate_1' },
-				expressPaymentType: 'express',
-			};
-			order = 123;
-		} );
-
-		afterEach( () => {
-			jest.clearAllMocks();
-		} );
-
-		test( 'should abort payment if elements.submit fails', async () => {
-			elements.submit.mockResolvedValue( {
-				error: { message: 'Submit error' },
-			} );
-
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-			} );
-
-			expect( elements.submit ).toHaveBeenCalled();
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Submit error'
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment if stripe.createPaymentMethod fails', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				error: { message: 'Payment method error' },
-			} );
-
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-			} );
-
-			expect( elements.submit ).toHaveBeenCalled();
-			expect( stripe.createPaymentMethod ).toHaveBeenCalledWith( {
-				elements,
-			} );
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Payment method error'
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment if expressCheckoutECECreateOrder fails', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'error',
-					payment_details: [
-						{
-							key: 'errorMessage',
-							value: 'Order creation error',
+						address: {
+							country: 'US',
+							line1: '123 Main St',
+							line2: 'Apt 4B',
+							city: 'New York',
+							state: 'NY',
+							postal_code: '10001',
 						},
-					],
-				},
+					},
+					shippingRate: { id: 'rate_1' },
+					expressPaymentType: 'express',
+				};
+				order = 123;
 			} );
 
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
+			afterEach( () => {
+				jest.clearAllMocks();
 			} );
 
-			const expectedOrderData = normalizeOrderData( {
-				event,
-				paymentMethodId: 'pm_123',
-			} );
-			expect( api.expressCheckoutECECreateOrder ).toHaveBeenCalledWith(
-				expectedOrderData
-			);
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Order creation error',
-				true
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
+			test( 'should abort payment if elements.submit fails', async () => {
+				elements.submit.mockResolvedValue( {
+					error: { message: 'Submit error' },
+				} );
 
-		test( 'should complete payment if confirmationRequest is true', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( true );
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+				} );
 
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
+				expect( elements.submit ).toHaveBeenCalled();
+				expect( abortPayment ).toHaveBeenCalledWith(
+					event,
+					'Submit error'
+				);
+				expect( completePayment ).not.toHaveBeenCalled();
 			} );
 
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
-		} );
+			test( 'should abort payment if stripe.createPaymentMethod fails', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					error: { message: 'Payment method error' },
+				} );
 
-		test( 'should complete payment if confirmationRequest returns a redirect URL', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+				} );
+
+				expect( elements.submit ).toHaveBeenCalled();
+				expect( stripe.createPaymentMethod ).toHaveBeenCalledWith( {
+					elements,
+				} );
+				expect( abortPayment ).toHaveBeenCalledWith(
+					event,
+					'Payment method error'
+				);
+				expect( completePayment ).not.toHaveBeenCalled();
 			} );
-			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
+
+			test( 'should abort payment if expressCheckoutECECreateOrder fails', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECECreateOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'error',
+						payment_details: [
+							{
+								key: 'errorMessage',
+								value: 'Order creation error',
+							},
+						],
+					},
+				} );
+
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+				} );
+
+				const expectedOrderData = normalizeOrderData( {
+					event,
+					paymentMethodId: 'pm_123',
+				} );
+				expect(
+					api.expressCheckoutECECreateOrder
+				).toHaveBeenCalledWith( expectedOrderData );
+				expect( abortPayment ).toHaveBeenCalledWith(
+					event,
+					'Order creation error',
+					true
+				);
+				expect( completePayment ).not.toHaveBeenCalled();
 			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.resolve(
+
+			test( 'should complete payment if confirmationRequest is true', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECECreateOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'success',
+						redirect_url: 'https://example.com/redirect',
+					},
+				} );
+				api.confirmIntent.mockReturnValue( true );
+
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+				} );
+
+				expect( api.confirmIntent ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( completePayment ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( abortPayment ).not.toHaveBeenCalled();
+			} );
+
+			test( 'should complete payment if confirmationRequest returns a redirect URL', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECECreateOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'success',
+						redirect_url: 'https://example.com/redirect',
+					},
+				} );
+				api.confirmIntent.mockReturnValue( {
+					request: Promise.resolve(
+						'https://example.com/confirmation_redirect'
+					),
+				} );
+
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+				} );
+
+				expect( api.confirmIntent ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( completePayment ).toHaveBeenCalledWith(
 					'https://example.com/confirmation_redirect'
-				),
+				);
+				expect( abortPayment ).not.toHaveBeenCalled();
 			} );
 
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
+			test( 'should abort payment if confirmIntent throws an error', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECECreateOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'success',
+						redirect_url: 'https://example.com/redirect',
+					},
+				} );
+				api.confirmIntent.mockReturnValue( {
+					request: Promise.reject(
+						new Error( 'Intent confirmation error' )
+					),
+				} );
+
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+				} );
+
+				expect( api.confirmIntent ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( abortPayment ).toHaveBeenCalledWith(
+					event,
+					'Intent confirmation error',
+					true
+				);
+				expect( completePayment ).not.toHaveBeenCalled();
 			} );
 
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/confirmation_redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
-		} );
+			test( 'should abort payment if expressCheckoutECEPayForOrder fails', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECEPayForOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'error',
+						payment_details: [
+							{
+								key: 'errorMessage',
+								value: 'Order creation error',
+							},
+						],
+					},
+				} );
 
-		test( 'should abort payment if confirmIntent throws an error', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECECreateOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.reject(
-					new Error( 'Intent confirmation error' )
-				),
-			} );
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+					order,
+				} );
 
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-			} );
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Intent confirmation error',
-				true
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should abort payment if expressCheckoutECEPayForOrder fails', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'error',
-					payment_details: [
-						{
-							key: 'errorMessage',
-							value: 'Order creation error',
-						},
-					],
-				},
+				const expectedOrderData = normalizeOrderData( {
+					event,
+					paymentMethodId: 'pm_123',
+				} );
+				expect(
+					api.expressCheckoutECEPayForOrder
+				).toHaveBeenCalledWith( 123, {}, expectedOrderData );
+				expect( abortPayment ).toHaveBeenCalledWith(
+					event,
+					'Order creation error',
+					true
+				);
+				expect( completePayment ).not.toHaveBeenCalled();
 			} );
 
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order,
+			test( 'should complete payment (pay for order) if confirmationRequest is true', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECEPayForOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'success',
+						redirect_url: 'https://example.com/redirect',
+					},
+				} );
+				api.confirmIntent.mockReturnValue( true );
+
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+					order,
+				} );
+
+				expect( api.confirmIntent ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( completePayment ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( abortPayment ).not.toHaveBeenCalled();
 			} );
 
-			const expectedOrderData = normalizeOrderData( {
-				event,
-				paymentMethodId: 'pm_123',
-			} );
-			expect( api.expressCheckoutECEPayForOrder ).toHaveBeenCalledWith(
-				123,
-				{},
-				expectedOrderData
-			);
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Order creation error',
-				true
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
+			test( 'should complete payment (pay for order) if confirmationRequest returns a redirect URL', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECEPayForOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'success',
+						redirect_url: 'https://example.com/redirect',
+					},
+				} );
+				api.confirmIntent.mockReturnValue( {
+					request: Promise.resolve(
+						'https://example.com/confirmation_redirect'
+					),
+				} );
 
-		test( 'should complete payment (pay for order) if confirmationRequest is true', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( true );
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+					order,
+				} );
 
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order,
-			} );
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
-		} );
-
-		test( 'should complete payment (pay for order) if confirmationRequest returns a redirect URL', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.resolve(
+				expect( api.confirmIntent ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( completePayment ).toHaveBeenCalledWith(
 					'https://example.com/confirmation_redirect'
-				),
+				);
+				expect( abortPayment ).not.toHaveBeenCalled();
 			} );
 
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order,
-			} );
+			test( 'should abort payment (pay for order) if confirmIntent throws an error', async () => {
+				elements.submit.mockResolvedValue( {} );
+				stripe.createPaymentMethod.mockResolvedValue( {
+					paymentMethod: { id: 'pm_123' },
+				} );
+				api.expressCheckoutECEPayForOrder.mockResolvedValue( {
+					payment_result: {
+						payment_status: 'success',
+						redirect_url: 'https://example.com/redirect',
+					},
+				} );
+				api.confirmIntent.mockReturnValue( {
+					request: Promise.reject(
+						new Error( 'Intent confirmation error' )
+					),
+				} );
 
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( completePayment ).toHaveBeenCalledWith(
-				'https://example.com/confirmation_redirect'
-			);
-			expect( abortPayment ).not.toHaveBeenCalled();
+				await onConfirmHandler( {
+					api,
+					stripe,
+					elements,
+					completePayment,
+					abortPayment,
+					event,
+					order,
+				} );
+
+				expect( api.confirmIntent ).toHaveBeenCalledWith(
+					'https://example.com/redirect'
+				);
+				expect( abortPayment ).toHaveBeenCalledWith(
+					event,
+					'Intent confirmation error',
+					true
+				);
+				expect( completePayment ).not.toHaveBeenCalled();
+			} );
 		} );
-
-		test( 'should abort payment (pay for order) if confirmIntent throws an error', async () => {
-			elements.submit.mockResolvedValue( {} );
-			stripe.createPaymentMethod.mockResolvedValue( {
-				paymentMethod: { id: 'pm_123' },
-			} );
-			api.expressCheckoutECEPayForOrder.mockResolvedValue( {
-				payment_result: {
-					payment_status: 'success',
-					redirect_url: 'https://example.com/redirect',
-				},
-			} );
-			api.confirmIntent.mockReturnValue( {
-				request: Promise.reject(
-					new Error( 'Intent confirmation error' )
-				),
-			} );
-
-			await onConfirmHandler( {
-				api,
-				stripe,
-				elements,
-				completePayment,
-				abortPayment,
-				event,
-				order,
-			} );
-
-			expect( api.confirmIntent ).toHaveBeenCalledWith(
-				'https://example.com/redirect'
-			);
-			expect( abortPayment ).toHaveBeenCalledWith(
-				event,
-				'Intent confirmation error',
-				true
-			);
-			expect( completePayment ).not.toHaveBeenCalled();
-		} );
-	} );
+	}
 } );

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -1,5 +1,10 @@
 import { __ } from '@wordpress/i18n';
-import { getErrorMessageFromNotice, normalizeOrderData } from './utils';
+import {
+	getErrorMessageFromNotice,
+	normalizeOrderData,
+	normalizeOrderDataLegacy,
+	normalizePayForOrderDataLegacy,
+} from './utils';
 
 // @todo Disabling the StoreAPI temporarily due incompatibility with old version of the Order Status Manager plugin.
 const useLegacyCartEndpoints = true;
@@ -155,19 +160,11 @@ const processOrder = async ( {
 		if ( order ) {
 			orderResponse = await api.expressCheckoutECEPayForOrderLegacy(
 				order,
-				normalizeOrderData( {
-					event,
-					paymentMethodId,
-					confirmationTokenId,
-				} )
+				normalizePayForOrderDataLegacy( event, paymentMethodId )
 			);
 		} else {
 			orderResponse = await api.expressCheckoutECECreateOrderLegacy(
-				normalizeOrderData( {
-					event,
-					paymentMethodId,
-					confirmationTokenId,
-				} )
+				normalizeOrderDataLegacy( event, paymentMethodId )
 			);
 		}
 	} else if ( order ) {
@@ -191,10 +188,14 @@ const processOrder = async ( {
 	}
 
 	return {
-		result: orderResponse?.payment_result?.payment_status,
-		errorMessage: orderResponse?.payment_result?.payment_details?.find(
-			( detail ) => detail.key === 'errorMessage'
-		)?.value,
+		result: useLegacyCartEndpoints
+			? orderResponse.result
+			: orderResponse?.payment_result?.payment_status,
+		errorMessage: useLegacyCartEndpoints
+			? getErrorMessageFromNotice( orderResponse.messages )
+			: orderResponse?.payment_result?.payment_details?.find(
+					( detail ) => detail.key === 'errorMessage'
+			  )?.value,
 		redirect: orderResponse?.payment_result?.redirect_url,
 	};
 };

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -1,6 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { getErrorMessageFromNotice, normalizeOrderData } from './utils';
 
+// @todo Disabling the StoreAPI temporarily due incompatibility with old version of the Order Status Manager plugin.
+const useLegacyCartEndpoints = true;
+
 const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 	let errorMessage;
 	if ( exception.message ) {
@@ -148,7 +151,26 @@ const processOrder = async ( {
 	orderDetails = {},
 } ) => {
 	let orderResponse;
-	if ( order ) {
+	if ( useLegacyCartEndpoints ) {
+		if ( order ) {
+			orderResponse = await api.expressCheckoutECEPayForOrderLegacy(
+				order,
+				normalizeOrderData( {
+					event,
+					paymentMethodId,
+					confirmationTokenId,
+				} )
+			);
+		} else {
+			orderResponse = await api.expressCheckoutECECreateOrderLegacy(
+				normalizeOrderData( {
+					event,
+					paymentMethodId,
+					confirmationTokenId,
+				} )
+			);
+		}
+	} else if ( order ) {
 		orderResponse = await api.expressCheckoutECEPayForOrder(
 			order,
 			orderDetails,

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -1,4 +1,5 @@
 import { applyFilters } from '@wordpress/hooks';
+import { extractOrderAttributionData } from 'wcstripe/blocks/utils';
 
 /**
  * Normalizes incoming cart total items for use as a displayItems with the Stripe api.
@@ -86,6 +87,80 @@ export const normalizeOrderData = ( {
 			'wcstripe.express-checkout.cart-place-order-extension-data',
 			{}
 		),
+	};
+};
+
+/**
+ * Normalize order data from Stripe's object to the expected format for WC (legacy version, non-StoreAPI).
+ *
+ * @param {Object} event Stripe's event object.
+ * @param {string} paymentMethodId Stripe's payment method id.
+ *
+ * @return {Object} Order object in the format WooCommerce expects.
+ */
+export const normalizeOrderDataLegacy = ( event, paymentMethodId ) => {
+	const name = event?.billingDetails?.name;
+	const email = event?.billingDetails?.email ?? '';
+	const billing = event?.billingDetails?.address ?? {};
+	const shipping = event?.shippingAddress ?? {};
+
+	const phone =
+		event?.billingDetails?.phone?.replace( /[() -]/g, '' ) ??
+		event?.payerPhone?.replace( /[() -]/g, '' ) ??
+		'';
+
+	return {
+		billing_first_name:
+			name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
+		billing_last_name: name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '-',
+		billing_company: billing?.organization ?? '',
+		billing_email: email ?? event?.payerEmail ?? '',
+		billing_phone: phone,
+		billing_country: billing?.country ?? '',
+		billing_address_1: billing?.line1 ?? '',
+		billing_address_2: billing?.line2 ?? '',
+		billing_city: billing?.city ?? '',
+		billing_state: billing?.state ?? '',
+		billing_postcode: billing?.postal_code ?? '',
+		shipping_first_name:
+			shipping?.name?.split( ' ' )?.slice( 0, 1 )?.join( ' ' ) ?? '',
+		shipping_last_name:
+			shipping?.name?.split( ' ' )?.slice( 1 )?.join( ' ' ) ?? '',
+		shipping_company: shipping?.organization ?? '',
+		shipping_phone: phone,
+		shipping_country: shipping?.address?.country ?? '',
+		shipping_address_1: shipping?.address?.line1 ?? '',
+		shipping_address_2: shipping?.address?.line2 ?? '',
+		shipping_city: shipping?.address?.city ?? '',
+		shipping_state: shipping?.address?.state ?? '',
+		shipping_postcode: shipping?.address?.postal_code ?? '',
+		shipping_method: [ event?.shippingRate?.id ?? null ],
+		order_comments: '',
+		payment_method: 'stripe',
+		ship_to_different_address: 1,
+		terms: 1,
+		'wc-stripe-payment-method': paymentMethodId,
+		express_checkout_type: event?.expressPaymentType,
+		express_payment_type: event?.expressPaymentType,
+		'wc-stripe-is-deferred-intent': true,
+		...extractOrderAttributionData(),
+	};
+};
+
+/**
+ * Normalize Pay for Order data from Stripe's object to the expected format for WC (legacy version, non-StoreAPI).
+ *
+ * @param {Object} event Stripe's event object.
+ * @param {string} paymentMethodId Stripe's payment method id.
+ *
+ * @return {Object} Order object in the format WooCommerce expects.
+ */
+export const normalizePayForOrderDataLegacy = ( event, paymentMethodId ) => {
+	return {
+		payment_method: 'stripe',
+		'wc-stripe-is-deferred-intent': true, // Set the deferred intent flag, so the deferred intent flow is used.
+		'wc-stripe-payment-method': paymentMethodId,
+		express_payment_type: event?.expressPaymentType,
 	};
 };
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -303,7 +303,6 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 	 * @deprecated 9.2.0 Payment is processed using the Blocks API by default.
 	 */
 	public function ajax_create_order() {
-		_deprecated_function( __METHOD__, '9.2.0' );
 		try {
 			if ( WC()->cart->is_empty() ) {
 				wp_send_json_error( __( 'Empty cart', 'woocommerce-gateway-stripe' ) );
@@ -354,7 +353,6 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 	 * @deprecated 9.2.0 Payment is processed using the Blocks API by default.
 	 */
 	public function ajax_pay_for_order() {
-		_deprecated_function( __METHOD__, '9.2.0' );
 		check_ajax_referer( 'wc-stripe-pay-for-order' );
 
 		if (

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.3.0 - xxxx-xx-xx =
+* Fix - Temporarily disables the Store API integration for ECE due incompatibility issues with the Order Status Manager extension.
 * Dev - Adds a new README.md file to the plugin with specific development-focused instructions.
 * Add - Implements the Single Payment Element feature for the new checkout experience on the block checkout page.
 * Dev - Additional replacements for payment method constant values on the backend.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See p6q7sZ-iSH-p2

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

This PR temporarily reverses the Store API implementation for ECE due to incompatibilities with the Order Status Management extension. It is just a backup solution; it is not yet intended to move forward.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`fix/disabling-store-api-due-incompatibility-issues`)
- Connect your Stripe account
- Enable express payment methods (Google Pay, Apple Pay)
- As a shopper, accessing the store using a public-facing address, try to purchase any product using express methods
- Confirm you can complete it successfully

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
