### PR TITLE
Prevent fatals in `WC_Stripe_Express_Checkout_Helper`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
 * Fix - Add caching for the Stripe Payment Method Configuration API
+* Fix - Prevents fatal errors for cases where we fail to load product details
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -221,6 +221,10 @@ class WC_Stripe_Express_Checkout_Helper {
 		$product      = $this->get_product();
 		$variation_id = 0;
 
+		if ( ! $product ) {
+			return false;
+		}
+
 		if ( in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
 			$variation_attributes = $product->get_variation_attributes();
 			$attributes           = [];
@@ -513,6 +517,9 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		if ( $this->is_product() ) {
 			$product = $this->get_product();
+			if ( ! $product ) {
+				return false;
+			}
 			if ( WC_Subscriptions_Product::is_subscription( $product ) ) {
 				return true;
 			}
@@ -540,7 +547,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	/**
 	 * Get product from product page or product_page shortcode.
 	 *
-	 * @return WC_Product Product object.
+	 * @return WC_Product|false Product object, or false if product is not found.
 	 */
 	public function get_product() {
 		global $post;
@@ -620,33 +627,43 @@ class WC_Stripe_Express_Checkout_Helper {
 			return false;
 		}
 
+		$is_product = $this->is_product();
+
 		// Don't show if product page ECE is disabled.
-		if ( $this->is_product() && ! $this->should_show_ece_on_product_pages() ) {
+		if ( $is_product && ! $this->should_show_ece_on_product_pages() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
 			return false;
 		}
 
+		$product = $this->get_product();
+
+		if ( $is_product && ! $product ) {
+			$request_uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
+			WC_Stripe_Logger::log( 'Failed to identify product; not showing Stripe Express Checkout. Current URI: ' . $request_uri );
+			return false;
+		}
+
 		// Don't show if product on current page is not supported.
-		if ( $this->is_product() && ! $this->is_product_supported( $this->get_product() ) ) {
-			WC_Stripe_Logger::log( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $this->get_product()->get_id() );
+		if ( $is_product && ! $this->is_product_supported( $product ) ) {
+			WC_Stripe_Logger::log( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $product->get_id() );
 			return false;
 		}
 
 		// Don't show if the total price is 0.
 		// ToDo: support free trials. Free trials should be supported if the product does not require shipping.
-		if ( ( ! ( $this->is_pay_for_order_page() || $this->is_product() ) &&
+		if ( ( ! ( $this->is_pay_for_order_page() || $is_product ) &&
 			isset( WC()->cart ) && ! WC()->cart->is_empty() && 0.0 === (float) WC()->cart->get_total( false ) )
-			|| ( $this->is_product() && 0.0 === (float) $this->get_product()->get_price() )
+			|| ( $is_product && $product && 0.0 === (float) $product->get_price() )
 		) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout does not support free products.' );
 			return false;
 		}
 
-		if ( $this->is_product() && in_array( $this->get_product()->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
-			$stock_availability = array_column( $this->get_product()->get_available_variations(), 'is_in_stock' );
+		if ( $is_product && $product && in_array( $product->get_type(), [ 'variable', 'variable-subscription' ], true ) ) {
+			$stock_availability = array_column( $product->get_available_variations(), 'is_in_stock' );
 			// Don't show if all product variations are out-of-stock.
 			if ( ! in_array( true, $stock_availability, true ) ) {
-				WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due to product variations being out of stock. Product ID: ' . $this->get_product()->get_id() );
+				WC_Stripe_Logger::log( 'Stripe Express Checkout is hidden due to product variations being out of stock. Product ID: ' . $product->get_id() );
 				return false;
 			}
 		}
@@ -708,6 +725,9 @@ class WC_Stripe_Express_Checkout_Helper {
 		// Product page: check the product's tax status.
 		if ( is_product() ) {
 			$product = $this->get_product();
+			if ( ! $product ) {
+				return false;
+			}
 			return $product->get_tax_status() !== 'none';
 		}
 
@@ -743,6 +763,9 @@ class WC_Stripe_Express_Checkout_Helper {
 		// Product page.
 		if ( is_product() ) {
 			$product = $this->get_product();
+			if ( ! $product ) {
+				return false;
+			}
 			return wc_shipping_enabled() &&
 				0 !== wc_get_shipping_method_count( true ) &&
 				$product->needs_shipping();
@@ -809,7 +832,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
-	 * Returns true if a the provided product is supported, false otherwise.
+	 * Returns true if the provided product is supported, false otherwise.
 	 *
 	 * @param WC_Product $param  The product that's being checked for support.
 	 *

--- a/readme.txt
+++ b/readme.txt
@@ -121,5 +121,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
 * Fix - Add caching for the Stripe Payment Method Configuration API
+* Fix - Prevents fatal errors for cases where we fail to load product details
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-410

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

The main purpose of this PR is to address a fatal error in `WC_Stripe_Express_Checkout_Helper` that we identified from internal logs. However, the PR also makes three broader changes:
 * The PHPDoc for `WC_Stripe_Express_Checkout_Helper->get_product()` has been updated to reflect that it may return `false`, which reflects both the code in the function and the possible return values from `wc_get_product()`
 * Various blocks of code in `WC_Stripe_Express_Checkout_Helper` that call `$this->get_product()` have been updated to add defensive checks for a false/non-object return value.
   - The specific fatal we identified from our logs was in the following code block where `$this->get_product()->get_id()` would trigger a fatal
https://github.com/woocommerce/woocommerce-gateway-stripe/blob/3bc7a8c86d2bdb6203915fb1dd6ca6f00d8fb0f4/includes/payment-methods/class-wc-stripe-express-checkout-helper.php#L629-L633
 * I refactored the code in `WC_Stripe_Express_Checkout_Helper->should_show_express_checkout_button()` to use local variables for the return values from `$this->is_product()` and `$this->get_product()` - we shouldn't need to repeat that logic within the code block.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Set up a test site with the Stripe gateway active, and express checkout enabled
* Create or edit a page that includes the `shortcode` block, and add `[product_page id="12345678"]` to the block, where 12345678 is any non-existent product ID
* Publish the page
* View the page without this patch, and verify that you get a fatal error
* Apply this patch, and verify that the page displays correctly
* Navigate to _WooCommerce_ -> _Status_ -> _Logs_ and view the current `woocommerce-gateway-stripe` logs
* Verify that you see a log entry with the text: 
```
Failed to identify product; not showing Stripe Express Checkout. Current URI: /path-to-your-page/`
```

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [N/A] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
