### PR TITLE
Amazon Pay ECE: update selected payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Tweak - Updates the Single Payment Element setting copy. Now it is labeled "Smart Checkout".
 * Update - Enable/disable Amazon Pay by adding/removing it from the enabled payment methods list.
 * Add - Add ACSS payment tokenization.
+* Update - Update payment method type for Amazon Pay orders.
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1490,7 +1490,17 @@ class WC_Stripe_Helper {
 	 * @return bool Whether the payment method allows manual capture.
 	 */
 	public static function payment_method_allows_manual_capture( string $payment_method_id ) {
-		return in_array( $payment_method_id, [ 'stripe', 'stripe_affirm', 'stripe_klarna', 'stripe_afterpay_clearpay' ], true );
+		return in_array(
+			$payment_method_id,
+			[
+				'stripe',
+				'stripe_affirm',
+				'stripe_klarna',
+				'stripe_afterpay_clearpay',
+				'stripe_amazon_pay',
+			],
+			true
+		);
 	}
 
 	/**

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -71,11 +71,11 @@ class WC_Stripe_Payment_Methods {
 	];
 
 	/**
-	 * List of express payment methods labels (excluding Link).
+	 * List of express payment methods labels. Amazon Pay and Link are not included,
+	 * as they have their own payment method classes.
 	 */
 	const EXPRESS_METHODS_LABELS = [
-		self::AMAZON_PAY => self::AMAZON_PAY_LABEL,
-		'google_pay'     => self::GOOGLE_PAY_LABEL,
-		'apple_pay'      => self::APPLE_PAY_LABEL,
+		'google_pay' => self::GOOGLE_PAY_LABEL,
+		'apple_pay'  => self::APPLE_PAY_LABEL,
 	];
 }

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -31,7 +31,6 @@ class WC_Stripe_Payment_Methods {
 	const WECHAT_PAY        = 'wechat_pay';
 
 	// Payment method labels
-	const AMAZON_PAY_LABEL      = 'Amazon Pay';
 	const BACS_DEBIT_LABEL      = 'Bacs Direct Debit';
 	const GOOGLE_PAY_LABEL      = 'Google Pay';
 	const APPLE_PAY_LABEL       = 'Apple Pay';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -262,9 +262,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		add_action( 'customize_save_after', [ $this, 'clear_appearance_transients' ] );
 		add_action( 'save_post', [ $this, 'clear_appearance_transients_block_theme' ], 10, 2 );
 
-		// Hide action buttons for pending Amazon Pay orders (as they take a while to be confirmed).
+		// Hide action buttons for pending orders if they take a while to be confirmed.
 		add_filter( 'woocommerce_my_account_my_orders_actions', [ $this, 'filter_my_account_my_orders_actions' ], 10, 2 );
-		add_filter( 'woocommerce_thankyou_order_received_text', [ $this, 'filter_thankyou_order_received_text' ], 10, 2 );
 	}
 
 	/**
@@ -2950,7 +2949,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	}
 
 	/**
-	 * Hide "Pay" and "Cancel" action buttons for pending Amazon Pay or BACS Debit orders (as they take a while to be confirmed).
+	 * Hide "Pay" and "Cancel" action buttons for pending orders if they take a while to be confirmed.
 	 *
 	 * @param $actions array An array with the default actions.
 	 * @param $order WC_Order The order.
@@ -2958,29 +2957,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function filter_my_account_my_orders_actions( $actions, $order ) {
 		$methods_with_delayed_confirmation = [
-			WC_Stripe_Payment_Methods::AMAZON_PAY_LABEL . WC_Stripe_Express_Checkout_Helper::get_payment_method_title_suffix(),
 			WC_Stripe_Payment_Methods::BACS_DEBIT_LABEL,
 		];
 		if ( is_order_received_page() && in_array( $order->get_payment_method_title(), $methods_with_delayed_confirmation, true ) && $order->has_status( 'pending' ) ) {
 			unset( $actions['pay'], $actions['cancel'] );
 		}
 		return $actions;
-	}
-
-	/**
-	 * Filter the order received text for Amazon Pay orders, including the delayed confirmation information.
-	 *
-	 * @param string $text Default text.
-	 * @param WC_Order|bool $order Order data.
-	 * @return string
-	 */
-	public function filter_thankyou_order_received_text( $text, $order ) {
-		$amazon_pay_title = WC_Stripe_Payment_Methods::AMAZON_PAY_LABEL . WC_Stripe_Express_Checkout_Helper::get_payment_method_title_suffix();
-		if ( is_a( $order, 'WC_Order' ) && $order->get_payment_method_title() === $amazon_pay_title && $order->has_status( 'pending' ) ) {
-			$text .= '<p class="woocommerce-info">';
-			$text .= esc_html( 'The payment is being processed and it might take a few minutes before it\'s confirmed.' );
-			$text .= '</p>';
-		}
-		return $text;
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2418,6 +2418,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return '';
 		}
 
+		// Amazon Pay is available as an express checkout method only, for now.
+		// To prevent WooCommerce from rendering it as a standard payment method in checkout, we make
+		// WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_available() return false.
+		// We set the payment method to 'amazon_pay' here, instead of earlier (i.e. passing
+		// 'stripe_amazon_pay' in the POST request) to avoid WooCommerce rejecting the order for
+		// having an "unavailable" payment method type.
+		if ( WC_Stripe_Payment_Methods::AMAZON_PAY === $this->get_express_payment_type_from_request() ) {
+			return WC_Stripe_Payment_Methods::AMAZON_PAY;
+		}
+
 		return substr( $payment_method_type, 0, 7 ) === 'stripe_' ? substr( $payment_method_type, 7 ) : 'card';
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -41,10 +41,6 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 	 * @return string
 	 */
 	public function get_title( $payment_details = false ) {
-		if ( WC_Stripe_Payment_Methods::AMAZON_PAY === ( $payment_details->type ?? null ) ) {
-			return $this->get_card_wallet_type_title( WC_Stripe_Payment_Methods::AMAZON_PAY );
-		}
-
 		$wallet_type = $payment_details->card->wallet->type ?? null;
 		if ( $payment_details && $wallet_type ) {
 			return $this->get_card_wallet_type_title( $wallet_type );

--- a/readme.txt
+++ b/readme.txt
@@ -119,5 +119,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Updates the Single Payment Element setting copy. Now it is labeled "Smart Checkout".
 * Update - Enable/disable Amazon Pay by adding/removing it from the enabled payment methods list.
 * Add - Add ACSS payment tokenization.
+* Update - Update payment method type for Amazon Pay orders.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
@@ -2826,35 +2826,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	public function payment_method_titles_provider() {
 		return [
-			'Amazon' => [ WC_Stripe_Payment_Methods::AMAZON_PAY_LABEL . WC_Stripe_Express_Checkout_Helper::get_payment_method_title_suffix() ],
-			'Bacs'   => [ WC_Stripe_Payment_Methods::BACS_DEBIT_LABEL ],
+			'Bacs' => [ WC_Stripe_Payment_Methods::BACS_DEBIT_LABEL ],
 		];
-	}
-
-	/**
-	 * Test for `filter_thankyou_order_received_text`.
-	 *
-	 * @return void
-	 */
-	public function test_filter_thankyou_order_received_text() {
-		$default_text = 'Thank you. Your order has been received.';
-
-		// Order is invalid.
-		$actual   = $this->mock_gateway->filter_thankyou_order_received_text( $default_text, false );
-		$expected = $default_text;
-
-		$this->assertEquals( $expected, $actual );
-
-		// Order exists.
-		$payment_method_suffix = WC_Stripe_Express_Checkout_Helper::get_payment_method_title_suffix();
-		$order                 = WC_Helper_Order::create_order();
-		$order->set_status( 'pending' );
-		$order->set_payment_method_title( WC_Stripe_Payment_Methods::AMAZON_PAY_LABEL . $payment_method_suffix );
-
-		$actual   = $this->mock_gateway->filter_thankyou_order_received_text( $default_text, $order );
-		$expected = $default_text . '<p class="woocommerce-info">The payment is being processed and it might take a few minutes before it&#039;s confirmed.</p>';
-
-		$this->assertEquals( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-method-cc.php
+++ b/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-method-cc.php
@@ -32,13 +32,6 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_get_title() {
 		return [
-			'Amazon Pay'             => [
-				'settings'        => [],
-				'payment details' => [
-					'type' => WC_Stripe_Payment_Methods::AMAZON_PAY,
-				],
-				'expected'        => 'Amazon Pay (Stripe)',
-			],
 			'Google Pay'             => [
 				'settings'        => [],
 				'payment details' => [

--- a/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
@@ -198,9 +198,9 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 				'title'    => 'test',
 				'expected' => 'test',
 			],
-			'Amazon Pay'   => [
-				'title'    => 'Amazon Pay (Stripe)',
-				'expected' => 'Amazon Pay (Stripe)',
+			'Google Pay'   => [
+				'title'    => 'Google Pay (Stripe)',
+				'expected' => 'Google Pay (Stripe)',
 			],
 		];
 	}

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -344,6 +344,10 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 				'payment_method' => 'stripe_eps',
 				'expected'       => false,
 			],
+			'AmazonPay'         => [
+				'payment_method' => 'stripe_amazon_pay',
+				'expected'       => true,
+			],
 		];
 	}
 


### PR DESCRIPTION
Part of #3859 
Builds on changes introduced in #4015 and #4022 
Prerequisite for #4008 

## Changes proposed in this Pull Request:
As part of supporting subscriptions and saved payment methods for Amazon Pay, we want Amazon Pay orders to use `amazon_pay` instead of `card` as the selected payment method, for the following reasons:
   - When crafting payment method options, we need to use `amazon_pay` instead of `card`. Otherwise, the payment method will not attach to the customer.
   - We need to have a separate logic when creating payment tokens. Amazon Pay does not expose card details such as last 4 digits or brand, so we cannot use the existing payment token logic for cards.

This PR also removes overrides and custom logic that are no longer necessary:
   - Payment method title overrides. No longer necessary as Amazon Pay is now its own payment method and no longer riding on the `card` payment method.
   - Code for warning shoppers regarding delayed payment verification. No longer necessary as Amazon Pay does not have to be async after all.

## Testing instructions
1. Turn on the Amazon Pay feature flag using the Stripe helper plugin, or by setting `_wcstripe_feature_amazon_pay` to `yes` in `wp_options`.
2. As a shopper, purchase any product using Amazon Pay.
3. In the Order Received confirmation page, verify that the payment method correctly says "Amazon Pay". 
4. In wp-admin Edit Order page, verify that the order says "Payment via Amazon Pay".
5. In Stripe settings, enable manual capture, i.e. `Issue an authorization on checkout, and capture later`.
6. As a shopper, make another purchase via Amazon Pay.
7. As the merchant, manually capture the charge by setting the order to "Processing".
8. Verify that the charge was successfully captured.
   - Under Order Notes, you will see a `Stripe charge complete (Charge ID: py_xxxx)` note.


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
