### PR TITLE
Filter to force express checkout button display

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.4.0 - xxxx-xx-xx =
+* Add - New filter to allow merchants to force the display of the express payment method buttons (`should_show_express_checkout_button`).
 * Dev - Implements the new Stripe order class into abstract/base classes, and the webhook handler.
 * Dev - Implements the new Stripe order class into the legacy checkout classes.
 * Dev - Do not generate filenames with underscores.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -571,92 +571,56 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return  boolean  True if express checkout elements are supported on current page, false otherwise
 	 */
 	public function should_show_express_checkout_button() {
+		$product            = $this->get_product();
+		$should_show_button = false;
+		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
+		$stock_availability = in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true )
+			? array_column( $product->get_available_variations(), 'is_in_stock' )
+			: [ $product->is_in_stock() ];
+
 		// Bail if account is not connected.
 		if ( ! WC_Stripe::get_instance()->connect->is_connected() ) {
 			WC_Stripe_Logger::log( 'Account is not connected.' );
-			return false;
-		}
-
-		// If no SSL bail.
-		if ( ! $this->testmode && ! is_ssl() ) {
+		} elseif ( ! $this->testmode && ! is_ssl() ) { // If no SSL bail.
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
 			WC_Stripe_Logger::log( 'Stripe Express Checkout live mode requires SSL. ' . print_r( [ 'url' => get_permalink() ], true ) );
-			return false;
-		}
-
-		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		if ( ! isset( $available_gateways['stripe'] ) ) {
+		} elseif ( ! isset( $available_gateways['stripe'] ) ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout requires the Stripe gateway to be enabled.' );
-			return false;
-		}
-
-		// Don't show if on the cart or checkout page, or if page contains the cart or checkout
-		// shortcodes, with items in the cart that aren't supported.
-		if (
-			WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
-			&& ! $this->allowed_items_in_cart()
-		) {
+		} elseif ( WC_Stripe_Helper::has_cart_or_checkout_on_current_page() && ! $this->allowed_items_in_cart() ) {
+			// Don't show if on the cart or checkout page, or if page contains the cart or checkout
+			// shortcodes, with items in the cart that aren't supported.
 			WC_Stripe_Logger::log( 'Some items in cart are not compatible with Stripe Express Checkout. ' );
-			return false;
-		}
-
-		// Don't show on cart if disabled.
-		if ( is_cart() && ! $this->should_show_ece_on_cart_page() ) {
+		} elseif ( is_cart() && ! $this->should_show_ece_on_cart_page() ) { // Don't show on cart if disabled.
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on cart is disabled. ' );
-			return false;
-		}
-
-		// Don't show on checkout if disabled.
-		if ( is_checkout() && ! $this->should_show_ece_on_checkout_page() ) {
+		} elseif ( is_checkout() && ! $this->should_show_ece_on_checkout_page() ) { // Don't show on checkout if disabled.
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
-			return false;
-		}
-
-		// Don't show if product page ECE is disabled.
-		if ( $this->is_product() && ! $this->should_show_ece_on_product_pages() ) {
+		} elseif ( $this->is_product() && ! $this->should_show_ece_on_product_pages() ) { // Don't show if product page ECE is disabled.
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
-			return false;
-		}
-
-		// Don't show if product on current page is not supported.
-		if ( $this->is_product() && ! $this->is_product_supported( $this->get_product() ) ) {
-			WC_Stripe_Logger::log( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $this->get_product()->get_id() );
-			return false;
-		}
-
-		// Don't show if the total price is 0.
-		// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
-		if ( ( ! ( $this->is_pay_for_order_page() || $this->is_product() ) && isset( WC()->cart ) && 0.0 === (float) WC()->cart->get_total( false ) )
-			|| ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() )
-		) {
+		} elseif ( $this->is_product() && ! $this->is_product_supported( $product ) ) { // Don't show if product on current page is not supported.
+			WC_Stripe_Logger::log( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $product->get_id() );
+		} elseif ( ( ! ( $this->is_pay_for_order_page() || $this->is_product() ) && isset( WC()->cart ) && 0.0 === (float) WC()->cart->get_total( false ) )
+			|| ( $this->is_product() && 0.0 === (float) $product->get_price() )
+		) { // Don't show if the total price is 0.
+			// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
 			WC_Stripe_Logger::log( 'Stripe Express Checkout does not support free products.' );
-			return false;
-		}
-
-		if ( $this->is_product() && in_array( $this->get_product()->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
-			$stock_availability = array_column( $this->get_product()->get_available_variations(), 'is_in_stock' );
-			// Don't show if all product variations are out-of-stock.
-			if ( ! in_array( true, $stock_availability, true ) ) {
-				WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product variations being out of stock. Product ID: ' . $this->get_product()->get_id() );
-				return false;
-			}
-		}
-
-		// Hide if cart/product doesn't require shipping and tax is based on billing or shipping address.
-		if (
+		} elseif ( $this->is_product() && ! in_array( true, $stock_availability, true ) ) { // Don't show if all product variations are out-of-stock.
+			WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product variations being out of stock. Product ID: ' . $product->get_id() );
+		} elseif (
 			! $this->is_pay_for_order_page() &&
 			(
-				( is_product() && ! $this->product_needs_shipping( $this->get_product() ) ) ||
+				( is_product() && ! $this->product_needs_shipping( $product ) ) ||
 				( ( is_cart() || is_checkout() ) && ( ! WC()->cart || ! WC()->cart->needs_shipping() ) )
 			) &&
 			wc_tax_enabled() &&
 			in_array( get_option( 'woocommerce_tax_based_on' ), [ 'billing', 'shipping' ], true )
-		) {
+		) { // Hide if cart/product doesn't require shipping and tax is based on billing or shipping address.
 			WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
-			return false;
+		} else { // If all checks pass, show the button by default.
+			$should_show_button = true;
 		}
 
-		return true;
+		// Allow other plugins to filter the visibility of the button.
+		return apply_filters( 'should_show_express_checkout_button', $should_show_button );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -571,52 +571,68 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return  boolean  True if express checkout elements are supported on current page, false otherwise
 	 */
 	public function should_show_express_checkout_button() {
-		$product            = $this->get_product();
 		$should_show_button = false;
-		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
-		$stock_availability = in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true )
-			? array_column( $product->get_available_variations(), 'is_in_stock' )
-			: [ $product->is_in_stock() ];
 
-		// Bail if account is not connected.
-		if ( ! WC_Stripe::get_instance()->connect->is_connected() ) {
-			WC_Stripe_Logger::log( 'Account is not connected.' );
-		} elseif ( ! $this->testmode && ! is_ssl() ) { // If no SSL bail.
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
-			WC_Stripe_Logger::log( 'Stripe Express Checkout live mode requires SSL. ' . print_r( [ 'url' => get_permalink() ], true ) );
-		} elseif ( ! isset( $available_gateways['stripe'] ) ) {
-			WC_Stripe_Logger::log( 'Stripe Express Checkout requires the Stripe gateway to be enabled.' );
-		} elseif ( WC_Stripe_Helper::has_cart_or_checkout_on_current_page() && ! $this->allowed_items_in_cart() ) {
-			// Don't show if on the cart or checkout page, or if page contains the cart or checkout
-			// shortcodes, with items in the cart that aren't supported.
-			WC_Stripe_Logger::log( 'Some items in cart are not compatible with Stripe Express Checkout. ' );
-		} elseif ( is_cart() && ! $this->should_show_ece_on_cart_page() ) { // Don't show on cart if disabled.
-			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on cart is disabled. ' );
-		} elseif ( is_checkout() && ! $this->should_show_ece_on_checkout_page() ) { // Don't show on checkout if disabled.
-			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
-		} elseif ( $this->is_product() && ! $this->should_show_ece_on_product_pages() ) { // Don't show if product page ECE is disabled.
-			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
-		} elseif ( $this->is_product() && ! $this->is_product_supported( $product ) ) { // Don't show if product on current page is not supported.
-			WC_Stripe_Logger::log( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $product->get_id() );
-		} elseif ( ( ! ( $this->is_pay_for_order_page() || $this->is_product() ) && isset( WC()->cart ) && 0.0 === (float) WC()->cart->get_total( false ) )
-			|| ( $this->is_product() && 0.0 === (float) $product->get_price() )
-		) { // Don't show if the total price is 0.
-			// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
-			WC_Stripe_Logger::log( 'Stripe Express Checkout does not support free products.' );
-		} elseif ( $this->is_product() && ! in_array( true, $stock_availability, true ) ) { // Don't show if all product variations are out-of-stock.
-			WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product variations being out of stock. Product ID: ' . $product->get_id() );
-		} elseif (
-			! $this->is_pay_for_order_page() &&
-			(
-				( is_product() && ! $this->product_needs_shipping( $product ) ) ||
-				( ( is_cart() || is_checkout() ) && ( ! WC()->cart || ! WC()->cart->needs_shipping() ) )
-			) &&
-			wc_tax_enabled() &&
-			in_array( get_option( 'woocommerce_tax_based_on' ), [ 'billing', 'shipping' ], true )
-		) { // Hide if cart/product doesn't require shipping and tax is based on billing or shipping address.
-			WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
-		} else { // If all checks pass, show the button by default.
-			$should_show_button = true;
+		$product               = $this->get_product();
+		$available_gateways    = WC()->payment_gateways->get_available_payment_gateways();
+		$tax_based_on_location = wc_tax_enabled() && in_array( get_option( 'woocommerce_tax_based_on' ), [ 'billing', 'shipping' ], true );
+		$stock_availability    = in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true )
+									? array_column( $product->get_available_variations(), 'is_in_stock' )
+									: [ $product->is_in_stock() ];
+
+		switch ( true ) {
+			case ! WC_Stripe::get_instance()->connect->is_connected():
+				// Bail if account is not connected.
+				WC_Stripe_Logger::log( 'Account is not connected.' );
+				break;
+			case ! $this->testmode && ! is_ssl():
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions
+				WC_Stripe_Logger::log( 'Stripe Express Checkout live mode requires SSL. ' . print_r( [ 'url' => get_permalink() ], true ) );
+				break;
+			case ! isset( $available_gateways['stripe'] ):
+				WC_Stripe_Logger::log( 'Stripe Express Checkout requires the Stripe gateway to be enabled.' );
+				break;
+			case WC_Stripe_Helper::has_cart_or_checkout_on_current_page() && ! $this->allowed_items_in_cart():
+				// Don't show if on the cart or checkout page, or if page contains the cart or checkout
+				// shortcodes, with items in the cart that aren't supported.
+				WC_Stripe_Logger::log( 'Some items in cart are not compatible with Stripe Express Checkout. ' );
+				break;
+			case is_cart() && ! $this->should_show_ece_on_cart_page():
+				// Don't show on cart if disabled.
+				WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on cart is disabled. ' );
+				break;
+			case is_checkout() && ! $this->should_show_ece_on_checkout_page():
+				// Don't show on checkout if disabled.
+				WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
+				break;
+			case $this->is_product() && ! $this->should_show_ece_on_product_pages():
+				// Don't show if product page ECE is disabled.
+				WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
+				break;
+			case $this->is_product() && ! $this->is_product_supported( $product ):
+				// Don't show if product on current page is not supported.
+				WC_Stripe_Logger::log( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $product->get_id() );
+				break;
+			case $this->is_product() && ! in_array( true, $stock_availability, true ):
+				// Don't show if all product variations are out-of-stock.
+				WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product variations being out of stock. Product ID: ' . $product->get_id() );
+				break;
+			case ( ! $this->is_pay_for_order_page() && isset( WC()->cart ) && 0.0 === (float) WC()->cart->get_total( false ) )
+				|| ( $this->is_product() && 0.0 === (float) $product->get_price() ):
+				// Don't show if the total price is 0.
+				// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
+				WC_Stripe_Logger::log( 'Stripe Express Checkout does not support free products.' );
+				break;
+			case ! $this->is_pay_for_order_page() && (
+					( $this->is_product() && ! $this->product_needs_shipping( $product ) )
+					|| ( ( is_cart() || is_checkout() ) && ( ! WC()->cart || ! WC()->cart->needs_shipping() ) )
+				) && $tax_based_on_location:
+				// Hide if cart/product doesn't require shipping and tax is based on billing or shipping address.
+				WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
+				break;
+			default:
+				// If all checks pass, show the button by default.
+				$should_show_button = true;
 		}
 
 		// Allow other plugins to filter the visibility of the button.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -576,9 +576,14 @@ class WC_Stripe_Express_Checkout_Helper {
 		$product               = $this->get_product();
 		$available_gateways    = WC()->payment_gateways->get_available_payment_gateways();
 		$tax_based_on_location = wc_tax_enabled() && in_array( get_option( 'woocommerce_tax_based_on' ), [ 'billing', 'shipping' ], true );
-		$stock_availability    = in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true )
-									? array_column( $product->get_available_variations(), 'is_in_stock' )
-									: [ $product->is_in_stock() ];
+
+		if ( $product ) {
+			$stock_availability = in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true )
+				? array_column( $product->get_available_variations(), 'is_in_stock' )
+				: [ $product->is_in_stock() ];
+		} else {
+			$stock_availability = [];
+		}
 
 		switch ( true ) {
 			case ! WC_Stripe::get_instance()->connect->is_connected():

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -620,7 +620,7 @@ class WC_Stripe_Express_Checkout_Helper {
 				break;
 			case $this->is_product() && ! in_array( true, $stock_availability, true ):
 				// Don't show if all product variations are out-of-stock.
-				WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product variations being out of stock. Product ID: ' . $product->get_id() );
+				WC_Stripe_Logger::log( 'Stripe Express Checkout may be hidden due product variations being out of stock. Product ID: ' . $product->get_id() );
 				break;
 			case ( ! $this->is_pay_for_order_page() && isset( WC()->cart ) && 0.0 === (float) WC()->cart->get_total( false ) )
 				|| ( $this->is_product() && 0.0 === (float) $product->get_price() ):
@@ -633,7 +633,7 @@ class WC_Stripe_Express_Checkout_Helper {
 					|| ( ( is_cart() || is_checkout() ) && ( ! WC()->cart || ! WC()->cart->needs_shipping() ) )
 				) && $tax_based_on_location:
 				// Hide if cart/product doesn't require shipping and tax is based on billing or shipping address.
-				WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
+				WC_Stripe_Logger::log( 'Stripe Express Checkout may be hidden due product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
 				break;
 			default:
 				// If all checks pass, show the button by default.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.4.0 - xxxx-xx-xx =
+* Add - New filter to allow merchants to force the display of the express payment method buttons (`should_show_express_checkout_button`).
 * Dev - Implements the new Stripe order class into abstract/base classes, and the webhook handler.
 * Dev - Implements the new Stripe order class into the legacy checkout classes.
 * Dev - Do not generate filenames with underscores.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See p1743685289245929-slack-CHG7MTCAF

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As suggested by @aheckler, this PR introduces a new filter (`should_show_express_checkout_button`) to allow merchants to force the display of express payment method buttons.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/filter-to-force-ece-button-display`)
- Add the following snippet to force the buttons to display:
```php
add_filter( 'should_show_express_checkout_button', function () { return true; }, 10, 2 );
```
- Connect your Stripe account
- Enable express payment methods (Google Pay, Apple Pay, Link)
- Create a virtual product
- Enable taxes. Set taxes based on either the customer's billing or shipping addresses
- Access the store using a public-facing URL as a shopper
- Add a virtual product to your cart and try to checkout
- Confirm the buttons are displayed

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

cc @aheckler @annemirasol 