### PR TITLE
Add after-merge QIT run workflow

### DIFF
--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -47,7 +47,7 @@ jobs:
           payload: |
             icon: ":workflow-cancelled:"
             status: "cancelled"
-            workflowName: "${{ github.workflow }} / ${{ github.head_ref }}"
+            workflowName: "${{ github.workflow }} | ${{ github.head_ref }}"
             workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   handle-error:
@@ -63,5 +63,5 @@ jobs:
           payload: |
             icon: ":workflow-failed:"
             status: "failed"
-            workflowName: "${{ github.workflow }} / ${{ github.head_ref }}"
+            workflowName: "${{ github.workflow }} | ${{ github.head_ref }}"
             workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -1,61 +1,67 @@
 name: Merge to Develop CI
 
 on:
-    pull_request:
-        branches:
-            - develop
-        types:
-            - closed
+  pull_request:
+    branches:
+      - develop
+    types:
+      - closed
 
 concurrency:
-    group: ${{ github.workflow }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 jobs:
-    build_project:
-        if: github.event.pull_request.merged == true
-        name: Build package
-        uses: ./.github/workflows/build-upload-zip.yml
+  build_project:
+    if: github.event.pull_request.merged == true
+    name: Build package
+    uses: ./.github/workflows/build-upload-zip.yml
+    with:
+      artifact: 'pr-merge-test-package'
+
+  qit-tests:
+    if: github.event.pull_request.merged == true
+    name: Run QIT tests
+    needs: build_project
+    uses: ./.github/workflows/run-qit.yml
+    secrets: inherit
+    with:
+      extension: 'woocommerce-gateway-stripe'
+      artifact: 'pr-merge-test-package'
+      test-activation: true
+      test-security: true
+      test-phpcompatibility: true
+      test-validation: true
+      test-phpstan: false # TODO: Enable this once the PHPStan tests are fixed
+
+  handle-cancelled:
+    if: ${{ cancelled() }}
+    needs: qit-tests
+    name: Handle cancellation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v2.0.0
         with:
-            artifact: 'pr-merge-test-package'
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            icon: ":workflow-cancelled:"
+            status: "cancelled"
+            workflowName: "${{ github.workflow }} / ${{ github.ref }}"
+            workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-    qit-tests:
-        if: github.event.pull_request.merged == true
-        name: Run QIT tests
-        needs: build_project
-        uses: ./.github/workflows/run-qit.yml
-        secrets: inherit
+  handle-error:
+    if: ${{ failure() }}
+    needs: qit-tests
+    name: Handle failure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v2.0.0
         with:
-            extension: 'woocommerce-gateway-stripe'
-            artifact: 'pr-merge-test-package'
-            test-activation: true
-            test-security: true
-            test-phpcompatibility: true
-            test-validation: true
-            test-phpstan: false # TODO: Enable this once the PHPStan tests are fixed
-
-    handle-cancelled:
-        if: ${{ cancelled() }}
-        needs: qit-tests
-        name: Handle cancellation
-        runs-on: ubuntu-latest
-        env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        steps:
-            - uses: act10ns/slack@v2
-              with:
-                  status: cancelled
-                  message: 'Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> cancelled.'
-
-    handle-error:
-        if: ${{ failure() }}
-        needs: qit-tests
-        name: Handle failure
-        runs-on: ubuntu-latest
-        env:
-            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        steps:
-            - uses: act10ns/slack@v2
-              with:
-                  status: failure
-                  message: 'Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> failed.'
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            icon: ":workflow-failed:"
+            status: "failed"
+            workflowName: "${{ github.workflow }} / ${{ github.ref }}"
+            workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_project:
+  build-project:
     if: github.event.pull_request.merged == true
     name: Build package
     uses: ./.github/workflows/build-upload-zip.yml
@@ -22,7 +22,7 @@ jobs:
   qit-tests:
     if: github.event.pull_request.merged == true
     name: Run QIT tests
-    needs: build_project
+    needs: build-project
     uses: ./.github/workflows/run-qit.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -1,0 +1,61 @@
+name: Merge to Develop CI
+
+on:
+    pull_request:
+        branches:
+            - develop
+        types:
+            - closed
+
+concurrency:
+    group: ${{ github.workflow }}
+    cancel-in-progress: true
+
+jobs:
+    build_project:
+        if: github.event.pull_request.merged == true
+        name: Build package
+        uses: ./.github/workflows/build-upload-zip.yml
+        with:
+            artifact: 'pr-merge-test-package'
+
+    qit-tests:
+        if: github.event.pull_request.merged == true
+        name: Run QIT tests
+        needs: build_project
+        uses: ./.github/workflows/run-qit.yml
+        secrets: inherit
+        with:
+            extension: 'woocommerce-gateway-stripe'
+            artifact: 'pr-merge-test-package'
+            test-activation: true
+            test-security: true
+            test-phpcompatibility: true
+            test-validation: true
+            test-phpstan: false # TODO: Enable this once the PHPStan tests are fixed
+
+    handle-cancelled:
+        if: ${{ cancelled() }}
+        needs: qit-tests
+        name: Handle cancellation
+        runs-on: ubuntu-latest
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        steps:
+            - uses: act10ns/slack@v2
+              with:
+                  status: cancelled
+                  message: 'Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> cancelled.'
+
+    handle-error:
+        if: ${{ failure() }}
+        needs: qit-tests
+        name: Handle failure
+        runs-on: ubuntu-latest
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        steps:
+            - uses: act10ns/slack@v2
+              with:
+                  status: failure
+                  message: 'Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> failed.'

--- a/.github/workflows/ci-merge.yml
+++ b/.github/workflows/ci-merge.yml
@@ -1,4 +1,4 @@
-name: Merge to Develop CI
+name: Post PR Merge QIT
 
 on:
   pull_request:
@@ -47,7 +47,7 @@ jobs:
           payload: |
             icon: ":workflow-cancelled:"
             status: "cancelled"
-            workflowName: "${{ github.workflow }} / ${{ github.ref }}"
+            workflowName: "${{ github.workflow }} / ${{ github.head_ref }}"
             workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   handle-error:
@@ -63,5 +63,5 @@ jobs:
           payload: |
             icon: ":workflow-failed:"
             status: "failed"
-            workflowName: "${{ github.workflow }} / ${{ github.ref }}"
+            workflowName: "${{ github.workflow }} / ${{ github.head_ref }}"
             workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Fixes #4100

## Changes proposed in this Pull Request:

This PR adds a workflow to run the QIT tests when a PR is merged into develop.

More info:
- pb22l9-43G-p2
- pdqkbG-5bb-p2

The following QIT tests are enabled:

- [Activation Test](https://qit.woo.com/docs/managed-tests/activation) - Activates your plugin and logs any PHP notice, warning, or error.
- [Security Test](https://qit.woo.com/docs/managed-tests/security) - Scan your plugin for adherence to best practices in writing secure code.
- [PHP Compatibility Test](https://qit.woo.com/docs/managed-tests/phpcompatibility) - Run PHPCompatibility tests to detect issues with different PHP versions.
- [Validation tests](https://qit.woo.com/docs/managed-tests/validation) - Verifies headers, WooCommerce feature compatibility, and detects outdated theme templates.

The following checks are currently disabled and will be enabled in a future PR:

- [PHPStan Test](https://qit.woo.com/docs/managed-tests/phpstan) - Run PHPStan checks to catch issues early.
Errors: 0, File Errors: 805

---

In case of execution failure or cancellation, a Slack message with a link to the run logs is sent.

The Slack Workflow used to send the message is configured with the secret SLACK_WEBHOOK_URL, and the channel and message template are configured in the [Slack Workflow](https://slack.com/shortcuts/Ft08JM8QAERL/becb042b980d7c5c5f627ac94e715425).

![Screenshot 2025-03-25 at 11 29 29](https://github.com/user-attachments/assets/1c7e08ce-8ca1-41cc-ab40-631686c5a337)


## Testing instructions

I tested this in a fork (to avoid the dummy merges and workflow executions), the action runs are [here](https://github.com/diegocurbelo/woocommerce-gateway-stripe/actions/workflows/ci-merge.yml), and the Slack message temp channel [here](https://a8c.slack.com/archives/C07FPDQ2RLM)

- Normal execution: https://github.com/diegocurbelo/woocommerce-gateway-stripe/actions/runs/14061900213
- Cancelled execution: https://github.com/diegocurbelo/woocommerce-gateway-stripe/actions/runs/14062104840

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment 
Not customer/merchant facing

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)