### PR TITLE
Enable ACSS feature flag by default

### DIFF
--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -26,7 +26,7 @@ class WC_Stripe_Feature_Flags {
 		self::AMAZON_PAY_FEATURE_FLAG_NAME     => 'no',
 		self::SPE_FEATURE_FLAG_NAME            => 'no',
 		self::LPM_ACH_FEATURE_FLAG_NAME        => 'yes',
-		self::LPM_ACSS_FEATURE_FLAG_NAME       => 'no',
+		self::LPM_ACSS_FEATURE_FLAG_NAME       => 'yes',
 		self::LPM_BACS_FEATURE_FLAG_NAME       => 'yes',
 		self::LPM_BECS_DEBIT_FEATURE_FLAG_NAME => 'no',
 		self::LPM_BLIK_FEATURE_FLAG_NAME       => 'no',

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller-gb.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller-gb.php
@@ -103,6 +103,7 @@ class WC_REST_Stripe_Settings_Controller_Test_GB extends WP_UnitTestCase {
 			WC_Stripe_Payment_Methods::MULTIBANCO,
 			WC_Stripe_Payment_Methods::LINK,
 			WC_Stripe_Payment_Methods::WECHAT_PAY,
+			WC_Stripe_Payment_Methods::ACSS_DEBIT,
 			WC_Stripe_Payment_Methods::BACS_DEBIT,
 		];
 
@@ -133,6 +134,7 @@ class WC_REST_Stripe_Settings_Controller_Test_GB extends WP_UnitTestCase {
 			WC_Stripe_Payment_Methods::P24,
 			WC_Stripe_Payment_Methods::MULTIBANCO,
 			WC_Stripe_Payment_Methods::WECHAT_PAY,
+			WC_Stripe_Payment_Methods::ACSS_DEBIT,
 			WC_Stripe_Payment_Methods::BACS_DEBIT,
 		];
 

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -257,6 +257,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			// 'link', // Link is excluded as it is a express method.
 			WC_Stripe_Payment_Methods::WECHAT_PAY,
 			WC_Stripe_Payment_Methods::CASHAPP_PAY,
+			WC_Stripe_Payment_Methods::ACSS_DEBIT,
 		];
 		$available_method_ids = $response->get_data()['available_payment_method_ids'];
 
@@ -305,6 +306,7 @@ class WC_REST_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 			WC_Stripe_Payment_Methods::MULTIBANCO,
 			WC_Stripe_Payment_Methods::WECHAT_PAY,
 			WC_Stripe_Payment_Methods::CASHAPP_PAY,
+			WC_Stripe_Payment_Methods::ACSS_DEBIT,
 		];
 
 		$response           = $this->rest_get_settings();

--- a/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway-gb.php
+++ b/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway-gb.php
@@ -83,6 +83,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test_GB extends WP_UnitTestCase {
 					WC_Stripe_UPE_Payment_Method_Multibanco::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID, // TODO: Verify if Link is actually returned/needed in the frontend.
 					WC_Stripe_UPE_Payment_Method_Wechat_Pay::STRIPE_ID,
+					WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Bacs_Debit::STRIPE_ID,
 				],
 			],


### PR DESCRIPTION
Fixes #4167 

## Changes proposed in this Pull Request:

Enable ACSS feature flag by default.

## Testing instructions

1. Make sure you are connected with a US Stripe account and Pre-Authorized Debit is active in the Stripe dashboard.
2. Make sure the store currency is set to CAD.
3. Delete the `_wcstripe_feature_lpm_acss` option from your local environment.
4. Navigate to the plugin settings and make sure Pre-Authorized Debit is available.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
