### PR TITLE
Track SPE enablement

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 = 9.4.0 - xxxx-xx-xx =
 * Add - Add Amazon Pay payment method class.
+* Tweak - Record a Tracks event when enabling/disabling SPE
 
 = 9.3.0 - 2025-03-13 =
 * Dev - Adds a new README.md file to the plugin with specific development-focused instructions.

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -597,12 +597,20 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 */
 	private function update_is_spe_enabled( WP_REST_Request $request ) {
 		$is_spe_enabled = $request->get_param( 'is_spe_enabled' );
+		$current_spe_enabled = $this->gateway->get_option( 'single_payment_element' );
 
 		if ( null === $is_spe_enabled ) {
 			return;
 		}
 
-		$this->gateway->update_option( 'single_payment_element', $is_spe_enabled ? 'yes' : 'no' );
+		if ( $is_spe_enabled !== $current_spe_enabled ) {
+			$this->gateway->update_option( 'single_payment_element', $is_spe_enabled ? 'yes' : 'no' );
+			wc_admin_record_tracks_event(
+				$is_spe_enabled ? 'wcstripe_spe_enabled' : 'wcstripe_spe_disabled',
+				[ 'test_mode' => WC_Stripe_Mode::is_test() ? 1 : 0 ]
+			);
+		}
+
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -112,5 +112,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.4.0 - xxxx-xx-xx =
 * Add - Add Amazon Pay payment method class.
+* Tweak - Record a Tracks event when enabling/disabling SPE
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to #3895 

## Changes proposed in this Pull Request:

This introduces the following two Tracks events that get emitted when enabling and disabling the SPE feature via settings.

- `wcadmin_wcstripe_spe_enabled`
- `wcadmin_wcstripe_spe_disabled`


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Enable SPE feature flag by returning `true` [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7d11977d63d06388313656030511e894fda253ed/includes/class-wc-stripe-feature-flags.php#L158).
2. As a merchant, enable SPE feature via WooCommerce -> Settings -> Payments -> Stripe -> Settings -> Advanced settings
3. In about 5 minutes, check MC Tracks Live events page for the presence of a `wcadmin_wcstripe_spe_enabled` event.
4. As a merchant, disable SPE feature.
5.  In about 5 minutes, check MC Tracks Live events page for the presence of a `wcadmin_wcstripe_spe_disabled` event.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

![CleanShot 2025-03-14 at 01 56 35](https://github.com/user-attachments/assets/a104dd57-076c-431a-8673-d613a8223b8a)


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
