### PR TITLE
Using the new tax status constants

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
-* Dev - Implements WooCommerce constants for the tax statuses.
+* Dev - Implements WooCommerce constants for the tax statuses
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
+* Dev - Implements WooCommerce constants for the tax statuses.
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\WooCommerce\Enums\ProductType;
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -765,7 +766,7 @@ class WC_Stripe_Express_Checkout_Helper {
 			if ( ! $product ) {
 				return false;
 			}
-			return $product->get_tax_status() !== 'none';
+			return $product->get_tax_status() !== ProductTaxStatus::NONE;
 		}
 
 		// Cart or checkout page: the cart is taxable if any item in the cart
@@ -782,7 +783,7 @@ class WC_Stripe_Express_Checkout_Helper {
 				$cart_item_key
 			);
 
-			if ( 'none' !== $product->get_tax_status() ) {
+			if ( ProductTaxStatus::NONE !== $product->get_tax_status() ) {
 				return true;
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
-* Dev - Implements WooCommerce constants for the tax statuses.
+* Dev - Implements WooCommerce constants for the tax statuses
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
+* Dev - Implements WooCommerce constants for the tax statuses.
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner

--- a/tests/phpunit/Helpers/WC_Helper_Product.php
+++ b/tests/phpunit/Helpers/WC_Helper_Product.php
@@ -2,6 +2,7 @@
 
 namespace WooCommerce\Stripe\Tests\Helpers;
 
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use WC_Cache_Helper;
 use WC_Product_Attribute;
 use WC_Product_External;
@@ -50,7 +51,7 @@ class WC_Helper_Product {
 				'price'         => 10,
 				'sku'           => 'DUMMY SKU',
 				'manage_stock'  => false,
-				'tax_status'    => 'taxable',
+				'tax_status'    => ProductTaxStatus::TAXABLE,
 				'downloadable'  => false,
 				'virtual'       => false,
 				'stock_status'  => 'instock',

--- a/tests/phpunit/Helpers/WC_Helper_Shipping.php
+++ b/tests/phpunit/Helpers/WC_Helper_Shipping.php
@@ -2,6 +2,7 @@
 
 namespace WooCommerce\Stripe\Tests\Helpers;
 
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use WC_Cache_Helper;
 
 /**
@@ -28,7 +29,7 @@ class WC_Helper_Shipping {
 			'title'        => 'Flat rate',
 			'availability' => 'all',
 			'countries'    => '',
-			'tax_status'   => 'taxable',
+			'tax_status'   => ProductTaxStatus::TAXABLE,
 			'cost'         => $cost,
 		];
 

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -2,6 +2,7 @@
 
 namespace WooCommerce\Stripe\Tests\PaymentMethods;
 
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use WC_Gateway_Stripe;
 use WC_Stripe_UPE_Payment_Gateway;
 use WC_Gateway_Stripe_Alipay;
@@ -163,17 +164,17 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		$virtual_nontaxable_product = WC_Helper_Product::create_simple_product();
 		$virtual_nontaxable_product->set_virtual( true );
-		$virtual_nontaxable_product->set_tax_status( 'none' );
+		$virtual_nontaxable_product->set_tax_status( ProductTaxStatus::NONE );
 		$virtual_nontaxable_product->save();
 
 		$virtual_taxable_product = WC_Helper_Product::create_simple_product();
 		$virtual_taxable_product->set_virtual( true );
-		$virtual_taxable_product->set_tax_status( 'taxable' );
+		$virtual_taxable_product->set_tax_status( ProductTaxStatus::TAXABLE );
 		$virtual_taxable_product->save();
 
 		$shippable_taxable_product = WC_Helper_Product::create_simple_product();
 		$shippable_taxable_product->set_virtual( false );
-		$shippable_taxable_product->set_tax_status( 'taxable' );
+		$shippable_taxable_product->set_tax_status( ProductTaxStatus::TAXABLE );
 		$shippable_taxable_product->save();
 		$this->products = [
 			'virtual_nontaxable' => $virtual_nontaxable_product,
@@ -291,7 +292,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		// Add a non-taxable product to the cart.
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_virtual( false );
-		$product->set_tax_status( 'none' );
+		$product->set_tax_status( ProductTaxStatus::NONE );
 		$product->save();
 
 		WC()->session->init();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

New constants for tax statuses have been available since WooCommerce version 9.8. This PR implements those on the Stripe extension code. It also updates the minimum WC (and the future minimum) to avoid issues.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review. Check if the tests are still passing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
