### PR TITLE
Caching primary payment method configuration

### DIFF
--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -30,6 +30,13 @@ class WC_Stripe_Payment_Method_Configurations {
 	const LIVE_MODE_CONFIGURATION_PARENT_ID = 'pmc_1LEKjAGX8lmJQndTk2ziRchV';
 
 	/**
+	 * The primary configuration option key (for cache purposes).
+	 *
+	 * @var string
+	 */
+	const PRIMARY_CONFIGURATION_OPTION = 'wcstripe_primary_configuration';
+
+	/**
 	 * Reset the primary configuration.
 	 */
 	public static function reset_primary_configuration() {
@@ -44,6 +51,13 @@ class WC_Stripe_Payment_Method_Configurations {
 	private static function get_primary_configuration() {
 		if ( null !== self::$primary_configuration ) {
 			return self::$primary_configuration;
+		}
+
+		// Check if the primary configuration is already cached.
+		$configuration_cache = self::read_primary_configuration_from_cache();
+		if ( ! empty( $configuration_cache ) && isset( $configuration_cache->id ) ) {
+			self::$primary_configuration = $configuration_cache;
+			return $configuration_cache;
 		}
 
 		$result = WC_Stripe_API::get_instance()->get_payment_method_configurations();
@@ -64,7 +78,18 @@ class WC_Stripe_Payment_Method_Configurations {
 				return $payment_method_configuration;
 			}
 		}
+
 		return null;
+	}
+
+	/**
+	 * Get the primary configuration from the cache.
+	 *
+	 * @return object
+	 */
+	private static function read_primary_configuration_from_cache() {
+		$configuration_cache = json_decode( wp_json_encode( get_transient( self::PRIMARY_CONFIGURATION_OPTION ) ) );
+		return false === $configuration_cache ? new stdClass() : $configuration_cache;
 	}
 
 	/**

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -60,6 +60,26 @@ class WC_Stripe_Payment_Method_Configurations {
 			return $configuration_cache;
 		}
 
+		// If not, fetch it from Stripe and cache it.
+		return self::cache_primary_configuration();
+	}
+
+	/**
+	 * Get the primary configuration from the cache.
+	 *
+	 * @return object
+	 */
+	private static function read_primary_configuration_from_cache() {
+		$configuration_cache = json_decode( wp_json_encode( get_transient( self::PRIMARY_CONFIGURATION_OPTION ) ) );
+		return false === $configuration_cache ? new stdClass() : $configuration_cache;
+	}
+
+	/**
+	 * Cache the primary configuration data.
+	 *
+	 * @return object|null empty when no data found in transient, otherwise returns cached data
+	 */
+	private static function cache_primary_configuration() {
 		$result = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$payment_method_configurations = $result->data ?? null;
 
@@ -79,17 +99,14 @@ class WC_Stripe_Payment_Method_Configurations {
 			}
 		}
 
-		return null;
-	}
+		if ( ! self::$primary_configuration ) {
+			return null;
+		}
 
-	/**
-	 * Get the primary configuration from the cache.
-	 *
-	 * @return object
-	 */
-	private static function read_primary_configuration_from_cache() {
-		$configuration_cache = json_decode( wp_json_encode( get_transient( self::PRIMARY_CONFIGURATION_OPTION ) ) );
-		return false === $configuration_cache ? new stdClass() : $configuration_cache;
+		// Create or update the account option cache.
+		set_transient( self::PRIMARY_CONFIGURATION_OPTION, self::$primary_configuration, 20 * MINUTE_IN_SECONDS );
+
+		return json_decode( wp_json_encode( self::$primary_configuration ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://wordpress.org/support/topic/slows-down-your-site-3/
https://wordpress.org/support/topic/slowed-my-site-down-3/
https://wordpress.org/support/topic/excessive-api-calls-to-payment_method_configurations-causing-429-errors/

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
