### PR TITLE
Remove 401 flag block for API calls

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Send correct attribute when setting the default payment method.
 * Dev - Build dynamic WordPress and WooCommerce dependencies for unit tests
 * Add - Implement custom database cache for persistent caching with in-memory optimization.
+* Update - Remove feature that flags 401s and proactively blocks subsequent API calls until the store has reauthenticated.
 
 = 9.5.1 - 2025-05-17 =
 * Fix - Add a fetch cooldown to the payment method configuration retrieval endpoint to prevent excessive requests.

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -17,20 +17,6 @@ class WC_Stripe_API {
 	const STRIPE_API_VERSION = '2024-06-20';
 
 	/**
-	 * The test mode invalid API keys option key.
-	 *
-	 * @var string
-	 */
-	const TEST_MODE_INVALID_API_KEYS_OPTION_KEY = 'wc_stripe_test_invalid_api_keys_detected';
-
-	/**
-	 * The live mode invalid API keys option key.
-	 *
-	 * @var string
-	 */
-	const LIVE_MODE_INVALID_API_KEYS_OPTION_KEY = 'wc_stripe_live_invalid_api_keys_detected';
-
-	/**
 	 * Secret API Key.
 	 *
 	 * @var string

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -245,13 +245,6 @@ class WC_Stripe_API {
 	 * @param string $api
 	 */
 	public static function retrieve( $api ) {
-		// If we have an option flag indicating that the secret key is not valid, we don't attempt the API call and we return an error.
-		$invalid_api_keys_option_key = WC_Stripe_Mode::is_test() ? self::TEST_MODE_INVALID_API_KEYS_OPTION_KEY : self::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
-		$invalid_api_keys_detected   = get_option( $invalid_api_keys_option_key );
-		if ( $invalid_api_keys_detected ) {
-			return null; // The UI expects this empty response in case of invalid API keys.
-		}
-
 		WC_Stripe_Logger::log( "{$api}" );
 
 		$response = wp_safe_remote_get(
@@ -265,13 +258,6 @@ class WC_Stripe_API {
 
 		// If we get a 401 error, we know the secret key is not valid.
 		if ( is_array( $response ) && isset( $response['response'] ) && is_array( $response['response'] ) && isset( $response['response']['code'] ) && 401 === $response['response']['code'] ) {
-			// We save a flag in the options to avoid making calls until the secret key gets updated.
-			update_option( $invalid_api_keys_option_key, true );
-			update_option( $invalid_api_keys_option_key . '_at', time() );
-
-			// We delete the transient for the account data to trigger the not-connected UI in the admin dashboard.
-			delete_transient( WC_Stripe_Mode::is_test() ? WC_Stripe_Account::TEST_ACCOUNT_OPTION : WC_Stripe_Account::LIVE_ACCOUNT_OPTION );
-
 			// Stripe redacts API keys in the response.
 			WC_Stripe_Logger::log( "Error: GET {$api} returned a 401 " . print_r( $response, true ) );
 

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -183,11 +183,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( 'wc_stripe_' . $prefix . 'oauth_failed_attempts', 0 );
 			update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', '' );
 
-			// Clear the invalid API keys transient.
-			$invalid_api_keys_option_key = $is_test ? WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY : WC_Stripe_API::LIVE_MODE_INVALID_API_KEYS_OPTION_KEY;
-			update_option( $invalid_api_keys_option_key, false );
-			update_option( $invalid_api_keys_option_key . '_at', time() );
-
 			if ( 'app' === $type ) {
 				// Stripe App OAuth access_tokens expire after 1 hour:
 				// https://docs.stripe.com/stripe-apps/api-authentication/oauth#refresh-access-token

--- a/readme.txt
+++ b/readme.txt
@@ -120,5 +120,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Send correct attribute when setting the default payment method.
 * Dev - Build dynamic WordPress and WooCommerce dependencies for unit tests
 * Add - Implement custom database cache for persistent caching with in-memory optimization.
+* Update - Remove feature that flags 401s and proactively blocks subsequent API calls until the store has reauthenticated.
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -96,44 +96,6 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test WC_Stripe_API::retrieve() when API returns 401 error.
-	 */
-	public function test_retrieve_handles_401_error() {
-		// Mock a 401 API response
-		add_filter( 'pre_http_request', [ $this, 'mock_401_response' ] );
-
-		// Call the retrieve method
-		$result = WC_Stripe_API::retrieve( 'test_endpoint' );
-
-		// Verify the result is null
-		$this->assertNull( $result );
-
-		// Verify the invalid API keys option was set
-		$this->assertTrue( get_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY ) );
-
-		// Clean up
-		remove_filter( 'pre_http_request', [ $this, 'mock_401_response' ] );
-		delete_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY );
-	}
-
-	/**
-	 * Test WC_Stripe_API::retrieve() when API keys are invalid.
-	 */
-	public function test_retrieve_returns_null_when_api_keys_are_invalid() {
-		// Set up the invalid API keys option
-		update_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY, true );
-
-		// Call the retrieve method
-		$result = WC_Stripe_API::retrieve( 'test_endpoint' );
-
-		// Verify the result is null
-		$this->assertNull( $result );
-
-		// Clean up
-		delete_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY );
-	}
-
-	/**
 	 * Test WC_Stripe_API::retrieve() when API keys are valid.
 	 */
 	public function test_retrieve_makes_api_call_when_api_keys_are_valid() {
@@ -159,10 +121,10 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	public function mock_successful_response() {
 		return [
 			'response' => [
-				'code' => 200,
+				'code'    => 200,
 				'message' => 'OK',
 			],
-			'body' => json_encode( 'success' ),
+			'body'     => json_encode( 'success' ),
 		];
 	}
 
@@ -172,10 +134,10 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	public function mock_401_response() {
 		return [
 			'response' => [
-				'code' => 401,
+				'code'    => 401,
 				'message' => 'Unauthorized',
 			],
-			'body' => '',
+			'body'     => '',
 		];
 	}
 }

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -124,17 +124,4 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			'body'     => json_encode( 'success' ),
 		];
 	}
-
-	/**
-	 * Helper method to mock a 401 API response.
-	 */
-	public function mock_401_response() {
-		return [
-			'response' => [
-				'code'    => 401,
-				'message' => 'Unauthorized',
-			],
-			'body'     => '',
-		];
-	}
 }

--- a/tests/phpunit/test-class-wc-stripe-api.php
+++ b/tests/phpunit/test-class-wc-stripe-api.php
@@ -99,9 +99,6 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	 * Test WC_Stripe_API::retrieve() when API keys are valid.
 	 */
 	public function test_retrieve_makes_api_call_when_api_keys_are_valid() {
-		// Ensure no invalid API keys option exists
-		delete_option( WC_Stripe_API::TEST_MODE_INVALID_API_KEYS_OPTION_KEY );
-
 		// Mock a successful API response
 		add_filter( 'pre_http_request', [ $this, 'mock_successful_response' ] );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:
- Removes setting a flag when a 401 is received
- Removes blocks when said flag is set
- Keeps logging of 401s

## Testing instructions
Code review.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
