### PR TITLE
Settings Synchronization: Update PMC with DB enabled Payment Methods

### DIFF
--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -200,7 +200,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	/**
 	 * Migrates the payment methods from the DB option to PMC if needed.
 	 */
-	private static function maybe_migrate_payment_methods_from_db_to_pmc() {
+	public static function maybe_migrate_payment_methods_from_db_to_pmc() {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		// Skip if PMC is not enabled or migration already done
@@ -208,28 +208,32 @@ class WC_Stripe_Payment_Method_Configurations {
 			return;
 		}
 
-		if ( ! isset( $stripe_settings['upe_checkout_experience_accepted_payments'] ) ) {
+		// Skip if there is no PMC available
+		$merchant_payment_method_configuration = self::get_primary_configuration();
+		if ( ! $merchant_payment_method_configuration ) {
 			return;
 		}
 
-		$enabled_payment_methods = $stripe_settings['upe_checkout_experience_accepted_payments'];
-		if ( empty( $enabled_payment_methods ) ) {
-			return;
+		$enabled_payment_methods = [];
+
+		if ( isset( $stripe_settings['upe_checkout_experience_accepted_payments'] ) &&
+				! empty( $stripe_settings['upe_checkout_experience_accepted_payments'] ) ) {
+			$enabled_payment_methods = array_merge(
+				$enabled_payment_methods,
+				$stripe_settings['upe_checkout_experience_accepted_payments']
+			);
 		}
 
-		try {
-			$merchant_payment_method_configuration = self::get_primary_configuration();
-			if ( ! $merchant_payment_method_configuration ) {
-				return;
-			}
+		// Add Google Pay and Apple Pay to the list if payment_request is enabled
+		if ( ! empty( $stripe_settings['payment_request'] ) && 'yes' === $stripe_settings['payment_request'] ) {
+			$enabled_payment_methods = array_merge(
+				$enabled_payment_methods,
+				[ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY ]
+			);
+		}
 
-			// Add Google Pay and Apple Pay to the list if payment_request is enabled
-			if ( ! empty( $stripe_settings['payment_request'] ) && 'yes' === $stripe_settings['payment_request'] ) {
-				$enabled_payment_methods = array_merge(
-					$enabled_payment_methods,
-					[ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY ]
-				);
-			}
+		// Update the PMC if there are any enabled payment methods
+		if ( ! empty( $enabled_payment_methods ) ) {
 
 			// Get all available payment method IDs from the configuration.
 			// We explicitly disable all payment methods that are not in the enabled_payment_methods array
@@ -240,17 +244,14 @@ class WC_Stripe_Payment_Method_Configurations {
 				}
 			}
 
-			// Update the configuration
 			self::update_payment_method_configuration(
 				$enabled_payment_methods,
 				$available_payment_method_ids
 			);
-
-			// Mark migration as complete in stripe settings
-			$stripe_settings['pmc_enabled'] = 'yes';
-			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-		} catch ( Exception $e ) {
-			WC_Stripe_Logger::log( 'Error migrating payment methods to PMC: ' . $e->getMessage() );
 		}
+
+		// Mark migration as complete in stripe settings
+		$stripe_settings['pmc_enabled'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}
 }

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -81,6 +81,9 @@ class WC_Stripe_Payment_Method_Configurations {
 				: [ WC_Stripe_Payment_Methods::CARD ];
 		}
 
+		// Migrate payment methods from DB to Stripe PMC if needed
+		self::maybe_migrate_payment_methods_from_db_to_pmc();
+
 		$enabled_payment_method_ids            = [];
 		$merchant_payment_method_configuration = self::get_primary_configuration();
 
@@ -192,5 +195,60 @@ class WC_Stripe_Payment_Method_Configurations {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$key             = WC_Stripe_Mode::is_test() ? 'test_connection_type' : 'connection_type';
 		return isset( $stripe_settings[ $key ] ) && 'connect' === $stripe_settings[ $key ];
+	}
+
+	/**
+	 * Migrates the payment methods from the DB option to PMC if needed.
+	 */
+	private static function maybe_migrate_payment_methods_from_db_to_pmc() {
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+
+		// Skip if PMC is not enabled or migration already done
+		if ( ! self::is_enabled() || ! empty( $stripe_settings['pmc_migration_complete'] ) ) {
+			return;
+		}
+
+		if ( ! isset( $stripe_settings['upe_checkout_experience_accepted_payments'] ) ) {
+			return;
+		}
+
+		$enabled_payment_methods = $stripe_settings['upe_checkout_experience_accepted_payments'];
+		if ( empty( $enabled_payment_methods ) ) {
+			return;
+		}
+
+		try {
+			$merchant_payment_method_configuration = self::get_primary_configuration();
+			if ( ! $merchant_payment_method_configuration ) {
+				return;
+			}
+
+			// Add Google Pay and Apple Pay to the list if payment_request is enabled
+			if ( ! empty( $stripe_settings['payment_request'] ) && 'yes' === $stripe_settings['payment_request'] ) {
+				$enabled_payment_methods = array_merge(
+					$enabled_payment_methods,
+					[ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY ]
+				);
+			}
+
+			// Update each payment method to be enabled
+			foreach ( $enabled_payment_methods as $payment_method_id ) {
+				if ( isset( $merchant_payment_method_configuration[ $payment_method_id ] ) ) {
+					$merchant_payment_method_configuration[ $payment_method_id ]->display_preference->value = 'on';
+				}
+			}
+
+			// Update the configuration
+			self::update_payment_method_configuration(
+				$enabled_payment_methods,
+				array_keys( $merchant_payment_method_configuration )
+			);
+
+			// Mark migration as complete in stripe settings
+			$stripe_settings['pmc_migration_complete'] = true;
+			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log( 'Error migrating payment methods to PMC: ' . $e->getMessage() );
+		}
 	}
 }

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -204,7 +204,7 @@ class WC_Stripe_Payment_Method_Configurations {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		// Skip if PMC is not enabled or migration already done
-		if ( ! self::is_enabled() || ! empty( $stripe_settings['pmc_migration_complete'] ) ) {
+		if ( ! self::is_enabled() || ! empty( $stripe_settings['pmc_enabled'] ) ) {
 			return;
 		}
 
@@ -231,21 +231,23 @@ class WC_Stripe_Payment_Method_Configurations {
 				);
 			}
 
-			// Update each payment method to be enabled
-			foreach ( $enabled_payment_methods as $payment_method_id ) {
-				if ( isset( $merchant_payment_method_configuration[ $payment_method_id ] ) ) {
-					$merchant_payment_method_configuration[ $payment_method_id ]->display_preference->value = 'on';
+			// Get all available payment method IDs from the configuration.
+			// We explicitly disable all payment methods that are not in the enabled_payment_methods array
+			$available_payment_method_ids = [];
+			foreach ( $merchant_payment_method_configuration as $payment_method_id => $payment_method ) {
+				if ( isset( $payment_method->display_preference ) ) {
+					$available_payment_method_ids[] = $payment_method_id;
 				}
 			}
 
 			// Update the configuration
 			self::update_payment_method_configuration(
 				$enabled_payment_methods,
-				array_keys( $merchant_payment_method_configuration )
+				$available_payment_method_ids
 			);
 
 			// Mark migration as complete in stripe settings
-			$stripe_settings['pmc_migration_complete'] = true;
+			$stripe_settings['pmc_enabled'] = 'yes';
 			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::log( 'Error migrating payment methods to PMC: ' . $e->getMessage() );

--- a/tests/phpunit/admin/migrations/test-class-migrate-payment-methods-from-db-to-pmc.php
+++ b/tests/phpunit/admin/migrations/test-class-migrate-payment-methods-from-db-to-pmc.php
@@ -46,12 +46,14 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 	public function test_migration_executed_when_pmc_enabled_is_not_set() {
 		// Set pmc_enabled to '' to trigger migration
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['pmc_enabled'] = '';
+		$stripe_settings['test_connection_type']                      = 'connect';
+		$stripe_settings['payment_request']                           = 'yes';
 		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'link', 'sepa_debit' ];
+		$stripe_settings['pmc_enabled']                               = '';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		$this->mock_payment_method_configurations( [ 'link', 'sepa_debit' ], [] );
-		$this->expect_payment_method_configurations_update( [ 'link', 'sepa_debit' ] );
+		$this->mock_payment_method_configurations( [], [ 'link', 'sepa_debit', 'google_pay', 'apple_pay' ] );
+		$this->expect_payment_method_configurations_update( [ 'link', 'sepa_debit', 'google_pay', 'apple_pay' ], [] );
 
 		// Execute migration
 		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();

--- a/tests/phpunit/admin/migrations/test-class-migrate-payment-methods-from-db-to-pmc.php
+++ b/tests/phpunit/admin/migrations/test-class-migrate-payment-methods-from-db-to-pmc.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Class Migrate_Payment_Methods_From_Db_To_Pmc_Test
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Migrate_Payment_Methods_From_DB_To_PMC_Test unit tests.
+ */
+class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
+
+	/**
+	 * @var WC_Stripe_Payment_Method_Configurations
+	 */
+	private $pmc;
+
+	public function set_up() {
+		parent::set_up();
+
+		$this->pmc = new WC_Stripe_Payment_Method_Configurations();
+
+		// Set up test connection type to enable PMC
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_connection_type'] = 'connect';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+	}
+
+	public function test_migration_not_executed_when_pmc_enabled_is_yes() {
+		// Set up environment with pmc_enabled = 'yes'
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['pmc_enabled'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		// Mock payment method configurations to verify they are not updated
+		$this->mock_payment_method_configurations( [ 'card' ], [] );
+
+		// Migration should not update payment method configurations
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		// Verify payment method configurations were not updated
+		$this->stripe_api->expects( $this->never() )
+			->method( 'update_payment_method_configurations' );
+	}
+
+	public function test_migration_executed_when_pmc_enabled_is_not_set() {
+		// Set pmc_enabled to '' to trigger migration
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['pmc_enabled'] = '';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'link', 'sepa_debit' ];
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->mock_payment_method_configurations( [ 'link', 'sepa_debit' ], [] );
+		$this->expect_payment_method_configurations_update( [ 'link', 'sepa_debit' ] );
+
+		// Execute migration
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		// Verify pmc_enabled is set to 'yes'
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
+		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
+	}
+
+	public function test_migration_handles_empty_enabled_payment_methods() {
+		// Set up environment with pmc_enabled not set
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['pmc_enabled'] = '';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [];
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->mock_payment_method_configurations( [], [] );
+		$this->expect_payment_method_configurations_update( [] );
+
+		// Execute migration
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		// Verify pmc_enabled is set to 'yes'
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
+		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
+	}
+}

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-settings-controller.php
@@ -111,7 +111,14 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	 * Test that the update_settings method updates the payment method configurations settings.
 	 */
 	public function test_update_stripe_payment_method_configurations_settings() {
+		// Set up initial state with only card enabled
 		$this->mock_payment_method_configurations( [ 'card' ], [] );
+
+		// Set pmc_enabled to yes to prevent migration
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['pmc_enabled'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
 		$this->expect_payment_method_configurations_update( [ 'amazon_pay', 'card' ] );
 
 		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );

--- a/tests/phpunit/helpers/class-upe-test-helper.php
+++ b/tests/phpunit/helpers/class-upe-test-helper.php
@@ -41,6 +41,7 @@ class UPE_Test_Helper {
 		$settings                           = WC_Stripe_Helper::get_stripe_settings();
 		$settings['connection_type']      = 'connect';
 		$settings['test_connection_type'] = 'connect';
+		$settings['pmc_enabled']          = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 		WC_Stripe_Helper::$stripe_legacy_gateways = [];
 	}


### PR DESCRIPTION
Fixes #3916

## Changes proposed in this Pull Request:

This PR adds a migration workflow to update the PMC with the currently active payment methods (stored in the DB)

The enabled payment methods are stored in the plugin settings in the DB, most of them in the key `upe_checkout_experience_accepted_payments` while for _Apple Pay_ and _Google Pay_ the key `payment_request` is used.

Using PMC is only possible when the new checkout is enabled and the stripe account is connected via OAuth (re-authenticated), if that criteria is met and it is not already enabled/migrated (`pmc_enabled` set to `yes`)

## Testing instructions

1. Simulate a non-connected account; removing the the `connection_type`with `wp-cli` (or modify the DB manually):
    `wp option patch delete woocommerce_stripe_settings test_connection_type`
    And, remove the `pmc_enabled` migration flag (it might have already run if the account was connected):
   `wp option patch delete woocommerce_stripe_settings pmc_enabled`
2. Go to the `WP-Admin > WooCommerce > Payments > Stripe` and then click the `Payment Methods` tab.
3. Check that the `Re-authenticate` banner is visible: 
    ![Screenshot 2025-04-11 at 00 10 04](https://github.com/user-attachments/assets/874a1c6d-6373-4fd0-a6d0-6488ba39fb03)
4. Go to the [Stripe Dashboard > Payment methods](https://dashboard.stripe.com/test/settings/payment_methods)  (make sure `test mode` is enabled) and select the Default configuration for the plugin (WooCommerce Inc configuration):
    ![Screenshot_2025-04-10_at_23_37_43](https://github.com/user-attachments/assets/d14859fa-3a3c-460a-811c-c38978a17407)
5. Turn off all payment methods (you can leave Cards/Link and the other inherited from platform On if you want)
    ![Screenshot 2025-04-11 at 16 14 43](https://github.com/user-attachments/assets/ceaf8b08-41ff-41e6-9e33-48c3ff962c52)
6. Go to the `WP-Admin > WooCommerce > Payments > Stripe` and then click the `Payment Methods` tab.
7. Enable `Credit card / debit card`, `Klarna`, Affirm, `Cash App Pay`, `WeChat Pay`, `Apple Pay / Google Pay` and `Link`.
8. Save changes.
9. Click the `Re-authentiate` button in the "Make your store more secure" banner
10. Connect with the same Stripe account you used in Step 4.
11. Go to the `Payment Methods` tab.
12. Check that the banner is no longer visible.
13. Check that the same payment methods are still enabled (`Credit card / debit card`, `Klarna`, Affirm, `Cash App Pay`, `WeChat Pay`, `Apple Pay / Google Pay` and `Link`)
14. Go to the [Stripe Dashboard > Payment methods](https://dashboard.stripe.com/test/settings/payment_methods) and select the Default configuration for the plugin
15. Check that the Active payment methods match those in the plugin settings:
    ![Screenshot 2025-04-11 at 16 19 29](https://github.com/user-attachments/assets/b5f06760-0890-4f36-8bc8-adbd34acee80)
    ![Screenshot 2025-04-11 at 16 19 36](https://github.com/user-attachments/assets/f6390622-b269-47ab-9ba2-d6f6f1e260c2)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
