### PR TITLE
Enable BECS feature flag by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -45,6 +45,7 @@
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 * Fix - Checkout page focus loss
 * Fix - Updated payment method radio button selector to correctly find the selected payment method in different themes.
+* Add - Support for BECS Direct Debit as a new payment method for Australian accounts.
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -28,7 +28,7 @@ class WC_Stripe_Feature_Flags {
 		self::LPM_ACH_FEATURE_FLAG_NAME        => 'yes',
 		self::LPM_ACSS_FEATURE_FLAG_NAME       => 'no',
 		self::LPM_BACS_FEATURE_FLAG_NAME       => 'yes',
-		self::LPM_BECS_DEBIT_FEATURE_FLAG_NAME => 'no',
+		self::LPM_BECS_DEBIT_FEATURE_FLAG_NAME => 'yes',
 		self::LPM_BLIK_FEATURE_FLAG_NAME       => 'no',
 	];
 

--- a/readme.txt
+++ b/readme.txt
@@ -154,5 +154,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 * Fix - Checkout page focus loss
 * Fix - Updated payment method radio button selector to correctly find the selected payment method in different themes.
+* Add - Support for BECS Direct Debit as a new payment method for Australian accounts.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -63,7 +63,7 @@ redirect_output cli wp core install \
 
 if [[ -n "$WP_VERSION" && "$WP_VERSION" != "latest" ]]; then
 	echo " - Installing WordPress ${WP_VERSION}..."
-	redirect_output cli wp core update --version="$WP_VERSION" --force --quiet
+	redirect_output cli wp core update --version="$WP_VERSION" --forc_wcstripe_feature_lpm_becs_debitache --quiet
 else
 	echo " - Updating WordPress to the latest version"
 	redirect_output cli wp core update --quiet
@@ -138,7 +138,7 @@ echo " - Updating WooCommerce Gateway Stripe settings"
 redirect_output cli wp option set woocommerce_stripe_settings --format=json "{\"enabled\":\"yes\",\"title\":\"Credit Card (Stripe)\",\"description\":\"Pay with your credit card via Stripe.\",\"api_credentials\":\"\",\"testmode\":\"yes\",\"test_publishable_key\":\"${STRIPE_PUB_KEY}\",\"test_secret_key\":\"${STRIPE_SECRET_KEY}\",\"publishable_key\":\"\",\"secret_key\":\"\",\"webhook\":\"\",\"test_webhook_secret\":\"\",\"webhook_secret\":\"\",\"inline_cc_form\":\"no\",\"statement_descriptor\":\"\",\"short_statement_descriptor\":\"\",\"capture\":\"yes\",\"payment_request\":\"yes\",\"payment_request_button_type\":\"buy\",\"payment_request_button_theme\":\"dark\",\"payment_request_button_locations\":[\"product\",\"cart\",\"checkout\"],\"payment_request_button_size\":\"default\",\"saved_cards\":\"yes\",\"logging\":\"no\",\"upe_checkout_experience_enabled\":\"yes\"}"
 
 echo " - Enabling the ACH feature flag"
-redirect_output cli wp option update _wcstripe_feature_lpm_ach 'yes'
+redirect_output cli wp option update _wcstripe_feature_lpm_becs_debit 'yes'
 
 step "Installing Woo Subscriptions"
 echo " - Fetching latest version"

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -63,7 +63,7 @@ redirect_output cli wp core install \
 
 if [[ -n "$WP_VERSION" && "$WP_VERSION" != "latest" ]]; then
 	echo " - Installing WordPress ${WP_VERSION}..."
-	redirect_output cli wp core update --version="$WP_VERSION" --forc_wcstripe_feature_lpm_becs_debitache --quiet
+	redirect_output cli wp core update --version="$WP_VERSION" --force --quiet
 else
 	echo " - Updating WordPress to the latest version"
 	redirect_output cli wp core update --quiet
@@ -138,7 +138,7 @@ echo " - Updating WooCommerce Gateway Stripe settings"
 redirect_output cli wp option set woocommerce_stripe_settings --format=json "{\"enabled\":\"yes\",\"title\":\"Credit Card (Stripe)\",\"description\":\"Pay with your credit card via Stripe.\",\"api_credentials\":\"\",\"testmode\":\"yes\",\"test_publishable_key\":\"${STRIPE_PUB_KEY}\",\"test_secret_key\":\"${STRIPE_SECRET_KEY}\",\"publishable_key\":\"\",\"secret_key\":\"\",\"webhook\":\"\",\"test_webhook_secret\":\"\",\"webhook_secret\":\"\",\"inline_cc_form\":\"no\",\"statement_descriptor\":\"\",\"short_statement_descriptor\":\"\",\"capture\":\"yes\",\"payment_request\":\"yes\",\"payment_request_button_type\":\"buy\",\"payment_request_button_theme\":\"dark\",\"payment_request_button_locations\":[\"product\",\"cart\",\"checkout\"],\"payment_request_button_size\":\"default\",\"saved_cards\":\"yes\",\"logging\":\"no\",\"upe_checkout_experience_enabled\":\"yes\"}"
 
 echo " - Enabling the ACH feature flag"
-redirect_output cli wp option update _wcstripe_feature_lpm_becs_debit 'yes'
+redirect_output cli wp option update _wcstripe_feature_lpm_ach 'yes'
 
 step "Installing Woo Subscriptions"
 echo " - Fetching latest version"


### PR DESCRIPTION
Closes STRIPE-381

## Changes proposed in this Pull Request:

Enable BECS feature flag by default.

## Testing instructions

1. Delete the `_wcstripe_feature_lpm_becs_debit` option from your local environment.  
2. Ensure that the following criteria are met:  
   - The Stripe account is registered in **Australia**.  
   - The store currency is set to **AUD**.  
3. Navigate to the **Plugin Settings** (`/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`) page.  
4. Verify that **BECS Direct Debit** appears as an available payment option in the settings.  

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
