### PR TITLE
Adding a fetch cooldown to PM config retrieval endpoint calls

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Fix - Adds a fetch cooldown to the payment method configuration retrieval endpoint to prevent excessive requests.
 * Fix - Fixes the payment method title when using the classic checkout with the Optimized Checkout enabled.
 * Fix - Fix fatal error when checking for a payment method availability using a specific order ID.
 * Fix - Stop checking for detached subscriptions for admin users, as it was slowing down wp-admin

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -78,7 +78,7 @@ class WC_Stripe_Payment_Method_Configurations {
 			return self::$primary_configuration;
 		}
 
-		$cache_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
+		$cache_key                    = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
 		$cached_primary_configuration = get_transient( $cache_key );
 		if ( false === $cached_primary_configuration || null === $cached_primary_configuration ) {
 			return null;
@@ -114,10 +114,17 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return object|null
 	 */
 	private static function get_payment_method_configuration_from_stripe() {
+		// Only allow fetching payment configuration once per minute.
+		$fetch_cooldown = get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
+		if ( $fetch_cooldown > time() ) {
+			return null;
+		}
+
 		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$configurations = $result->data ?? null;
 
 		if ( ! $configurations ) {
+			update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
 			return null;
 		}
 

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -66,16 +66,13 @@ class WC_Stripe_Payment_Method_Configurations {
 				return $cached_primary_configuration;
 			}
 
-			// If we are in cooldown and cache is not available, return fallback configuration
-			// using legacy settings.
-			$pmc_configuration_from_legacy_settings = self::get_fallback_pmc_configuration();
-			if ( ! empty( $pmc_configuration_from_legacy_settings ) ) {
-				error_log( 'Returning PMC configuration from legacy settings: ' . print_r( $pmc_configuration_from_legacy_settings, true ) );
-				return $pmc_configuration_from_legacy_settings;
+			$fallback_cache = self::get_payment_method_configuration_from_cache( true );
+			if ( $fallback_cache ) {
+				return $fallback_cache;
 			}
 
 			// Final fallback: return minimal card configuration.
-			return self::get_fallback_pmc_configuration( true );
+			return self::get_minimal_card_config();
 		}
 
 		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
@@ -105,42 +102,11 @@ class WC_Stripe_Payment_Method_Configurations {
 	}
 
 	/**
-	 * Get fallback payment method configuration, using legacy settings.
-	 *
-	 * @param bool $card_only Whether to enable only the card payment method.
-	 * @return array
-	 */
-	private static function get_fallback_pmc_configuration( $card_only = false ) {
-		$stripe_settings   = WC_Stripe_Helper::get_stripe_settings();
-		$pmc_configuration = [];
-
-		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $payment_method_id => $payment_method_name ) {
-			$is_enabled = $card_only ?
-				WC_Stripe_Payment_Methods::CARD === $payment_method_id :
-				! empty( $stripe_settings['upe_checkout_experience_accepted_payments'] ) &&
-					is_array( $stripe_settings['upe_checkout_experience_accepted_payments'] ) &&
-					in_array( $payment_method_id, $stripe_settings['upe_checkout_experience_accepted_payments'], true );
-
-			$pmc_configuration[ $payment_method_id ] = (object) [
-				'parent'             => WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_PARENT_ID : self::LIVE_MODE_CONFIGURATION_PARENT_ID,
-				'available'          => $is_enabled,
-				'display_preference' => (object) [
-					'overridable' => null,
-					'preference'  => $is_enabled ? 'on' : 'off',
-					'value'       => $is_enabled ? 'on' : 'off',
-				],
-			];
-		}
-
-		return $pmc_configuration;
-	}
-
-	/**
 	 * Get the payment method configuration from cache.
 	 *
 	 * @return object|null
 	 */
-	private static function get_payment_method_configuration_from_cache() {
+	private static function get_payment_method_configuration_from_cache( $use_fallback = false ) {
 		if ( null !== self::$primary_configuration ) {
 			return self::$primary_configuration;
 		}
@@ -148,6 +114,9 @@ class WC_Stripe_Payment_Method_Configurations {
 		$cache_key                    = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
 		$cached_primary_configuration = get_transient( $cache_key );
 		if ( false === $cached_primary_configuration || null === $cached_primary_configuration ) {
+			if ( $use_fallback ) {
+				return get_option( $cache_key );
+			}
 			return null;
 		}
 
@@ -162,6 +131,7 @@ class WC_Stripe_Payment_Method_Configurations {
 		self::$primary_configuration = null;
 		$cache_key                   = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
 		delete_transient( $cache_key );
+		delete_option( $cache_key );
 	}
 
 	/**
@@ -173,6 +143,9 @@ class WC_Stripe_Payment_Method_Configurations {
 		self::$primary_configuration = $configuration;
 		$cache_key                   = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
 		set_transient( $cache_key, $configuration, self::CONFIGURATION_CACHE_TRANSIENT_EXPIRATION );
+
+		// To be used as fallback if we are in API cooldown and the transient is not available.
+		update_option( $cache_key, $configuration );
 	}
 
 	/**
@@ -258,13 +231,6 @@ class WC_Stripe_Payment_Method_Configurations {
 					$enabled_payment_method_ids[] = $payment_method_id;
 				}
 			}
-		}
-
-		// Save in options, so we can use this as a fallback.
-		if ( $force_refresh ) {
-			$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-			$stripe_settings['upe_checkout_experience_accepted_payments'] = $enabled_payment_method_ids;
-			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 		}
 
 		return $enabled_payment_method_ids;

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -58,6 +58,12 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return object|null
 	 */
 	private static function get_primary_configuration( $force_refresh = false ) {
+		// Only allow fetching payment configuration once per minute.
+		$fetch_cooldown = get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
+		if ( $fetch_cooldown > time() ) {
+			return null;
+		}
+
 		if ( ! $force_refresh ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
 			if ( $cached_primary_configuration ) {
@@ -65,7 +71,14 @@ class WC_Stripe_Payment_Method_Configurations {
 			}
 		}
 
-		return self::get_payment_method_configuration_from_stripe();
+		$configuration = self::get_payment_method_configuration_from_stripe();
+		if ( ! $configuration ) {
+			return null;
+		}
+
+		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
+
+		return $configuration;
 	}
 
 	/**
@@ -114,19 +127,8 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return object|null
 	 */
 	private static function get_payment_method_configuration_from_stripe() {
-		// Only allow fetching payment configuration once per minute.
-		$fetch_cooldown = get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
-		if ( $fetch_cooldown > time() ) {
-			return null;
-		}
-
 		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$configurations = $result->data ?? null;
-
-		if ( ! $configurations ) {
-			update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
-			return null;
-		}
 
 		// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.
 		// This new payment method configuration has the WooCommerce Platform payment method configuration as parent, and inherits it's default payment methods.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -52,6 +52,11 @@ class WC_Stripe_Payment_Method_Configurations {
 	const CONFIGURATION_CACHE_TRANSIENT_EXPIRATION = 10 * MINUTE_IN_SECONDS;
 
 	/**
+	 * The payment method configuration fetch cooldown transient key.
+	 */
+	const FETCH_COOLDOWN_TRANSIENT_KEY = 'wcstripe_payment_method_config_fetch_cooldown';
+
+	/**
 	 * Get the merchant payment method configuration in Stripe.
 	 *
 	 * @param bool $force_refresh Whether to force a refresh of the payment method configuration from Stripe.
@@ -59,7 +64,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
-		$fetch_cooldown = defined( 'WC_STRIPE_IS_TESTING' ) && WC_STRIPE_IS_TESTING ? 0 : get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
+		$fetch_cooldown = defined( 'WC_STRIPE_IS_TESTING' ) && WC_STRIPE_IS_TESTING ? 0 : get_option( self::FETCH_COOLDOWN_TRANSIENT_KEY, 0 );
 		$is_in_cooldown = $fetch_cooldown > time();
 		if ( ! $force_refresh || $is_in_cooldown ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
@@ -81,7 +86,7 @@ class WC_Stripe_Payment_Method_Configurations {
 			// so we will fetch it if we don't have anything locally.
 		}
 
-		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
+		update_option( self::FETCH_COOLDOWN_TRANSIENT_KEY, time() + MINUTE_IN_SECONDS );
 
 		return self::get_payment_method_configuration_from_stripe();
 	}

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -73,36 +73,12 @@ class WC_Stripe_Payment_Method_Configurations {
 				if ( $fallback_cache ) {
 					return $fallback_cache;
 				}
-
-				// If even the fallback cache is not available, return minimal card configuration.
-				return self::get_minimal_card_config();
 			}
 		}
 
 		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
 
 		return self::get_payment_method_configuration_from_stripe();
-	}
-
-	/**
-	 * Get the minimal card configuration. This is used when the payment method configuration API is not available.
-	 *
-	 * @return object
-	 */
-	private static function get_minimal_card_config() {
-		return (object) [
-			'active'                        => true,
-			'livemode'                      => ! WC_Stripe_Mode::is_test(),
-			'parent'                        => WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_PARENT_ID : self::LIVE_MODE_CONFIGURATION_PARENT_ID,
-			WC_Stripe_Payment_Methods::CARD => (object) [
-				'available'          => true,
-				'display_preference' => (object) [
-					'overridable' => null,
-					'preference'  => 'on',
-					'value'       => 'on',
-				],
-			],
-		];
 	}
 
 	/**

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -74,9 +74,10 @@ class WC_Stripe_Payment_Method_Configurations {
 					return $fallback_cache;
 				}
 			}
-			// Intentionally fall through to fetching the data from Stripe if we don't have it locally, 
+
+			// Intentionally fall through to fetching the data from Stripe if we don't have it locally,
 			// even when $force_refresh = false and/or $is_in_cooldown is true.
-			// We _need_ the payment method configuration for things to work as expected, 
+			// We _need_ the payment method configuration for things to work as expected,
 			// so we will fetch it if we don't have anything locally.
 		}
 

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -54,7 +54,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	/**
 	 * The payment method configuration fetch cooldown transient key.
 	 */
-	const FETCH_COOLDOWN_TRANSIENT_KEY = 'wcstripe_payment_method_config_fetch_cooldown';
+	const FETCH_COOLDOWN_OPTION_KEY = 'wcstripe_payment_method_config_fetch_cooldown';
 
 	/**
 	 * Get the merchant payment method configuration in Stripe.
@@ -64,7 +64,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
-		$fetch_cooldown = defined( 'WC_STRIPE_IS_TESTING' ) && WC_STRIPE_IS_TESTING ? 0 : get_option( self::FETCH_COOLDOWN_TRANSIENT_KEY, 0 );
+		$fetch_cooldown = defined( 'WC_STRIPE_IS_TESTING' ) && WC_STRIPE_IS_TESTING ? 0 : get_option( self::FETCH_COOLDOWN_OPTION_KEY, 0 );
 		$is_in_cooldown = $fetch_cooldown > time();
 		if ( ! $force_refresh || $is_in_cooldown ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
@@ -86,7 +86,7 @@ class WC_Stripe_Payment_Method_Configurations {
 			// so we will fetch it if we don't have anything locally.
 		}
 
-		update_option( self::FETCH_COOLDOWN_TRANSIENT_KEY, time() + MINUTE_IN_SECONDS );
+		update_option( self::FETCH_COOLDOWN_OPTION_KEY, time() + MINUTE_IN_SECONDS );
 
 		return self::get_payment_method_configuration_from_stripe();
 	}

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -60,7 +60,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
 		$fetch_cooldown = defined( 'IS_TESTING' ) ? 0 : get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
-		if ( ! $force_refresh && $fetch_cooldown > time() ) {
+		if ( ! $force_refresh || $fetch_cooldown > time() ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
 			if ( $cached_primary_configuration ) {
 				return $cached_primary_configuration;

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -74,6 +74,10 @@ class WC_Stripe_Payment_Method_Configurations {
 					return $fallback_cache;
 				}
 			}
+			// Intentionally fall through to fetching the data from Stripe if we don't have it locally, 
+			// even when $force_refresh = false and/or $is_in_cooldown is true.
+			// We _need_ the payment method configuration for things to work as expected, 
+			// so we will fetch it if we don't have anything locally.
 		}
 
 		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -64,9 +64,18 @@ class WC_Stripe_Payment_Method_Configurations {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
 			if ( $cached_primary_configuration ) {
 				return $cached_primary_configuration;
-			} else {
-				return self::get_minimal_card_config();
 			}
+
+			// If we are in cooldown and cache is not available, return fallback configuration
+			// using legacy settings.
+			$pmc_configuration_from_legacy_settings = self::get_fallback_pmc_configuration();
+			if ( ! empty( $pmc_configuration_from_legacy_settings ) ) {
+				error_log( 'Returning PMC configuration from legacy settings: ' . print_r( $pmc_configuration_from_legacy_settings, true ) );
+				return $pmc_configuration_from_legacy_settings;
+			}
+
+			// Final fallback: return minimal card configuration.
+			return self::get_fallback_pmc_configuration( true );
 		}
 
 		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
@@ -91,6 +100,37 @@ class WC_Stripe_Payment_Method_Configurations {
 				],
 			],
 		];
+	}
+
+	/**
+	 * Get fallback payment method configuration, using legacy settings.
+	 *
+	 * @param bool $card_only Whether to enable only the card payment method.
+	 * @return array
+	 */
+	private static function get_fallback_pmc_configuration( $card_only = false ) {
+		$stripe_settings   = WC_Stripe_Helper::get_stripe_settings();
+		$pmc_configuration = [];
+
+		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $payment_method_id => $payment_method_name ) {
+			$is_enabled = $card_only ?
+				WC_Stripe_Payment_Methods::CARD === $payment_method_id :
+				! empty( $stripe_settings['upe_checkout_experience_accepted_payments'] ) &&
+					is_array( $stripe_settings['upe_checkout_experience_accepted_payments'] ) &&
+					in_array( $payment_method_id, $stripe_settings['upe_checkout_experience_accepted_payments'], true );
+
+			$pmc_configuration[ $payment_method_id ] = (object) [
+				'parent'             => WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_PARENT_ID : self::LIVE_MODE_CONFIGURATION_PARENT_ID,
+				'available'          => $is_enabled,
+				'display_preference' => (object) [
+					'overridable' => null,
+					'preference'  => $is_enabled ? 'on' : 'off',
+					'value'       => $is_enabled ? 'on' : 'off',
+				],
+			];
+		}
+
+		return $pmc_configuration;
 	}
 
 	/**
@@ -216,6 +256,13 @@ class WC_Stripe_Payment_Method_Configurations {
 					$enabled_payment_method_ids[] = $payment_method_id;
 				}
 			}
+		}
+
+		// Save in options, so we can use this as a fallback.
+		if ( $force_refresh ) {
+			$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+			$stripe_settings['upe_checkout_experience_accepted_payments'] = $enabled_payment_method_ids;
+			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 		}
 
 		return $enabled_payment_method_ids;

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -60,19 +60,23 @@ class WC_Stripe_Payment_Method_Configurations {
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
 		$fetch_cooldown = defined( 'IS_TESTING' ) ? 0 : get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
-		if ( ! $force_refresh || $fetch_cooldown > time() ) {
+		$is_in_cooldown = $fetch_cooldown > time();
+		if ( ! $force_refresh || $is_in_cooldown ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
 			if ( $cached_primary_configuration ) {
 				return $cached_primary_configuration;
 			}
 
-			$fallback_cache = self::get_payment_method_configuration_from_cache( true );
-			if ( $fallback_cache ) {
-				return $fallback_cache;
-			}
+			// If we are hitting the API too much, and our main cache is not working, use the fallback cache.
+			if ( $is_in_cooldown ) {
+				$fallback_cache = self::get_payment_method_configuration_from_cache( true );
+				if ( $fallback_cache ) {
+					return $fallback_cache;
+				}
 
-			// Final fallback: return minimal card configuration.
-			return self::get_minimal_card_config();
+				// If even the fallback cache is not available, return minimal card configuration.
+				return self::get_minimal_card_config();
+			}
 		}
 
 		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -52,7 +52,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	const CONFIGURATION_CACHE_TRANSIENT_EXPIRATION = 10 * MINUTE_IN_SECONDS;
 
 	/**
-	 * The payment method configuration fetch cooldown transient key.
+	 * The payment method configuration fetch cooldown option key.
 	 */
 	const FETCH_COOLDOWN_OPTION_KEY = 'wcstripe_payment_method_config_fetch_cooldown';
 

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -59,7 +59,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
-		$fetch_cooldown = defined( 'IS_TESTING' ) ? 0 : get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
+		$fetch_cooldown = defined( 'WC_STRIPE_IS_TESTING' ) && WC_STRIPE_IS_TESTING ? 0 : get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
 		$is_in_cooldown = $fetch_cooldown > time();
 		if ( ! $force_refresh || $is_in_cooldown ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -149,22 +149,13 @@ class WC_Stripe_Payment_Method_Configurations {
 		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$configurations = $result->data ?? [];
 
-		if ( ! empty( $configurations ) ) {
-			// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.
-			// This new payment method configuration has the WooCommerce Platform payment method configuration as parent, and inherits it's default payment methods.
-			$selected_configuration = null;
-			foreach ( $configurations as $configuration ) {
-				// The API returns data for the corresponding mode of the api keys used, so we'll get either test or live PMCs, but never both.
-				if ( $configuration->parent && ( self::LIVE_MODE_CONFIGURATION_PARENT_ID === $configuration->parent || self::TEST_MODE_CONFIGURATION_PARENT_ID === $configuration->parent ) ) {
-					self::set_payment_method_configuration_cache( $configuration );
-					$selected_configuration = $configuration;
-				}
-			}
-
-			if ( null === $selected_configuration ) {
-				// If we don't have a selected configuration, we can assume that the merchant is not connected to the WooCommerce Platform account.
-				// Log the error and return null.
-				WC_Stripe_Logger::log( 'No payment method configuration found for the current mode. Please check your Stripe account settings.' );
+		// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.
+		// This new payment method configuration has the WooCommerce Platform payment method configuration as parent, and inherits it's default payment methods.
+		foreach ( $configurations as $configuration ) {
+			// The API returns data for the corresponding mode of the api keys used, so we'll get either test or live PMCs, but never both.
+			if ( $configuration->parent && ( self::LIVE_MODE_CONFIGURATION_PARENT_ID === $configuration->parent || self::TEST_MODE_CONFIGURATION_PARENT_ID === $configuration->parent ) ) {
+				self::set_payment_method_configuration_cache( $configuration );
+				return $configuration;
 			}
 		}
 

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -81,6 +81,8 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_minimal_card_config() {
 		return (object) [
+			'active'                        => true,
+			'livemode'                      => ! WC_Stripe_Mode::is_test(),
 			'parent'                        => WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_PARENT_ID : self::LIVE_MODE_CONFIGURATION_PARENT_ID,
 			WC_Stripe_Payment_Methods::CARD => (object) [
 				'available'          => true,

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -59,7 +59,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
-		$fetch_cooldown = get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
+		$fetch_cooldown = defined( 'IS_TESTING' ) ? 0 : get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
 		if ( ! $force_refresh && $fetch_cooldown > time() ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
 			if ( $cached_primary_configuration ) {
@@ -142,7 +142,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_payment_method_configuration_from_stripe() {
 		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
-		$configurations = $result->data ?? null;
+		$configurations = $result->data ?? [];
 
 		// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.
 		// This new payment method configuration has the WooCommerce Platform payment method configuration as parent, and inherits it's default payment methods.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -60,25 +60,37 @@ class WC_Stripe_Payment_Method_Configurations {
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
 		$fetch_cooldown = get_option( 'wcstripe_payment_method_config_fetch_cooldown', 0 );
-		if ( $fetch_cooldown > time() ) {
-			return null;
-		}
-
-		if ( ! $force_refresh ) {
+		if ( ! $force_refresh && $fetch_cooldown > time() ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();
 			if ( $cached_primary_configuration ) {
 				return $cached_primary_configuration;
+			} else {
+				return self::get_minimal_card_config();
 			}
-		}
-
-		$configuration = self::get_payment_method_configuration_from_stripe();
-		if ( ! $configuration ) {
-			return null;
 		}
 
 		update_option( 'wcstripe_payment_method_config_fetch_cooldown', time() + MINUTE_IN_SECONDS );
 
-		return $configuration;
+		return self::get_payment_method_configuration_from_stripe();
+	}
+
+	/**
+	 * Get the minimal card configuration. This is used when the payment method configuration API is not available.
+	 *
+	 * @return object
+	 */
+	private static function get_minimal_card_config() {
+		return (object) [
+			'parent'                        => WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_PARENT_ID : self::LIVE_MODE_CONFIGURATION_PARENT_ID,
+			WC_Stripe_Payment_Methods::CARD => (object) [
+				'available'          => true,
+				'display_preference' => (object) [
+					'overridable' => null,
+					'preference'  => 'on',
+					'value'       => 'on',
+				],
+			],
+		];
 	}
 
 	/**
@@ -106,7 +118,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	public static function clear_payment_method_configuration_cache() {
 		self::$primary_configuration = null;
-		$cache_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
+		$cache_key                   = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
 		delete_transient( $cache_key );
 	}
 
@@ -117,7 +129,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function set_payment_method_configuration_cache( $configuration ) {
 		self::$primary_configuration = $configuration;
-		$cache_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
+		$cache_key                   = WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY : self::LIVE_MODE_CONFIGURATION_CACHE_TRANSIENT_KEY;
 		set_transient( $cache_key, $configuration, self::CONFIGURATION_CACHE_TRANSIENT_EXPIRATION );
 	}
 

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -149,13 +149,22 @@ class WC_Stripe_Payment_Method_Configurations {
 		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$configurations = $result->data ?? [];
 
-		// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.
-		// This new payment method configuration has the WooCommerce Platform payment method configuration as parent, and inherits it's default payment methods.
-		foreach ( $configurations as $configuration ) {
-			// The API returns data for the corresponding mode of the api keys used, so we'll get either test or live PMCs, but never both.
-			if ( $configuration->parent && ( self::LIVE_MODE_CONFIGURATION_PARENT_ID === $configuration->parent || self::TEST_MODE_CONFIGURATION_PARENT_ID === $configuration->parent ) ) {
-				self::set_payment_method_configuration_cache( $configuration );
-				return $configuration;
+		if ( ! empty( $configurations ) ) {
+			// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.
+			// This new payment method configuration has the WooCommerce Platform payment method configuration as parent, and inherits it's default payment methods.
+			$selected_configuration = null;
+			foreach ( $configurations as $configuration ) {
+				// The API returns data for the corresponding mode of the api keys used, so we'll get either test or live PMCs, but never both.
+				if ( $configuration->parent && ( self::LIVE_MODE_CONFIGURATION_PARENT_ID === $configuration->parent || self::TEST_MODE_CONFIGURATION_PARENT_ID === $configuration->parent ) ) {
+					self::set_payment_method_configuration_cache( $configuration );
+					$selected_configuration = $configuration;
+				}
+			}
+
+			if ( null === $selected_configuration ) {
+				// If we don't have a selected configuration, we can assume that the merchant is not connected to the WooCommerce Platform account.
+				// Log the error and return null.
+				WC_Stripe_Logger::log( 'No payment method configuration found for the current mode. Please check your Stripe account settings.' );
 			}
 		}
 

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -104,6 +104,8 @@ class WC_Stripe_Payment_Method_Configurations {
 	/**
 	 * Get the payment method configuration from cache.
 	 *
+	 * @param bool $use_fallback Whether to use the fallback cache if the transient is not available.
+	 *
 	 * @return object|null
 	 */
 	private static function get_payment_method_configuration_from_cache( $use_fallback = false ) {

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -64,7 +64,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_primary_configuration( $force_refresh = false ) {
 		// Only allow fetching payment configuration once per minute.
-		$fetch_cooldown = defined( 'WC_STRIPE_IS_TESTING' ) && WC_STRIPE_IS_TESTING ? 0 : get_option( self::FETCH_COOLDOWN_OPTION_KEY, 0 );
+		$fetch_cooldown = get_option( self::FETCH_COOLDOWN_OPTION_KEY, 0 );
 		$is_in_cooldown = $fetch_cooldown > time();
 		if ( ! $force_refresh || $is_in_cooldown ) {
 			$cached_primary_configuration = self::get_payment_method_configuration_from_cache();

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,7 +25,4 @@
 			<html outputDirectory="phpunit-html"/>
 		</report>
 	</coverage>
-	<php>
-		<const name="WC_STRIPE_IS_TESTING" value="1"/>
-	</php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,6 +26,6 @@
 		</report>
 	</coverage>
 	<php>
-		<const name="IS_TESTING" value="1"/>
+		<const name="WC_STRIPE_IS_TESTING" value="1"/>
 	</php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,5 +25,7 @@
 			<html outputDirectory="phpunit-html"/>
 		</report>
 	</coverage>
-
+	<php>
+		<const name="IS_TESTING" value="1"/>
+	</php>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Fix - Adds a fetch cooldown to the payment method configuration retrieval endpoint to prevent excessive requests.
 * Fix - Fixes the payment method title when using the classic checkout with the Optimized Checkout enabled.
 * Fix - Fix fatal error when checking for a payment method availability using a specific order ID.
 * Fix - Stop checking for detached subscriptions for admin users, as it was slowing down wp-admin

--- a/tests/phpunit/setup.php
+++ b/tests/phpunit/setup.php
@@ -3,13 +3,3 @@
  * Set up shared by all tests.
  */
 update_option( 'woocommerce_default_country', 'US:CA' );
-
-/**
- * Disables the transient cooldown for the payment method configuration fetch.
- */
-add_filter(
-	'transient_wcstripe_payment_method_config_fetch_cooldown',
-	function () {
-		return 0;
-	}
-);

--- a/tests/phpunit/setup.php
+++ b/tests/phpunit/setup.php
@@ -3,3 +3,13 @@
  * Set up shared by all tests.
  */
 update_option( 'woocommerce_default_country', 'US:CA' );
+
+/**
+ * Disables the transient cooldown for the payment method configuration fetch.
+ */
+add_filter(
+	'transient_wcstripe_payment_method_config_fetch_cooldown',
+	function () {
+		return 0;
+	}
+);


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See p1747425481186179-slack-C08SUDB2YKC?thread_ts=1747424546.927019&cid=C08SUDB2YKC

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR adds a fetch cooldown (handled using a new option) to the calls we do to retrieve the merchant's payment method configuration. This mitigates possible rate-limiting issues, blocking requests for a while (1 minute). It was suggested by @ebinnion .

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Verify that `/payment_method_configurations` is not called more than once per minute, e.g. add debugging code inside WC_Stripe_API::retrieve(), and repeatedly refreshing checkout page or settings page
- Simulate unreliable transient cache by force returning null or setting a super short expiry, and verify that a) still no excessive API calls and b) there are no unexpected behavior with enabled payment methods

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

cc @ebinnion @woocommerce/quark 