### PR TITLE
Fix Subscriptions related regressions

### DIFF
--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1241,8 +1241,8 @@ class WC_Stripe_Intent_Controller {
 
 			// Set the new Stripe payment method ID and customer ID on the subscription.
 			$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
-			$gateway->set_customer_id_for_order( $subscription, $customer->get_id() );
-			$gateway->set_payment_method_id_for_order( $subscription, $token->get_token() );
+			$gateway->set_customer_id_for_subscription( $subscription, $customer->get_id() );
+			$gateway->set_payment_method_id_for_subscription( $subscription, $token->get_token() );
 
 			// Check if the subscription has the delayed update all flag and attempt to update all subscriptions after the intent has been confirmed. If successful, display the "updated all subscriptions" notice.
 			if ( WC_Subscriptions_Change_Payment_Gateway::will_subscription_update_all_payment_methods( $subscription ) && WC_Subscriptions_Change_Payment_Gateway::update_all_payment_methods_from_subscription( $subscription, $token->get_gateway_id() ) ) {

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -319,8 +319,8 @@ trait WC_Stripe_Subscriptions_Trait {
 				WC_Subscriptions_Change_Payment_Gateway::update_payment_method( $subscription, $new_payment_method );
 
 				// Attach the new payment method ID and the customer ID to the subscription on success.
-				$this->set_payment_method_id_for_order( $subscription, $payment_method_id );
-				$this->set_customer_id_for_order( $subscription, $payment_information['customer'] );
+				$this->set_payment_method_id_for_subscription( $subscription, $payment_method_id );
+				$this->set_customer_id_for_subscription( $subscription, $payment_information['customer'] );
 
 				// Trigger wc_stripe_change_subs_payment_method_success action hook to preserve backwards compatibility, see process_change_subscription_payment_method().
 				do_action(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2692,12 +2692,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// If the payment method object is a Link payment method, use Link as the payment method type.
 		if ( isset( $payment_method_object->type ) && WC_Stripe_Payment_Methods::LINK === $payment_method_object->type ) {
 			$payment_method_type = WC_Stripe_Payment_Methods::LINK;
+			$payment_method_instance = $this->get_payment_method_instance( $payment_method_type );
 		} elseif ( $this->spe_enabled && isset( $payment_method_object->type ) ) {
 			// When SPE is enabled, use the payment method type from the payment method object
 			$payment_method_type = $payment_method_object->type;
+			$payment_method_instance = $this->get_payment_method_instance( $payment_method_type );
+		} else {
+			$payment_method_instance = $this->payment_methods[ $payment_method_type ];
 		}
-
-		$payment_method_instance = $this->get_payment_method_instance( $payment_method_type );
 
 		// Searches for an existing duplicate token to update.
 		$found_token = WC_Stripe_Payment_Tokens::get_duplicate_token( $payment_method_object, $customer->get_user_id(), $this->id );
@@ -2737,6 +2739,17 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	}
 
 	/**
+	 * Set the payment metadata for payment method id for subscription.
+	 *
+	 * @param WC_Subscription $order The order.
+	 * @param string   $payment_method_id The value to be set.
+	 */
+	public function set_payment_method_id_for_subscription( $subscription, string $payment_method_id ) {
+		$subscription->update_meta_data( '_stripe_source_id', $payment_method_id );
+		$subscription->save_meta_data();
+	}
+
+	/**
 	 * Set the payment metadata for customer id.
 	 *
 	 * Set to public so it can be called from confirm_change_payment_from_setup_intent_ajax()
@@ -2747,6 +2760,19 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public function set_customer_id_for_order( WC_Order $order, string $customer_id ) {
 		$order->set_stripe_customer_id( $customer_id );
 		$order->save_meta_data();
+	}
+
+	/**
+	 * Set the payment metadata for customer id for subscription.
+	 *
+	 * Set to public so it can be called from confirm_change_payment_from_setup_intent_ajax()
+	 *
+	 * @param WC_Stripe_Order $order The order.
+	 * @param string   $customer_id The value to be set.
+	 */
+	public function set_customer_id_for_subscription( $subscription, string $customer_id ) {
+		$subscription->update_meta_data( '_stripe_customer_id', $customer_id );
+		$subscription->save_meta_data();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-420

## Changes proposed in this Pull Request:

This PR fixes two separate recently introduced regressions affecting subscriptions.
1. In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4223, I updated `handle_saving_payment_method` function, which breaks the placing of subscription orders. In this PR, I am reintroducing a code branch that was removed in the above PR.
2. In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4111, we updated some of order related code to use the new wrapper class. In some places, we use the same methods (`set_payment_method_id_for_order` and `set_customer_id_for_order`) for both orders and subscriptions. This breaks subscription renewals via the My Account page. I am proposing separate methods for order and subscriptions handling to fix this.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

To test the 1st issue:
1. As a merchant, enable SEPA payment method.
2. Change currency to EUR.
3. Create a subscription product.
4. As a shopper, purchase a subscription product using SEPA.
5. The order should be placed with no fatal errors.

To test the 2nd issue:
1. Go to My Account -> Subscriptions.
2. Select the subscription that was created from the previous test.
3. Go to Change Payments.
4. Update the payment method to a new SEPA method.
11. There should not be a fatal error.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
Fixes unreleased regressions.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
