### PR TITLE
Fix invalid IP address during mandate data creation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@
 * Update - Add support for customer order notes and express checkout
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
+* Fix - Fix invalid IP address error encountered during mandate data creation.
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1600,11 +1600,11 @@ class WC_Stripe_Helper {
 		$url_parts         = wp_parse_url( $url );
 		$webhook_url_parts = wp_parse_url( $webhook_url );
 
-		$url_host     = $url_parts['host'] ?? '';
-		$url_path     = $url_parts['path'] ?? '';
-		$url_query    = $url_parts['query'] ?? '';
-		$webhook_host = $webhook_url_parts['host'] ?? '';
-		$webhook_path = $webhook_url_parts['path'] ?? '';
+		$url_host      = $url_parts['host'] ?? '';
+		$url_path      = $url_parts['path'] ?? '';
+		$url_query     = $url_parts['query'] ?? '';
+		$webhook_host  = $webhook_url_parts['host'] ?? '';
+		$webhook_path  = $webhook_url_parts['path'] ?? '';
 		$webhook_query = $webhook_url_parts['query'] ?? '';
 
 		if ( $url_host !== $webhook_host || $url_path !== $webhook_path ) {
@@ -1624,7 +1624,7 @@ class WC_Stripe_Helper {
 			return false;
 		}
 
-		$url_query_parts = [];
+		$url_query_parts     = [];
 		$webhook_query_parts = [];
 
 		parse_str( $url_query, $url_query_parts );
@@ -1727,6 +1727,11 @@ class WC_Stripe_Helper {
 	 */
 	public static function add_mandate_data( $request ) {
 		$ip_address = WC_Geolocation::get_ip_address();
+
+		// Handle cases where WC_Geolocation::get_ip_address() returns multiple, comma-separated IP addresses.
+		// TODO: Remove this block when WooCommerce 9.9.0 is released.
+		$ip_address = trim( current( preg_split( '/,/', sanitize_text_field( wp_unslash( $ip_address ) ) ) ) );
+
 		self::maybe_log_ip_issues( $ip_address );
 
 		$request['mandate_data'] = [

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1729,8 +1729,11 @@ class WC_Stripe_Helper {
 		$ip_address = WC_Geolocation::get_ip_address();
 
 		// Handle cases where WC_Geolocation::get_ip_address() returns multiple, comma-separated IP addresses.
+		// This will be addressed upstream in WooCommerce 9.9.0 as of (https://github.com/woocommerce/woocommerce/pull/57284).
 		// TODO: Remove this block when WooCommerce 9.9.0 is released.
-		$ip_address = trim( current( preg_split( '/,/', sanitize_text_field( wp_unslash( $ip_address ) ) ) ) );
+		if ( str_contains( $ip_address, ',' ) ) {
+			$ip_address = trim( current( preg_split( '/,/', $ip_address ) ) );
+		}
 
 		self::maybe_log_ip_issues( $ip_address );
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,5 +138,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Add support for customer order notes and express checkout
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
+* Fix - Fix invalid IP address error encountered during mandate data creation.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -524,6 +524,7 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 
 		$_SERVER[ $index ] = $value;
 		$request           = WC_Stripe_Helper::add_mandate_data( [] );
+		$this->assertTrue( isset( $request['mandate_data']['customer_acceptance']['online']['ip_address'] ) );
 		$ip_address        = $request['mandate_data']['customer_acceptance']['online']['ip_address'];
 		$this->assertSame( $expected, $ip_address );
 	}

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -394,9 +394,9 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_handle_main_stripe_settings() {
-		WC_Stripe_Helper::update_main_stripe_settings( [ 'test' => 'test' ] );
+		WC_Stripe_Helper::update_main_stripe_settings( [ 'test' => 'abc' ] );
 		$current_settings = WC_Stripe_Helper::get_stripe_settings();
-		$this->assertSame( [ 'test' => 'test' ], $current_settings );
+		$this->assertSame( $current_settings['test'], 'abc' );
 
 		WC_Stripe_Helper::delete_main_stripe_settings();
 		$current_settings = WC_Stripe_Helper::get_stripe_settings();
@@ -506,5 +506,43 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe'] );
 		$this->assertTrue( $gateway_order['stripe'] < $gateway_order['stripe_affirm'] );
 		$this->assertTrue( $gateway_order['stripe_affirm'] < $gateway_order['cheque'] );
+	}
+
+	/**
+	 * Test for `add_mandate_data`.
+	 *
+	 * @param string $index The index of the server variable to set.
+	 * @param string $value The value to set the server variable to.
+	 * @param string $expected The expected IP address.
+	 * @dataProvider provider_test_add_mandate_data
+	 * @return void
+	 */
+	public function test_add_mandate_data( $index, $value, $expected ) {
+		unset( $_SERVER['REMOTE_ADDR'] );
+		unset( $_SERVER['HTTP_X_REAL_IP'] );
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+
+		$_SERVER[ $index ] = $value;
+		$request           = WC_Stripe_Helper::add_mandate_data( [] );
+		$ip_address        = $request['mandate_data']['customer_acceptance']['online']['ip_address'];
+		$this->assertSame( $expected, $ip_address );
+	}
+
+	/**
+	 * Data provider for `test_add_mandate_data`.
+	 *
+	 * @return array
+	 */
+	public function provider_test_add_mandate_data() {
+		return [
+			[ 'REMOTE_ADDR', '192.168.1.1', '192.168.1.1' ],
+			[ 'REMOTE_ADDR', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
+			[ 'HTTP_X_REAL_IP', '192.168.1.1', '192.168.1.1' ],
+			[ 'HTTP_X_REAL_IP', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
+			[ 'HTTP_X_FORWARDED_FOR', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
+			[ 'HTTP_X_FORWARDED_FOR', '192.168.1.1', '192.168.1.1' ],
+			[ 'HTTP_X_REAL_IP', 'invalid-ip-address', 'invalid-ip-address' ],
+			[ 'HTTP_X_REAL_IP', '', '' ],
+		];
 	}
 }

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -511,22 +511,22 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	/**
 	 * Test for `add_mandate_data`.
 	 *
-	 * @param string $index The index of the server variable to set.
-	 * @param string $value The value to set the server variable to.
-	 * @param string $expected The expected IP address.
+	 * @param string $server_variable_key   The key of the server variable to set.
+	 * @param string $server_variable_value The value to set the server variable to.
+	 * @param string $expected_ip_address    The expected IP address.
 	 * @dataProvider provider_test_add_mandate_data
 	 * @return void
 	 */
-	public function test_add_mandate_data( $index, $value, $expected ) {
+	public function test_add_mandate_data( $server_variable_key, $server_variable_value, $expected_ip_address ) {
 		unset( $_SERVER['REMOTE_ADDR'] );
 		unset( $_SERVER['HTTP_X_REAL_IP'] );
 		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
 
-		$_SERVER[ $index ] = $value;
-		$request           = WC_Stripe_Helper::add_mandate_data( [] );
+		$_SERVER[ $server_variable_key ] = $server_variable_value;
+		$request                         = WC_Stripe_Helper::add_mandate_data( [] );
 		$this->assertTrue( isset( $request['mandate_data']['customer_acceptance']['online']['ip_address'] ) );
-		$ip_address        = $request['mandate_data']['customer_acceptance']['online']['ip_address'];
-		$this->assertSame( $expected, $ip_address );
+		$ip_address = $request['mandate_data']['customer_acceptance']['online']['ip_address'];
+		$this->assertSame( $expected_ip_address, $ip_address );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-233
Fixes #3543 

## Changes proposed in this Pull Request:
While waiting for [the fix](https://github.com/woocommerce/woocommerce/pull/57284) in core to land (WooCommerce 9.9.0), we will handle cases where `WC_Geolocation::get_ip_address();` returns multiple, comma-separated IP addresses.


## Testing instructions
1. Enable "Log error messages" in WooCommerce > Payments > Stripe > Settings.
2. Smoke test mandate data creation by purchasing any item using [any of the payment methods listed here](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/0a9c6b9e2757b2f57689e0e57bdfb021464a18cf/includes/class-wc-stripe-intent-controller.php#L1059). For example, ACH Direct Debit.
3. The order should be successful.
4. Check your PHP logs for errors.
5. Check WooCommerce > Status > Logs > woocommerce-gateway-stripe for errors.
 
---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
