### PR TITLE
Update the link in the deprecated payment method list to redirect to the docs hosted at woocommerce.com

### DIFF
--- a/client/components/payment-method-deprecation-pill/index.js
+++ b/client/components/payment-method-deprecation-pill/index.js
@@ -60,7 +60,7 @@ const PaymentMethodDeprecationPill = () => {
 					components: {
 						currencySettingsLink: (
 							<StyledLink
-								href="https://support.stripe.com/topics/shutdown-of-the-legacy-sources-api-for-non-card-payment-methods"
+								href="https://woocommerce.com/document/stripe/admin-experience/legacy-checkout-experience/"
 								target="_blank"
 								rel="noreferrer"
 								onClick={ ( ev ) => {


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Updates the deprecated tooltips link to [Stripe's doc on the Sources API](https://support.stripe.com/topics/shutdown-of-the-legacy-sources-api-for-non-card-payment-methods) to point to the [specific gateway docs](https://woocommerce.com/document/stripe/admin-experience/legacy-checkout-experience/).

## Testing instructions

0. Make sure to run `npm start` to transpile the js assets.
1. Go to the plugin settings page and make sure that legacy checkout experience is enabled.
2. Check that the new url is used in the tooltips:
    <img width="937" alt="Screenshot_2025-03-14_at_14_47_32" src="https://github.com/user-attachments/assets/d844b2df-e74a-43bb-a60e-f6dadb6b5fb4" />


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
