### PR TITLE
Amazon Pay ECE: display custom error message for amount mismatch declines

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2276,7 +2276,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				throw new WC_Stripe_Exception(
 					// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 					print_r( $payment_intent, true ),
-					$payment_intent->error->message
+					$this->get_payment_intent_error_message( $payment_intent )
 				);
 			}
 
@@ -2300,6 +2300,27 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->save_intent_to_order( $order, $payment_intent );
 
 		return $payment_intent;
+	}
+
+	/**
+	 * Return specific error messages for payment intent errors.
+	 *
+	 * @param stdClass $payment_intent The payment intent object.
+	 * @return string The error message.
+	 */
+	private function get_payment_intent_error_message( $payment_intent ) {
+		if ( isset( $payment_intent->error->payment_intent->payment_method_types[0] ) &&
+			'amazon_pay' === $payment_intent->error->payment_intent->payment_method_types[0] &&
+			isset( $payment_intent->error->decline_code ) &&
+			'generic_decline' === $payment_intent->error->decline_code
+		) {
+			return __(
+				'Amazon Pay is not compatible for this order. Please try a different payment method.',
+				'woocommerce-gateway-stripe'
+			);
+		}
+
+		return $payment_intent->error->message;
 	}
 
 	/**


### PR DESCRIPTION
Fixes STRIPE-377

## Changes proposed in this Pull Request:

When taxes are calculated based on billing address, and the shopper uses express checkout, we don’t have access to their billing address early enough to ensure accurate tax calculation in the payment modal.

For Amazon Pay, any mismatch between the pre-authorized amount (shown in the payment modal) and the final charged amount results in a transaction decline. This security feature does is not present in Apple Pay or Google Pay.

Rather than disabling Amazon Pay for this common tax configuration, we've opted to allow the decline to occur and instead show a more user-friendly error message, encouraging the shopper to choose a different payment method.

## Testing instructions
1. Turn on the feature flag and enable Amazon Pay as a payment method.
2. In WooCommerce > Settings > General, choose `No location by default` for **Default customer location**.
3. Enable taxes and set tax computation to customer billing address.
   - In WooCommerce > Settings > General, check `Enable tax rates and calculations`,
   - In WooCommerce > Settings > Tax > Tax options, choose `Customer billing address` for **Calculate tax based on**
4. In WooCommerce > Settings > Tax > Standard rates, enter different tax rates for your Amazon Pay shipping address, and the Amazon Pay test card billing address (Wisconsin). See screenshot below for my setup.
5. As a shopper, go to a shippable product page.
6. Clear your site cookies to clear previous orders' billing address information.
7. Use Amazon Pay to purchase the product.
   - In `develop`, the error message is a generic `The payment failed.`
   - In this branch, the error message is `Amazon Pay is not compatible for this order. Please try a different payment method.`
 
Sample tax setup:
<img width="756" alt="Screenshot 2025-04-25 at 4 12 20 PM" src="https://github.com/user-attachments/assets/10f037df-0071-4d32-992f-27099f9e5dd8" />



---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

The changes in this PR are for a still-unreleased payment method.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
