### PR TITLE
Reduce SPE e2e tests flakiness

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Dev - Updates the Code Sniffer package to version 1.0.0.
 * Fix - Add caching for the Stripe Payment Method Configuration API
 * Fix - Prevent deletion of webhooks for other tools
+* Dev - Improve SPE e2e tests to reduce flakiness
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/readme.txt
+++ b/readme.txt
@@ -122,5 +122,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Updates the Code Sniffer package to version 1.0.0.
 * Fix - Add caching for the Stripe Payment Method Configuration API
 * Fix - Prevent deletion of webhooks for other tools
+* Dev - Improve SPE e2e tests to reduce flakiness
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/blocks/spe.spec.js
+++ b/tests/e2e/tests/checkout/blocks/spe.spec.js
@@ -9,6 +9,7 @@ const {
 	setupBlocksCheckout,
 	setupSPECheckout,
 	fillSPEDetails,
+	clickPlaceOrder,
 } = payments;
 
 test.describe( 'SPE payment tests @blocks', () => {
@@ -38,7 +39,7 @@ test.describe( 'SPE payment tests @blocks', () => {
 	test( 'customer can pay with SPE @smoke', async ( { page } ) => {
 		await setupSPECheckout( page, 'blocks' );
 		await fillSPEDetails( page, config.get( 'cards.basic' ) );
-		await page.locator( 'text=Place order' ).click();
+		await clickPlaceOrder( page );
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
@@ -59,9 +60,8 @@ test.describe( 'SPE payment tests @blocks', () => {
 				);
 				await setupSPECheckout( page, 'blocks' );
 				await page.getByLabel( 'Save payment information' ).click();
-				// await page.locator( 'text=Place order' ).click();
 				await fillSPEDetails( page, config.get( 'cards.basic' ) );
-				await page.locator( 'text=Place order' ).click();
+				await clickPlaceOrder( page );
 				await page.waitForURL( '**/checkout/order-received/**' );
 				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 					'Order received'
@@ -83,7 +83,7 @@ test.describe( 'SPE payment tests @blocks', () => {
 					.locator( 'label' )
 					.filter( { hasText: 'Visa ending in 4242 (expires' } )
 					.click();
-				await page.locator( 'text=Place order' ).click();
+				await clickPlaceOrder( page );
 				await page.waitForURL( '**/checkout/order-received/**' );
 				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 					'Order received'

--- a/tests/e2e/tests/checkout/shortcode/spe.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/spe.spec.js
@@ -9,6 +9,7 @@ const {
 	setupShortcodeCheckout,
 	setupSPECheckout,
 	fillSPEDetails,
+	clickPlaceOrder,
 } = payments;
 
 test.describe( 'SPE payment tests @shortcode', () => {
@@ -38,7 +39,7 @@ test.describe( 'SPE payment tests @shortcode', () => {
 	test( 'customer can pay with SPE @smoke', async ( { page } ) => {
 		await setupSPECheckout( page, 'shortcode' );
 		await fillSPEDetails( page, config.get( 'cards.basic' ), 'shortcode' );
-		await page.locator( 'text=Place order' ).click();
+		await clickPlaceOrder( page );
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'
@@ -68,7 +69,7 @@ test.describe( 'SPE payment tests @shortcode', () => {
 						name: 'Save payment information to',
 					} )
 					.check( { force: true } );
-				await page.locator( 'text=Place order' ).click();
+				await clickPlaceOrder( page );
 				await fillSPEDetails(
 					page,
 					config.get( 'cards.basic' ),
@@ -97,7 +98,7 @@ test.describe( 'SPE payment tests @shortcode', () => {
 					.locator( '.woocommerce-SavedPaymentMethods-token' )
 					.first()
 					.click();
-				await page.locator( 'text=Place order' ).click();
+				await clickPlaceOrder( page );
 				await page.waitForURL( '**/checkout/order-received/**' );
 				await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 					'Order received'


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

This PR is an attempt to reduce the flakiness around SPE tests. This replaces the use of `page.locator( 'text=Place order' ).click();` with existing `clickPlaceOrder` function which handles the place order action better by waiting for the button to be available and dispatching the click event rather than clicking the button directly. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
We mostly need a code review. 
In addition:
- Check if the tests pass on GH ✅ 
- Run the tests locally with `npm run test:e2e-spe`. Make sure they pass.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
