### PR TITLE
Fix 401 re-connect loop

### DIFF
--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -176,6 +176,17 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// Enable ECE for new connections.
 			$this->enable_ece_in_new_accounts();
 
+			// If we are already using the UPE gateway, update the PMC with the currently enabled payment methods.
+			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+			if ( $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
+				// The UPE accepted payment list does not include Apple Pay/Google Pay, but PMC does, so we need to add them (if they are enabled).
+				$enabled_payment_methods = array_merge(
+					$options['upe_checkout_experience_accepted_payments'],
+					$gateway->is_payment_request_enabled() ? [ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ] : []
+				);
+				$options['upe_checkout_experience_accepted_payments'] = $enabled_payment_methods;
+			}
+
 			WC_Stripe_Helper::update_main_stripe_settings( $options );
 
 			// Similar to what we do for webhooks, we save some stats to help debug oauth problems.
@@ -197,17 +208,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				WC_Stripe::get_instance()->account->configure_webhooks( $is_test ? 'test' : 'live', $secret_key );
 			} catch ( Exception $e ) {
 				return new WP_Error( 'wc_stripe_webhook_error', $e->getMessage() );
-			}
-
-			// If we are already using the UPE gateway, update the PMC with the currently enabled payment methods.
-			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-			if ( $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
-				// The UPE accepted payment list does not include Apple Pay/Google Pay, but PMC does, so we need to add them (if they are enabled).
-				$enabled_payment_methods = array_merge(
-					$options['upe_checkout_experience_accepted_payments'],
-					$gateway->is_payment_request_enabled() ? [ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ] : []
-				);
-				$gateway->update_enabled_payment_methods( $enabled_payment_methods );
 			}
 
 			return $result;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -708,7 +708,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public function update_enabled_payment_methods( $payment_method_ids_to_enable ) {
 		// If the payment method configurations API is not enabled, we fallback to store the enabled payment methods in the DB.
 		if ( ! WC_Stripe_Payment_Method_Configurations::is_enabled() ) {
-			// This fallback is used during the account connect flow, for compatibility we want to use the local get_option here and not the value directly from the DB.
 			$currently_enabled_payment_method_ids      = (array) $this->get_option( 'upe_checkout_experience_accepted_payments' );
 			$upe_checkout_experience_accepted_payments = [];
 
@@ -717,11 +716,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					$upe_checkout_experience_accepted_payments[] = $gateway::STRIPE_ID;
 				}
 			}
-
-			// Read the current settings and update only the enabled payment methods to avoid overriding any other updated setting.
-			$current_options                                              = WC_Stripe_Helper::get_stripe_settings();
-			$current_options['upe_checkout_experience_accepted_payments'] = $upe_checkout_experience_accepted_payments;
-			WC_Stripe_Helper::update_main_stripe_settings( $current_options );
+			$this->update_option( 'upe_checkout_experience_accepted_payments', $upe_checkout_experience_accepted_payments );
 
 			// After updating payment methods record tracks events.
 			$newly_enabled_methods  = array_diff( $upe_checkout_experience_accepted_payments, $currently_enabled_payment_method_ids );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -708,6 +708,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	public function update_enabled_payment_methods( $payment_method_ids_to_enable ) {
 		// If the payment method configurations API is not enabled, we fallback to store the enabled payment methods in the DB.
 		if ( ! WC_Stripe_Payment_Method_Configurations::is_enabled() ) {
+			// This fallback is used during the account connect flow, for compatibility we want to use the local get_option here and not the value directly from the DB.
 			$currently_enabled_payment_method_ids      = (array) $this->get_option( 'upe_checkout_experience_accepted_payments' );
 			$upe_checkout_experience_accepted_payments = [];
 
@@ -716,7 +717,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 					$upe_checkout_experience_accepted_payments[] = $gateway::STRIPE_ID;
 				}
 			}
-			$this->update_option( 'upe_checkout_experience_accepted_payments', $upe_checkout_experience_accepted_payments );
+
+			// Read the current settings and update only the enabled payment methods to avoid overriding any other updated setting.
+			$current_options                                              = WC_Stripe_Helper::get_stripe_settings();
+			$current_options['upe_checkout_experience_accepted_payments'] = $upe_checkout_experience_accepted_payments;
+			WC_Stripe_Helper::update_main_stripe_settings( $current_options );
 
 			// After updating payment methods record tracks events.
 			$newly_enabled_methods  = array_diff( $upe_checkout_experience_accepted_payments, $currently_enabled_payment_method_ids );


### PR DESCRIPTION
Fixes STRIPE-461, STRIPE-462, STRIPE-470
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

This PR reads the plugin settings before updating the `upe_checkout_experience_accepted_payments` to avoid overwriting them during the Account Connect flow.

## Testing instructions

1. Simulate an invalid connection configuration
    `wp option patch update woocommerce_stripe_settings test_secret_key 'sk_test_INVALID'`
    `wp option patch update woocommerce_stripe_settings pmc_enabled 'no'`
2. Go to `WP-Admin > WooCommerce > Settings > Payments` and select `Stripe` 
3. Go to the `Settings` and `Refresh account details`:
    <img width="874" alt="Screenshot_2025-05-21_at_21_05_32" src="https://github.com/user-attachments/assets/c2669f03-dcef-41fc-bef0-34afffb4f5f1" /> 
4. Check that the connection error message is displayed:
    <img width="765" alt="Screenshot 2025-05-21 at 21 09 28" src="https://github.com/user-attachments/assets/76bd1fb9-515e-4e07-9399-83edee76274e" />
5. Now reconnect the account and check that the connection succeeds

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
