### PR TITLE
Force page reload after enabling the new checkout using the Promotional banner CTA

### DIFF
--- a/client/settings/payment-settings/promotional-banner-section.js
+++ b/client/settings/payment-settings/promotional-banner-section.js
@@ -99,6 +99,8 @@ const PromotionalBannerSection = ( {
 						'woocommerce-gateway-stripe'
 					)
 				);
+
+				window.location.reload();
 			} catch ( err ) {
 				createErrorNotice(
 					__(


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR adds a page reload after the merchant enabled the New Checkout Experience using the Promotional Banner CTA

## Testing instructions

1. Go to the plugin settings page and make sure that legacy checkout experience is enabled
2. Click the `Enable the new checkout` CTA in the promotional banner:
    <img width="1086" alt="Screenshot 2025-03-14 at 14 05 47" src="https://github.com/user-attachments/assets/d01710d3-8cbb-41f8-94c0-e398fa1565ad" />
3. Verify that the page reloads after the new checkout is enabled.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
