### PR TITLE
Remove explicit version check for the legacy checkout deprecation notice

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -104,7 +104,7 @@ class WC_Stripe_Admin_Notices {
 	public static function display_legacy_deprecation_notice( $plugin_file ) {
 		global $wp_list_table;
 
-		if ( version_compare( WC_STRIPE_VERSION, '9.3.0', '!=' ) || WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return;
 		}
 
@@ -372,7 +372,7 @@ class WC_Stripe_Admin_Notices {
 
 			if ( empty( $legacy_deprecation_notice ) ) {
 				// Show legacy deprecation notice in version 9.3.0 if legacy checkout experience is enabled.
-				if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && version_compare( WC_STRIPE_VERSION, '9.3.0', '==' ) ) {
+				if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 					$setting_link = $this->get_setting_link();
 					$message = sprintf(
 						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR removes the version check for the legacy checkout deprecation notice.

The notice should be shown when the legacy checkout is enabled, so the version check is unnecessary and causes the tests to fail after each release because the WC_STRIPE_VERSION gets bumped.

## Testing instructions

1. Go to the plugin settings page and make sure that legacy checkout experience is enabled.
2. Check that the legacy checkout deprecation banner is shown:
    <img width="1565" alt="Screenshot 2025-03-14 at 14 29 37" src="https://github.com/user-attachments/assets/348b4b97-7c7e-4fe4-b1bd-bc567c8e8509" />
3. Click the `Enable the new checkout` CTA in the promotional banner.
4. Check that the notice is no longer present after the page refreshes.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
