### PR TITLE
Prevent deletion of unrelated Stripe webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
+* Fix - Prevent deletion of webhooks for other tools
 
 = 9.4.0 - 2025-04-16 =
 * Add - New filter to allow merchants to bypass the default visibility of the express payment method buttons when taxes are based on customer's billing address (`wc_stripe_should_hide_express_checkout_button_based_on_tax_setup`).

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1572,12 +1572,17 @@ class WC_Stripe_Helper {
 	 * Checks if a given URL matches the current site's Webhook URL.
 	 *
 	 * This function ignores trailing slashes and compares the host and path of the URLs.
-	 * The protocol is not compared.
+	 * The protocol is ignored. It also requires that any query parameters in the
+	 * webhook URL are present in the supplied URL, though extra query parameters in the
+	 * supplied URL are ignored.
+	 * There is one special case: when the supplied URL has the same host and path,
+	 * but an empty query string, it is treated as a match. This is to allow for cleanup
+	 * of webhook URLs that don't have identifying URL parameters.
 	 *
 	 * @param string $url         The URL to check.
 	 * @param string $webhook_url The webhook URL to compare against.
 	 *
-	 * @return bool Whether the URL is a webhook URL.
+	 * @return bool Whether the URL is a matching webhook URL.
 	 */
 	public static function is_webhook_url( $url, $webhook_url = '' ) {
 		if ( empty( $webhook_url ) ) {
@@ -1592,15 +1597,58 @@ class WC_Stripe_Helper {
 			return true;
 		}
 
-		$webhook_url_parts = wp_parse_url( $url );
-		$url_parts         = wp_parse_url( $webhook_url );
+		$url_parts         = wp_parse_url( $url );
+		$webhook_url_parts = wp_parse_url( $webhook_url );
 
 		$url_host     = $url_parts['host'] ?? '';
 		$url_path     = $url_parts['path'] ?? '';
+		$url_query    = $url_parts['query'] ?? '';
 		$webhook_host = $webhook_url_parts['host'] ?? '';
 		$webhook_path = $webhook_url_parts['path'] ?? '';
+		$webhook_query = $webhook_url_parts['query'] ?? '';
 
-		return $url_host === $webhook_host && $url_path === $webhook_path;
+		if ( $url_host !== $webhook_host || $url_path !== $webhook_path ) {
+			return false;
+		}
+
+		// If the supplied URL has an empty query string, we will treat it as a webhook URL for the plugin,
+		// as we're guessing that it was created manually in the long-distant past when webhook
+		// management was all manual.
+		if ( '' === $url_query ) {
+			return true;
+		}
+
+		// For our standard webhook URL, we should never hit this condition, but we'll treat them as
+		// a mismatch, as we already know the supplied URL has a non-empty query.
+		if ( '' === $webhook_query ) {
+			return false;
+		}
+
+		$url_query_parts = [];
+		$webhook_query_parts = [];
+
+		parse_str( $url_query, $url_query_parts );
+		parse_str( $webhook_query, $webhook_query_parts );
+
+		if ( [] === $url_query_parts && [] === $webhook_query_parts ) {
+			return true;
+		}
+
+		// We ignore extra URL parameters in the supplied URL,
+		// but we require all query parameters from the webhook URL to
+		// be present in the supplied URL.
+		foreach ( $webhook_query_parts as $webhook_query_key => $webhook_query_value ) {
+			if ( ! isset( $url_query_parts[ $webhook_query_key ] ) ) {
+				return false;
+			}
+
+			if ( $url_query_parts[ $webhook_query_key ] !== $webhook_query_value ) {
+				return false;
+			}
+		}
+
+		// If we get here, the supplied URL has all the query parameters from the webhook URL.
+		return true;
 	}
 
 	public static function get_transaction_url( $is_test_mode = false ) {

--- a/readme.txt
+++ b/readme.txt
@@ -118,5 +118,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
+* Fix - Prevent deletion of webhooks for other tools
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe.php
+++ b/tests/phpunit/test-wc-stripe.php
@@ -203,4 +203,32 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$ideal_settings = get_option( 'woocommerce_stripe_ideal_settings' );
 		$this->assertEquals( 'yes', $ideal_settings['enabled'] );
 	}
+
+	/**
+	 * Test that {@see WC_Stripe_Helper::is_webhook_url()} works as expected.
+	 *
+	 * @dataProvider is_webhook_url_provider
+	 * @covers WC_Stripe_Helper::is_webhook_url()
+	 */
+	public function test_is_webhook_url( $url, $webhook_url, $expected_result ) {
+		$this->assertEquals( $expected_result, WC_Stripe_Helper::is_webhook_url( $url, $webhook_url ) );
+	}
+
+	/**
+	 * Data provider for {@see test_is_webhook_url()}.
+	 *
+	 * @return array
+	 */
+	public function is_webhook_url_provider() {
+		return [
+			'webhook URLs with mismatched protocol should match'       => [ 'https://example.com/?wc-api=wc_stripe', 'http://example.com/?wc-api=wc_stripe', true ],
+			'webhook URLs with mismatched host should not match'       => [ 'https://example.com/?wc-api=wc_stripe', 'https://test.example.com/?wc-api=wc_stripe', false ],
+			'webhook URLs with mismatched path should not match'       => [ 'https://example.com/foo?wc-api=wc_stripe', 'https://example.com/bar?wc-api=wc_stripe', false ],
+			'webhook URL with empty query string should match'         => [ 'https://example.com/test/', 'https://example.com/test/', true ],
+			'webhook URL with empty comparison query should not match' => [ 'https://example.com/test/?foo=bar', 'https://example.com/test/', false ],
+			'webhook URL with missing parameter should not match'      => [ 'https://example.com/test/?wc-api=wc_stripe', 'https://example.com/test/?wc-api=wc_stripe&foo=bar', false ],
+			'webhook URL with wrong parameter should not match'        => [ 'https://example.com/test/?wc-api=wc_stripe_BAD', 'https://example.com/test/?wc-api=wc_stripe', false ],
+			'webhook URL with extra parameters should match'           => [ 'https://example.com/test/?wc-api=wc_stripe&foo=bar', 'https://example.com/test/?wc-api=wc_stripe', true ],
+		];
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-359
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4116

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR uses stricter checks for comparing webhooks to ensure that we don't remove webhooks that were created for other purposes. The removed webhooks reported in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4116 stem from two underlying issues:
 * When we check for valid webhooks, we remove webhook configurations that don't match the current webhook ID _and_ match the current webhook URL for the site
 * The comparison we're using for webhook URLs in `WC_Stripe_Helper::is_webhook_url()` is very loose, and only checks that the host and URL path match, which means we incorrectly detect unrelated webhooks as being from Stripe
   - @diegocurbelo mentioned that this was likely lingering from the days of manually created webhooks

The key problem stems from the matching logic, because we're not being selective enough. This PR updates the comparison logic in `WC_Stripe_Helper::is_webhook_url()` to be notably stricter:
 * We continue to ignore the protocol from the URL (though we could change this to require both are one of `http` or `https`)
 * If the host or path don't match, we flag the supplied URL as a mismatch
 * If the supplied URL doesn't include any URL query parameters, we flag it as a match, as this is likely a misconfigured webhook
    - This restriction could be relaxed, but it feels like a webhook URL with that format is going to be hard to process for _anyone_ - I am happy to take feedback on this call
 * If the webhook URL doesn't have any URL query parameters, we flag it as a mismatch, as the supplied URL has query parameters. (This won't occur for our default webhook URL, but the method allows alternative webhook URLs to be supplied.)
 * We then process each of the key/value pairs in the webhook URL, and verify that the supplied URL includes all of them.
   - If a key is missing, or the value is not identical, we flag it as a mismatch.
   - If the supplied URL includes all of those key/value pairs, and possibly additional URL parameters, we flag it as a match.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Create a test site that has a domain reachable/addressable by webhook targets (i.e. not a local site)
* Ensure that the test site has WooCommerce installed
* Ensure that the test site has an earlier version of the WooCommerce Stripe payment gateway installed -- version 9.3.2 should be enough. You can download the older version from https://wordpress.org/plugins/woocommerce-gateway-stripe/advanced/#download-previous-link.
* Ensure that you have created a connection to Stripe where you can access the Stripe dashboard
* Check out this code locally and create an installable zip file by running `npm run build`

For ease of use, it's going to be easiest if you get set up with three tabs:
 * One open to wp-admin for your test site
 * One tab should be open to the Stripe webhook configuration. I've enabled their Workbench feature, so that's at https://dashboard.stripe.com/test/workbench/webhooks for me. (You can drop `/test` from the path if you're testing in live mode.)
 * One tab open to the Stripe logs, which is at https://dashboard.stripe.com/test/workbench/logs. (As above, remove the `/test` if you're in Live mode.)

* In the Stripe webhooks UI create the following webhook destinations:
  - `https://yourstore.url/` - you should replicate the host and path for the existing webhook that was configured during connection, but leave no other URL parameters on the URL. Feel free to name this webhook to reflect that we expect to delete it.
  - `https://yourstore.url/?wc-api=wc_stripe&test=true` - As above, replicate the host name and path from the existing webhook. You can add further URL parameters or replace the `test` URL parameter with another value. Feel free to give the webhook a name that reflects it has an extra parameter _and that we expect it to be removed_.
  - `https://yourstore.url/?test=webhook` - you should replicate the host and path as above, and can add anything to the URL query string. We expect this webhook to be retained.
 * In your wp-admin tab, navigate to _Plugins_ -> _Add Plugin_, and then click on the "Upload plugin" button
 * Select the zip file created by `npm run build` and continue with the installation
 * If you're prompted to confirm the plugin upgrade, do so.
 * Verify that the plugin upgrade proceeds
 * Refresh your Stripe webhooks tab, and verify the following:
   - the main webhook for the site (with `?wc-api=wc_stripe`) should still be present
   - the webhook with no query string should not be present
   - the webhook that included `wc-api=wc_stripe` as well as additional parameters should not be present
   - the webhook that included a non-empty test string should still be present
 * Refresh the Stripe Logs tab and verify that you see multiple `DELETE
/v1/webhook_endpoints/we_****` events, and that each of those `DELETE` events includes a User agent that starts with `WooCommerce Stripe Gateway/`

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
