### PR TITLE
Prevent Stripe API calls after detecting the API keys are not valid (401 response from API)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Update - Remove BACS from the unsupported 'change payment method for subscription' page.
 * Fix - Fix payment method title display when new payment settings experience is enabled
 * Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
-* Fix - Prevert further Stripe API calls if API keys are invalid (401 response).
+* Fix - Prevent further Stripe API calls if API keys are invalid (401 response).
 
 = 9.5.0 - 2025-05-13 =
 * Fix - Fixes the listing of payment methods on the classic checkout when the Optimized Checkout is enabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Update - Remove BACS from the unsupported 'change payment method for subscription' page.
 * Fix - Fix payment method title display when new payment settings experience is enabled
 * Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
+* Fix - Prevert further Stripe API calls if API keys are invalid (401 response).
 
 = 9.5.0 - 2025-05-13 =
 * Fix - Fixes the listing of payment methods on the classic checkout when the Optimized Checkout is enabled.

--- a/client/settings/account-details/index.js
+++ b/client/settings/account-details/index.js
@@ -133,11 +133,11 @@ const AccountDetails = () => {
 					{ createInterpolateElement(
 						isTestModeEnabled
 							? __(
-									"Seems like the test API keys we've saved for you are no longer valid. If you recently updated them, use the <strong>Configure Connection</strong> button below to reconnect.",
+									"We couldn't connect to your account, it seems like the test API keys we've saved for you are no longer valid. Please use the <strong>Configure connection</strong> button below to reconnect.",
 									'woocommerce-gateway-stripe'
 							  )
 							: __(
-									"Seems like the live API keys we've saved for you are no longer valid. If you recently updated them, use the <strong>Configure Connection</strong> button below to reconnect.",
+									"We couldn't connect to your account, it seems like the live API keys we've saved for you are no longer valid. Please use the <strong>Configure connection</strong> button below to reconnect.",
 									'woocommerce-gateway-stripe'
 							  ),
 						{

--- a/client/settings/stripe-auth-account/account-status-panel.js
+++ b/client/settings/stripe-auth-account/account-status-panel.js
@@ -150,7 +150,7 @@ const getAccountStatus = ( accountKeys, data, testMode ) => {
 		},
 	};
 
-	if ( ! hasKeys ) {
+	if ( ! hasKeys || data?.account === null ) {
 		return accountStatusMap.disconnected;
 	}
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -17,6 +17,20 @@ class WC_Stripe_API {
 	const STRIPE_API_VERSION = '2024-06-20';
 
 	/**
+	 * The test mode invalid API keys transient key.
+	 *
+	 * @var string
+	 */
+	const TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY = 'wcstripe_test_invalid_api_keys_detected';
+
+	/**
+	 * The live mode invalid API keys transient key.
+	 *
+	 * @var string
+	 */
+	const LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY = 'wcstripe_live_invalid_api_keys_detected';
+
+	/**
 	 * Secret API Key.
 	 *
 	 * @var string
@@ -233,6 +247,13 @@ class WC_Stripe_API {
 	public static function retrieve( $api ) {
 		WC_Stripe_Logger::log( "{$api}" );
 
+		// If we have a transient indicating that the secret key is not valid, we dont't attempt the API call and we return an error.
+		$transient_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : self::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY;
+		$invalid_api_keys_detected = get_transient( $transient_key );
+		if ( $invalid_api_keys_detected ) {
+			return new WP_Error( 'stripe_error', __( 'The Stripe API keys are not valid.', 'woocommerce-gateway-stripe' ) );
+		}
+
 		$response = wp_safe_remote_get(
 			self::ENDPOINT . $api,
 			[
@@ -241,6 +262,13 @@ class WC_Stripe_API {
 				'timeout' => 70,
 			]
 		);
+
+		// If we get a 401 error, we know the secret key is not valid, we save a transient to avoid making calls until the secrect key gets updated.
+		if ( ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
+			$transient_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : self::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY;
+			set_transient( $transient_key, true );
+			return new WP_Error( 'stripe_error', __( 'The Stripe API keys are not valid.', 'woocommerce-gateway-stripe' ) );
+		}
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
 			WC_Stripe_Logger::log( 'Error Response: ' . print_r( $response, true ) );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -17,14 +17,14 @@ class WC_Stripe_API {
 	const STRIPE_API_VERSION = '2024-06-20';
 
 	/**
-	 * The test mode invalid API keys transient key.
+	 * The test mode invalid API keys option key.
 	 *
 	 * @var string
 	 */
 	const TEST_MODE_INVALID_API_KEYS_OPTION_KEY = 'wc_stripe_test_invalid_api_keys_detected';
 
 	/**
-	 * The live mode invalid API keys transient key.
+	 * The live mode invalid API keys option key.
 	 *
 	 * @var string
 	 */
@@ -245,7 +245,7 @@ class WC_Stripe_API {
 	 * @param string $api
 	 */
 	public static function retrieve( $api ) {
-		// If we have a transient indicating that the secret key is not valid, we dont't attempt the API call and we return an error.
+		// If we have an option flag indicating that the secret key is not valid, we dont't attempt the API call and we return an error.
 		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_OPTION_KEY : self::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
 		$invalid_api_keys_detected = get_option( $invalid_api_keys_option_key );
 		if ( $invalid_api_keys_detected ) {
@@ -263,7 +263,7 @@ class WC_Stripe_API {
 			]
 		);
 
-		// If we get a 401 error, we know the secret key is not valid, we save a transient to avoid making calls until the secrect key gets updated.
+		// If we get a 401 error, we know the secret key is not valid, we save a flag in the options to avoid making calls until the secret key gets updated.
 		if ( is_array( $response ) && ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
 			update_option( $invalid_api_keys_option_key, true );
 			update_option( $invalid_api_keys_option_key . '_at', time() );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -21,14 +21,14 @@ class WC_Stripe_API {
 	 *
 	 * @var string
 	 */
-	const TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY = 'wcstripe_test_invalid_api_keys_detected';
+	const TEST_MODE_INVALID_API_KEYS_OPTION_KEY = 'wc_stripe_test_invalid_api_keys_detected';
 
 	/**
 	 * The live mode invalid API keys transient key.
 	 *
 	 * @var string
 	 */
-	const LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY = 'wcstripe_live_invalid_api_keys_detected';
+	const LIVE_MODE_INVALID_API_KEYS_OPTION_KEY = 'wc_stripe_live_invalid_api_keys_detected';
 
 	/**
 	 * Secret API Key.
@@ -246,8 +246,8 @@ class WC_Stripe_API {
 	 */
 	public static function retrieve( $api ) {
 		// If we have a transient indicating that the secret key is not valid, we dont't attempt the API call and we return an error.
-		$invalid_api_keys_transient_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : self::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY;
-		$invalid_api_keys_detected = get_transient( $invalid_api_keys_transient_key );
+		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_OPTION_KEY : self::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
+		$invalid_api_keys_detected = get_option( $invalid_api_keys_option_key );
 		if ( $invalid_api_keys_detected ) {
 			return json_decode( '' ); // The UI expects this empty response in case of invalid API keys.
 		}
@@ -265,7 +265,8 @@ class WC_Stripe_API {
 
 		// If we get a 401 error, we know the secret key is not valid, we save a transient to avoid making calls until the secrect key gets updated.
 		if ( is_array( $response ) && ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
-			set_transient( $invalid_api_keys_transient_key, true );
+			update_option( $invalid_api_keys_option_key, true );
+			update_option( $invalid_api_keys_option_key . '_at', time() );
 			return json_decode( '' ); // The UI expects this empty response in case of invalid API keys.
 		}
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -245,14 +245,14 @@ class WC_Stripe_API {
 	 * @param string $api
 	 */
 	public static function retrieve( $api ) {
-		WC_Stripe_Logger::log( "{$api}" );
-
 		// If we have a transient indicating that the secret key is not valid, we dont't attempt the API call and we return an error.
-		$transient_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : self::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY;
-		$invalid_api_keys_detected = get_transient( $transient_key );
+		$invalid_api_keys_transient_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : self::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY;
+		$invalid_api_keys_detected = get_transient( $invalid_api_keys_transient_key );
 		if ( $invalid_api_keys_detected ) {
-			return new WP_Error( 'stripe_error', __( 'The Stripe API keys are not valid.', 'woocommerce-gateway-stripe' ) );
+			return json_decode( '' ); // The UI expects this empty response in case of invalid API keys.
 		}
+
+		WC_Stripe_Logger::log( "{$api}" );
 
 		$response = wp_safe_remote_get(
 			self::ENDPOINT . $api,
@@ -265,9 +265,8 @@ class WC_Stripe_API {
 
 		// If we get a 401 error, we know the secret key is not valid, we save a transient to avoid making calls until the secrect key gets updated.
 		if ( is_array( $response ) && ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
-			$transient_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : self::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY;
-			set_transient( $transient_key, true );
-			return new WP_Error( 'stripe_error', __( 'The Stripe API keys are not valid.', 'woocommerce-gateway-stripe' ) );
+			set_transient( $invalid_api_keys_transient_key, true );
+			return json_decode( '' ); // The UI expects this empty response in case of invalid API keys.
 		}
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -264,7 +264,7 @@ class WC_Stripe_API {
 		);
 
 		// If we get a 401 error, we know the secret key is not valid, we save a transient to avoid making calls until the secrect key gets updated.
-		if ( ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
+		if ( is_array( $response ) && ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
 			$transient_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : self::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY;
 			set_transient( $transient_key, true );
 			return new WP_Error( 'stripe_error', __( 'The Stripe API keys are not valid.', 'woocommerce-gateway-stripe' ) );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -264,7 +264,7 @@ class WC_Stripe_API {
 		);
 
 		// If we get a 401 error, we know the secret key is not valid.
-		if ( is_array( $response ) && ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
+		if ( is_array( $response ) && isset( $response['response'] ) && is_array( $response['response'] ) && isset( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
 			// We save a flag in the options to avoid making calls until the secret key gets updated.
 			update_option( $invalid_api_keys_option_key, true );
 			update_option( $invalid_api_keys_option_key . '_at', time() );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -263,10 +263,15 @@ class WC_Stripe_API {
 			]
 		);
 
-		// If we get a 401 error, we know the secret key is not valid, we save a flag in the options to avoid making calls until the secret key gets updated.
+		// If we get a 401 error, we know the secret key is not valid.
 		if ( is_array( $response ) && ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
+			// We save a flag in the options to avoid making calls until the secret key gets updated.
 			update_option( $invalid_api_keys_option_key, true );
 			update_option( $invalid_api_keys_option_key . '_at', time() );
+
+			// We delete the transient for the account data to trigger the not-connected UI in the admin dashboard.
+			delete_transient( WC_Stripe_Mode::is_test() ? WC_Stripe_Account::TEST_ACCOUNT_OPTION : WC_Stripe_Account::LIVE_ACCOUNT_OPTION );
+
 			return null; // The UI expects this empty response in case of invalid API keys.
 		}
 

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -245,11 +245,11 @@ class WC_Stripe_API {
 	 * @param string $api
 	 */
 	public static function retrieve( $api ) {
-		// If we have an option flag indicating that the secret key is not valid, we dont't attempt the API call and we return an error.
+		// If we have an option flag indicating that the secret key is not valid, we don't attempt the API call and we return an error.
 		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_OPTION_KEY : self::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
 		$invalid_api_keys_detected = get_option( $invalid_api_keys_option_key );
 		if ( $invalid_api_keys_detected ) {
-			return json_decode( '' ); // The UI expects this empty response in case of invalid API keys.
+			return null; // The UI expects this empty response in case of invalid API keys.
 		}
 
 		WC_Stripe_Logger::log( "{$api}" );
@@ -267,7 +267,7 @@ class WC_Stripe_API {
 		if ( is_array( $response ) && ! empty( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
 			update_option( $invalid_api_keys_option_key, true );
 			update_option( $invalid_api_keys_option_key . '_at', time() );
-			return json_decode( '' ); // The UI expects this empty response in case of invalid API keys.
+			return null; // The UI expects this empty response in case of invalid API keys.
 		}
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -183,6 +183,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( 'wc_stripe_' . $prefix . 'oauth_failed_attempts', 0 );
 			update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', '' );
 
+			// Clear the invalid API keys transient.
+			delete_transient( $is_test ? WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY );
+
 			if ( 'app' === $type ) {
 				// Stripe App OAuth access_tokens expire after 1 hour:
 				// https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -184,7 +184,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', '' );
 
 			// Clear the invalid API keys transient.
-			delete_transient( $is_test ? WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_TRANSIENT_KEY : WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_TRANSIENT_KEY );
+			$invalid_api_keys_option_key = $is_test ? WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY : WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
+			update_option( $invalid_api_keys_option_key, false );
+			update_option( $invalid_api_keys_option_key . '_at', time() );
 
 			if ( 'app' === $type ) {
 				// Stripe App OAuth access_tokens expire after 1 hour:

--- a/readme.txt
+++ b/readme.txt
@@ -118,7 +118,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Remove BACS from the unsupported 'change payment method for subscription' page.
 * Fix - Fix payment method title display when new payment settings experience is enabled
 * Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
-* Fix - Prevert further Stripe API calls if API keys are invalid (401 response).
+* Fix - Prevent further Stripe API calls if API keys are invalid (401 response).
 
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Remove BACS from the unsupported 'change payment method for subscription' page.
 * Fix - Fix payment method title display when new payment settings experience is enabled
 * Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
+* Fix - Prevert further Stripe API calls if API keys are invalid (401 response).
 
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -162,7 +162,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 				'code' => 200,
 				'message' => 'OK',
 			],
-			'body' => 'success',
+			'body' => json_encode( 'success' ),
 		];
 	}
 

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -109,15 +109,11 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		$this->assertNull( $result );
 
 		// Verify the invalid API keys option was set
-		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ?
-			WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY :
-			WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
-
-		$this->assertTrue( get_option( $invalid_api_keys_option_key ) );
+		$this->assertTrue( get_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY ) );
 
 		// Clean up
 		remove_filter( 'pre_http_request', [ $this, 'mock_401_response' ] );
-		delete_option( $invalid_api_keys_option_key );
+		delete_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY );
 	}
 
 	/**
@@ -125,10 +121,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	 */
 	public function test_retrieve_returns_null_when_api_keys_are_invalid() {
 		// Set up the invalid API keys option
-		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ?
-			WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY :
-			WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
-		update_option( $invalid_api_keys_option_key, true );
+		update_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY, true );
 
 		// Call the retrieve method
 		$result = WC_Stripe_API::retrieve( 'test_endpoint' );
@@ -137,7 +130,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		$this->assertNull( $result );
 
 		// Clean up
-		delete_option( $invalid_api_keys_option_key );
+		delete_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY );
 	}
 
 	/**
@@ -145,10 +138,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	 */
 	public function test_retrieve_makes_api_call_when_api_keys_are_valid() {
 		// Ensure no invalid API keys option exists
-		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ?
-			WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY :
-			WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
-		delete_option( $invalid_api_keys_option_key );
+		delete_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY );
 
 		// Mock a successful API response
 		add_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -94,4 +94,98 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		WC_Stripe_API::set_secret_key_for_mode( 'invalid' );
 		$this->assertEquals( self::LIVE_SECRET_KEY, WC_Stripe_API::get_secret_key() );
 	}
+
+	/**
+	 * Test WC_Stripe_API::retrieve() when API returns 401 error.
+	 */
+	public function test_retrieve_handles_401_error() {
+		// Mock a 401 API response
+		add_filter( 'pre_http_request', [ $this, 'mock_401_response' ] );
+
+		// Call the retrieve method
+		$result = WC_Stripe_API::retrieve( 'test_endpoint' );
+
+		// Verify the result is null
+		$this->assertNull( $result );
+
+		// Verify the invalid API keys option was set
+		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ?
+			WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY :
+			WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
+
+		$this->assertTrue( get_option( $invalid_api_keys_option_key ) );
+
+		// Clean up
+		remove_filter( 'pre_http_request', [ $this, 'mock_401_response' ] );
+		delete_option( $invalid_api_keys_option_key );
+	}
+
+	/**
+	 * Test WC_Stripe_API::retrieve() when API keys are invalid.
+	 */
+	public function test_retrieve_returns_null_when_api_keys_are_invalid() {
+		// Set up the invalid API keys option
+		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ?
+			WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY :
+			WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
+		update_option( $invalid_api_keys_option_key, true );
+
+		// Call the retrieve method
+		$result = WC_Stripe_API::retrieve( 'test_endpoint' );
+
+		// Verify the result is null
+		$this->assertNull( $result );
+
+		// Clean up
+		delete_option( $invalid_api_keys_option_key );
+	}
+
+	/**
+	 * Test WC_Stripe_API::retrieve() when API keys are valid.
+	 */
+	public function test_retrieve_makes_api_call_when_api_keys_are_valid() {
+		// Ensure no invalid API keys option exists
+		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ?
+			WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY :
+			WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
+		delete_option( $invalid_api_keys_option_key );
+
+		// Mock a successful API response
+		add_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );
+
+		// Call the retrieve method
+		$result = WC_Stripe_API::retrieve( 'test_endpoint' );
+
+		// Verify the result matches our mock response
+		$this->assertEquals( 'success', $result );
+
+		// Clean up
+		remove_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );
+	}
+
+	/**
+	 * Helper method to mock a successful API response.
+	 */
+	public function mock_successful_response() {
+		return [
+			'response' => [
+				'code' => 200,
+				'message' => 'OK',
+			],
+			'body' => 'success',
+		];
+	}
+
+	/**
+	 * Helper method to mock a 401 API response.
+	 */
+	public function mock_401_response() {
+		return [
+			'response' => [
+				'code' => 401,
+				'message' => 'Unauthorized',
+			],
+			'body' => '',
+		];
+	}
 }


### PR DESCRIPTION
Fixes #4270
Relates to STRIPE-445

## Changes proposed in this Pull Request:

This PR implements a mechanism to prevent unnecessary Stripe API calls when the API keys are invalid (401 response). 
- Added an option to track invalid API keys state
- Added automatic clearing of invalid API keys state when new keys are saved
- Updated the notice messages, and the state in the connection status check to show the Account as disconnected when API keys are invalid

This helps reduce unnecessary API calls and improves error notices/UI for merchants with invalid API credentials:

<img width="1561" alt="Screenshot 2025-05-15 at 16 16 00" src="https://github.com/user-attachments/assets/b6ae3334-aa79-428d-b2ab-25be674b162c" />

![Screenshot 2025-05-16 at 10 42 29](https://github.com/user-attachments/assets/98b4a58f-ba95-400f-9d1a-4868f2a885cf)

![Screenshot 2025-05-16 at 12 50 36](https://github.com/user-attachments/assets/dafedfbb-1818-44da-9832-389f60ee57ff)

## Testing instructions

1. Navigate to `WP-Admin > WooCommerce > Settings > Payments`, and select the `Stripe` option from the list
2. Go to the `Settings` tab and make sure the account is correctly connected:
    ![Screenshot 2025-05-16 at 13 10 22](https://github.com/user-attachments/assets/3fbfd0dd-aef4-498a-9327-02195fd58607)
3. Replace the API keys with an invalid value:
    `wp option patch update woocommerce_stripe_settings test_secret_key 'sk_test_INVALID'`
4. Navigate to the `WP-Admin` dashboard and check that Stripe notice is shwon:
    ![Screenshot 2025-05-16 at 13 13 54](https://github.com/user-attachments/assets/4bd79da5-9b15-44b7-aec9-2e673fe56c33)
5. Navigate to `WP-Admin > WooCommerce > Settings > Payments`, and select the `Stripe` option from the list 
6. Go to the `Settings` tab and make sure the account status has the connection error message:
    ![Screenshot 2025-05-16 at 13 16 09](https://github.com/user-attachments/assets/97656b83-37c8-4765-853e-66d739fd2222)
7. Click `Configure connection` and make sure the Account status is `Disconnected`
    ![Screenshot 2025-05-16 at 13 16 59](https://github.com/user-attachments/assets/7f3bee56-e010-4743-afc9-c290d211e426)
8. Click the `Create or connect a test account` button, a re-connect your account
9. Check that after returning to the WP-Admin dasboard, the top notice is no longere present, and the acount status section has been restored:
    ![Screenshot 2025-05-16 at 13 25 43](https://github.com/user-attachments/assets/a49105a3-6124-4c21-a5f5-ddd7637c7b27)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
