### PR TITLE
Use the default ordering of the payment methods for new installations when the new settings sync is enabled

### DIFF
--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -357,6 +357,11 @@ class WC_Stripe_Payment_Method_Configurations {
 			);
 		}
 
+		// If there is no payment method order defined, set it to the default order
+		if ( empty( $stripe_settings['stripe_upe_payment_method_order'] ) ) {
+			$stripe_settings['stripe_upe_payment_method_order'] = array_keys( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS );
+		}
+
 		// Mark migration as complete in stripe settings
 		$stripe_settings['pmc_enabled'] = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );

--- a/tests/phpunit/admin/migrations/test-class-migrate-payment-methods-from-db-to-pmc.php
+++ b/tests/phpunit/admin/migrations/test-class-migrate-payment-methods-from-db-to-pmc.php
@@ -82,4 +82,43 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
 		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
 	}
+
+	public function test_migration_sets_default_payment_method_order() {
+		// Set up environment with pmc_enabled not set and no payment method order
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_connection_type'] = 'connect';
+		$stripe_settings['pmc_enabled'] = '';
+		$stripe_settings['stripe_upe_payment_method_order'] = '';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->mock_payment_method_configurations( [], [] );
+
+		// Execute migration
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		// Verify payment method order is set to default
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'stripe_upe_payment_method_order', $updated_settings );
+		$this->assertEquals( array_keys( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS ), $updated_settings['stripe_upe_payment_method_order'] );
+	}
+
+	public function test_migration_preserves_existing_payment_method_order() {
+		// Set up environment with pmc_enabled not set and existing payment method order
+		$existing_order = [ 'card', 'sepa_debit', 'ideal' ];
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_connection_type'] = 'connect';
+		$stripe_settings['pmc_enabled'] = '';
+		$stripe_settings['stripe_upe_payment_method_order'] = $existing_order;
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->mock_payment_method_configurations( [], [] );
+
+		// Execute migration
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		// Verify payment method order is preserved
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'stripe_upe_payment_method_order', $updated_settings );
+		$this->assertEquals( $existing_order, $updated_settings['stripe_upe_payment_method_order'] );
+	}
 }


### PR DESCRIPTION
Fixes STRIPE-434

## Changes proposed in this Pull Request:

The default payment method order in new installations differs when using Settings Sync. This PR sets the default payment method order to `WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS` instead of using the order received from the Payment Method Configuration API to restore the previous behavior.

## Testing instructions

1. Remove the plugin settings:
    `wp option delete woocommerce_stripe_settings`
2. Connect your Stripe account
3. Check that the default payment method order is used:
    ![image (3)](https://github.com/user-attachments/assets/65838155-009d-4d00-8f9d-bbf73a7cb926)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
