### PR TITLE
Add notices for active and repeated rate limiting

### DIFF
--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -63,6 +63,9 @@ class WC_Stripe_Admin_Notices {
 		// Main Stripe payment method.
 		$this->stripe_check_environment();
 
+		// Check if we are hitting Stripe API rate limits.
+		$this->stripe_rate_limit_check();
+
 		// All other payment methods.
 		$this->payment_methods_check_environment();
 
@@ -456,6 +459,82 @@ class WC_Stripe_Admin_Notices {
 		if ( ! empty( $currency_messages ) && 'no' !== $show_notice ) {
 			$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true );
 		}
+	}
+
+	/**
+	 * Check if we should show any notices due to us hitting Stripe API rate limits.
+	 *
+	 * @since x.x.x
+	 */
+	public function stripe_rate_limit_check() {
+		if ( WC_Stripe_API::is_stripe_api_rate_limited() ) {
+			$this->add_admin_notice(
+				'wc_stripe_api_rate_limit_active',
+				'notice notice-error',
+				__(
+					'The Stripe API is currently rate limited. If this persists for more than a minute or two, please contact our support team to investigate.',
+					'woocommerce-gateway-stripe'
+				),
+				false
+			);
+			return;
+		}
+
+		$is_test_mode = WC_Stripe_Mode::is_test();
+		$rate_limit_option_key = $is_test_mode ? WC_Stripe_API::TEST_MODE_STRIPE_API_RATE_LIMIT_OPTION_KEY : WC_Stripe_API::LIVE_MODE_STRIPE_API_RATE_LIMIT_OPTION_KEY;
+		$rate_limit_history = get_option( $rate_limit_option_key . '_history', [] );
+		if ( empty( $rate_limit_history ) ) {
+			return;
+		}
+
+		// Look back to see if we have had 3 or more rate limit errors in the last hour.
+		$timestamps = wp_list_pluck( $rate_limit_history, 'timestamp' );
+		if ( count( $timestamps ) < 3 ) {
+			return;
+		}
+
+		$current_timestamp = time();
+
+		$timestamps_in_last_hour = array_filter(
+			$timestamps,
+			function ( $timestamp ) use ( $current_timestamp ) {
+				return $current_timestamp - $timestamp <= HOUR_IN_SECONDS;
+			}
+		);
+
+		if ( count( $timestamps_in_last_hour ) >= 3 ) {
+			$this->add_admin_notice(
+				'wc_stripe_api_rate_limit_hour_3',
+				'notice notice-error',
+				__(
+					'The Stripe API has been rate limited 3 or more times in the last hour. Please contact our support team to investigate.',
+					'woocommerce-gateway-stripe'
+				),
+				false
+			);
+			return;
+		}
+
+		$timestamps_in_last_day = array_filter(
+			$timestamps,
+			function ( $timestamp ) use ( $current_timestamp ) {
+				return $current_timestamp - $timestamp <= DAY_IN_SECONDS;
+			}
+		);
+
+		if ( count( $timestamps_in_last_day ) < 5 ) {
+			return;
+		}
+
+		$this->add_admin_notice(
+			'wc_stripe_api_rate_limit_day_10',
+			'notice notice-error',
+			__(
+				'The Stripe API has been rate limited 5 or more times in the last day. Please contact our support team to investigate.',
+				'woocommerce-gateway-stripe'
+			),
+			false
+		);
 	}
 
 	/**

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -351,8 +351,8 @@ class WC_Stripe_API {
 				'datetime'  => gmdate( 'Y-m-d H:i:s', $timestamp ) . ' UTC',
 				'duration'  => self::STRIPE_API_RATE_LIMIT_DURATION_IN_SECONDS,
 			];
-			// Note that we set autoload to false - we don't want this option to be autoloaded by default.
-			update_option( $history_option_key, $history, false );
+
+			update_option( $history_option_key, $history );
 		}
 	}
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR builds on #4327 and adds notices based on the data that we're tracking for rate limiting. In particular, it shows a notice for the following cases:
 * When API calls are currently rate limited
 * When there have been 3 or more periods of rate limiting in the last hour
 * When there have been 5 or more periods of rate limiting in the last 24 hours

None of the notices are dismissible. It may make more sense for the repeated ones to be dismissible, especially the 24 hour one, as users may resolve the issue.

There are still some outstanding issues:
 * The wording and CTA for the notices is very much a first draft -- what should we ask users to do if their site is being rate limited?
 * I picked the timing for these options without thinking about it too much. We should consider what they look like.
 * Should we include the repeated notices in this first pass?
 * Should we also trigger emails when we trigger rate limiting? This feels like it should be a future improvement.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
