### PR TITLE
Fix payment container layout when SPE is disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.4.0 - xxxx-xx-xx =
+* Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.
 * Dev - Implements the new Stripe order class into the express checkout classes.
 * Dev - Implements the new Stripe order class into the wp-admin related classes.
 * Dev - Replaces references to order status values with their respective constants from the WooCommerce plugin.

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -57,7 +57,6 @@ const getStripeElementOptions = () => {
 			applePay: 'never',
 			googlePay: 'never',
 		},
-		layout: 'accordion',
 	};
 
 	// Prefill Link customer data if available.
@@ -78,6 +77,14 @@ const getStripeElementOptions = () => {
 				},
 			};
 		}
+	}
+
+	// Set the layout to accordion if SPE is enabled.
+	if ( getBlocksConfiguration()?.isSPEEnabled ) {
+		options = {
+			...options,
+			layout: 'accordion',
+		};
 	}
 
 	return options;

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -162,15 +162,29 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		}
 	};
 
-	const createdStripePaymentElement = elements.create( 'payment', {
+	let paymentElementOptions = {
 		...getUpeSettings(),
 		...getDefaultValues(),
 		wallets: {
 			applePay: 'never',
 			googlePay: 'never',
 		},
-		layout: 'accordion',
-	} );
+	};
+
+	// Set the layout to accordion if SPE is enabled.
+	if ( getStripeServerData()?.isSPEEnabled ) {
+		paymentElementOptions = {
+			...paymentElementOptions,
+			...{
+				layout: 'accordion',
+			},
+		};
+	}
+
+	const createdStripePaymentElement = elements.create(
+		'payment',
+		paymentElementOptions
+	);
 
 	gatewayUPEComponents[ paymentMethodType ].elements = elements;
 	gatewayUPEComponents[

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.4.0 - xxxx-xx-xx =
+* Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.
 * Dev - Implements the new Stripe order class into the express checkout classes.
 * Dev - Implements the new Stripe order class into the wp-admin related classes.
 * Dev - Replaces references to order status values with their respective constants from the WooCommerce plugin.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See p1742811317755489-slack-CHG7MTCAF

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes a small visual issue with the Stripe checkout container when Smart Checkout is disabled.

Before the introduction of Smart Checkout:
![Screenshot taken on 2025-03-24 at 10 12 00 UTC](https://github.com/user-attachments/assets/31520d72-7d90-4133-9965-431920cb5c7a)

After:
![Screenshot taken on 2025-03-24 at 10 12 34 UTC@2x](https://github.com/user-attachments/assets/eb750713-17ae-4e66-89ab-0cf8aac22e62)

(using @aheckler's screenshots)

The change here reverts the looks of the original version.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`fix/payment-container-layout-when-spe-is-disabled`)
- Connect your Stripe account
- Disable the legacy checkout experience
- Make sure Smart Checkout is disabled
- As a shopper, add any product to your cart
- Go to the shortcode/classic checkout page
- Confirm the Stripe container has no borders
- Go to the block checkout page and confirm the same

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

cc @aheckler 