### PR TITLE
Fix Auth Requested email preview

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Update - Enable/disable Amazon Pay by adding/removing it from the enabled payment methods list.
 * Add - Add ACSS payment tokenization.
 * Update - Update payment method type for Amazon Pay orders.
+* Fix - Compatibility with email preview in the Auth Requested email
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -37,7 +37,7 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 		$this->description = __( 'Payment authentication requested emails are sent to chosen recipient(s) when an attempt to automatically process a subscription renewal payment fails because the transaction requires an SCA verification, the customer is requested to authenticate the payment, and a retry rule has been applied to notify the customer again within a certain time period.', 'woocommerce-gateway-stripe' );
 
 		$this->heading = __( 'Automatic renewal payment failed due to authentication required', 'woocommerce-gateway-stripe' );
-		$this->subject = __( '[{site_title}] Automatic payment failed for {order_number}. Customer asked to authenticate payment and will be notified again {retry_time}', 'woocommerce-gateway-stripe' );
+		$this->subject = __( '[{site_title}] Automatic payment failed for {order_number}. Customer asked to authenticate payment and will be notified again in {retry_time}', 'woocommerce-gateway-stripe' );
 
 		$this->template_html  = 'emails/failed-renewal-authentication-requested.php';
 		$this->template_plain = 'emails/plain/failed-renewal-authentication-requested.php';

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -73,8 +73,7 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 	 */
 	public function get_default_subject() {
 		if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
-			$interval = 12 * HOUR_IN_SECONDS;
-			$retry_time = human_time_diff( time(), time() + ( $interval ) );
+			$retry_time = $this->get_retry_time();
 			return str_replace( '{retry_time}', $retry_time, $this->subject );
 		}
 		return $this->subject;

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -22,6 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order {
 
 	/**
+	 * The retry object for the order
+	 *
+	 * @var WCS_Retry|null
+	 */
+	protected $retry;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -59,6 +66,33 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 	 */
 	public function get_default_heading() {
 		return $this->heading;
+	}
+
+	/**
+	 * Creates a dummy retry for use when previewing failed subscription payment retry emails.
+	 *
+	 * @param WC_Order $order The order object to create a dummy retry for.
+	 * @return WCS_Retry|null The dummy retry object.
+	 */
+	private function get_dummy_retry( $order ) {
+		if ( ! class_exists( 'WCS_Retry_Manager' ) ) {
+			return null;
+		}
+
+		$order_id = is_a( $order, 'WC_Order' ) ? $order->get_id() : 12345;
+		$retry_rule = WCS_Retry_Manager::rules()->get_rule( 1, $order_id );
+
+		if ( ! $retry_rule ) {
+			return null;
+		}
+
+		$retry = new WCS_Retry();
+		$retry->set_order_id( $order_id );
+		$retry->set_rule_id( 1 );
+		$retry->set_time( time() + ( 12 * HOUR_IN_SECONDS ) );
+		$retry->set_status( 'pending' );
+
+		return $retry;
 	}
 
 	/**

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -51,6 +51,22 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 	}
 
 	/**
+	 * Get retry time.
+	 *
+	 * @return string
+	 */
+	public function get_retry_time() {
+		if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
+			$interval = 12 * HOUR_IN_SECONDS;
+			return human_time_diff( time(), time() + $interval );
+		}
+
+		return ( is_a( $this->retry, 'WCS_Retry' ) && method_exists( $this->retry, 'get_time' ) )
+			? wcs_get_human_time_diff( $this->retry->get_time() )
+			: '';
+	}
+
+	/**
 	 * Get the default e-mail subject.
 	 *
 	 * @return string

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -56,6 +56,11 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 	 * @return string
 	 */
 	public function get_default_subject() {
+		if ( apply_filters( 'woocommerce_is_email_preview', false ) ) {
+			$interval = 12 * HOUR_IN_SECONDS;
+			$retry_time = human_time_diff( time(), time() + ( $interval ) );
+			return str_replace( '{retry_time}', $retry_time, $this->subject );
+		}
 		return $this->subject;
 	}
 

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -86,10 +86,12 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 			return null;
 		}
 
+		$interval = 12 * HOUR_IN_SECONDS;
+
 		$retry = new WCS_Retry();
 		$retry->set_order_id( $order_id );
 		$retry->set_rule_id( 1 );
-		$retry->set_time( time() + ( 12 * HOUR_IN_SECONDS ) );
+		$retry->set_time( time() + ( $interval ) );
 		$retry->set_status( 'pending' );
 
 		return $retry;

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -74,35 +74,6 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 	}
 
 	/**
-	 * Creates a dummy retry for use when previewing failed subscription payment retry emails.
-	 *
-	 * @param WC_Order $order The order object to create a dummy retry for.
-	 * @return WCS_Retry|null The dummy retry object.
-	 */
-	private function get_dummy_retry( $order ) {
-		if ( ! class_exists( 'WCS_Retry_Manager' ) ) {
-			return null;
-		}
-
-		$order_id = is_a( $order, 'WC_Order' ) ? $order->get_id() : 12345;
-		$retry_rule = WCS_Retry_Manager::rules()->get_rule( 1, $order_id );
-
-		if ( ! $retry_rule ) {
-			return null;
-		}
-
-		$interval = 12 * HOUR_IN_SECONDS;
-
-		$retry = new WCS_Retry();
-		$retry->set_order_id( $order_id );
-		$retry->set_rule_id( 1 );
-		$retry->set_time( time() + ( $interval ) );
-		$retry->set_status( 'pending' );
-
-		return $retry;
-	}
-
-	/**
 	 * Trigger.
 	 *
 	 * @param int           $order_id The order ID.

--- a/readme.txt
+++ b/readme.txt
@@ -123,5 +123,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add ACSS payment tokenization.
 * Fix - Fix variable dump in ACH customer error message when retrying a payment.
 * Update - Update payment method type for Amazon Pay orders.
+* Fix - Compatibility with email preview in the Auth Requested email
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/templates/emails/failed-renewal-authentication-requested.php
+++ b/templates/emails/failed-renewal-authentication-requested.php
@@ -17,15 +17,6 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <p>
 	<?php
-	$is_preview = apply_filters( 'woocommerce_is_email_preview', false );
-	$retry_time = '';
-
-	if ( $is_preview ) {
-		$interval = 12 * HOUR_IN_SECONDS;
-		$retry_time = human_time_diff( time(), time() + ( $interval ) );
-	} elseif ( is_a( $retry, 'WCS_Retry' ) && method_exists( $retry, 'get_time' ) ) {
-		$retry_time = wcs_get_human_time_diff( $retry->get_time() );
-	}
 
 	echo esc_html(
 		sprintf(
@@ -37,7 +28,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 			),
 			$order->get_order_number(),
 			$order->get_formatted_billing_full_name(),
-			$retry_time
+			$email->get_retry_time()
 		)
 	);
 	?>

--- a/templates/emails/failed-renewal-authentication-requested.php
+++ b/templates/emails/failed-renewal-authentication-requested.php
@@ -17,6 +17,15 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <p>
 	<?php
+	$is_preview = apply_filters( 'woocommerce_is_email_preview', false );
+	$retry_time = '';
+
+	if ( $is_preview ) {
+		$retry_time = human_time_diff( time(), time() + ( 12 * HOUR_IN_SECONDS ) );
+	} elseif ( is_a( $retry, 'WCS_Retry' ) && method_exists( $retry, 'get_time' ) ) {
+		$retry_time = wcs_get_human_time_diff( $retry->get_time() );
+	}
+
 	echo esc_html(
 		sprintf(
 			// translators: 1) an order number, 2) the customer's full name, 3) lowercase human time diff in the form returned by wcs_get_human_time_diff(), e.g. 'in 12 hours'.
@@ -27,7 +36,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 			),
 			$order->get_order_number(),
 			$order->get_formatted_billing_full_name(),
-			function_exists( 'wcs_get_human_time_diff' ) ? wcs_get_human_time_diff( $retry->get_time() ) : ''
+			$retry_time
 		)
 	);
 	?>

--- a/templates/emails/failed-renewal-authentication-requested.php
+++ b/templates/emails/failed-renewal-authentication-requested.php
@@ -21,7 +21,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	$retry_time = '';
 
 	if ( $is_preview ) {
-		$retry_time = human_time_diff( time(), time() + ( 12 * HOUR_IN_SECONDS ) );
+		$interval = 12 * HOUR_IN_SECONDS;
+		$retry_time = human_time_diff( time(), time() + ( $interval ) );
 	} elseif ( is_a( $retry, 'WCS_Retry' ) && method_exists( $retry, 'get_time' ) ) {
 		$retry_time = wcs_get_human_time_diff( $retry->get_time() );
 	}

--- a/templates/emails/plain/failed-renewal-authentication-requested.php
+++ b/templates/emails/plain/failed-renewal-authentication-requested.php
@@ -12,16 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
-$is_preview = apply_filters( 'woocommerce_is_email_preview', false );
-$retry_time = '';
-
-if ( $is_preview ) {
-	$interval = 12 * HOUR_IN_SECONDS;
-	$retry_time = human_time_diff( time(), time() + ( $interval ) );
-} elseif ( is_a( $retry, 'WCS_Retry' ) && method_exists( $retry, 'get_time' ) ) {
-	$retry_time = wcs_get_human_time_diff( $retry->get_time() );
-}
-
 printf(
 	// translators: 1) an order number, 2) the customer's full name, 3) lowercase human time diff in the form returned by wcs_get_human_time_diff(), e.g. 'in 12 hours'.
 	esc_html_x(
@@ -31,7 +21,7 @@ printf(
 	),
 	esc_html( $order->get_order_number() ),
 	esc_html( $order->get_formatted_billing_full_name() ),
-	esc_html( $retry_time )
+	esc_html( $email->get_retry_time() )
 ) . "\n\n";
 printf( esc_html__( 'The renewal order is as follows:', 'woocommerce-gateway-stripe' ) ) . "\n\n";
 

--- a/templates/emails/plain/failed-renewal-authentication-requested.php
+++ b/templates/emails/plain/failed-renewal-authentication-requested.php
@@ -12,6 +12,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
+$is_preview = apply_filters( 'woocommerce_is_email_preview', false );
+$retry_time = '';
+
+if ( $is_preview ) {
+	$retry_time = human_time_diff( time(), time() + ( 12 * HOUR_IN_SECONDS ) );
+} elseif ( is_a( $retry, 'WCS_Retry' ) && method_exists( $retry, 'get_time' ) ) {
+	$retry_time = wcs_get_human_time_diff( $retry->get_time() );
+}
+
 printf(
 	// translators: 1) an order number, 2) the customer's full name, 3) lowercase human time diff in the form returned by wcs_get_human_time_diff(), e.g. 'in 12 hours'.
 	esc_html_x(
@@ -21,7 +30,7 @@ printf(
 	),
 	esc_html( $order->get_order_number() ),
 	esc_html( $order->get_formatted_billing_full_name() ),
-	function_exists( 'wcs_get_human_time_diff' ) ? esc_html( wcs_get_human_time_diff( $retry->get_time() ) ) : ''
+	esc_html( $retry_time )
 ) . "\n\n";
 printf( esc_html__( 'The renewal order is as follows:', 'woocommerce-gateway-stripe' ) ) . "\n\n";
 

--- a/templates/emails/plain/failed-renewal-authentication-requested.php
+++ b/templates/emails/plain/failed-renewal-authentication-requested.php
@@ -16,7 +16,8 @@ $is_preview = apply_filters( 'woocommerce_is_email_preview', false );
 $retry_time = '';
 
 if ( $is_preview ) {
-	$retry_time = human_time_diff( time(), time() + ( 12 * HOUR_IN_SECONDS ) );
+	$interval = 12 * HOUR_IN_SECONDS;
+	$retry_time = human_time_diff( time(), time() + ( $interval ) );
 } elseif ( is_a( $retry, 'WCS_Retry' ) && method_exists( $retry, 'get_time' ) ) {
 	$retry_time = wcs_get_human_time_diff( $retry->get_time() );
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #4092 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This fixes an error when previewing the Authentication Requested Email in the Admin area by serving dummy data.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->
1. Enable Email improvements via Settings > Advanced > Features > Email improvements. 
2. Go to Settings > Emails > Payment Authentication Requested Email > Manage.
3. Preview should be displayed without any error.
4. Switch the email type to Plain Text and make sure the email is previewable.
5. Install [WP Email Catcher](https://wordpress.org/plugins/wp-mail-catcher/)
6. Click "Send a test email" button in preview.
7. Go to WP Mail Logging -> Email log and make sure the email content is displayed.

We should also test an actual email in a non-preview mode with a test order, but I am not sure how to go about testing it. Would appreciate any help there.  

Before
![Image](https://github.com/user-attachments/assets/43b18d9f-d699-488c-b7e4-e5a2c152bf24)

Now
![CleanShot 2025-03-19 at 10 44 28](https://github.com/user-attachments/assets/855d240d-1ccd-4dcc-8b5d-8817fc02d80b)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
