### PR TITLE
Update ACH capability check key

### DIFF
--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -738,6 +738,9 @@ class WC_Stripe_Helper {
 
 		foreach ( $payment_method_ids as $payment_method_id ) {
 			$key = $payment_method_id . '_payments';
+			if ( WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID === $payment_method_id ) {
+				$key = $payment_method_id . '_ach_payments';
+			}
 			// Check if the payment method has capabilities set in the account data.
 			// Generally the key is the payment method id appended with '_payments' (i.e. 'card_payments', 'sepa_debit_payments', 'klarna_payments').
 			// In some cases, the Stripe account might have the legacy key set. For example, for Klarna, the legacy key is 'klarna'.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This fix is to make the ACH capability key match the key we use in the plugin. It was discovered that all other payment methods have a capability name of `<payment_method_id>_payments`, but ACH has a capability name of `<payment_method_id>_ach_payments`. After reviewing the [list of capabilities](https://docs.stripe.com/connect/account-capabilities#payment-methods), it appears ACH is the only exception to the rule, so instead of a more robust solution, we opted for a straightforward and focused fix to alter the ACH capability key to check with this PR.

This was originally missed as we were working and testing in test mode, which includes a condition to skip all capability checks when in test mode. To properly test this, we'll need to comment out that check going forward during development.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->
Ensure you are starting with a viable Stripe account that is US-based and a store that is using USD as the currency. Ensure that you have ACH enabled in your Stripe Payment Methods as well.

**Reproduce the issue**
- With the `develop` branch pulled, comment out the [early return when in test mode here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/class-wc-stripe-helper.php#L734). So that the full capabilities check runs.
- Check the list of payment methods from the Stripe Gateway settings page.
- Confirm that ACH is not displayed even though all conditions are met.
- For extra confirmation, run in debugger and confirm that the account.data.capabilities contains `us_bank_account_ach_payments`.

**Confirm the fix**
- With this branch pulled down, comment out the [early return when in test mode here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/class-wc-stripe-helper.php#L734). So that the full capabilities check runs.
- Check the list of payment methods from the Stripe Gateway settings page.
- Confirm that ACH is displayed now.
- For extra confirmation, run in debugger and confirm that the account.data.capabilities contains `us_bank_account_ach_payments` and that the key update now matches the capability.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
