### PR TITLE
Add debugging to OAuth redirect handling for user issue

### DIFF
--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -107,6 +107,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			}
 
 			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+				if ( isset( $_GET['wcs_stripe_code'], $_GET['wcs_stripe_state'] ) ) {
+					error_log( 'woocommerce_stripe: Current user does not have manage_woocommerce capability' );
+				}
 				return;
 			}
 
@@ -115,6 +118,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				$nonce = isset( $_GET['_wpnonce'] ) ? wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) : '';
 
 				if ( ! wp_verify_nonce( $nonce, 'wcs_stripe_connected' ) ) {
+					error_log( 'woocommerce_stripe: Invalid nonce received from Stripe server' );
 					return new WP_Error( 'Invalid nonce received from Stripe server' );
 				}
 
@@ -125,6 +129,11 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 				$response = $this->connect_oauth( $state, $code, $type, $mode );
 
+				if ( is_wp_error( $response ) ) {
+					error_log( 'woocommerce_stripe: Error processing OAuth response: [' . $response->get_error_code() . '] ' . $response->get_error_message() );
+				} else {
+					error_log( 'woocommerce_stripe: OAuth response processed successfully' );
+				}
 				$this->record_account_connect_track_event( is_wp_error( $response ) );
 
 				wp_safe_redirect( esc_url_raw( remove_query_arg( [ 'wcs_stripe_state', 'wcs_stripe_code', 'wcs_stripe_type', 'wcs_stripe_mode' ] ) ) );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

This PR adds some raw debugging to try and uncover more details about the issue a merchant is seeing in [this forum thread](https://wordpress.org/support/topic/connection-issue-with-9-5-1-yet-another-thread/). As a result, the PR is based off the code in `release/9.5.2`, which is the version the user is using.

Based on the server logs I looked at (for `api.woocommerce.com`), the redirect back to the Stripe settings page in `wp-admin` is working as expected, so we suspect something is going awry when handling the redirect. Hence the logging here.

Note that the code is intentionally using `error_log()` as the user can't access the main settings page to toggle logging.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
