### PR TITLE
Updating the min WC version to 9.8

### DIFF
--- a/.github/workflows/php-code-coverage.yml
+++ b/.github/workflows/php-code-coverage.yml
@@ -13,11 +13,11 @@ jobs:
   test:
     if: ${{ ! contains( github.event.head_commit.message, 'Merge branch' ) }}
     runs-on: ubuntu-22.04
-    name: PHP=8.1, WP=6.7, WC=9.5.2
+    name: PHP=8.1, WP=6.7, WC=9.8.5
     env:
       PHP_VERSION: '8.1'
       WP_VERSION: '6.7'
-      WC_VERSION: '9.5.2'
+      WC_VERSION: '9.8.5'
     steps:
       - name: Get Changed Files
         id: get-changed-files

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -16,11 +16,11 @@ jobs:
         include:
           # WooCommerce
           - woocommerce_support_policy: L
-            woocommerce: '9.8.1'
+            woocommerce: '9.8.2'
           - woocommerce_support_policy: L-1
-            woocommerce: '9.7.1'
+            woocommerce: '9.8.1'
           - woocommerce_support_policy: L-2
-            woocommerce: '9.6.2'
+            woocommerce: '9.8.0'
           # WordPress
           - wordpress_support_policy: L
             wordpress: '6.7.2'

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.5.0 - xxxx-xx-xx =
+* Dev - Updates the minimum supported WooCommerce version to 9.8.0.
 * Fix - Fixes the listing of payment methods on the classic checkout when the Optimized Checkout is enabled.
 * Fix - Fixes the availability of WeChat Pay when the Optimized Checkout is enabled on the block checkout. Removes it from the classic/shortcode checkout to avoid issues.
 * Dev - Renames all references to "Smart Checkout" and "Single Payment Element" (and "SPE") to "Optimized Checkout" (and "OC"), following the feature rebranding.

--- a/readme.txt
+++ b/readme.txt
@@ -165,6 +165,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 **Internal Changes and Upcoming Features**
 
+* Dev - Updates the minimum supported WooCommerce version to 9.8.0.
 * Feature - Work to support Optimized Checkout
 * Feature - Work to support Amazon Pay
 * Dev - Splits the code coverage GitHub Actions Workflow into two separate actions

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -9,8 +9,8 @@
  * Requires Plugins: woocommerce
  * Requires at least: 6.5
  * Tested up to: 6.7
- * WC requires at least: 9.5
- * WC tested up to: 9.7
+ * WC requires at least: 9.8
+ * WC tested up to: 9.8
  * Text Domain: woocommerce-gateway-stripe
  * Domain Path: /languages
  */
@@ -24,8 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 define( 'WC_STRIPE_VERSION', '9.4.0' ); // WRCS: DEFINED_VERSION.
 define( 'WC_STRIPE_MIN_PHP_VER', '7.4' );
-define( 'WC_STRIPE_MIN_WC_VER', '9.5' );
-define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '9.6' );
+define( 'WC_STRIPE_MIN_WC_VER', '9.8' );
+define( 'WC_STRIPE_FUTURE_MIN_WC_VER', '9.9' );
 define( 'WC_STRIPE_MAIN_FILE', __FILE__ );
 define( 'WC_STRIPE_ABSPATH', __DIR__ . '/' );
 define( 'WC_STRIPE_PLUGIN_URL', untrailingslashit( plugin_dir_url( WC_STRIPE_MAIN_FILE ) ) );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR updates the minimum supported version of WooCommerce to 9.8, so we can make use of the newly introduced constants for product types and tax statuses.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review. Check if the tests are still passing.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
