### PR TITLE
Add logging for when we receive a 401

### DIFF
--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -247,7 +247,7 @@ class WC_Stripe_API {
 	public static function retrieve( $api ) {
 		// If we have an option flag indicating that the secret key is not valid, we don't attempt the API call and we return an error.
 		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_OPTION_KEY : self::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
-		$invalid_api_keys_detected = get_option( $invalid_api_keys_option_key );
+		$invalid_api_keys_detected   = get_option( $invalid_api_keys_option_key );
 		if ( $invalid_api_keys_detected ) {
 			return null; // The UI expects this empty response in case of invalid API keys.
 		}
@@ -271,6 +271,9 @@ class WC_Stripe_API {
 
 			// We delete the transient for the account data to trigger the not-connected UI in the admin dashboard.
 			delete_transient( WC_Stripe_Mode::is_test() ? WC_Stripe_Account::TEST_ACCOUNT_OPTION : WC_Stripe_Account::LIVE_ACCOUNT_OPTION );
+
+			// Stripe redacts API keys in the response.
+			WC_Stripe_Logger::log( "Error: GET {$api} returned a 401 " . print_r( $response, true ) );
 
 			return null; // The UI expects this empty response in case of invalid API keys.
 		}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Add logging for when we receive a 401 from Stripe. This is to help understand reports where accounts may be getting falsely flagged as having invalid keys. Context: p1747756807103199-slack-C055WHLA98D

## Testing instructions
Code review should be enough.

If you want to see what the logs look like:

1. Change your Stripe API keys to something invalid, e.g. `wp option patch update woocommerce_stripe_settings test_secret_key 'sk_test_abc123iamnotavalidkey`
2. In Stripe settings, Account Status, click "Refresh account details".
3. View logs.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Internal change (added logging) only.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)