### PR TITLE
Fix reconnect loop and PMC sync after reconnect

### DIFF
--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -146,7 +146,13 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return object|null
 	 */
 	private static function get_payment_method_configuration_from_stripe() {
-		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
+		$result = WC_Stripe_API::get_instance()->get_payment_method_configurations();
+
+		// If the result does not have a data property, it means we received an error from the API.
+		if ( ! isset( $result->data ) ) {
+			return null;
+		}
+
 		$configurations = $result->data ?? [];
 
 		// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.
@@ -213,6 +219,7 @@ class WC_Stripe_Payment_Method_Configurations {
 				: [ WC_Stripe_Payment_Methods::CARD ];
 		}
 
+		wc_get_logger()->debug( 'get_upe_enabled_payment_method_ids----' );
 		// Migrate payment methods from DB to Stripe PMC if needed
 		self::maybe_migrate_payment_methods_from_db_to_pmc();
 
@@ -237,6 +244,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @param array $available_payment_method_ids
 	 */
 	public static function update_payment_method_configuration( $enabled_payment_method_ids, $available_payment_method_ids ) {
+		wc_get_logger()->debug( 'update_payment_method_configuration----' );
 		$payment_method_configuration         = self::get_primary_configuration();
 		$updated_payment_method_configuration = [];
 		$newly_enabled_methods                = [];

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -199,17 +199,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return new WP_Error( 'wc_stripe_webhook_error', $e->getMessage() );
 			}
 
-			// If we are already using the UPE gateway, update the PMC with the currently enabled payment methods.
-			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-			if ( $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
-				// The UPE accepted payment list does not include Apple Pay/Google Pay, but PMC does, so we need to add them (if they are enabled).
-				$enabled_payment_methods = array_merge(
-					$options['upe_checkout_experience_accepted_payments'],
-					$gateway->is_payment_request_enabled() ? [ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ] : []
-				);
-				$gateway->update_enabled_payment_methods( $enabled_payment_methods );
-			}
-
 			return $result;
 		}
 


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:
- Removes the code that updates PMC with data from `upe_checkout_experience_accepted_payments` on connect/re-connect. When `pmc_enabled` is empty, this is handled in the `maybe_migrate_payment_methods_from_db_to_pmc` function
- Prevents disabling pmc when `get_payment_method_configurations` returns an api error by bailing early.

## Testing instructions

1. Simulate an invalid connection configuration
    `wp option patch update woocommerce_stripe_settings test_secret_key 'sk_test_INVALID'`
    `wp option patch update woocommerce_stripe_settings pmc_enabled 'no'`
2. Go to `WP-Admin > WooCommerce > Settings > Payments` and select `Stripe` 
3. Go to the `Settings` and `Refresh account details`:
    <img width="874" alt="Screenshot_2025-05-21_at_21_05_32" src="https://github.com/user-attachments/assets/c2669f03-dcef-41fc-bef0-34afffb4f5f1" /> 
4. Check that the connection error message is displayed:
    <img width="765" alt="Screenshot 2025-05-21 at 21 09 28" src="https://github.com/user-attachments/assets/76bd1fb9-515e-4e07-9399-83edee76274e" />
5. Now reconnect the account and check that the connection succeeds.
6. Check `wp option pluck woocommerce_stripe_settings pmc_enabled`. It should be set to `yes`.
