### PR TITLE
ECE: Checkout failure when using extensions that reduce the cart total

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@
 * Tweak - SPE: Remove radio buttons
 * Update - Hide express checkout buttons when no product variation is selected.
 * Add - Add ACSS support for WC Subscriptions.
+* Fix - ECE checkout error when using extensions that reduce total cart amount (eg: Gift Cards)
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -76,8 +76,24 @@ export const useExpressCheckout = ( {
 				return defaultShippingOption ? [ defaultShippingOption ] : [];
 			};
 
+			const lineItems = normalizeLineItems( billing.cartTotalItems );
+			const totalAmountOfLineItems = lineItems.reduce(
+				( acc, lineItem ) => {
+					return acc + lineItem.amount;
+				},
+				0
+			);
+
 			const options = {
-				lineItems: normalizeLineItems( billing?.cartTotalItems ),
+				// if the `billing.cartTotal.value` is less than the total of `lineItems`, Stripe throws an error
+				// it can sometimes happen that the total is _slightly_ less, due to rounding errors on individual items/taxes/shipping
+				// (or with the `woocommerce_tax_round_at_subtotal` setting).
+				// if that happens, let's just not return any of the line items.
+				// This way, just the total amount will be displayed to the customer.
+				lineItems:
+					billing.cartTotal.value < totalAmountOfLineItems
+						? []
+						: lineItems,
 				emailRequired: true,
 				shippingAddressRequired: shippingData?.needsShipping,
 				phoneNumberRequired:
@@ -109,6 +125,7 @@ export const useExpressCheckout = ( {
 		[
 			onClick,
 			billing.cartTotalItems,
+			billing.cartTotal.value,
 			shippingData.needsShipping,
 			shippingData.shippingRates,
 		]

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -88,6 +88,13 @@ jQuery( function ( $ ) {
 		$( '.wc-bookings-booking-form' ).length > 0;
 
 	const resolveClickEvent = ( event, options ) => {
+		const getDefaultShippingRates = () => {
+			// Return a default shipping option when shipping is required but no rates are provided
+			const defaultShippingOption = getExpressCheckoutData( 'checkout' )
+				?.default_shipping_option;
+			return defaultShippingOption ? [ defaultShippingOption ] : [];
+		};
+
 		const clickOptions = {
 			lineItems: useLegacyCartEndpoints
 				? normalizeLineItems( options.displayItems )
@@ -95,7 +102,12 @@ jQuery( function ( $ ) {
 			emailRequired: true,
 			shippingAddressRequired: options.requestShipping,
 			phoneNumberRequired: options.requestPhone,
-			shippingRates: options.shippingRates,
+			...( options.requestShipping && {
+				shippingRates:
+					options.shippingRates?.length > 0
+						? options.shippingRates
+						: getDefaultShippingRates(),
+			} ),
 		};
 
 		return event.resolve( clickOptions );

--- a/client/express-checkout/transformers/__tests__/wc-to-stripe.test.js
+++ b/client/express-checkout/transformers/__tests__/wc-to-stripe.test.js
@@ -203,6 +203,113 @@ describe( 'wc-to-stripe transformers', () => {
 				} )
 			).toStrictEqual( [] );
 		} );
+
+		it( 'does not return line items when there is a discrepancy with the totals', () => {
+			expect(
+				transformCartDataForDisplayItems( {
+					items: [
+						{
+							key: '6fd9b4da889ae534ceae47561b939f24',
+							id: 214,
+							type: 'simple',
+							quantity: 2,
+							name: 'Deposit',
+							variation: [],
+							item_data: [
+								{
+									name: 'Payment Plan',
+									value: 'Deposit 30',
+									display: '',
+								},
+								{
+									key: 'Payable In Total',
+									value: '&#36;45.00 payable over 20 days',
+								},
+							],
+							prices: {
+								price: '4500',
+								regular_price: '5000',
+								sale_price: '4500',
+								price_range: null,
+								currency_code: 'USD',
+								currency_symbol: '$',
+								currency_minor_unit: 2,
+								currency_decimal_separator: '.',
+								currency_thousand_separator: ',',
+								currency_prefix: '$',
+								currency_suffix: '',
+								raw_prices: {
+									precision: 6,
+									price: '45000000',
+									regular_price: '50000000',
+									sale_price: '45000000',
+								},
+							},
+							totals: {
+								line_subtotal: '1350',
+								line_subtotal_tax: 0,
+								line_total: '4500',
+								line_total_tax: '388',
+								currency_code: 'USD',
+								currency_symbol: '$',
+								currency_minor_unit: 2,
+								currency_decimal_separator: '.',
+								currency_thousand_separator: ',',
+								currency_prefix: '$',
+								currency_suffix: '',
+							},
+							catalog_visibility: 'visible',
+							extensions: {
+								'woocommerce-deposits': {
+									is_deposit: true,
+									has_payment_plan: true,
+									plan_schedule: [
+										{
+											schedule_id: '2',
+											schedule_index: '0',
+											plan_id: '2',
+											amount: '30',
+											interval_amount: '0',
+											interval_unit: '0',
+										},
+										{
+											schedule_id: '3',
+											schedule_index: '1',
+											plan_id: '2',
+											amount: '70',
+											interval_amount: '20',
+											interval_unit: 'day',
+										},
+									],
+								},
+								bundles: [],
+							},
+						},
+					],
+					shipping_rates: [],
+					totals: {
+						total_items: '0',
+						total_items_tax: '0',
+						total_fees: '0',
+						total_fees_tax: '0',
+						total_discount: '0',
+						total_discount_tax: '0',
+						total_shipping: '0',
+						total_shipping_tax: '0',
+						total_price: '0',
+						total_tax: '0',
+						tax_lines: [],
+						currency_code: 'USD',
+						currency_symbol: '$',
+						currency_minor_unit: 2,
+						currency_decimal_separator: '.',
+						currency_thousand_separator: ',',
+						currency_prefix: '$',
+						currency_suffix: '',
+					},
+				} )
+			).toStrictEqual( [] );
+		} );
 	} );
 
 	describe( 'transformPrice', () => {

--- a/client/express-checkout/transformers/wc-to-stripe.js
+++ b/client/express-checkout/transformers/wc-to-stripe.js
@@ -101,6 +101,24 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 		} );
 	}
 
+	const totalAmount = transformPrice(
+		parseInt( cartData.totals.total_price, 10 ) -
+			parseInt( cartData.totals.total_refund || 0, 10 ),
+		cartData.totals
+	);
+	const totalAmountOfDisplayItems = displayItems.reduce(
+		( acc, { amount } ) => acc + amount,
+		0
+	);
+
+	// if `totalAmount` is less than the total of `displayItems`, Stripe throws an error
+	// it can sometimes happen that the total is _slightly_ less, due to rounding errors on individual items/taxes/shipping
+	// (or with the `woocommerce_tax_round_at_subtotal` setting).
+	// if that happens, let's just not return any of the line items. This way, just the total amount will be displayed to the customer.
+	if ( totalAmount < totalAmountOfDisplayItems ) {
+		return [];
+	}
+
 	return displayItems;
 };
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1236,22 +1236,24 @@ class WC_Stripe_Express_Checkout_Helper {
 		$display_items = ! apply_filters( 'wc_stripe_payment_request_hide_itemization', true ) || $itemized_display_items;
 		$has_deposits  = false;
 
-		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-			// Hide itemization/subtotals for Apple Pay and Google Pay when deposits are present.
-			if ( ! empty( $cart_item['is_deposit'] ) ) {
-				$has_deposits = true;
-				continue;
+		if ( $display_items ) {
+			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+				// Hide itemization/subtotals for Apple Pay and Google Pay when deposits are present.
+				if ( ! empty( $cart_item['is_deposit'] ) ) {
+					$has_deposits = true;
+					continue;
+				}
+
+				$subtotal      += $cart_item['line_subtotal'];
+				$amount         = $cart_item['line_subtotal'];
+				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
+				$product_name   = $cart_item['data']->get_name();
+
+				$lines[] = [
+					'label'  => $product_name . $quantity_label,
+					'amount' => WC_Stripe_Helper::get_stripe_amount( $amount ),
+				];
 			}
-
-			$subtotal      += $cart_item['line_subtotal'];
-			$amount         = $cart_item['line_subtotal'];
-			$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
-			$product_name   = $cart_item['data']->get_name();
-
-			$lines[] = [
-				'label'  => $product_name . $quantity_label,
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $amount ),
-			];
 		}
 
 		if ( $display_items && ! $has_deposits ) {

--- a/readme.txt
+++ b/readme.txt
@@ -144,5 +144,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - SPE: Remove radio buttons
 * Update - Hide express checkout buttons when no product variation is selected.
 * Add - Add ACSS support for WC Subscriptions.
+* Fix - ECE checkout error when using extensions that reduce total cart amount (eg: Gift Cards)
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4123

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This adapts the same solution made in https://github.com/Automattic/woocommerce-payments/pull/10311 to address the following error that occurs when using express checkout buttons with reduced cart totals in various scenarios.

```
Uncaught (in promise) IntegrationError: The amount 650 is less than the total amount of the line items provided.
```

Unrelated to the above error, I encountered the following error when testing ECE on the classic checkout page. 

```
IntegrationError: When `shippingAddressRequired` is true, you must specify `shippingRates`
```
This is addressed in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/7bb37c2768dd09303414ea825f65aba476c53956



<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Install and activate the [Gift Cards for WooCommerce](https://woocommerce.com/products/gift-cards/) extension.
2. Create a gift card product priced at $10 ([instructions](https://woocommerce.com/document/gift-cards/store-owners-guide/#creating-gift-card-products)).
3. Purchase a gift card and note down the gift card code.
4. Ensure Google Pay or Apple Pay via WooCommerce Stripe is enabled.
5. Add products worth more than $10 to the cart.
6. Navigate to the checkout page (block-based or shortcode-based).
7. Apply the gift card code obtained earlier to lower the cart total.
8. Attempt to checkout using Google Pay or Apple Pay button.
9. The payment modal should show up, and you should be able to complete the purchase.
10. As the merchant, go to WooCommerce -> Settings -> Gift Cards -> Enable cart page features
11. As a shopper, repeat steps 3 to 5. This time go to the Cart page.
12. Apply the gift card.
13. Attempt to checkout from Google Pay or Apple Pay and make sure you're able to place an order.




<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
