### PR TITLE
PoC: Add tokenization support to BLIK

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -26,6 +26,7 @@ class WC_Stripe_Customer {
 		WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID,
 		WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID,
 		WC_Stripe_UPE_Payment_Method_Bacs_Debit::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID,
 		WC_Stripe_UPE_Payment_Method_Amazon_Pay::STRIPE_ID,
 	];
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
@@ -17,7 +17,7 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 		parent::__construct();
 		$this->stripe_id                = self::STRIPE_ID;
 		$this->title                    = 'BLIK';
-		$this->is_reusable              = false;
+		$this->is_reusable              = true;
 		$this->supported_currencies     = [ WC_Stripe_Currency_Code::POLISH_ZLOTY ];
 		$this->supported_countries      = [ 'PL' ];
 		$this->label                    = 'BLIK';
@@ -26,6 +26,7 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 			'woocommerce-gateway-stripe'
 		);
 		$this->supports_deferred_intent = false;
+		$this->supports[]               = 'tokenization';
 	}
 
 	/**
@@ -47,6 +48,8 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 
 	public function payment_fields() {
 		try {
+			$display_tokenization = $this->is_reusable() && is_checkout();
+
 			if ( $this->testmode && ! empty( $this->get_testing_instructions() ) ) : ?>
 				<p class="testmode-info"><?php echo wp_kses_post( $this->get_testing_instructions() ); ?></p>
 			<?php endif; ?>
@@ -54,6 +57,13 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 			<?php if ( ! empty( $this->get_description() ) ) : ?>
 				<p><?php echo wp_kses_post( $this->get_description() ); ?></p>
 			<?php endif; ?>
+
+			<?php
+			if ( $display_tokenization ) {
+				$this->tokenization_script();
+				$this->saved_payment_methods();
+			}
+			?>
 
 			<fieldset id="wc-<?php echo esc_attr( $this->id ); ?>-form" class="wc-payment-form" style="font-size: inherit;">
 				<?php
@@ -73,6 +83,13 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 			</fieldset>
 
 			<?php
+			if ( $this->should_show_save_option() ) {
+				$force_save_payment = ( $display_tokenization && ! apply_filters( 'wc_stripe_display_save_payment_method_checkbox', $display_tokenization ) ) || is_add_payment_method_page();
+				if ( is_user_logged_in() ) {
+					$this->save_payment_method_checkbox( $force_save_payment );
+				}
+			}
+
 			do_action( 'wc_stripe_payment_fields_' . $this->id, $this->id );
 		} catch ( Exception $e ) {
 			// Output the error message.
@@ -83,5 +100,30 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 			</div>
 			<?php
 		}
+	}
+
+	/**
+	 * Creates a BLIK payment token for the customer.
+	 *
+	 * @param int      $user_id        The customer ID the payment token is associated with.
+	 * @param stdClass $payment_method The payment method object.
+	 *
+	 * @return WC_Payment_Token_BLIK|null The payment token created.
+	 */
+	public function create_payment_token_for_user( $user_id, $payment_method ) {
+		if ( ! isset( $payment_method->id ) || ! isset( $payment_method->blik ) ) {
+			return null;
+		}
+
+		$payment_token = new WC_Payment_Token_BLIK();
+		$payment_token->set_gateway_id( WC_Stripe_Payment_Tokens::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ self::STRIPE_ID ] );
+		$payment_token->set_user_id( $user_id );
+		$payment_token->set_token( $payment_method->id );
+		$payment_token->set_last4( $payment_method->blik->last4 );
+		$payment_token->set_bank_name( $payment_method->blik->bank_name );
+		$payment_token->set_fingerprint( $payment_method->blik->fingerprint );
+		$payment_token->save();
+
+		return $payment_token;
 	}
 }

--- a/includes/payment-tokens/class-wc-stripe-blik-payment-token.php
+++ b/includes/payment-tokens/class-wc-stripe-blik-payment-token.php
@@ -1,0 +1,146 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+// phpcs:disable WordPress.Files.FileName
+
+/**
+ * WooCommerce Stripe BLIK Payment Token.
+ *
+ * Representation of a payment token for BLIK.
+ *
+ * @class    WC_Payment_Token_BLIK
+ * @since    x.x.x
+ */
+class WC_Payment_Token_BLIK extends WC_Payment_Token implements WC_Stripe_Payment_Method_Comparison_Interface {
+
+	use WC_Stripe_Fingerprint_Trait;
+
+	/**
+	 * Stores payment type.
+	 *
+	 * @var string
+	 */
+	protected $type = WC_Stripe_Payment_Methods::BLIK;
+
+	/**
+	 * Stores BLIK payment token data.
+	 *
+	 * @var array
+	 */
+	protected $extra_data = [
+		'bank_name'           => '',
+		'last4'               => '',
+		'payment_method_type' => WC_Stripe_Payment_Methods::BLIK,
+		'fingerprint'         => '',
+	];
+
+	/**
+	 * Get type to display to user.
+	 *
+	 * @param  string $deprecated Deprecated since WooCommerce 3.0
+	 * @return string
+	 */
+	public function get_display_name( $deprecated = '' ) {
+		$display = sprintf(
+			/* translators: bank name, last 4 digits of account. */
+			__( 'Saved BLIK payment method', 'woocommerce-gateway-stripe' ),
+			$this->get_last4(),
+			$this->get_bank_name()
+		);
+
+		return $display;
+	}
+
+	/**
+	 * Hook prefix
+	 */
+	protected function get_hook_prefix() {
+		return 'woocommerce_payment_token_blik_get_';
+	}
+
+	/**
+	 * Validate BLIK payment tokens.
+	 *
+	 * These fields are required by all BLIK payment tokens:
+	 * last4  - string Last 4 digits of the Account Number
+	 * bank_name - string Name of the bank
+	 * fingerprint - string Unique identifier for the bank account
+	 *
+	 * @return boolean True if the passed data is valid
+	 */
+	public function validate() {
+		if ( false === parent::validate() ) {
+			return false;
+		}
+
+		if ( ! $this->get_last4( 'edit' ) ) {
+			return false;
+		}
+
+		if ( ! $this->get_bank_name( 'edit' ) ) {
+			return false;
+		}
+
+		if ( ! $this->get_fingerprint( 'edit' ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get the bank name.
+	 *
+	 * @param string $context What the value is for. Valid values are view and edit.
+	 * @return string
+	 */
+	public function get_bank_name( $context = 'view' ) {
+		return $this->get_prop( 'bank_name', $context );
+	}
+
+	/**
+	 * Set the bank name.
+	 *
+	 * @param string $bank_name
+	 */
+	public function set_bank_name( $bank_name ) {
+		$this->set_prop( 'bank_name', $bank_name );
+	}
+
+	/**
+	 * Returns the last four digits.
+	 *
+	 * @param  string $context What the value is for. Valid values are view and edit.
+	 * @return string Last 4 digits
+	 */
+	public function get_last4( $context = 'view' ) {
+		return $this->get_prop( 'last4', $context );
+	}
+
+	/**
+	 * Set the last four digits.
+	 *
+	 * @param string $last4
+	 */
+	public function set_last4( $last4 ) {
+		$this->set_prop( 'last4', $last4 );
+	}
+
+	/**
+	 * Checks if the payment method token is equal a provided payment method.
+	 *
+	 * @inheritDoc
+	 */
+	public function is_equal_payment_method( $payment_method ): bool {
+		if (
+			WC_Stripe_Payment_Methods::BLIK === $payment_method->type
+			&& ( $payment_method->{WC_Stripe_Payment_Methods::BLIK}->fingerprint ?? null ) === $this->get_fingerprint() ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -21,17 +21,18 @@ class WC_Stripe_Payment_Tokens {
 	 * The values are the related gateway ID we use for them in the extension.
 	 */
 	const UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD = [
-		WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID         => WC_Stripe_UPE_Payment_Gateway::ID,
-		WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID       => WC_Stripe_UPE_Payment_Gateway::ID,
-		WC_Stripe_UPE_Payment_Method_Amazon_Pay::STRIPE_ID => WC_Stripe_UPE_Payment_Gateway::ID,
-		WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID        => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID      => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID       => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID     => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID           => WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID         => WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Method_Amazon_Pay::STRIPE_ID   => WC_Stripe_UPE_Payment_Gateway::ID,
+		WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID          => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID   => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID        => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID         => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID       => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Sofort::STRIPE_ID,
 		WC_Stripe_UPE_Payment_Method_Cash_App_Pay::STRIPE_ID => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Cash_App_Pay::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Method_Bacs_Debit::STRIPE_ID => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bacs_Debit::STRIPE_ID,
-		WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID       => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_Bacs_Debit::STRIPE_ID   => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_Bacs_Debit::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID         => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID,
+		WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID         => WC_Stripe_UPE_Payment_Gateway::ID . '_' . WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID,
 	];
 
 	/**
@@ -425,6 +426,10 @@ class WC_Stripe_Payment_Tokens {
 				$item['method']['brand'] = $payment_token->get_bank_name();
 				$item['method']['last4'] = $payment_token->get_last4();
 				break;
+			case WC_Stripe_Payment_Methods::BLIK:
+				$item['method']['brand'] = $payment_token->get_bank_name();;
+				$item['method']['last4'] = $payment_token->get_last4();
+				break;
 			case WC_Stripe_Payment_Methods::LINK:
 				$item['method']['brand'] = sprintf(
 					/* translators: customer email */
@@ -558,6 +563,18 @@ class WC_Stripe_Payment_Tokens {
 				$token->set_fingerprint( $payment_method->bacs_debit->fingerprint );
 				$token->set_payment_method_type( $payment_method_type );
 				break;
+			case WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID:
+				$token = new WC_Payment_Token_BLIK();
+				if ( isset( $payment_method->blik->last4 ) ) {
+					$token->set_last4( $payment_method->blik->last4 );
+				}
+				if ( isset( $payment_method->blik->fingerprint ) ) {
+					$token->set_fingerprint( $payment_method->blik->fingerprint );
+				}
+				if ( isset( $payment_method->blik->bank_name ) ) {
+					$token->set_bank_name( $payment_method->blik->bank_name );
+				}
+				break;
 			case WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID:
 				$token = new WC_Payment_Token_Link();
 				$token->set_email( $payment_method->link->email );
@@ -652,6 +669,7 @@ class WC_Stripe_Payment_Tokens {
 		$payment_method_types = [
 			WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID,
 			WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID,
+			WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID,
 			WC_Stripe_UPE_Payment_Method_Cash_App_Pay::STRIPE_ID,
 			WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 			WC_Stripe_UPE_Payment_Method_Bacs_Debit::STRIPE_ID,
@@ -750,7 +768,7 @@ class WC_Stripe_Payment_Tokens {
 			/**
 			 * Token object.
 			 *
-			 * @var WC_Payment_Token_CashApp|WC_Stripe_Payment_Token_CC|WC_Payment_Token_Link|WC_Payment_Token_SEPA|WC_Payment_Token_ACH|WC_Payment_Token_ACSS $token
+			 * @var WC_Payment_Token_CashApp|WC_Stripe_Payment_Token_CC|WC_Payment_Token_Link|WC_Payment_Token_SEPA|WC_Payment_Token_ACH|WC_Payment_Token_ACSS|WC_Payment_Token_BLIK $token
 			 */
 			if ( $token->is_equal_payment_method( $payment_method ) ) {
 				return $token;
@@ -775,6 +793,9 @@ class WC_Stripe_Payment_Tokens {
 		}
 		if ( WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID === $type ) {
 			return WC_Payment_Token_ACSS::class;
+		}
+		if ( WC_Stripe_UPE_Payment_Method_BLIK::STRIPE_ID === $type ) {
+			return WC_Payment_Token_BLIK::class;
 		}
 		return $class;
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Closes #3955.

## Changes proposed in this Pull Request:

In this branch, I explored implementing tokenization for the BLIK payment method and as the initial assessment of the pcrvl0-1E6-p2 suggested, BLIK really doesn't support tokenization. Trying to checkout with BLIK and saving the payment method triggers an error from Stripe:

>There was an error processing the payment: A `setup_future_usage` value of off_session cannot be used with one or more of the values you specified in `payment_method_types`. Please remove `setup_future_usage` or remove these types from `payment_method_types`: [blik].

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

N/A.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)