### PR TITLE
Remove BLIK feature flag

### DIFF
--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -32,7 +32,6 @@ const isAcssEnabled = window.wc_stripe_settings_params?.is_acss_enabled === '1';
 const isBacsEnabled = window.wc_stripe_settings_params?.is_bacs_enabled === '1';
 const isBecsDebitEnabled =
 	window.wc_stripe_settings_params?.is_becs_debit_enabled === '1';
-const isBlikEnabled = window.wc_stripe_settings_params?.is_blik_enabled === '1';
 
 const paymentMethodsMap = {
 	card: {
@@ -268,6 +267,16 @@ const paymentMethodsMap = {
 		Icon: icons.cashapp,
 		currencies: [ 'USD' ],
 		capability: 'cashapp_payments',
+	},
+	blik: {
+		id: PAYMENT_METHOD_BLIK,
+		label: 'BLIK',
+		description: __(
+			'BLIK enables customers in Poland to pay directly via online payouts from their bank account.',
+			'woocommerce-gateway-stripe'
+		),
+		Icon: icons.blik,
+		currencies: [ 'PLN' ],
 	},
 };
 

--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -336,18 +336,4 @@ if ( isBecsDebitEnabled ) {
 	};
 }
 
-// Enable BLIK according to feature flag value.
-if ( isBlikEnabled ) {
-	paymentMethodsMap.blik = {
-		id: PAYMENT_METHOD_BLIK,
-		label: 'BLIK',
-		description: __(
-			'BLIK enables customers in Poland to pay directly via online payouts from their bank account.',
-			'woocommerce-gateway-stripe'
-		),
-		Icon: icons.blik,
-		currencies: [ 'PLN' ],
-	};
-}
-
 export default paymentMethodsMap;

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -238,7 +238,6 @@ class WC_Stripe_Settings_Controller {
 			'is_ach_enabled'            => WC_Stripe_Feature_Flags::is_ach_lpm_enabled(),
 			'is_acss_enabled'           => WC_Stripe_Feature_Flags::is_acss_lpm_enabled(),
 			'is_bacs_enabled'           => WC_Stripe_Feature_Flags::is_bacs_lpm_enabled(),
-			'is_blik_enabled'           => WC_Stripe_Feature_Flags::is_blik_lpm_enabled(),
 			'is_becs_debit_enabled'     => WC_Stripe_Feature_Flags::is_becs_debit_lpm_enabled(),
 			'stripe_oauth_url'          => $oauth_url,
 			'stripe_test_oauth_url'     => $test_oauth_url,

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -11,7 +11,6 @@ class WC_Stripe_Feature_Flags {
 	const LPM_ACH_FEATURE_FLAG_NAME           = '_wcstripe_feature_lpm_ach';
 	const LPM_ACSS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_acss';
 	const LPM_BACS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_bacs';
-	const LPM_BLIK_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_blik';
 	const LPM_BECS_DEBIT_FEATURE_FLAG_NAME    = '_wcstripe_feature_lpm_becs_debit';
 
 	/**
@@ -29,7 +28,6 @@ class WC_Stripe_Feature_Flags {
 		self::LPM_ACSS_FEATURE_FLAG_NAME       => 'yes',
 		self::LPM_BACS_FEATURE_FLAG_NAME       => 'yes',
 		self::LPM_BECS_DEBIT_FEATURE_FLAG_NAME => 'yes',
-		self::LPM_BLIK_FEATURE_FLAG_NAME       => 'yes',
 	];
 
 	/**
@@ -90,16 +88,6 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_bacs_lpm_enabled(): bool {
 		return 'yes' === self::get_option_with_default( self::LPM_BACS_FEATURE_FLAG_NAME );
-	}
-
-	/**
-	 * Checks whether BLIK LPM (Local Payment Method) feature flag is enabled.
-	 * BLIK LPM is a feature that allows merchants to enable/disable the BLIK payment method.
-	 *
-	 * @return bool
-	 */
-	public static function is_blik_lpm_enabled(): bool {
-		return 'yes' === self::get_option_with_default( self::LPM_BLIK_FEATURE_FLAG_NAME );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -198,11 +198,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					continue;
 				}
 
-				// Show BLIK only if feature is enabled.
-				if ( WC_Stripe_UPE_Payment_Method_BLIK::class === $payment_method_class && ! WC_Stripe_Feature_Flags::is_blik_lpm_enabled() ) {
-					continue;
-				}
-
 				/** Show Sofort if it's already enabled. Hide from the new merchants and keep it for the old ones who are already using this gateway, until we remove it completely.
 				 * Stripe is deprecating Sofort https://support.stripe.com/questions/sofort-is-being-deprecated-as-a-standalone-payment-method.
 				 */
@@ -489,9 +484,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// ACSS LPM Feature flag.
 		$stripe_params['is_acss_enabled'] = WC_Stripe_Feature_Flags::is_acss_lpm_enabled();
-
-		// BLIK LPM Feature flag.
-		$stripe_params['is_blik_enabled'] = WC_Stripe_Feature_Flags::is_blik_lpm_enabled();
 
 		// BECS Debit LPM Feature flag.
 		$stripe_params['is_becs_debit_enabled'] = WC_Stripe_Feature_Flags::is_becs_debit_lpm_enabled();


### PR DESCRIPTION
Fixes STRIPE-380 #4175 

## Changes proposed in this Pull Request:
- Removed the BLIK feature flag.
- Removed all the checks for BLIK feature flag.
- Removed all the checks from frontend.


## Testing instructions
- Ensure you are connected with a Poland Stripe account and BLIK is active in the Stripe dashboard.
- Delete the `_wcstripe_feature_lpm_blik` option from your local environment.
- As a merchant, change the store currency to PLN.
- Navigate to the plugin settings and make sure BLIK is available.
- As a shopper, add a product to the cart, navigate to checkout and make sure BLIK is available.