### PR TITLE
Implementing the Stripe order class in unit tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.4.0 - xxxx-xx-xx =
+* Dev - Implements the new Stripe order class into the PHP unit tests.
 * Dev - Introduces new payment method constants for the express methods: Google Pay, Apple Pay, Link, and Amazon Pay (backend version).
 * Dev - Introduces a new Stripe Order class to wrap Stripe-specific logic and data on the backend.
 * Dev - Improves how we handle express payment method titles by introducing new constants and methods to replace duplicate code.

--- a/includes/class-wc-stripe-order.php
+++ b/includes/class-wc-stripe-order.php
@@ -182,7 +182,7 @@ class WC_Stripe_Order extends WC_Order {
 	 * @param $order_data array Order data.
 	 * @return bool|WC_Stripe_Order
 	 */
-	public static function create( $order_data ) {
+	public static function create( $order_data = [] ) {
 		$order = wc_create_order( $order_data );
 		if ( ! $order ) {
 			return false;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -701,7 +701,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false, $previous_error = false, $use_order_source = false ) {
 		$payment_intent_id     = isset( $_POST['wc_payment_intent_id'] ) ? wc_clean( wp_unslash( $_POST['wc_payment_intent_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$order                 = wc_get_order( $order_id );
+		$order                 = WC_Stripe_Order::get_by_id( $order_id );
 		$selected_payment_type = $this->get_selected_payment_method_type_from_request();
 
 		if ( $payment_intent_id && ! $this->payment_methods[ $selected_payment_type ]->supports_deferred_intent() ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1403,7 +1403,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @version 5.5.0
 	 */
 	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $is_pay_for_order = false ) {
-		$order = wc_get_order( $order_id );
+		$order = WC_Stripe_Order::get_by_id( $order_id );
 
 		if ( ! is_object( $order ) ) {
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.4.0 - xxxx-xx-xx =
+* Dev - Implements the new Stripe order class into the PHP unit tests.
 * Dev - Introduces new payment method constants for the express methods: Google Pay, Apple Pay, Link, and Amazon Pay (backend version).
 * Dev - Introduces a new Stripe Order class to wrap Stripe-specific logic and data on the backend.
 * Dev - Improves how we handle express payment method titles by introducing new constants and methods to replace duplicate code.

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
@@ -73,9 +73,9 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 
 		$order    = WC_Helper_Order::create_order();
 		$endpoint = '/' . strval( $order->get_id() ) . '/create_customer';
-		$order->add_meta_data( '_stripe_customer_id', 'cus_12345', true );
+		$order->set_stripe_customer_id( 'cus_12345' );
 		$order->save();
-		$this->assertEquals( 'cus_12345', $order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( 'cus_12345', $order->get_stripe_customer_id() );
 
 		// Mock response from Stripe API using request arguments.
 		$test_request = function ( $preempt, $parsed_args, $url ) {
@@ -140,10 +140,12 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 		$request->set_param( 'payment_intent_id', 'pi_12345' );
 		$response = rest_do_request( $request );
 
+		$order = WC_Stripe_Order::get_by_id( $order->get_id() );
+
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'succeeded', $response->get_data()['status'] );
 		$this->assertEquals( 'ch_12345', $response->get_data()['id'] );
-		$this->assertEquals( 'pi_12345', $order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertEquals( 'pi_12345', $order->get_intent_id() );
 
 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -82,11 +82,8 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_add_buttons_action_is_called_on_order_admin_page() {
-		$order    = WC_Helper_Order::create_order();
-		$order_id = $order->get_id();
-
-		$intent_id = 'pi_mock';
-		update_post_meta( $order_id, '_stripe_intent_id', $intent_id );
+		$order = WC_Helper_Order::create_order();
+		$order->set_intent_id( 'pi_mock' );
 
 		$intent = (object) [
 			'id'     => 'pi_123',

--- a/tests/phpunit/helpers/class-wc-helper-order.php
+++ b/tests/phpunit/helpers/class-wc-helper-order.php
@@ -19,7 +19,7 @@ class WC_Helper_Order {
 	 */
 	public static function delete_order( $order_id ) {
 
-		$order = wc_get_order( $order_id );
+		$order = WC_Stripe_Order::get_by_id( $order_id );
 
 		// Delete all products in the order.
 		foreach ( $order->get_items() as $item ) {

--- a/tests/phpunit/helpers/class-wc-helper-order.php
+++ b/tests/phpunit/helpers/class-wc-helper-order.php
@@ -42,7 +42,7 @@ class WC_Helper_Order {
 	 * @param WC_Product $product The product to add to the order.
 	 * @param array      $order_props Order properties.
 	 *
-	 * @return WC_Order
+	 * @return WC_Stripe_Order
 	 */
 	public static function create_order( $customer_id = 1, $product = null, $order_props = [] ) {
 
@@ -60,7 +60,7 @@ class WC_Helper_Order {
 		];
 
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception.
-		$order                  = wc_create_order( $order_data );
+		$order                  = WC_Stripe_Order::create( $order_data );
 
 		// Add order products.
 		$item = new WC_Order_Item_Product();

--- a/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
@@ -2440,7 +2440,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		];
 
 		// Save the failed intent ID to the order
-		$order->update_meta_data( '_stripe_intent_id', $mock_failed_intent->id );
+		$order->set_intent_id( $mock_failed_intent->id );
 		$order->save();
 
 		// Mock that we find an existing failed intent on the order

--- a/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
@@ -331,9 +331,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$currency          = $order->get_currency();
 		$order_id          = $order->get_id();
 
-		$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
-		$order->update_meta_data( '_stripe_upe_payment_type', '' );
-		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
+		$order->set_intent_id( $payment_intent_id );
+		$order->set_upe_payment_type( '' );
+		$order->set_upe_waiting_for_redirect( true );
 		$order->save();
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
@@ -353,7 +353,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -362,7 +362,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->with(
 				"payment_intents/$payment_intent_id",
 				$expected_request,
-				wc_get_order( $order_id )
+				WC_Stripe_Order::get_by_id( $order_id )
 			)
 			->will(
 				$this->returnValue( [] )
@@ -675,7 +675,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'failure', $response['result'] );
 
-		$processed_order = wc_get_order( $order_id );
+		$processed_order = WC_Stripe_Order::get_by_id( $order_id );
 		$this->assertEquals( 'failed', $processed_order->get_status() );
 	}
 
@@ -744,7 +744,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'failure', $response['result'] );
 
-		$processed_order = wc_get_order( $order_id );
+		$processed_order = WC_Stripe_Order::get_by_id( $order_id );
 		$this->assertEquals( 'failed', $processed_order->get_status() );
 	}
 
@@ -813,7 +813,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'failure', $response['result'] );
 
-		$processed_order = wc_get_order( $order_id );
+		$processed_order = WC_Stripe_Order::get_by_id( $order_id );
 		$this->assertEquals( 'failed', $processed_order->get_status() );
 	}
 
@@ -889,7 +889,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -899,8 +899,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'processing', $final_order->get_status() );
 		$this->assertEquals( 'Credit / Debit Card', $final_order->get_payment_method_title() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertTrue( (bool) $final_order->get_meta( '_stripe_upe_redirect_processed', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertTrue( $final_order->is_upe_redirect_processed() );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
@@ -952,7 +952,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$success_order = wc_get_order( $order_id );
+		$success_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$note = wc_get_order_notes(
 			[
@@ -964,8 +964,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// assert successful order processing
 		$this->assertEquals( 'processing', $success_order->get_status() );
 		$this->assertEquals( 'Credit / Debit Card', $success_order->get_payment_method_title() );
-		$this->assertEquals( $payment_intent_id, $success_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertTrue( (bool) $success_order->get_meta( '_stripe_upe_redirect_processed', true ) );
+		$this->assertEquals( $payment_intent_id, $success_order->get_intent_id() );
+		$this->assertTrue( $success_order->is_upe_redirect_processed() );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 
 		// simulate an order getting marked as failed as if from a webhook
@@ -975,7 +975,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// attempt to reprocess the order and confirm status is unchanged
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'failed', $final_order->get_status() );
 	}
@@ -1006,7 +1006,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1021,11 +1021,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $setup_intent_id, true );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
 		$this->assertEquals( 'Credit / Debit Card', $final_order->get_payment_method_title() );
 	}
 
@@ -1057,7 +1057,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1083,12 +1083,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, true );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
 	}
 
 	/**
@@ -1122,7 +1122,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1151,12 +1151,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, true );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $generated_payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $generated_payment_method_id, $final_order->get_source_id() );
 	}
 
 	/**
@@ -1197,7 +1197,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1210,11 +1210,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $setup_intent_id, true );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $generated_payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $generated_payment_method_id, $final_order->get_source_id() );
 	}
 
 	/**
@@ -1287,29 +1287,29 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		// Test no charge captured.
 		$charge_mock['captured'] = false;
 		$charge_mock['id']       = 'ch_mock_1';
-		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
-		$test_order = wc_get_order( $order_id );
+		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
+		$test_order = WC_Stripe_Order::get_by_id( $order_id );
 
-		$this->assertEquals( 'no', $test_order->get_meta( '_stripe_charge_captured', true ) );
+		$this->assertFalse( $test_order->is_charge_captured() );
 		$this->assertEquals( $charge_mock['id'], $test_order->get_transaction_id() );
 		$this->assertEquals( 'on-hold', $test_order->get_status() );
 
 		// Test charge succeeds.
 		$charge_mock['captured'] = true;
 		$charge_mock['id']       = 'ch_mock_2';
-		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
-		$test_order = wc_get_order( $order_id );
+		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
+		$test_order = WC_Stripe_Order::get_by_id( $order_id );
 
-		$this->assertEquals( 'yes', $test_order->get_meta( '_stripe_charge_captured', true ) );
+		$this->assertTrue( $test_order->is_charge_captured() );
 		$this->assertEquals( 'processing', $test_order->get_status() );
 
 		// Test charge pending.
 		$charge_mock['status'] = 'pending';
 		$charge_mock['id']     = 'ch_mock_3';
-		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
-		$test_order = wc_get_order( $order_id );
+		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
+		$test_order = WC_Stripe_Order::get_by_id( $order_id );
 
-		$this->assertEquals( 'yes', $test_order->get_meta( '_stripe_charge_captured', true ) );
+		$this->assertTrue( $test_order->is_charge_captured() );
 		$this->assertEquals( $charge_mock['id'], $test_order->get_transaction_id() );
 		$this->assertEquals( 'on-hold', $test_order->get_status() );
 
@@ -1318,7 +1318,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$charge_mock['id']     = 'ch_mock_4';
 		$exception             = null;
 		try {
-			$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
+			$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
 		} catch ( WC_Stripe_Exception $e ) {
 			// Test that exception is thrown.
 			$exception = $e;
@@ -1409,7 +1409,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->willReturn( $this->array_to_object( $charge ) );
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -1419,9 +1419,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
@@ -1497,14 +1497,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->willReturn( $this->array_to_object( $charge ) );
 
 		$response      = $this->mock_gateway->process_payment( $order_id );
-		$final_order   = wc_get_order( $order_id );
+		$final_order   = WC_Stripe_Order::get_by_id( $order_id );
 		$client_secret = $payment_intent_mock->client_secret;
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( 'pending', $final_order->get_status() ); // Order status should be pending until 3DS is completed.
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
 		$this->assertMatchesRegularExpression( "/#wc-stripe-confirm-pi:$order_id:$client_secret/", $response['redirect'] );
 	}
 
@@ -1560,12 +1560,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'failure', $response['result'] );
 		$this->assertEquals( 'failed', $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
 	}
 
 	/**
@@ -1655,7 +1655,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->willReturn( $this->array_to_object( $charge ) );
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -1665,9 +1665,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( 'processing', $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
@@ -1750,11 +1750,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'failure', $response['result'] );
 		$this->assertEquals( 'failed', $final_order->get_status() );
-		$this->assertEquals( '', $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( '', $final_order->get_stripe_customer_id() );
 	}
 
 	/**
@@ -1771,9 +1771,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		$currency          = $order->get_currency();
 		$order_id          = $order->get_id();
 
-		$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
-		$order->update_meta_data( '_stripe_upe_payment_type', '' );
-		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
+		$order->set_intent_id( $payment_intent_id );
+		$order->set_upe_payment_type( '' );
+		$order->set_upe_waiting_for_redirect( true );
 		$order->save();
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
@@ -1805,7 +1805,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1815,7 +1815,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			->with(
 				"payment_intents/$payment_intent_id",
 				$expected_request,
-				wc_get_order( $order_id )
+				WC_Stripe_Order::get_by_id( $order_id )
 			)
 			->will(
 				$this->returnValue( [] )
@@ -1888,10 +1888,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
-		$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
+		$order->set_lock_payment( ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
 		$order->save();
 
-		$order = wc_get_order( $order_id );
+		$order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
 		$payment_method_mock['id']               = $payment_method_id;
@@ -1945,7 +1945,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_subscription_payment( $amount, $order, false, false );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -1982,10 +1982,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
-		$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
+		$order->set_lock_payment( ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
 		$order->save();
 
-		$order = wc_get_order( $order_id );
+		$order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
 		$payment_method_mock['id']               = $payment_method_id;
@@ -2047,7 +2047,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_subscription_payment( $amount, $order, false, false );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -2118,14 +2118,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			);
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'has_pre_order_charged_upon_release' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )
@@ -2144,13 +2144,13 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
 		$this->assertEquals( 'Credit / Debit Card', $final_order->get_payment_method_title() );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
-		$this->assertTrue( (bool) $final_order->get_meta( '_stripe_upe_redirect_processed', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
+		$this->assertTrue( $final_order->is_upe_redirect_processed() );
 	}
 
 	/**
@@ -2179,7 +2179,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( wc_get_order( $order_id ) )
+			->with( WC_Stripe_Order::get_by_id( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -2211,11 +2211,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $setup_intent_id, true );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
-		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
-		$this->assertTrue( (bool) $final_order->get_meta( '_stripe_upe_redirect_processed', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
+		$this->assertTrue( $final_order->is_upe_redirect_processed() );
 	}
 
 	/**
@@ -2568,7 +2568,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = wc_get_order( $order_id );
+		$final_order = WC_Stripe_Order::get_by_id( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -2577,7 +2577,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WP_UnitTestCase {
 		)[0];
 
 		$this->assertEquals( 'success', $response['result'] );
-		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 

--- a/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
@@ -141,13 +141,13 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_add_order_meta
 	 */
 	public function test_add_order_meta( $checkout_type, $expected ) {
-		$order = wc_create_order();
+		$order = WC_Stripe_Order::create();
 
 		$_POST['express_checkout_type'] = $checkout_type;
 		$_POST['payment_method']        = 'stripe';
 
 		$this->element->add_order_meta( $order->get_id(), [] );
-		$order = wc_get_order( $order->get_id() );
+		$order = WC_Stripe_Order::get_by_id( $order->get_id() );
 
 		$this->assertSame( $expected, $order->get_payment_method_title() );
 	}

--- a/tests/phpunit/test-class-wc-stripe-order-handler.php
+++ b/tests/phpunit/test-class-wc-stripe-order-handler.php
@@ -19,10 +19,10 @@ class WC_Stripe_Order_Handler_Test extends WP_UnitTestCase {
 
 	public function test_prevent_cancelling_orders_awaiting_action() {
 		$order = WC_Helper_Order::create_order();
-		WC_Stripe_Helper::set_payment_awaiting_action( $order );
+		$order->set_payment_awaiting_action();
 
 		// Read in a fresh order object with meta like `date_modified` set.
-		$order = wc_get_order( $order->get_id() );
+		$order = WC_Stripe_Order::get_by_id( $order->get_id() );
 
 		// Test when false is passed that the order is not cancelled.
 		$this->assertFalse( $this->order_handler->prevent_cancelling_orders_awaiting_action( false, $order ) );

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -212,6 +212,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 
 		$intent_id = 'pi_mock';
 		$order->set_intent_id( $intent_id );
+		$order->save_meta_data();
 
 		$order = WC_Stripe_Order::get_by_intent_id( $intent_id );
 		if ( $success ) {
@@ -393,6 +394,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		WC_Stripe_Helper::update_main_stripe_settings( [ 'test' => 'test' ] );
 		$current_settings = WC_Stripe_Helper::get_stripe_settings();
 		$this->assertSame( [ 'test' => 'test' ], $current_settings );
+
 		WC_Stripe_Helper::delete_main_stripe_settings();
 		$current_settings = WC_Stripe_Helper::get_stripe_settings();
 		$this->assertSame( [], $current_settings );

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -213,7 +213,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		$intent_id = 'pi_mock';
 		update_post_meta( $order_id, '_stripe_intent_id', $intent_id );
 
-		$order = WC_Stripe_Helper::get_order_by_intent_id( $intent_id );
+		$order = WC_Stripe_Order::get_by_intent_id( $intent_id );
 		if ( $success ) {
 			$this->assertInstanceOf( WC_Order::class, $order );
 		} else {

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -207,15 +207,15 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
 
-		$order = wc_get_order( $order_id );
+		$order = WC_Stripe_Order::get_by_id( $order_id );
 		$order->set_status( $status );
 
 		$intent_id = 'pi_mock';
-		update_post_meta( $order_id, '_stripe_intent_id', $intent_id );
+		$order->set_intent_id( $intent_id );
 
 		$order = WC_Stripe_Order::get_by_intent_id( $intent_id );
 		if ( $success ) {
-			$this->assertInstanceOf( WC_Order::class, $order );
+			$this->assertInstanceOf( WC_Stripe_Order::class, $order );
 		} else {
 			$this->assertFalse( $order );
 		}

--- a/tests/phpunit/test-wc-stripe-order.php
+++ b/tests/phpunit/test-wc-stripe-order.php
@@ -116,7 +116,7 @@ class WC_Stripe_Order_Test extends WP_UnitTestCase {
 		);
 		$order->set_upe_redirect_processed( true );
 		$order->set_upe_waiting_for_redirect( true );
-		$order->set_charge_captured( true );
+		$order->set_charge_captured( 'yes' );
 		$order->set_status_final( true );
 
 		$order->set_fee( 100 );

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -578,8 +578,8 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$mock_subscription = WC_Helper_Order::create_order(); // We can use an order as a subscription.
 		$mock_subscription->set_payment_method( 'stripe' );
 
-		$mock_subscription->update_meta_data( '_stripe_source_id', 'src_mock' );
-		$mock_subscription->update_meta_data( '_stripe_customer_id', 'cus_mock' );
+		$mock_subscription->set_source_id( 'src_mock' );
+		$mock_subscription->set_stripe_customer_id( 'cus_mock' );
 		$mock_subscription->save();
 
 		// This is the key the customer's payment methods are stored under in the transient.
@@ -631,45 +631,45 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	public function test_lock_order_payment() {
 		$order_1 = WC_Helper_Order::create_order();
-		$locked  = $this->gateway->lock_order_payment( $order_1 );
+		$locked  = $order_1->lock_payment();
 
 		$this->assertFalse( $locked );
 		$current_lock = $order_1->get_meta( '_stripe_lock_payment' );
 		$this->assertEqualsWithDelta( (int) $current_lock, ( time() + 5 * MINUTE_IN_SECONDS ), 3 );
 
-		$locked = $this->gateway->lock_order_payment( $order_1 );
+		$locked = $order_1->lock_payment();
 		$this->assertTrue( $locked );
 
 		// lock with an intent ID.
 		$order_2   = WC_Helper_Order::create_order();
 		$intent_id = 'pi_123intent';
 
-		$locked       = $this->gateway->lock_order_payment( $order_2, $intent_id );
+		$locked       = $order_2->lock_payment( $intent_id );
 		$current_lock = $order_2->get_meta( '_stripe_lock_payment' );
 
 		$this->assertFalse( $locked );
-		$locked = $this->gateway->lock_order_payment( $order_2, $intent_id );
+		$locked = $order_2->lock_payment( $intent_id );
 		$this->assertTrue( $locked );
-		$locked = $this->gateway->lock_order_payment( $order_2 ); // test that you don't need to pass the intent ID to check lock.
+		$locked = $order_2->lock_payment(); // test that you don't need to pass the intent ID to check lock.
 		$this->assertTrue( $locked );
 
 		// test expired locks.
 		$order_3 = WC_Helper_Order::create_order();
-		$order_3->update_meta_data( '_stripe_lock_payment', time() - 1 );
+		$order_3->set_lock_payment( time() - 1 );
 		$order_3->save_meta_data();
 
-		$locked       = $this->gateway->lock_order_payment( $order_3, $intent_id );
-		$current_lock = $order_3->get_meta( '_stripe_lock_payment' );
+		$locked       = $order_3->lock_payment( $intent_id );
+		$current_lock = $order_3->get_lock_payment();
 
 		$this->assertFalse( $locked );
 		$this->assertEqualsWithDelta( (int) $current_lock, ( time() + 5 * MINUTE_IN_SECONDS ), 3 );
 
 		// test two instances of the same order, one locked and one not.
 		$order_4   = WC_Helper_Order::create_order();
-		$dup_order = wc_get_order( $order_4->get_id() );
+		$dup_order = WC_Stripe_Order::get_by_id( $order_4->get_id() );
 
-		$this->gateway->lock_order_payment( $order_4 );
-		$dup_locked = $this->gateway->lock_order_payment( $dup_order );
+		$order_4->lock_payment();
+		$dup_locked = $dup_order->lock_payment();
 		$this->assertTrue( $dup_locked ); // Confirms lock from $order_4 prevents payment on $dup_order.
 	}
 

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -634,7 +634,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$locked  = $order_1->lock_payment();
 
 		$this->assertFalse( $locked );
-		$current_lock = $order_1->get_meta( '_stripe_lock_payment' );
+		$current_lock = $order_1->get_lock_payment();
 		$this->assertEqualsWithDelta( (int) $current_lock, ( time() + 5 * MINUTE_IN_SECONDS ), 3 );
 
 		$locked = $order_1->lock_payment();
@@ -645,7 +645,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$intent_id = 'pi_123intent';
 
 		$locked       = $order_2->lock_payment( $intent_id );
-		$current_lock = $order_2->get_meta( '_stripe_lock_payment' );
+		$current_lock = $order_2->get_lock_payment();
 
 		$this->assertFalse( $locked );
 		$locked = $order_2->lock_payment( $intent_id );
@@ -706,7 +706,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->set_currency( 'USD' );
 		$order->set_transaction_id( 'ch_123' );
-		$order->update_meta_data( '_stripe_charge_captured', 'yes' );
+		$order->set_charge_captured( 'yes' );
 		$order->save();
 		$order_id = $order->get_id();
 

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -194,8 +194,8 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result['result'], 'success' );
 		$this->assertArrayHasKey( 'redirect', $result );
 
-		$order      = wc_get_order( $order_id );
-		$order_data = $order->get_meta( '_stripe_intent_id' );
+		$order      = WC_Stripe_Order::get_by_id( $order_id );
+		$order_data = $order->get_intent_id();
 
 		$this->assertEquals( $order_data, 'pi_123abc' );
 

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -339,9 +339,10 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result, null );
 
 		// Assert that we saved the payment intent to the order.
-		$order_id             = $renewal_order->get_id();
-		$order                = wc_get_order( $order_id );
-		$order_data           = $order->get_meta( '_stripe_intent_id' );
+		$order_id = $renewal_order->get_id();
+		$order    = WC_Stripe_Order::get_by_id( $order_id );
+
+		$order_data           = $order->get_intent_id();
 		$order_transaction_id = $order->get_transaction_id();
 
 		// Intent was saved to order even though there was an error in the response body.

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -224,8 +224,8 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		// Assert that we saved the payment intent to the order.
 		$order_id   = $renewal_order->get_id();
-		$order      = wc_get_order( $order_id );
-		$order_data = $order->get_meta( '_stripe_intent_id' );
+		$order      = WC_Stripe_Order::get_by_id( $order_id );
+		$order_data = $order->get_intent_id();
 
 		$this->assertEquals( $order_data, 'pi_123abc' );
 

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -239,7 +239,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler->process_webhook_charge_failed( $notification );
 
 		if ( $charge_id ) { // Order not found charge ID.
-			$final_order = wc_get_order( $order->get_id() );
+			$final_order = WC_Stripe_Order::get_by_id( $order->get_id() );
 			$this->assertEquals( $expected_status, $final_order->get_status() );
 
 			if ( $expected_note ) {
@@ -313,7 +313,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order->set_status( $order_status );
 		$order->set_transaction_id( $charge_id );
 		if ( $order_status_final ) {
-			$order->update_meta_data( '_stripe_status_final', true );
+			$order->set_status_final( true );
 		}
 		$order->save();
 
@@ -329,7 +329,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_webhook_dispute( $notification );
 
-		$final_order = wc_get_order( $order->get_id() );
+		$final_order = WC_Stripe_Order::get_by_id( $order->get_id() );
 
 		$notes = wc_get_order_notes(
 			[
@@ -423,13 +423,13 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( $order_status );
 		if ( $order_locked ) {
-			$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) );
+			$order->lock_payment();
 		}
 		if ( $order_status_final ) {
-			$order->update_meta_data( '_stripe_status_final', true );
+			$order->set_status_final( true );
 		}
-		$order->update_meta_data( '_stripe_upe_payment_type', $payment_type );
-		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
+		$order->set_upe_payment_type( $payment_type );
+		$order->set_upe_waiting_for_redirect( true );
 		$order->save_meta_data();
 		$order->save();
 
@@ -456,7 +456,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_payment_intent( $notification );
 
-		$final_order = wc_get_order( $order->get_id() );
+		$final_order = WC_Stripe_Order::get_by_id( $order->get_id() );
 
 		$this->assertSame( $expected_status, $final_order->get_status() );
 		if ( ! empty( $expected_note ) ) {
@@ -496,7 +496,9 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		// Order must be previously set to pending and have at least the payment intent set.
 		$order = WC_Helper_Order::create_order();
+
 		WC_Stripe_Helper::add_payment_intent_to_order( $notification->data->object->id, $order );
+
 		$order->set_status( 'pending' );
 		$order->save();
 
@@ -508,7 +510,8 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_payment_intent( $notification );
 
-		$updated_order = wc_get_order( $order->get_id() );
+		$updated_order = WC_Stripe_Order::get_by_id( $order->get_id() );
+
 		$this->assertEquals( 'on-hold', $updated_order->get_status() );
 		$this->assertEquals( 'ch_mock', $updated_order->get_transaction_id() );
 

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -223,7 +223,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order->set_status( $order_status );
 		$order->set_transaction_id( $charge_id );
 		if ( $order_status_final ) {
-			$order->update_meta_data( '_stripe_status_final', true );
+			$order->set_status_final( true );
 		}
 		$order->save();
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

First PR: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4080

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR is the second in a series of implementations of the proposal of https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3654. This iteration implements the order wrapper class on our PHP unit tests.

Two changes to the main code had to be made so tests could pass.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Code review. Check if the tests are still passing. A slight smoke test would be nice since two changes were made in the main code. Setting up Stripe and trying to buy something, for example.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
