### PR TITLE
Add SPE e2e tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        checkout: [ 'Default', 'Legacy', 'spe' ]
+        checkout: [ 'Default', 'Legacy', 'SPE' ]
 
     name: ${{ matrix.checkout }} WP=latest, WC=latest, PHP=7.4
     steps:
@@ -85,7 +85,14 @@ jobs:
         env:
           STRIPE_PUB_KEY: ${{ secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
           STRIPE_SECRET_KEY: ${{ secrets.E2E_STRIPE_SECRET_KEY }}
-        run: npm run test:e2e${{ matrix.checkout == 'Legacy' && '-legacy' || '' }}
+        run: |
+          if [ "${{ matrix.checkout }}" = "Legacy" ]; then
+            npm run test:e2e-legacy
+          elif [ "${{ matrix.checkout }}" = "SPE" ]; then
+            npm run test:e2e-spe
+          else
+            npm run test:e2e
+          fi
       
       - name: Upload ${{ matrix.checkout }} E2E test results
         if: ${{ failure() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        checkout: [ 'Default', 'Legacy' ]
+        checkout: [ 'Default', 'Legacy', 'spe' ]
 
     name: ${{ matrix.checkout }} WP=latest, WC=latest, PHP=7.4
     steps:

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        project: [ 'default', 'legacy', 'acss' ]
+        project: [ 'default', 'legacy', 'acss', 'spe' ]
 
     name: E2E - ${{ matrix.project }} (WP=${{ inputs.wp-version }}, WC=${{ inputs.wc-version }}, PHP=${{ inputs.php-version }})
     steps:

--- a/package.json
+++ b/package.json
@@ -162,7 +162,9 @@
     "test:e2e-legacy": "./tests/e2e/bin/run-tests.sh --project=legacy",
     "test:e2e-legacy-debug": "npm run test:e2e-legacy -- --debug",
     "test:e2e-lpm-acss": "./tests/e2e/bin/run-tests.sh --project=acss",
-    "test:e2e-lmp-acss-debug": "npm run test:e2e-lpm-acss -- --debug",
+    "test:e2e-lpm-acss-debug": "npm run test:e2e-lpm-acss -- --debug",
+    "test:e2e-spe": "./tests/e2e/bin/run-tests.sh --project=spe",
+    "test:e2e-spe-debug": "npm run test:e2e-spe -- --debug",
     "changelog": "node bin/changelog.js"
   },
   "engines": {

--- a/tests/e2e/bin/setup.sh
+++ b/tests/e2e/bin/setup.sh
@@ -143,6 +143,9 @@ redirect_output cli wp option update _wcstripe_feature_lpm_ach 'yes'
 echo " - Enabling the ACSS feature flag"
 redirect_output cli wp option update _wcstripe_feature_lpm_acss 'yes'
 
+echo " - Enabling the SPE feature flag"
+redirect_output cli wp option update _wcstripe_feature_spe 'yes'
+
 step "Installing Woo Subscriptions"
 echo " - Fetching latest version"
 LATEST_RELEASE_ASSET_ID=$(curl -sH "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/woocommerce/woocommerce-subscriptions/releases/latest | jq -r '.assets[0].id')

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -106,6 +106,17 @@ const config = {
 			dependencies: [ 'legacy-setup' ],
 			use: { ...devices[ 'Desktop Chrome' ] },
 		},
+		{
+			name: 'spe-setup',
+			testMatch: '/spe.setup.js',
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
+		{
+			name: 'spe',
+			testMatch: '**/spe.spec.js',
+			dependencies: [ 'spe-setup' ],
+			use: { ...devices[ 'Desktop Chrome' ] },
+		},
 	],
 };
 

--- a/tests/e2e/tests/checkout/blocks/spe.spec.js
+++ b/tests/e2e/tests/checkout/blocks/spe.spec.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { randomUUID } from 'crypto';
 import config from 'config';
-import { admin, payments, api, user } from '../../../utils';
+import { payments, api, user } from '../../../utils';
 
 const {
 	emptyCart,

--- a/tests/e2e/tests/checkout/blocks/spe.spec.js
+++ b/tests/e2e/tests/checkout/blocks/spe.spec.js
@@ -1,0 +1,94 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import config from 'config';
+import { admin, payments, api, user } from '../../../utils';
+
+const {
+	emptyCart,
+	setupCart,
+	setupBlocksCheckout,
+	setupSPECheckout,
+	fillSPEDetails,
+} = payments;
+
+test.describe( 'SPE payment tests @blocks', () => {
+	let username, userEmail;
+
+	test.describe.configure( { mode: 'serial' } );
+
+	test.beforeAll( async ( { browser } ) => {
+		await test.step( 'Setup test environment', async () => {
+			// Create test user.
+			const randomString = randomUUID();
+			userEmail =
+				randomString + '+' + config.get( 'users.customer.email' );
+			username =
+				randomString + '.' + config.get( 'users.customer.username' );
+
+			const testUser = {
+				...config.get( 'users.customer' ),
+				...config.get( 'addresses.customer' ),
+				email: userEmail,
+				username,
+			};
+			await api.create.customer( testUser );
+		} );
+	} );
+
+	test( 'customer can pay with SPE @smoke', async ( { page } ) => {
+		await setupSPECheckout( page, 'blocks' );
+		await fillSPEDetails( page, config.get( 'cards.basic' ) );
+		await page.locator( 'text=Place order' ).click();
+		await page.waitForURL( '**/checkout/order-received/**' );
+		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+			'Order received'
+		);
+	} );
+
+	test( 'customer can save and reuse ACSS payment method @smoke', async ( {
+		page,
+	} ) => {
+		// First order - Save the payment method.
+		await test.step(
+			'Save payment method during first checkout',
+			async () => {
+				await user.login(
+					page,
+					username,
+					config.get( 'users.customer.password' )
+				);
+				await setupSPECheckout( page, 'blocks' );
+				await page.getByLabel( 'Save payment information' ).click();
+				// await page.locator( 'text=Place order' ).click();
+				await fillSPEDetails( page, config.get( 'cards.basic' ) );
+				await page.locator( 'text=Place order' ).click();
+				await page.waitForURL( '**/checkout/order-received/**' );
+				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+					'Order received'
+				);
+			}
+		);
+
+		// Second order - Use saved payment method.
+		await test.step(
+			'Use saved payment method for second checkout',
+			async () => {
+				await emptyCart( page );
+				await setupCart( page );
+				await setupBlocksCheckout(
+					page,
+					config.get( 'addresses.customer.billing' )
+				);
+				await page
+					.locator( 'label' )
+					.filter( { hasText: 'Visa ending in 4242 (expires' } )
+					.click();
+				await page.locator( 'text=Place order' ).click();
+				await page.waitForURL( '**/checkout/order-received/**' );
+				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+					'Order received'
+				);
+			}
+		);
+	} );
+} );

--- a/tests/e2e/tests/checkout/blocks/spe.spec.js
+++ b/tests/e2e/tests/checkout/blocks/spe.spec.js
@@ -45,7 +45,7 @@ test.describe( 'SPE payment tests @blocks', () => {
 		);
 	} );
 
-	test( 'customer can save and reuse ACSS payment method @smoke', async ( {
+	test( 'customer can save and reuse SPE payment method @smoke', async ( {
 		page,
 	} ) => {
 		// First order - Save the payment method.

--- a/tests/e2e/tests/checkout/shortcode/spe.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/spe.spec.js
@@ -1,0 +1,108 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import config from 'config';
+import { payments, api, user } from '../../../utils';
+
+const {
+	emptyCart,
+	setupCart,
+	setupShortcodeCheckout,
+	setupSPECheckout,
+	fillSPEDetails,
+} = payments;
+
+test.describe( 'SPE payment tests @shortcode', () => {
+	let username, userEmail;
+
+	test.describe.configure( { mode: 'serial' } );
+
+	test.beforeAll( async ( { browser } ) => {
+		await test.step( 'Setup test environment', async () => {
+			// Create test user.
+			const randomString = randomUUID();
+			userEmail =
+				randomString + '+' + config.get( 'users.customer.email' );
+			username =
+				randomString + '.' + config.get( 'users.customer.username' );
+
+			const testUser = {
+				...config.get( 'users.customer' ),
+				...config.get( 'addresses.customer' ),
+				email: userEmail,
+				username,
+			};
+			await api.create.customer( testUser );
+		} );
+	} );
+
+	test( 'customer can pay with SPE @smoke', async ( { page } ) => {
+		await setupSPECheckout( page, 'shortcode' );
+		await fillSPEDetails( page, config.get( 'cards.basic' ), 'shortcode' );
+		await page.locator( 'text=Place order' ).click();
+		await page.waitForURL( '**/checkout/order-received/**' );
+		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+			'Order received'
+		);
+	} );
+
+	test( 'customer can save and reuse SPE payment method @smoke', async ( {
+		page,
+	} ) => {
+		// First order - Save the payment method.
+		await test.step(
+			'Save payment method during first checkout',
+			async () => {
+				await user.login(
+					page,
+					username,
+					config.get( 'users.customer.password' )
+				);
+				await setupSPECheckout( page, 'shortcode' );
+				await fillSPEDetails(
+					page,
+					config.get( 'cards.basic' ),
+					'shortcode'
+				);
+				await page
+					.getByRole( 'checkbox', {
+						name: 'Save payment information to',
+					} )
+					.click();
+				await page.locator( 'text=Place order' ).click();
+				await fillSPEDetails(
+					page,
+					config.get( 'cards.basic' ),
+					'shortcode'
+				);
+				await page.waitForURL( '**/checkout/order-received/**' );
+				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+					'Order received'
+				);
+			}
+		);
+
+		// Second order - Use saved payment method.
+		await test.step(
+			'Use saved payment method for second checkout',
+			async () => {
+				await emptyCart( page );
+				await setupCart( page );
+				await setupShortcodeCheckout(
+					page,
+					config.get( 'addresses.customer.billing' )
+				);
+				await page.getByText( 'Visa ending in 4242 (expires' ).click();
+				await page.waitForTimeout( 1000 );
+				await page
+					.locator( '.woocommerce-SavedPaymentMethods-token' )
+					.first()
+					.click();
+				await page.locator( 'text=Place order' ).click();
+				await page.waitForURL( '**/checkout/order-received/**' );
+				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
+					'Order received'
+				);
+			}
+		);
+	} );
+} );

--- a/tests/e2e/tests/spe.setup.js
+++ b/tests/e2e/tests/spe.setup.js
@@ -19,7 +19,7 @@ setup( 'Configure store for SPE tests', async ( { browser } ) => {
 	if ( ! isChecked ) {
 		await checkbox.click();
 		await page.click( 'text=Save changes' );
-		await expect( page.getByText( 'Settings saved.' ) ).toBeDefined();
+		await expect( page.getByText( 'Settings saved.' ) ).toBeVisible();
 		await expect(
 			page.getByTestId( 'single-payment-element-checkbox' )
 		).toBeChecked();

--- a/tests/e2e/tests/spe.setup.js
+++ b/tests/e2e/tests/spe.setup.js
@@ -18,7 +18,11 @@ setup( 'Configure store for SPE tests', async ( { browser } ) => {
 	if ( ! isChecked ) {
 		await checkbox.click();
 		await page.click( 'text=Save changes' );
-		await expect( page.getByText( 'Settings saved.' ) ).toBeVisible();
+		await expect(
+			page.locator(
+				'.components-snackbar__content:has-text("Settings saved.")'
+			)
+		).toBeVisible();
 		await expect(
 			page.getByTestId( 'single-payment-element-checkbox' )
 		).toBeChecked();

--- a/tests/e2e/tests/spe.setup.js
+++ b/tests/e2e/tests/spe.setup.js
@@ -1,0 +1,29 @@
+import { test as setup } from '@playwright/test';
+import { admin } from '../utils';
+
+setup( 'Configure store for SPE tests', async ( { browser } ) => {
+	const adminContext = await browser.newContext( {
+		storageState: process.env.ADMINSTATE,
+	} );
+
+	const page = await adminContext.newPage();
+
+	// Enable SPE in the admin.
+	await page.goto(
+		'/wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings'
+	);
+
+	const checkbox = page.getByTestId( 'single-payment-element-checkbox' );
+	const isChecked = await checkbox.isChecked();
+
+	if ( ! isChecked ) {
+		await checkbox.click();
+		await page.click( 'text=Save changes' );
+		await expect( page.getByText( 'Settings saved.' ) ).toBeDefined();
+		await expect(
+			page.getByTestId( 'single-payment-element-checkbox' )
+		).toBeChecked();
+	}
+
+	await adminContext.close();
+} );

--- a/tests/e2e/tests/spe.setup.js
+++ b/tests/e2e/tests/spe.setup.js
@@ -1,5 +1,4 @@
-import { test as setup } from '@playwright/test';
-import { admin } from '../utils';
+import { test as setup, expect } from '@playwright/test';
 
 setup( 'Configure store for SPE tests', async ( { browser } ) => {
 	const adminContext = await browser.newContext( {

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -548,7 +548,6 @@ export const setupSPECheckout = async (
 		await setupCart( page );
 	}
 
-	// Define selectors based on checkout type
 	const selectors = {
 		blocks: {
 			iframe:
@@ -585,7 +584,7 @@ export const setupSPECheckout = async (
 			);
 		}
 
-		// Wait for the Stripe iframe with configurable timeout
+		// Wait for the Stripe iframe
 		await page.waitForSelector( currentSelectors.iframe, {
 			state: 'visible',
 			timeout: options.timeout,
@@ -594,7 +593,8 @@ export const setupSPECheckout = async (
 		// Get the payment frame
 		const paymentFrame = await page
 			.locator( currentSelectors.iframe )
-			.contentFrame();
+			.contentFrame()
+			.first();
 
 		if ( ! paymentFrame ) {
 			throw new Error(
@@ -764,7 +764,10 @@ export const fillSPEDetails = async ( page, card, checkoutType = 'blocks' ) => {
 		timeout: 10000,
 	} );
 
-	const paymentFrame = await page.locator( iframeSelector ).contentFrame();
+	const paymentFrame = await page
+		.locator( iframeSelector )
+		.contentFrame()
+		.first();
 
 	if ( ! paymentFrame ) {
 		throw new Error( 'Could not find Stripe payment element frame' );

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -528,6 +528,61 @@ export const setupACSSCheckout = async ( page, checkoutType = 'blocks' ) => {
 };
 
 /**
+ * Set up the checkout page for SPE.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {string} checkoutType The type of checkout ('blocks' or 'shortcode').
+ */
+export const setupSPECheckout = async ( page, checkoutType = 'blocks' ) => {
+	await emptyCart( page );
+	await setupCart( page );
+
+	if ( checkoutType === 'blocks' ) {
+		await setupBlocksCheckout(
+			page,
+			config.get( 'addresses.customer.billing' )
+		);
+
+		await page.waitForTimeout( 1000 );
+
+		// Wait for the Stripe iframe within payment options container
+		await page.waitForSelector(
+			'#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]'
+		);
+
+		const paymentFrame = await page
+			.locator(
+				'#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]'
+			)
+			.contentFrame();
+
+		if ( ! paymentFrame ) {
+			throw new Error( 'Could not find Stripe payment element frame' );
+		}
+	} else {
+		await setupShortcodeCheckout(
+			page,
+			config.get( 'addresses.customer.billing' )
+		);
+
+		// Wait for the Stripe iframe within WooCommerce Stripe container
+		await page.waitForSelector(
+			'#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]'
+		);
+
+		const paymentFrame = await page
+			.locator(
+				'#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]'
+			)
+			.contentFrame();
+
+		if ( ! paymentFrame ) {
+			throw new Error( 'Could not find Stripe payment element frame' );
+		}
+	}
+};
+
+/**
  * Interact with the Stripe Elements iframe to fill in the ACSS details.
  *
  * @param {Page} page Playwright page fixture.
@@ -661,3 +716,37 @@ export async function handleCheckoutCashAppPay(
 		.getByRole( 'link', { name: 'Authorize Test Payment' } )
 		.click();
 }
+
+/**
+ * Fill in the payment details for Stripe Payment Element (SPE) checkout.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {Object} card The CC info in the format provided on the test-data.
+ * @param {string} checkoutType The type of checkout ('blocks' or 'shortcode').
+ */
+export const fillSPEDetails = async ( page, card, checkoutType = 'blocks' ) => {
+	// Determine the appropriate iframe selector based on checkout type
+	const iframeSelector =
+		checkoutType === 'blocks'
+			? '#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]'
+			: '#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]';
+
+	// Wait for the Stripe iframe to be visible
+	await page.waitForSelector( iframeSelector, {
+		state: 'visible',
+		timeout: 10000,
+	} );
+
+	const paymentFrame = await page.locator( iframeSelector ).contentFrame();
+
+	if ( ! paymentFrame ) {
+		throw new Error( 'Could not find Stripe payment element frame' );
+	}
+
+	// Fill in test card details
+	await paymentFrame.locator( '[name="number"]' ).fill( card.number );
+	await paymentFrame
+		.locator( '[name="expiry"]' )
+		.fill( card.expires.month + card.expires.year );
+	await paymentFrame.locator( '[name="cvc"]' ).fill( card.cvc );
+};

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -528,57 +528,84 @@ export const setupACSSCheckout = async ( page, checkoutType = 'blocks' ) => {
 };
 
 /**
- * Set up the checkout page for SPE.
+ * Set up the checkout page for Stripe Payment Element (SPE).
  *
  * @param {Page} page Playwright page fixture.
  * @param {string} checkoutType The type of checkout ('blocks' or 'shortcode').
+ * @param {Object} options Optional configuration parameters.
+ * @param {number} options.timeout Timeout in milliseconds for waiting operations (default: 10000).
+ * @param {boolean} options.skipCartSetup Skip cart setup if it's already configured (default: false).
+ * @returns {Promise<void>} Resolves when setup is complete.
+ * @throws {Error} If iframe cannot be found or initialization fails.
  */
-export const setupSPECheckout = async ( page, checkoutType = 'blocks' ) => {
-	await emptyCart( page );
-	await setupCart( page );
+export const setupSPECheckout = async (
+	page,
+	checkoutType = 'blocks',
+	options = { timeout: 10000, skipCartSetup: false }
+) => {
+	if ( ! options.skipCartSetup ) {
+		await emptyCart( page );
+		await setupCart( page );
+	}
 
-	if ( checkoutType === 'blocks' ) {
-		await setupBlocksCheckout(
-			page,
-			config.get( 'addresses.customer.billing' )
-		);
+	// Define selectors based on checkout type
+	const selectors = {
+		blocks: {
+			iframe:
+				'#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]',
+			container:
+				'#radio-control-wc-payment-method-options-stripe__content',
+		},
+		shortcode: {
+			iframe:
+				'#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]',
+			container: '#wc-stripe-upe-form',
+		},
+	};
 
-		await page.waitForTimeout( 1000 );
+	try {
+		// Set up appropriate checkout type
+		if ( checkoutType === 'blocks' ) {
+			await setupBlocksCheckout(
+				page,
+				config.get( 'addresses.customer.billing' )
+			);
+		} else {
+			await setupShortcodeCheckout(
+				page,
+				config.get( 'addresses.customer.billing' )
+			);
+		}
 
-		// Wait for the Stripe iframe within payment options container
-		await page.waitForSelector(
-			'#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]'
-		);
+		// Get the correct selectors for this checkout type
+		const currentSelectors = selectors[ checkoutType ];
+		if ( ! currentSelectors ) {
+			throw new Error(
+				`Invalid checkout type: ${ checkoutType }. Must be 'blocks' or 'shortcode'.`
+			);
+		}
 
+		// Wait for the Stripe iframe with configurable timeout
+		await page.waitForSelector( currentSelectors.iframe, {
+			state: 'visible',
+			timeout: options.timeout,
+		} );
+
+		// Get the payment frame
 		const paymentFrame = await page
-			.locator(
-				'#radio-control-wc-payment-method-options-stripe__content iframe[name^="__privateStripeFrame"]'
-			)
+			.locator( currentSelectors.iframe )
 			.contentFrame();
 
 		if ( ! paymentFrame ) {
-			throw new Error( 'Could not find Stripe payment element frame' );
+			throw new Error(
+				`Could not find Stripe payment element frame in ${ currentSelectors.container }`
+			);
 		}
-	} else {
-		await setupShortcodeCheckout(
-			page,
-			config.get( 'addresses.customer.billing' )
-		);
 
-		// Wait for the Stripe iframe within WooCommerce Stripe container
-		await page.waitForSelector(
-			'#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]'
-		);
-
-		const paymentFrame = await page
-			.locator(
-				'#wc-stripe-upe-form .StripeElement iframe[name^="__privateStripeFrame"]'
-			)
-			.contentFrame();
-
-		if ( ! paymentFrame ) {
-			throw new Error( 'Could not find Stripe payment element frame' );
-		}
+		// Select the card payment method
+		await paymentFrame.getByRole( 'button', { name: 'Card' } ).click();
+	} catch ( error ) {
+		throw new Error( `Failed to set up SPE checkout: ${ error.message }` );
 	}
 };
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->
Fixes STRIPE-383
## Changes proposed in this Pull Request:

This PR introduces E2E tests to cover SPE usage on Blocks and shortcode checkouts.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Locally run the tests with `npm run test:e2e-spe` and make sure they pass.
2. Make sure the GH tests for this PR passes (✅ )
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
SPE is not yet released.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
