### PR TITLE
Only store appearance styles on checkout pages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
 * Fix - Fix invalid IP address error encountered during mandate data creation.
+* Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
 
 = 9.4.1 - 2025-04-17 =
 * Dev - Forces rollback of version 9.4.0.

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -158,18 +158,6 @@ export const getUPETerms = ( value = 'always' ) => {
 };
 
 /**
- * `storageKeys` object contains keys for storing values related to the appearance
- *  settings of Stripe UPE (Universal Payment Element) in different contexts.
- */
-export const storageKeys = {
-	// Key to store the appearance settings for Stripe UPE in the general WooCommerce context
-	UPE_APPEARANCE: 'wc_stripe_upe_appearance',
-
-	// Key to store the appearance settings for Stripe UPE when used within WooCommerce Blocks context
-	WC_BLOCKS_UPE_APPEARANCE: 'wc_stripe_wc_blocks_upe_appearance',
-};
-
-/**
  * Sets a key-value pair in the localStorage along with a time-to-live (TTL) value, which specifies
  * the time (in milliseconds) after which the item will be considered expired.
  *

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -616,14 +616,15 @@ export const initializeUPEAppearance = ( api, isBlockCheckout = 'false' ) => {
 			: getStripeServerData()?.appearance;
 
 	const data = getStripeServerData();
-	const isValidContext =
+
+	const isValidUpdateContext =
 		isBlockCheckout === 'true' ||
 		( data.isCheckout && ! data.isOrderPay && ! data.isChangingPayment );
 
-	// If appearance is empty, only save it if in a valid context.
 	if ( ! appearance ) {
 		appearance = getAppearance( isBlockCheckout === 'true' );
-		if ( isValidContext ) {
+		// If we have re-built the appearance, only update the settings in the checkout context
+		if ( isValidUpdateContext ) {
 			api.saveAppearance( appearance, isBlockCheckout );
 		}
 	}

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -627,10 +627,17 @@ export const initializeUPEAppearance = ( api, isBlockCheckout = 'false' ) => {
 			? getStripeServerData()?.blocksAppearance
 			: getStripeServerData()?.appearance;
 
-	// If appearance is empty, get a fresh copy and save it in a transient.
+	const data = getStripeServerData();
+	const isValidContext =
+		isBlockCheckout === 'true' ||
+		( data.isCheckout && ! data.isOrderPay && ! data.isChangingPayment );
+
+	// If appearance is empty, only save it if in a valid context.
 	if ( ! appearance ) {
 		appearance = getAppearance( isBlockCheckout === 'true' );
-		api.saveAppearance( appearance, isBlockCheckout );
+		if ( isValidContext ) {
+			api.saveAppearance( appearance, isBlockCheckout );
+		}
 	}
 
 	return appearance;

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -617,12 +617,15 @@ export const initializeUPEAppearance = ( api, isBlockCheckout = 'false' ) => {
 
 	const data = getStripeServerData();
 
-	const isValidUpdateContext =
-		isBlockCheckout === 'true' ||
-		( data.isCheckout && ! data.isOrderPay && ! data.isChangingPayment );
-
 	if ( ! appearance ) {
 		appearance = getAppearance( isBlockCheckout === 'true' );
+
+		const isValidUpdateContext =
+			isBlockCheckout === 'true' ||
+			( data.isCheckout &&
+				! data.isOrderPay &&
+				! data.isChangingPayment );
+
 		// If we have re-built the appearance, only update the settings in the checkout context
 		if ( isValidUpdateContext ) {
 			api.saveAppearance( appearance, isBlockCheckout );

--- a/readme.txt
+++ b/readme.txt
@@ -139,5 +139,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Minor fix to e2e setup code
 * Dev - Make PHP error log from Docker container available in docker/logs/php/error.log
 * Fix - Fix invalid IP address error encountered during mandate data creation.
+* Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-114
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2417

## Changes proposed in this Pull Request:

This PR updates the logic for persisting the appearance settings. Previously, the frontend would always store the appearance styles regardless of the context. With this change, we only store the appearance data from checkout pages. 
Other pages(Add payment method, change payment method, pay for order) will compute the appearance data or reuse any existing data (same as before).

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Remove appearance transients (I do this directly on the db by deleting the results of `select * from wp_options where option_name like '%appearance%'`)
2. Visit My account > Add payment method > Stripe.
3. Visit the shortcode checkout page.
4. Notice the styles of the payment element.
5. Remove the transient again.
6. This time, visit the checkout page (without visiting the my account -> add payment)
7. Notice the styles of the payment element, it should look exactly as before (Step 4)
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
