### PR TITLE
Remove BECS feature flag

### DIFF
--- a/client/payment-methods-map.js
+++ b/client/payment-methods-map.js
@@ -30,8 +30,6 @@ const accountCountry =
 const isAchEnabled = window.wc_stripe_settings_params?.is_ach_enabled === '1';
 const isAcssEnabled = window.wc_stripe_settings_params?.is_acss_enabled === '1';
 const isBacsEnabled = window.wc_stripe_settings_params?.is_bacs_enabled === '1';
-const isBecsDebitEnabled =
-	window.wc_stripe_settings_params?.is_becs_debit_enabled === '1';
 const isBlikEnabled = window.wc_stripe_settings_params?.is_blik_enabled === '1';
 
 const paymentMethodsMap = {
@@ -269,6 +267,16 @@ const paymentMethodsMap = {
 		currencies: [ 'USD' ],
 		capability: 'cashapp_payments',
 	},
+	au_becs_debit: {
+		id: PAYMENT_METHOD_BECS,
+		label: __( 'BECS Direct Debit', 'woocommerce-gateway-stripe' ),
+		description: __(
+			'Australia BECS Direct Debit enables your store to accept payments from customers with an Australian bank account.',
+			'woocommerce-gateway-stripe'
+		),
+		Icon: icons.au_becs_debit,
+		currencies: [ 'AUD' ],
+	},
 };
 
 // Enable ACH according to feature flag value.
@@ -310,20 +318,6 @@ if ( isBacsEnabled ) {
 		),
 		Icon: icons.bacs_debit,
 		currencies: [ 'GBP' ],
-	};
-}
-
-// Enable BECS Debit according to feature flag value.
-if ( isBecsDebitEnabled ) {
-	paymentMethodsMap.au_becs_debit = {
-		id: PAYMENT_METHOD_BECS,
-		label: __( 'BECS Direct Debit', 'woocommerce-gateway-stripe' ),
-		description: __(
-			'Australia BECS Direct Debit enables your store to accept payments from customers with an Australian bank account.',
-			'woocommerce-gateway-stripe'
-		),
-		Icon: icons.au_becs_debit,
-		currencies: [ 'AUD' ],
 	};
 }
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -239,7 +239,6 @@ class WC_Stripe_Settings_Controller {
 			'is_acss_enabled'           => WC_Stripe_Feature_Flags::is_acss_lpm_enabled(),
 			'is_bacs_enabled'           => WC_Stripe_Feature_Flags::is_bacs_lpm_enabled(),
 			'is_blik_enabled'           => WC_Stripe_Feature_Flags::is_blik_lpm_enabled(),
-			'is_becs_debit_enabled'     => WC_Stripe_Feature_Flags::is_becs_debit_lpm_enabled(),
 			'stripe_oauth_url'          => $oauth_url,
 			'stripe_test_oauth_url'     => $test_oauth_url,
 			'show_customization_notice' => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -12,7 +12,6 @@ class WC_Stripe_Feature_Flags {
 	const LPM_ACSS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_acss';
 	const LPM_BACS_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_bacs';
 	const LPM_BLIK_FEATURE_FLAG_NAME          = '_wcstripe_feature_lpm_blik';
-	const LPM_BECS_DEBIT_FEATURE_FLAG_NAME    = '_wcstripe_feature_lpm_becs_debit';
 
 	/**
 	 * Map of feature flag option names => their default "yes"/"no" value.
@@ -28,7 +27,6 @@ class WC_Stripe_Feature_Flags {
 		self::LPM_ACH_FEATURE_FLAG_NAME        => 'yes',
 		self::LPM_ACSS_FEATURE_FLAG_NAME       => 'yes',
 		self::LPM_BACS_FEATURE_FLAG_NAME       => 'yes',
-		self::LPM_BECS_DEBIT_FEATURE_FLAG_NAME => 'yes',
 		self::LPM_BLIK_FEATURE_FLAG_NAME       => 'yes',
 	];
 
@@ -100,16 +98,6 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_blik_lpm_enabled(): bool {
 		return 'yes' === self::get_option_with_default( self::LPM_BLIK_FEATURE_FLAG_NAME );
-	}
-
-	/**
-	 * Checks whether BECS Debit LPM (Local Payment Method) feature flag is enabled.
-	 * https://docs.stripe.com/payments/au-becs-debit.
-	 *
-	 * @return bool
-	 */
-	public static function is_becs_debit_lpm_enabled(): bool {
-		return 'yes' === self::get_option_with_default( self::LPM_BECS_DEBIT_FEATURE_FLAG_NAME );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -193,11 +193,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					continue;
 				}
 
-				// Show BECS Debit only if feature is enabled.
-				if ( WC_Stripe_UPE_Payment_Method_Becs_Debit::class === $payment_method_class && ! WC_Stripe_Feature_Flags::is_becs_debit_lpm_enabled() ) {
-					continue;
-				}
-
 				// Show BLIK only if feature is enabled.
 				if ( WC_Stripe_UPE_Payment_Method_BLIK::class === $payment_method_class && ! WC_Stripe_Feature_Flags::is_blik_lpm_enabled() ) {
 					continue;
@@ -492,9 +487,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// BLIK LPM Feature flag.
 		$stripe_params['is_blik_enabled'] = WC_Stripe_Feature_Flags::is_blik_lpm_enabled();
-
-		// BECS Debit LPM Feature flag.
-		$stripe_params['is_becs_debit_enabled'] = WC_Stripe_Feature_Flags::is_becs_debit_lpm_enabled();
 
 		// Single Payment Element feature flag + setting.
 		$stripe_params['isSPEEnabled'] = $this->spe_enabled;


### PR DESCRIPTION
Fixes STRIPE-382 #4177 

## Changes proposed in this Pull Request:

- Removed the BECS feature flag.
- Removed all the checks for BECS feature flag.
- Removed all the checks from frontend.

## Testing instructions

- Ensure you are connected with an Australia Stripe account and BECS is active in the Stripe dashboard.
- Delete the `_wcstripe_feature_lpm_becs_debit` option from your local environment.
- As a merchant, change the store currency to AUD.
- Navigate to the plugin settings and make sure BECS is available.
- As a shopper, add a product to the cart, navigate to checkout and make sure BECS is available.