### PR TITLE
Fix translation warning

### DIFF
--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -43,8 +43,15 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	public function __construct( $payment_request_configuration = null, $express_checkout_configuration = null ) {
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_payment_request_order_meta' ], 8, 2 );
 		add_action( 'woocommerce_rest_checkout_process_payment_with_context', [ $this, 'add_stripe_intents' ], 9999, 2 );
-		$this->payment_request_configuration  = null !== $payment_request_configuration ? $payment_request_configuration : new WC_Stripe_Payment_Request();
-		$this->express_checkout_configuration = null !== $express_checkout_configuration ? $express_checkout_configuration : new WC_Stripe_Express_Checkout_Element();
+		$this->payment_request_configuration = null !== $payment_request_configuration ? $payment_request_configuration : new WC_Stripe_Payment_Request();
+
+		if ( null === $express_checkout_configuration ) {
+			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+			$helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
+			$ajax_handler = new WC_Stripe_Express_Checkout_Ajax_Handler( $helper );
+			$express_checkout_configuration = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
+		}
+		$this->express_checkout_configuration = $express_checkout_configuration;
 	}
 
 	/**

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -291,11 +291,8 @@ function woocommerce_gateway_stripe() {
 				$this->payment_request_configuration = new WC_Stripe_Payment_Request();
 				$this->account                       = new WC_Stripe_Account( $this->connect, 'WC_Stripe_API' );
 
-				// Express checkout configurations.
-				$express_checkout_helper              = new WC_Stripe_Express_Checkout_Helper( $this->get_main_stripe_gateway() );
-				$express_checkout_ajax_handler        = new WC_Stripe_Express_Checkout_Ajax_Handler( $express_checkout_helper );
-				$this->express_checkout_configuration = new WC_Stripe_Express_Checkout_Element( $express_checkout_ajax_handler, $express_checkout_helper );
-				$this->express_checkout_configuration->init();
+				// Initialize Express Checkout after translations are loaded
+				add_action( 'init', [ $this, 'init_express_checkout' ], 11 );
 
 				$intent_controller = new WC_Stripe_Intent_Controller();
 				$intent_controller->init_hooks();
@@ -348,6 +345,17 @@ function woocommerce_gateway_stripe() {
 
 				// Initialize the class for handling the status page.
 				add_action( 'init', [ $this, 'initialize_status_page' ], 15 );
+			}
+
+			/**
+			 * Initialize Express Checkout after translations are loaded.
+			 */
+			public function init_express_checkout() {
+				// Express checkout configurations.
+				$express_checkout_helper              = new WC_Stripe_Express_Checkout_Helper( $this->get_main_stripe_gateway() );
+				$express_checkout_ajax_handler        = new WC_Stripe_Express_Checkout_Ajax_Handler( $express_checkout_helper );
+				$this->express_checkout_configuration = new WC_Stripe_Express_Checkout_Element( $express_checkout_ajax_handler, $express_checkout_helper );
+				$this->express_checkout_configuration->init();
 			}
 
 			/**


### PR DESCRIPTION
Fixes STRIPE-399
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

This PR makes the following changes to fix the translation-related warnings:

- Move Express Checkout setup to a dedicated method initialized after translations are loaded.
- Update the constructor in WC_Stripe_Blocks_Support to create Express Checkout configuration if not provided.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

To reproduce the issue:
1. Switch to `tags/9.4.0-test-2` branch.
2. Enable debugging by adding `define( 'WP_DEBUG', true );` to your `wp-config.php`
3. Change site language to `English (UK)` via Settings -> General -> Site Language.
4. Go to Dashboards -> Updates. Click on "Re-install version 6.7.2–en_GB"
5. Notice the warning on top of the page.

![CleanShot 2025-04-16 at 12 05 14@2x](https://github.com/user-attachments/assets/bfe8fbdd-ed3b-4b91-a74f-474a76a21cf9)

Test the fix
1. On this branch, the warning should not appear.
2. Test placing an order via blocks checkout (using card and express payment methods)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fixes an issue that's not in the released version of the plugin.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
