### PR TITLE
Update changelog to include 9.4.1 rollback

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Changelog ***
 
-= 9.4.1 - xxxx-xx-xx =
+= 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.
 
 = 9.4.0 - 2025-04-16 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 9.4.1 - xxxx-xx-xx =
+* Dev - Forces rollback of version 9.4.0.
+
 = 9.4.0 - 2025-04-16 =
 * Add - New filter to allow merchants to bypass the default visibility of the express payment method buttons when taxes are based on customer's billing address (`wc_stripe_should_hide_express_checkout_button_based_on_tax_setup`).
 * Dev - Improves Smart Checkout code with shared and new methods, on both front and backend.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce-gateway-stripe",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce-gateway-stripe",
   "title": "WooCommerce Gateway Stripe",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "license": "GPL-3.0",
   "homepage": "http://wordpress.org/plugins/woocommerce-gateway-stripe/",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,9 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
+= 9.4.1 - xxxx-xx-xx =
+* Dev - Forces rollback of version 9.4.0.
+
 = 9.4.0 - 2025-04-16 =
 * Add - New filter to allow merchants to bypass the default visibility of the express payment method buttons when taxes are based on customer's billing address (`wc_stripe_should_hide_express_checkout_button_based_on_tax_setup`).
 * Dev - Improves Smart Checkout code with shared and new methods, on both front and backend.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, apple pay, payment request, google pay, sepa, bancont
 Requires at least: 6.5
 Tested up to: 6.7
 Requires PHP: 7.4
-Stable tag: 9.4.0
+Stable tag: 9.4.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe
@@ -110,7 +110,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
-= 9.4.1 - xxxx-xx-xx =
+= 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.
 
 = 9.4.0 - 2025-04-16 =

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -5,7 +5,7 @@
  * Description: Take credit card payments on your store using Stripe.
  * Author: Stripe
  * Author URI: https://stripe.com/
- * Version: 9.4.0
+ * Version: 9.4.1
  * Requires Plugins: woocommerce
  * Requires at least: 6.5
  * Tested up to: 6.7
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_STRIPE_VERSION', '9.4.0' ); // WRCS: DEFINED_VERSION.
+define( 'WC_STRIPE_VERSION', '9.4.1' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.4' );
 define( 'WC_STRIPE_MIN_WC_VER', '9.5' );
 define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '9.6' );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4248, which performs the same actions for `develop`

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

During the emergency release of 9.4.1, we rolled back the plugin code to 9.3.2. As a result, we don't want to merge the `release/9.4.1` branch into the `release/9.4.2` branch, because we still want to keep all the code that was shipped in 9.4.0. However, we're missing various version bumps and the changelog entry that were originally added for the 9.4.1 release. This PR effectively cherry-picks the following two commits:
 * a15547bf35169277084159d07fd6d10744223f19
 * 4a1d481a90b99f478ffd3678469a41dfa97c2044

Note that the sibling PR in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4248 only pulls the changes to `changelog.txt` into `develop`, as we don't necessarily want all the other version bumps in that case.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Inspection should be sufficient, as this is a changelog-only commit. You can see the files in the `release/9.4.1` branch at https://github.com/woocommerce/woocommerce-gateway-stripe/tree/release/9.4.1

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This change is focused on changelog cleanup, so no separate entry is needed.

</details>

**Post merge**

-   [N/A] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [N/A] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [N/A] Included this PR in the Release Thread scope (or does not apply)
