### PR TITLE
SPE: Remove radio buttons

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@
 * Update - Update handling of PR as a country in the terminal locations endpoint.
 * Fix - Hide Amazon Pay in settings when legacy checkout is enabled.
 * Fix - Fix subscription renewal issues for Amazon Pay.
+* Tweak - SPE: Remove radio buttons
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -146,10 +146,6 @@ const PaymentElements = ( {
 			};
 			options = {
 				...options,
-				layout: {
-					type: 'accordion',
-					radios: false,
-				},
 				...{
 					paymentMethodConfiguration: 'pmc_...',
 				},

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -146,6 +146,10 @@ const PaymentElements = ( {
 			};
 			options = {
 				...options,
+				layout: {
+					type: 'accordion',
+					radios: false,
+				},
 				...{
 					paymentMethodConfiguration: 'pmc_...',
 				},

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -80,6 +80,16 @@ const getStripeElementOptions = () => {
 		}
 	}
 
+	if ( getBlocksConfiguration()?.isSPEEnabled ) {
+		options = {
+			...options,
+			layout: {
+				type: 'accordion',
+				radios: false,
+			},
+		};
+	}
+
 	return options;
 };
 

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -142,6 +142,10 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		if ( getStripeServerData()?.isSPEEnabled ) {
 			options = {
 				...options,
+				layout: {
+					type: 'accordion',
+					radios: false,
+				},
 				paymentMethodConfiguration: 'pmc_...',
 			};
 		} else {
@@ -169,7 +173,12 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 			applePay: 'never',
 			googlePay: 'never',
 		},
-		layout: 'accordion',
+		layout: getStripeServerData()?.isSPEEnabled
+			? {
+					type: 'accordion',
+					radios: false,
+			  }
+			: 'accordion',
 	} );
 
 	gatewayUPEComponents[ paymentMethodType ].elements = elements;

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -142,10 +142,6 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		if ( getStripeServerData()?.isSPEEnabled ) {
 			options = {
 				...options,
-				layout: {
-					type: 'accordion',
-					radios: false,
-				},
 				paymentMethodConfiguration: 'pmc_...',
 			};
 		} else {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -175,10 +175,10 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	if ( getStripeServerData()?.isSPEEnabled ) {
 		paymentElementOptions = {
 			...paymentElementOptions,
-      layout: {
-        type: 'accordion',
-        radios: false,
-      }
+			layout: {
+				type: 'accordion',
+				radios: false,
+			},
 		};
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,5 +138,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Update handling of PR as a country in the terminal locations endpoint.
 * Fix - Hide Amazon Pay in settings when legacy checkout is enabled.
 * Fix - Fix subscription renewal issues for Amazon Pay.
+* Tweak - SPE: Remove radio buttons
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4115

## Changes proposed in this Pull Request:
Hide the radio buttons in the SPE by updating the options passed into Stripe.

|| Before | After |
|---|---|---|
| Classic | ![CleanShot 2025-03-24 at 15 03 12](https://github.com/user-attachments/assets/4f2712ba-a175-4bef-a625-e8491443e785) | ![CleanShot 2025-03-24 at 15 01 59](https://github.com/user-attachments/assets/4e7fa267-7322-4540-afa6-92aa5d6d56f9) |
|Block| ![CleanShot 2025-03-24 at 15 03 41](https://github.com/user-attachments/assets/24ac047d-18e4-4acf-bc2a-1c1ed534616e) | ![CleanShot 2025-03-24 at 15 07 03](https://github.com/user-attachments/assets/c9411d47-0e79-4a47-a008-82a417fe8a50) |
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

- Checkout and build this branch on your test environment (`tweak/spe-changes-to-match-woo-visuals`)
- Connect your Stripe account
- On your Stripe dashboard, enable multiple payment methods
- Copy your child payment method configuration ID from here: `https://dashboard.stripe.com/settings/payment_methods` (labeled "Your configuration")
- Insert the ID above on `client/blocks/upe/upe-deferred-intent-creation/payment-elements.js:139`. This is temporary until the parent configuration, labeled WooCommerce Inc., supports all methods by default
- Insert the ID above on `client/classic/upe/payment-processing.js:136` as well
- Build the frontend files (`npm run build:webpack`)
- Enable the SPE feature flag (`_wcstripe_feature_spe`). You can do it by either hardcoding the return value of `is_spe_available` to `true` or by running `npm run wp option update _wcstripe_feature_spe 'yes'`
- As a merchant, disable the legacy checkout experience in settings (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`)
- Enable the Single Payment Element feature
- As a shopper, add any product to the cart and visit Block checkout.
- Make sure no radio buttons show up in SPE.
- Switch to the classic checkout.
- Make sure no radio buttons show up in SPE.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
