### PR TITLE
ECE: Delay zero cart total check to support dynamic updates

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
+* Update - Add ECE support for One Page Checkout and other dynamic cart update scenarios
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -83,6 +83,10 @@ const expressCheckoutElement = ( expressPaymentMethod, api ) => {
 	);
 	const edit = getEditorElement( expressPaymentMethod );
 	const canMakePayment = ( { cart } ) => {
+		if ( parseFloat( cart.cartTotals.total_price ) === 0.0 ) {
+			return false;
+		}
+
 		if ( ! getBlocksConfiguration()?.shouldShowExpressCheckoutButton ) {
 			return false;
 		}

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -534,6 +534,12 @@ jQuery( function ( $ ) {
 							parseInt( cart.totals.total_refund || 0, 10 ),
 						cart.totals
 					);
+
+					if ( total === 0 ) {
+						wcStripeECE.hide();
+						return;
+					}
+
 					wcStripeECE.startExpressCheckout( {
 						mode: 'payment',
 						total,

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -229,9 +229,11 @@ jQuery( function ( $ ) {
 		renderButton: ( eceButton, expressPaymentType ) => {
 			if ( $( '#wc-stripe-express-checkout-element' ).length ) {
 				const containerName = `wc-stripe-express-checkout-element-${ expressPaymentType }`;
-				$( '#wc-stripe-express-checkout-element' ).append(
-					`<div id="${ containerName }"></div>`
-				);
+				if ( ! $( `#${ containerName }` ).length ) {
+					$( '#wc-stripe-express-checkout-element' ).append(
+						`<div id="${ containerName }"></div>`
+					);
+				}
 
 				eceButton.mount( `#${ containerName }` );
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -632,12 +632,9 @@ class WC_Stripe_Express_Checkout_Helper {
 			return false;
 		}
 
-		// Don't show if the total price is 0.
+		// Don't show in the product page if the product price is 0.
 		// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
-		if ( ( ! ( $this->is_pay_for_order_page() || $this->is_product() ) &&
-			isset( WC()->cart ) && ! WC()->cart->is_empty() && 0.0 === (float) WC()->cart->get_total( false ) )
-			|| ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() )
-		) {
+		if ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout does not support free products.' );
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -120,5 +120,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
+* Update - Add ECE support for One Page Checkout and other dynamic cart update scenarios
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-346
Fixes #4079 

## Changes proposed in this Pull Request:
As part of #4164, we tweaked the express checkout "zero cart total" check to only apply when the cart is not empty. This fixed the first issue described in #4079 where express checkout buttons remain hidden even when products have been added to the cart (dynamically, via the One Page Checkout plugin). An unsupported edge case is when the cart contains free products, or has a coupon that zeroes out the total (as the cart is no longer empty).

We go further in this PR, and move the PHP-side "zero cart total" check to the JS side. This will better support cases where the cart total is dynamically updated, such as switching from free shipping to paid (i.e. priority) shipping causing the cart total to be non-zero.
 
We also address the second issue described in #4164 where express checkout buttons remain visible even when the cart total is zeroed dynamically.

## Testing instructions
1. Install WooCommerce One Page Checkout: https://woocommerce.com/products/woocommerce-one-page-checkout/
2. Create a One Page Checkout page:
   - Create a shortcode block containing the following: `[woocommerce_one_page_checkout template="pricing-table" product_ids="31,32"]` (change `31,32` with your product IDs)
4. Make sure your cart is empty, then navigate to your one page checkout page.
5. Using product quantity controls, add a product to cart. Express checkout buttons should appear.
6. Using product quantity controls, empty the cart. Express checkout buttons should disappear.

**Regression test**
1. As a shopper, add a free product or a free trial sub to cart.
2. With DevTools open, navigate to shortcode/block cart and shortcode/block checkout pages.
3. Verify there are no `IntegrationError`s.


![one-page-checkout](https://github.com/user-attachments/assets/bb3c4f60-d286-465e-8dd6-48210f4bcecf)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
