### PR TITLE
Fix undefined method when processing refunds

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
+* Fix - Fix undefined method error when processing order refunds.
 
 = 9.4.0 - 2025-04-16 =
 * Add - New filter to allow merchants to bypass the default visibility of the express payment method buttons when taxes are based on customer's billing address (`wc_stripe_should_hide_express_checkout_button_based_on_tax_setup`).

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -158,7 +158,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 
 			if ( $webhook->url === $webhook_url ) {
-				$number_of_webhooks++;
+				++$number_of_webhooks;
 			}
 		}
 
@@ -328,7 +328,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 						sleep( $this->retry_interval );
 
-						$this->retry_interval++;
+						++$this->retry_interval;
 						return $this->process_webhook_payment( $notification, true );
 					} else {
 						$localized_message = __( 'Sorry, we are unable to process your payment at this time. Please retry later.', 'woocommerce-gateway-stripe' );
@@ -682,7 +682,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
-			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
+			$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->id );
 		}
 
 		if ( ! $order ) {

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -678,7 +678,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund( $notification ) {
 		$refund_object = $this->get_refund_object( $notification );
-		$order         = WC_Stripe_Order::get_by_refund_id( $refund_object->id );
+		// TODO: For testing only. Remove before merging.
+		// TODO: For testing only. Remove before merging.
+		// TODO: For testing only. Remove before merging.
+		$order = null; //WC_Stripe_Order::get_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );

--- a/readme.txt
+++ b/readme.txt
@@ -117,5 +117,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
+* Fix - Fix undefined method error when processing order refunds.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -686,4 +686,85 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 			'sepa_debit'     => [ WC_Stripe_Payment_Methods::SEPA_DEBIT ],
 		];
 	}
+
+	/**
+	 * Test for `process_webhook_refund`.
+	 */
+	public function test_process_webhook_refund() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'stripe' );
+		$order->set_transaction_id( 'ch_mock123' );
+		$order->update_meta_data( '_stripe_charge_captured', 'yes' );
+		$order->save();
+
+		$refund_id     = 're_mock123';
+		$refund_amount = 1000;
+		$refund_object = (object) [
+			'id'                  => $refund_id,
+			'amount'              => $refund_amount,
+			'balance_transaction' => (object) [
+				'fee' => 50,
+			],
+		];
+		$notification  = (object) [
+			'type' => 'charge.refunded',
+			'data' => (object) [
+				'object' => (object) [
+					'id'              => 'ch_mock123',
+					'amount_refunded' => $refund_amount,
+					'currency'        => 'usd',
+					'refunds'         => (object) [
+						'data' => [
+							$refund_object,
+						],
+					],
+				],
+			],
+		];
+
+		$mock_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'get_refund_object', 'get_refund_amount', 'update_fees' ] )
+			->getMock();
+
+		// Mock the get_refund_object method to return our mock refund
+		$mock_handler->expects( $this->once() )
+			->method( 'get_refund_object' )
+			->with( $notification )
+			->willReturn( $refund_object );
+
+		$mock_handler->expects( $this->once() )
+			->method( 'get_refund_amount' )
+			->with( $notification )
+			->willReturn( $refund_amount / 100 );
+
+		$mock_handler->expects( $this->once() )
+			->method( 'update_fees' )
+			->with(
+				$this->callback(
+					function ( $order ) {
+						return $order instanceof WC_Order;
+					}
+				),
+				$refund_object->balance_transaction
+			);
+
+		// Process the webhook refund
+		$mock_handler->process_webhook_refund( $notification );
+
+		// Refresh order from database to ensure we have the latest metadata
+		$order = wc_get_order( $order->get_id() );
+
+		// Verify the refund was processed correctly
+		$this->assertEquals( 10.0, $order->get_total_refunded(), 'Refund amount was not set correctly' );
+		$this->assertEquals( $refund_id, $order->get_meta( '_stripe_refund_id' ), 'Refund ID was not saved correctly' );
+
+		// Verify an order note was added
+		$order_notes = wc_get_order_notes( [ 'order_id' => $order->get_id() ] );
+		$this->assertStringContainsString(
+			'Refunded via Stripe Dashboard',
+			$order_notes[0]->content,
+			'Refund note was not added correctly'
+		);
+		$this->assertStringContainsString( $refund_id, $order_notes[0]->content, 'Refund ID not found in order note' );
+	}
 }


### PR DESCRIPTION
Reported in p1744970921607459/1744276820.614439-slack-C7U3Y3VMY

## Changes proposed in this Pull Request:

Fixes the following error, encountered when processing refunds:
```
CRITICAL Uncaught Error: Call to undefined method Automattic\WooCommerce\Admin\Overrides\Order::lock_refund() in [redacted]wp-content/plugins/woocommerce-gateway-stripe/includes/class-wc-stripe-webhook-handler.php:721
```

`lock_refund()` is a method in the `WC_Stripe_Order` class.

## Testing instructions
1. https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4244/commits/508be8e59ed127622b37df16564aee823144da33 forces the situation where we fail to retrieve an oder by refund ID and have to use charge ID. **This is for testing convenience only -- I will drop this commit before merge.**
3. As a shopper, make a purchase.
4. As the merchant, process the refund. 
   - In `develop`, logs will show a fatal error: `Uncaught Error: Call to undefined method Automattic\WooCommerce\Admin\Overrides\Order::lock_refund()`
   - In this branch, there should be no fatals. 


---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)