### PR TITLE
Add instanceof check before trying to update the UPE payment methods

### DIFF
--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -647,7 +647,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$this->gateway->update_enabled_payment_methods( $payment_method_ids_to_enable );
+		if ( $this->gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
+			$this->gateway->update_enabled_payment_methods( $payment_method_ids_to_enable );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR adds the instanceof WC_Stripe_UPE_Payment_Gateway before attempting to update the PMC

## Testing instructions

1. Go to the plugin settings page
2. Enable the Legacy checkout
3. Save changes.
4. Disable the Legacy checkout
5. Save changes.
6. Check that the settings were saved successfully:
    ![Screenshot 2025-04-16 at 18 17 26](https://github.com/user-attachments/assets/837c4a3d-62ea-4b96-955c-8c70861d4cda)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
