### PR TITLE
Add BECS support for WC Subscriptions

### DIFF
--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -1007,6 +1007,13 @@ trait WC_Stripe_Subscriptions_Trait {
 								$source->us_bank_account->last4
 							);
 							break 3;
+						case WC_Stripe_Payment_Methods::BECS_DEBIT:
+							$payment_method_to_display = sprintf(
+								/* translators: last 4 digits of account. */
+								__( 'BECS Direct Debit ending in %2$s', 'woocommerce-gateway-stripe' ),
+								$source->au_becs_debit->last4
+							);
+							break 3;
 						case WC_Stripe_Payment_Methods::ACSS_DEBIT:
 							$payment_method_to_display = sprintf(
 								/* translators: 1) bank name, 2) last 4 digits of account. */

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -1010,7 +1010,7 @@ trait WC_Stripe_Subscriptions_Trait {
 						case WC_Stripe_Payment_Methods::BECS_DEBIT:
 							$payment_method_to_display = sprintf(
 								/* translators: last 4 digits of account. */
-								__( 'BECS Direct Debit ending in %2$s', 'woocommerce-gateway-stripe' ),
+								__( 'BECS Direct Debit ending in %s', 'woocommerce-gateway-stripe' ),
 								$source->au_becs_debit->last4
 							);
 							break 3;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @extends WC_Stripe_UPE_Payment_Method
  */
 class WC_Stripe_UPE_Payment_Method_Becs_Debit extends WC_Stripe_UPE_Payment_Method {
+	use WC_Stripe_Subscriptions_Trait;
 
 	/**
 	 * Stripe's internal identifier for BECS Direct Debit.
@@ -29,6 +30,10 @@ class WC_Stripe_UPE_Payment_Method_Becs_Debit extends WC_Stripe_UPE_Payment_Meth
 		$this->supported_currencies = [ WC_Stripe_Currency_Code::AUSTRALIAN_DOLLAR ];
 		$this->supported_countries  = [ 'AU' ];
 		$this->supports[]           = 'tokenization';
+		$this->supports[]           = 'subscriptions';
+
+		// Check if subscriptions are enabled and add support for them.
+		$this->maybe_init_subscriptions();
 	}
 
 	/**


### PR DESCRIPTION
Closes #3967 

## Changes proposed in this Pull Request:

Add BECS support for WC Subscriptions.

## Testing instructions

Reproduce the following critical flows using BECS for payments:

- [Purchase subscription product](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#purchase-subscription-product)
- [Purchase free trial subscription](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#purchase-free-trial-subscription)
- [Renew subscription](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#renew-subscription)
- [Change default payment method](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows-%E2%80%90-Instructions#change-default-payment-method)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
