### PR TITLE
Fix initial payment method list migration to PMC

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Update - Remove feature that flags 401s and proactively blocks subsequent API calls until the store has reauthenticated.
 * Fix - Disable payment settings sync when we receive unsupported payment method configurations.
 * Fix - Ensure that we use current Stripe API keys after settings updates
+* Fix - Fix initial enabled payment methods migration to the Stripe Payment Methods Configuration API
 
 = 9.5.1 - 2025-05-17 =
 * Fix - Add a fetch cooldown to the payment method configuration retrieval endpoint to prevent excessive requests.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -348,12 +348,19 @@ class WC_Stripe_Payment_Method_Configurations {
 
 	/**
 	 * Migrates the payment methods from the DB option to PMC if needed.
+	 *
+	 * @param bool $force_migration Whether to force the migration.
 	 */
-	public static function maybe_migrate_payment_methods_from_db_to_pmc() {
+	public static function maybe_migrate_payment_methods_from_db_to_pmc( $force_migration = false ) {
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
-		// Skip if PMC is not enabled or migration already done (pmc_enabled is set).
-		if ( ! self::is_enabled() || ! empty( $stripe_settings['pmc_enabled'] ) ) {
+		// Skip if PMC is not enabled.
+		if ( ! self::is_enabled() ) {
+			return;
+		}
+
+		// Skip if migration already done (pmc_enabled is set) and we are not forcing the migration.
+		if ( ! empty( $stripe_settings['pmc_enabled'] ) && ! $force_migration ) {
 			return;
 		}
 

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -163,7 +163,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$options[ $prefix . 'publishable_key' ]     = $publishable_key;
 			$options[ $prefix . 'secret_key' ]          = $secret_key;
 			$options[ $prefix . 'connection_type' ]     = $type;
-			$options['pmc_enabled']                     = 'connect' === $type ? '' : 'no'; // When not connected via oauth, the PMC is disabled. Otherwise, set to empty string which will be set to 'yes' after the migration in 'maybe_migrate_payment_methods_from_db_to_pmc'.
+			$options['pmc_enabled']                     = 'connect' === $type ? 'yes' : 'no'; // When not connected via Connect OAuth, the PMC is disabled.
 			if ( 'app' === $type ) {
 				$options[ $prefix . 'refresh_token' ] = $result->refreshToken; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			}
@@ -199,15 +199,15 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return new WP_Error( 'wc_stripe_webhook_error', $e->getMessage() );
 			}
 
-			// If we are already using the UPE gateway, update the PMC with the currently enabled payment methods.
+			// For new installs the legacy gateway gets instantiated because there is no settings in the DB yet,
+			// so we need to instantiate the UPE gateway just for the PMC migration.
 			$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
-			if ( $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
-				// The UPE accepted payment list does not include Apple Pay/Google Pay, but PMC does, so we need to add them (if they are enabled).
-				$enabled_payment_methods = array_merge(
-					$options['upe_checkout_experience_accepted_payments'],
-					$gateway->is_payment_request_enabled() ? [ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ] : []
-				);
-				$gateway->update_enabled_payment_methods( $enabled_payment_methods );
+			if ( ! $gateway instanceof WC_Stripe_UPE_Payment_Gateway ) {
+				$gateway = new WC_Stripe_UPE_Payment_Gateway();
+			}
+			// If pmc_enabled is not set (aka new install) or is not 'yes' (aka migration already done) we need to migrate the payment methods from the DB option to Stripe PMC API.
+			if ( empty( $current_options ) || ! isset( $current_options['pmc_enabled'] ) || 'yes' !== $current_options['pmc_enabled'] ) {
+				WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc( true );
 			}
 
 			return $result;

--- a/readme.txt
+++ b/readme.txt
@@ -125,5 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Remove feature that flags 401s and proactively blocks subsequent API calls until the store has reauthenticated.
 * Fix - Disable payment settings sync when we receive unsupported payment method configurations.
 * Fix - Ensure that we use current Stripe API keys after settings updates
+* Fix - Fix initial enabled payment methods migration to the Stripe Payment Methods Configuration API
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes #STRIPE-461, STRIPE-462, STRIPE-470

## Changes proposed in this Pull Request:

This PR fixes the payment method migration from local DB to Stripe PMC API, keeping the behavior consistent on what payment methods are pushed to the Stripe Payments Configuration API (PMC):
- **new installs**: The default payment method list is used.
- **plugin update**: The locally enabled payment methods are used.
- **re-connecting account**:
    - **if the store was not using PMC**: The locally enabled payment methods are used
    - **if PMC was enabled**: PMC is used
    - **if PMC was disbaled**: The locally enabled payment methods are used

## Testing instructions

**New install**

1. Delete the plugin settings
    `wp option delete woocommerce_stripe_settings`
2. Go to `WP-Admin > WooCommerce > Settings`, and select `Stripe`
3. Complete the plugin onboarding (connect an account)
4. Go to the `Payment Methods` tab
5. Check that the default payment methods are enabled (CC and express checkouts)
6. Go to the Stripe dashboard  > Payment methods (https://dashboard.stripe.com/test/settings/payment_methods) and check that the PMC was updated successfully.

**Plugin update**
1. Set the `pmc_enabled` flag to **no**
    `wp option patch update woocommerce_stripe_settings pmc_enabled 'no'`
2. Go to `WP-Admin > WooCommerce > Settings`, and select `Stripe`
3. Go to the `Payment Methods` tab, and enable `Affirm` and `Klarna`
4. Remove the `pmc_enabled` flag, and reload (it will trigger the autoupdate, simulating a plugin update from a version without settings sync)
    `wp option patch delete woocommerce_stripe_settings pmc_enabled`
5. Refresh the page and check that nothing changed (Affirm and Klarna are still enabled)
6. Go to the Stripe dashboard  > Payment methods (https://dashboard.stripe.com/test/settings/payment_methods)
7. Check that `Affirm` and `Klarna` are enabled

**Re-connecting account**
1. Go to `WP-Admin > WooCommerce > Settings`, and select `Stripe`
2. Go to the `Payment Methods` tab, and enable `Affirm` and `Klarna` (if not already)
3. Go to the `Settings` tab, and re-connect (Configure connection > connect an account)
4. Go to the `Payment Methods` tab again and check that nothing has changed.
5. Go to the Stripe dashboard  > Payment methods (https://dashboard.stripe.com/test/settings/payment_methods)
6. Check that the enabled payment methods match those enabled in the plugin

**Re-connecting account (with previous failed keys; pmc_enabled=no**)
1. Set the `pmc_enabled` flag to **no**
    `wp option patch update woocommerce_stripe_settings pmc_enabled 'no'`
2. Go to `WP-Admin > WooCommerce > Settings`, and select `Stripe`
3. Go to the `Payment Methods` tab, and disable all payment methods except `Cards`, `WeChat` and the express checkouts
4. Simulate breaking the Stripe connection:
    `wp option patch update woocommerce_stripe_settings test_secret_key 'sk_test_INVALID'`
5. Go to the `Settings` tab, and in the "Account status" section, click on the kebab menu, and select "Refresh account details."
6. Verify that you see the connection error.
7. Click on the "Configure connection" button and reconnect the account
8. Check that it succeeds
9. Go to the `Payment Methods` tab again and check that `Cards`, `WeChat`, and the express checkouts are enabled.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
