### PR TITLE
Settings synchronization: hook up Apple Pay and Google Pay

### DIFF
--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -294,12 +294,15 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$this->update_is_stripe_enabled( $request );
 		$this->update_is_test_mode_enabled( $request );
 
-		/* Settings > Payments accepted on checkout */
-		$this->update_enabled_payment_methods( $request );
+		/* Settings > Payments accepted on checkout + Express checkouts */
+		$payment_method_ids_to_enable = $this->get_payment_method_ids_to_enable( $request );
+		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
+		$this->update_enabled_payment_methods( $payment_method_ids_to_enable, $is_upe_enabled );
+		if ( ! $is_upe_enabled ) {
+			// We need to update a separate setting for legacy checkout.
+			$this->update_is_payment_request_enabled_for_legacy_checkout( $request );
+		}
 		$this->update_individual_payment_method_settings( $request );
-
-		/* Settings > Express checkouts */
-		$this->update_is_payment_request_enabled( $request );
 		$this->update_payment_request_settings( $request );
 		$this->update_amazon_pay_settings( $request );
 
@@ -316,6 +319,28 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$this->update_is_spe_enabled( $request );
 
 		return new WP_REST_Response( [], 200 );
+	}
+
+	/**
+	 * Returns the payment method IDs to enable.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return string[]
+	 */
+	private function get_payment_method_ids_to_enable( WP_REST_Request $request ) {
+		$payment_method_ids_to_enable = $request->get_param( 'enabled_payment_method_ids' );
+		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
+		$is_payment_request_enabled   = $request->get_param( 'is_payment_request_enabled' );
+
+		if ( $is_upe_enabled && $is_payment_request_enabled ) {
+			$payment_method_ids_to_enable = array_merge(
+				$payment_method_ids_to_enable,
+				[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
+			);
+		}
+
+		return $payment_method_ids_to_enable;
 	}
 
 	/**
@@ -393,18 +418,18 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 */
-	private function update_is_payment_request_enabled( WP_REST_Request $request ) {
+	private function update_is_payment_request_enabled_for_legacy_checkout( WP_REST_Request $request ) {
+		if ( ! $request->get_param( 'is_upe_enabled' ) ) {
+			return;
+		}
+
 		$is_payment_request_enabled = $request->get_param( 'is_payment_request_enabled' );
 
 		if ( null === $is_payment_request_enabled ) {
 			return;
 		}
 
-		if ( $is_payment_request_enabled ) {
-			$this->gateway->enable_payment_request();
-		} else {
-			$this->gateway->disable_payment_request();
-		}
+		$this->gateway->update_option( 'payment_request', $is_payment_request_enabled ? 'yes' : 'no' );
 	}
 
 	/**
@@ -598,12 +623,10 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	/**
 	 * Updates the list of enabled payment methods.
 	 *
-	 * @param WP_REST_Request $request Request object.
+	 * @param array $payment_method_ids_to_enable The list of payment method ids to enable.
+	 * @param bool $is_upe_enabled Whether UPE is enabled.
 	 */
-	private function update_enabled_payment_methods( WP_REST_Request $request ) {
-		$payment_method_ids_to_enable = $request->get_param( 'enabled_payment_method_ids' );
-		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
-
+	private function update_enabled_payment_methods( $payment_method_ids_to_enable, $is_upe_enabled ) {
 		if ( null === $is_upe_enabled ) {
 			return;
 		}

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -263,7 +263,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				/* Settings > Express checkouts */
 				'amazon_pay_button_size'                   => $this->gateway->get_validated_option( 'amazon_pay_button_size' ),
 				'amazon_pay_button_locations'              => $this->gateway->get_validated_option( 'amazon_pay_button_locations' ),
-				'is_payment_request_enabled'               => 'yes' === $this->gateway->get_option( 'payment_request' ),
+				'is_payment_request_enabled'               => $this->gateway->is_payment_request_enabled(),
 				'payment_request_button_type'              => $this->gateway->get_validated_option( 'payment_request_button_type' ),
 				'payment_request_button_theme'             => $this->gateway->get_validated_option( 'payment_request_button_theme' ),
 				'payment_request_button_size'              => $this->gateway->get_validated_option( 'payment_request_button_size' ),
@@ -400,7 +400,11 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$this->gateway->update_option( 'payment_request', $is_payment_request_enabled ? 'yes' : 'no' );
+		if ( $is_payment_request_enabled ) {
+			$this->gateway->enable_payment_request();
+		} else {
+			$this->gateway->disable_payment_request();
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -419,7 +419,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @param WP_REST_Request $request Request object.
 	 */
 	private function update_is_payment_request_enabled_for_legacy_checkout( WP_REST_Request $request ) {
-		if ( ! $request->get_param( 'is_upe_enabled' ) ) {
+		if ( $request->get_param( 'is_upe_enabled' ) ) {
 			return;
 		}
 

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1232,22 +1232,4 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	public function is_payment_request_enabled() {
 		return 'yes' === $this->get_option( 'payment_request' );
 	}
-
-	/**
-	 * Disables Google Pay and Apple Pay (PRB) for the legacy checkout.
-	 *
-	 * WC_Stripe_UPE_Payment_Gateway overrides this method.
-	 */
-	public function disable_payment_request() {
-		return $this->update_option( 'payment_request', 'no' );
-	}
-
-	/**
-	 * Enables Google Pay and Apple Pay (PRB) for the legacy checkout.
-	 *
-	 * WC_Stripe_UPE_Payment_Gateway overrides this method.
-	 */
-	public function enable_payment_request() {
-		return $this->update_option( 'payment_request', 'yes' );
-	}
 }

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -1220,4 +1220,34 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		return $this->validate_text_field( $field_key, $field_value );
 	}
+
+	/**
+	 * Returns whether Google Pay and Apple Pay (PRBs) are enabled,
+	 * for the legacy checkout.
+	 *
+	 * WC_Stripe_UPE_Payment_Gateway overrides this method.
+	 *
+	 * @return bool
+	 */
+	public function is_payment_request_enabled() {
+		return 'yes' === $this->get_option( 'payment_request' );
+	}
+
+	/**
+	 * Disables Google Pay and Apple Pay (PRB) for the legacy checkout.
+	 *
+	 * WC_Stripe_UPE_Payment_Gateway overrides this method.
+	 */
+	public function disable_payment_request() {
+		return $this->update_option( 'payment_request', 'no' );
+	}
+
+	/**
+	 * Enables Google Pay and Apple Pay (PRB) for the legacy checkout.
+	 *
+	 * WC_Stripe_UPE_Payment_Gateway overrides this method.
+	 */
+	public function enable_payment_request() {
+		return $this->update_option( 'payment_request', 'yes' );
+	}
 }

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -46,7 +46,7 @@ class WC_Stripe_Payment_Method_Configurations {
 			return self::$primary_configuration;
 		}
 
-		$result = WC_Stripe_API::get_instance()->get_payment_method_configurations();
+		$result                        = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$payment_method_configurations = $result->data ?? null;
 
 		if ( ! $payment_method_configurations ) {

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -46,7 +46,7 @@ class WC_Stripe_Payment_Method_Configurations {
 			return self::$primary_configuration;
 		}
 
-		$result                        = WC_Stripe_API::get_instance()->get_payment_method_configurations();
+		$result = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$payment_method_configurations = $result->data ?? null;
 
 		if ( ! $payment_method_configurations ) {

--- a/includes/class-wc-stripe-status.php
+++ b/includes/class-wc-stripe-status.php
@@ -48,7 +48,7 @@ class WC_Stripe_Status {
 	 */
 	public function render_status_report_section() {
 		$account_data            = $this->account->get_cached_account_data();
-		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper();
+		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper( $this->gateway );
 		?>
 		<table class="wc_status_table widefat" cellspacing="0">
 			<thead>

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -188,9 +188,9 @@ class WC_Stripe_Express_Checkout_Element {
 				'publishable_key'             => WC_Stripe_Mode::is_test() ? $this->stripe_settings['test_publishable_key'] : $this->stripe_settings['publishable_key'],
 				'allow_prepaid_card'          => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
 				'locale'                      => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
-				'is_link_enabled'             => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
+				'is_link_enabled'             => $this->express_checkout_helper->is_link_enabled(),
 				'is_express_checkout_enabled' => $this->express_checkout_helper->is_express_checkout_enabled(),
-				'is_amazon_pay_enabled'       => WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled(),
+				'is_amazon_pay_enabled'       => $this->express_checkout_helper->is_amazon_pay_enabled(),
 				'is_payment_request_enabled'  => $this->express_checkout_helper->is_payment_request_enabled(),
 			],
 			'nonce'                  => [

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -33,9 +33,17 @@ class WC_Stripe_Express_Checkout_Helper {
 	public $testmode;
 
 	/**
+	 * Gateway.
+	 *
+	 * @var WC_Gateway_Stripe
+	 */
+	private $gateway;
+
+	/**
 	 * Constructor.
 	 */
-	public function __construct() {
+	public function __construct( $gateway ) {
+		$this->gateway         = $gateway;
 		$this->stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$this->testmode        = WC_Stripe_Mode::is_test();
 		$this->total_label     = ! empty( $this->stripe_settings['statement_descriptor'] ) ? WC_Stripe_Helper::clean_statement_descriptor( $this->stripe_settings['statement_descriptor'] ) : '';
@@ -1452,7 +1460,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return boolean
 	 */
 	public function is_payment_request_enabled() {
-		return isset( $this->stripe_settings['payment_request'] ) && 'yes' === $this->stripe_settings['payment_request'];
+		return $this->gateway->is_payment_request_enabled();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1450,8 +1450,8 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_express_checkout_enabled() {
 		return $this->is_payment_request_enabled() ||
-			WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled() ||
-			WC_Stripe_UPE_Payment_Method_Link::is_link_enabled();
+			$this->is_amazon_pay_enabled() ||
+			$this->is_link_enabled();
 	}
 
 	/**
@@ -1461,6 +1461,24 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_payment_request_enabled() {
 		return $this->gateway->is_payment_request_enabled();
+	}
+
+	/**
+	 * Returns whether Amazon Pay is enabled.
+	 *
+	 * @return boolean
+	 */
+	public function is_amazon_pay_enabled() {
+		return WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled( $this->gateway );
+	}
+
+	/**
+	 * Returns whether Link is enabled.
+	 *
+	 * @return boolean
+	 */
+	public function is_link_enabled() {
+		return WC_Stripe_UPE_Payment_Method_Link::is_link_enabled( $this->gateway );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -812,7 +812,7 @@ class WC_Stripe_Payment_Request {
 				'key'                        => $this->publishable_key,
 				'allow_prepaid_card'         => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
 				'locale'                     => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
-				'is_link_enabled'            => WC_Stripe_UPE_Payment_Method_Link::is_link_enabled(),
+				'is_link_enabled'            => false, // Link is not available for PRB.
 				'is_payment_request_enabled' => $this->is_payment_request_enabled(),
 			],
 			'nonce'              => [
@@ -966,11 +966,6 @@ class WC_Stripe_Payment_Request {
 	public function is_at_least_one_payment_request_button_enabled() {
 		// Apple Pay / Google Pay is enabled.
 		if ( $this->is_payment_request_enabled() ) {
-			return true;
-		}
-
-		// Link is enabled.
-		if ( WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() ) {
 			return true;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -468,7 +468,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 		}
 
-		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper();
+		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper( $this );
 
 		$stripe_params['isCheckout']                       = ( is_checkout() || has_block( 'woocommerce/checkout' ) ) && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
 		$stripe_params['return_url']                       = $this->get_stripe_return_url();
@@ -668,9 +668,19 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * Updates the enabled payment methods.
 	 *
 	 * @param string[] $payment_method_ids_to_enable
+	 * @param bool $include_express_payment_methods Optional.
+	 *     Whether to include Apple Pay and Google Pay in the list of payment methods to update.
 	 */
-	public function update_enabled_payment_methods( $payment_method_ids_to_enable ) {
-		WC_Stripe_Payment_Method_Configurations::update_payment_method_configuration( $payment_method_ids_to_enable, $this->get_stripe_supported_payment_methods() );
+	public function update_enabled_payment_methods( $payment_method_ids_to_enable, $include_express_payment_methods = false ) {
+		$payment_method_ids_to_update = $this->get_stripe_supported_payment_methods();
+		if ( $include_express_payment_methods ) {
+			$payment_method_ids_to_update[] = WC_Stripe_Payment_Methods::APPLE_PAY;
+			$payment_method_ids_to_update[] = WC_Stripe_Payment_Methods::GOOGLE_PAY;
+		}
+		WC_Stripe_Payment_Method_Configurations::update_payment_method_configuration(
+			$payment_method_ids_to_enable,
+			$payment_method_ids_to_update
+		);
 	}
 
 	/**
@@ -3133,5 +3143,63 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			unset( $actions['pay'], $actions['cancel'] );
 		}
 		return $actions;
+	}
+
+	/**
+	 * Checks if Google Pay and Apple Pay (ECE) are enabled.
+	 *
+	 * Overrides WC_Gateway_Stripe::is_payment_request_enabled().
+	 *
+	 * @return bool
+	 */
+	public function is_payment_request_enabled() {
+		$enabled_payment_method_ids = $this->get_upe_enabled_payment_method_ids();
+
+		// Apple Pay and Google Pay settings are currently unified in wp-admin.
+		// However, they are managed separately within the Stripe dashboard.
+		// Until we move to separate settings in wp-admin, both payment methods will be
+		// considered enabled if either is enabled in Stripe.
+		return in_array( WC_Stripe_Payment_Methods::APPLE_PAY, $enabled_payment_method_ids, true ) ||
+			in_array( WC_Stripe_Payment_Methods::GOOGLE_PAY, $enabled_payment_method_ids, true );
+	}
+
+	/**
+	 * Disables Google Pay and Apple Pay (ECE) payment methods.
+	 *
+	 * Overrides WC_Gateway_Stripe::disable_payment_request().
+	 *
+	 * @return void
+	 */
+	public function disable_payment_request() {
+		// TODO: consider selective update of payment methods, to avoid
+		// sending entire lists of payment methods to the Stripe API.
+		$enabled_payment_method_ids    = $this->get_upe_enabled_payment_method_ids();
+		$payment_method_ids_to_disable = [
+			WC_Stripe_Payment_Methods::APPLE_PAY,
+			WC_Stripe_Payment_Methods::GOOGLE_PAY,
+		];
+		$payment_method_ids_to_enable  = array_diff( $enabled_payment_method_ids, $payment_method_ids_to_disable );
+		$this->update_enabled_payment_methods( $payment_method_ids_to_enable, true );
+	}
+
+	/**
+	 * Enables Google Pay and Apple Pay (ECE) payment methods.
+	 *
+	 * Overrides WC_Gateway_Stripe::enable_payment_request().
+	 *
+	 * @return void
+	 */
+	public function enable_payment_request() {
+		// TODO: consider selective update of payment methods, to avoid
+		// sending entire lists of payment methods to the Stripe API.
+		$enabled_payment_method_ids   = $this->get_upe_enabled_payment_method_ids();
+		$payment_method_ids_to_enable = array_merge(
+			$enabled_payment_method_ids,
+			[
+				WC_Stripe_Payment_Methods::APPLE_PAY,
+				WC_Stripe_Payment_Methods::GOOGLE_PAY,
+			]
+		);
+		$this->update_enabled_payment_methods( $payment_method_ids_to_enable, true );
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -488,8 +488,8 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['cartContainsSubscription']         = $this->is_subscription_item_in_cart();
 		$stripe_params['accountCountry']                   = WC_Stripe::get_instance()->account->get_account_country();
 		$stripe_params['isPaymentRequestEnabled']          = $express_checkout_helper->is_payment_request_enabled();
-		$stripe_params['isAmazonPayEnabled']               = WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled();
-		$stripe_params['isLinkEnabled']                    = WC_Stripe_UPE_Payment_Method_Link::is_link_enabled();
+		$stripe_params['isAmazonPayEnabled']               = $express_checkout_helper->is_amazon_pay_enabled();
+		$stripe_params['isLinkEnabled']                    = $express_checkout_helper->is_link_enabled();
 
 		// Add appearance settings.
 		$stripe_params['appearance']          = get_transient( $this->get_appearance_transient_key() );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -668,15 +668,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * Updates the enabled payment methods.
 	 *
 	 * @param string[] $payment_method_ids_to_enable
-	 * @param bool $include_express_payment_methods Optional.
-	 *     Whether to include Apple Pay and Google Pay in the list of payment methods to update.
 	 */
-	public function update_enabled_payment_methods( $payment_method_ids_to_enable, $include_express_payment_methods = false ) {
-		$payment_method_ids_to_update = $this->get_stripe_supported_payment_methods();
-		if ( $include_express_payment_methods ) {
-			$payment_method_ids_to_update[] = WC_Stripe_Payment_Methods::APPLE_PAY;
-			$payment_method_ids_to_update[] = WC_Stripe_Payment_Methods::GOOGLE_PAY;
-		}
+	public function update_enabled_payment_methods( $payment_method_ids_to_enable ) {
+		$payment_method_ids_to_update = array_merge(
+			$this->get_stripe_supported_payment_methods(),
+			[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
+		);
+
 		WC_Stripe_Payment_Method_Configurations::update_payment_method_configuration(
 			$payment_method_ids_to_enable,
 			$payment_method_ids_to_update
@@ -3161,45 +3159,5 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// considered enabled if either is enabled in Stripe.
 		return in_array( WC_Stripe_Payment_Methods::APPLE_PAY, $enabled_payment_method_ids, true ) ||
 			in_array( WC_Stripe_Payment_Methods::GOOGLE_PAY, $enabled_payment_method_ids, true );
-	}
-
-	/**
-	 * Disables Google Pay and Apple Pay (ECE) payment methods.
-	 *
-	 * Overrides WC_Gateway_Stripe::disable_payment_request().
-	 *
-	 * @return void
-	 */
-	public function disable_payment_request() {
-		// TODO: consider selective update of payment methods, to avoid
-		// sending entire lists of payment methods to the Stripe API.
-		$enabled_payment_method_ids    = $this->get_upe_enabled_payment_method_ids();
-		$payment_method_ids_to_disable = [
-			WC_Stripe_Payment_Methods::APPLE_PAY,
-			WC_Stripe_Payment_Methods::GOOGLE_PAY,
-		];
-		$payment_method_ids_to_enable  = array_diff( $enabled_payment_method_ids, $payment_method_ids_to_disable );
-		$this->update_enabled_payment_methods( $payment_method_ids_to_enable, true );
-	}
-
-	/**
-	 * Enables Google Pay and Apple Pay (ECE) payment methods.
-	 *
-	 * Overrides WC_Gateway_Stripe::enable_payment_request().
-	 *
-	 * @return void
-	 */
-	public function enable_payment_request() {
-		// TODO: consider selective update of payment methods, to avoid
-		// sending entire lists of payment methods to the Stripe API.
-		$enabled_payment_method_ids   = $this->get_upe_enabled_payment_method_ids();
-		$payment_method_ids_to_enable = array_merge(
-			$enabled_payment_method_ids,
-			[
-				WC_Stripe_Payment_Methods::APPLE_PAY,
-				WC_Stripe_Payment_Methods::GOOGLE_PAY,
-			]
-		);
-		$this->update_enabled_payment_methods( $payment_method_ids_to_enable, true );
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
@@ -60,9 +60,11 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 	/**
 	 * Return if Amazon Pay is enabled.
 	 *
+	 * @param WC_Gateway_Stripe $gateway The gateway instance.
+	 *
 	 * @return bool
 	 */
-	public static function is_amazon_pay_enabled() {
+	public static function is_amazon_pay_enabled( WC_Gateway_Stripe $gateway ) {
 		// Amazon Pay is disabled if feature flag is disabled.
 		if ( ! WC_Stripe_Feature_Flags::is_amazon_pay_available() ) {
 			return false;
@@ -73,8 +75,7 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 			return false;
 		}
 
-		$wc_stripe_upe_payment_method_amazon_pay = new self();
-		$upe_enabled_method_ids = $wc_stripe_upe_payment_method_amazon_pay->get_upe_enabled_payment_method_ids();
+		$upe_enabled_method_ids = $gateway->get_upe_enabled_payment_method_ids();
 
 		return is_array( $upe_enabled_method_ids ) && in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -31,16 +31,16 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	/**
 	 * Return if Stripe Link is enabled
 	 *
+	 * @param WC_Gateway_Stripe $gateway The gateway instance.
 	 * @return bool
 	 */
-	public static function is_link_enabled() {
+	public static function is_link_enabled( WC_Gateway_Stripe $gateway ) {
 		// Assume Link is disabled if UPE is disabled.
 		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return false;
 		}
 
-		$upe_gateway            = new WC_Stripe_UPE_Payment_Gateway();
-		$upe_enabled_method_ids = $upe_gateway->get_upe_enabled_payment_method_ids();
+		$upe_enabled_method_ids = $gateway->get_upe_enabled_payment_method_ids();
 
 		return is_array( $upe_enabled_method_ids ) && in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );
 	}

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -402,11 +402,53 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 		$this->assertEquals( 'no', $notice_option );
 	}
 
+	/**
+	 * @dataProvider is_payment_request_enabled_provider
+	 */
+	public function test_is_payment_request_enabled( $is_enabled, $enabled_payment_method_ids, $disabled_payment_method_ids ) {
+		$this->mock_payment_method_configurations(
+			$enabled_payment_method_ids,
+			$disabled_payment_method_ids
+		);
+		$request  = new WP_REST_Request( 'GET', self::SETTINGS_ROUTE );
+		$response = $this->controller->get_settings( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $is_enabled, $response->get_data()['is_payment_request_enabled'] );
+	}
+
+	public function is_payment_request_enabled_provider() {
+		return [
+			[ true, [ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::GOOGLE_PAY ], [] ],
+			[ false, [], [ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::LINK, WC_Stripe_Payment_Methods::AMAZON_PAY ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider is_payment_request_enabled_legacy_provider
+	 */
+	public function test_is_payment_request_enabled_legacy( $is_enabled, $option_value ) {
+		// Settings controller with non-UPE gateway.
+		$gateway = new WC_Gateway_Stripe();
+		$gateway->update_option( 'payment_request', $option_value );
+		$controller = new WC_REST_Stripe_Settings_Controller( $gateway );
+
+		$request  = new WP_REST_Request( 'GET', self::SETTINGS_ROUTE );
+		$response = $controller->get_settings( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $is_enabled, $response->get_data()['is_payment_request_enabled'] );
+	}
+
+	public function is_payment_request_enabled_legacy_provider() {
+		return [
+			[ true, 'yes' ],
+			[ false, 'no' ],
+		];
+	}
+
 	public function boolean_field_provider() {
 		return [
 			'is_stripe_enabled'                     => [ 'is_stripe_enabled', 'enabled' ],
 			'is_test_mode_enabled'                  => [ 'is_test_mode_enabled', 'testmode' ],
-			'is_payment_request_enabled'            => [ 'is_payment_request_enabled', 'payment_request' ],
 			'is_spe_enabled'                        => [ 'is_spe_enabled', 'single_payment_element' ],
 			'is_manual_capture_enabled'             => [ 'is_manual_capture_enabled', 'capture', true ],
 			'is_saved_cards_enabled'                => [ 'is_saved_cards_enabled', 'saved_cards' ],

--- a/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
@@ -27,8 +27,13 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
 			->disableOriginalConstructor()
+			->getMock();
+
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->setConstructorArgs( [ $gateway ] )
+			->setMethods( [ 'is_page_supported', 'should_show_express_checkout_button' ] )
 			->getMock();
 
 		$this->element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
@@ -60,8 +65,12 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
 			->disableOriginalConstructor()
+			->getMock();
+
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->setConstructorArgs( [ $gateway ] )
 			->getMock();
 
 		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
@@ -87,8 +96,12 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
 			->disableOriginalConstructor()
+			->getMock();
+
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->setConstructorArgs( [ $gateway ] )
 			->setMethods( [ 'is_page_supported', 'should_show_express_checkout_button' ] )
 			->getMock();
 

--- a/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-helper.php
@@ -68,7 +68,6 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'allowed_items_in_cart',
 				'should_show_ece_on_cart_page',
 				'should_show_ece_on_checkout_page',
-				'is_pay_for_order_page',
 			],
 			[ $gateway ]
 		);
@@ -116,6 +115,14 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * Create products for test_hides_ece_if_cannot_compute_taxes.
 	 */
 	private function create_products_for_test_hides_ece_if_cannot_compute_taxes() {
+		if (
+			isset( $this->products['virtual_nontaxable'] ) &&
+			isset( $this->products['virtual_taxable'] ) &&
+			isset( $this->products['shippable_taxable'] )
+		) {
+			return;
+		}
+
 		$virtual_nontaxable_product = WC_Helper_Product::create_simple_product();
 		$virtual_nontaxable_product->set_virtual( true );
 		$virtual_nontaxable_product->set_tax_status( 'none' );

--- a/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-helper.php
@@ -57,6 +57,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		$this->set_up_shipping_methods();
 		$this->create_products_for_test_hides_ece_if_cannot_compute_taxes();
 
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$wc_stripe_ece_helper_mock = $this->createPartialMock(
 			WC_Stripe_Express_Checkout_Helper::class,
 			[
@@ -64,8 +68,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'allowed_items_in_cart',
 				'should_show_ece_on_cart_page',
 				'should_show_ece_on_checkout_page',
-			]
+				'is_pay_for_order_page',
+			],
+			[ $gateway ]
 		);
+
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( false );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_cart_page' )->willReturn( true );
@@ -160,6 +167,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	public function test_hides_ece_if_stripe_gateway_unavailable() {
 		$this->set_up_shipping_methods();
 
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$wc_stripe_ece_helper_mock = $this->createPartialMock(
 			WC_Stripe_Express_Checkout_Helper::class,
 			[
@@ -167,7 +178,8 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'allowed_items_in_cart',
 				'should_show_ece_on_cart_page',
 				'should_show_ece_on_checkout_page',
-			]
+			],
+			[ $gateway ]
 		);
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( false );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
@@ -217,7 +229,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		$this->set_up_shipping_methods();
 
-		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
 		$checkout_data        = $wc_stripe_ece_helper->get_checkout_data();
 
 		$this->assertNotEmpty( $checkout_data['url'] );
@@ -237,7 +253,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_checkout_data_no_shipping_zones() {
 		// When no shipping zones are set up, the default shipping option should be empty.
-		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
 		$checkout_data        = $wc_stripe_ece_helper->get_checkout_data();
 		$this->assertEmpty( $checkout_data['default_shipping_option'] );
 	}
@@ -246,11 +266,16 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * Test for is_authentication_required().
 	 */
 	public function test_is_authentication_required() {
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$wc_stripe_ece_helper_mock = $this->createPartialMock(
 			WC_Stripe_Express_Checkout_Helper::class,
 			[
 				'is_account_creation_possible',
-			]
+			],
+			[ $gateway ]
 		);
 		$wc_stripe_ece_helper_mock->expects( $this->any() )
 			->method( 'is_account_creation_possible' )
@@ -273,11 +298,16 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * Test for is_account_creation_possible().
 	 */
 	public function test_is_account_creation_possible() {
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$wc_stripe_ece_helper_mock = $this->createPartialMock(
 			WC_Stripe_Express_Checkout_Helper::class,
 			[
 				'has_subscription_product',
-			]
+			],
+			[ $gateway ]
 		);
 		$wc_stripe_ece_helper_mock->expects( $this->any() )
 			->method( 'has_subscription_product' )
@@ -300,7 +330,8 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			WC_Stripe_Express_Checkout_Helper::class,
 			[
 				'has_subscription_product',
-			]
+			],
+			[ $gateway ]
 		);
 		$wc_stripe_ece_helper_mock2->expects( $this->any() )
 			->method( 'has_subscription_product' )
@@ -327,7 +358,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_get_normalized_postal_code
 	 */
 	public function test_get_normalized_postal_code( $postal_code, $country, $expected ) {
-		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
 		$this->assertEquals( $expected, $wc_stripe_ece_helper->get_normalized_postal_code( $postal_code, $country ) );
 	}
 

--- a/tests/phpunit/payment-methods/test-wc-stripe-payment-request.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-payment-request.php
@@ -189,15 +189,6 @@ class WC_Stripe_Payment_Request_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$this->assertEquals( $expected_shipping_options, $data['shipping_options'], 'Shipping options mismatch' );
 	}
 
-	public function test_is_at_least_one_payment_request_button_enabled_link_enabled() {
-		$this->pr->stripe_settings = [ 'payment_request' => false ];
-
-		$this->upe_helper->enable_upe();
-		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::LINK ], [] );
-
-		$this->assertTrue( $this->pr->is_at_least_one_payment_request_button_enabled() );
-	}
-
 	public function test_is_at_least_one_payment_request_button_enabled_pr_enabled() {
 		$this->pr->stripe_settings = [ 'payment_request' => 'yes' ];
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -292,7 +292,7 @@ function woocommerce_gateway_stripe() {
 				$this->account                       = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
 
 				// Express checkout configurations.
-				$express_checkout_helper              = new WC_Stripe_Express_Checkout_Helper();
+				$express_checkout_helper              = new WC_Stripe_Express_Checkout_Helper( $this->get_main_stripe_gateway() );
 				$express_checkout_ajax_handler        = new WC_Stripe_Express_Checkout_Ajax_Handler( $express_checkout_helper );
 				$this->express_checkout_configuration = new WC_Stripe_Express_Checkout_Element( $express_checkout_ajax_handler, $express_checkout_helper );
 				$this->express_checkout_configuration->init();

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -795,7 +795,8 @@ function woocommerce_gateway_stripe() {
 			 * @return array WooCommerce checkout fields.
 			 */
 			public function checkout_update_email_field_priority( $fields ) {
-				if ( isset( $fields['billing_email'] ) && WC_Stripe_UPE_Payment_Method_Link::is_link_enabled() ) {
+				$gateway = $this->get_main_stripe_gateway();
+				if ( isset( $fields['billing_email'] ) && WC_Stripe_UPE_Payment_Method_Link::is_link_enabled( $gateway ) ) {
 					// Update the field priority.
 					$fields['billing_email']['priority'] = 1;
 


### PR DESCRIPTION
Fixes STRIPE-324

## Changes proposed in this Pull Request:
- Update how we enable Apple Pay/Google Pay for UPE, from using a flag stored in options, to checking the list of enabled payment methods.
- Add backwards compatibility support for legacy checkout, sticking to using the old flag for enabling Apple Pay/Google Pay.
- Refactor how we check if Link and Amazon Pay are enabled, for consistency with Apple Pay/Google Pay.

## Testing instructions

1. Verify that Apple Pay/Google Pay settings are consistent across wp-admin, Stripe dashboard, and the store front (product, cart, checkout).
    a. Make sure legacy checkout is disabled.
    b. From wp-admin, enable `Apple Pay/Google Pay`.
    c. Verify that both Apple Pay and Google Pay are enabled in the Stripe dashboard.
    d. Verify that Apple Pay¹ and Google Pay are enabled on the store front.
    e. From wp-admin, disable `Apple Pay/Google Pay`. 
    f. Verify Apple Pay and Google Pay are also disabled in the Stripe dashboard and store front.
    f. From the Stripe dashboard, enable BOTH Apple Pay and Google Pay.
    g. Verify that `Apple Pay/Google Pay` in wp-admin is enabled, and Apple Pay¹ and Google Pay are enabled on the store front.
2. Verify the "either-or" behavior for the combined `Apple Pay/Google` Pay wp-admin setting.
    a. In the Stripe dashboard, enable Google Pay, but disable Apple Pay.
    b. Refresh wp-admin, and verify that `Apple Pay/Google Pay` is still enabled.
    c. Verify that Google Pay, but not Apple Pay, is enabled on the store front.
3. Verify that legacy checkout/PRBs is unaffected.
    a. Enable legacy checkout.
    b. Still in wp-admin, refresh the page and enable `Apple Pay/Google Pay`.
    c. In the Stripe dashboard, turn off both Apple Pay and Google Pay.
    d. Back in wp-admin, refresh the page and verify that `Apple Pay/Google Pay` is unaffected and still enabled.
    e. Verify that Apple Pay and Google Pay² are enabled on the store front.
    
Notes:
¹ Apple Pay will only show up in Safari, and with Apple Wallet set up.
² Google Pay PRB will only show up in Chrome, and while logged in with pay.google.com. (Google Pay ECE should always show up, regardless.)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
