### PR TITLE
Move capability ID to a helper function

### DIFF
--- a/client/components/payment-method-capability-status-pill/index.js
+++ b/client/components/payment-method-capability-status-pill/index.js
@@ -47,7 +47,10 @@ const IconComponent = ( { children, ...props } ) => (
 
 const PaymentMethodCapabilityStatusPill = ( { id, label } ) => {
 	const capabilities = useGetCapabilities();
-	const capabilityStatus = capabilities[ `${ id }_payments` ];
+	const capabilityStatus =
+		id === 'us_bank_account'
+			? capabilities[ `${ id }_ach_payments` ]
+			: capabilities[ `${ id }_payments` ];
 
 	return (
 		<>

--- a/client/data/account/actions.js
+++ b/client/data/account/actions.js
@@ -40,11 +40,18 @@ export function* refreshAccount() {
 
 		// Check new payment methods available for account.
 		const newPaymentMethods = activeCapabilitiesAfterRefresh.filter(
-			( paymentMethod ) =>
-				! activeCapabilitiesBeforeRefresh.includes( paymentMethod ) &&
-				PaymentMethodsMap[
-					paymentMethod.replace( '_payments', '' )
-				] !== undefined
+			( capability ) => {
+				const paymentMethodFromCapability =
+					capability === 'us_bank_account_ach_payments'
+						? 'us_bank_account'
+						: capability.replace( '_payments', '' );
+
+				return (
+					! activeCapabilitiesBeforeRefresh.includes( capability ) &&
+					PaymentMethodsMap[ paymentMethodFromCapability ] !==
+						undefined
+				);
+			}
 		);
 
 		// If there are new payment methods available, show a toast informing the user.
@@ -57,9 +64,14 @@ export function* refreshAccount() {
 						'woocommerce-gateway-stripe'
 					),
 					newPaymentMethods
-						.map( ( method ) => {
+						.map( ( capability ) => {
+							const paymentMethodFromCapability =
+								capability === 'us_bank_account_ach_payments'
+									? 'us_bank_account'
+									: capability.replace( '_payments', '' );
+
 							return PaymentMethodsMap[
-								method.replace( '_payments', '' )
+								paymentMethodFromCapability
 							].label;
 						} )
 						.join( ', ' )

--- a/client/settings/general-settings-section/payment-methods-unavailable-list.js
+++ b/client/settings/general-settings-section/payment-methods-unavailable-list.js
@@ -10,10 +10,13 @@ const PaymentMethodsUnavailableList = () => {
 	const capabilities = useGetCapabilities();
 	const upePaymentMethodIds = useGetAvailablePaymentMethodIds();
 	const unavailablePaymentMethodIds = upePaymentMethodIds
-		.filter(
-			( methodId ) =>
-				! capabilities.hasOwnProperty( `${ methodId }_payments` )
-		)
+		.filter( ( methodId ) => {
+			const capabilityId =
+				methodId === 'us_bank_account'
+					? `${ methodId }_ach_payments`
+					: `${ methodId }_payments`;
+			return ! capabilities.hasOwnProperty( capabilityId );
+		} )
 		.filter( ( id ) => id !== PAYMENT_METHOD_LINK );
 	const unavailablePaymentMethods = unavailablePaymentMethodIds
 		.filter( ( methodId, idx ) => idx < countIconsToDisplay )

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -737,10 +737,7 @@ class WC_Stripe_Helper {
 		$payment_method_ids_with_capability = [];
 
 		foreach ( $payment_method_ids as $payment_method_id ) {
-			$key = $payment_method_id . '_payments';
-			if ( WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID === $payment_method_id ) {
-				$key = $payment_method_id . '_ach_payments';
-			}
+			$key = self::get_payment_method_capability_id( $payment_method_id );
 			// Check if the payment method has capabilities set in the account data.
 			// Generally the key is the payment method id appended with '_payments' (i.e. 'card_payments', 'sepa_debit_payments', 'klarna_payments').
 			// In some cases, the Stripe account might have the legacy key set. For example, for Klarna, the legacy key is 'klarna'.
@@ -1655,5 +1652,19 @@ class WC_Stripe_Helper {
 
 			WC_Stripe_Logger::log( 'Invalid IP address detected. Data: ' . wp_json_encode( $log_data ) );
 		}
+	}
+
+	/**
+	 * Return capability ID based on payment method ID.
+	 *
+	 * @param string $payment_method_id The payment method ID.
+	 * @return string The capability ID.
+	 */
+	public static function get_payment_method_capability_id( $payment_method_id ) {
+		if ( WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID === $payment_method_id ) {
+			return $payment_method_id . '_ach_payments';
+		}
+
+		return $payment_method_id . '_payments';
 	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1661,6 +1661,7 @@ class WC_Stripe_Helper {
 	 * @return string The capability ID.
 	 */
 	public static function get_payment_method_capability_id( $payment_method_id ) {
+		// "_payments" is a suffix that comes from Stripe API, except when it is "transfers" or ACH.
 		if ( WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID === $payment_method_id ) {
 			return $payment_method_id . '_ach_payments';
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1841,7 +1841,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		foreach ( $this->payment_methods as $method_id => $method ) {
 			$method_enabled       = in_array( $method_id, $this->get_upe_enabled_payment_method_ids(), true ) && ( $is_automatic_capture_enabled || ! $method->requires_automatic_capture() ) ? 'enabled' : 'disabled';
 			$method_enabled_label = 'enabled' === $method_enabled ? __( 'enabled', 'woocommerce-gateway-stripe' ) : __( 'disabled', 'woocommerce-gateway-stripe' );
-			$capability_id        = "{$method_id}_payments"; // "_payments" is a suffix that comes from Stripe API, except when it is "transfers", which does not apply here
+			$capability_id        = WC_Stripe_Helper::get_payment_method_capability_id( $method_id ); // "_payments" is a suffix that comes from Stripe API, except when it is "transfers", which does not apply here
 			$method_status        = isset( $stripe_capabilities[ $capability_id ] ) ? $stripe_capabilities[ $capability_id ] : 'inactive';
 			$subtext_messages     = $method->get_subtext_messages( $method_status );
 			$aria_label           = sprintf(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1841,7 +1841,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		foreach ( $this->payment_methods as $method_id => $method ) {
 			$method_enabled       = in_array( $method_id, $this->get_upe_enabled_payment_method_ids(), true ) && ( $is_automatic_capture_enabled || ! $method->requires_automatic_capture() ) ? 'enabled' : 'disabled';
 			$method_enabled_label = 'enabled' === $method_enabled ? __( 'enabled', 'woocommerce-gateway-stripe' ) : __( 'disabled', 'woocommerce-gateway-stripe' );
-			$capability_id        = WC_Stripe_Helper::get_payment_method_capability_id( $method_id ); // "_payments" is a suffix that comes from Stripe API, except when it is "transfers", which does not apply here
+			$capability_id        = WC_Stripe_Helper::get_payment_method_capability_id( $method_id );
 			$method_status        = isset( $stripe_capabilities[ $capability_id ] ) ? $stripe_capabilities[ $capability_id ] : 'inactive';
 			$subtext_messages     = $method->get_subtext_messages( $method_status );
 			$aria_label           = sprintf(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -342,7 +342,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		if ( empty( $capabilities ) ) {
 			return false;
 		}
-		$key = $this->get_id() . '_payments';
+		$key = WC_Stripe_Helper::get_payment_method_capability_id( $this->get_id() );
 		return isset( $capabilities[ $key ] ) && 'active' === $capabilities[ $key ];
 	}
 

--- a/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-method.php
+++ b/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-method.php
@@ -125,28 +125,28 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 	 * Mock capabilities object from Stripe response--all active.
 	 */
 	const MOCK_ACTIVE_CAPABILITIES_RESPONSE = [
-		'alipay_payments'            => 'active',
-		'bancontact_payments'        => 'active',
-		'card_payments'              => 'active',
-		'eps_payments'               => 'active',
-		'giropay_payments'           => 'active',
-		'klarna_payments'            => 'active',
-		'affirm_payments'            => 'active',
-		'clearpay_afterpay_payments' => 'active',
-		'ideal_payments'             => 'active',
-		'p24_payments'               => 'active',
-		'sepa_debit_payments'        => 'active',
-		'sofort_payments'            => 'active',
-		'transfers'                  => 'active',
-		'multibanco_payments'        => 'active',
-		'boleto_payments'            => 'active',
-		'oxxo_payments'              => 'active',
-		'link_payments'              => 'active',
-		'cashapp_payments'           => 'active',
-		'wechat_pay_payments'        => 'active',
-		'acss_debit_payments'        => 'active',
-		'us_bank_account_payments'   => 'active',
-		'bacs_debit_payments'        => 'active',
+		'alipay_payments'              => 'active',
+		'bancontact_payments'          => 'active',
+		'card_payments'                => 'active',
+		'eps_payments'                 => 'active',
+		'giropay_payments'             => 'active',
+		'klarna_payments'              => 'active',
+		'affirm_payments'              => 'active',
+		'clearpay_afterpay_payments'   => 'active',
+		'ideal_payments'               => 'active',
+		'p24_payments'                 => 'active',
+		'sepa_debit_payments'          => 'active',
+		'sofort_payments'              => 'active',
+		'transfers'                    => 'active',
+		'multibanco_payments'          => 'active',
+		'boleto_payments'              => 'active',
+		'oxxo_payments'                => 'active',
+		'link_payments'                => 'active',
+		'cashapp_payments'             => 'active',
+		'wechat_pay_payments'          => 'active',
+		'acss_debit_payments'          => 'active',
+		'us_bank_account_ach_payments' => 'active',
+		'bacs_debit_payments'          => 'active',
 	];
 
 	/**
@@ -482,7 +482,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WP_UnitTestCase {
 
 			$this->assertFalse( $payment_method->is_enabled_at_checkout( null, $currency ) );
 
-			$capability_key                                = $payment_method->get_id() . '_payments';
+			$capability_key                                = WC_Stripe_Helper::get_payment_method_capability_id( $payment_method->get_id() );
 			$mock_capabilities_response[ $capability_key ] = 'active';
 
 			$this->set_mock_payment_method_return_value( 'get_capabilities_response', $mock_capabilities_response, true );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
After discovering several places where we had to update the capability ID for ACH, I have moved that logic into a helper function now so it can be shared and also used for any future exceptions as well.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Ensure you are starting with a viable Stripe account that is US-based and a store that is using USD as the currency. Ensure that you have ACH enabled in your Stripe Payment Methods as well.

**Reproduce the issue**
- With the `develop` branch pulled, comment out the [early return when in test mode here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/class-wc-stripe-helper.php#L734) and the [early return for test mode here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7f639d041611e32f071e472ebe229ea974661fc3/includes/payment-methods/class-wc-stripe-upe-payment-method.php#L337). So that the full capabilities check runs.
- Check the list of payment methods from the Stripe Gateway settings page.
- Confirm that ACH is not displayed even though all conditions are met.
- For extra confirmation, run in debugger and confirm that the account.data.capabilities contains `us_bank_account_ach_payments`.
- Confirm that ACH is not displayed for a shopper with US billing address.

**Confirm the fix**
- With the `develop` branch pulled, comment out the [early return when in test mode here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/class-wc-stripe-helper.php#L734) and the [early return for test mode here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7f639d041611e32f071e472ebe229ea974661fc3/includes/payment-methods/class-wc-stripe-upe-payment-method.php#L337). So that the full capabilities check runs.
- Check the list of payment methods from the Stripe Gateway settings page.
- Confirm that ACH is displayed now.
- For extra confirmation, run in debugger and confirm that the account.data.capabilities contains `us_bank_account_ach_payments` and that the key update now matches the capability.
- Go through a successful checkout with a shopper with a US billing address.

To set the capability to inactive I had to modify the serialized account data in the DB for these tests. Reset to inactive after each test below.

**Check Capability Status Pill**
- Disable ACH from Stripe dashboard.
- Refresh account (it seems to take a while) until the `us_bank_account_ach_payments` capability is inactive.
- Check the Settings Payment Method list and confirm you see a requires activation pill.

![Screenshot 2025-03-14 at 6 19 58 PM](https://github.com/user-attachments/assets/9282b350-a7cb-44b5-9c3f-a64c1610fffc)

**Check unavailable payment methods**
- With ACH still disabled from above.
- Go to wp-admin > WooCommerce > Settings > Payments > Stripe.
- In the Payment methods section, verify that the unavailable payment methods' icons appear at the bottom, next to the Get more payment methods button. Also note that if more than 3 payment methods are not available, a + # more text element appears.

**Check toast notification**
- With ACH disabled from the previous test, re-enable it in Stripe.
- Go to the Payment Methods setting page, click the ellipses and select Refresh Payment Methods.
- Confirm you see a toast notification that ACH is now available to you.

![Screenshot 2025-03-14 at 6 10 25 PM](https://github.com/user-attachments/assets/a0f7f2d9-17a8-4f0e-9939-eac734ca85b1)

![Screenshot 2025-03-14 at 6 21 05 PM](https://github.com/user-attachments/assets/8c4c850a-a686-4e5d-b8d4-f8066b9ce397)



---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
