### PR TITLE
Settings Synchronization: Fix connect failing the first time

### DIFF
--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -296,9 +296,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		/* Settings > Payments accepted on checkout + Express checkouts */
 		$payment_method_ids_to_enable = $this->get_payment_method_ids_to_enable( $request );
-		$is_upe_enabled               = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
+		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
 		$this->update_enabled_payment_methods( $payment_method_ids_to_enable, $is_upe_enabled );
-		if ( ! $is_upe_enabled || ! WC_Stripe_Payment_Method_Configurations::is_enabled() ) {
+		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() || ! WC_Stripe_Payment_Method_Configurations::is_enabled() ) {
 			// We need to update a separate setting for legacy checkout.
 			$this->update_is_payment_request_enabled_for_legacy_checkout( $request );
 		}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -199,6 +199,12 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return new WP_Error( 'wc_stripe_webhook_error', $e->getMessage() );
 			}
 
+			// If we are already using the UPE gateway, update the PMC with the currently enabled payment methods.
+			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+			if ( $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
+				$gateway->update_enabled_payment_methods( $options['upe_checkout_experience_accepted_payments'] );
+			}
+
 			return $result;
 		}
 

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -202,7 +202,12 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// If we are already using the UPE gateway, update the PMC with the currently enabled payment methods.
 			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
 			if ( $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
-				$gateway->update_enabled_payment_methods( $options['upe_checkout_experience_accepted_payments'] );
+				// The UPE accepted payment list does not include Apple Pay/Google Pay, but PMC does, so we need to add them (if they are enabled).
+				$enabled_payment_methods = array_merge(
+					$options['upe_checkout_experience_accepted_payments'],
+					$gateway->is_payment_request_enabled() ? [ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ] : []
+				);
+				$gateway->update_enabled_payment_methods( $enabled_payment_methods );
 			}
 
 			return $result;

--- a/tests/e2e/tests/checkout/shortcode/pre-order-product.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/pre-order-product.spec.js
@@ -4,10 +4,7 @@ import config from 'config';
 import { api, payments, products } from '../../../utils';
 import { isPluginInstalled } from '../../../utils/plugin-utils';
 
-const {
-	setupShortcodeCheckout,
-	fillCreditCardDetailsShortcodeLegacy,
-} = payments;
+const { setupShortcodeCheckout, fillCreditCardDetailsShortcode } = payments;
 
 let productId;
 
@@ -44,10 +41,7 @@ test( 'customer can purchase a pre-order product @pre-orders', async ( {
 	};
 
 	await setupShortcodeCheckout( page, customerData );
-	await fillCreditCardDetailsShortcodeLegacy(
-		page,
-		config.get( 'cards.basic' )
-	);
+	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
 
 	await page.locator( 'text="Place pre-order now"' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -179,7 +179,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 
 		$result = WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
 		// In legacy mode (when UPE is disabled), Stripe refers to Card as payment method.
-		$this->assertEquals( [ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::EPS, WC_Stripe_Payment_Methods::GIROPAY, WC_Stripe_Payment_Methods::P24 ], $result );
+		$this->assertEquals( [ WC_Stripe_Payment_Methods::EPS, WC_Stripe_Payment_Methods::GIROPAY, WC_Stripe_Payment_Methods::P24 ], $result );
 	}
 
 	public function test_get_legacy_individual_payment_method_settings() {

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -141,8 +141,6 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$this->assertEquals( 'no', $stripe_settings['enabled'] );
 		$this->assertEquals( 'no', $stripe_settings['upe_checkout_experience_enabled'] );
-		$this->mock_payment_method_configurations( [], [] );
-		$this->expect_payment_method_configurations_update( [ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::LINK ], [] );
 
 		$stripe_settings['upe_checkout_experience_enabled'] = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
@@ -157,13 +155,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		update_option( 'woocommerce_currency', 'EUR' );
 		$this->upe_helper->enable_upe_feature_flag();
 
-		// Enable the EPS UPE method. Now when UPE is disabled, the EPS LPM should be enabled.
-		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::EPS, WC_Stripe_Payment_Methods::SEPA_DEBIT, WC_Stripe_Payment_Methods::IDEAL ] );
-
 		// Enable sepa and iDEAL LPM gateways.
 		update_option( 'woocommerce_stripe_sepa_settings', [ 'enabled' => 'yes' ] );
 		update_option( 'woocommerce_stripe_ideal_settings', [ 'enabled' => 'yes' ] );
-		$this->expect_payment_method_configurations_update( [ WC_Stripe_Payment_Methods::SEPA_DEBIT, WC_Stripe_Payment_Methods::IDEAL ], [ WC_Stripe_Payment_Methods::CARD ] );
 		$this->upe_helper->reload_payment_gateways();
 
 		// Initialize default stripe settings, turn on UPE.

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -621,7 +621,7 @@ function woocommerce_gateway_stripe() {
 			}
 
 			protected function enable_upe( $settings ) {
-				$payment_methods_to_enable = [];
+				$settings['upe_checkout_experience_accepted_payments'] = [];
 
 				$payment_gateways = WC_Stripe_Helper::get_legacy_payment_methods();
 				foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $method_class ) {
@@ -647,23 +647,20 @@ function woocommerce_gateway_stripe() {
 							'yes'
 						);
 						// ENABLE UPE METHOD
-						$payment_methods_to_enable[] = $method_class::STRIPE_ID;
+						$settings['upe_checkout_experience_accepted_payments'][] = $method_class::STRIPE_ID;
 					}
 
 					if ( 'stripe' === $lpm_gateway_id && isset( $this->stripe_gateway ) && $this->stripe_gateway->is_enabled() ) {
-						$payment_methods_to_enable[] = 'card';
-						$payment_methods_to_enable[] = 'link';
+						$settings['upe_checkout_experience_accepted_payments'][] = 'card';
+						$settings['upe_checkout_experience_accepted_payments'][] = 'link';
 					}
 				}
-				if ( empty( $payment_methods_to_enable ) ) {
-					$payment_methods_to_enable = [ 'card', 'link' ];
+				if ( empty( $settings['upe_checkout_experience_accepted_payments'] ) ) {
+					$settings['upe_checkout_experience_accepted_payments'] = [ 'card', 'link' ];
 				} else {
 					// The 'stripe' gateway must be enabled for UPE if any LPMs were enabled.
 					$settings['enabled'] = 'yes';
 				}
-
-				$upe_gateway = new WC_Stripe_UPE_Payment_Gateway();
-				$upe_gateway->update_enabled_payment_methods( $payment_methods_to_enable );
 
 				return $settings;
 			}
@@ -693,7 +690,9 @@ function woocommerce_gateway_stripe() {
 					$settings['enabled'] = 'no';
 				}
 				// DISABLE ALL UPE METHODS
-				$upe_gateway->update_enabled_payment_methods( [] );
+				if ( ! isset( $settings['upe_checkout_experience_accepted_payments'] ) ) {
+					$settings['upe_checkout_experience_accepted_payments'] = [];
+				}
 				return $settings;
 			}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Currently, the first attempt to connect a Stripe account fails, and the merchant is redirected back to the connect screen. Trying again succeeds, but the default settings are not updated, causing the legacy checkout to be enabled by default and all LPM to be unavailable.

This PR reverts the changes to `enable_upe`/`disable_upe` and, similar to what we are doling with ECE, it updates the PMC enabled payment methods (if UPE was already enabled) for new connections.

## Testing instructions

1. Delete the plugin settings (to simulate a new merchant install) - Or create a new JN site
    For example with WP-CLI: `wp option delete woocommerce_stripe_settings`
2. Complete the Account Connect flow
3. Verify that it succeeds the first time, and that the Legacy checkout is not enabled
4. Check that the following payment methods are enabled: `Cards`, `Apple Pay/Google Pay` and `Link`.

Test that the PMC gets updated with the currently enabled payment methods when reconnecting; use the Testing instructions from #4218

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
