### PR TITLE
Fix for order mandate on setup intents from Add Payment Method page

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1082,14 +1082,16 @@ class WC_Stripe_Intent_Controller {
 			unset( $request['return_url'] );
 		}
 
-		$order = $payment_information['order'];
-		// Run the necessary filter to make sure mandate information is added when it's required.
-		$request = apply_filters(
-			'wc_stripe_generate_create_intent_request',
-			$request,
-			$order,
-			null // $prepared_source parameter is not necessary for adding mandate information.
-		);
+		if ( isset( $payment_information['order'] ) ) {
+			$order = $payment_information['order'];
+			// Run the necessary filter to make sure mandate information is added when it's required.
+			$request = apply_filters(
+				'wc_stripe_generate_create_intent_request',
+				$request,
+				$order,
+				null // $prepared_source parameter is not necessary for adding mandate information.
+			);
+		}
 
 		$setup_intent = WC_Stripe_API::request( $request, 'setup_intents' );
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes regression introduced in #4094 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

While testing the Add Payment Method flow from the My Account page, I was getting the following error / notice when Subscriptions plugin was active:

```
Notice: Undefined index: order in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-intent-controller.php on line 1085

Fatal error: Uncaught Error: Call to a member function get_id() on null in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/compat/trait-wc-stripe-subscriptions.php:750
Stack trace:
#0 /var/www/html/wp-includes/class-wp-hook.php(324): WC_Stripe_Payment_Gateway->add_subscription_information_to_intent(Array, NULL, NULL)
#1 /var/www/html/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array)
#2 /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-intent-controller.php(1091): apply_filters('wc_stripe_gener...', Array, NULL, NULL)
#3 /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-intent-controller.php(1147): WC_Stripe_Intent_Controller->create_and_confirm_setup_intent(Array)
#4 /var/www/html/wp-includes/class-wp-hook.php(324): WC_Stripe_Intent_Controller->create_and_confirm_setup_intent_ajax('')
#5 /var/www/html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)
#6 /var/www/html/wp-includes/plugin.php(517): W in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/compat/trait-wc-stripe-subscriptions.php on line 750
```

![Screenshot 2025-04-02 at 10 37 45 AM](https://github.com/user-attachments/assets/fce289e4-b6f4-462b-bb84-b494f63b9eac)

This was due to the fact we were expecting on order on every setup intent, but in the Add Payment Method flow that is not the case. This PR just checks if we have an order to work on, then we add the relevant mandate data.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

**Confirm this fixes Add Payment Method**
- With this branch applied. go to the My Account page of a logged in shopper.
- Click on Payment Methods.
- Click Add Payment Method.
- Use the default Credit Card and complete the form to save the payment method.
- Confirm the method was successfully saved and displayed in the list now.
- Repeat these steps, but use a different payment method and confirm it is successfully saved.

**Confirm original fix still applies**
- With this branch applied, subscriptions enabled, a free trial subscription product, a non-Indian Stripe account, and a store currency of USD or EUR.
- Add free trial product to cart.
- Go to checkout and use the following CC number: `4000003560000123`
- Click Place Order.
- Confirm that you get the 3DS modal prompt before completing the order.
- With a new shopper account, add this payment method to saved payment methods.
- Go to checkout a free trial subscription with this new saved payment method.
- Confirm you get the 3DS prompt still.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
I opted to not include a changelog since this is just a minor adjustment to a feature/fix that is already mentioned in the changelog and hasn't been released yet.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
