### PR TITLE
Fix failing Pre-Orders e2e test

### DIFF
--- a/tests/e2e/tests/checkout/blocks/pre-order-product.spec.js
+++ b/tests/e2e/tests/checkout/blocks/pre-order-product.spec.js
@@ -43,7 +43,7 @@ test( 'customer can purchase a pre-order product @blocks @pre-orders', async ( {
 	await setupBlocksCheckout( page, customerData );
 	await fillCreditCardDetails( page, config.get( 'cards.no-3ds' ) );
 
-	await page.locator( 'text="Place Order"' ).click();
+	await page.locator( 'text="Place pre-order now"' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Pre-Orders 2.2.6 fixed the block checkout "Place order" button text, to follow store settings. This PR fixes our Pre-Orders e2e tests accordingly.

## Testing instructions
Verify that e2e tests are 🟢 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Trivial tweak to dev-facing feature.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
