### PR TITLE
Fix Admin Notices faling tests

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '9.5.2'
+            woocommerce: '9.7.1'
           - woocommerce_support_policy: L-1
-            woocommerce: '9.3.4'
+            woocommerce: '9.6.2'
           - woocommerce_support_policy: L-2
-            woocommerce: '9.2.3'
+            woocommerce: '9.5.2'
           # WordPress
           - wordpress_support_policy: L
             wordpress: '6.7'

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -23,11 +23,13 @@ jobs:
             woocommerce: '9.5.2'
           # WordPress
           - wordpress_support_policy: L
-            wordpress: '6.7'
+            wordpress: '6.7.2'
           - wordpress_support_policy: L-1
-            wordpress: '6.6'
+            wordpress: '6.6.2'
+          # WooCommerce 9.5.0+ requires WordPress 6.6+
+          # (we'll keep two versions from the 6.6 branch until Apr when WP 6.8 is released)
           - wordpress_support_policy: L-2
-            wordpress: '6.5'
+            wordpress: '6.6'
           # PHP
           - php_support_policy: L
             php: '8.1'

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -55,11 +55,14 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		$notices = new WC_Stripe_Admin_Notices();
 		ob_start();
 		$notices->admin_notices();
-		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
-			// Displaying the style notice results in an early return.
-			if ( ! in_array( 'style', $expected_notices, true ) ) {
+		// Displaying the style notice results in an early return.
+		if ( ! in_array( 'style', $expected_notices, true ) ) {
+			if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
 				// This means a version support notice will be added.
 				$expected_notices[] = 'wcver';
+			}
+			if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+				$expected_notices[] = 'legacy_deprecation';
 			}
 		}
 

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -62,6 +62,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 				$expected_notices[] = 'wcver';
 			}
 			if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+				// This means the legacy checkout support notice will be added.
 				$expected_notices[] = 'legacy_deprecation';
 			}
 		}
@@ -146,6 +147,7 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		);
 		update_option( 'wc_stripe_show_style_notice', 'no' );
 		update_option( 'wc_stripe_show_sca_notice', 'no' );
+		update_option( 'wc_stripe_show_legacy_deprecation_notice', 'no' );
 		update_option( 'home', 'https://...' );
 
 		$notices = new WC_Stripe_Admin_Notices();

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -52,16 +52,18 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		foreach ( $options_to_set as $option_name => $option_value ) {
 			update_option( $option_name, $option_value );
 		}
-		update_option( 'wc_stripe_show_legacy_deprecation_notice', 'no' );
-
 		$notices = new WC_Stripe_Admin_Notices();
 		ob_start();
 		$notices->admin_notices();
-		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
-			// Displaying the style notice results in an early return.
-			if ( ! in_array( 'style', $expected_notices, true ) ) {
+		// Displaying the style notice results in an early return.
+		if ( ! in_array( 'style', $expected_notices, true ) ) {
+			if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
 				// This means a version support notice will be added.
 				$expected_notices[] = 'wcver';
+			}
+			if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+				// This means the legacy checkout support notice will be added.
+				$expected_notices[] = 'legacy_deprecation';
 			}
 		}
 

--- a/tests/phpunit/admin/test-wc-stripe-admin-notices.php
+++ b/tests/phpunit/admin/test-wc-stripe-admin-notices.php
@@ -52,18 +52,16 @@ class WC_Stripe_Admin_Notices_Test extends WP_UnitTestCase {
 		foreach ( $options_to_set as $option_name => $option_value ) {
 			update_option( $option_name, $option_value );
 		}
+		update_option( 'wc_stripe_show_legacy_deprecation_notice', 'no' );
+
 		$notices = new WC_Stripe_Admin_Notices();
 		ob_start();
 		$notices->admin_notices();
-		// Displaying the style notice results in an early return.
-		if ( ! in_array( 'style', $expected_notices, true ) ) {
-			if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
+		if ( WC_Stripe_Helper::is_wc_lt( WC_STRIPE_FUTURE_MIN_WC_VER ) ) {
+			// Displaying the style notice results in an early return.
+			if ( ! in_array( 'style', $expected_notices, true ) ) {
 				// This means a version support notice will be added.
 				$expected_notices[] = 'wcver';
-			}
-			if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-				// This means the legacy checkout support notice will be added.
-				$expected_notices[] = 'legacy_deprecation';
 			}
 		}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

In `9.3.0`, we added a conditional notice for the legacy checkout deprecation, which is only displayed if the version is 9.3.0 and the legacy checkout is enabled.

This PR adds the same check, and if the legacy checkout is enabled, it now expects a `legacy_deprecation` notice during the other tests.

It also updates the WooCommerce L, L-1, and L-2 versions used by the php tests.

## Testing instructions

Check that all tests pass

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

The change is not customer or merchant facing.

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
