### PR TITLE
Remove BACS on the incompatible change payment method for subscriptions page.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@
 * Update - Add support for customer order notes and express checkout
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
+* Update - Remove BACS from the unsupported 'change payment method for subscription' page.
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
@@ -102,7 +102,8 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 				if (
 					$this->should_hide_bacs_for_pre_orders_charge_upon_release() ||
 					$this->should_hide_bacs_for_subscriptions_with_free_trials() ||
-					$this->should_hide_bacs_on_add_payment_method_page()
+					$this->should_hide_bacs_on_add_payment_method_page() ||
+					$this->should_hide_bacs_on_change_subscription_payment_method_page()
 				) {
 					unset( $available_gateways['stripe_bacs_debit'] );
 				}
@@ -162,5 +163,14 @@ class WC_Stripe_UPE_Payment_Method_Bacs_Debit extends WC_Stripe_UPE_Payment_Meth
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Determines whether the Bacs payment gateway should be hidden on the change payment method page for subscriptions.
+	 *
+	 * @return bool True if the Bacs payment gateway should be hidden, false otherwise.
+	 */
+	public function should_hide_bacs_on_change_subscription_payment_method_page() {
+		return $this->is_changing_payment_method_for_subscription();
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -138,5 +138,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Add support for customer order notes and express checkout
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
+* Update - Remove BACS from the unsupported 'change payment method for subscription' page.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-421

## Changes proposed in this Pull Request:

BACS is not yet supported on any of the change payment method pages, and is already hidden on those pages. We've missed hiding it when changing the payment method of an existing subscription. This PR covers that flow.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

To test BACS, you will need a Stripe account that is based in the UK, a Stripe account with BACS Direct Debit enabled, a store using GBP currency, and a shopper billing address in the UK. 

1. As a merchant, enable BACS.
2. As a shopper, purchase a subscription using BACS.
3. Go to My Account -> Subscriptions -> Change Payment.
4. Select BACS Direct Debit -> Use a new payment method.
5. BACS Direct Debit should not be listed on the payment method list.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
