### PR TITLE
Refactor WC_Stripe_Express_Checkout_Helper to remove gateway dependency

### DIFF
--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -46,8 +46,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		$this->payment_request_configuration = null !== $payment_request_configuration ? $payment_request_configuration : new WC_Stripe_Payment_Request();
 
 		if ( null === $express_checkout_configuration ) {
-			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-			$helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
+			$helper = new WC_Stripe_Express_Checkout_Helper();
 			$ajax_handler = new WC_Stripe_Express_Checkout_Ajax_Handler( $helper );
 			$express_checkout_configuration = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
 		}

--- a/includes/class-wc-stripe-status.php
+++ b/includes/class-wc-stripe-status.php
@@ -48,7 +48,7 @@ class WC_Stripe_Status {
 	 */
 	public function render_status_report_section() {
 		$account_data            = $this->account->get_cached_account_data();
-		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper( $this->gateway );
+		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper();
 		?>
 		<table class="wc_status_table widefat" cellspacing="0">
 			<thead>

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -42,8 +42,8 @@ class WC_Stripe_Express_Checkout_Helper {
 	/**
 	 * Constructor.
 	 */
-	public function __construct( $gateway ) {
-		$this->gateway         = $gateway;
+	public function __construct() {
+		$this->gateway         = WC_Stripe::get_instance()->get_main_stripe_gateway();
 		$this->stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$this->testmode        = WC_Stripe_Mode::is_test();
 		$this->total_label     = ! empty( $this->stripe_settings['statement_descriptor'] ) ? WC_Stripe_Helper::clean_statement_descriptor( $this->stripe_settings['statement_descriptor'] ) : '';

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -483,7 +483,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 		}
 
-		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper( $this );
+		$express_checkout_helper = new WC_Stripe_Express_Checkout_Helper();
 
 		$stripe_params['isCheckout']                       = ( is_checkout() || has_block( 'woocommerce/checkout' ) ) && empty( $_GET['pay_for_order'] ); // wpcs: csrf ok.
 		$stripe_params['return_url']                       = $this->get_stripe_return_url();

--- a/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-helper.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-helper.php
@@ -284,11 +284,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		$this->set_up_shipping_methods();
 
-		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 		$checkout_data        = $wc_stripe_ece_helper->get_checkout_data();
 
 		$this->assertNotEmpty( $checkout_data['url'] );
@@ -312,7 +308,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 		$checkout_data        = $wc_stripe_ece_helper->get_checkout_data();
 		$this->assertEmpty( $checkout_data['default_shipping_option'] );
 	}
@@ -413,11 +409,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_get_normalized_postal_code
 	 */
 	public function test_get_normalized_postal_code( $postal_code, $country, $expected ) {
-		$gateway = $this->getMockBuilder( WC_Gateway_Stripe::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 		$this->assertEquals( $expected, $wc_stripe_ece_helper->get_normalized_postal_code( $postal_code, $country ) );
 	}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -352,7 +352,7 @@ function woocommerce_gateway_stripe() {
 			 */
 			public function init_express_checkout() {
 				// Express checkout configurations.
-				$express_checkout_helper              = new WC_Stripe_Express_Checkout_Helper( $this->get_main_stripe_gateway() );
+				$express_checkout_helper              = new WC_Stripe_Express_Checkout_Helper();
 				$express_checkout_ajax_handler        = new WC_Stripe_Express_Checkout_Ajax_Handler( $express_checkout_helper );
 				$this->express_checkout_configuration = new WC_Stripe_Express_Checkout_Element( $express_checkout_ajax_handler, $express_checkout_helper );
 				$this->express_checkout_configuration->init();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:
This PR proposes following changes to cleanup the use of `WC_Stripe_Express_Checkout_Helper` class to avoid extra dependency parsing. This will also fix the fatal errors when third-party plugins (eg: Cartflows) rely on this class.

* Updated the constructor of `WC_Stripe_Express_Checkout_Helper` to no longer require a gateway parameter, using the main Stripe gateway internally instead.
* Adjusted instances of `WC_Stripe_Express_Checkout_Helper` across various files to reflect this change.

Additional context: p1745425274668209/1745425236.454659-slack-C055WHLA98D
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

A code review and a smoke test should be enough.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fixes an issue that's not yet present in the most recent released version.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)