### PR TITLE
Fix charging wrong amount after order amount update following a failed payment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Tweak - Updates the Single Payment Element setting copy. Now it is labeled "Smart Checkout".
 * Update - Enable/disable Amazon Pay by adding/removing it from the enabled payment methods list.
 * Add - Add ACSS payment tokenization.
+* Fix - Prevent reuse of payment intents when order total doesn't match intent amount.
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2687,6 +2687,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return null;
 		}
 
+		// Check if the order total matches the existing intent amount.
+		$order_total = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $order->get_currency() );
+		if ( $order_total !== $intent->amount ) {
+			return null;
+		}
+
 		// Check if the status of the intent still allows update.
 		if ( in_array( $intent->status, [ WC_Stripe_Intent_Status::CANCELED, WC_Stripe_Intent_Status::SUCCEEDED ], true ) ) {
 			return null;

--- a/readme.txt
+++ b/readme.txt
@@ -118,5 +118,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Updates the Single Payment Element setting copy. Now it is labeled "Smart Checkout".
 * Update - Enable/disable Amazon Pay by adding/removing it from the enabled payment methods list.
 * Add - Add ACSS payment tokenization.
+* Fix - Prevent reuse of payment intents when order total doesn't match intent amount.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #3995

## Changes proposed in this Pull Request:
The `get_existing_compatible_payment_intent` function checks if we can use the existing intent for creating the charge. I have added an additional check in this compatibility function to check if the amount of the intent is the same as the current order total. If not, we return `null`.

## Testing instructions

- Enable card payment method in Stripe settings page.
- As a customer, add a product to your cart and go to the checkout page.
- Try to complete checkout with a card that declines payment (https://docs.stripe.com/testing#declined-payments)
- The checkout should fail.
- As an admin, go to the order edit page.
- If the order is in failed status, move it back to the pending payment status and update the order.
- Now edit the product price in this order and set a lesser amount. i,e. if the product price was $18, change it to $10. (update it in the order edit page, not the original product's price on the product page). Update the order.
- Now copy the customer payment link and try to pay it as the customer.
- This time use a valid card (https://docs.stripe.com/testing#cards) so that the checkout is successful.

**In `develop` branch**
- Check the order edit page. Notice that the total here is correct with the updated amount ($10), but the Stripe fee and Stripe Payout refers to the previous amount ($18).


<img width="980" alt="Screenshot 2025-03-19 at 4 30 25 PM" src="https://github.com/user-attachments/assets/a5ea0c46-8578-4e85-9b91-ae46b0f752c7" />

- Check the order notes. You will find that only one intent has been created for this order.

<img width="297" alt="Screenshot 2025-03-19 at 4 30 08 PM" src="https://github.com/user-attachments/assets/48678f07-fa6c-4d24-befd-8cbca033d165" />

- Now check your Stripe dashboard. Notice that the charged amount is the previous one ($18).

**In this branch**
- Check the order edit page. Notice that the total here is correct with the updated amount ($10), and the Stripe fee and Stripe Payout also refer to the updated amount ($10).

<img width="989" alt="Screenshot 2025-03-19 at 2 16 47 PM" src="https://github.com/user-attachments/assets/8ebf7f3a-9133-4c91-a2d8-404db8cf7a6f" />

- Check the order notes. You will find that two intents have been created for this order because the first one was not compatible anymore due to the changed amount.

<img width="297" alt="Screenshot 2025-03-19 at 2 25 49 PM" src="https://github.com/user-attachments/assets/9b1bd227-a63c-4e35-b898-80425df5086f" />

- Now check your Stripe dashboard. Notice that the charged amount is the updated one ($10)