### PR TITLE
Unit tests: use env var for XDEBUG_MODE if set

### DIFF
--- a/bin/run-tests.sh
+++ b/bin/run-tests.sh
@@ -9,7 +9,10 @@ docker compose exec -u www-data wordpress \
 
 echo "Running the tests..."
 
-docker compose exec -u www-data -e XDEBUG_MODE=coverage wordpress \
+# Use XDEBUG_MODE_PHPUNIT if set, otherwise use "coverage" as default.
+XDEBUG_MODE=${XDEBUG_MODE_PHPUNIT:-coverage}
+
+docker compose exec -u www-data -e XDEBUG_MODE=$XDEBUG_MODE wordpress \
 	/var/www/html/wp-content/plugins/woocommerce-gateway-stripe/vendor/bin/phpunit \
 	--configuration /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/phpunit.xml.dist \
 	$*


### PR DESCRIPTION
## Changes proposed in this Pull Request:
I use Xdebug a lot when writing and debugging unit tests. For that, I need XDEBUG_MODE to be `debug` instead of `coverage`. This tweak allows our unit test script to pull the mode from environment vars. If not set, it uses `coverage` as the default mode.

## Testing instructions
Code review only.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️) N/A
-   [x] Tested on mobile (or does not apply) N/A

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
