### PR TITLE
ECE: enforce separate location settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
+* Fix - Fixes Amazon Pay display inside the Apple Pay/Google Pay container. And location settings for those methods affecting each other
 * Dev - Upgrades the `nock` NPM package to version `^13.5.6` to remove the lodash.set dependency
 * Add - Add a new filter allowing third-party plugins to hook captcha solutions when creating and confirming setup intents
 * Dev - Add track events when clicking the "Reconnect to Stripe" button (both in the settings page and the admin notice)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
-* Fix - Fixes Amazon Pay display inside the Apple Pay/Google Pay container. And location settings for those methods affecting each other
+* Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Update - Remove `redirect_url` parameter from ECE payment flow
 * Fix - Adjust UI spacing of help text on express checkout theme settings page
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout

--- a/client/entrypoints/amazon-pay-settings/express-checkout-preview-component.js
+++ b/client/entrypoints/amazon-pay-settings/express-checkout-preview-component.js
@@ -44,6 +44,10 @@ const ExpressCheckoutPreviewComponent = ( { size } ) => {
 		buttonHeight: Math.min( Math.max( height, 40 ), 55 ),
 		paymentMethods: {
 			amazonPay: 'auto',
+			link: 'never',
+			googlePay: 'never',
+			applePay: 'never',
+			klarna: 'never',
 		},
 		layout: { overflow: 'never' },
 	};

--- a/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
+++ b/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
@@ -84,6 +84,7 @@ const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 			link: 'never',
 			googlePay: 'always',
 			applePay: 'always',
+			amazonPay: 'never',
 		},
 		layout: { overflow: 'never' },
 	};

--- a/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
+++ b/client/entrypoints/express-checkout-settings/express-checkout-preview-component.js
@@ -85,6 +85,7 @@ const ExpressCheckoutPreviewComponent = ( { buttonType, theme, size } ) => {
 			googlePay: 'always',
 			applePay: 'always',
 			amazonPay: 'never',
+			klarna: 'never',
 		},
 		layout: { overflow: 'never' },
 	};

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -46,8 +46,8 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 		$this->payment_request_configuration = null !== $payment_request_configuration ? $payment_request_configuration : new WC_Stripe_Payment_Request();
 
 		if ( null === $express_checkout_configuration ) {
-			$helper = new WC_Stripe_Express_Checkout_Helper();
-			$ajax_handler = new WC_Stripe_Express_Checkout_Ajax_Handler( $helper );
+			$helper                         = new WC_Stripe_Express_Checkout_Helper();
+			$ajax_handler                   = new WC_Stripe_Express_Checkout_Ajax_Handler( $helper );
 			$express_checkout_configuration = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
 		}
 		$this->express_checkout_configuration = $express_checkout_configuration;
@@ -278,35 +278,6 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return boolean True if ECEs should be displayed, false otherwise.
 	 */
 	private function should_show_express_checkout_button() {
-		// Don't show if ECEs are turned off in settings.
-		if ( ! $this->express_checkout_configuration->express_checkout_helper->is_express_checkout_enabled() ) {
-			return false;
-		}
-
-		// Don't show if ECEs are supposed to be hidden on the cart page.
-		if (
-			has_block( 'woocommerce/cart' )
-			&& ! $this->express_checkout_configuration->express_checkout_helper->should_show_ece_on_cart_page()
-		) {
-			return false;
-		}
-
-		// Don't show if ECEs are supposed to be hidden on the checkout page.
-		if (
-			has_block( 'woocommerce/checkout' )
-			&& ! $this->express_checkout_configuration->express_checkout_helper->should_show_ece_on_checkout_page()
-		) {
-			return false;
-		}
-
-		// Don't show ECEs if there are unsupported products in the cart.
-		if (
-			( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) )
-			&& ! $this->express_checkout_configuration->express_checkout_helper->allowed_items_in_cart()
-		) {
-			return false;
-		}
-
 		return $this->express_checkout_configuration->express_checkout_helper->should_show_express_checkout_button();
 	}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -548,7 +548,7 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
-		if ( is_checkout() && ! in_array( 'checkout', $this->express_checkout_helper->get_button_locations(), true ) ) {
+		if ( is_checkout() && ! $this->express_checkout_helper->should_show_on_checkout_page() ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -236,7 +236,7 @@ class WC_Stripe_Express_Checkout_Element {
 			'is_product_page'            => $this->express_checkout_helper->is_product(),
 			'is_checkout_page'           => $this->express_checkout_helper->is_checkout(),
 			'product'                    => $this->express_checkout_helper->get_product_data(),
-			'is_cart_page'               => is_cart(),
+			'is_cart_page'               => $this->express_checkout_helper->is_cart(),
 			'taxes_based_on_billing'     => wc_tax_enabled() && get_option( 'woocommerce_tax_based_on' ) === 'billing',
 			'allowed_shipping_countries' => $this->express_checkout_helper->get_allowed_shipping_countries(),
 			'custom_checkout_fields'     => ( new WC_Stripe_Express_Checkout_Custom_Fields() )->get_custom_checkout_fields(),

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -544,11 +544,11 @@ class WC_Stripe_Express_Checkout_Element {
 	 * Display express checkout button separator.
 	 */
 	public function display_express_checkout_button_separator_html() {
-		if ( ! is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) ) {
+		if ( ! $this->express_checkout_helper->is_checkout() && ! is_wc_endpoint_url( 'order-pay' ) ) {
 			return;
 		}
 
-		if ( is_checkout() && ! $this->express_checkout_helper->should_show_ece_on_checkout_page() ) {
+		if ( $this->express_checkout_helper->is_checkout() && ! $this->express_checkout_helper->should_show_ece_on_checkout_page() ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -548,7 +548,7 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
-		if ( is_checkout() && ! $this->express_checkout_helper->should_show_on_checkout_page() ) {
+		if ( is_checkout() && ! $this->express_checkout_helper->should_show_ece_on_checkout_page() ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -677,13 +677,13 @@ class WC_Stripe_Express_Checkout_Helper {
 		}
 
 		// Don't show on cart if disabled.
-		if ( is_cart() && ! $this->should_show_ece_on_cart_page() ) {
+		if ( $this->is_cart() && ! $this->should_show_ece_on_cart_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on cart is disabled. ' );
 			return false;
 		}
 
 		// Don't show on checkout if disabled.
-		if ( is_checkout() && ! $this->should_show_ece_on_checkout_page() ) {
+		if ( $this->is_checkout() && ! $this->should_show_ece_on_checkout_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
 			return false;
 		}
@@ -842,13 +842,13 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
-	 * Returns true if express checkout buttons are enabled on the cart page, false
+	 * Returns true if any express checkout buttons are enabled on the cart page, false
 	 * otherwise.
 	 *
-	 * @return  boolean  True if express checkout buttons are enabled on the cart page, false otherwise
+	 * @return  boolean  True if any express checkout buttons are enabled on the cart page, false otherwise.
 	 */
 	public function should_show_ece_on_cart_page() {
-		$should_show_on_cart_page = in_array( 'cart', $this->get_button_locations(), true );
+		$should_show_on_cart_page = $this->should_show_ece_on_page( 'cart' );
 
 		return apply_filters(
 			'wc_stripe_show_payment_request_on_cart',
@@ -865,7 +865,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	public function should_show_ece_on_checkout_page() {
 		global $post;
 
-		$should_show_on_checkout_page = in_array( 'checkout', $this->get_button_locations(), true );
+		$should_show_on_checkout_page = $this->should_show_ece_on_page( 'checkout' );
 
 		return apply_filters(
 			'wc_stripe_show_payment_request_on_checkout',
@@ -875,15 +875,15 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
-	 * Returns true if express checkout buttons are enabled on product pages, false
+	 * Returns true if any express checkout buttons are enabled on product pages, false
 	 * otherwise.
 	 *
-	 * @return  boolean  True if express checkout buttons are enabled on product pages, false otherwise
+	 * @return  boolean  True if any express checkout buttons are enabled on product pages, false otherwise
 	 */
 	public function should_show_ece_on_product_pages() {
 		global $post;
 
-		$should_show_on_product_page = in_array( 'product', $this->get_button_locations(), true );
+		$should_show_on_product_page = $this->should_show_ece_on_page( 'product' );
 
 		// Note the negation because if the filter returns `true` that means we should hide the PRB.
 		return ! apply_filters(
@@ -891,6 +891,18 @@ class WC_Stripe_Express_Checkout_Helper {
 			! $should_show_on_product_page,
 			$post
 		);
+	}
+
+	/**
+	 * Returns true if any express checkout buttons are enabled on the given page, false
+	 * otherwise.
+	 *
+	 * @param string $page The page to check.
+	 * @return boolean True if any express checkout buttons are enabled on the given page, false otherwise.
+	 */
+	private function should_show_ece_on_page( $page ) {
+		return $this->is_enabled_for_location( 'payment_request', $page ) ||
+			$this->is_enabled_for_location( 'amazon_pay', $page );
 	}
 
 	/**
@@ -1379,6 +1391,15 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
+	 * Checks if this is the cart page or content contains a cart block.
+	 *
+	 * @return boolean
+	 */
+	public function is_cart() {
+		return is_cart() || has_block( 'woocommerce/cart' );
+	}
+
+	/**
 	 * Builds the shippings methods to pass to express checkout elements.
 	 */
 	protected function build_shipping_methods( $shipping_methods ) {
@@ -1549,22 +1570,52 @@ class WC_Stripe_Express_Checkout_Helper {
 	/**
 	 * Pages where the express checkout buttons should be displayed.
 	 *
+	 * @param string $express_checkout_type The type of express checkout.
 	 * @return array
 	 */
-	public function get_button_locations() {
-		// If the locations have not been set return the default setting.
-		if ( ! isset( $this->stripe_settings['payment_request_button_locations'] ) ) {
-			return [ 'product', 'cart' ];
+	public function get_button_locations( $express_checkout_type ) {
+		switch ( $express_checkout_type ) {
+			case 'payment_request':
+				$key = 'payment_request_button_locations';
+				break;
+			case 'link':
+				// Link does not yet have its own Customize page. It shares the same location settings
+				// as Apple Pay and Google Pay.
+				$key = 'payment_request_button_locations';
+				break;
+			case 'amazon_pay':
+				$key = 'amazon_pay_button_locations';
+				break;
+			default:
+				$key = 'payment_request_button_locations';
+				break;
 		}
 
-		// If all locations are removed through the settings UI the location config will be set to
-		// an empty string "". If that's the case (and if the settings are not an array for any
-		// other reason) we should return an empty array.
-		if ( ! is_array( $this->stripe_settings['payment_request_button_locations'] ) ) {
-			return [];
+		if ( ! isset( $this->stripe_settings[ $key ] ) ) {
+			// If the locations have not been set/modified, return the default setting.
+			$enabled_locations = [ 'product', 'cart' ];
+		} elseif ( ! is_array( $this->stripe_settings[ $key ] ) ) {
+			// If all locations are removed through the settings UI the location config will be set to
+			// an empty string "". If that's the case (and if the settings are not an array for any
+			// other reason) we should return an empty array.
+			$enabled_locations = [];
+		} else {
+			$enabled_locations = $this->stripe_settings[ $key ];
 		}
 
-		return $this->stripe_settings['payment_request_button_locations'];
+		return $enabled_locations;
+	}
+
+	/**
+	 * Check if the express checkout type is enabled for the given location.
+	 *
+	 * @param string $express_checkout_type The type of express checkout.
+	 * @param string $location The location to check.
+	 * @return boolean
+	 */
+	public function is_enabled_for_location( $express_checkout_type = 'payment_request', $location = '' ) {
+		$enabled_locations = $this->get_button_locations( $express_checkout_type );
+		return in_array( $location, $enabled_locations, true );
 	}
 
 	/**
@@ -1584,7 +1635,14 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return boolean
 	 */
 	public function is_payment_request_enabled() {
-		return $this->gateway->is_payment_request_enabled();
+		$is_enabled = $this->gateway->is_payment_request_enabled();
+		if ( is_product() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'product' );
+		} elseif ( is_cart() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'cart' );
+		}
+
+		return $is_enabled;
 	}
 
 	/**
@@ -1593,7 +1651,14 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return boolean
 	 */
 	public function is_amazon_pay_enabled() {
-		return WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled( $this->gateway );
+		$is_enabled = WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled( $this->gateway );
+		if ( is_product() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'product' );
+		} elseif ( is_cart() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'cart' );
+		}
+
+		return $is_enabled;
 	}
 
 	/**
@@ -1602,7 +1667,14 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return boolean
 	 */
 	public function is_link_enabled() {
-		return WC_Stripe_UPE_Payment_Method_Link::is_link_enabled( $this->gateway );
+		$is_enabled = WC_Stripe_UPE_Payment_Method_Link::is_link_enabled( $this->gateway );
+		if ( is_product() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'link', 'product' );
+		} elseif ( is_cart() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'link', 'cart' );
+		}
+
+		return $is_enabled;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1570,10 +1570,10 @@ class WC_Stripe_Express_Checkout_Helper {
 	/**
 	 * Pages where the express checkout buttons should be displayed.
 	 *
-	 * @param string $express_checkout_type The type of express checkout.
+	 * @param string|null $express_checkout_type The type of express checkout.
 	 * @return array
 	 */
-	public function get_button_locations( $express_checkout_type ) {
+	public function get_button_locations( ?string $express_checkout_type = null ) {
 		switch ( $express_checkout_type ) {
 			case 'amazon_pay':
 				$key = 'amazon_pay_button_locations';

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1575,17 +1575,11 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function get_button_locations( $express_checkout_type ) {
 		switch ( $express_checkout_type ) {
-			case 'payment_request':
-				$key = 'payment_request_button_locations';
-				break;
-			case 'link':
-				// Link does not yet have its own Customize page. It shares the same location settings
-				// as Apple Pay and Google Pay.
-				$key = 'payment_request_button_locations';
-				break;
 			case 'amazon_pay':
 				$key = 'amazon_pay_button_locations';
 				break;
+			case 'payment_request':
+			case 'link': // Link does not yet have its own Customize page. It shares the same location settings as Apple Pay and Google Pay.
 			default:
 				$key = 'payment_request_button_locations';
 				break;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1630,6 +1630,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_enabled_for_location( string $express_checkout_type = 'payment_request', string $location = '' ): bool {
 		$enabled_locations = $this->get_button_locations( $express_checkout_type );
+
 		return in_array( $location, $enabled_locations, true );
 	}
 
@@ -1645,25 +1646,37 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
+	 * Checks if the given express checkout type is enabled for the current page context.
+	 *
+	 * @param string $express_checkout_type The type of express checkout.
+	 *
+	 * @return boolean
+	 */
+	private function is_enabled_for_current_context( string $express_checkout_type ): bool {
+		if ( $this->is_product() ) {
+			return $this->is_enabled_for_location( $express_checkout_type, 'product' );
+		}
+
+		if ( $this->is_cart() ) {
+			return $this->is_enabled_for_location( $express_checkout_type, 'cart' );
+		}
+
+		if ( $this->is_checkout() ) {
+			return $this->is_enabled_for_location( $express_checkout_type, 'checkout' );
+		}
+
+		return true;
+	}
+
+	/**
 	 * Checks if Apple Pay and Google Pay buttons are enabled.
 	 *
 	 * @return boolean
 	 */
 	public function is_payment_request_enabled() {
 		$is_enabled = $this->gateway->is_payment_request_enabled();
-		if ( $this->is_product() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'product' );
-		}
 
-		if ( $this->is_cart() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'cart' );
-		}
-
-		if ( $this->is_checkout() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'checkout' );
-		}
-
-		return $is_enabled;
+		return $is_enabled && $this->is_enabled_for_current_context( 'payment_request' );
 	}
 
 	/**
@@ -1673,19 +1686,8 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_amazon_pay_enabled() {
 		$is_enabled = WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled( $this->gateway );
-		if ( $this->is_product() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'product' );
-		}
 
-		if ( $this->is_cart() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'cart' );
-		}
-
-		if ( $this->is_checkout() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'checkout' );
-		}
-
-		return $is_enabled;
+		return $is_enabled && $this->is_enabled_for_current_context( 'amazon_pay' );
 	}
 
 	/**
@@ -1695,19 +1697,8 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_link_enabled() {
 		$is_enabled = WC_Stripe_UPE_Payment_Method_Link::is_link_enabled( $this->gateway );
-		if ( $this->is_product() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'link', 'product' );
-		}
 
-		if ( $this->is_cart() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'link', 'cart' );
-		}
-
-		if ( $this->is_checkout() ) {
-			return $is_enabled && $this->is_enabled_for_location( 'link', 'checkout' );
-		}
-
-		return $is_enabled;
+		return $is_enabled && $this->is_enabled_for_current_context( 'link' );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -92,7 +92,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		$is_signup_on_checkout_allowed =
 			'yes' === get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'no' ) ||
 			( $this->has_subscription_product() &&
-			  'yes' === get_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'no' ) );
+				'yes' === get_option( 'woocommerce_enable_signup_from_checkout_for_subscriptions', 'no' ) );
 
 		// Account creation is not possible for express checkout if we cannot automatically generate the username and password.
 		$username_password_generation_enabled =
@@ -583,8 +583,8 @@ class WC_Stripe_Express_Checkout_Helper {
 				return false;
 			}
 			if ( class_exists( 'WC_Subscriptions_Product' )
-			     && WC_Subscriptions_Product::is_subscription( $product )
-			     && WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
+				&& WC_Subscriptions_Product::is_subscription( $product )
+				&& WC_Subscriptions_Product::get_trial_length( $product ) > 0 ) {
 				return true;
 			}
 		} elseif ( WC_Stripe_Helper::has_cart_or_checkout_on_current_page() ) {
@@ -636,8 +636,8 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_page_supported() {
 		return $this->is_product()
-		       || WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
-		       || is_wc_endpoint_url( 'order-pay' );
+				|| WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
+				|| is_wc_endpoint_url( 'order-pay' );
 	}
 
 	/**
@@ -829,8 +829,8 @@ class WC_Stripe_Express_Checkout_Helper {
 				return false;
 			}
 			return wc_shipping_enabled() &&
-			       0 !== wc_get_shipping_method_count( true ) &&
-			       $product->needs_shipping();
+					0 !== wc_get_shipping_method_count( true ) &&
+					$product->needs_shipping();
 		}
 
 		// Cart or checkout page.
@@ -902,7 +902,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	private function should_show_ece_on_page( $page ) {
 		return $this->is_enabled_for_location( 'payment_request', $page ) ||
-		       $this->is_enabled_for_location( 'amazon_pay', $page );
+				$this->is_enabled_for_location( 'amazon_pay', $page );
 	}
 
 	/**
@@ -1619,8 +1619,8 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_express_checkout_enabled() {
 		return $this->is_payment_request_enabled() ||
-		       $this->is_amazon_pay_enabled() ||
-		       $this->is_link_enabled();
+				$this->is_amazon_pay_enabled() ||
+				$this->is_link_enabled();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -848,7 +848,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return  boolean  True if any express checkout buttons are enabled on the cart page, false otherwise
 	 */
 	public function should_show_ece_on_cart_page() {
-		$should_show_on_cart_page = $this->should_show_ece_on_page( 'cart' );
+		$should_show_on_cart_page = $this->should_show_ece_on_location( 'cart' );
 
 		return apply_filters(
 			'wc_stripe_show_payment_request_on_cart',
@@ -865,7 +865,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	public function should_show_ece_on_checkout_page() {
 		global $post;
 
-		$should_show_on_checkout_page = $this->should_show_ece_on_page( 'checkout' );
+		$should_show_on_checkout_page = $this->should_show_ece_on_location( 'checkout' );
 
 		return apply_filters(
 			'wc_stripe_show_payment_request_on_checkout',
@@ -883,7 +883,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	public function should_show_ece_on_product_pages() {
 		global $post;
 
-		$should_show_on_product_page = $this->should_show_ece_on_page( 'product' );
+		$should_show_on_product_page = $this->should_show_ece_on_location( 'product' );
 
 		// Note the negation because if the filter returns `true` that means we should hide the PRB.
 		return ! apply_filters(
@@ -894,15 +894,16 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
-	 * Returns true if any express checkout buttons are enabled on the given page, false
+	 * Returns true if any express checkout buttons are enabled on the given location, false
 	 * otherwise.
 	 *
-	 * @param string $page The page to check.
+	 * @param string $location The location to check.
+	 *
 	 * @return boolean True if any express checkout buttons are enabled on the given page, false otherwise.
 	 */
-	private function should_show_ece_on_page( $page ) {
-		return $this->is_enabled_for_location( 'payment_request', $page ) ||
-				$this->is_enabled_for_location( 'amazon_pay', $page );
+	private function should_show_ece_on_location( string $location ): bool {
+		return $this->is_enabled_for_location( 'payment_request', $location ) ||
+				$this->is_enabled_for_location( 'amazon_pay', $location );
 	}
 
 	/**
@@ -1573,7 +1574,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @param string|null $express_checkout_type The type of express checkout.
 	 * @return array
 	 */
-	public function get_button_locations( ?string $express_checkout_type = null ) {
+	public function get_button_locations( ?string $express_checkout_type = null ): array {
 		switch ( $express_checkout_type ) {
 			case 'amazon_pay':
 				$key = 'amazon_pay_button_locations';
@@ -1587,17 +1588,17 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		if ( ! isset( $this->stripe_settings[ $key ] ) ) {
 			// If the locations have not been set/modified, return the default setting.
-			$enabled_locations = [ 'product', 'cart' ];
-		} elseif ( ! is_array( $this->stripe_settings[ $key ] ) ) {
+			return [ 'product', 'cart' ];
+		}
+
+		if ( ! is_array( $this->stripe_settings[ $key ] ) ) {
 			// If all locations are removed through the settings UI the location config will be set to
 			// an empty string "". If that's the case (and if the settings are not an array for any
 			// other reason) we should return an empty array.
-			$enabled_locations = [];
-		} else {
-			$enabled_locations = $this->stripe_settings[ $key ];
+			return [];
 		}
 
-		return $enabled_locations;
+		return $this->stripe_settings[ $key ];
 	}
 
 	/**
@@ -1605,9 +1606,10 @@ class WC_Stripe_Express_Checkout_Helper {
 	 *
 	 * @param string $express_checkout_type The type of express checkout.
 	 * @param string $location The location to check.
+	 *
 	 * @return boolean
 	 */
-	public function is_enabled_for_location( $express_checkout_type = 'payment_request', $location = '' ) {
+	public function is_enabled_for_location( string $express_checkout_type = 'payment_request', string $location = '' ): bool {
 		$enabled_locations = $this->get_button_locations( $express_checkout_type );
 		return in_array( $location, $enabled_locations, true );
 	}
@@ -1630,11 +1632,15 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_payment_request_enabled() {
 		$is_enabled = $this->gateway->is_payment_request_enabled();
-		if ( is_product() ) {
+		if ( $this->is_product() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'product' );
-		} elseif ( $this->is_cart() ) {
+		}
+
+		if ( $this->is_cart() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'cart' );
-		} elseif ( $this->is_checkout() ) {
+		}
+
+		if ( $this->is_checkout() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'checkout' );
 		}
 
@@ -1648,11 +1654,15 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_amazon_pay_enabled() {
 		$is_enabled = WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_enabled( $this->gateway );
-		if ( is_product() ) {
+		if ( $this->is_product() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'product' );
-		} elseif ( $this->is_cart() ) {
+		}
+
+		if ( $this->is_cart() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'cart' );
-		} elseif ( $this->is_checkout() ) {
+		}
+
+		if ( $this->is_checkout() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'checkout' );
 		}
 
@@ -1666,11 +1676,15 @@ class WC_Stripe_Express_Checkout_Helper {
 	 */
 	public function is_link_enabled() {
 		$is_enabled = WC_Stripe_UPE_Payment_Method_Link::is_link_enabled( $this->gateway );
-		if ( is_product() ) {
+		if ( $this->is_product() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'link', 'product' );
-		} elseif ( $this->is_cart() ) {
+		}
+
+		if ( $this->is_cart() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'link', 'cart' );
-		} elseif ( $this->is_checkout() ) {
+		}
+
+		if ( $this->is_checkout() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'link', 'checkout' );
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -683,7 +683,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		}
 
 		// Don't show on checkout if disabled.
-		if ( is_checkout() && ! $this->should_show_ece_on_checkout_page() ) {
+		if ( $this->is_checkout() && ! $this->should_show_ece_on_checkout_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
 			return false;
 		}
@@ -1634,6 +1634,8 @@ class WC_Stripe_Express_Checkout_Helper {
 			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'product' );
 		} elseif ( $this->is_cart() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'cart' );
+		} elseif ( $this->is_checkout() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'payment_request', 'checkout' );
 		}
 
 		return $is_enabled;
@@ -1650,6 +1652,8 @@ class WC_Stripe_Express_Checkout_Helper {
 			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'product' );
 		} elseif ( $this->is_cart() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'cart' );
+		} elseif ( $this->is_checkout() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'amazon_pay', 'checkout' );
 		}
 
 		return $is_enabled;
@@ -1666,6 +1670,8 @@ class WC_Stripe_Express_Checkout_Helper {
 			return $is_enabled && $this->is_enabled_for_location( 'link', 'product' );
 		} elseif ( $this->is_cart() ) {
 			return $is_enabled && $this->is_enabled_for_location( 'link', 'cart' );
+		} elseif ( $this->is_checkout() ) {
+			return $is_enabled && $this->is_enabled_for_location( 'link', 'checkout' );
 		}
 
 		return $is_enabled;

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.1.0 - xxxx-xx-xx =
+* Fix - Fixes Amazon Pay display inside the Apple Pay/Google Pay container. And location settings for those methods affecting each other
 * Dev - Upgrades the `nock` NPM package to version `^13.5.6` to remove the lodash.set dependency
 * Add - Add a new filter allowing third-party plugins to hook captcha solutions when creating and confirming setup intents
 * Dev - Add track events when clicking the "Reconnect to Stripe" button (both in the settings page and the admin notice)

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
@@ -355,15 +355,6 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'get_button_locations' ] )
-			->getMock();
-
-		$helper->expects( $this->any() )
-			->method( 'get_button_locations' )
-			->willReturn( [ $button_location ] );
-
 		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
 
 		ob_start();

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
@@ -355,6 +355,15 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_button_locations' ] )
+			->getMock();
+
+		$helper->expects( $this->any() )
+			->method( 'get_button_locations' )
+			->willReturn( [ $button_location ] );
+
 		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
 
 		ob_start();

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -984,4 +984,110 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Tests for `is_cart`.
+	 *
+	 * @return void
+	 */
+	public function test_is_cart(): void {
+		add_filter( 'woocommerce_is_cart', '__return_true' );
+
+		$helper = new WC_Stripe_Express_Checkout_Helper();
+
+		$actual = $helper->is_cart();
+
+		// Clean up.
+		remove_filter( 'woocommerce_is_cart', '__return_true' );
+
+		$this->assertTrue( $actual );
+
+		$actual = $helper->is_cart();
+
+		$this->assertFalse( $actual );
+	}
+
+	/**
+	 * Teats for `get_button_locations`.
+	 *
+	 * @param string $express_checkout_type Express checkout type.
+	 * @param array  $settings              Settings array.
+	 * @param array  $expected              Expected locations.
+	 * @return void
+	 *
+	 * @dataProvider provide_test_get_button_locations
+	 */
+	public function test_get_button_locations( string $express_checkout_type, array $settings = [], $expected = [] ): void {
+		$helper = new WC_Stripe_Express_Checkout_Helper();
+		$helper->stripe_settings = $settings;
+
+		$actual = $helper->get_button_locations( $express_checkout_type );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	public function provide_test_get_button_locations(): array {
+		return [
+			'payment request, settings exists' => [
+				'express checkout type' => 'payment_request',
+				'settings'              => [ 'payment_request_button_locations' => [ 'checkout', 'cart' ] ],
+				'expected'              => [ 'checkout', 'cart' ],
+			],
+			'payment request, settings exists, but not a valid array' => [
+				'express checkout type' => 'payment_request',
+				'settings'              => [ 'payment_request_button_locations' => 'invalid_value' ],
+				'expected'              => [],
+			],
+			'payment request, settings do not exist' => [
+				'express checkout type' => 'payment_request',
+				'settings'              => [],
+				'expected'              => [ 'product', 'cart' ],
+			],
+			'link, settings exists' => [
+				'express checkout type' => 'link',
+				'settings'              => [ 'payment_request_button_locations' => [ 'cart' ] ],
+				'expected'              => [ 'cart' ],
+			],
+			'link, settings exists, but not a valid array' => [
+				'express checkout type' => 'link',
+				'settings'              => [ 'payment_request_button_locations' => 'invalid_value' ],
+				'expected'              => [],
+			],
+			'link, settings do not exist' => [
+				'express checkout type' => 'link',
+				'settings'              => [],
+				'expected'              => [ 'product', 'cart' ],
+			],
+			'amazon pay, settings exists' => [
+				'express checkout type' => 'amazon_pay',
+				'settings'              => [ 'amazon_pay_button_locations' => [ 'checkout' ] ],
+				'expected'              => [ 'checkout' ],
+			],
+			'amazon pay, settings exists, but not a valid array' => [
+				'express checkout type' => 'amazon_pay',
+				'settings'              => [ 'amazon_pay_button_locations' => 'invalid_value' ],
+				'expected'              => [],
+			],
+			'amazon pay, settings do not exist' => [
+				'express checkout type' => 'amazon_pay',
+				'settings'              => [],
+				'expected'              => [ 'product', 'cart' ],
+			],
+			'default, settings exists' => [
+				'express checkout type' => 'default',
+				'settings'              => [ 'payment_request_button_locations' => [ 'checkout', 'cart' ] ],
+				'expected'              => [ 'checkout', 'cart' ],
+			],
+			'default, settings exists, but not a valid array' => [
+				'express checkout type' => 'default',
+				'settings'              => [ 'payment_request_button_locations' => 'invalid_value' ],
+				'expected'              => [],
+			],
+			'default, settings do not exist' => [
+				'express checkout type' => 'default',
+				'settings'              => [],
+				'expected'              => [ 'product', 'cart' ],
+			],
+		];
+	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1030,12 +1030,12 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		return [
 			'payment request, settings exists' => [
 				'express checkout type' => 'payment_request',
-				'settings'              => [ 'payment_request_button_locations' => [ 'checkout', 'cart' ] ],
+				'settings'              => [ 'express_checkout_button_locations' => [ 'checkout', 'cart' ] ],
 				'expected'              => [ 'checkout', 'cart' ],
 			],
 			'payment request, settings exists, but not a valid array' => [
 				'express checkout type' => 'payment_request',
-				'settings'              => [ 'payment_request_button_locations' => 'invalid_value' ],
+				'settings'              => [ 'express_checkout_button_locations' => 'invalid_value' ],
 				'expected'              => [],
 			],
 			'payment request, settings do not exist' => [
@@ -1045,12 +1045,12 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 			'link, settings exists' => [
 				'express checkout type' => 'link',
-				'settings'              => [ 'payment_request_button_locations' => [ 'cart' ] ],
+				'settings'              => [ 'express_checkout_button_locations' => [ 'cart' ] ],
 				'expected'              => [ 'cart' ],
 			],
 			'link, settings exists, but not a valid array' => [
 				'express checkout type' => 'link',
-				'settings'              => [ 'payment_request_button_locations' => 'invalid_value' ],
+				'settings'              => [ 'express_checkout_button_locations' => 'invalid_value' ],
 				'expected'              => [],
 			],
 			'link, settings do not exist' => [
@@ -1075,12 +1075,12 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 			'default, settings exists' => [
 				'express checkout type' => 'default',
-				'settings'              => [ 'payment_request_button_locations' => [ 'checkout', 'cart' ] ],
+				'settings'              => [ 'express_checkout_button_locations' => [ 'checkout', 'cart' ] ],
 				'expected'              => [ 'checkout', 'cart' ],
 			],
 			'default, settings exists, but not a valid array' => [
 				'express checkout type' => 'default',
-				'settings'              => [ 'payment_request_button_locations' => 'invalid_value' ],
+				'settings'              => [ 'express_checkout_button_locations' => 'invalid_value' ],
 				'expected'              => [],
 			],
 			'default, settings do not exist' => [

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1008,7 +1008,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Teats for `get_button_locations`.
+	 * Tests for `get_button_locations`.
 	 *
 	 * @param string $express_checkout_type Express checkout type.
 	 * @param array  $settings              Settings array.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-286
Fixes #3935
## Changes proposed in this Pull Request:

- Fixes the issue where the Amazon Pay button shows up inside the Customize page for Apple Pay/Google Pay
- Fixes the issue where location settings for Amazon Pay and Apple Pay/Google Pay can affect each other.

## Testing instructions

1. Enable the  Amazon Pay feature flag: `wp option update _wcstripe_feature_amazon_pay yes`
2. Enable Amazon Pay express checkout.
3. Go to Customize, and enable it only for Checkout.
4. Enable Apple Pay/Google Pay.
5. Go to Customize, and disable it for Checkout.
6. Confirm Amazon Pay shows up on checkout, while Google Pay and Apple does not, but they show up on the other pages

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
