### PR TITLE
Ensure we clear the in-memory Stripe API keys for key situations

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Add - Implement custom database cache for persistent caching with in-memory optimization.
 * Update - Remove feature that flags 401s and proactively blocks subsequent API calls until the store has reauthenticated.
 * Fix - Disable payment settings sync when we receive unsupported payment method configurations.
+* Fix - Ensure that we use current Stripe API keys after settings updates
 
 = 9.5.1 - 2025-05-17 =
 * Fix - Add a fetch cooldown to the payment method configuration retrieval endpoint to prevent excessive requests.

--- a/readme.txt
+++ b/readme.txt
@@ -122,5 +122,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Implement custom database cache for persistent caching with in-memory optimization.
 * Update - Remove feature that flags 401s and proactively blocks subsequent API calls until the store has reauthenticated.
 * Fix - Disable payment settings sync when we receive unsupported payment method configurations.
+* Fix - Ensure that we use current Stripe API keys after settings updates
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -598,6 +598,28 @@ function woocommerce_gateway_stripe() {
 					$settings     = array_merge( $old_settings, $settings );
 				}
 
+				// If we're making a change that impacts which secret key we should be using,
+				// we need to clear the static key being used by WC_Stripe_API.
+				// Note that this also needs to run before we call toggle_upe() below.
+				$should_clear_stripe_api_key = false;
+
+				// If we are switching 'testmode', we need to clear the in-memory Stripe API key.
+				if ( isset( $settings['testmode'] ) && isset( $old_settings['testmode'] ) && $settings['testmode'] !== $old_settings['testmode'] ) {
+					$should_clear_stripe_api_key = true;
+				}
+
+				// If we are updating secret_key or test_secret_key, we need to clear the Stripe API key.
+				if ( isset( $settings['secret_key'] ) && isset( $old_settings['secret_key'] ) && $settings['secret_key'] !== $old_settings['secret_key'] ) {
+					$should_clear_stripe_api_key = true;
+				}
+				if ( isset( $settings['test_secret_key'] ) && isset( $old_settings['test_secret_key'] ) && $settings['test_secret_key'] !== $old_settings['test_secret_key'] ) {
+					$should_clear_stripe_api_key = true;
+				}
+
+				if ( $should_clear_stripe_api_key ) {
+					WC_Stripe_API::get_instance()->set_secret_key( '' );
+				}
+
 				if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 					return $settings;
 				}

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -636,7 +636,7 @@ function woocommerce_gateway_stripe() {
 				}
 
 				if ( $should_clear_stripe_api_key ) {
-					WC_Stripe_API::get_instance()->set_secret_key( '' );
+					WC_Stripe_API::set_secret_key( '' );
 				}
 			}
 

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -622,17 +622,17 @@ function woocommerce_gateway_stripe() {
 				// Note that this also needs to run before we call toggle_upe() below.
 				$should_clear_stripe_api_key = false;
 
-				// If we are switching 'testmode', we need to clear the in-memory Stripe API key.
-				if ( isset( $settings['testmode'] ) && isset( $old_settings['testmode'] ) && $settings['testmode'] !== $old_settings['testmode'] ) {
-					$should_clear_stripe_api_key = true;
-				}
+				$settings_to_check = [
+					'testmode',
+					'secret_key',
+					'test_secret_key',
+				];
 
-				// If we are updating secret_key or test_secret_key, we need to clear the Stripe API key.
-				if ( isset( $settings['secret_key'] ) && isset( $old_settings['secret_key'] ) && $settings['secret_key'] !== $old_settings['secret_key'] ) {
-					$should_clear_stripe_api_key = true;
-				}
-				if ( isset( $settings['test_secret_key'] ) && isset( $old_settings['test_secret_key'] ) && $settings['test_secret_key'] !== $old_settings['test_secret_key'] ) {
-					$should_clear_stripe_api_key = true;
+				foreach ( $settings_to_check as $setting_to_check ) {
+					if ( isset( $settings[ $setting_to_check ] ) && isset( $old_settings[ $setting_to_check ] ) && $settings[ $setting_to_check ] !== $old_settings[ $setting_to_check ] ) {
+						$should_clear_stripe_api_key = true;
+						break;
+					}
 				}
 
 				if ( $should_clear_stripe_api_key ) {

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -598,6 +598,25 @@ function woocommerce_gateway_stripe() {
 					$settings     = array_merge( $old_settings, $settings );
 				}
 
+				// Note that we need to run these checks before we call toggle_upe() below.
+				$this->maybe_reset_stripe_in_memory_key( $settings, $old_settings );
+
+				if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
+					return $settings;
+				}
+
+				return $this->toggle_upe( $settings, $old_settings );
+			}
+
+			/**
+			 * Helper function that ensures we clear the in-memory Stripe API key in {@see WC_Stripe_API}
+			 * when we're making a change to our settings that impacts which secret key we should be using.
+			 *
+			 * @param array $settings     New settings that have just been saved.
+			 * @param array $old_settings Old settings that were previously saved.
+			 * @return void
+			 */
+			protected function maybe_reset_stripe_in_memory_key( $settings, $old_settings ) {
 				// If we're making a change that impacts which secret key we should be using,
 				// we need to clear the static key being used by WC_Stripe_API.
 				// Note that this also needs to run before we call toggle_upe() below.
@@ -619,12 +638,6 @@ function woocommerce_gateway_stripe() {
 				if ( $should_clear_stripe_api_key ) {
 					WC_Stripe_API::get_instance()->set_secret_key( '' );
 				}
-
-				if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-					return $settings;
-				}
-
-				return $this->toggle_upe( $settings, $old_settings );
 			}
 
 			/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-461, STRIPE-462, STRIPE-470

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
In 9.5.x, we've seeng situations where users end up in authentication loops: they keep reconnecting to Stripe, but we continue to disable their access. This PR aims to resolve that issue by ensuring that the static, in-memory key used by `WC_Stripe_API` is cleared when we update specific settings that mean we should use a new key. Those settings are:
 * When `testmode` is modified
 * When `secret_key` is modified
 * When `test_secret_key` is modified

In terms of implementation, the logic is triggered by the existing `WC_Stripe->gateway_settings_update()` function, which itself is hooked into the `pre_update_option_woocommerce_stripe_settings` filter. It specifically checks if those keys exist in both the new and old settings arrays, and then calls `WC_Stripe_API::set_secret_key( '' )` to reset `WC_Stripe_API::$secret_key`. That way future calls from the current process will look up the correct key on the next attempt to call Stripe.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

### Reproduce the problem

Using a current/recent build without this patch, do the following:
* Navigate to _WooCommerce_ > _Settings_ > _Payments_ and select the Stripe option from the list
* If you are not already connected to Stripe, connect using a test account
* Switch to the "Payment Methods" tab
* Ensure that the "Apple Pay / Google Pay" option is enabled, and save the changes if needed
* Switch back to the "Settings" tab
* Run the following WP-CLI commands to simulate breaking the Stripe connection:
```
wp option patch update woocommerce_stripe_settings test_secret_key 'sk_test_INVALID'
wp option patch update woocommerce_stripe_settings pmc_enabled 'no'
```
* In the "Account status" section, click on the kebab menu, and select "Refresh account details"
<img width="874" alt="stripe_refresh_details" src="https://github.com/user-attachments/assets/3003710c-362c-4b6c-b871-6807f1bfd71f" />
* Verify that you see the connection error displayed
<img width="765" alt="stripe_account_not_connected" src="https://github.com/user-attachments/assets/e5ec7bbf-c223-4396-af26-4af1381e2812" />
* If you click on the "Configure connection" button and reconnect the account, you keep getting stuck in this state

### Verify the fix

Now apply the changes from this branch.
* Navigate to _WooCommerce_ > _Settings_ > _Payments_ and select the Stripe option from the list
* Switch to the "Settings" tab
* Click on "Configure connection" button and work through the flow to reconnect the account
* The account connection should succeed

### Smoke test `testmode` changes

This is less likely to be problematic, given that the entities for live and test mode are not distinct for the most part, but I think it's good hygiene regardless. It does require you to have an eligible, live Stripe account to connect, however.
 * Get the site back into the broken state.
 * On the "Settings" tab, toggle the "Enable test mode" setting and save the changes
 * Nothing should break. (Feel free to toggle back too!)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
