### PR TITLE
ECE: display notice on tax limitations

### DIFF
--- a/client/components/express-checkout-inaccurate-taxes-pill/__tests__/index.test.js
+++ b/client/components/express-checkout-inaccurate-taxes-pill/__tests__/index.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import ExpressCheckoutInaccurateTaxesPill from '..';
+
+describe( 'ExpressCheckoutInaccurateTaxesPill', () => {
+	it( 'should render the "Tax-based limitations" text', () => {
+		render( <ExpressCheckoutInaccurateTaxesPill taxBasedOn="billing" /> );
+
+		expect(
+			screen.queryByText( 'Tax-based limitations' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render when taxes are not based on billing address', () => {
+		const { container } = render(
+			<ExpressCheckoutInaccurateTaxesPill taxBasedOn="shipping" />
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should not render when taxes are based on billing address', () => {
+		render( <ExpressCheckoutInaccurateTaxesPill taxBasedOn="billing" /> );
+
+		expect(
+			screen.queryByText( 'Tax-based limitations' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/components/express-checkout-inaccurate-taxes-pill/index.js
+++ b/client/components/express-checkout-inaccurate-taxes-pill/index.js
@@ -1,0 +1,80 @@
+import { __ } from '@wordpress/i18n';
+import React from 'react';
+import styled from '@emotion/styled';
+import interpolateComponents from 'interpolate-components';
+import { Icon, info } from '@wordpress/icons';
+import Popover from 'wcstripe/components/popover';
+
+const StyledPill = styled.span`
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 8px;
+	border: 1px solid #fcf9e8;
+	border-radius: 2px;
+	background-color: #fcf9e8;
+	color: #674600;
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 16px;
+	width: fit-content;
+`;
+
+const StyledLink = styled.a`
+	&:focus,
+	&:visited {
+		box-shadow: none;
+	}
+`;
+
+const IconWrapper = styled.span`
+	height: 16px;
+	cursor: pointer;
+`;
+
+const AlertIcon = styled( Icon )`
+	fill: #674600;
+`;
+
+const IconComponent = ( { children, ...props } ) => (
+	<IconWrapper { ...props }>
+		<AlertIcon icon={ info } size="16" />
+		{ children }
+	</IconWrapper>
+);
+
+const ExpressCheckoutInaccurateTaxesPill = ( { taxBasedOn } ) => {
+	if ( taxBasedOn === 'billing' ) {
+		return (
+			<StyledPill>
+				{ __( 'Tax-based limitations', 'woocommerce-gateway-stripe' ) }
+				<Popover
+					BaseComponent={ IconComponent }
+					content={ interpolateComponents( {
+						mixedString: __(
+							'Express Checkout is not available for virtual products when taxes are based on billing address. {{taxSettingsLink}}Manage tax settings{{/taxSettingsLink}}',
+							'woocommerce-gateway-stripe'
+						),
+						components: {
+							taxSettingsLink: (
+								<StyledLink
+									href="/wp-admin/admin.php?page=wc-settings&tab=tax"
+									target="_blank"
+									rel="noreferrer"
+									onClick={ ( ev ) => {
+										// Stop propagation is necessary so it doesn't trigger the tooltip click event.
+										ev.stopPropagation();
+									} }
+								/>
+							),
+						},
+					} ) }
+				/>
+			</StyledPill>
+		);
+	}
+
+	return null;
+};
+
+export default ExpressCheckoutInaccurateTaxesPill;

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -17,6 +17,7 @@ import {
 import './styles.scss';
 import AmazonPayIcon from '../../payment-method-icons/amazon-pay';
 import PaymentMethodMissingCurrencyPill from '../../components/payment-method-missing-currency-pill';
+import ExpressCheckoutInaccurateTaxesPill from '../../components/express-checkout-inaccurate-taxes-pill';
 import {
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_LINK,
@@ -113,6 +114,12 @@ const PaymentRequestSection = () => {
 										'Apple Pay / Google Pay',
 										'woocommerce-gateway-stripe'
 									) }
+									<ExpressCheckoutInaccurateTaxesPill
+										taxBasedOn={
+											// eslint-disable-next-line camelcase
+											wc_stripe_settings_params.tax_based_on
+										}
+									/>
 								</div>
 								<div className="express-checkout__description">
 									{
@@ -183,6 +190,12 @@ const PaymentRequestSection = () => {
 										'Link by Stripe',
 										'woocommerce-gateway-stripe'
 									) }
+									<ExpressCheckoutInaccurateTaxesPill
+										taxBasedOn={
+											// eslint-disable-next-line camelcase
+											wc_stripe_settings_params.tax_based_on
+										}
+									/>
 								</div>
 								<div className="express-checkout__description">
 									{

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -248,6 +248,7 @@ class WC_Stripe_Settings_Controller {
 			'is_amazon_pay_available'   => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
 			'is_spe_available'          => WC_Stripe_Feature_Flags::is_spe_available(),
 			'oauth_nonce'               => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
+			'tax_based_on'              => get_option( 'woocommerce_tax_based_on' ),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',


### PR DESCRIPTION
## Changes proposed in this Pull Request:

**Background**
When taxes are based on billing address, we are unable to compute accurate taxes for express checkout. This is because we do not have access to the billing address until after the payment is submitted, i.e. we receive it only on the confirm event. 

Currently, we are choosing to hide express checkout when:
   - the product/cart is not shippable, e.g. virtual products
   - taxes are based on billing address

In this PR, we add a notice pill for express checkout methods, to inform the merchant that even when enabled, Apple Pay, Google Pay, and Link will not be available if the above conditions are true.

Note: Amazon Pay is not included in these changes, as we will be turning it off outright when taxes are based on billing address. See STRIPE-377

<img width="576" alt="Screenshot 2025-03-31 at 4 19 57 PM" src="https://github.com/user-attachments/assets/55793fc8-5bda-466a-bfbb-d6e5effaa33b" />


## Testing instructions
TBD

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
