### PR TITLE
Update payment method type check for charge.succeeded

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Update - Update payment method type for Amazon Pay orders.
 * Fix - Compatibility with email preview in the Auth Requested email
 * Update - Update Alipay and bank debit icons.
+* Tweak - Update payment method type check for charge.succeeded webhook.
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -535,16 +535,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		// The following payment methods are synchronous so does not need to be handled via webhook.
 		$payment_method_type = $this->get_payment_method_type_from_charge( $charge );
-		if (
-			in_array(
-				$payment_method_type,
-				[
-					WC_Stripe_Payment_Methods::CARD,
-					WC_Stripe_Payment_Methods::AMAZON_PAY,
-					'three_d_secure',
-				],
-				true
-			) ) {
+		$synchronous_methods = [
+			WC_Stripe_Payment_Methods::CARD,
+			WC_Stripe_Payment_Methods::AMAZON_PAY,
+			'three_d_secure',
+		];
+
+		if ( in_array( $payment_method_type, $synchronous_methods, true ) ) {
 			return;
 		}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -526,7 +526,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_charge_succeeded( $notification ) {
 		if ( empty( $notification->data->object ) ) {
-			WC_Stripe_Logger::log( 'Missing charge object in charge.succeeded webhook' );
+			WC_Stripe_Logger::log( 'Missing charge object in charge.succeeded webhook, Event ID: %s', $notification->id ?? 'unknown' );
 			return;
 		}
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -525,15 +525,32 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_charge_succeeded( $notification ) {
-		// The following payment methods are synchronous so does not need to be handle via webhook.
-		if ( ( isset( $notification->data->object->source->type ) && WC_Stripe_Payment_Methods::CARD === $notification->data->object->source->type ) || ( isset( $notification->data->object->source->type ) && 'three_d_secure' === $notification->data->object->source->type ) ) {
+		if ( empty( $notification->data->object ) ) {
+			WC_Stripe_Logger::log( 'Missing charge object in charge.succeeded webhook' );
 			return;
 		}
 
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
+		// https://docs.stripe.com/api/events/types#event_types-charge.succeeded
+		$charge = $notification->data->object;
+
+		// The following payment methods are synchronous so does not need to be handled via webhook.
+		$payment_method_type = $this->get_payment_method_type_from_charge( $charge );
+		if (
+			in_array(
+				$payment_method_type,
+				[
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::AMAZON_PAY,
+					'three_d_secure',
+				],
+				true
+			) ) {
+			return;
+		}
+		$order = WC_Stripe_Helper::get_order_by_charge_id( $charge->id );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
+			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $charge->id );
 			return;
 		}
 
@@ -545,15 +562,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		// setting is enabled, Stripe API still sends a "charge.succeeded" webhook but
 		// the payment has not been captured, yet. This ensures that the payment has been
 		// captured, before completing the payment.
-		if ( ! $notification->data->object->captured ) {
+		if ( ! $charge->captured ) {
 			return;
 		}
 
 		// Store other data such as fees
-		$order->set_transaction_id( $notification->data->object->id );
+		$order->set_transaction_id( $charge->id );
 
-		if ( isset( $notification->data->object->balance_transaction ) ) {
-			$this->update_fees( $order, $notification->data->object->balance_transaction );
+		if ( isset( $charge->balance_transaction ) ) {
+			$this->update_fees( $order, $charge->balance_transaction );
 		}
 
 		/**
@@ -568,10 +585,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		 * to ensure the review.closed event handler will update the status to the proper status.
 		 */
 		if ( 'manual_review' !== $this->get_risk_outcome( $notification ) ) {
-			$order->payment_complete( $notification->data->object->id );
+			$order->payment_complete( $charge->id );
 
 			/* translators: transaction id */
-			$order->add_order_note( sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $notification->data->object->id ) );
+			$order->add_order_note( sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $charge->id ) );
 		}
 
 		if ( is_callable( [ $order, 'save' ] ) ) {
@@ -1357,6 +1374,27 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		// Fall back to finding the order via the intent ID.
 		return WC_Stripe_Helper::get_order_by_intent_id( $intent->id );
+	}
+
+	/**
+	 * Get the payment method type from the charge object.
+	 * https://docs.stripe.com/api/charges/object
+	 *
+	 * @param object $charge The charge object from Stripe
+	 * @return string|null The payment method type, or null if not found
+	 */
+	private function get_payment_method_type_from_charge( $charge ) {
+		// We don't expect $charge->source to be set,
+		// but we keep it here to ensure backwards compatibility.
+		if ( isset( $charge->source->type ) ) {
+			return $charge->source->type;
+		}
+
+		if ( isset( $charge->payment_method_details->type ) ) {
+			return $charge->payment_method_details->type;
+		}
+
+		return null;
 	}
 }
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -547,6 +547,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			) ) {
 			return;
 		}
+
 		$order = WC_Stripe_Helper::get_order_by_charge_id( $charge->id );
 
 		if ( ! $order ) {

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Update payment method type for Amazon Pay orders.
 * Fix - Compatibility with email preview in the Auth Requested email
 * Update - Update Alipay and bank debit icons.
+* Tweak - Update payment method type check for charge.succeeded webhook.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -624,4 +624,48 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Test for `process_webhook_charge_succeeded`, that it is skipped for synchronous payment methods.
+	 *
+	 * @param string $payment_method_type The payment method type.
+	 * @return void
+	 * @dataProvider provide_test_process_webhook_charge_succeeded_skipped_for_synchronous_payment_methods
+	 */
+	public function test_process_webhook_charge_succeeded_skipped_for_synchronous_payment_methods( $payment_method_type ) {
+		$notification = (object) [
+			'type' => 'charge.succeeded',
+			'data' => (object) [
+				'object' => (object) [
+					'id'                     => 'ch_mock',
+					'payment_method_details' => (object) [
+						'type' => $payment_method_type,
+					],
+				],
+			],
+		];
+
+		// Mock WC_Stripe_Helper::get_order_by_charge_id
+		$helper_mock = $this->getMockBuilder( WC_Stripe_Helper::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$helper_mock::expects( $this->never() )
+			->method( 'get_order_by_charge_id' );
+
+		$this->mock_webhook_handler->process_webhook_charge_succeeded( $notification );
+	}
+
+	/**
+	 * Provider for `test_process_webhook_charge_succeeded_skipped_for_synchronous_payment_methods`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_process_webhook_charge_succeeded_skipped_for_synchronous_payment_methods() {
+		return [
+			'card'           => [ WC_Stripe_Payment_Methods::CARD ],
+			'amazon_pay'     => [ WC_Stripe_Payment_Methods::AMAZON_PAY ],
+			'three_d_secure' => [ 'three_d_secure' ],
+		];
+	}
 }

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -54,6 +54,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'get_intent_from_order',
 			'get_latest_charge_from_intent',
 			'process_response',
+			'update_fees',
 		];
 
 		$methods = array_diff( $methods, $exclude_methods );
@@ -633,25 +634,40 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_process_webhook_charge_succeeded_skipped_for_synchronous_payment_methods
 	 */
 	public function test_process_webhook_charge_succeeded_skipped_for_synchronous_payment_methods( $payment_method_type ) {
+		$charge_id    = 'ch_mock9G5K2X1Q';
 		$notification = (object) [
 			'type' => 'charge.succeeded',
 			'data' => (object) [
 				'object' => (object) [
-					'id'                     => 'ch_mock',
+					'id'                     => $charge_id,
 					'payment_method_details' => (object) [
 						'type' => $payment_method_type,
+					],
+					'captured'               => true,
+					'balance_transaction'    => (object) [
+						'fee' => 100,
 					],
 				],
 			],
 		];
 
-		// Mock WC_Stripe_Helper::get_order_by_charge_id
-		$helper_mock = $this->getMockBuilder( WC_Stripe_Helper::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+		// We want to assert an early return by checking that we don't run the next line, i.e.
+		// retrieving the order by charge ID. However, we are using WC_Stripe_Helper::get_order_by_charge_id()
+		// which is a static method, and phpunit does not natively support mocking static methods.
 
-		$helper_mock::expects( $this->never() )
-			->method( 'get_order_by_charge_id' );
+		// We will instead create the mock order for the charge ID, so we are able to retrieve an order,
+		// and make sure the next few checks pass so that it reaches the line that calls update_fees()
+		// which we can mock and check if it was called.
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'on-hold' );
+		$order->set_transaction_id( $charge_id );
+		$order->save();
+
+		if ( WC_Stripe_Payment_Methods::SEPA_DEBIT === $payment_method_type ) {
+			$this->mock_webhook_handler->expects( $this->once() )->method( 'update_fees' );
+		} else {
+			$this->mock_webhook_handler->expects( $this->never() )->method( 'update_fees' );
+		}
 
 		$this->mock_webhook_handler->process_webhook_charge_succeeded( $notification );
 	}
@@ -666,6 +682,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'card'           => [ WC_Stripe_Payment_Methods::CARD ],
 			'amazon_pay'     => [ WC_Stripe_Payment_Methods::AMAZON_PAY ],
 			'three_d_secure' => [ 'three_d_secure' ],
+			'sepa_debit'     => [ WC_Stripe_Payment_Methods::SEPA_DEBIT ],
 		];
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request:

I noticed we've been getting a lot of `Could not find order via charge ID: ch_...` messages in our logs, and it was coming from `WC_Stripe_Webhook_Handler::process_webhook_charge_succeeded( $notification )`, even for orders purchased via synchronous payment methods.

We have existing logic that skips `WC_Stripe_Webhook_Handler::process_webhook_charge_succeeded()` if the payment method is expected to be synchronous, but it looks like it has not been updated from the deprecated Sources API. It still tries to get the payment method type from `$notification->data->object->source->type`. 

This PR updates the logic to get the payment method type from `$notification->data->object->payment_method_details->type` (https://docs.stripe.com/api/charges/object).

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Go to Stripe settings, and ensure `Log error messages` is enabled.
2. As a shopper, make any purchase via credit card. Google Pay, Apple Pay or Link can also be used.
3. Go to WooCommerce > Status > Logs, open woocommerce-gateway-stripe for the current date, and search for the most recent `Webhook received: charge.succeeded` instance.
   - In `develop`, you will see the message `Could not find order via charge ID: ch_...` after the webhook log.
   - In this branch, you should not see this message.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
