### PR TITLE
Add slack notification for Scheduled QIT execution failures

### DIFF
--- a/.github/workflows/ci-cron-qit.yml
+++ b/.github/workflows/ci-cron-qit.yml
@@ -31,3 +31,19 @@ jobs:
       test-woo-api: true
       test-woo-e2e: true
       test-malware: true
+
+  handle-error:
+    if: ${{ failure() }}
+    needs: qit-tests
+    name: Handle failure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            icon: ":workflow-failed:"
+            status: "failed"
+            workflowName: "${{ github.workflow }}"
+            workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR adds a step to the Scheduled Weekly QIT workflow to send a Slack message in case of workflow failure.

The Slack Workflow used to send the message is configured with the secret _SLACK_WEBHOOK_URL_, and the channel (and message template) is configured in the Slack Workflow itself.

![Screenshot 2025-03-24 at 17 40 48](https://github.com/user-attachments/assets/8c234ff3-9f45-41c8-9c87-8e358fb5b058)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

I tested this in a fork (to avoid the dummy merges and workflow executions), the action runs are [here](https://github.com/diegocurbelo/woocommerce-gateway-stripe/actions/workflows/ci-cron-qit.yml), and the Slack message temp channel [here](https://a8c.slack.com/archives/C07FPDQ2RLM)

- Successful execution (no message sent): https://github.com/diegocurbelo/woocommerce-gateway-stripe/actions/runs/13979924418
- Failed execution (message sent): https://github.com/diegocurbelo/woocommerce-gateway-stripe/actions/runs/14045333326

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

Not customer/merchant facing

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
