### PR TITLE
Fix fatal when changing subscription payment method for legacy

### DIFF
--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -127,15 +127,16 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	}
 
 	/**
-	 * Checks if the given object is a WC_Subscription.
+	 * Checks if the given order is a subscription.
 	 *
 	 * Slightly more performant than has_subscription() which checks wcs_order_contains_subscription() first.
 	 *
-	 * @param  mixed $subscription
+	 * @param  mixed $order
 	 *
 	 * @return boolean
 	 */
-	public function is_subscription( $subscription ) {
-		return function_exists( 'wcs_is_subscription' ) && wcs_is_subscription( $subscription );
+	public function is_subscription( $order ) {
+		return ( function_exists( 'wcs_is_subscription' ) && wcs_is_subscription( $order ) ) ||
+			( $order instanceof WC_Order && $order->get_type() === 'shop_subscription' );
 	}
 }

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -238,7 +238,8 @@ trait WC_Stripe_Subscriptions_Trait {
 	 */
 	public function process_change_subscription_payment_method( $order_id ) {
 		try {
-			$subscription    = WC_Stripe_Order::get_by_id( $order_id );
+			// Do not convert to WC_Stripe_Order object to avoid overwriting the order type.
+			$subscription    = wc_get_order( $order_id );
 			$prepared_source = $this->prepare_source( get_current_user_id(), true );
 
 			$this->maybe_disallow_prepaid_card( $prepared_source->source_object );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2774,7 +2774,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Set the payment metadata for payment method id for subscription.
 	 *
-	 * @param WC_Subscription $order The order.
+	 * @param WC_Subscription $subscription The subscription.
 	 * @param string   $payment_method_id The value to be set.
 	 */
 	public function set_payment_method_id_for_subscription( $subscription, string $payment_method_id ) {
@@ -2800,7 +2800,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 *
 	 * Set to public so it can be called from confirm_change_payment_from_setup_intent_ajax()
 	 *
-	 * @param WC_Stripe_Order $order The order.
+	 * @param WC_Subscription $subscription The subscription.
 	 * @param string   $customer_id The value to be set.
 	 */
 	public function set_customer_id_for_subscription( $subscription, string $customer_id ) {

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -780,7 +780,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		};
 
 		return [
-			'default'                => [
+			'default'                    => [
 				'optimized checkout enabled' => false,
 				'filter'                     => null,
 				'expected'                   => [
@@ -808,8 +808,8 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 			],
 			'Optimized Checkout enabled' => [
 				'optimized checkout enabled' => true,
-				'filter'                 => null,
-				'expected'               => [
+				'filter'                     => null,
+				'expected'                   => [
 					'us_bank_account' => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/bank-debit.svg" class="stripe-ach-icon stripe-icon" alt="ACH" />',
 					'acss_debit'      => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/bank-debit.svg" class="stripe-ach-icon stripe-icon" alt="Pre-Authorized Debit" />',
 					'alipay'          => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/alipay.svg" class="stripe-alipay-icon stripe-icon" alt="Alipay" />',
@@ -832,11 +832,64 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 					'cashapp'         => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/cashapp.svg" class="stripe-cashapp-icon stripe-icon" alt="Cash App Pay" />',
 				],
 			],
-			'filter applied'         => [
+			'filter applied'             => [
 				'optimized checkout enabled' => false,
-				'filter'                 => $mocked_filter,
-				'expected'               => [],
+				'filter'                     => $mocked_filter,
+				'expected'                   => [],
 			],
 		];
+	}
+
+	/**
+	 * Test for `save_source_to_order`.
+	 */
+	public function test_save_source_to_order() {
+		$source = (object) [
+			'customer' => 'cus_123',
+			'source'   => 'src_123',
+		];
+
+		// Set up a WC_Order instance order.
+		$order = WC_Helper_Order::create_order();
+		$order->set_payment_method( 'stripe' );
+		$order->save();
+
+		// Verify correct behavior for WC_Order.
+		$this->gateway->save_source_to_order( $order, $source );
+		$this->assertEquals( $source->source, $order->get_meta( '_stripe_source_id' ) );
+		$this->assertEquals( $source->customer, $order->get_meta( '_stripe_customer_id' ) );
+
+		// Set up a WC_Stripe_Order instance.
+		$wc_stripe_order = WC_Stripe_Order::to_instance( WC_Helper_Order::create_order() );
+		$wc_stripe_order->set_payment_method( 'stripe' );
+		$wc_stripe_order->save();
+
+		// Verify correct behavior for WC_Stripe_Order.
+		$this->gateway->save_source_to_order( $wc_stripe_order, $source );
+		$this->assertEquals( $source->source, $wc_stripe_order->get_source_id() );
+		$this->assertEquals( $source->customer, $wc_stripe_order->get_stripe_customer_id() );
+	}
+
+	/**
+	 * Test for `save_source_to_order` for WC_Subscription orders.
+	 */
+	public function test_save_source_to_order_for_subscription() {
+		$source = (object) [
+			'customer' => 'cus_123',
+			'source'   => 'src_123',
+		];
+
+		// Set up a WC_Subscription instance.
+		$subscription = new WC_Subscription();
+		$subscription->set_payment_method( 'stripe' );
+		$subscription->save();
+
+		// Verify correct behavior for WC_Subscription.
+		$this->gateway->save_source_to_order( $subscription, $source );
+		$this->assertEquals( $source->source, $subscription->get_meta( '_stripe_source_id' ) );
+		$this->assertEquals( $source->customer, $subscription->get_meta( '_stripe_customer_id' ) );
+
+		// Check that the order type has not been changed.
+		$this->assertEquals( 'shop_subscription', $subscription->get_type() );
 	}
 }


### PR DESCRIPTION
Fixes subscription switch issue found by GlobalStep testing for v9.5.0. See p1746708036253349/1743679022.910909-slack-C011ENB20Q1

## Changes proposed in this Pull Request:
1. https://github.com/woocommerce/woocommerce-gateway-stripe/commit/d5c7ca583300eaf52a3a925fb0dbe3fdd60835a6: Similar to #4222, we should avoid converting a `WC_Subscription` object to `WC_Stripe_Order` to prevent overwriting the order type, from `shop_subscription`.
2. https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4296/commits/397435be112b8767b02ef60c2190a091181755a0: We modify the `is_subscription()` check to also check for the order type. This function is being used in `save_intent_to_order()` ([code](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/7bd0453165047151150a8adbe41ccaf02ff6821b/includes/abstracts/abstract-wc-stripe-payment-gateway.php#L1664)), and allows us to bail early (correct behavior) even for cases where the subscription order has been converted to `WC_Stripe_Order`.
3. Added unit tests in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4296/commits/4accb3e26ff9ce297d0aa1bd157163a8201bfa50
4. Minor docblock fix in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4296/commits/d81baa7f68100c0c3d13b3699b9d200016dd4db4

## Testing instructions
1. Enable legacy checkout.
2. As a shopper, verify that you are able to purchase subscriptions without any trouble.
5. Go to My Account > Subscriptions. Verify that you are able to change the payment method for your subscription.
6. As the merchant, verify that you can process renewals in wp-admin successfully.
7. Disable legacy checkout and perform Steps 2-4.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply) -- NA

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This is a followup for the fix in #4222.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)