### PR TITLE
Reduce PMC API calls

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -31,9 +31,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	/**
 	 * Fallback method to be inherited by all payment methods. Stripe UPE will override it.
 	 *
+	 * @param bool $force_refresh Whether to force a refresh of the payment method configuration.
 	 * @return string[]
 	 */
-	public function get_upe_enabled_payment_method_ids() {
+	public function get_upe_enabled_payment_method_ids( $force_refresh = false ) {
 		return [ WC_Stripe_Payment_Methods::CARD ];
 	}
 

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -241,7 +241,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$is_upe_enabled               = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
 		$available_payment_method_ids = $is_upe_enabled ? $this->gateway->get_upe_available_payment_methods() : WC_Stripe_Helper::get_legacy_available_payment_method_ids();
 		$ordered_payment_method_ids   = $is_upe_enabled ? WC_Stripe_Helper::get_upe_ordered_payment_method_ids( $this->gateway ) : $available_payment_method_ids;
-		$enabled_payment_method_ids   = $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids() : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
+		$enabled_payment_method_ids   = $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids( true) : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
 
 		return new WP_REST_Response(
 			[

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -81,11 +81,11 @@ class WC_Stripe_Payment_Method_Configurations {
 				: [ WC_Stripe_Payment_Methods::CARD ];
 		}
 
-		// Migrate payment methods from DB to Stripe PMC if needed
-		self::maybe_migrate_payment_methods_from_db_to_pmc();
-
 		$enabled_payment_method_ids            = [];
 		$merchant_payment_method_configuration = self::get_primary_configuration();
+
+		// Migrate payment methods from DB to Stripe PMC if needed
+		self::maybe_migrate_payment_methods_from_db_to_pmc( $merchant_payment_method_configuration );
 
 		if ( $merchant_payment_method_configuration ) {
 			foreach ( $merchant_payment_method_configuration as $payment_method_id => $payment_method ) {
@@ -199,8 +199,10 @@ class WC_Stripe_Payment_Method_Configurations {
 
 	/**
 	 * Migrates the payment methods from the DB option to PMC if needed.
+	 *
+	 * @param object $merchant_payment_method_configuration The payment method configuration in Stripe dashboard.
 	 */
-	public static function maybe_migrate_payment_methods_from_db_to_pmc() {
+	public static function maybe_migrate_payment_methods_from_db_to_pmc( $merchant_payment_method_configuration ) {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		// Skip if PMC is not enabled or migration already done
@@ -209,7 +211,6 @@ class WC_Stripe_Payment_Method_Configurations {
 		}
 
 		// Skip if there is no PMC available
-		$merchant_payment_method_configuration = self::get_primary_configuration();
 		if ( ! $merchant_payment_method_configuration ) {
 			return;
 		}

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -30,6 +30,13 @@ class WC_Stripe_Payment_Method_Configurations {
 	const LIVE_MODE_CONFIGURATION_PARENT_ID = 'pmc_1LEKjAGX8lmJQndTk2ziRchV';
 
 	/**
+	 * The transient key for the UPE enabled payment method IDs.
+	 *
+	 * @var string
+	*/
+	const UPE_ENABLED_PAYMENT_METHOD_IDS_TRANSIENT_KEY = 'wc_stripe_upe_enabled_payment_method_ids';
+
+	/**
 	 * Reset the primary configuration.
 	 */
 	public static function reset_primary_configuration() {
@@ -70,15 +77,20 @@ class WC_Stripe_Payment_Method_Configurations {
 	/**
 	 * Get the UPE enabled payment method IDs.
 	 *
+	 * @param bool $force_refresh Whether to force a refresh of the payment method configuration.
 	 * @return array
 	 */
-	public static function get_upe_enabled_payment_method_ids() {
+	public static function get_upe_enabled_payment_method_ids( $force_refresh = false ) {
 		// If the payment method configurations API is not enabled, we fallback to the enabled payment methods stored in the DB.
 		if ( ! self::is_enabled() ) {
 			$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 			return isset( $stripe_settings['upe_checkout_experience_accepted_payments'] ) && ! empty( $stripe_settings['upe_checkout_experience_accepted_payments'] )
 				? $stripe_settings['upe_checkout_experience_accepted_payments']
 				: [ WC_Stripe_Payment_Methods::CARD ];
+		}
+
+		if ( ! $force_refresh && ! empty( get_transient( self::UPE_ENABLED_PAYMENT_METHOD_IDS_TRANSIENT_KEY ) ) ) {
+			return get_transient( self::UPE_ENABLED_PAYMENT_METHOD_IDS_TRANSIENT_KEY );
 		}
 
 		$enabled_payment_method_ids            = [];
@@ -94,6 +106,8 @@ class WC_Stripe_Payment_Method_Configurations {
 				}
 			}
 		}
+
+		set_transient( self::UPE_ENABLED_PAYMENT_METHOD_IDS_TRANSIENT_KEY, $enabled_payment_method_ids, HOUR_IN_SECONDS );
 
 		return $enabled_payment_method_ids;
 	}
@@ -137,6 +151,9 @@ class WC_Stripe_Payment_Method_Configurations {
 			$payment_method_configuration->id,
 			$updated_payment_method_configuration
 		);
+
+		// clear transient to force a refresh on the next call.
+		delete_transient( self::UPE_ENABLED_PAYMENT_METHOD_IDS_TRANSIENT_KEY );
 
 		self::record_payment_method_settings_event( $newly_enabled_methods, $newly_disabled_methods );
 	}

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -89,15 +89,15 @@ class WC_Stripe_Payment_Method_Configurations {
 				: [ WC_Stripe_Payment_Methods::CARD ];
 		}
 
+		// Migrate payment methods from DB to Stripe PMC if needed
+		self::maybe_migrate_payment_methods_from_db_to_pmc();
+
 		if ( ! $force_refresh && ! empty( get_transient( self::UPE_ENABLED_PAYMENT_METHOD_IDS_TRANSIENT_KEY ) ) ) {
 			return get_transient( self::UPE_ENABLED_PAYMENT_METHOD_IDS_TRANSIENT_KEY );
 		}
 
 		$enabled_payment_method_ids            = [];
 		$merchant_payment_method_configuration = self::get_primary_configuration();
-
-		// Migrate payment methods from DB to Stripe PMC if needed
-		self::maybe_migrate_payment_methods_from_db_to_pmc( $merchant_payment_method_configuration );
 
 		if ( $merchant_payment_method_configuration ) {
 			foreach ( $merchant_payment_method_configuration as $payment_method_id => $payment_method ) {
@@ -216,10 +216,8 @@ class WC_Stripe_Payment_Method_Configurations {
 
 	/**
 	 * Migrates the payment methods from the DB option to PMC if needed.
-	 *
-	 * @param object $merchant_payment_method_configuration The payment method configuration in Stripe dashboard.
 	 */
-	public static function maybe_migrate_payment_methods_from_db_to_pmc( $merchant_payment_method_configuration ) {
+	public static function maybe_migrate_payment_methods_from_db_to_pmc() {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		// Skip if PMC is not enabled or migration already done
@@ -228,6 +226,7 @@ class WC_Stripe_Payment_Method_Configurations {
 		}
 
 		// Skip if there is no PMC available
+		$merchant_payment_method_configuration = self::get_primary_configuration();
 		if ( ! $merchant_payment_method_configuration ) {
 			return;
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -623,10 +623,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Returns UPE enabled payment method IDs.
 	 *
+	 * @param bool $force_refresh Whether to force a refresh of the payment method configuration.
 	 * @return string[]
 	 */
-	public function get_upe_enabled_payment_method_ids() {
-		return WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids();
+	public function get_upe_enabled_payment_method_ids( $force_refresh = false ) {
+		return WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids( $force_refresh );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -762,9 +762,10 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	/**
 	 * Returns UPE enabled payment method IDs.
 	 *
+	 * @param bool $force_refresh Whether to force a refresh of the payment method configuration.
 	 * @return string[]
 	 */
-	public function get_upe_enabled_payment_method_ids() {
-		return WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids();
+	public function get_upe_enabled_payment_method_ids( $force_refresh = false ) {
+		return WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids( $force_refresh );
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request:
- Added cache for storing PMC 
- Sending the `force_fetch: true` only on the plugin settings page. Whenever the settings page is refreshed, PMC will be retrieved.
- PMC will be retrieved if the cache is empty (i.e, not set initially or after expiration of the transient)
- Clearing the cache when merchant updates the enabled/disabled methods on the plugin setting page. This ensures that the latest PMC will be fetched on next call.


## Testing instructions
- Smoke test PMC