### PR TITLE
Fix undefined payment element setting error

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -367,8 +367,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'cards'                                => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/cards.svg" class="stripe-cards-icon stripe-icon" alt="' . __( 'Credit / Debit Card', 'woocommerce-gateway-stripe' ) . '" />',
 			WC_Stripe_Payment_Methods::CASHAPP_PAY => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/cashapp.svg" class="stripe-cashapp-icon stripe-icon" alt="Cash App Pay" />',
 		];
-		$settings  = WC_Stripe_Helper::get_stripe_settings();
-		if ( 'yes' === ( $settings['single_payment_element'] ?? null ) ) {
+		$settings    = WC_Stripe_Helper::get_stripe_settings();
+		$spe_setting = $settings['single_payment_element'] ?? null;
+		if ( 'yes' === $spe_setting ) {
 			$icon_list['cards'] = '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/stripe.svg" class="stripe-cards-icon stripe-icon" alt="' . __( 'Stripe', 'woocommerce-gateway-stripe' ) . '" />';
 		}
 		return apply_filters( 'wc_stripe_payment_icons', $icon_list );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -368,7 +368,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			WC_Stripe_Payment_Methods::CASHAPP_PAY => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/cashapp.svg" class="stripe-cashapp-icon stripe-icon" alt="Cash App Pay" />',
 		];
 		$settings  = WC_Stripe_Helper::get_stripe_settings();
-		if ( 'yes' === $settings['single_payment_element'] ) {
+		if ( 'yes' === ( $settings['single_payment_element'] ?? null ) ) {
 			$icon_list['cards'] = '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/stripe.svg" class="stripe-cards-icon stripe-icon" alt="' . __( 'Stripe', 'woocommerce-gateway-stripe' ) . '" />';
 		}
 		return apply_filters( 'wc_stripe_payment_icons', $icon_list );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://wordpress.org/support/topic/error-notice-after-9-4-0-update/

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes a possible issue when the `single_payment_element` does not exist during the rendering of payment method icons on the checkout. The fix consists of adding `null` as the default value for the key if it does not exist.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

It's hard to reproduce and test this, since it seems to be an issue specific to the merchant who reported it in the forums. So, a code review should be enough.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
