### PR TITLE
Handle uninitialized WC cart in Express Checkout

### DIFF
--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -699,6 +699,10 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Cart or checkout page: the cart is taxable if any item in the cart
 		// is taxable.
+		if ( ! isset( WC()->cart ) || empty( WC()->cart ) ) {
+			return false;
+		}
+
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 			$product = apply_filters(
 				'woocommerce_cart_item_product',
@@ -731,6 +735,10 @@ class WC_Stripe_Express_Checkout_Helper {
 		}
 
 		// Cart or checkout page.
+		if ( ! isset( WC()->cart ) || empty( WC()->cart ) ) {
+			return false;
+		}
+
 		return WC()->cart->needs_shipping();
 	}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -699,7 +699,7 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Cart or checkout page: the cart is taxable if any item in the cart
 		// is taxable.
-		if ( ! isset( WC()->cart ) || empty( WC()->cart ) ) {
+		if ( empty( WC()->cart ) ) {
 			return false;
 		}
 
@@ -735,7 +735,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		}
 
 		// Cart or checkout page.
-		if ( ! isset( WC()->cart ) || empty( WC()->cart ) ) {
+		if ( empty( WC()->cart ) ) {
 			return false;
 		}
 


### PR DESCRIPTION

<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

Prevents fatal errors in Express Checkout helper by adding safety checks for WC()->cart before accessing cart methods. This fixes issues that occur when cart methods are called before WooCommerce fully initializes, particularly in admin contexts like the site editor.

Specifically:
- Add null checks for WC()->cart in is_product_or_cart_taxable()
- Add null checks for WC()->cart in product_or_cart_needs_shipping()
- Return appropriate fallback values when cart is not available

This resolves fatal errors:
- "Call to a member function get_cart() on null"
- "Call to a member function needs_shipping() on null"

Error:

```
Fatal error: Uncaught Error: Call to a member function get_cart() on null in /Users/malithsenaweera/projects/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-express-checkout-helper.php:702 
```
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. On `develop`, as a merchant, go to Appearance -> Themes
2. Enable a Block theme like Twenty-Twenty-Five.
3. Click customize.
4. Notice the Fatal error.
5. On this branch, the fatal error should not happen.
6. (Optional regression test) Go through test instructions in this PR: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4164  

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Fixes an error that's not yet merged to `trunk`

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
