### PR TITLE
RFC: add feature tags to changelog

### DIFF
--- a/.changelog.features.json
+++ b/.changelog.features.json
@@ -1,0 +1,32 @@
+{
+	"features": [
+		{
+			"tag": "ACSS",
+			"description": "Add support for ACSS payments in Canada",
+			"type": "Local payment method"
+		},
+		{
+			"tag": "Amazon Pay",
+			"description": "Add support for Amazon Pay to express checkout",
+			"type": "Express checkout"
+		},
+		{
+			"tag": "BECS",
+			"description": "Add support for BECS Direct Debits in Australia",
+			"type": "Local payment method"
+		},
+		{
+			"tag": "BLIK",
+			"description": "Add support for BLIK payments in Poland",
+			"type": "Local payment method"
+		},
+		{
+			"tag": "Settings Sync",
+			"description": "Synchronize payment method settings with Stripe dashboard"
+		},
+		{
+			"tag": "Smart Checkout",
+			"description": "Add support for Smart Checkout/ Dynamic Payment Element"
+		}
+	]
+}

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -92,6 +92,12 @@ async function main() {
             value: feature,
         }));
 
+        // Ensure we have an escape hatch!
+        features.unshift({
+            name: '\u001B[3mNever mind (No feature)\u001B[23m', // Escape sequences start and stop italics
+            value: null,
+        });
+
         // Get user input
         const answers = await inquirer.prompt([
             {
@@ -120,7 +126,7 @@ async function main() {
                 name: 'feature',
                 message: 'Select the feature:',
                 choices: features,
-                default: null,
+                default: 0,
             }
         ]);
         const feature = featureAnswer?.feature ?? null;

--- a/bin/changelog.js
+++ b/bin/changelog.js
@@ -28,20 +28,31 @@ async function findUpcomingVersionSection(content) {
     throw new Error('Could not find upcoming version section (xxxx-xx-xx)');
 }
 
-async function insertChangelogEntry(filePath, entry) {
+async function insertChangelogEntry(filePath, entry, feature) {
     try {
         const content = await fs.readFile(filePath, 'utf8');
         const lines = content.split('\n');
         const { startLine, endLine } = await findUpcomingVersionSection(content);
-        
+
+        const featurePrefix = feature ? `* [${feature.tag}] ` : null;
         // Find the last entry in the current version section
+        // If we have a feature tag, track the last line with that tag
         let insertPosition = startLine + 1;
+        let lastFeatureTagLine = null;
         for (let i = startLine + 1; i <= endLine; i++) {
-            if (lines[i].trim().startsWith('*')) {
+            const currentLine = lines[i].trim();
+            if (currentLine.startsWith('*')) {
+                if (featurePrefix && currentLine.startsWith(featurePrefix)) {
+                    lastFeatureTagLine = i;
+                }
                 insertPosition = i + 1;
             }
         }
-        
+
+        if ( lastFeatureTagLine ) {
+            insertPosition = lastFeatureTagLine + 1;
+        }
+
         // Insert the new entry after the last existing entry
         lines.splice(insertPosition, 0, entry);
         
@@ -51,12 +62,34 @@ async function insertChangelogEntry(filePath, entry) {
     }
 }
 
+async function getChangelogFeatures() {
+    try {
+        const featureFileContents = await fs.readFile('.changelog.features.json', 'utf8');
+        const featureFileJSON = JSON.parse(featureFileContents);
+        if ( Array.isArray(featureFileJSON.features) ) {
+            // Require a tag and description for each feature
+            return featureFileJSON.features.filter(feature => feature.tag && feature.description);
+        }
+
+        // If 
+        throw new Error('Invalid features array in .changelog.features.json');
+    } catch (error) {
+        throw new Error(`Failed to read .changelog.features.json: ${error.message}`);
+    }
+}
+
 async function main() {
     try {
         // Prepare type choices for inquirer
         const typeChoices = Object.entries(CHANGE_TYPES).map(([type, description]) => ({
             name: `${type} - ${description}`,
             value: type
+        }));
+
+        const rawFeatures = await getChangelogFeatures();
+        const features = rawFeatures.map(feature => ({
+            name: `[${feature.tag}] - ${feature.description}` + (feature.type ? ` (${feature.type})` : ''),
+            value: feature,
         }));
 
         // Get user input
@@ -72,15 +105,33 @@ async function main() {
                 name: 'message',
                 message: 'Enter the changelog message:',
                 validate: input => input.trim().length > 0 || 'Message cannot be empty'
-            }
+            },
+            {
+                type: 'confirm',
+                name: 'isForFeature',
+                message: 'Is this change for a feature?',
+                default: false
+            },
         ]);
 
-        const entry = `* ${answers.changeType} - ${answers.message.trim()}`;
-        
+        const featureAnswer = !answers.isForFeature ? null : await inquirer.prompt([
+            {
+                type: 'list',
+                name: 'feature',
+                message: 'Select the feature:',
+                choices: features,
+                default: null,
+            }
+        ]);
+        const feature = featureAnswer?.feature ?? null;
+
+        const entryPrefix = '* ' + (feature ? `[${feature.tag}] ` : '');
+        const entry = `${entryPrefix}${answers.changeType} - ${answers.message.trim()}`;
+
         // Update both files
         const files = ['changelog.txt', 'readme.txt'];
         for (const file of files) {
-            await insertChangelogEntry(file, entry);
+            await insertChangelogEntry(file, entry, feature);
         }
 
         console.log('✅ Changelog entries added successfully to changelog.txt and readme.txt');

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Dev - Improve SPE e2e tests to reduce flakiness
 * Fix - Prevents fatal errors for cases where we fail to load product details
 * Fix - Address an edge case with webhook URL comparisons
+* Tweak - Add feature support to the changelog tool
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/readme.txt
+++ b/readme.txt
@@ -127,5 +127,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Improve SPE e2e tests to reduce flakiness
 * Fix - Prevents fatal errors for cases where we fail to load product details
 * Fix - Address an edge case with webhook URL comparisons
+* Tweak - Add feature support to the changelog tool
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
We have been discussing how to improve our changelog for our next release. I had a discussion with @diegocurbelo yesterday that solidified this idea for me: what if our automated changelog script could tag and group entries so it's easier to identify what changes did/do? That should hugely simplify the process of collating and organising our release notes and changelogs in future.

The implementation is pretty straightforward:
 * When starting a new project/feature, add an entry to `.changelog.features.json`
 * When making changes related to a feature, allow developers to pick from the available features (or skip that entirely)
 * If a change was for a feature, add a `[tag]` to the changelog entry for that specific feature

Then, when we're collating release notes or prepping the changelog for release, we can easily group features and remove any noisy/unnecessary items.

### Open questions

* How should we manage our changelog over time? Should we keep or remove the tags when we release? How should we manage `.changelog.features.json` over time? Should we keep all features in there indefinitely? Or clean it up from time to time?
  - The combined answers have implications for the usability of our basic changelog:
     * If we clean up the changelog for each release and remove all the tags, we can keep the JSON list of features small. It would mean that our develop branch would need to pick up release notes from the release, and we'd rewrite the changelog for each release, with some extra work for late patches/fixes flowing in
     * If we keep the tags in the changelog, that will generate a lot of noise. And we then need to consider whether we use a different format for the feature list, as we'll either need to maintain it in perpetuity so folks can identify what each tag means, or we'll need to keep it clean but then leave the changelog with indecipherable tags.
* Are there some internal features/categories that might make sense? e.g. CI/Tests, Tools?
  - Not directly related, but maybe we should have a separate `Test` option for the basic changelog types?

**@woocommerce/quark, please share feedback on the approach as much as the code!**

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Check out this branch locally
* Run `npm run changelog`
* Pick a change type
* Enter a changelog message
* Confirm that you see a `Is this change for a feature?` prompt
* Enter `n` or `N` to indicate it is not related to a feature
* Verify that you get a changelog entry without a tag at the end of the current version's entries
* Run `npm run changelog`
* Pick a change type
* Enter a changelog message
* Confirm that you see a `Is this change for a feature?` prompt
* Enter `y` or `Y` to indicate the change is related to a feature
* Confirm that you see the following list of options:
```
  Never mind (No feature) 
  [ACSS] - Add support for ACSS payments in Canada (Local payment method) 
  [Amazon Pay] - Add support for Amazon Pay to express checkout (Express checkout) 
  [BECS] - Add support for BECS Direct Debits in Australia (Local payment method) 
  [BLIK] - Add support for BLIK payments in Poland (Local payment method) 
  [Settings Sync] - Synchronize payment method settings with Stripe dashboard 
  [Smart Checkout] - Add support for Smart Checkout/ Dynamic Payment Element 
```
* Pick "_Never mind (No feature)_"
* Verify that the generated entry doesn't have a tag, and appears at the end of the file
* Walk through the steps again and pick one of the features this time
* Verify that the generated entry includes the `[Tag]` from the selected list and appears at the end of the list, e.g.
```
* [Amazon Pay] Fix - Your changelog message
```
* Repeat the steps above with a different tag, and confirm it appears below the entry above
* Repeat the steps above with the same tag as the first tag, and confirm it appears immediately after the first entry for that tag

To clean up after you're done, run `git restore changelog.txt readme.txt`

#### Screenshot

![Screenshot 2025-04-25 at 13 52 36](https://github.com/user-attachments/assets/56fad1c5-b1b7-4036-97e3-08573e842f97)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [N/A] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [N/A] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [N/A] Included this PR in the Release Thread scope (or does not apply)
