### PR TITLE
Fix Docker and VS Code settings for Xdebug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,10 +8,8 @@
             "name": "Listen for Xdebug (remote/docker)",
             "type": "php",
             "request": "launch",
-            "hostname": "0.0.0.0",
-            "port": 9000,
+            "port": 9009,
             "pathMappings": {
-                "/var/www/html/": "${workspaceFolder}/docker/wordpress",
                 "/var/www/html/wp-content/plugins/woocommerce-gateway-stripe/": "${workspaceFolder}"
             },
             "preLaunchTask": "enable:xdebug",

--- a/docker/wordpress_xdebug/Dockerfile
+++ b/docker/wordpress_xdebug/Dockerfile
@@ -3,9 +3,7 @@ RUN pecl install xdebug-3.1.6 \
 	&& echo 'xdebug.mode=off' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.start_with_request=yes' >> $PHP_INI_DIR/php.ini \
 	&& echo 'xdebug.client_host=host.docker.internal' >> $PHP_INI_DIR/php.ini \
-	&& echo 'xdebug.discover_client_host=1' >> $PHP_INI_DIR/php.ini \
-	&& echo 'xdebug.client_port=9000' >> $PHP_INI_DIR/php.ini \
-	&& echo 'xdebug.log=/tmp/xdebug.log' >> $PHP_INI_DIR/php.ini \
+	&& echo 'xdebug.client_port=9009' >> $PHP_INI_DIR/php.ini \
 	&& docker-php-ext-enable xdebug
 RUN apt-get update \
 	&& apt-get install --assume-yes --quiet --no-install-recommends gnupg2 subversion mariadb-client less jq


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR fixes the Docker and VS Code settings to ensure **Xdebug** works out of the box, without requiring additional configuration.

## Testing instructions

1. Restart your environment: `npm run down && npm run up`.
2. In VS Code, set a breakpoint in a part of the code that is always executed.
3. Start the debugger using the configuration: `Listen for Xdebug (remote/docker)`.
4. Open the website in your browser and verify that execution stops at the breakpoint.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
