### PR TITLE
Add BLIK support for WooCommerce Pre-Orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@
 * Fix - ECE checkout error when using extensions that reduce total cart amount (eg: Gift Cards)
 * Add - Add WooCommerce Pre-Orders support to ACSS.
 * Update - Remove unused express checkout button tracking.
+* Add - Add BLIK support for WooCommerce Pre-Orders
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 
 = 9.3.1 - 2025-03-14 =

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
@@ -26,6 +26,11 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 			'woocommerce-gateway-stripe'
 		);
 		$this->supports_deferred_intent = false;
+
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
+
+		$this->maybe_hide_blik();
 	}
 
 	/**
@@ -83,5 +88,42 @@ class WC_Stripe_UPE_Payment_Method_BLIK extends WC_Stripe_UPE_Payment_Method {
 			</div>
 			<?php
 		}
+	}
+
+	/**
+	 * Determines whether BLIK should be hidden.
+	 *
+	 * It should hide for pre-orders that are charged upon release.
+	 * WooCommerce Pre-Orders allows merchants to choose when to charge customers.
+	 * BLIK only supports upfront charges.
+	 *
+	 * @return bool True if BLIK should be hidden, false otherwise.
+	 */
+	public function should_hide_blik() {
+		if ( $this->is_pre_order_item_in_cart() ) {
+			$product = $this->get_pre_order_product_from_cart();
+
+			if ( $this->is_pre_order_product_charged_upon_release( $product ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Conditionally hides BLIK in specific scenarios.
+	 */
+	public function maybe_hide_blik() {
+		add_filter(
+			'woocommerce_available_payment_gateways',
+			function ( $available_gateways ) {
+				if ( $this->should_hide_blik() ) {
+					unset( $available_gateways['stripe_blik'] );
+				}
+
+				return $available_gateways;
+			}
+		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -284,8 +284,9 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		}
 
 		// If cart or order contains pre-order, enable payment method if it's reusable.
+		// BLIK supports pre-order when product is charged upfront. We're handling availability in WC_Stripe_UPE_Payment_Method_BLIK.
 		if ( $this->is_pre_order_item_in_cart() || ( ! empty( $order_id ) && $this->has_pre_order( $order_id ) ) ) {
-			return $this->is_reusable();
+			return $this->is_reusable() || WC_Stripe_Payment_Methods::BLIK === $this->stripe_id;
 		}
 
 		// Note: this $this->is_automatic_capture_enabled() call will be handled by $this->__call() and fall through to the UPE gateway class.

--- a/readme.txt
+++ b/readme.txt
@@ -149,6 +149,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - ECE checkout error when using extensions that reduce total cart amount (eg: Gift Cards)
 * Add - Add WooCommerce Pre-Orders support to ACSS.
 * Update - Remove unused shopper tracking
+* Add - Add BLIK support for WooCommerce Pre-Orders
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to #3962.

## Changes proposed in this Pull Request:

Add BLIK Pre-Orders support.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Pre-requisites**

1. Enable the BLIK feature flag:
   - Use the Stripe Dev Tools plugin to enable the BLIK feature flag.
2. Enable BLIK in Stripe:
   - Navigate to the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods).
   - Enable "BLIK" in the payment methods settings.
3. Enable BLIK in WC Stripe:
   - Go to **WooCommerce > Settings > Payments > Stripe**.
   - Enable "BLIK".
4. Ensure you're listening to webhooks.
5. Change the store currency to PLN.
6. From the checkout page, use the following information for the address:
   - **Country:** Poland
   - **ZIP code:** `00-892`

### Test: Ensure you CAN checkout with Pre-Order (Charge Up Front)

> [!IMPORTANT]
> Test shortcode and Blocks checkouts.

1. As a merchant, create a product, enable Pre-Orders, set **When to Charge** to **Upfront**.
2. As a customer, purchase this product with BLIK. Note the order ID.
3. As a merchant, navigate to the order detail and ensure the status is **Pending Payment**.
4. You can speed up the processing by going to **WP Admin > Tools > Scheduled Actions > Pending** and running the `wc_stripe_deferred_webhook` item with the relevant order ID.
5. After receiving the webhook , the order status should be **Pre-ordered**.
6. Click on the payment intent and ensure amount, order data and metadata are correct in the intent.
7. In **WooCommerce > Pre-Orders**, release the product and confirm no additional charge occurs and order status is **Processing**.

### Test: Ensure you CAN'T checkout with Pre-Order (Charge Upon Release)

> [!IMPORTANT]
> Test shortcode and Blocks checkouts.

1. As a merchant, create a product, enable Pre-Orders, set **When to Charge** to **Upon Release**.
2. As a customer, add this product to cart and navigate to checkout.
3. Confirm you **can't** select BLIK as the payment method and it doesn't appear at all.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
