### PR TITLE
Prevent checkout page focus loss

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -41,6 +41,7 @@
 * Add - Add WooCommerce Pre-Orders support to ACSS.
 * Update - Remove unused express checkout button tracking.
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
+* Fix - Checkout page focus loss
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/client/styles/upe/__tests__/index.js
+++ b/client/styles/upe/__tests__/index.js
@@ -135,13 +135,6 @@ describe( 'Getting styles for automated theming', () => {
 						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
 					outline: '1px solid rgb(150, 88, 138)',
 				},
-				'.Input:focus': {
-					backgroundColor: 'rgba(0, 0, 0, 0)',
-					color: 'rgb(109, 109, 109)',
-					fontFamily:
-						'"Source Sans Pro", HelveticaNeue-Light, "Helvetica Neue Light"',
-					outline: '1px solid rgb(150, 88, 138)',
-				},
 				'.Label': {
 					color: 'rgb(109, 109, 109)',
 					fontFamily:

--- a/client/styles/upe/index.js
+++ b/client/styles/upe/index.js
@@ -262,7 +262,7 @@ const hiddenElementsForUPE = {
 	},
 };
 
-export const getFieldStyles = ( selector, upeElement, focus = false ) => {
+export const getFieldStyles = ( selector, upeElement ) => {
 	if ( ! document.querySelector( selector ) ) {
 		return {};
 	}
@@ -270,9 +270,6 @@ export const getFieldStyles = ( selector, upeElement, focus = false ) => {
 	const validProperties = upeRestrictedProperties[ upeElement ];
 
 	const elem = document.querySelector( selector );
-	if ( focus ) {
-		elem.focus( { preventScroll: true } );
-	}
 
 	const styles = window.getComputedStyle( elem );
 
@@ -347,11 +344,6 @@ export const getAppearance = ( isBlocksCheckout = false ) => {
 	hiddenElementsForUPE.init( isBlocksCheckout );
 
 	const inputRules = getFieldStyles( selectors.hiddenInput, '.Input' );
-	const inputFocusRules = getFieldStyles(
-		selectors.hiddenInput,
-		'.Input',
-		true
-	);
 	const inputInvalidRules = getFieldStyles(
 		selectors.hiddenInvalidInput,
 		'.Input'
@@ -403,7 +395,6 @@ export const getAppearance = ( isBlocksCheckout = false ) => {
 		theme: isColorLight( backgroundColor ) ? 'stripe' : 'night',
 		rules: {
 			'.Input': inputRules,
-			'.Input:focus': inputFocusRules,
 			'.Input--invalid': inputInvalidRules,
 			'.Block': blockRules,
 			'.Label': labelRules,

--- a/readme.txt
+++ b/readme.txt
@@ -150,5 +150,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add WooCommerce Pre-Orders support to ACSS.
 * Update - Remove unused shopper tracking
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
+* Fix - Checkout page focus loss
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes #4142 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR removes the input focus style retrieval for the use in Stripe Appearance API. Current implementation works by adding a hidden element and then focusing the element to get the computed focus styles. While this works, it degrades the user experience on the checkout pages for first-time users.
The obvious downside of this PR is that Stripe's input field will not have the same focus style as the rest of the page.
FWIW, input focus styles were removed in WooPayments due to this same issue https://github.com/Automattic/woocommerce-payments/pull/8230/commits/a3f4194e3178a2e53cf62309da69c419e59b2f8b

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
The easiest way to recreate the issue is by removing the condition [here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/cf6c6aafe1ae8b4a9d4576662aab89a91d13e37d/client/stripe-utils/utils.js#L605) so that `getAppearance` is always called.

1. To recreate, in `develop`, add a product to the cart and go to the checkout page.
2. Click on the email input field. 
3. Try to enter email address.
4. Notice that the field loses focus on each character.
5. Switch to the PR branch.
6. Focus loss should not happen.  
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)