### PR TITLE
Hook up Amazon Pay configuration

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -44,6 +44,7 @@
 * Fix - Prevent potential duplicate renewal charges by ensuring subscription integration hooks are only attached once per Gateway ID
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
 * Add - Show upcoming legacy checkout experience deprecation notice.
+* Dev - Fetch Stripe settings with Stripe configuration API.
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
 * Add - Show upcoming legacy checkout experience deprecation notice.
 * Dev - Fetch Stripe settings with Stripe configuration API.
+* Add - Hook up Amazon Pay configuration
 
 = 9.2.0 - 2025-02-13 =
 * Fix - Fix missing product_id parameter for the express checkout add-to-cart operation.

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -25,12 +25,20 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	private $gateway;
 
 	/**
+	 * Stripe payment gateway.
+	 *
+	 * @var WC_Stripe_API
+	 */
+	private $stripe_api;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WC_Gateway_Stripe $gateway Stripe payment gateway.
 	 */
-	public function __construct( WC_Gateway_Stripe $gateway ) {
+	public function __construct( WC_Gateway_Stripe $gateway, WC_Stripe_API $stripe_api ) {
 		$this->gateway = $gateway;
+		$this->stripe_api = $stripe_api;
 	}
 
 	/**
@@ -245,7 +253,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	public function get_settings() {
 		$merchant_payment_method_configuration = $this->get_merchant_payment_method_configurations();
 
-		$is_amazon_pay_enabled        = 'on' === $merchant_payment_method_configuration->amazon_pay->display_preference->value;
+		$is_amazon_pay_enabled        = $merchant_payment_method_configuration && 'on' === $merchant_payment_method_configuration->amazon_pay->display_preference->value;
 		$is_upe_enabled               = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
 		$available_payment_method_ids = $is_upe_enabled ? $this->gateway->get_upe_available_payment_methods() : WC_Stripe_Helper::get_legacy_available_payment_method_ids();
 		$ordered_payment_method_ids   = $is_upe_enabled ? WC_Stripe_Helper::get_upe_ordered_payment_method_ids( $this->gateway ) : $available_payment_method_ids;
@@ -404,7 +412,12 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return array|null
 	 */
 	private function get_merchant_payment_method_configurations() {
-		$payment_method_configurations = WC_Stripe_API::get_payment_method_configurations()->data;
+		$payment_method_configurations =
+			property_exists( $this->stripe_api->get_payment_method_configurations(), 'data' ) ? $this->stripe_api->get_payment_method_configurations()->data : null;
+
+		if ( ! $payment_method_configurations ) {
+			return null;
+		}
 
 		foreach ( $payment_method_configurations as $payment_method_configuration ) {
 			if ( $payment_method_configuration->active && $payment_method_configuration->parent ) {
@@ -427,7 +440,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		WC_Stripe_API::update_payment_method_configurations(
+		$this->stripe_api->update_payment_method_configurations(
 			$merchant_payment_method_configuration->id,
 			[
 				'amazon_pay' => [

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -243,6 +243,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return WP_REST_Response
 	 */
 	public function get_settings() {
+		$merchant_payment_method_configuration = $this->get_merchant_payment_method_configurations();
+
+		$is_amazon_pay_enabled        = 'on' === $merchant_payment_method_configuration->amazon_pay->display_preference->value;
 		$is_upe_enabled               = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
 		$available_payment_method_ids = $is_upe_enabled ? $this->gateway->get_upe_available_payment_methods() : WC_Stripe_Helper::get_legacy_available_payment_method_ids();
 		$ordered_payment_method_ids   = $is_upe_enabled ? WC_Stripe_Helper::get_upe_ordered_payment_method_ids( $this->gateway ) : $available_payment_method_ids;
@@ -266,7 +269,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'individual_payment_method_settings'       => $is_upe_enabled ? WC_Stripe_Helper::get_upe_individual_payment_method_settings( $this->gateway ) : WC_Stripe_Helper::get_legacy_individual_payment_method_settings(),
 
 				/* Settings > Express checkouts */
-				'is_amazon_pay_enabled'                    => 'yes' === $this->gateway->get_option( 'amazon_pay' ),
+				'is_amazon_pay_enabled'                    => $is_amazon_pay_enabled,
 				'amazon_pay_button_size'                   => $this->gateway->get_validated_option( 'amazon_pay_button_size' ),
 				'amazon_pay_button_locations'              => $this->gateway->get_validated_option( 'amazon_pay_button_locations' ),
 				'is_payment_request_enabled'               => 'yes' === $this->gateway->get_option( 'payment_request' ),
@@ -396,18 +399,44 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	}
 
 	/**
-	 * Updates the "Amazon Pay" enable/disable settings.
+	 * Get the default active payment method configuration.
+	 *
+	 * @return array|null
+	 */
+	private function get_merchant_payment_method_configurations() {
+		$payment_method_configurations = WC_Stripe_API::get_payment_method_configurations()->data;
+
+		foreach ( $payment_method_configurations as $payment_method_configuration ) {
+			if ( $payment_method_configuration->active && $payment_method_configuration->parent ) {
+				return $payment_method_configuration;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Updates the "Amazon Pay" enable/disable settings in Stripe.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 */
 	private function update_is_amazon_pay_enabled( WP_REST_Request $request ) {
-		$is_amazon_pay_enabled = $request->get_param( 'is_amazon_pay_enabled' );
+		$merchant_payment_method_configuration = $this->get_merchant_payment_method_configurations();
 
-		if ( null === $is_amazon_pay_enabled ) {
+		if ( null === $merchant_payment_method_configuration ) {
 			return;
 		}
 
-		$this->gateway->update_option( 'amazon_pay', $is_amazon_pay_enabled ? 'yes' : 'no' );
+		WC_Stripe_API::update_payment_method_configurations(
+			$merchant_payment_method_configuration->id,
+			[
+				'amazon_pay' => [
+					'display_preference' => [
+						'preference' => $request->get_param( 'is_amazon_pay_enabled' ) ? 'on' : 'off',
+					],
+				],
+			]
+		);
 	}
 
 	/**

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -435,4 +435,13 @@ class WC_Stripe_API {
 
 		return true;
 	}
+
+	/**
+	 * Get the payment method configuration.
+	 *
+	 * @return array The response from the API request.
+	 */
+	public static function get_payment_method_configurations() {
+		return self::retrieve( 'payment_method_configurations' );
+	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -444,4 +444,16 @@ class WC_Stripe_API {
 	public static function get_payment_method_configurations() {
 		return self::retrieve( 'payment_method_configurations' );
 	}
+
+	/**
+	 * Update the payment method configuration.
+	 *
+	 * @param array $payment_method_configurations The payment method configurations to update.
+	 */
+	public static function update_payment_method_configurations( $id, $payment_method_configurations ) {
+		return self::request(
+			$payment_method_configurations,
+			'payment_method_configurations/' . $id
+		);
+	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -441,7 +441,7 @@ class WC_Stripe_API {
 	 *
 	 * @return array The response from the API request.
 	 */
-	public static function get_payment_method_configurations() {
+	public function get_payment_method_configurations() {
 		return self::retrieve( 'payment_method_configurations' );
 	}
 
@@ -450,7 +450,7 @@ class WC_Stripe_API {
 	 *
 	 * @param array $payment_method_configurations The payment method configurations to update.
 	 */
-	public static function update_payment_method_configurations( $id, $payment_method_configurations ) {
+	public function update_payment_method_configurations( $id, $payment_method_configurations ) {
 		return self::request(
 			$payment_method_configurations,
 			'payment_method_configurations/' . $id

--- a/readme.txt
+++ b/readme.txt
@@ -155,5 +155,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
 * Add - Show upcoming legacy checkout experience deprecation notice.
 * Dev - Fetch Stripe settings with Stripe configuration API
+* Add - Hook up Amazon Pay configuration
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -154,5 +154,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent potential duplicate renewal charges by ensuring subscription integration hooks are only attached once per Gateway ID
 * Update - Update Amazon Pay icon to use image from WooCommerce Design Library.
 * Add - Show upcoming legacy checkout experience deprecation notice.
+* Dev - Fetch Stripe settings with Stripe configuration API
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -17,6 +17,20 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	const SETTINGS_ROUTE = '/wc/v3/wc_stripe/settings';
 
 	/**
+	 * Controller instance
+	 *
+	 * @var WC_REST_Stripe_Settings_Controller
+	 */
+	private $controller;
+
+	/**
+	 * Stripe API instance that the controller uses.
+	 *
+	 * @var WC_Stripe_API
+	 */
+	private $stripe_api;
+
+	/**
 	 * Gateway instance that the controller uses.
 	 *
 	 * @var WC_Gateway_Stripe
@@ -66,6 +80,9 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			$this->markTestSkipped( 'The controller is not compatible with older WC versions, due to the missing `update_option` method on the gateway.' );
 		}
 
+		$this->stripe_api = $this->createMock( WC_Stripe_API::class );
+		$this->controller = new WC_REST_Stripe_Settings_Controller( new WC_Gateway_Stripe(), $this->stripe_api );
+
 		add_action( 'rest_api_init', [ $this, 'deregister_wc_blocks_rest_api' ], 5 );
 
 		// Set the user so that we can pass the authentication.
@@ -78,6 +95,32 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		delete_option( WC_Stripe_Feature_Flags::LPM_BACS_FEATURE_FLAG_NAME );
 		delete_option( WC_Stripe_Feature_Flags::LPM_ACH_FEATURE_FLAG_NAME );
 		delete_option( WC_Stripe_Feature_Flags::AMAZON_PAY_FEATURE_FLAG_NAME );
+	}
+
+	/**
+	 * @dataProvider stripe_payment_method_configurations_provider
+	 */
+	public function test_stripe_payment_method_configurations_settings( $payment_method, $display_preference, $expected_result, $rest_key ) {
+		$this->stripe_api->method( 'get_payment_method_configurations' )->willReturn(
+			(object) [
+				'data' => [
+					(object) [
+						'id'       => 'pmc_abcdef',
+						'object'   => 'payment_method_configuration',
+						'active'   => true,
+						'parent'   => true,
+						$payment_method => (object) [
+							'display_preference' => (object) [ 'value' => $display_preference ],
+						],
+					],
+				],
+			],
+		);
+
+		$response = $this->controller->get_settings();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $expected_result, $response->get_data()[ $rest_key ] );
 	}
 
 	/**
@@ -361,7 +404,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			'is_stripe_enabled'                     => [ 'is_stripe_enabled', 'enabled' ],
 			'is_test_mode_enabled'                  => [ 'is_test_mode_enabled', 'testmode' ],
 			'is_payment_request_enabled'            => [ 'is_payment_request_enabled', 'payment_request' ],
-			'is_amazon_pay_enabled'                 => [ 'is_amazon_pay_enabled', 'amazon_pay' ],
 			'is_spe_enabled'                        => [ 'is_spe_enabled', 'single_payment_element' ],
 			'is_manual_capture_enabled'             => [ 'is_manual_capture_enabled', 'capture', true ],
 			'is_saved_cards_enabled'                => [ 'is_saved_cards_enabled', 'saved_cards' ],
@@ -371,6 +413,13 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 				'is_short_statement_descriptor_enabled',
 			],
 			'is_debug_log_enabled'                  => [ 'is_debug_log_enabled', 'logging' ],
+		];
+	}
+
+	public function stripe_payment_method_configurations_provider() {
+		return [
+			'amazon_pay' => [ 'amazon_pay', 'on', true, 'is_amazon_pay_enabled' ],
+			'amazon_pay' => [ 'amazon_pay', 'off', false, 'is_amazon_pay_enabled' ],
 		];
 	}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -751,7 +751,7 @@ function woocommerce_gateway_stripe() {
 					$upe_flag_toggle_controller = new WC_Stripe_REST_UPE_Flag_Toggle_Controller();
 					$upe_flag_toggle_controller->register_routes();
 
-					$settings_controller = new WC_REST_Stripe_Settings_Controller( $this->get_main_stripe_gateway() );
+					$settings_controller = new WC_REST_Stripe_Settings_Controller( $this->get_main_stripe_gateway(), new WC_Stripe_API() );
 					$settings_controller->register_routes();
 
 					$stripe_account_keys_controller = new WC_REST_Stripe_Account_Keys_Controller( $this->account );


### PR DESCRIPTION
Fixes #3917

## Changes proposed in this Pull Request:
This PR hooks up Amazon Pay configuration settings to the admin Stripe Amazon Pay settings that check for payment-enabled/disabled. 

https://github.com/user-attachments/assets/295715ab-a030-4b81-b1e3-a98a89312e1a


## Testing instructions
1. Turn the feature flag on, by setting the `_wcstripe_feature_amazon_pay` option to yes
2. Verify that Amazon Pay is now available in Stripe settings
3. Disable the Amazon Pay setting from admin payment settings
4. The Amazon Pay setting for the merchant copy configuration in the [Stripe dashboard ](https://dashboard.stripe.com/test/settings/payment_methods) should be disabled
5. Turn on Amazon Pay in Stripe
6. The Amazon Pay setting in admin should be enabled

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Hook up payment methods configuration

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
