### PR TITLE
Avoid requiring files during an install or upgrade

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -187,13 +187,15 @@ function woocommerce_gateway_stripe() {
 			 * @version 5.0.0
 			 */
 			public function init() {
+				// Check if an upgrade is in progress. Some files might not be available to require.
+				if ( get_option( 'wcstripe_upgrade_in_progress' ) ) {
+					return;
+				}
+
 				if ( is_admin() ) {
 					require_once __DIR__ . '/includes/admin/class-wc-stripe-privacy.php';
 				}
-				if ( file_exists( __DIR__ . '/includes/class-wc-stripe-feature-flags.php' ) ) {
-					require_once __DIR__ . '/includes/class-wc-stripe-feature-flags.php';
-				}
-
+				require_once __DIR__ . '/includes/class-wc-stripe-feature-flags.php';
 				require_once __DIR__ . '/includes/class-wc-stripe-order.php';
 				require_once __DIR__ . '/includes/class-wc-stripe-upe-compatibility.php';
 				require_once __DIR__ . '/includes/class-wc-stripe-co-branded-cc-compatibility.php';
@@ -955,3 +957,24 @@ add_action(
 		}
 	}
 );
+
+add_action( 'upgrader_process_complete', 'wcstripe_upgrader_process_complete', 10, 2 );
+
+function wcstripe_upgrader_process_complete( $upgrader_object, $options ) {
+	$current_plugin_path_name = plugin_basename( __FILE__ );
+	if ( 'update' === $options['action'] && 'plugin' === $options['type'] ) {
+		foreach ( $options['plugins'] as $plugin ) {
+			if ( $plugin === $current_plugin_path_name ) {
+				update_option( 'wcstripe_upgrade_in_progress', true );
+			}
+		}
+	}
+}
+
+add_action( 'upgrader_post_install', 'wcstripe_upgrader_post_install' );
+
+function wcstripe_upgrader_post_install( $response, $hook_extra, $result ) {
+	if ( ! empty( $result['destination_name'] ) && 'woocommerce-gateway-stripe' === $result['destination_name'] ) {
+		update_option( 'wcstripe_upgrade_in_progress', false );
+	}
+}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -958,23 +958,20 @@ add_action(
 	}
 );
 
-add_action( 'upgrader_process_complete', 'wcstripe_upgrader_process_complete', 10, 2 );
+add_action( 'upgrader_pre_install', 'wcstripe_upgrader_pre_install', 10, 2 );
 
 /**
  * Set the upgrade in progress flag.
  *
- * @param WP_Upgrader $upgrader_object WP_Upgrader instance.
- * @param array $options Extra arguments passed to hooked filters.
+ * @param bool $response Installation response.
+ * @param array $hook_extra Extra arguments passed to hooked filters.
  * @return void
  */
-function wcstripe_upgrader_process_complete( $upgrader_object, $options ) {
-	$current_plugin_path_name = plugin_basename( __FILE__ );
-	if ( 'update' === $options['action'] && 'plugin' === $options['type'] ) {
-		foreach ( $options['plugins'] as $plugin ) {
-			if ( $plugin === $current_plugin_path_name ) {
-				update_option( 'wcstripe_upgrade_in_progress', true );
-			}
-		}
+function wcstripe_upgrader_pre_install( $response, $hook_extra ) {
+	$plugin_base = strtolower( $hook_extra['plugin'] );
+	$plugin_slug = str_replace( '.php', '', basename( $plugin_base ) );
+	if ( 'woocommerce-gateway-stripe' === $plugin_slug ) {
+		update_option( 'wcstripe_upgrade_in_progress', true );
 	}
 }
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -960,6 +960,13 @@ add_action(
 
 add_action( 'upgrader_process_complete', 'wcstripe_upgrader_process_complete', 10, 2 );
 
+/**
+ * Set the upgrade in progress flag.
+ *
+ * @param WP_Upgrader $upgrader_object WP_Upgrader instance.
+ * @param array $options Extra arguments passed to hooked filters.
+ * @return void
+ */
 function wcstripe_upgrader_process_complete( $upgrader_object, $options ) {
 	$current_plugin_path_name = plugin_basename( __FILE__ );
 	if ( 'update' === $options['action'] && 'plugin' === $options['type'] ) {
@@ -973,6 +980,14 @@ function wcstripe_upgrader_process_complete( $upgrader_object, $options ) {
 
 add_action( 'upgrader_post_install', 'wcstripe_upgrader_post_install' );
 
+/**
+ * Set the upgrade in progress flag.
+ *
+ * @param bool $response Installation response.
+ * @param array $hook_extra Extra arguments passed to hooked filters.
+ * @param array $result Installation result data.
+ * @return void
+ */
 function wcstripe_upgrader_post_install( $response, $hook_extra, $result ) {
 	if ( ! empty( $result['destination_name'] ) && 'woocommerce-gateway-stripe' === $result['destination_name'] ) {
 		update_option( 'wcstripe_upgrade_in_progress', false );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

We have been constantly getting fatal PHP errors on our Grafana logs when files are required but do not exist. We believe those errors happen during an extension install or upgrade.

Example error:
```
PHP Fatal error:  Uncaught Error: Failed opening required '/wordpress/plugins/woocommerce-gateway-stripe/9.5.1/includes/admin/stripe-settings.php' (include_path='/:.') in /wordpress/plugins/woocommerce-gateway-stripe/9.5.1/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php:389
```

This PR fixes that possible issue by checking if an install/upgrade is being made before trying to include the files.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
