### PR TITLE
Update breadcrumbs back link to wc_back_header 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 * Fix - Checkout page focus loss
 * Fix - Updated payment method radio button selector to correctly find the selected payment method in different themes.
+* Update - Back button for tertiary level pages in settings page.
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/changelog.txt
+++ b/changelog.txt
@@ -47,7 +47,7 @@
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 * Fix - Checkout page focus loss
 * Fix - Updated payment method radio button selector to correctly find the selected payment method in different themes.
-* Update - Back button for tertiary level pages in settings page.
+* Update - Back button on the settings pages.
 
 = 9.3.1 - 2025-03-14 =
 * Fix - Temporarily disables the subscriptions detached notice feature due to long loading times on stores with many subscriptions.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -102,15 +102,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function admin_options() {
 		$form_fields = $this->get_form_fields();
 		$return_url  = admin_url( 'admin.php?page=wc-settings&tab=checkout' );
+		$header      = $this->get_method_title();
+		$return_text = __( 'Return to payments', 'woocommerce-gateway-stripe' );
 
-		if ( function_exists( 'wc_back_header' ) ) {
-			wc_back_header( $this->get_method_title(), __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-		} else {
-			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
-			echo '<h2>' . esc_html( $this->get_method_title() );
-			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-			echo '</h2>';
-		}
+		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
 
 		$this->render_upe_settings();
 	}

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -101,10 +101,16 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 */
 	public function admin_options() {
 		$form_fields = $this->get_form_fields();
+		$return_url  = admin_url( 'admin.php?page=wc-settings&tab=checkout' );
 
-		echo '<h2>' . esc_html( $this->get_method_title() );
-		wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout' ) );
-		echo '</h2>';
+		if ( function_exists( 'wc_back_header' ) ) {
+			wc_back_header( $this->get_method_title(), __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+		} else {
+			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
+			echo '<h2>' . esc_html( $this->get_method_title() );
+			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+			echo '</h2>';
+		}
 
 		$this->render_upe_settings();
 	}

--- a/includes/admin/class-wc-stripe-amazon-pay-controller.php
+++ b/includes/admin/class-wc-stripe-amazon-pay-controller.php
@@ -67,7 +67,7 @@ class WC_Stripe_Amazon_Pay_Controller {
 		$hide_save_button = true;
 		$return_url      = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
 		$header          = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
-		$return_text     = __( 'Return to payments', 'woocommerce-gateway-stripe' );
+		$return_text     = __( 'Return to Stripe', 'woocommerce-gateway-stripe' );
 
 		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
 		echo '<div class="wrap"><div id="wc-stripe-amazon-pay-settings-container"></div></div>';

--- a/includes/admin/class-wc-stripe-amazon-pay-controller.php
+++ b/includes/admin/class-wc-stripe-amazon-pay-controller.php
@@ -65,17 +65,11 @@ class WC_Stripe_Amazon_Pay_Controller {
 	public function admin_options() {
 		global $hide_save_button;
 		$hide_save_button = true;
-		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
-		$header           = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
+		$return_url      = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
+		$header          = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
+		$return_text     = __( 'Return to payments', 'woocommerce-gateway-stripe' );
 
-		if ( function_exists( 'wc_back_header' ) ) {
-			wc_back_header( $header, __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-		} else {
-			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
-			echo '<h2>' . esc_html( $header );
-			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-			echo '</h2>';
-		}
+		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
 		echo '<div class="wrap"><div id="wc-stripe-amazon-pay-settings-container"></div></div>';
 	}
 }

--- a/includes/admin/class-wc-stripe-amazon-pay-controller.php
+++ b/includes/admin/class-wc-stripe-amazon-pay-controller.php
@@ -65,9 +65,17 @@ class WC_Stripe_Amazon_Pay_Controller {
 	public function admin_options() {
 		global $hide_save_button;
 		$hide_save_button = true;
-		echo '<h2>' . esc_html__( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
-		wc_back_link( __( 'Return to Stripe', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' ) );
-		echo '</h2>';
+		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
+		$header           = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
+
+		if ( function_exists( 'wc_back_header' ) ) {
+			wc_back_header( $header, __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+		} else {
+			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
+			echo '<h2>' . esc_html( $header );
+			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+			echo '</h2>';
+		}
 		echo '<div class="wrap"><div id="wc-stripe-amazon-pay-settings-container"></div></div>';
 	}
 }

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -68,16 +68,10 @@ class WC_Stripe_Payment_Requests_Controller {
 		global $hide_save_button;
 		$hide_save_button = true;
 		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
-		$header = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
+		$header          = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
+		$return_text     = __( 'Return to payments', 'woocommerce-gateway-stripe' );
 
-		if ( function_exists( 'wc_back_header' ) ) {
-			wc_back_header( $header, __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-		} else {
-			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
-			echo '<h2>' . esc_html( $header );
-			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-			echo '</h2>';
-		}
+		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
 
 		echo '<div class="wrap"><div id="wc-stripe-payment-request-settings-container"></div></div>';
 	}

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -69,7 +69,7 @@ class WC_Stripe_Payment_Requests_Controller {
 		$hide_save_button = true;
 		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
 		$header          = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
-		$return_text     = __( 'Return to payments', 'woocommerce-gateway-stripe' );
+		$return_text     = __( 'Return to Stripe', 'woocommerce-gateway-stripe' );
 
 		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
 

--- a/includes/admin/class-wc-stripe-payment-requests-controller.php
+++ b/includes/admin/class-wc-stripe-payment-requests-controller.php
@@ -67,9 +67,18 @@ class WC_Stripe_Payment_Requests_Controller {
 	public function admin_options() {
 		global $hide_save_button;
 		$hide_save_button = true;
-		echo '<h2>' . esc_html__( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
-		wc_back_link( __( 'Return to Stripe', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' ) );
-		echo '</h2>';
+		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' );
+		$header = __( 'Customize express checkouts', 'woocommerce-gateway-stripe' );
+
+		if ( function_exists( 'wc_back_header' ) ) {
+			wc_back_header( $header, __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+		} else {
+			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
+			echo '<h2>' . esc_html( $header );
+			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+			echo '</h2>';
+		}
+
 		echo '<div class="wrap"><div id="wc-stripe-payment-request-settings-container"></div></div>';
 	}
 }

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -107,15 +107,10 @@ class WC_Stripe_Settings_Controller {
 
 		$hide_save_button = true;
 		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout' );
+		$header          = $gateway->get_method_title();
+		$return_text     = __( 'Return to payments', 'woocommerce-gateway-stripe' );
 
-		if ( function_exists( 'wc_back_header' ) ) {
-			wc_back_header( $gateway->get_method_title(), __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-		} else {
-			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
-			echo '<h2>' . esc_html( $gateway->get_method_title() );
-			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
-			echo '</h2>';
-		}
+		WC_Stripe_Helper::render_admin_header( $header, $return_text, $return_url );
 
 		$settings = WC_Stripe_Helper::get_stripe_settings();
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -104,11 +104,18 @@ class WC_Stripe_Settings_Controller {
 	 */
 	public function admin_options( WC_Stripe_Payment_Gateway $gateway ) {
 		global $hide_save_button;
-		$hide_save_button = true;
 
-		echo '<h2>' . esc_html( $gateway->get_method_title() );
-		wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), admin_url( 'admin.php?page=wc-settings&tab=checkout' ) );
-		echo '</h2>';
+		$hide_save_button = true;
+		$return_url       = admin_url( 'admin.php?page=wc-settings&tab=checkout' );
+
+		if ( function_exists( 'wc_back_header' ) ) {
+			wc_back_header( $gateway->get_method_title(), __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+		} else {
+			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
+			echo '<h2>' . esc_html( $gateway->get_method_title() );
+			wc_back_link( __( 'Return to payments', 'woocommerce-gateway-stripe' ), $return_url );
+			echo '</h2>';
+		}
 
 		$settings = WC_Stripe_Helper::get_stripe_settings();
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1681,4 +1681,23 @@ class WC_Stripe_Helper {
 
 		return $payment_method_id . '_payments';
 	}
+
+	/**
+	 * Renders the admin header with back link consistently across admin pages.
+	 *
+	 * @param string $header_text The text to display in the header.
+	 * @param string $return_text The text for the return link.
+	 * @param string $return_url  The URL for the return link.
+	 * @return void
+	 */
+	public static function render_admin_header( $header_text, $return_text, $return_url ) {
+		if ( function_exists( 'wc_back_header' ) ) {
+			wc_back_header( $header_text, $return_text, $return_url );
+		} else {
+			// Until the wc_back_header function is available (WC Core 9.9) use the current available version.
+			echo '<h2>' . esc_html( $header_text );
+			wc_back_link( $return_text, $return_url );
+			echo '</h2>';
+		}
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -157,6 +157,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 * Fix - Checkout page focus loss
 * Fix - Updated payment method radio button selector to correctly find the selected payment method in different themes.
-* Update - Back button for tertiary level pages in settings page.
+* Update - Back button on the settings pages.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -155,5 +155,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Add save payment method parameter to update intent call for non-deferred intent payment methods.
 * Fix - Checkout page focus loss
 * Fix - Updated payment method radio button selector to correctly find the selected payment method in different themes.
+* Update - Back button for tertiary level pages in settings page.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-386

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR adds the new back header (available in WC 9.9) or the current back link `wc_back_link` into the following pages:

- Stripe settings
- Amazon Pay customize
- ApplePay / GooglePay customize

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

**WC Core with wc_back_header**
1. Make sure your local test site uses the current `trunk` of WooCommerce.
2. Build the latest WC changes `pnpm install && pnpm --filter=@woocommerce/plugin-woocommerce build`
3. Test the Stripe settings page, Amazon Pay customize page and the Apple Pay / Google Pay customize page.
4. Make sure the breadcrumbs match the screenshots below and they are functional.
![CleanShot 2025-04-02 at 11 36 12](https://github.com/user-attachments/assets/77a13d99-cb3e-4be9-a57a-152183787db3)
![CleanShot 2025-04-02 at 11 36 35](https://github.com/user-attachments/assets/838ac98f-cd11-4db5-90d6-de27e81e9b34)
![CleanShot 2025-04-02 at 11 36 54](https://github.com/user-attachments/assets/3d7e56f3-c60e-483b-ba18-20f2c8f35a45)

**WC Core without wc_back_header** 
1. Either download and install the latest published version of WC (v9.7.1) or switch to the correct tag in dev repo with `git checkout tags/9.7.1 && pnpm install && pnpm --filter=@woocommerce/plugin-woocommerce build`
2. Test the Stripe settings page, Amazon Pay customize page and the Apple Pay / Google Pay customize page.
3. Make sure the breadcrumbs are still functional and there aren't any visual regressions.
![CleanShot 2025-04-02 at 11 32 26](https://github.com/user-attachments/assets/e3255f48-885e-4e40-bb20-182958923f2c)
![CleanShot 2025-04-02 at 11 32 53](https://github.com/user-attachments/assets/02d02bdf-c9ed-4549-8415-36f935910f57)
![CleanShot 2025-04-02 at 11 33 20](https://github.com/user-attachments/assets/3619898f-9b9e-4581-bb5d-47619125a5ff)


<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
