### PR TITLE
Fix _load_textdomain_just_in_time warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@
 * Fix - Fix subscription renewal issues for Amazon Pay.
 * Tweak - SPE: Remove radio buttons
 * Update - Hide express checkout buttons when no product variation is selected.
+* Fix - Translation warning when initializing the status page information.
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/readme.txt
+++ b/readme.txt
@@ -142,5 +142,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix subscription renewal issues for Amazon Pay.
 * Tweak - SPE: Remove radio buttons
 * Update - Hide express checkout buttons when no product variation is selected.
+* Fix - Translation warning when initializing the status page information.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -316,10 +316,6 @@ function woocommerce_gateway_stripe() {
 						require_once __DIR__ . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
 						new WC_Stripe_Payment_Gateways_Controller();
 					}
-
-					// Initialize the class for handling the status page.
-					$wcstripe_status = new WC_Stripe_Status( self::get_main_stripe_gateway(), $this->account );
-					$wcstripe_status->init_hooks();
 				}
 
 				// REMOVE IN THE FUTURE.
@@ -344,9 +340,12 @@ function woocommerce_gateway_stripe() {
 
 				new WC_Stripe_UPE_Compatibility_Controller();
 
-				// Intitialize the class for updating subscriptions' Legacy SEPA payment methods.
+				// Initialize the class for updating subscriptions' Legacy SEPA payment methods.
 				add_action( 'init', [ $this, 'initialize_subscriptions_updater' ] );
 				add_action( 'init', [ $this, 'load_plugin_textdomain' ] );
+
+				// Initialize the class for handling the status page.
+				add_action( 'init', [ $this, 'initialize_status_page' ], 15 );
 			}
 
 			/**
@@ -823,6 +822,20 @@ function woocommerce_gateway_stripe() {
 
 			public function load_plugin_textdomain() {
 				load_plugin_textdomain( 'woocommerce-gateway-stripe', false, plugin_basename( __DIR__ ) . '/languages' );
+			}
+
+			/**
+			 * Initializes the status page.
+			 *
+			 * @return void
+			 */
+			public function initialize_status_page() {
+				if ( ! is_admin() ) {
+					return;
+				}
+
+				$wcstripe_status = new WC_Stripe_Status( self::get_main_stripe_gateway(), $this->account );
+				$wcstripe_status->init_hooks();
 			}
 		}
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #4085, #4140

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR fixes a warning that occurs when translations are loaded too early in the WordPress lifecycle. The warning appears as:

```
Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the woocommerce-gateway-stripe domain was triggered too early.
```

The issue was introduced when the Status page updates were added in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3878, which instantiates the payment gateway during `plugins_loaded`. This caused translations to be loaded before WordPress's text domain infrastructure was fully initialized.
Initially, I considered moving the entire plugin initialization from `plugins_loaded` to `init`. While that fixed the error and should avoid any future instances that could lead to similar errors, it would have been too broad of a change with potential side effects.
Instead, this PR proposes a more targeted fix of only initializing the status page updates during `init`.

This ensures:

- Translations are loaded at the correct time (priority 10)
- Status page is initialized after translations (priority 15)
- Only the Status page functionality is affected,


<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**To reproduce the error:**

1. Switch to develop.
2. Enable debugging by adding `define( 'WP_DEBUG', true );` to your `wp-config.php`
3. Change site language to `English (UK)` via Settings -> General -> Site Language.
4. Go to Dashboards -> Updates. Click on "Re-install version 6.7.2–en_GB"
5. Notice the warning on top of the page.

**Test the fix:**
1. Switch to this branch.
2. Above notice should no longer be visible.

**Test for regressions:**

Follow the instructions in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/3878

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)