### PR TITLE
Update issue id format in PR description to include both IDs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ Did I add a title? A descriptive, yet concise, title.
 Issue: Link to the GitHub issue this PR addresses (if appropriate).
 -->
 
-Fixes STRIPE-<issue_id>
+Fixes STRIPE-<linear_issue_id>, #<github_issue_id>
 
 ## Changes proposed in this Pull Request:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,8 @@ Did I add a title? A descriptive, yet concise, title.
 Issue: Link to the GitHub issue this PR addresses (if appropriate).
 -->
 
-Fixes STRIPE-<linear_issue_id>, #<github_issue_id>
+Fixes STRIPE-<linear_issue_id>
+Fixes #<github_issue_id>
 
 ## Changes proposed in this Pull Request:
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:
I updated the PR template in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4160 to use the Linear issue ID instead of the GH issue ID. I discovered that the GH issues do not have any context of the related PR anymore (not synced with linear). Added  back the GH issue ID in the template.

## Testing instructions
Code review.