### PR TITLE
Revert order wrapper class

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -37,7 +37,6 @@
 * Tweak - Correctly handles the display of payment method instructions when Smart Checkout is enabled.
 * Dev - Do not generate filenames with underscores.
 * Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.
-* Dev - Implements the new Stripe order class into the express checkout classes.
 * Dev - Implements the new Stripe order class into the wp-admin related classes.
 * Dev - Replaces references to order status values with their respective constants from the WooCommerce plugin.
 * Tweak - Updates the Smart Checkout (classic/shortcode checkout version) to make all the payment methods look as similar as possible to any other WooCommerce payment method.

--- a/changelog.txt
+++ b/changelog.txt
@@ -81,7 +81,6 @@
 * Add - Support for BECS Direct Debit as a new payment method for Australian accounts.
 * Update - Back button on the settings pages.
 * Update - Use individual product tax status instead of storewide tax setup when determining express checkout availability.
-* Fix - Ensure the subscription object is not converted into a Stripe order object.
 * Update - Credit and Bank (BECS and ACSS) icons on the Block checkout page.
 * Fix - Fix BLIK visibility based on account and billing countries.
 * Add - Use Stripe Configuration API to manage payment methods enabled/disabled states.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,6 @@
 * Dev - Renames all references to "Smart Checkout" and "Single Payment Element" (and "SPE") to "Optimized Checkout" (and "OC"), following the feature rebranding.
 * Tweak - Updates the "Smart Checkout" setting name to "Optimized Checkout", and the description accordingly.
 * Fix - Checks for the existence of the WC_Stripe_Feature_Flags class before including it during extension initialization.
-* Dev - Implements the new Stripe order class into the new checkout experience files.
 * Dev - Splits the code coverage GitHub Actions Workflow into two separate actions.
 * Dev - Implements the new Stripe order class into the root extension files.
 * Fix - Fixes the listing of payment methods in the Stripe settings page when the Smart Checkout is enabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -83,7 +83,6 @@
 * Update - Back button on the settings pages.
 * Update - Use individual product tax status instead of storewide tax setup when determining express checkout availability.
 * Fix - Ensure the subscription object is not converted into a Stripe order object.
-* Fix - Ensure the subscription and pre-order objects are not converted into a Stripe order object in legacy experience.
 * Update - Credit and Bank (BECS and ACSS) icons on the Block checkout page.
 * Fix - Fix BLIK visibility based on account and billing countries.
 * Add - Use Stripe Configuration API to manage payment methods enabled/disabled states.

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,7 +11,6 @@
 * Tweak - Passes the correct parent payment method configuration ID (retrieved from the backend) to the Smart Checkout payment element.
 * Tweak - Removes the Stripe icon beside the Smart Checkout payment element from the checkout pages.
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
-* Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
 * Update - Add ECE support for One Page Checkout and other dynamic cart update scenarios
 * Fix - Show error notice when 'Add payment method' fails on My Account page in block-based themes.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,6 @@
 * Tweak - Updates the "Smart Checkout" setting name to "Optimized Checkout", and the description accordingly.
 * Fix - Checks for the existence of the WC_Stripe_Feature_Flags class before including it during extension initialization.
 * Dev - Splits the code coverage GitHub Actions Workflow into two separate actions.
-* Dev - Implements the new Stripe order class into the root extension files.
 * Fix - Fixes the listing of payment methods in the Stripe settings page when the Smart Checkout is enabled.
 * Tweak - Passes the correct parent payment method configuration ID (retrieved from the backend) to the Smart Checkout payment element.
 * Tweak - Removes the Stripe icon beside the Smart Checkout payment element from the checkout pages.

--- a/changelog.txt
+++ b/changelog.txt
@@ -41,7 +41,6 @@
 * Tweak - Updates the Smart Checkout (classic/shortcode checkout version) to make all the payment methods look as similar as possible to any other WooCommerce payment method.
 * Tweak - Updates the Smart Checkout (block checkout version) to make all the payment methods look as similar as possible to any other WooCommerce payment method.
 * Fix - Improves the subscriptions detached admin notice, making it less intrusive and limiting the querying to 5 subscriptions (avoiding slow loading times).
-* Dev - Implements the new Stripe order class into the PHP unit tests.
 * Dev - Introduces new payment method constants for the express methods: Google Pay, Apple Pay, Link, and Amazon Pay (backend version).
 * Dev - Introduces a new Stripe Order class to wrap Stripe-specific logic and data on the backend.
 * Dev - Improves how we handle express payment method titles by introducing new constants and methods to replace duplicate code.

--- a/changelog.txt
+++ b/changelog.txt
@@ -35,7 +35,6 @@
 * Dev - Improves Smart Checkout code with shared and new methods, on both front and backend.
 * Fix - Fixes the saving of payment methods when Smart Checkout is enabled.
 * Tweak - Correctly handles the display of payment method instructions when Smart Checkout is enabled.
-* Dev - Implements the new Stripe order class into abstract/base classes, and the webhook handler.
 * Dev - Implements the new Stripe order class into the legacy checkout classes.
 * Dev - Do not generate filenames with underscores.
 * Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -35,7 +35,6 @@
 * Dev - Improves Smart Checkout code with shared and new methods, on both front and backend.
 * Fix - Fixes the saving of payment methods when Smart Checkout is enabled.
 * Tweak - Correctly handles the display of payment method instructions when Smart Checkout is enabled.
-* Dev - Implements the new Stripe order class into the legacy checkout classes.
 * Dev - Do not generate filenames with underscores.
 * Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.
 * Dev - Implements the new Stripe order class into the express checkout classes.

--- a/changelog.txt
+++ b/changelog.txt
@@ -37,7 +37,6 @@
 * Tweak - Correctly handles the display of payment method instructions when Smart Checkout is enabled.
 * Dev - Do not generate filenames with underscores.
 * Fix - Fixes the Stripe checkout container visuals when Smart Checkout is disabled.
-* Dev - Implements the new Stripe order class into the wp-admin related classes.
 * Dev - Replaces references to order status values with their respective constants from the WooCommerce plugin.
 * Tweak - Updates the Smart Checkout (classic/shortcode checkout version) to make all the payment methods look as similar as possible to any other WooCommerce payment method.
 * Tweak - Updates the Smart Checkout (block checkout version) to make all the payment methods look as similar as possible to any other WooCommerce payment method.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
@@ -227,7 +227,7 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 
 		if ( $this->is_valid_pay_for_order_endpoint() ) {
 			$order_id                          = absint( get_query_var( 'order-pay' ) );
-			$stripe_params['stripe_order_key'] = ! empty( $order_id ) ? WC_Stripe_Order::get_by_id( $order_id )->get_order_key() : null;
+			$stripe_params['stripe_order_key'] = ! empty( $order_id ) ? wc_get_order( $order_id )->get_order_key() : null;
 		}
 
 		return $stripe_params;
@@ -256,7 +256,7 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_save = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			if ( ! in_array( $order->get_billing_country(), $this->supported_countries ) ) {
 				throw new \Exception( __( 'This payment method is not available in the selected country', 'woocommerce-gateway-stripe' ) );
@@ -264,11 +264,11 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 
 			$intent = $this->create_or_update_payment_intent( $order );
 
-			$order->set_upe_payment_type( $this->stripe_id );
+			$order->update_meta_data( '_stripe_upe_payment_type', $this->stripe_id );
 			$order->update_status( OrderStatus::PENDING, __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
 			$order->save();
 
-			$order->add_payment_intent_to_order( $intent->id );
+			WC_Stripe_Helper::add_payment_intent_to_order( $intent->id, $order );
 
 			return [
 				'result'               => 'success',
@@ -375,7 +375,7 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 				throw new \Exception( __( 'Order Id not found, send an order id', 'woocommerce-gateway-stripe' ) );
 			}
 
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			$order_key = isset( $_POST['stripe_order_key'] ) ? wc_clean( wp_unslash( $_POST['stripe_order_key'] ) ) : null;
 			if ( $order->get_order_key() !== $order_key ) {
@@ -386,7 +386,7 @@ abstract class WC_Stripe_Payment_Gateway_Voucher extends WC_Stripe_Payment_Gatew
 			$intent = $this->create_or_update_payment_intent( $order );
 
 			$order->update_status( OrderStatus::PENDING, __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
-			$order->set_upe_payment_type( $this->stripe_id );
+			$order->update_meta_data( '_stripe_upe_payment_type', $this->stripe_id );
 			$order->save();
 
 			wp_send_json(

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1630,12 +1630,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param stdClass $intent Payment intent information.
 	 */
 	public function save_intent_to_order( $order, $intent ) {
+		$order = WC_Stripe_Order::to_instance( $order );
+
 		// Don't save any intent information on a subscription.
 		if ( $this->is_subscription( $order ) ) {
 			return;
 		}
-
-		$order = WC_Stripe_Order::to_instance( $order );
 
 		if ( 'payment_intent' === $intent->object ) {
 			WC_Stripe_Helper::add_payment_intent_to_order( $intent->id, $order );

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -345,7 +345,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return array
 	 */
 	public function payment_icons() {
-		$icon_list = [
+		$icon_list  = [
 			WC_Stripe_Payment_Methods::ACH         => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/bank-debit.svg" class="stripe-ach-icon stripe-icon" alt="ACH" />',
 			WC_Stripe_Payment_Methods::ACSS_DEBIT  => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/bank-debit.svg" class="stripe-ach-icon stripe-icon" alt="' . __( 'Pre-Authorized Debit', 'woocommerce-gateway-stripe' ) . '" />',
 			WC_Stripe_Payment_Methods::ALIPAY      => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/alipay.svg" class="stripe-alipay-icon stripe-icon" alt="Alipay" />',
@@ -1630,8 +1630,6 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param stdClass $intent Payment intent information.
 	 */
 	public function save_intent_to_order( $order, $intent ) {
-		$order = WC_Stripe_Order::to_instance( $order );
-
 		// Don't save any intent information on a subscription.
 		if ( $this->is_subscription( $order ) ) {
 			return;

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -379,16 +379,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Validates that the order meets the minimum order amount
 	 * set by Stripe.
 	 *
-	 * @param WC_Order $order
-	 *
-	 * @throws WC_Stripe_Exception If the order does not meet the minimum amount.
-	 *
 	 * @since 4.0.0
-	 * @deprecated 9.4.0
 	 * @version 4.0.0
+	 * @param object $order
 	 */
 	public function validate_minimum_order_amount( $order ) {
-		// _deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Helper::validate_minimum_amount' ); // @todo Re-enable this after all classes get updated.
 		if ( $order->get_total() * 100 < WC_Stripe_Helper::get_minimum_amount() ) {
 			/* translators: 1) amount (including currency symbol) */
 			throw new WC_Stripe_Exception( 'Did not meet minimum amount', sprintf( __( 'Sorry, the minimum allowed order total is %1$s to use this payment method.', 'woocommerce-gateway-stripe' ), wc_price( WC_Stripe_Helper::get_minimum_amount() / 100 ) ) );
@@ -410,16 +405,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	/**
 	 * Gets the saved customer id if exists.
 	 *
-	 * @param WC_Stripe_Order|WC_Order $order The order object.
-	 * @return string The customer id.
-	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
 	 */
 	public function get_stripe_customer_id( $order ) {
 		// Try to get it via the order first.
-		$order    = WC_Stripe_Order::to_instance( $order );
-		$customer = $order->get_stripe_customer_id();
+		$customer = $order->get_meta( '_stripe_customer_id', true );
+
 		if ( empty( $customer ) ) {
 			$customer = get_user_option( '_stripe_customer_id', $order->get_customer_id() );
 		}
@@ -546,16 +538,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	/**
 	 * Store extra meta data for an order from a Stripe Response.
 	 *
-	 * @param object $response The Stripe response.
-	 * @param WC_Order|WC_Stripe_Order $order The order object.
 	 * @throws WC_Stripe_Exception
 	 */
 	public function process_response( $response, $order ) {
 		WC_Stripe_Logger::log( 'Processing response: ' . print_r( $response, true ) );
 
-		$order = WC_Stripe_Order::to_instance( $order );
-
-		$potential_order = WC_Stripe_Order::get_by_charge_id( $response->id );
+		$potential_order = WC_Stripe_Helper::get_order_by_charge_id( $response->id );
 		if ( $potential_order && $potential_order->get_id() !== $order->get_id() ) {
 			WC_Stripe_Logger::log( 'Aborting, transaction already consumed by another order.' );
 			$localized_message = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
@@ -566,7 +554,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';
 
 		// Store charge data.
-		$order->set_charge_captured( $captured );
+		$order->update_meta_data( '_stripe_charge_captured', $captured );
 
 		if ( isset( $response->balance_transaction ) ) {
 			$this->update_fees( $order, is_string( $response->balance_transaction ) ? $response->balance_transaction : $response->balance_transaction->id );
@@ -576,9 +564,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		// The mandate ID is not available for the intent object, so we need to fetch the charge.
 		// Mandate ID is necessary for renewal payments for certain payment methods and Indian cards.
 		if ( isset( $response->payment_method_details->card->mandate ) ) {
-			$order->set_mandate_id( $response->payment_method_details->card->mandate );
+			$order->update_meta_data( '_stripe_mandate_id', $response->payment_method_details->card->mandate );
 		} elseif ( isset( $response->payment_method_details->acss_debit->mandate ) ) {
-			$order->set_mandate_id( $response->payment_method_details->acss_debit->mandate );
+			$order->update_meta_data( '_stripe_mandate_id', $response->payment_method_details->acss_debit->mandate );
 		}
 
 		if ( isset( $response->payment_method, $response->payment_method_details ) ) {
@@ -616,7 +604,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				 * to ensure the review.closed event handler will update the status to the proper status.
 				 */
 				if ( 'manual_review' === $this->get_risk_outcome( $response ) ) {
-					$order->set_status_before_hold( 'default_payment_complete' );
+					$this->set_stripe_order_status_before_hold( $order, 'default_payment_complete' );
 					$order->set_transaction_id( $response->id ); // Save the transaction ID to link the order to the Stripe charge ID. This is to fix reviews that result in refund.
 				} else {
 					$order->payment_complete( $response->id );
@@ -696,13 +684,10 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @return object $details
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public function get_owner_details( $order ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_owner_details' );
 		$billing_first_name = $order->get_billing_first_name();
 		$billing_last_name  = $order->get_billing_last_name();
 
@@ -978,7 +963,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 3.1.0
 	 * @version 4.0.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @return object
 	 */
 	public function prepare_order_source( $order = null ) {
@@ -988,22 +973,20 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$source_object   = false;
 
 		if ( $order ) {
-			$order = WC_Stripe_Order::to_instance( $order );
-
 			$stripe_customer_id = $this->get_stripe_customer_id( $order );
 
 			if ( $stripe_customer_id ) {
 				$stripe_customer->set_id( $stripe_customer_id );
 			}
 
-			$source_id = $order->get_source_id();
+			$source_id = $order->get_meta( '_stripe_source_id', true );
 
 			// Since 4.0.0, we changed card to source so we need to account for that.
 			if ( empty( $source_id ) ) {
 				$source_id = $order->get_meta( '_stripe_card_id', true );
 
 				// Take this opportunity to update the key name.
-				$order->set_source_id( $source_id );
+				$order->update_meta_data( '_stripe_source_id', $source_id );
 
 				if ( is_callable( [ $order, 'save' ] ) ) {
 					$order->save();
@@ -1050,30 +1033,17 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 3.1.0
 	 * @version 4.0.0
-	 * @param WC_Order|WC_Stripe_Order $order For to which the source applies.
+	 * @param WC_Order $order For to which the source applies.
 	 * @param stdClass $source Source information.
 	 */
 	public function save_source_to_order( $order, $source ) {
-		$customer_id = $source->customer ?? null;
-		$source_id   = $source->source ?? null;
+		// Store source in the order.
+		if ( $source->customer ) {
+			$order->update_meta_data( '_stripe_customer_id', $source->customer );
+		}
 
-		if ( $this->is_subscription( $order ) || $this->has_pre_order( $order->get_id() ) ) {
-			if ( $customer_id ) {
-				$order->update_meta_data( '_stripe_customer_id', $customer_id );
-			}
-
-			if ( $source_id ) {
-				$order->update_meta_data( '_stripe_source_id', $source_id );
-			}
-		} else {
-			$order = WC_Stripe_Order::to_instance( $order );
-
-			if ( $customer_id ) {
-				$order->set_stripe_customer_id( $customer_id );
-			}
-			if ( $source_id ) {
-				$order->set_source_id( $source_id );
-			}
+		if ( $source->source ) {
+			$order->update_meta_data( '_stripe_source_id', $source->source );
 		}
 
 		if ( is_callable( [ $order, 'save' ] ) ) {
@@ -1089,7 +1059,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.6
-	 * @param WC_Stripe_Order $order The order object
+	 * @param object $order The order object
 	 * @param int    $balance_transaction_id
 	 */
 	public function update_fees( $order, $balance_transaction_id ) {
@@ -1097,26 +1067,24 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		if ( empty( $balance_transaction->error ) ) {
 			if ( isset( $balance_transaction ) && isset( $balance_transaction->fee ) ) {
-				$order = WC_Stripe_Order::to_instance( $order );
-
 				// Fees and Net needs to both come from Stripe to be accurate as the returned
 				// values are in the local currency of the Stripe account, not from WC.
 				$fee_refund = ! empty( $balance_transaction->fee ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'fee' ) : 0;
 				$net_refund = ! empty( $balance_transaction->net ) ? WC_Stripe_Helper::format_balance_fee( $balance_transaction, 'net' ) : 0;
 
 				// Current data fee & net.
-				$fee_current = $order->get_fee();
-				$net_current = $order->get_net();
+				$fee_current = WC_Stripe_Helper::get_stripe_fee( $order );
+				$net_current = WC_Stripe_Helper::get_stripe_net( $order );
 
 				// Calculation.
 				$fee = (float) $fee_current + (float) $fee_refund;
 				$net = (float) $net_current + (float) $net_refund;
 
-				$order->set_fee( $fee );
-				$order->set_net( $net );
+				WC_Stripe_Helper::update_stripe_fee( $order, $fee );
+				WC_Stripe_Helper::update_stripe_net( $order, $net );
 
 				$currency = ! empty( $balance_transaction->currency ) ? strtoupper( $balance_transaction->currency ) : null;
-				$order->set_stripe_currency( $currency );
+				WC_Stripe_Helper::update_stripe_currency( $order, $currency );
 
 				if ( is_callable( [ $order, 'save' ] ) ) {
 					$order->save();
@@ -1139,7 +1107,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @throws Exception Throws exception when charge wasn't captured.
 	 */
 	public function process_refund( $order_id, $amount = null, $reason = '' ) {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		if ( ! $order ) {
 			return false;
@@ -1148,7 +1116,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$request = [];
 
 		$order_currency = $order->get_currency();
-		$captured       = $order->is_charge_captured();
+		$captured       = $order->get_meta( '_stripe_charge_captured', true );
 		$charge_id      = $order->get_transaction_id();
 
 		if ( ! $charge_id ) {
@@ -1160,7 +1128,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		// If order is only authorized, don't pass amount.
-		if ( ! $captured ) {
+		if ( 'yes' !== $captured ) {
 			unset( $request['amount'] );
 		}
 
@@ -1214,13 +1182,13 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				}
 			}
 
-			if ( ! $intent_cancelled && $captured ) {
-				$order->lock_refund();
+			if ( ! $intent_cancelled && 'yes' === $captured ) {
+				$this->lock_order_refund( $order );
 				$response = WC_Stripe_API::request( $request, 'refunds' );
 			}
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
-			$order->unlock_refund();
+			$this->unlock_order_refund( $order );
 
 			return new WP_Error(
 				'stripe_error',
@@ -1234,7 +1202,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 
 		if ( ! empty( $response->error ) ) { // @phpstan-ignore-line (return statement is added)
 			WC_Stripe_Logger::log( 'Error: ' . $response->error->message );
-			$order->unlock_refund();
+			$this->unlock_order_refund( $order );
 
 			return new WP_Error(
 				'stripe_error',
@@ -1252,7 +1220,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			}
 
 			// If charge wasn't captured, skip creating a refund and cancel order.
-			if ( ! $captured ) {
+			if ( 'yes' !== $captured ) {
 				/* translators: amount (including currency symbol) */
 				$order->add_order_note( sprintf( __( 'Pre-Authorization for %s voided.', 'woocommerce-gateway-stripe' ), $formatted_amount ) );
 				$order->update_status( OrderStatus::CANCELLED );
@@ -1266,7 +1234,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 				}
 			}
 
-			$order->set_refund_id( $response->id );
+			$order->update_meta_data( '_stripe_refund_id', $response->id );
 
 			if ( isset( $response->balance_transaction ) ) {
 				$this->update_fees( $order, $response->balance_transaction );
@@ -1276,7 +1244,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$refund_message = sprintf( __( 'Refunded %1$s - Refund ID: %2$s - Reason: %3$s', 'woocommerce-gateway-stripe' ), $formatted_amount, $response->id, $reason );
 
 			$order->add_order_note( $refund_message );
-			$order->unlock_refund();
+			$this->unlock_order_refund( $order );
 
 			WC_Stripe_Logger::log( 'Success: ' . html_entity_decode( wp_strip_all_tags( $refund_message ), ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ) );
 
@@ -1658,8 +1626,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Saves intent to order.
 	 *
 	 * @since 3.2.0
-	 * @param WC_Stripe_Order|WC_Order $order  For to which the source applies.
-	 * @param stdClass                 $intent Payment intent information.
+	 * @param WC_Order $order For to which the source applies.
+	 * @param stdClass $intent Payment intent information.
 	 */
 	public function save_intent_to_order( $order, $intent ) {
 		// Don't save any intent information on a subscription.
@@ -1670,7 +1638,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		$order = WC_Stripe_Order::to_instance( $order );
 
 		if ( 'payment_intent' === $intent->object ) {
-			$order->add_payment_intent_to_order( $intent->id );
+			WC_Stripe_Helper::add_payment_intent_to_order( $intent->id, $order );
 
 			// TODO: Refactor and add mandate ID support for other payment methods, if necessary.
 			// The mandate ID is not available for the intent object, so we need to fetch the charge.
@@ -1678,16 +1646,16 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$charge = $this->get_latest_charge_from_intent( $intent );
 
 			if ( isset( $charge->payment_method_details->card->mandate ) ) {
-				$order->set_mandate_id( $charge->payment_method_details->card->mandate );
+				$order->update_meta_data( '_stripe_mandate_id', $charge->payment_method_details->card->mandate );
 			} elseif ( isset( $charge->payment_method_details->acss_debit->mandate ) ) {
-				$order->set_mandate_id( $charge->payment_method_details->acss_debit->mandate );
+				$order->update_meta_data( '_stripe_mandate_id', $charge->payment_method_details->acss_debit->mandate );
 			}
 		} elseif ( 'setup_intent' === $intent->object ) {
-			$order->set_setup_intent( $intent->id );
+			$order->update_meta_data( '_stripe_setup_intent', $intent->id );
 
 			// Add mandate for free trial subscriptions.
 			if ( isset( $intent->mandate ) ) {
-				$order->set_mandate_id( $intent->mandate );
+				$order->update_meta_data( '_stripe_mandate_id', $intent->mandate );
 			}
 		}
 
@@ -1701,18 +1669,18 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 4.2
 	 * @param WC_Order $order The order to retrieve an intent for.
-	 * @return object|bool    Either the intent object or `false`.
+	 * @return obect|bool     Either the intent object or `false`.
 	 */
 	public function get_intent_from_order( $order ) {
-		$order = WC_Stripe_Order::to_instance( $order );
+		$intent_id = $order->get_meta( '_stripe_intent_id' );
 
-		$intent_id = $order->get_intent_id();
 		if ( $intent_id ) {
 			return $this->get_intent( 'payment_intents', $intent_id );
 		}
 
 		// The order doesn't have a payment intent, but it may have a setup intent.
-		$intent_id = $order->get_setup_intent();
+		$intent_id = $order->get_meta( '_stripe_setup_intent' );
+
 		if ( $intent_id ) {
 			return $this->get_intent( 'setup_intents', $intent_id );
 		}
@@ -1749,13 +1717,11 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Locks an order for payment intent processing for 5 minutes.
 	 *
 	 * @since 4.2
-	 * @deprecated 9.4.0 Use WC_Stripe_Order::lock_payment instead.
 	 * @param WC_Order $order  The order that is being paid.
 	 * @param stdClass $intent The intent that is being processed.
 	 * @return bool            A flag that indicates whether the order is already locked.
 	 */
 	public function lock_order_payment( $order, $intent = null ) {
-		// wc_deprecated_function( __FUNCTION__, '9.4.0', 'WC_Stripe_Order::lock_payment' ); @todo Re-enable deprecation notice once all classes get updated.
 		$order->read_meta_data( true );
 
 		$existing_lock = $order->get_meta( '_stripe_lock_payment', true );
@@ -1783,11 +1749,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * Unlocks an order for processing by payment intents.
 	 *
 	 * @since 4.2
-	 * @deprecated 9.4.0 Use WC_Stripe_Order::unlock_payment instead.
 	 * @param WC_Order $order The order that is being unlocked.
 	 */
 	public function unlock_order_payment( $order ) {
-		// wc_deprecated_function( __FUNCTION__, '9.4.0', 'WC_Stripe_Order::unlock_payment' ); @todo Re-enable deprecation notice once all classes get updated.
 		$order->delete_meta_data( '_stripe_lock_payment' );
 		$order->save_meta_data();
 	}
@@ -1798,11 +1762,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @since 9.1.0
 	 * @param WC_Order $order  The order that is being refunded.
 	 * @return bool            A flag that indicates whether the order is already locked.
-	 *
-	 * @deprecated 9.4.0 Use WC_Stripe_Order::lock_refund instead.
 	 */
 	public function lock_order_refund( $order ) {
-		_deprecated_function( __FUNCTION__, '9.4.0', 'WC_Stripe_Order::lock_refund' );
 		$order->read_meta_data( true );
 
 		$existing_lock = $order->get_meta( '_stripe_lock_refund', true );
@@ -1829,11 +1790,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 *
 	 * @since 9.1.0
 	 * @param WC_Order $order The order that is being unlocked.
-	 *
-	 * @deprecated 9.4.0 Use WC_Stripe_Order::unlock_refund instead.
 	 */
 	public function unlock_order_refund( $order ) {
-		_deprecated_function( __FUNCTION__, '9.4.0', 'WC_Stripe_Order::unlock_refund' );
 		$order->delete_meta_data( '_stripe_lock_refund' );
 		$order->save_meta_data();
 	}
@@ -1853,7 +1811,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	/**
 	 * Creates a SetupIntent for future payments, and saves it to the order.
 	 *
-	 * @param WC_Stripe_Order $order    The ID of the (free/pre- order).
+	 * @param WC_Order $order           The ID of the (free/pre- order).
 	 * @param object   $prepared_source The source, entered/chosen by the customer.
 	 * @return string|null              The client secret of the intent, used for confirmation in JS.
 	 */
@@ -1878,7 +1836,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		if ( is_wp_error( $setup_intent ) ) {
 			WC_Stripe_Logger::log( "Unable to create SetupIntent for Order #$order_id: " . print_r( $setup_intent, true ) );
 		} elseif ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $setup_intent->status ) {
-			$order->set_setup_intent( $setup_intent->id );
+			$order->update_meta_data( '_stripe_setup_intent', $setup_intent->id );
 			$order->save();
 
 			return $setup_intent->client_secret;
@@ -1999,7 +1957,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		}
 
 		$order_id = absint( get_query_var( 'order-pay' ) );
-		$order    = WC_Stripe_Order::get_by_id( $order_id );
+		$order    = wc_get_order( $order_id );
 
 		// If the order is not found or the param `key` is not set or the order key does not match the order key in the URL param, return false.
 		if ( ! $order || ! isset( $_GET['key'] ) || wc_clean( wp_unslash( $_GET['key'] ) ) !== $order->get_order_key() ) {
@@ -2038,7 +1996,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			return false;
 		}
 
-		$order = WC_Stripe_Order::get_by_id( $order_id_from_order_key );
+		$order = wc_get_order( $order_id_from_order_key );
 
 		// If the order doesn't need payment, return false.
 		if ( ! $order->needs_payment() ) {
@@ -2196,7 +2154,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		// If we're on the pay page we need to pass stripe.js the address of the order.
 		if ( $this->is_valid_pay_for_order_endpoint() || $this->is_changing_payment_method_for_subscription() ) {
 			$order_id = absint( get_query_var( 'order-pay' ) );
-			$order    = WC_Stripe_Order::get_by_id( $order_id );
+			$order    = wc_get_order( $order_id );
 
 			if ( is_a( $order, 'WC_Order' ) ) {
 				$stripe_params['billing_first_name'] = $order->get_billing_first_name();
@@ -2323,6 +2281,25 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
+	 * Stores the status of the order before being put on hold in metadata.
+	 *
+	 * @since 8.3.0
+	 *
+	 * @param WC_Order  $order  The order.
+	 * @param string    $status The order status to store. Accepts 'default_payment_complete' which will fetch the default status for payment complete orders.
+	 *
+	 * @return void
+	 */
+	protected function set_stripe_order_status_before_hold( $order, $status ) {
+		if ( 'default_payment_complete' === $status ) {
+			$payment_complete_status = $order->needs_processing() ? OrderStatus::PROCESSING : OrderStatus::COMPLETED;
+			$status                  = apply_filters( 'woocommerce_payment_complete_order_status', $payment_complete_status, $order->get_id(), $order );
+		}
+
+		$order->update_meta_data( '_stripe_status_before_hold', $status );
+	}
+
+	/**
 	 * Retrieves the risk/fraud outcome from the webhook payload.
 	 *
 	 * @param object $event_data The event data from the webhook.
@@ -2348,7 +2325,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @param WC_Order|int $order             Order object or id.
 	 */
 	public function update_saved_payment_method( $payment_method_id, $order ) {
-		$order = ! is_a( $order, 'WC_Order' ) ? WC_Stripe_Order::get_by_id( $order ) : $order;
+		$order = ! is_a( $order, 'WC_Order' ) ? wc_get_order( $order ) : $order;
 
 		if ( ! $order || ! $this->is_type_payment_method( $payment_method_id ) ) {
 			return;
@@ -2452,7 +2429,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return string The order's unique signature. Format: order_id:md5(order_id-order_key-customer_id-order_total).
 	 */
 	protected function get_order_signature( $order ) {
-		$order = ! is_a( $order, 'WC_Order' ) ? WC_Stripe_Order::get_by_id( $order ) : $order;
+		$order = ! is_a( $order, 'WC_Order' ) ? wc_get_order( $order ) : $order;
 
 		$signature = [
 			absint( $order->get_id() ),

--- a/includes/admin/class-wc-rest-stripe-orders-controller.php
+++ b/includes/admin/class-wc-rest-stripe-orders-controller.php
@@ -107,7 +107,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 		$order_id = $request['order_id'];
 
 		// Ensure order exists.
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 		if ( false === $order || ! ( $order instanceof WC_Order ) ) {
 			return new WP_Error( 'wc_stripe', __( 'Order not found', 'woocommerce-gateway-stripe' ), [ 'status' => 404 ] );
 		}
@@ -126,7 +126,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 		$customer = new WC_Stripe_Customer( $order_user->ID );
 
 		// Set the customer ID if known but not already set.
-		$customer_id = $order->get_stripe_customer_id();
+		$customer_id = $order->get_meta( '_stripe_customer_id', true );
 		if ( ! $customer->get_id() && $customer_id ) {
 			$customer->set_id( $customer_id );
 		}
@@ -143,7 +143,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 			return new WP_Error( 'stripe_error', $e->getMessage() );
 		}
 
-		$order->set_stripe_customer_id( $customer_id );
+		$order->update_meta_data( '_stripe_customer_id', $customer_id );
 		$order->save();
 
 		return rest_ensure_response( [ 'id' => $customer_id ] );
@@ -153,7 +153,7 @@ class WC_REST_Stripe_Orders_Controller extends WC_Stripe_REST_Base_Controller {
 		try {
 			$intent_id = $request['payment_intent_id'];
 			$order_id  = $request['order_id'];
-			$order     = WC_Stripe_Order::get_by_id( $order_id );
+			$order     = wc_get_order( $order_id );
 
 			// Check that order exists before capturing payment.
 			if ( ! $order ) {

--- a/includes/admin/class-wc-stripe-privacy.php
+++ b/includes/admin/class-wc-stripe-privacy.php
@@ -133,11 +133,11 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 					'data'        => [
 						[
 							'name'  => __( 'Stripe payment id', 'woocommerce-gateway-stripe' ),
-							'value' => $order->get_source_id(),
+							'value' => $order->get_meta( '_stripe_source_id', true ),
 						],
 						[
 							'name'  => __( 'Stripe customer id', 'woocommerce-gateway-stripe' ),
-							'value' => $order->get_stripe_customer_id(),
+							'value' => $order->get_meta( '_stripe_customer_id', true ),
 						],
 					],
 				];
@@ -305,7 +305,7 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 		$messages       = [];
 
 		foreach ( (array) $orders as $order ) {
-			$order = WC_Stripe_Order::get_by_id( $order->get_id() );
+			$order = wc_get_order( $order->get_id() );
 
 			list( $removed, $retained, $msgs ) = $this->maybe_handle_order( $order );
 			$items_removed                    |= $removed;
@@ -384,13 +384,13 @@ class WC_Stripe_Privacy extends WC_Abstract_Privacy {
 	/**
 	 * Handle eraser of data tied to Orders
 	 *
-	 * @param WC_Stripe_Order $order
+	 * @param WC_Order $order
 	 * @return array
 	 */
 	protected function maybe_handle_order( $order ) {
-		$stripe_source_id   = $order->get_source_id();
-		$stripe_refund_id   = $order->get_refund_id();
-		$stripe_customer_id = $order->get_stripe_customer_id();
+		$stripe_source_id   = $order->get_meta( '_stripe_source_id', true );
+		$stripe_refund_id   = $order->get_meta( '_stripe_refund_id', true );
+		$stripe_customer_id = $order->get_meta( '_stripe_customer_id', true );
 
 		if ( ! $this->is_retention_expired( $order->get_date_created()->getTimestamp() ) ) {
 			/* translators: %d Order ID */

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -223,7 +223,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		// If paying for order, we need to get email from the order not the user account.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order      = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order      = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$user_email = $order->get_billing_email();
 		} elseif ( $user->ID ) {
 				$user_email = get_user_meta( $user->ID, 'billing_email', true );
@@ -388,7 +388,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false, $previous_error = false, $use_order_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			if ( $this->has_subscription( $order_id ) ) {
 				$force_save_source = true;
@@ -443,7 +443,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			}
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			WC_Stripe_Logger::log( "Info: Begin processing payment for order $order_id for the amount of {$order->get_total()}" );
 
@@ -455,7 +455,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 			// Confirm the intent after locking the order to make sure webhooks will not interfere.
 			if ( empty( $intent->error ) ) {
-				$order->lock_payment( $intent );
+				$this->lock_order_payment( $order, $intent );
 				$intent = $this->confirm_intent( $intent, $order, $prepared_source );
 			}
 
@@ -469,7 +469,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 					return $this->retry_after_error( $intent, $order, $retry, $force_save_source, $previous_error, $use_order_source );
 				}
 
-				$order->unlock_payment();
+				$this->unlock_order_payment( $order );
 				$this->throw_localized_message( $intent, $order );
 			}
 
@@ -483,10 +483,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 				// If the intent requires a 3DS flow, redirect to it.
 				if ( WC_Stripe_Intent_Status::REQUIRES_ACTION === $intent->status ) {
-					$order->unlock_payment();
+					$this->unlock_order_payment( $order );
 
 					// If the order requires some action from the customer, add meta to the order to prevent it from being cancelled by WooCommerce's hold stock settings.
-					$order->set_payment_awaiting_action();
+					WC_Stripe_Helper::set_payment_awaiting_action( $order );
 
 					if ( is_wc_endpoint_url( 'order-pay' ) ) {
 						$redirect_url = add_query_arg( 'wc-stripe-confirmation', 1, $order->get_checkout_payment_url( false ) );
@@ -521,7 +521,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			}
 
 			// Unlock the order.
-			$order->unlock_payment();
+			$this->unlock_order_payment( $order );
 
 			// Return thank you page redirect.
 			return [
@@ -557,10 +557,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
-		$fee      = $order->get_fee();
-		$currency = $order->get_stripe_currency();
+		$fee      = WC_Stripe_Helper::get_stripe_fee( $order );
+		$currency = WC_Stripe_Helper::get_stripe_currency( $order );
 
 		if ( ! $fee || ! $currency ) {
 			return;
@@ -594,10 +594,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
-		$net      = $order->get_net();
-		$currency = $order->get_stripe_currency();
+		$net      = WC_Stripe_Helper::get_stripe_net( $order );
+		$currency = WC_Stripe_Helper::get_stripe_currency( $order );
 
 		if ( ! $net || ! $currency ) {
 			return;
@@ -700,7 +700,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function prepare_intent_for_order_pay_page( $order = null ) {
 		if ( ! isset( $order ) || empty( $order ) ) {
-			$order = WC_Stripe_Order::get_by_id( absint( get_query_var( 'order-pay' ) ) );
+			$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
 		}
 		$intent = $this->get_intent_from_order( $order );
 
@@ -745,7 +745,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 */
 	public function render_payment_intent_inputs( $order = null ) {
 		if ( ! isset( $order ) || empty( $order ) ) {
-			$order = WC_Stripe_Order::get_by_id( absint( get_query_var( 'order-pay' ) ) );
+			$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
 		}
 		if ( ! isset( $this->order_pay_intent ) ) {
 			$this->prepare_intent_for_order_pay_page( $order );
@@ -791,7 +791,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = WC_Stripe_Order::get_by_id( absint( $order_id ) );
+		$order = wc_get_order( absint( $order_id ) );
 
 		if ( ! $order ) {
 			return;
@@ -867,7 +867,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	 * method updates orders based on the status of associated PaymentIntents.
 	 *
 	 * @since 4.2.0
-	 * @param WC_Stripe_Order $order The order which is in a transitional state.
+	 * @param WC_Order $order The order which is in a transitional state.
 	 */
 	public function verify_intent_after_checkout( $order ) {
 		$payment_method = $order->get_payment_method();
@@ -884,7 +884,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 		// A webhook might have modified or locked the order while the intent was retreived. This ensures we are reading the right status.
 		clean_post_cache( $order->get_id() );
-		$order = WC_Stripe_Order::get_by_id( $order->get_id() );
+		$order = wc_get_order( $order->get_id() );
 
 		if ( ! $order->has_status(
 			apply_filters(
@@ -897,7 +897,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( $order->lock_payment( $intent ) ) {
+		if ( $this->lock_order_payment( $order, $intent ) ) {
 			return;
 		}
 
@@ -916,13 +916,13 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 			$this->handle_intent_verification_failure( $order, $intent );
 		}
 
-		$order->unlock_payment();
+		$this->unlock_order_payment( $order );
 
 		/**
 		 * This meta is to prevent stores with short hold stock settings from cancelling orders while waiting for payment to be finalised by Stripe or the customer (i.e. completing 3DS or payment redirects).
 		 * Now that payment is confirmed, we can remove this meta.
 		 */
-		$order->remove_payment_awaiting_action();
+		WC_Stripe_Helper::remove_payment_awaiting_action( $order );
 	}
 
 	/**

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -64,13 +64,10 @@ class WC_Stripe_Helper {
 	 * Gets the Stripe currency for order.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @return string $currency
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_stripe_currency( $order = null ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_stripe_currency' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -82,13 +79,10 @@ class WC_Stripe_Helper {
 	 * Updates the Stripe currency for order.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @param string $currency
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function update_stripe_currency( $order, $currency ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::set_stripe_currency' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -100,13 +94,10 @@ class WC_Stripe_Helper {
 	 * Gets the Stripe fee for order. With legacy check.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @return string $amount
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_stripe_fee( $order = null ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_fee' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -130,13 +121,10 @@ class WC_Stripe_Helper {
 	 * Updates the Stripe fee for order.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @param float  $amount
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function update_stripe_fee( $order = null, $amount = 0.0 ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::set_fee' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -148,12 +136,9 @@ class WC_Stripe_Helper {
 	 * Deletes the Stripe fee for order.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
-	 *
-	 * @deprecated 9.4.0
+	 * @param object $order
 	 */
 	public static function delete_stripe_fee( $order = null ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::delete_fee' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -166,13 +151,10 @@ class WC_Stripe_Helper {
 	 * Gets the Stripe net for order. With legacy check.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @return string $amount
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_stripe_net( $order = null ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_net' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -196,13 +178,10 @@ class WC_Stripe_Helper {
 	 * Updates the Stripe net for order.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
+	 * @param object $order
 	 * @param float  $amount
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function update_stripe_net( $order = null, $amount = 0.0 ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::set_net' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -214,12 +193,9 @@ class WC_Stripe_Helper {
 	 * Deletes the Stripe net for order.
 	 *
 	 * @since 4.1.0
-	 * @param WC_Order $order
-	 *
-	 * @deprecated 9.4.0
+	 * @param object $order
 	 */
 	public static function delete_stripe_net( $order = null ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::delete_net' );
 		if ( is_null( $order ) ) {
 			return false;
 		}
@@ -891,11 +867,8 @@ class WC_Stripe_Helper {
 	 * @since 4.0.0
 	 * @version 4.0.0
 	 * @param string $source_id
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_order_by_source_id( $source_id ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_by_source_id' );
 		global $wpdb;
 
 		if ( WC_Stripe_Woo_Compat_Utils::is_custom_orders_table_enabled() ) {
@@ -928,11 +901,8 @@ class WC_Stripe_Helper {
 	 * @since 4.0.0
 	 * @since 4.1.16 Return false if charge_id is empty.
 	 * @param string $charge_id
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_order_by_charge_id( $charge_id ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_by_charge_id' );
 		global $wpdb;
 
 		if ( empty( $charge_id ) ) {
@@ -963,11 +933,8 @@ class WC_Stripe_Helper {
 	 *
 	 * @since 7.5.0
 	 * @param string $refund_id
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_order_by_refund_id( $refund_id ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_by_refund_id' );
 		global $wpdb;
 
 		if ( WC_Stripe_Woo_Compat_Utils::is_custom_orders_table_enabled() ) {
@@ -1000,11 +967,8 @@ class WC_Stripe_Helper {
 	 * @since 4.2
 	 * @param string $intent_id The ID of the intent.
 	 * @return WC_Order|bool Either an order or false when not found.
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_order_by_intent_id( $intent_id ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_by_intent_id' );
 		global $wpdb;
 
 		if ( WC_Stripe_Woo_Compat_Utils::is_custom_orders_table_enabled() ) {
@@ -1041,11 +1005,8 @@ class WC_Stripe_Helper {
 	 * @since 4.3
 	 * @param string $intent_id The ID of the intent.
 	 * @return WC_Order|bool Either an order or false when not found.
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function get_order_by_setup_intent_id( $intent_id ) {
-		_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::get_by_setup_intent_id' );
 		global $wpdb;
 
 		if ( WC_Stripe_Woo_Compat_Utils::is_custom_orders_table_enabled() ) {
@@ -1304,12 +1265,9 @@ class WC_Stripe_Helper {
 	 * Adds payment intent id and order note to order if payment intent is not already saved
 	 *
 	 * @param $payment_intent_id
-	 * @param $order WC_Order
-	 *
-	 * @deprecated 9.4.0
+	 * @param $order
 	 */
 	public static function add_payment_intent_to_order( $payment_intent_id, $order ) {
-		// wc_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::add_payment_intent' ); @todo Re-enable deprecation notice once all classes get updated.
 
 		$old_intent_id = $order->get_meta( '_stripe_intent_id' );
 
@@ -1420,16 +1378,15 @@ class WC_Stripe_Helper {
 	/**
 	 * Returns the payment intent or setup intent ID from a given order object.
 	 *
-	 * @param WC_Stripe_Order $order The order to fetch the Stripe intent from.
+	 * @param WC_Order $order The order to fetch the Stripe intent from.
 	 *
 	 * @return string|bool  The intent ID if found, false otherwise.
 	 */
 	public static function get_intent_id_from_order( $order ) {
-		$order = WC_Stripe_Order::to_instance( $order );
+		$intent_id = $order->get_meta( '_stripe_intent_id' );
 
-		$intent_id = $order->get_intent_id();
 		if ( ! $intent_id ) {
-			$intent_id = $order->get_setup_intent();
+			$intent_id = $order->get_meta( '_stripe_setup_intent' );
 		}
 
 		return $intent_id ?? false;
@@ -1462,11 +1419,8 @@ class WC_Stripe_Helper {
 	 * @param bool     $save  Whether to save the order after adding the metadata.
 	 *
 	 * @return void
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function set_payment_awaiting_action( $order, $save = true ) {
-		// wc_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::set_payment_awaiting_action' ); @todo Re-enable deprecation notice once all classes get updated.
 		$order->update_meta_data( self::PAYMENT_AWAITING_ACTION_META, wc_bool_to_string( true ) );
 
 		if ( $save ) {
@@ -1481,11 +1435,8 @@ class WC_Stripe_Helper {
 	 * @param bool     $save  Whether to save the order after removing the metadata.
 	 *
 	 * @return void
-	 *
-	 * @deprecated 9.4.0
 	 */
 	public static function remove_payment_awaiting_action( $order, $save = true ) {
-		// wc_deprecated_function( __METHOD__, '9.4.0', 'WC_Stripe_Order::remove_payment_awaiting_action' ); @todo Re-enable deprecation notice once all classes get updated.
 		$order->delete_meta_data( self::PAYMENT_AWAITING_ACTION_META );
 
 		if ( $save ) {

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -91,7 +91,7 @@ class WC_Stripe_Intent_Controller {
 		}
 
 		// Retrieve the order.
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		if ( ! $order ) {
 			throw new WC_Stripe_Exception( 'missing-order', __( 'Missing order ID for payment confirmation', 'woocommerce-gateway-stripe' ) );
@@ -329,7 +329,7 @@ class WC_Stripe_Intent_Controller {
 			$payment_method_type = isset( $_POST['payment_method_type'] ) ? wc_clean( wp_unslash( $_POST['payment_method_type'] ) ) : '';
 
 			if ( $order_id ) {
-				$order = WC_Stripe_Order::get_by_id( $order_id );
+				$order = wc_get_order( $order_id );
 				if ( ! $order || ! $order->needs_payment() ) {
 					throw new Exception( __( 'Unable to process your request. Please reload the page and try again.', 'woocommerce-gateway-stripe' ) );
 				}
@@ -360,7 +360,7 @@ class WC_Stripe_Intent_Controller {
 	 */
 	public function create_payment_intent( $order_id = null, $payment_method_type = null ) {
 		$amount = WC()->cart->get_total( false );
-		$order  = WC_Stripe_Order::get_by_id( $order_id );
+		$order  = wc_get_order( $order_id );
 		if ( is_a( $order, 'WC_Order' ) ) {
 			$amount = $order->get_total();
 		}
@@ -408,7 +408,7 @@ class WC_Stripe_Intent_Controller {
 			$save_payment_method       = isset( $_POST['save_payment_method'] ) ? 'yes' === wc_clean( wp_unslash( $_POST['save_payment_method'] ) ) : false;
 			$selected_upe_payment_type = ! empty( $_POST['selected_upe_payment_type'] ) ? wc_clean( wp_unslash( $_POST['selected_upe_payment_type'] ) ) : '';
 
-			$order_from_payment = WC_Stripe_Order::get_by_intent_id( $payment_intent_id );
+			$order_from_payment = WC_Stripe_Helper::get_order_by_intent_id( $payment_intent_id );
 			if ( ! $order_from_payment || $order_from_payment->get_id() !== $order_id ) {
 				throw new Exception( __( 'Unable to verify your request. Please reload the page and try again.', 'woocommerce-gateway-stripe' ) );
 			}
@@ -441,7 +441,7 @@ class WC_Stripe_Intent_Controller {
 	 * @return array|null An array with result of the update, or nothing
 	 */
 	public function update_intent( $intent_id = '', $order_id = null, $save_payment_method = false, $selected_upe_payment_type = '' ) {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		if ( ! is_a( $order, 'WC_Order' ) ) {
 			return;
@@ -483,7 +483,7 @@ class WC_Stripe_Intent_Controller {
 						WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 					];
 				}
-				$order->set_upe_payment_type( $selected_upe_payment_type );
+				$order->update_meta_data( '_stripe_upe_payment_type', $selected_upe_payment_type );
 			}
 			if ( ! empty( $customer ) && $customer->get_id() ) {
 				$request['customer'] = $customer->get_id();
@@ -508,7 +508,7 @@ class WC_Stripe_Intent_Controller {
 				$order->update_status( OrderStatus::PENDING, __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
 			}
 			$order->save();
-			$order->add_payment_intent_to_order( $intent_id );
+			WC_Stripe_Helper::add_payment_intent_to_order( $intent_id, $order );
 		}
 
 		return [
@@ -609,7 +609,7 @@ class WC_Stripe_Intent_Controller {
 			}
 
 			$order_id = isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : false;
-			$order    = WC_Stripe_Order::get_by_id( $order_id );
+			$order    = wc_get_order( $order_id );
 			if ( ! $order ) {
 				throw new WC_Stripe_Exception( 'order_not_found', __( "We're not able to process this payment. Please try again later.", 'woocommerce-gateway-stripe' ) );
 			}
@@ -642,7 +642,7 @@ class WC_Stripe_Intent_Controller {
 			/* translators: error message */
 			if ( $order ) {
 				// Remove the awaiting confirmation order meta, don't save the order since it'll be saved in the next `update_status()` call.
-				$order->remove_payment_awaiting_action();
+				WC_Stripe_Helper::remove_payment_awaiting_action( $order, false );
 				$order->update_status( OrderStatus::FAILED );
 			}
 
@@ -673,9 +673,9 @@ class WC_Stripe_Intent_Controller {
 
 			$order_id  = isset( $_POST['order_id'] ) ? absint( $_POST['order_id'] ) : null;
 			$intent_id = isset( $_POST['intent_id'] ) ? wc_clean( wp_unslash( $_POST['intent_id'] ) ) : '';
-			$order     = WC_Stripe_Order::get_by_id( $order_id );
+			$order     = wc_get_order( $order_id );
 
-			$order_from_payment = WC_Stripe_Order::get_by_intent_id( $intent_id );
+			$order_from_payment = WC_Stripe_Helper::get_order_by_intent_id( $intent_id );
 			if ( ! $order_from_payment || $order_from_payment->get_id() !== $order_id ) {
 				wp_send_json_error( __( 'Unable to verify your request. Please reload the page and try again.', 'woocommerce-gateway-stripe' ) );
 			}
@@ -757,7 +757,7 @@ class WC_Stripe_Intent_Controller {
 
 		$this->validate_payment_intent_required_params( $required_params, $non_empty_params, $instance_params, $payment_information );
 
-		$order                 = WC_Stripe_Order::to_instance( $payment_information['order'] );
+		$order                 = $payment_information['order'];
 		$selected_payment_type = $payment_information['selected_payment_type'];
 		$payment_method_types  = $payment_information['payment_method_types'];
 		$is_using_saved_token  = $payment_information['is_using_saved_payment_method'] ?? false;
@@ -813,7 +813,7 @@ class WC_Stripe_Intent_Controller {
 
 		// Only update the payment_type if we have a reference to the payment type the customer selected.
 		if ( '' !== $selected_payment_type ) {
-			$order->set_upe_payment_type( $selected_payment_type );
+			$order->update_meta_data( '_stripe_upe_payment_type', $selected_payment_type );
 		}
 
 		return $payment_intent;

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -51,7 +51,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param $order_id
 	 */
 	public function show_warning_for_uncaptured_orders( $order_id ) {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 		// Bail if payment method is not manual capture supporting stripe method.
 		if ( ! WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
 			return;
@@ -100,7 +100,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				return;
 			}
 
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			if ( ! is_object( $order ) ) {
 				return;
@@ -114,12 +114,12 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			$response = null;
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			WC_Stripe_Logger::log( "Info: (Redirect) Begin processing payment for order $order_id for the amount of {$order->get_total()}" );
 
 			// Lock the order or return if the order is already locked.
-			if ( $order->lock_payment( $order ) ) {
+			if ( $this->lock_order_payment( $order ) ) {
 				return;
 			}
 
@@ -184,7 +184,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				// We want to retry.
 				if ( $this->is_retryable_error( $response->error ) ) {
 					// Unlock the order before retrying.
-					$order->unlock_payment();
+					$this->unlock_order_payment( $order );
 
 					if ( $retry ) {
 						// Don't do anymore retries after this.
@@ -232,7 +232,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			$order->update_status( OrderStatus::FAILED, sprintf( __( 'Stripe payment failed: %s', 'woocommerce-gateway-stripe' ), $e->getLocalizedMessage() ) );
 
 			// Unlock the order.
-			$order->unlock_payment();
+			$this->unlock_order_payment( $order );
 
 			wc_add_notice( $e->getLocalizedMessage(), 'error' );
 			wp_safe_redirect( wc_get_checkout_url() );
@@ -240,7 +240,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		// Unlock the order.
-		$order->unlock_payment();
+		$this->unlock_order_payment( $order );
 	}
 
 	/**
@@ -284,14 +284,14 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function capture_payment( $order_id ) {
 		$result = new stdClass();
-		$order  = WC_Stripe_Order::get_by_id( $order_id );
+		$order  = wc_get_order( $order_id );
 
 		if ( WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
 			$charge             = $order->get_transaction_id();
-			$captured           = $order->is_charge_captured();
+			$captured           = $order->get_meta( '_stripe_charge_captured', true );
 			$is_stripe_captured = false;
 
-			if ( $charge && ! $captured ) {
+			if ( $charge && 'no' === $captured ) {
 				$order_total = $order->get_total();
 
 				if ( 0 < $order->get_total_refunded() ) {
@@ -361,7 +361,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				if ( $is_stripe_captured ) {
 					/* translators: transaction id */
 					$order->add_order_note( sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $result->id ) );
-					$order->set_charge_captured( 'yes' );
+					$order->update_meta_data( '_stripe_charge_captured', 'yes' );
 
 					// Store other data such as fees
 					$order->set_transaction_id( $result->id );
@@ -392,10 +392,12 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param  int $order_id
 	 */
 	public function cancel_payment( $order_id ) {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		if ( WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
-			if ( ! $order->is_charge_captured() ) {
+			$captured = $order->get_meta( '_stripe_charge_captured', true );
+
+			if ( 'no' === $captured ) {
 				// To cancel a pre-auth, we need to refund the charge.
 				$this->process_refund( $order_id );
 			}
@@ -453,7 +455,7 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 	 * @since 6.9.0
 	 *
 	 * @param bool     $cancel_order Whether to cancel the order.
-	 * @param WC_Stripe_Order $order The order object.
+	 * @param WC_Order $order        The order object.
 	 *
 	 * @return bool
 	 */
@@ -462,15 +464,13 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 			return $cancel_order;
 		}
 
-		$order = WC_Stripe_Order::to_instance( $order );
-
 		// Bail if payment method is not stripe or `stripe_{apm_method}` or doesn't have an intent yet.
 		if ( substr( (string) $order->get_payment_method(), 0, 6 ) !== 'stripe' || ! $this->get_intent_from_order( $order ) ) {
 			return $cancel_order;
 		}
 
 		// If the order is awaiting action and was modified within the last day, don't cancel it.
-		if ( $order->is_payment_awaiting_action() && $order->get_date_modified( 'edit' )->getTimestamp() > strtotime( '-1 day' ) ) {
+		if ( wc_string_to_bool( $order->get_meta( WC_Stripe_Helper::PAYMENT_AWAITING_ACTION_META, true ) ) && $order->get_date_modified( 'edit' )->getTimestamp() > strtotime( '-1 day' ) ) {
 			$cancel_order = false;
 		}
 

--- a/includes/class-wc-stripe-order.php
+++ b/includes/class-wc-stripe-order.php
@@ -185,7 +185,7 @@ class WC_Stripe_Order extends WC_Order {
 	 * @param $order_data array Order data.
 	 * @return bool|WC_Stripe_Order
 	 */
-	public static function create( $order_data = [] ) {
+	public static function create( $order_data ) {
 		$order = wc_create_order( $order_data );
 		if ( ! $order ) {
 			return false;

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -257,7 +257,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = WC_Stripe_Order::get_by_source_id( $notification->data->object->id );
+		$order = WC_Stripe_Helper::get_order_by_source_id( $notification->data->object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via source ID: ' . $notification->data->object->id );
@@ -268,7 +268,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		$is_pending_receiver = ( 'receiver' === $notification->data->object->flow );
 
-		if ( $order->lock_payment() ) {
+		if ( $this->lock_order_payment( $order ) ) {
 			return;
 		}
 
@@ -285,7 +285,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$response = null;
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			WC_Stripe_Logger::log( "Info: (Webhook) Begin processing payment for order $order_id for the amount of {$order->get_total()}" );
 
@@ -317,7 +317,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				// We want to retry.
 				if ( $this->is_retryable_error( $response->error ) ) {
 					// Unlock the order before retrying.
-					$order->unlock_payment();
+					$this->unlock_order_payment( $order );
 
 					if ( $retry ) {
 						// Don't do anymore retries after this.
@@ -371,7 +371,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		$order->unlock_payment();
+		$this->unlock_order_payment( $order );
 	}
 
 	/**
@@ -383,14 +383,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_dispute( $notification ) {
-		$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->charge );
+		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->charge );
 			return;
 		}
 
-		$order->set_status_before_hold( $order->get_status() );
+		$this->set_stripe_order_status_before_hold( $order, $order->get_status() );
 
 		$needs_response = in_array( $notification->data->object->status, [ 'needs_response', 'warning_needs_response' ], true );
 		if ( $needs_response ) {
@@ -678,7 +678,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund( $notification ) {
 		$refund_object = $this->get_refund_object( $notification );
-		$order         = WC_Stripe_Order::get_by_refund_id( $refund_object->id );
+		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
@@ -718,7 +718,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				return;
 			}
 
-			if ( $order->lock_refund() ) {
+			if ( $this->lock_order_refund( $order ) ) {
 				return;
 			}
 
@@ -749,7 +749,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$this->update_fees( $order, $refund_object->balance_transaction );
 				}
 
-				$order->unlock_refund();
+				$this->unlock_order_refund( $order );
 
 				/* translators: 1) amount (including currency symbol) 2) transaction id 3) refund message */
 				$order->add_order_note( sprintf( __( 'Refunded %1$s - Refund ID: %2$s - %3$s', 'woocommerce-gateway-stripe' ), $amount, $refund_object->id, $reason ) );
@@ -833,14 +833,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_review_opened( $notification ) {
 		if ( isset( $notification->data->object->payment_intent ) ) {
-			$order = WC_Stripe_Order::get_by_intent_id( $notification->data->object->payment_intent );
+			$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
 
 			if ( ! $order ) {
 				WC_Stripe_Logger::log( '[Review Opened] Could not find order via intent ID: ' . $notification->data->object->payment_intent );
 				return;
 			}
 		} else {
-			$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->charge );
+			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
 
 			if ( ! $order ) {
 				WC_Stripe_Logger::log( '[Review Opened] Could not find order via charge ID: ' . $notification->data->object->charge );
@@ -848,7 +848,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			}
 		}
 
-		$order->set_status_before_hold( $order->get_status() );
+		$this->set_stripe_order_status_before_hold( $order, $order->get_status() );
 
 		$message = sprintf(
 		/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag 3) The reason type. */
@@ -1007,7 +1007,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( $order->lock_payment( $intent ) ) {
+		if ( $this->lock_order_payment( $order, $intent ) ) {
 			return;
 		}
 
@@ -1094,12 +1094,12 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 		}
 
-		$order->unlock_payment();
+		$this->unlock_order_payment( $order );
 	}
 
 	public function process_setup_intent( $notification ) {
 		$intent = $notification->data->object;
-		$order  = WC_Stripe_Order::get_by_setup_intent_id( $intent->id );
+		$order  = WC_Stripe_Helper::get_order_by_setup_intent_id( $intent->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via setup intent ID: ' . $intent->id );
@@ -1115,7 +1115,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		if ( $order->lock_payment( $intent ) ) {
+		if ( $this->lock_order_payment( $order, $intent ) ) {
 			return;
 		}
 
@@ -1145,7 +1145,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$this->send_failed_order_email( $order_id, $status_update );
 		}
 
-		$order->unlock_payment();
+		$this->unlock_order_payment( $order );
 	}
 
 	/**
@@ -1329,7 +1329,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Fetches an order from a payment intent.
 	 *
 	 * @param stdClass $intent The Stripe PaymentIntent object.
-	 * @return WC_Stripe_Order|false The order object, or false if not found.
+	 * @return WC_Order|false The order object, or false if not found.
 	 */
 	private function get_order_from_intent( $intent ) {
 		// Attempt to get the order from the intent metadata.
@@ -1340,7 +1340,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$data      = explode( ':', $signature );
 
 				// Verify we received the order ID and signature (hash).
-				$order = isset( $data[0], $data[1] ) ? WC_Stripe_Order::get_by_id( absint( $data[0] ) ) : false;
+				$order = isset( $data[0], $data[1] ) ? wc_get_order( absint( $data[0] ) ) : false;
 
 				if ( $order ) {
 					$intent_id = WC_Stripe_Helper::get_intent_id_from_order( $order );
@@ -1362,7 +1362,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 			// Try to retrieve from the metadata order ID.
 			if ( isset( $intent->metadata->order_id ) ) {
-				return WC_Stripe_Order::get_by_id( absint( $intent->metadata->order_id ) );
+				return wc_get_order( absint( $intent->metadata->order_id ) );
 			}
 		}
 
@@ -1370,11 +1370,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		if ( ! empty( $intent->charges ) && is_array( $intent->charges ) ) {
 			$charge   = $intent->charges[0] ?? [];
 			$order_id = $charge->metadata->order_id ?? null;
-			return $order_id ? WC_Stripe_Order::get_by_id( $order_id ) : false;
+			return $order_id ? wc_get_order( $order_id ) : false;
 		}
 
 		// Fall back to finding the order via the intent ID.
-		return WC_Stripe_Order::get_by_intent_id( $intent->id );
+		return WC_Stripe_Helper::get_order_by_intent_id( $intent->id );
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -404,7 +404,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$message = __( 'A dispute was created for this order.', 'woocommerce-gateway-stripe' );
 		}
 
-		if ( ! $order->has_status( OrderStatus::CANCELLED ) && ! $order->is_status_final() ) {
+		if ( ! $order->has_status( OrderStatus::CANCELLED ) && ! $order->get_meta( '_stripe_status_final', false ) ) {
 			$order->update_status( OrderStatus::ON_HOLD, $message );
 		} else {
 			$order->add_order_note( $message );
@@ -424,7 +424,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_dispute_closed( $notification ) {
-		$order  = WC_Stripe_Order::get_by_charge_id( $notification->data->object->charge );
+		$order  = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
 		$status = $notification->data->object->status;
 
 		if ( ! $order ) {
@@ -444,10 +444,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( apply_filters( 'wc_stripe_webhook_dispute_change_order_status', true, $order, $notification ) ) {
 			// Mark final so that order status is not overridden by out-of-sequence events.
-			$order->set_status_final( true );
+			$order->update_meta_data( '_stripe_status_final', true );
 
 			// Fail order if dispute is lost, or else revert to pre-dispute status.
-			$order_status = 'lost' === $status ? OrderStatus::FAILED : $order->get_status_before_hold();
+			$order_status = 'lost' === $status ? OrderStatus::FAILED : $this->get_stripe_order_status_before_hold( $order );
 
 			// Do not re-send "Processing Order" email to customer after a dispute win.
 			if ( OrderStatus::PROCESSING === $order_status ) {
@@ -476,7 +476,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_capture( $notification ) {
-		$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->id );
+		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
@@ -485,10 +485,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( WC_Stripe_Helper::payment_method_allows_manual_capture( $order->get_payment_method() ) ) {
 			$charge   = $order->get_transaction_id();
-			$captured = $order->is_charge_captured();
+			$captured = $order->get_meta( '_stripe_charge_captured', true );
 
-			if ( $charge && ! $captured ) {
-				$order->set_charge_captured( 'yes' );
+			if ( $charge && 'no' === $captured ) {
+				$order->update_meta_data( '_stripe_charge_captured', 'yes' );
 
 				// Store other data such as fees
 				$order->set_transaction_id( $notification->data->object->id );
@@ -548,7 +548,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->id );
+		$order = WC_Stripe_Helper::get_order_by_charge_id( $charge->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $charge->id );
@@ -606,7 +606,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_charge_failed( $notification ) {
-		$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->id );
+		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
@@ -623,7 +623,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		} else {
 			$message = __( 'This payment failed to clear.', 'woocommerce-gateway-stripe' );
 		}
-		if ( ! $order->is_status_final() ) {
+		if ( ! $order->get_meta( '_stripe_status_final', false ) ) {
 			$order->update_status( OrderStatus::FAILED, $message );
 		} else {
 			$order->add_order_note( $message );
@@ -641,11 +641,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_source_canceled( $notification ) {
-		$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->id );
+		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
 
 		// If can't find order by charge ID, try source ID.
 		if ( ! $order ) {
-			$order = WC_Stripe_Order::get_by_source_id( $notification->data->object->id );
+			$order = WC_Stripe_Helper::get_order_by_source_id( $notification->data->object->id );
 
 			if ( ! $order ) {
 				WC_Stripe_Logger::log( 'Could not find order via charge/source ID: ' . $notification->data->object->id );
@@ -660,7 +660,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		$message = __( 'This payment was cancelled.', 'woocommerce-gateway-stripe' );
-		if ( ! $order->has_status( OrderStatus::CANCELLED ) && ! $order->is_status_final() ) {
+		if ( ! $order->has_status( OrderStatus::CANCELLED ) && ! $order->get_meta( '_stripe_status_final', false ) ) {
 			$order->update_status( OrderStatus::CANCELLED, $message );
 		} else {
 			$order->add_order_note( $message );
@@ -682,7 +682,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
-			$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->id );
+			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
 		}
 
 		if ( ! $order ) {
@@ -694,8 +694,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( 'stripe' === substr( (string) $order->get_payment_method(), 0, 6 ) ) {
 			$charge     = $order->get_transaction_id();
-			$captured   = $order->is_charge_captured();
-			$refund_id  = $order->get_refund_id();
+			$captured   = $order->get_meta( '_stripe_charge_captured' );
+			$refund_id  = $order->get_meta( '_stripe_refund_id' );
 			$currency   = $order->get_currency();
 			$raw_amount = $refund_object->amount;
 
@@ -706,7 +706,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$amount = wc_price( $raw_amount, [ 'currency' => $currency ] );
 
 			// If charge wasn't captured, skip creating a refund.
-			if ( ! $captured ) {
+			if ( 'yes' !== $captured ) {
 				// If the process was initiated from wp-admin,
 				// the order was already cancelled, so we don't need a new note.
 				if ( OrderStatus::CANCELLED !== $order->get_status() ) {
@@ -743,7 +743,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					WC_Stripe_Logger::log( $refund->get_error_message() );
 				}
 
-				$order->set_refund_id( $refund_object->id );
+				$order->update_meta_data( '_stripe_refund_id', $refund_object->id );
 
 				if ( isset( $refund_object->balance_transaction ) ) {
 					$this->update_fees( $order, $refund_object->balance_transaction );
@@ -764,7 +764,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_webhook_refund_updated( $notification ) {
 		$refund_object = $notification->data->object;
-		$order         = WC_Stripe_Order::get_by_charge_id( $refund_object->charge );
+		$order         = WC_Stripe_Helper::get_order_by_charge_id( $refund_object->charge );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order to update refund via charge ID: ' . $refund_object->charge );
@@ -775,7 +775,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		if ( 'stripe' === substr( (string) $order->get_payment_method(), 0, 6 ) ) {
 			$charge     = $order->get_transaction_id();
-			$refund_id  = $order->get_refund_id();
+			$refund_id  = $order->get_meta( '_stripe_refund_id' );
 			$currency   = $order->get_currency();
 			$raw_amount = $refund_object->amount;
 
@@ -858,7 +858,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			esc_html( $notification->data->object->reason )
 		);
 
-		if ( apply_filters( 'wc_stripe_webhook_review_change_order_status', true, $order, $notification ) && ! $order->is_status_final() ) {
+		if ( apply_filters( 'wc_stripe_webhook_review_change_order_status', true, $order, $notification ) && ! $order->get_meta( '_stripe_status_final', false ) ) {
 			$order->update_status( OrderStatus::ON_HOLD, $message );
 		} else {
 			$order->add_order_note( $message );
@@ -874,14 +874,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_review_closed( $notification ) {
 		if ( isset( $notification->data->object->payment_intent ) ) {
-			$order = WC_Stripe_Order::get_by_intent_id( $notification->data->object->payment_intent );
+			$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
 
 			if ( ! $order ) {
 				WC_Stripe_Logger::log( '[Review Closed] Could not find order via intent ID: ' . $notification->data->object->payment_intent );
 				return;
 			}
 		} else {
-			$order = WC_Stripe_Order::get_by_charge_id( $notification->data->object->charge );
+			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
 
 			if ( ! $order ) {
 				WC_Stripe_Logger::log( '[Review Closed] Could not find order via charge ID: ' . $notification->data->object->charge );
@@ -893,14 +893,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$message = sprintf( __( 'The opened review for this order is now closed. Reason: (%s)', 'woocommerce-gateway-stripe' ), $notification->data->object->reason );
 
 		// Only change the status if the charge was captured, status is not final, the order is on-hold and the review was approved.
-		if ( $order->is_charge_captured() &&
-			! $order->is_status_final() &&
+		if ( 'yes' === $order->get_meta( '_stripe_charge_captured' ) &&
+			! $order->get_meta( '_stripe_status_final', false ) &&
 			$order->has_status( OrderStatus::ON_HOLD ) &&
 			( ! empty( $notification->data->object->closed_reason ) && 'approved' === $notification->data->object->closed_reason ) &&
 			apply_filters( 'wc_stripe_webhook_review_change_order_status', true, $order, $notification )
 		) {
 			// If the status we stored before hold is an incomplete status, restore the status to processing/completed instead.
-			$status_after_review = $order->get_status_before_hold();
+			$status_after_review = $this->get_stripe_order_status_before_hold( $order );
 			if ( in_array( $status_after_review, apply_filters( 'woocommerce_valid_order_statuses_for_payment_complete', [ OrderStatus::ON_HOLD, OrderStatus::PENDING, OrderStatus::FAILED, OrderStatus::CANCELLED ], $order ), true ) ) {
 				$status_after_review = apply_filters( 'woocommerce_payment_complete_order_status', $order->needs_processing() ? OrderStatus::PROCESSING : OrderStatus::COMPLETED, $order->get_id(), $order );
 			}
@@ -1012,7 +1012,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		$order_id           = $order->get_id();
-		$payment_type_meta  = $order->get_upe_payment_type();
+		$payment_type_meta  = $order->get_meta( '_stripe_upe_payment_type' );
 		$is_voucher_payment = in_array( $payment_type_meta, WC_Stripe_Payment_Methods::VOUCHER_PAYMENT_METHODS, true );
 		$is_wallet_payment  = in_array( $payment_type_meta, WC_Stripe_Payment_Methods::WALLET_PAYMENT_METHODS, true );
 
@@ -1040,7 +1040,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				WC_Stripe_Logger::log( "Stripe PaymentIntent $intent->id succeeded for order $order_id" );
 
 				$process_webhook_async = apply_filters( 'wc_stripe_process_payment_intent_webhook_async', true, $order, $intent, $notification );
-				$is_awaiting_action    = $order->is_upe_waiting_for_redirect();
+				$is_awaiting_action    = $order->get_meta( '_stripe_upe_waiting_for_redirect' ) ?? false;
 
 				// Process the webhook now if it's for a voucher or wallet payment , or if filtered to process immediately and order is not awaiting action.
 				if ( $is_voucher_payment || $is_wallet_payment || ( ! $process_webhook_async && ! $is_awaiting_action ) ) {
@@ -1080,7 +1080,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$message = sprintf( __( 'Stripe SCA authentication failed. Reason: %s', 'woocommerce-gateway-stripe' ), $error_message );
 
 				$status_update = [];
-				if ( ! $order->is_status_final() ) {
+				if ( ! $order->get_meta( '_stripe_status_final', false ) ) {
 					$status_update['from'] = $order->get_status();
 					$status_update['to']   = OrderStatus::FAILED;
 					$order->update_status( OrderStatus::FAILED, $message );
@@ -1134,7 +1134,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			$message = sprintf( __( 'Stripe SCA authentication failed. Reason: %s', 'woocommerce-gateway-stripe' ), $error_message );
 
 			$status_update = [];
-			if ( ! $order->is_status_final() ) {
+			if ( ! $order->get_meta( '_stripe_status_final', false ) ) {
 				$status_update['from'] = $order->get_status();
 				$status_update['to']   = OrderStatus::FAILED;
 				$order->update_status( OrderStatus::FAILED, $message );
@@ -1180,7 +1180,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			switch ( $webhook_type ) {
 				case 'payment_intent.succeeded':
 				case 'payment_intent.amount_capturable_updated':
-					$order     = isset( $additional_data['order_id'] ) ? WC_Stripe_Order::get_by_id( $additional_data['order_id'] ) : null;
+					$order     = isset( $additional_data['order_id'] ) ? wc_get_order( $additional_data['order_id'] ) : null;
 					$intent_id = $additional_data['intent_id'] ?? '';
 
 					if ( empty( $order ) ) {

--- a/includes/compat/trait-wc-stripe-pre-orders.php
+++ b/includes/compat/trait-wc-stripe-pre-orders.php
@@ -200,10 +200,10 @@ trait WC_Stripe_Pre_Orders_Trait {
 	 */
 	public function process_pre_order( $order_id ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount(); // @phpstan-ignore-line (minimum amount is defined in the classes that use this trait)
+			$this->validate_minimum_order_amount( $order ); // @phpstan-ignore-line (minimum amount is defined in the classes that use this trait)
 
 			$prepared_source = $this->prepare_source( get_current_user_id(), true ); // @phpstan-ignore-line (prepare_source is defined in the classes that use this trait)
 

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -238,7 +238,7 @@ trait WC_Stripe_Subscriptions_Trait {
 	 */
 	public function process_change_subscription_payment_method( $order_id ) {
 		try {
-			$subscription    = WC_Stripe_Order::get_by_id( $order_id );
+			$subscription    = wc_get_order( $order_id );
 			$prepared_source = $this->prepare_source( get_current_user_id(), true );
 
 			$this->maybe_disallow_prepaid_card( $prepared_source->source_object );
@@ -361,7 +361,6 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * @param $renewal_order WC_Order A WC_Order object created to record the renewal payment.
 	 */
 	public function scheduled_subscription_payment( $amount_to_charge, $renewal_order ) {
-		$renewal_order = WC_Stripe_Order::to_instance( $renewal_order );
 		$this->process_subscription_payment( $amount_to_charge, $renewal_order, true, false );
 	}
 
@@ -373,10 +372,10 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * @since 4.1.0 Add fourth parameter to log previous errors.
 	 * @since 5.6.0 Process renewal payments for SEPA and UPE.
 	 *
-	 * @param float                    $amount
-	 * @param WC_Stripe_Order|WC_Order $renewal_order
-	 * @param bool                     $retry          Should we retry the process?
-	 * @param object                   $previous_error
+	 * @param float  $amount
+	 * @param mixed  $renewal_order
+	 * @param bool   $retry Should we retry the process?
+	 * @param object $previous_error
 	 */
 	public function process_subscription_payment( $amount, $renewal_order, $retry = true, $previous_error = false ) {
 		try {
@@ -457,7 +456,7 @@ trait WC_Stripe_Subscriptions_Trait {
 
 				$is_authentication_required = false;
 			} else {
-				$renewal_order->lock_payment();
+				$this->lock_order_payment( $renewal_order );
 				$response                   = $this->create_and_confirm_intent_for_off_session( $renewal_order, $prepared_source, $amount );
 				$is_authentication_required = $this->is_authentication_required_for_payment( $response );
 			}
@@ -518,7 +517,7 @@ trait WC_Stripe_Subscriptions_Trait {
 
 			/* translators: error message */
 			$renewal_order->update_status( OrderStatus::FAILED );
-			$renewal_order->unlock_payment();
+			$this->unlock_order_payment( $renewal_order );
 
 			return;
 		}
@@ -584,7 +583,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
 		}
 
-		$renewal_order->unlock_payment();
+		$this->unlock_order_payment( $renewal_order );
 	}
 
 	/**
@@ -649,13 +648,11 @@ trait WC_Stripe_Subscriptions_Trait {
 	/**
 	 * Don't transfer Stripe fee/ID meta to renewal orders.
 	 *
-	 * @param WC_Order $renewal_order The renewal order created for the subscription.
+	 * @param int $resubscribe_order The order created for the customer to resubscribe to the old expired/cancelled subscription
 	 */
 	public function delete_renewal_meta( $renewal_order ) {
-		$renewal_order = WC_Stripe_Order::to_instance( $renewal_order );
-
-		$renewal_order->delete_fee();
-		$renewal_order->delete_net();
+		WC_Stripe_Helper::delete_stripe_fee( $renewal_order );
+		WC_Stripe_Helper::delete_stripe_net( $renewal_order );
 
 		// Delete payment intent ID.
 		$renewal_order->delete_meta_data( '_stripe_intent_id' );
@@ -667,18 +664,13 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * Update the customer_id for a subscription after using Stripe to complete a payment to make up for
 	 * an automatic renewal payment which previously failed.
 	 *
-	 * @param WC_Subscription          $subscription The subscription for which the failing payment method relates.
-	 * @param WC_Order|WC_Stripe_Order $renewal_order The order which recorded the successful payment (to make up for the failed automatic payment).
+	 * @param WC_Subscription $subscription The subscription for which the failing payment method relates.
+	 * @param WC_Order        $renewal_order The order which recorded the successful payment (to make up for the failed automatic payment).
 	 * @return void
 	 */
 	public function update_failing_payment_method( $subscription, $renewal_order ) {
-		$renewal_order = WC_Stripe_Order::to_instance( $renewal_order );
-
-		$customer_id = $renewal_order->get_customer_id();
-		$source_id   = $renewal_order->get_source_id();
-
-		$subscription->update_meta_data( '_stripe_customer_id', $customer_id );
-		$subscription->update_meta_data( '_stripe_source_id', $source_id );
+		$subscription->update_meta_data( '_stripe_customer_id', $renewal_order->get_meta( '_stripe_customer_id', true ) );
+		$subscription->update_meta_data( '_stripe_source_id', $renewal_order->get_meta( '_stripe_source_id', true ) );
 		$subscription->save();
 	}
 
@@ -831,13 +823,13 @@ trait WC_Stripe_Subscriptions_Trait {
 		$renewal_order_ids = $order->get_related_orders( 'ids' );
 
 		foreach ( $renewal_order_ids as $renewal_order_id ) {
-			$renewal_order = WC_Stripe_Order::get_by_id( $renewal_order_id );
+			$renewal_order = wc_get_order( $renewal_order_id );
 			if ( ! $renewal_order instanceof WC_Order ) {
 				continue;
 			}
 
 			$mandate                      = $renewal_order->get_meta( '_stripe_mandate_id', true );
-			$renewal_order_payment_method = $renewal_order->get_source_id();
+			$renewal_order_payment_method = $renewal_order->get_meta( '_stripe_source_id', true );
 
 			// Return from the most recent renewal order with a valid mandate. Mandate is created against a payment method
 			// in Stripe so the payment method should also match to reuse the mandate.
@@ -985,16 +977,16 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		// If we couldn't find a Stripe customer linked to the account, fallback to the order meta data.
 		if ( ( ! $stripe_customer_id || ! is_string( $stripe_customer_id ) ) && false !== $subscription->get_parent() ) {
-			$parent_order       = WC_Stripe_Order::get_by_id( $subscription->get_parent_id() );
+			$parent_order       = wc_get_order( $subscription->get_parent_id() );
 			$stripe_customer_id = $parent_order->get_meta( '_stripe_customer_id', true );
-			$stripe_source_id   = $parent_order->get_source_id();
+			$stripe_source_id   = $parent_order->get_meta( '_stripe_source_id', true );
 
 			// For BW compat will remove in future.
 			if ( empty( $stripe_source_id ) ) {
 				$stripe_source_id = $parent_order->get_meta( '_stripe_card_id', true );
 
 				// Take this opportunity to update the key name.
-				$parent_order->set_source_id( $stripe_source_id );
+				$parent_order->update_meta_data( '_stripe_source_id', $stripe_source_id );
 				$parent_order->save();
 			}
 		}
@@ -1228,7 +1220,7 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * @return boolean true if the subscription can be edited, false otherwise.
 	 */
 	public function disable_subscription_edit_for_india( $editable, $order ) {
-		$parent_order = WC_Stripe_Order::get_by_id( $order->get_parent_id() );
+		$parent_order = wc_get_order( $order->get_parent_id() );
 		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled()
 			&& $this->is_subscription( $order )
 			&& $parent_order

--- a/includes/payment-methods/class-wc-gateway-stripe-alipay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-alipay.php
@@ -192,7 +192,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -220,7 +220,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -230,7 +230,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency'] = strtolower( $currency );
 		$post_data['type']     = WC_Stripe_Payment_Methods::ALIPAY;
-		$post_data['owner']    = $order->get_owner_details();
+		$post_data['owner']    = $this->get_owner_details( $order );
 		$post_data['redirect'] = [ 'return_url' => $return_url ];
 
 		if ( ! empty( $this->statement_descriptor ) ) {
@@ -255,10 +255,10 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_save = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -277,7 +277,7 @@ class WC_Gateway_Stripe_Alipay extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to Alipay...' );

--- a/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-bancontact.php
@@ -179,7 +179,7 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -207,7 +207,7 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -217,7 +217,7 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']     = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency']   = strtolower( $currency );
 		$post_data['type']       = WC_Stripe_Payment_Methods::BANCONTACT;
-		$post_data['owner']      = $order->get_owner_details();
+		$post_data['owner']      = $this->get_owner_details( $order );
 		$post_data['redirect']   = [ 'return_url' => $return_url ];
 		$post_data['bancontact'] = [ 'preferred_language' => $this->get_locale() ];
 
@@ -243,10 +243,10 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -265,7 +265,7 @@ class WC_Gateway_Stripe_Bancontact extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to Bancontact...' );

--- a/includes/payment-methods/class-wc-gateway-stripe-boleto.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-boleto.php
@@ -108,12 +108,12 @@ class WC_Gateway_Stripe_Boleto extends WC_Stripe_Payment_Gateway_Voucher {
 	 * Adds on-hold as accepted status during webhook handling on orders paid with voucher
 	 *
 	 * @param $allowed_statuses
-	 * @param $order WC_Stripe_Order
+	 * @param $order
 	 *
 	 * @return mixed
 	 */
 	public function add_allowed_payment_processing_statuses( $allowed_statuses, $order ) {
-		if ( $this->stripe_id === $order->get_upe_payment_type() && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
+		if ( $this->stripe_id === $order->get_meta( '_stripe_upe_payment_type' ) && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses ) ) {
 			$allowed_statuses[] = OrderStatus::ON_HOLD;
 		}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-eps.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-eps.php
@@ -179,7 +179,7 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -207,7 +207,7 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.1.0
 	 * @version 4.1.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -217,7 +217,7 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency'] = strtolower( $currency );
 		$post_data['type']     = WC_Stripe_Payment_Methods::EPS;
-		$post_data['owner']    = $order->get_owner_details();
+		$post_data['owner']    = $this->get_owner_details( $order );
 		$post_data['redirect'] = [ 'return_url' => $return_url ];
 
 		if ( ! empty( $this->statement_descriptor ) ) {
@@ -242,10 +242,10 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -264,7 +264,7 @@ class WC_Gateway_Stripe_Eps extends WC_Stripe_Payment_Gateway {
 				throw new Exception( $response->error->message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to EPS...' );

--- a/includes/payment-methods/class-wc-gateway-stripe-giropay.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-giropay.php
@@ -175,7 +175,7 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -203,7 +203,7 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -213,7 +213,7 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency'] = strtolower( $currency );
 		$post_data['type']     = WC_Stripe_Payment_Methods::GIROPAY;
-		$post_data['owner']    = $order->get_owner_details();
+		$post_data['owner']    = $this->get_owner_details( $order );
 		$post_data['redirect'] = [ 'return_url' => $return_url ];
 
 		if ( ! empty( $this->statement_descriptor ) ) {
@@ -238,10 +238,10 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -260,7 +260,7 @@ class WC_Gateway_Stripe_Giropay extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to giropay...' );

--- a/includes/payment-methods/class-wc-gateway-stripe-ideal.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-ideal.php
@@ -179,7 +179,7 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -207,7 +207,7 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -217,7 +217,7 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency'] = strtolower( $currency );
 		$post_data['type']     = WC_Stripe_Payment_Methods::IDEAL;
-		$post_data['owner']    = $order->get_owner_details();
+		$post_data['owner']    = $this->get_owner_details( $order );
 		$post_data['redirect'] = [ 'return_url' => $return_url ];
 
 		if ( ! empty( $this->statement_descriptor ) ) {
@@ -242,10 +242,10 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -264,7 +264,7 @@ class WC_Gateway_Stripe_Ideal extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to iDEAL...' );

--- a/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-multibanco.php
@@ -183,7 +183,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -241,14 +241,14 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.1.0
 	 * @version 4.1.0
-	 * @param int|WC_Stripe_Order $order
+	 * @param int|WC_Order $order
 	 */
 	public function get_instructions( $order, $plain_text = false ) {
 		if ( true === is_int( $order ) ) {
-			$order = WC_Stripe_Order::get_by_id( $order );
+			$order = wc_get_order( $order );
 		}
 
-		$data = $order->get_multibanco_data();
+		$data = $order->get_meta( '_stripe_multibanco' );
 
 		if ( $plain_text ) {
 			esc_html_e( 'MULTIBANCO INFORMAÇÕES DE ENCOMENDA:', 'woocommerce-gateway-stripe' ) . "\n\n";
@@ -287,7 +287,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.1.0
 	 * @version 4.1.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @param object $source_object
 	 */
 	public function save_instructions( $order, $source_object ) {
@@ -297,7 +297,9 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 			'reference' => $source_object->multibanco->reference,
 		];
 
-		$order->set_multibanco_data( $data );
+		$order_id = $order->get_id();
+
+		$order->update_meta_data( '_stripe_multibanco', $data );
 	}
 
 	/**
@@ -305,7 +307,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.1.0
 	 * @version 4.1.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -315,7 +317,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency'] = strtolower( $currency );
 		$post_data['type']     = WC_Stripe_Payment_Methods::MULTIBANCO;
-		$post_data['owner']    = $order->get_owner_details();
+		$post_data['owner']    = $this->get_owner_details( $order );
 		$post_data['redirect'] = [ 'return_url' => $return_url ];
 
 		if ( ! empty( $this->statement_descriptor ) ) {
@@ -340,10 +342,10 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -362,7 +364,7 @@ class WC_Gateway_Stripe_Multibanco extends WC_Stripe_Payment_Gateway {
 				throw new Exception( $response->error->message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			$this->save_instructions( $order, $response );

--- a/includes/payment-methods/class-wc-gateway-stripe-oxxo.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-oxxo.php
@@ -67,7 +67,7 @@ class WC_Gateway_Stripe_Oxxo extends WC_Stripe_Payment_Gateway_Voucher {
 	 * @return mixed
 	 */
 	public function add_allowed_payment_processing_statuses( $allowed_statuses, $order ) {
-		if ( $this->stripe_id === $order->get_upe_payment_type() && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
+		if ( $this->stripe_id === $order->get_meta( '_stripe_upe_payment_type' ) && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
 			$allowed_statuses[] = OrderStatus::ON_HOLD;
 		}
 

--- a/includes/payment-methods/class-wc-gateway-stripe-p24.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-p24.php
@@ -180,7 +180,7 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -208,7 +208,7 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -218,7 +218,7 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency'] = strtolower( $currency );
 		$post_data['type']     = WC_Stripe_Payment_Methods::P24;
-		$post_data['owner']    = $order->get_owner_details();
+		$post_data['owner']    = $this->get_owner_details( $order );
 		$post_data['redirect'] = [ 'return_url' => $return_url ];
 
 		WC_Stripe_Logger::log( 'Info: Begin creating P24 source' );
@@ -239,10 +239,10 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -261,7 +261,7 @@ class WC_Gateway_Stripe_P24 extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $response->error->message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to P24...' );

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -233,7 +233,7 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -283,7 +283,7 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			if ( $this->has_subscription( $order_id ) ) {
 				$force_save_source = true;
@@ -315,7 +315,7 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 
 			if ( $order->get_total() > 0 ) {
 				// This will throw exception if not valid.
-				$order->validate_minimum_amount();
+				$this->validate_minimum_order_amount( $order );
 
 				WC_Stripe_Logger::log( "Info: Begin processing payment for order $order_id for the amount of {$order->get_total()}" );
 

--- a/includes/payment-methods/class-wc-gateway-stripe-sofort.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sofort.php
@@ -179,7 +179,7 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 
 		// If paying from order, we need to get total from order not cart.
 		if ( parent::is_valid_pay_for_order_endpoint() ) {
-			$order = WC_Stripe_Order::get_by_id( wc_clean( $wp->query_vars['order-pay'] ) );
+			$order = wc_get_order( wc_clean( $wp->query_vars['order-pay'] ) );
 			$total = $order->get_total();
 		}
 
@@ -207,7 +207,7 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @return mixed
 	 */
 	public function create_source( $order ) {
@@ -218,7 +218,7 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 		$post_data['amount']   = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
 		$post_data['currency'] = strtolower( $currency );
 		$post_data['type']     = WC_Stripe_Payment_Methods::SOFORT;
-		$post_data['owner']    = $order->get_owner_details();
+		$post_data['owner']    = $this->get_owner_details( $order );
 		$post_data['redirect'] = [ 'return_url' => $return_url ];
 		$post_data['sofort']   = [
 			'country'            => $bank_country,
@@ -247,10 +247,10 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			// This will throw exception if not valid.
-			$order->validate_minimum_amount();
+			$this->validate_minimum_order_amount( $order );
 
 			// This comes from the create account checkbox in the checkout page.
 			$create_account = ! empty( $_POST['createaccount'] ) ? true : false;
@@ -277,7 +277,7 @@ class WC_Gateway_Stripe_Sofort extends WC_Stripe_Payment_Gateway {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 			}
 
-			$order->set_source_id( $response->id );
+			$order->update_meta_data( '_stripe_source_id', $response->id );
 			$order->save();
 
 			WC_Stripe_Logger::log( 'Info: Redirecting to Sofort...' );

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -378,7 +378,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 			wc_set_time_limit( 0 );
 
 			// Load the order.
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			if ( ! is_a( $order, WC_Order::class ) ) {
 				throw new Exception( __( 'Invalid order!', 'woocommerce-gateway-stripe' ) );

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -383,7 +383,7 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		$express_checkout_type = wc_clean( wp_unslash( $_POST['express_checkout_type'] ) );
 		$payment_method_title  = '';
@@ -421,7 +421,7 @@ class WC_Stripe_Express_Checkout_Element {
 
 		// If $theorder is empty (i.e. non-HPOS), fallback to using the global post object.
 		if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
-			$theorder = WC_Stripe_Order::get_by_id( $GLOBALS['post']->ID );
+			$theorder = wc_get_order( $GLOBALS['post']->ID );
 		}
 
 		if ( ! is_object( $theorder ) ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -478,7 +478,7 @@ class WC_Stripe_Payment_Request {
 
 		// If $theorder is empty (i.e. non-HPOS), fallback to using the global post object.
 		if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
-			$theorder = WC_Stripe_Order::get_by_id( $GLOBALS['post']->ID );
+			$theorder = wc_get_order( $GLOBALS['post']->ID );
 		}
 
 		if ( ! is_object( $theorder ) ) {
@@ -569,7 +569,7 @@ class WC_Stripe_Payment_Request {
 			return;
 		}
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		$payment_request_type = wc_clean( wp_unslash( $_POST['payment_request_type'] ) );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1537,7 +1537,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return bool
 	 */
 	private function is_order_associated_to_payment_intent( int $order_id, string $intent_id ): bool {
-		$order_from_payment_intent = WC_Stripe_Order::get_by_intent_id( $intent_id );
+		$order_from_payment_intent = WC_Stripe_Helper::get_order_by_intent_id( $intent_id );
 		return $order_from_payment_intent && $order_from_payment_intent->get_id() === $order_id;
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -851,7 +851,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function process_payment( $order_id, $retry = true, $force_save_source = false, $previous_error = false, $use_order_source = false ) {
 		$payment_intent_id     = isset( $_POST['wc_payment_intent_id'] ) ? wc_clean( wp_unslash( $_POST['wc_payment_intent_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Missing
-		$order                 = WC_Stripe_Order::get_by_id( $order_id );
+		$order                 = wc_get_order( $order_id );
 		$selected_payment_type = $this->get_selected_payment_method_type_from_request();
 		$save_payment_method   = $this->should_save_payment_method_from_request( $order_id, $selected_payment_type );
 
@@ -1582,7 +1582,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @version 5.5.0
 	 */
 	public function process_upe_redirect_payment( $order_id, $intent_id, $save_payment_method, $is_pay_for_order = false ) {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		if ( ! is_object( $order ) ) {
 			return;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -363,9 +363,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return array|bool
 	 */
 	public function can_refund_order( $order ) {
-		$order = WC_Stripe_Order::to_instance( $order );
-
-		$upe_payment_type = $order->get_upe_payment_type();
+		$upe_payment_type = $order->get_meta( '_stripe_upe_payment_type' );
 
 		if ( ! $upe_payment_type ) {
 			return true;
@@ -557,7 +555,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		if ( parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
 			$order_id = absint( get_query_var( 'order-pay' ) );
-			$order    = WC_Stripe_Order::get_by_id( $order_id );
+			$order    = wc_get_order( $order_id );
 
 			$stripe_params['orderId'] = $order_id;
 
@@ -949,15 +947,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					null // $prepared_source parameter is not necessary for adding mandate information.
 				);
 
-				$order->add_payment_intent_to_order( $payment_intent_id );
+				WC_Stripe_Helper::add_payment_intent_to_order( $payment_intent_id, $order );
 				$order->update_status( OrderStatus::PENDING, __( 'Awaiting payment.', 'woocommerce-gateway-stripe' ) );
-				$order->set_upe_payment_type( $selected_upe_payment_type );
+				$order->update_meta_data( '_stripe_upe_payment_type', $selected_upe_payment_type );
 
 				// TODO: This is a stop-gap to fix a critical issue, see
 				// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
 				// be better if we removed the need for additional meta data in favor of refactoring
 				// this part of the payment processing.
-				$order->set_upe_waiting_for_redirect( true );
+				$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 
 				$order->save();
 
@@ -1018,7 +1016,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return $this->process_change_subscription_payment_with_deferred_intent( $order_id );
 		}
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		try {
 			$payment_information = $this->prepare_payment_information_from_request( $order );
@@ -1072,11 +1070,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 
 			// Lock the order before we create and confirm the payment/setup intents to prevent Stripe sending the success webhook before this request is completed.
-			$order->lock_payment();
+			$this->lock_order_payment( $order );
 
 			if ( $payment_needed ) {
 				// Throw an exception if the minimum order amount isn't met.
-				$order->validate_minimum_amount();
+				$this->validate_minimum_order_amount( $order );
 
 				// Create a payment intent, or update an existing one associated with the order.
 				$payment_intent = $this->process_payment_intent_for_order( $order, $payment_information );
@@ -1141,10 +1139,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				}
 
 				// If the order requires some action from the customer, add meta to the order to prevent it from being cancelled by WooCommerce's hold stock settings.
-				$order->set_payment_awaiting_action( false );
+				WC_Stripe_Helper::set_payment_awaiting_action( $order, false );
 
 				// Prevent processing the payment intent webhooks while also processing the redirect payment (also prevents duplicate Stripe meta stored on the order).
-				$order->set_upe_waiting_for_redirect( true );
+				$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 				$order->save();
 
 				$redirect = $this->get_redirect_url( $this->get_return_url( $order ), $payment_intent, $payment_information, $order, $payment_needed );
@@ -1167,7 +1165,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				$redirect = $this->get_return_url( $order );
 			}
 
-			$order->unlock_payment();
+			$this->unlock_order_payment( $order );
 
 			return array_merge(
 				[
@@ -1189,7 +1187,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return array An array with the result of the payment processing, and a redirect URL on success.
 	 */
 	private function process_payment_with_confirmation_token( int $order_id ) {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		try {
 			$payment_information = $this->prepare_payment_information_from_request( $order );
@@ -1288,7 +1286,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function process_payment_with_saved_payment_method( $order_id, $can_retry = true ) {
 		try {
-			$order = WC_Stripe_Order::get_by_id( $order_id );
+			$order = wc_get_order( $order_id );
 
 			if ( $this->maybe_process_pre_orders( $order_id ) ) {
 				return $this->process_pre_order( $order_id );
@@ -1311,7 +1309,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			if ( $payment_needed ) {
 				// This will throw exception if not valid.
-				$order->validate_minimum_amount();
+				$this->validate_minimum_order_amount( $order );
 
 				$request_details = $this->generate_payment_request( $order, $prepared_payment_method );
 				$endpoint        = false !== $intent ? "payment_intents/$intent->id" : 'payment_intents';
@@ -1551,7 +1549,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return bool
 	 */
 	private function is_order_associated_to_setup_intent( int $order_id, string $intent_id ): bool {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 		if ( ! $order ) {
 			return false;
 		}
@@ -1594,7 +1592,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return;
 		}
 
-		if ( $order->is_upe_redirect_processed() ) {
+		if ( $order->get_meta( '_stripe_upe_redirect_processed', true ) ) {
 			return;
 		}
 
@@ -1625,7 +1623,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Update order and maybe save payment method for an order after an intent has been created and confirmed.
 	 *
-	 * @param WC_Stripe_Order $order        Order being processed.
+	 * @param WC_Order $order               Order being processed.
 	 * @param string   $intent_id           Stripe setup/payment ID.
 	 * @param bool     $save_payment_method Boolean representing whether payment method for order should be saved.
 	 */
@@ -1695,7 +1693,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		$this->save_intent_to_order( $order, $intent );
 		$this->set_payment_method_title_for_order( $order, $payment_method_type );
-		$order->set_upe_redirect_processed( true );
+		$order->update_meta_data( '_stripe_upe_redirect_processed', true );
 
 		// TODO: This is a stop-gap to fix a critical issue, see
 		// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/2536. It would
@@ -1707,7 +1705,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		 * This meta is to prevent stores with short hold stock settings from cancelling orders while waiting for payment to be finalised by Stripe or the customer (i.e. completing 3DS or payment redirects).
 		 * Now that payment is confirmed, we can remove this meta.
 		 */
-		$order->remove_payment_awaiting_action();
+		WC_Stripe_Helper::remove_payment_awaiting_action( $order, false );
 
 		$order->save();
 	}
@@ -1733,15 +1731,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Save payment method to order.
 	 *
-	 * @param WC_Stripe_Order $order For to which the source applies.
+	 * @param WC_Order $order For to which the source applies.
 	 * @param stdClass $payment_method Stripe Payment Method.
 	 */
 	public function save_payment_method_to_order( $order, $payment_method ) {
 		if ( $payment_method->customer ) {
-			$order->set_stripe_customer_id( $payment_method->customer );
+			$order->update_meta_data( '_stripe_customer_id', $payment_method->customer );
 		}
 		// Save the payment method id as `source_id`, because we use both `sources` and `payment_methods` APIs.
-		$order->set_source_id( $payment_method->payment_method );
+		$order->update_meta_data( '_stripe_source_id', $payment_method->payment_method );
 
 		if ( is_callable( [ $order, 'save' ] ) ) {
 			$order->save();
@@ -1823,7 +1821,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Free trial subscriptions without a sign up fee, or any other type
 		// of order with a `0` amount should fall into the logic below.
 		$amount = is_null( WC()->cart ) ? 0 : WC()->cart->get_total( false );
-		$order  = isset( $order_id ) ? WC_Stripe_Order::get_by_id( $order_id ) : null;
+		$order  = isset( $order_id ) ? wc_get_order( $order_id ) : null;
 		if ( is_a( $order, 'WC_Order' ) ) {
 			$amount = $order->get_total();
 		}
@@ -2596,15 +2594,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Conditionally stores the card brand to the order meta.
 	 *
-	 * @param WC_Stripe_Order $order   The WC Order for which we're processing a payment.
+	 * @param WC_Order $order          The WC Order for which we're processing a payment.
 	 * @param stdClass $payment_method The payment method object.
 	 */
-	private function maybe_set_preferred_card_brand_for_order( WC_Stripe_Order $order, $payment_method ) {
+	private function maybe_set_preferred_card_brand_for_order( WC_Order $order, $payment_method ) {
 		// Retrieve the preferred card brand for the payment method.
 		$preferred_brand = $payment_method->card->networks->preferred ?? null;
 		if ( WC_Stripe_Co_Branded_CC_Compatibility::is_wc_supported() && $preferred_brand ) {
 
-			$order->set_card_brand( $preferred_brand );
+			$order->update_meta_data( '_stripe_card_brand', $preferred_brand );
 			$order->save_meta_data();
 
 			if ( function_exists( 'wc_admin_record_tracks_event' ) ) {
@@ -2762,12 +2760,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Set the payment metadata for payment method id.
 	 *
-	 * @param WC_Stripe_Order $order The order.
+	 * @param WC_Order $order The order.
 	 * @param string   $payment_method_id The value to be set.
 	 */
 	public function set_payment_method_id_for_order( WC_Order $order, string $payment_method_id ) {
 		// Save the payment method id as `source_id`, because we use both `sources` and `payment_methods` APIs.
-		$order->set_source_id( $payment_method_id );
+		$order->update_meta_data( '_stripe_source_id', $payment_method_id );
 		$order->save_meta_data();
 	}
 
@@ -2787,11 +2785,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 *
 	 * Set to public so it can be called from confirm_change_payment_from_setup_intent_ajax()
 	 *
-	 * @param WC_Stripe_Order $order The order.
+	 * @param WC_Order $order The order.
 	 * @param string   $customer_id The value to be set.
 	 */
 	public function set_customer_id_for_order( WC_Order $order, string $customer_id ) {
-		$order->set_stripe_customer_id( $customer_id );
+		$order->update_meta_data( '_stripe_customer_id', $customer_id );
 		$order->save_meta_data();
 	}
 
@@ -2811,11 +2809,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Set the payment metadata for the selected payment type.
 	 *
-	 * @param WC_Stripe_Order $order                 The order for which we're setting the selected payment type.
+	 * @param WC_Order $order                 The order for which we're setting the selected payment type.
 	 * @param string   $selected_payment_type The selected payment type.
 	 */
 	private function set_selected_payment_type_for_order( WC_Order $order, string $selected_payment_type ) {
-		$order->set_upe_payment_type( $selected_payment_type );
+		$order->update_meta_data( '_stripe_upe_payment_type', $selected_payment_type );
 		$order->save_meta_data();
 	}
 	/**
@@ -2980,7 +2978,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	private function get_existing_compatible_payment_intent( $order, $payment_method_types ) {
 		// Reload the order to make sure we have the latest data.
-		$order  = WC_Stripe_Order::get_by_id( $order->get_id() );
+		$order  = wc_get_order( $order->get_id() );
 		$intent = $this->get_intent_from_order( $order );
 		if ( ! $intent ) {
 			return null;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-boleto.php
@@ -42,12 +42,12 @@ class WC_Stripe_UPE_Payment_Method_Boleto extends WC_Stripe_UPE_Payment_Method {
 	 * Adds on-hold as accepted status during webhook handling on orders paid with Boleto
 	 *
 	 * @param $allowed_statuses
-	 * @param $order WC_Stripe_Order
+	 * @param $order
 	 *
 	 * @return mixed
 	 */
 	public function add_allowed_payment_processing_statuses( $allowed_statuses, $order ) {
-		if ( WC_Stripe_Payment_Methods::BOLETO === $order->get_upe_payment_type() && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
+		if ( WC_Stripe_Payment_Methods::BOLETO === $order->get_meta( '_stripe_upe_payment_type' ) && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
 			$allowed_statuses[] = OrderStatus::ON_HOLD;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -124,7 +124,7 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 
 		// If $theorder is empty (i.e. non-HPOS), fallback to using the global post object.
 		if ( empty( $theorder ) && ! empty( $GLOBALS['post']->ID ) ) {
-			$theorder = WC_Stripe_Order::get_by_id( $GLOBALS['post']->ID );
+			$theorder = wc_get_order( $GLOBALS['post']->ID );
 		}
 
 		if ( ! is_object( $theorder ) ) {

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
@@ -44,7 +44,7 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 	 * @param int $order_id
 	 */
 	public function thankyou_page( $order_id ) {
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 		if ( ! $order ) {
 			return;
 		}
@@ -69,11 +69,11 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 	/**
 	 * Gets Multibanco payment instructions for the customer.
 	 *
-	 * @param WC_Stripe_Order $order
+	 * @param WC_Order $order
 	 * @param bool     $plain_text
 	 */
 	public function get_instructions( $order, $plain_text = false ) {
-		$data = $order->get_multibanco_data();
+		$data = $order->get_meta( '_stripe_multibanco' );
 		if ( ! $data ) {
 			return;
 		}
@@ -114,7 +114,7 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 	/**
 	 * Saves Multibanco information to the order meta for later use.
 	 *
-	 * @param WC_Stripe_Order $order
+	 * @param object $order
 	 * @param object $payment_intent. The PaymentIntent object.
 	 */
 	public function save_instructions( $order, $payment_intent ) {
@@ -128,19 +128,19 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 			'reference' => $payment_intent->next_action->multibanco_display_details->reference,
 		];
 
-		$order->set_multibanco_data( $data );
+		$order->update_meta_data( '_stripe_multibanco', $data );
 	}
 
 	/**
 	 * Adds on-hold as accepted status during webhook handling on orders paid with Mukltibanco
 	 *
 	 * @param $allowed_statuses
-	 * @param $order WC_Stripe_Order
+	 * @param $order
 	 *
 	 * @return mixed
 	 */
 	public function add_allowed_payment_processing_statuses( $allowed_statuses, $order ) {
-		if ( WC_Stripe_Payment_Methods::MULTIBANCO === $order->get_upe_payment_type() && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
+		if ( WC_Stripe_Payment_Methods::MULTIBANCO === $order->get_meta( '_stripe_upe_payment_type' ) && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
 			$allowed_statuses[] = OrderStatus::ON_HOLD;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-oxxo.php
@@ -42,12 +42,12 @@ class WC_Stripe_UPE_Payment_Method_Oxxo extends WC_Stripe_UPE_Payment_Method {
 	 * Adds on-hold as accepted status during webhook handling on orders paid with OXXO
 	 *
 	 * @param $allowed_statuses
-	 * @param $order WC_Stripe_Order
+	 * @param $order
 	 *
 	 * @return mixed
 	 */
 	public function add_allowed_payment_processing_statuses( $allowed_statuses, $order ) {
-		if ( WC_Stripe_Payment_Methods::OXXO === $order->get_upe_payment_type() && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
+		if ( WC_Stripe_Payment_Methods::OXXO === $order->get_meta( '_stripe_upe_payment_type' ) && ! in_array( OrderStatus::ON_HOLD, $allowed_statuses, true ) ) {
 			$allowed_statuses[] = OrderStatus::ON_HOLD;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -287,7 +287,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		$currencies             = $this->get_supported_currencies();
 		if ( ! empty( $currencies ) ) {
 			if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['key'] ) ) {
-				$order          = WC_Stripe_Order::get_by_id( $order_id ? $order_id : absint( get_query_var( 'order-pay' ) ) );
+				$order          = wc_get_order( $order_id ? $order_id : absint( get_query_var( 'order-pay' ) ) );
 				$order_currency = $order->get_currency();
 				if ( ! in_array( $order_currency, $currencies, true ) ) {
 					return false;
@@ -704,7 +704,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	 */
 	public function get_current_order_amount() {
 		if ( is_wc_endpoint_url( 'order-pay' ) && isset( $_GET['key'] ) ) {
-			$order = WC_Stripe_Order::get_by_id( absint( get_query_var( 'order-pay' ) ) );
+			$order = wc_get_order( absint( get_query_var( 'order-pay' ) ) );
 			return $order->get_total( '' );
 		} elseif ( WC()->cart ) {
 			return WC()->cart->get_total( '' );

--- a/readme.txt
+++ b/readme.txt
@@ -117,7 +117,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Updates the "Smart Checkout" setting name to "Optimized Checkout", and the description accordingly.
 * Fix - Checks for the existence of the WC_Stripe_Feature_Flags class before including it during extension initialization.
 * Dev - Splits the code coverage GitHub Actions Workflow into two separate actions.
-* Dev - Implements the new Stripe order class into the root extension files.
 * Fix - Fixes the listing of payment methods in the Stripe settings page when the Smart Checkout is enabled.
 * Tweak - Passes the correct parent payment method configuration ID (retrieved from the backend) to the Smart Checkout payment element.
 * Tweak - Removes the Stripe icon beside the Smart Checkout payment element from the checkout pages.

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Renames all references to "Smart Checkout" and "Single Payment Element" (and "SPE") to "Optimized Checkout" (and "OC"), following the feature rebranding.
 * Tweak - Updates the "Smart Checkout" setting name to "Optimized Checkout", and the description accordingly.
 * Fix - Checks for the existence of the WC_Stripe_Feature_Flags class before including it during extension initialization.
-* Dev - Implements the new Stripe order class into the new checkout experience files.
 * Dev - Splits the code coverage GitHub Actions Workflow into two separate actions.
 * Dev - Implements the new Stripe order class into the root extension files.
 * Fix - Fixes the listing of payment methods in the Stripe settings page when the Smart Checkout is enabled.

--- a/readme.txt
+++ b/readme.txt
@@ -121,7 +121,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Passes the correct parent payment method configuration ID (retrieved from the backend) to the Smart Checkout payment element.
 * Tweak - Removes the Stripe icon beside the Smart Checkout payment element from the checkout pages.
 * Add - New setting to allow merchants to set their preferred title for the Smart Checkout payment element. Defaults to "Stripe".
-* Dev - Implements the new Stripe order class into the compatibility classes.
 * Dev - Updates the Code Sniffer package to version 1.0.0.
 * Update - Add ECE support for One Page Checkout and other dynamic cart update scenarios
 * Fix - Show error notice when 'Add payment method' fails on My Account page in block-based themes.

--- a/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
+++ b/tests/phpunit/admin/test-class-wc-rest-stripe-orders-controller.php
@@ -73,9 +73,9 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 
 		$order    = WC_Helper_Order::create_order();
 		$endpoint = '/' . strval( $order->get_id() ) . '/create_customer';
-		$order->set_stripe_customer_id( 'cus_12345' );
+		$order->add_meta_data( '_stripe_customer_id', 'cus_12345', true );
 		$order->save();
-		$this->assertEquals( 'cus_12345', $order->get_stripe_customer_id() );
+		$this->assertEquals( 'cus_12345', $order->get_meta( '_stripe_customer_id', true ) );
 
 		// Mock response from Stripe API using request arguments.
 		$test_request = function ( $preempt, $parsed_args, $url ) {
@@ -140,12 +140,10 @@ class WC_REST_Stripe_Orders_Controller_Test extends WP_UnitTestCase {
 		$request->set_param( 'payment_intent_id', 'pi_12345' );
 		$response = rest_do_request( $request );
 
-		$order = WC_Stripe_Order::get_by_id( $order->get_id() );
-
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 'succeeded', $response->get_data()['status'] );
 		$this->assertEquals( 'ch_12345', $response->get_data()['id'] );
-		$this->assertEquals( 'pi_12345', $order->get_intent_id() );
+		$this->assertEquals( 'pi_12345', $order->get_meta( '_stripe_intent_id', true ) );
 
 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 	}

--- a/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
+++ b/tests/phpunit/admin/test-class-wc-stripe-settings-controller.php
@@ -82,8 +82,11 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_add_buttons_action_is_called_on_order_admin_page() {
-		$order = WC_Helper_Order::create_order();
-		$order->set_intent_id( 'pi_mock' );
+		$order    = WC_Helper_Order::create_order();
+		$order_id = $order->get_id();
+
+		$intent_id = 'pi_mock';
+		update_post_meta( $order_id, '_stripe_intent_id', $intent_id );
 
 		$intent = (object) [
 			'id'     => 'pi_123',

--- a/tests/phpunit/helpers/class-wc-helper-order.php
+++ b/tests/phpunit/helpers/class-wc-helper-order.php
@@ -21,7 +21,7 @@ class WC_Helper_Order {
 	 */
 	public static function delete_order( $order_id ) {
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		// Delete all products in the order.
 		foreach ( $order->get_items() as $item ) {
@@ -44,7 +44,7 @@ class WC_Helper_Order {
 	 * @param WC_Product $product The product to add to the order.
 	 * @param array      $order_props Order properties.
 	 *
-	 * @return WC_Stripe_Order
+	 * @return WC_Order
 	 */
 	public static function create_order( $customer_id = 1, $product = null, $order_props = [] ) {
 
@@ -62,7 +62,7 @@ class WC_Helper_Order {
 		];
 
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception.
-		$order                  = WC_Stripe_Order::create( $order_data );
+		$order                  = wc_create_order( $order_data );
 
 		// Add order products.
 		$item = new WC_Order_Item_Product();

--- a/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
+++ b/tests/phpunit/payment-methods/test-class-wc-stripe-upe-payment-gateway.php
@@ -354,9 +354,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$currency          = $order->get_currency();
 		$order_id          = $order->get_id();
 
-		$order->set_intent_id( $payment_intent_id );
-		$order->set_upe_payment_type( '' );
-		$order->set_upe_waiting_for_redirect( true );
+		$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
+		$order->update_meta_data( '_stripe_upe_payment_type', '' );
+		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 		$order->save();
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
@@ -376,7 +376,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -385,7 +385,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			->with(
 				"payment_intents/$payment_intent_id",
 				$expected_request,
-				WC_Stripe_Order::get_by_id( $order_id )
+				wc_get_order( $order_id )
 			)
 			->will(
 				$this->returnValue( [] )
@@ -698,7 +698,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertEquals( 'failure', $response['result'] );
 
-		$processed_order = WC_Stripe_Order::get_by_id( $order_id );
+		$processed_order = wc_get_order( $order_id );
 		$this->assertEquals( OrderStatus::FAILED, $processed_order->get_status() );
 	}
 
@@ -767,7 +767,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertEquals( 'failure', $response['result'] );
 
-		$processed_order = WC_Stripe_Order::get_by_id( $order_id );
+		$processed_order = wc_get_order( $order_id );
 		$this->assertEquals( OrderStatus::FAILED, $processed_order->get_status() );
 	}
 
@@ -836,7 +836,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertEquals( 'failure', $response['result'] );
 
-		$processed_order = WC_Stripe_Order::get_by_id( $order_id );
+		$processed_order = wc_get_order( $order_id );
 		$this->assertEquals( OrderStatus::FAILED, $processed_order->get_status() );
 	}
 
@@ -912,7 +912,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -922,8 +922,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
 		$this->assertEquals( 'Credit / Debit Card', $final_order->get_payment_method_title() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertTrue( $final_order->is_upe_redirect_processed() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertTrue( (bool) $final_order->get_meta( '_stripe_upe_redirect_processed', true ) );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
@@ -975,7 +975,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$success_order = WC_Stripe_Order::get_by_id( $order_id );
+		$success_order = wc_get_order( $order_id );
 
 		$note = wc_get_order_notes(
 			[
@@ -987,8 +987,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		// assert successful order processing
 		$this->assertEquals( OrderStatus::PROCESSING, $success_order->get_status() );
 		$this->assertEquals( 'Credit / Debit Card', $success_order->get_payment_method_title() );
-		$this->assertEquals( $payment_intent_id, $success_order->get_intent_id() );
-		$this->assertTrue( $success_order->is_upe_redirect_processed() );
+		$this->assertEquals( $payment_intent_id, $success_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertTrue( (bool) $success_order->get_meta( '_stripe_upe_redirect_processed', true ) );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 
 		// simulate an order getting marked as failed as if from a webhook
@@ -998,7 +998,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		// attempt to reprocess the order and confirm status is unchanged
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( OrderStatus::FAILED, $final_order->get_status() );
 	}
@@ -1029,7 +1029,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1044,11 +1044,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $setup_intent_id, true );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 		$this->assertEquals( 'Credit / Debit Card', $final_order->get_payment_method_title() );
 	}
 
@@ -1080,7 +1080,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1106,12 +1106,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, true );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 	}
 
 	/**
@@ -1145,7 +1145,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1174,12 +1174,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, true );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $generated_payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $generated_payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 	}
 
 	/**
@@ -1220,7 +1220,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1233,11 +1233,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $setup_intent_id, true );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $generated_payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $generated_payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 	}
 
 	/**
@@ -1310,29 +1310,29 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		// Test no charge captured.
 		$charge_mock['captured'] = false;
 		$charge_mock['id']       = 'ch_mock_1';
-		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
-		$test_order = WC_Stripe_Order::get_by_id( $order_id );
+		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
+		$test_order = wc_get_order( $order_id );
 
-		$this->assertFalse( $test_order->is_charge_captured() );
+		$this->assertEquals( 'no', $test_order->get_meta( '_stripe_charge_captured', true ) );
 		$this->assertEquals( $charge_mock['id'], $test_order->get_transaction_id() );
 		$this->assertEquals( OrderStatus::ON_HOLD, $test_order->get_status() );
 
 		// Test charge succeeds.
 		$charge_mock['captured'] = true;
 		$charge_mock['id']       = 'ch_mock_2';
-		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
-		$test_order = WC_Stripe_Order::get_by_id( $order_id );
+		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
+		$test_order = wc_get_order( $order_id );
 
-		$this->assertTrue( $test_order->is_charge_captured() );
+		$this->assertEquals( 'yes', $test_order->get_meta( '_stripe_charge_captured', true ) );
 		$this->assertEquals( OrderStatus::PROCESSING, $test_order->get_status() );
 
 		// Test charge pending.
 		$charge_mock['status'] = 'pending';
 		$charge_mock['id']     = 'ch_mock_3';
-		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
-		$test_order = WC_Stripe_Order::get_by_id( $order_id );
+		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
+		$test_order = wc_get_order( $order_id );
 
-		$this->assertTrue( $test_order->is_charge_captured() );
+		$this->assertEquals( 'yes', $test_order->get_meta( '_stripe_charge_captured', true ) );
 		$this->assertEquals( $charge_mock['id'], $test_order->get_transaction_id() );
 		$this->assertEquals( OrderStatus::ON_HOLD, $test_order->get_status() );
 
@@ -1341,7 +1341,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$charge_mock['id']     = 'ch_mock_4';
 		$exception             = null;
 		try {
-			$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), WC_Stripe_Order::get_by_id( $order_id ) );
+			$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
 		} catch ( WC_Stripe_Exception $e ) {
 			// Test that exception is thrown.
 			$exception = $e;
@@ -1432,7 +1432,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			->willReturn( $this->array_to_object( $charge ) );
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -1442,9 +1442,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
@@ -1520,14 +1520,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			->willReturn( $this->array_to_object( $charge ) );
 
 		$response      = $this->mock_gateway->process_payment( $order_id );
-		$final_order   = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order   = wc_get_order( $order_id );
 		$client_secret = $payment_intent_mock->client_secret;
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( OrderStatus::PENDING, $final_order->get_status() ); // Order status should be pending until 3DS is completed.
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 		$this->assertMatchesRegularExpression( "/#wc-stripe-confirm-pi:$order_id:$client_secret/", $response['redirect'] );
 	}
 
@@ -1583,12 +1583,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( 'failure', $response['result'] );
 		$this->assertEquals( OrderStatus::FAILED, $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 	}
 
 	/**
@@ -1678,7 +1678,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			->willReturn( $this->array_to_object( $charge ) );
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -1688,9 +1688,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->assertEquals( 'success', $response['result'] );
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 
@@ -1773,11 +1773,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( 'failure', $response['result'] );
 		$this->assertEquals( OrderStatus::FAILED, $final_order->get_status() );
-		$this->assertEquals( '', $final_order->get_stripe_customer_id() );
+		$this->assertEquals( '', $final_order->get_meta( '_stripe_customer_id', true ) );
 	}
 
 	/**
@@ -1794,9 +1794,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$currency          = $order->get_currency();
 		$order_id          = $order->get_id();
 
-		$order->set_intent_id( $payment_intent_id );
-		$order->set_upe_payment_type( '' );
-		$order->set_upe_waiting_for_redirect( true );
+		$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
+		$order->update_meta_data( '_stripe_upe_payment_type', '' );
+		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 		$order->save();
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
@@ -1828,7 +1828,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -1838,7 +1838,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			->with(
 				"payment_intents/$payment_intent_id",
 				$expected_request,
-				WC_Stripe_Order::get_by_id( $order_id )
+				wc_get_order( $order_id )
 			)
 			->will(
 				$this->returnValue( [] )
@@ -1911,10 +1911,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
-		$order->set_lock_payment( ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
+		$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
 		$order->save();
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
 		$payment_method_mock['id']               = $payment_method_id;
@@ -1968,7 +1968,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_subscription_payment( $amount, $order, false, false );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -2005,10 +2005,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		list( $amount, $description, $metadata ) = $this->get_order_details( $order );
 		$order->set_payment_method( WC_Stripe_UPE_Payment_Gateway::ID );
-		$order->set_lock_payment( ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
+		$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) ); // To assist with comparing expected order objects, set an existing lock.
 		$order->save();
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 
 		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
 		$payment_method_mock['id']               = $payment_method_id;
@@ -2070,7 +2070,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_subscription_payment( $amount, $order, false, false );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -2141,14 +2141,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			);
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'has_pre_order_charged_upon_release' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will( $this->returnValue( true ) );
 
 		$this->mock_gateway->expects( $this->once() )
@@ -2167,13 +2167,13 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
 		$this->assertEquals( 'Credit / Debit Card', $final_order->get_payment_method_title() );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertEquals( $payment_intent_id, $final_order->get_intent_id() );
-		$this->assertTrue( $final_order->is_upe_redirect_processed() );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertEquals( $payment_intent_id, $final_order->get_meta( '_stripe_intent_id', true ) );
+		$this->assertTrue( (bool) $final_order->get_meta( '_stripe_upe_redirect_processed', true ) );
 	}
 
 	/**
@@ -2202,7 +2202,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->any() )
 			->method( 'get_stripe_customer_from_order' )
-			->with( WC_Stripe_Order::get_by_id( $order_id ) )
+			->with( wc_get_order( $order_id ) )
 			->will(
 				$this->returnValue( $this->mock_stripe_customer )
 			);
@@ -2234,11 +2234,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $setup_intent_id, true );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
-		$this->assertEquals( $customer_id, $final_order->get_stripe_customer_id() );
-		$this->assertTrue( $final_order->is_upe_redirect_processed() );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
+		$this->assertEquals( $customer_id, $final_order->get_meta( '_stripe_customer_id', true ) );
+		$this->assertTrue( (bool) $final_order->get_meta( '_stripe_upe_redirect_processed', true ) );
 	}
 
 	/**
@@ -2468,7 +2468,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		];
 
 		// Save the failed intent ID to the order
-		$order->set_intent_id( $mock_failed_intent->id );
+		$order->update_meta_data( '_stripe_intent_id', $mock_failed_intent->id );
 		$order->save();
 
 		// Mock that we find an existing failed intent on the order
@@ -2596,7 +2596,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			);
 
 		$response    = $this->mock_gateway->process_payment( $order_id );
-		$final_order = WC_Stripe_Order::get_by_id( $order_id );
+		$final_order = wc_get_order( $order_id );
 		$note        = wc_get_order_notes(
 			[
 				'order_id' => $order_id,
@@ -2605,7 +2605,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		)[0];
 
 		$this->assertEquals( 'success', $response['result'] );
-		$this->assertEquals( $payment_method_id, $final_order->get_source_id() );
+		$this->assertEquals( $payment_method_id, $final_order->get_meta( '_stripe_source_id', true ) );
 		$this->assertMatchesRegularExpression( '/Charge ID: ch_mock/', $note->content );
 	}
 

--- a/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
+++ b/tests/phpunit/payment-methods/test-wc-stripe-express-checkout-element.php
@@ -154,13 +154,13 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_add_order_meta
 	 */
 	public function test_add_order_meta( $checkout_type, $expected ) {
-		$order = WC_Stripe_Order::create();
+		$order = wc_create_order();
 
 		$_POST['express_checkout_type'] = $checkout_type;
 		$_POST['payment_method']        = 'stripe';
 
 		$this->element->add_order_meta( $order->get_id(), [] );
-		$order = WC_Stripe_Order::get_by_id( $order->get_id() );
+		$order = wc_get_order( $order->get_id() );
 
 		$this->assertSame( $expected, $order->get_payment_method_title() );
 	}

--- a/tests/phpunit/test-class-wc-stripe-order-handler.php
+++ b/tests/phpunit/test-class-wc-stripe-order-handler.php
@@ -19,10 +19,10 @@ class WC_Stripe_Order_Handler_Test extends WP_UnitTestCase {
 
 	public function test_prevent_cancelling_orders_awaiting_action() {
 		$order = WC_Helper_Order::create_order();
-		$order->set_payment_awaiting_action();
+		WC_Stripe_Helper::set_payment_awaiting_action( $order );
 
 		// Read in a fresh order object with meta like `date_modified` set.
-		$order = WC_Stripe_Order::get_by_id( $order->get_id() );
+		$order = wc_get_order( $order->get_id() );
 
 		// Test when false is passed that the order is not cancelled.
 		$this->assertFalse( $this->order_handler->prevent_cancelling_orders_awaiting_action( false, $order ) );

--- a/tests/phpunit/test-wc-stripe-helper.php
+++ b/tests/phpunit/test-wc-stripe-helper.php
@@ -210,16 +210,15 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 		$order    = WC_Helper_Order::create_order();
 		$order_id = $order->get_id();
 
-		$order = WC_Stripe_Order::get_by_id( $order_id );
+		$order = wc_get_order( $order_id );
 		$order->set_status( $status );
 
 		$intent_id = 'pi_mock';
-		$order->set_intent_id( $intent_id );
-		$order->save_meta_data();
+		update_post_meta( $order_id, '_stripe_intent_id', $intent_id );
 
-		$order = WC_Stripe_Order::get_by_intent_id( $intent_id );
+		$order = WC_Stripe_Helper::get_order_by_intent_id( $intent_id );
 		if ( $success ) {
-			$this->assertInstanceOf( WC_Stripe_Order::class, $order );
+			$this->assertInstanceOf( WC_Order::class, $order );
 		} else {
 			$this->assertFalse( $order );
 		}

--- a/tests/phpunit/test-wc-stripe-order.php
+++ b/tests/phpunit/test-wc-stripe-order.php
@@ -118,7 +118,7 @@ class WC_Stripe_Order_Test extends WP_UnitTestCase {
 		);
 		$order->set_upe_redirect_processed( true );
 		$order->set_upe_waiting_for_redirect( true );
-		$order->set_charge_captured( 'yes' );
+		$order->set_charge_captured( true );
 		$order->set_status_final( true );
 
 		$order->set_fee( 100 );

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -578,8 +578,8 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$mock_subscription = WC_Helper_Order::create_order(); // We can use an order as a subscription.
 		$mock_subscription->set_payment_method( 'stripe' );
 
-		$mock_subscription->set_source_id( 'src_mock' );
-		$mock_subscription->set_stripe_customer_id( 'cus_mock' );
+		$mock_subscription->update_meta_data( '_stripe_source_id', 'src_mock' );
+		$mock_subscription->update_meta_data( '_stripe_customer_id', 'cus_mock' );
 		$mock_subscription->save();
 
 		// This is the key the customer's payment methods are stored under in the transient.
@@ -631,45 +631,45 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	 */
 	public function test_lock_order_payment() {
 		$order_1 = WC_Helper_Order::create_order();
-		$locked  = $order_1->lock_payment();
+		$locked  = $this->gateway->lock_order_payment( $order_1 );
 
 		$this->assertFalse( $locked );
-		$current_lock = $order_1->get_lock_payment();
+		$current_lock = $order_1->get_meta( '_stripe_lock_payment' );
 		$this->assertEqualsWithDelta( (int) $current_lock, ( time() + 5 * MINUTE_IN_SECONDS ), 3 );
 
-		$locked = $order_1->lock_payment();
+		$locked = $this->gateway->lock_order_payment( $order_1 );
 		$this->assertTrue( $locked );
 
 		// lock with an intent ID.
 		$order_2   = WC_Helper_Order::create_order();
 		$intent_id = 'pi_123intent';
 
-		$locked       = $order_2->lock_payment( $intent_id );
-		$current_lock = $order_2->get_lock_payment();
+		$locked       = $this->gateway->lock_order_payment( $order_2, $intent_id );
+		$current_lock = $order_2->get_meta( '_stripe_lock_payment' );
 
 		$this->assertFalse( $locked );
-		$locked = $order_2->lock_payment( $intent_id );
+		$locked = $this->gateway->lock_order_payment( $order_2, $intent_id );
 		$this->assertTrue( $locked );
-		$locked = $order_2->lock_payment(); // test that you don't need to pass the intent ID to check lock.
+		$locked = $this->gateway->lock_order_payment( $order_2 ); // test that you don't need to pass the intent ID to check lock.
 		$this->assertTrue( $locked );
 
 		// test expired locks.
 		$order_3 = WC_Helper_Order::create_order();
-		$order_3->set_lock_payment( time() - 1 );
+		$order_3->update_meta_data( '_stripe_lock_payment', time() - 1 );
 		$order_3->save_meta_data();
 
-		$locked       = $order_3->lock_payment( $intent_id );
-		$current_lock = $order_3->get_lock_payment();
+		$locked       = $this->gateway->lock_order_payment( $order_3, $intent_id );
+		$current_lock = $order_3->get_meta( '_stripe_lock_payment' );
 
 		$this->assertFalse( $locked );
 		$this->assertEqualsWithDelta( (int) $current_lock, ( time() + 5 * MINUTE_IN_SECONDS ), 3 );
 
 		// test two instances of the same order, one locked and one not.
 		$order_4   = WC_Helper_Order::create_order();
-		$dup_order = WC_Stripe_Order::get_by_id( $order_4->get_id() );
+		$dup_order = wc_get_order( $order_4->get_id() );
 
-		$order_4->lock_payment();
-		$dup_locked = $dup_order->lock_payment();
+		$this->gateway->lock_order_payment( $order_4 );
+		$dup_locked = $this->gateway->lock_order_payment( $dup_order );
 		$this->assertTrue( $dup_locked ); // Confirms lock from $order_4 prevents payment on $dup_order.
 	}
 
@@ -706,7 +706,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->set_currency( 'USD' );
 		$order->set_transaction_id( 'ch_123' );
-		$order->set_charge_captured( 'yes' );
+		$order->update_meta_data( '_stripe_charge_captured', 'yes' );
 		$order->save();
 		$order_id = $order->get_id();
 

--- a/tests/phpunit/test-wc-stripe-sub-initial.php
+++ b/tests/phpunit/test-wc-stripe-sub-initial.php
@@ -198,8 +198,8 @@ class WC_Stripe_Subscription_Initial_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result['result'], 'success' );
 		$this->assertArrayHasKey( 'redirect', $result );
 
-		$order      = WC_Stripe_Order::get_by_id( $order_id );
-		$order_data = $order->get_intent_id();
+		$order      = wc_get_order( $order_id );
+		$order_data = $order->get_meta( '_stripe_intent_id' );
 
 		$this->assertEquals( $order_data, 'pi_123abc' );
 

--- a/tests/phpunit/test-wc-stripe-sub-renewal.php
+++ b/tests/phpunit/test-wc-stripe-sub-renewal.php
@@ -230,8 +230,8 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		// Assert that we saved the payment intent to the order.
 		$order_id   = $renewal_order->get_id();
-		$order      = WC_Stripe_Order::get_by_id( $order_id );
-		$order_data = $order->get_intent_id();
+		$order      = wc_get_order( $order_id );
+		$order_data = $order->get_meta( '_stripe_intent_id' );
 
 		$this->assertEquals( $order_data, 'pi_123abc' );
 
@@ -349,10 +349,9 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$this->assertEquals( $result, null );
 
 		// Assert that we saved the payment intent to the order.
-		$order_id = $renewal_order->get_id();
-		$order    = WC_Stripe_Order::get_by_id( $order_id );
-
-		$order_data           = $order->get_intent_id();
+		$order_id             = $renewal_order->get_id();
+		$order                = wc_get_order( $order_id );
+		$order_data           = $order->get_meta( '_stripe_intent_id' );
 		$order_transaction_id = $order->get_transaction_id();
 
 		// Intent was saved to order even though there was an error in the response body.

--- a/tests/phpunit/test-wc-stripe-webhook-handler.php
+++ b/tests/phpunit/test-wc-stripe-webhook-handler.php
@@ -226,7 +226,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order->set_status( $order_status );
 		$order->set_transaction_id( $charge_id );
 		if ( $order_status_final ) {
-			$order->set_status_final( true );
+			$order->update_meta_data( '_stripe_status_final', true );
 		}
 		$order->save();
 
@@ -242,7 +242,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler->process_webhook_charge_failed( $notification );
 
 		if ( $charge_id ) { // Order not found charge ID.
-			$final_order = WC_Stripe_Order::get_by_id( $order->get_id() );
+			$final_order = wc_get_order( $order->get_id() );
 			$this->assertEquals( $expected_status, $final_order->get_status() );
 
 			if ( $expected_note ) {
@@ -316,7 +316,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order->set_status( $order_status );
 		$order->set_transaction_id( $charge_id );
 		if ( $order_status_final ) {
-			$order->set_status_final( true );
+			$order->update_meta_data( '_stripe_status_final', true );
 		}
 		$order->save();
 
@@ -332,7 +332,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_webhook_dispute( $notification );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order->get_id() );
+		$final_order = wc_get_order( $order->get_id() );
 
 		$notes = wc_get_order_notes(
 			[
@@ -425,13 +425,13 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( $order_status );
 		if ( $order_locked ) {
-			$order->lock_payment();
+			$order->update_meta_data( '_stripe_lock_payment', ( time() + MINUTE_IN_SECONDS ) );
 		}
 		if ( $order_status_final ) {
-			$order->set_status_final( true );
+			$order->update_meta_data( '_stripe_status_final', true );
 		}
-		$order->set_upe_payment_type( $payment_type );
-		$order->set_upe_waiting_for_redirect( true );
+		$order->update_meta_data( '_stripe_upe_payment_type', $payment_type );
+		$order->update_meta_data( '_stripe_upe_waiting_for_redirect', true );
 		$order->save_meta_data();
 		$order->save();
 
@@ -458,7 +458,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_payment_intent( $notification );
 
-		$final_order = WC_Stripe_Order::get_by_id( $order->get_id() );
+		$final_order = wc_get_order( $order->get_id() );
 
 		$this->assertSame( $expected_status, $final_order->get_status() );
 		if ( ! empty( $expected_note ) ) {
@@ -498,9 +498,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		// Order must be previously set to pending and have at least the payment intent set.
 		$order = WC_Helper_Order::create_order();
-
 		WC_Stripe_Helper::add_payment_intent_to_order( $notification->data->object->id, $order );
-
 		$order->set_status( OrderStatus::PENDING );
 		$order->save();
 
@@ -512,8 +510,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->process_payment_intent( $notification );
 
-		$updated_order = WC_Stripe_Order::get_by_id( $order->get_id() );
-
+		$updated_order = wc_get_order( $order->get_id() );
 		$this->assertEquals( OrderStatus::ON_HOLD, $updated_order->get_status() );
 		$this->assertEquals( 'ch_mock', $updated_order->get_transaction_id() );
 


### PR DESCRIPTION
Context: p1746714347971679-slack-C055WHLA98D

## Changes proposed in this Pull Request:
Batch revert of all changes related to the `WC_Stripe_Order` wrapper class.

## Testing instructions
This affects all areas, and end-to-end testing should be performed.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)