### PR TITLE
Fix payment method names in the new react-based settings page.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
 * Fix - Fix invalid IP address error encountered during mandate data creation.
+* Fix - Fix payment method title display when new payment settings experience is enabled
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -273,7 +273,7 @@ class WC_Stripe_Settings_Controller {
 	 */
 	public static function hide_gateways_on_settings_page() {
 		// Prevent hiding gateways in the new payments settings experience (React-based UI).
-		if ( 'yes' === get_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled' ) ) {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) && \Automattic\WooCommerce\Utilities\FeaturesUtil::feature_is_enabled( 'reactify-classic-payments-settings' ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -273,7 +273,7 @@ class WC_Stripe_Settings_Controller {
 	 */
 	public static function hide_gateways_on_settings_page() {
 		// Prevent hiding gateways in the new payments settings experience (React-based UI).
-		if ( get_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled' ) === 'yes' ) {
+		if ( 'yes' === get_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled' ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -272,6 +272,11 @@ class WC_Stripe_Settings_Controller {
 	 * to display the payment gateways on the WooCommerce Settings page.
 	 */
 	public static function hide_gateways_on_settings_page() {
+		// Prevent hiding gateways in the new payments settings experience (React-based UI).
+		if ( get_option( 'woocommerce_feature_reactify-classic-payments-settings_enabled' ) === 'yes' ) {
+			return;
+		}
+
 		$gateways_to_hide = [
 			// Hide all UPE payment methods.
 			WC_Stripe_UPE_Payment_Method::class,

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
 * Fix - Fix invalid IP address error encountered during mandate data creation.
+* Fix - Fix payment method title display when new payment settings experience is enabled
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-417

## Changes proposed in this Pull Request:

This PR addresses an issue where Stripe payment methods (such as SEPA, Bancontact, etc.) were not being recognized or displayed in the WooCommerce edit order page when the "New payments settings experience" is enabled. Previously, the `hide_gateways_on_settings_page` function was unconditionally removing these alternative payment methods from the global payment gateways list. This payment method removal is needed for the current settings pages, as we don't want to show every payment method offered under the Stripe gateway as a separate gateway. However, with the new React-based settings page, this appears to be no longer needed (Admittedly, I haven't found where in the WooCommerce code this is now handled ). 

With the new React-based payments settings, WooCommerce expects all available payment methods to be present in the gateways list for correct display and order management. Hiding these methods causes them to appear as undeclared or with generic IDs (e.g., stripe_sepa_debit) in the admin order view.

This PR proposes a simple conditional check at the start of `hide_gateways_on_settings_page` to detect if the new payments settings experience is enabled and to return early.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. As a shopper, purchase a subscription using SEPA.
2. As merchant, go to WooCommerce -> Settings -> Advanced -> Features and enable "Enable the new payments settings experience".
3. Go to order edit page of the subscription purchased in step 1.
4. Make sure payment method name is correctly displayed.
5. Under "Related orders" click the subscription order. Make sure Payment method shows up as "SEPA Direct Debit" instead of "Manual Renewal"
6. (Regression test) Go to WooCommerce -> Settings -> Payments page, make sure the gateway list doesn't list the individual payment methods offered under Stripe as gateways.

Before
![CleanShot 2025-05-07 at 14 24 27@2x](https://github.com/user-attachments/assets/cecb8ef3-6e1f-4345-ab05-ae437542b74c)

![CleanShot 2025-05-07 at 14 36 21@2x](https://github.com/user-attachments/assets/5752f857-9bb5-465f-8376-e555ecc675c0)


Now
![CleanShot 2025-05-07 at 14 23 43@2x](https://github.com/user-attachments/assets/e8cbf6d5-8a8a-4883-8602-dbeb4c08918c)

![CleanShot 2025-05-07 at 14 37 13@2x](https://github.com/user-attachments/assets/e0d9eb19-3f6f-42cb-9b12-2ded5d57262b)


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
