### PR TITLE
Void intent when cancelling an uncaptured order

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
 * Fix - Send correct attribute when setting the default payment method.
 * Dev - Build dynamic WordPress and WooCommerce dependencies for unit tests.
+* Fix - Void intent when cancelling an uncaptured order
 
 = 9.5.2 - 2025-05-22 =
 * Add - Implement custom database cache for persistent caching with in-memory optimization.

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1145,8 +1145,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			];
 		}
 
-		// Refund without an amount is a no-op, but required to succeed
-		if ( '0.00' === sprintf( '%0.2f', $amount ?? 0 ) ) {
+		// Only treat zero-amount as a no-op for captured charges (real refunds), not for voiding pre-auths.
+		if ( 'yes' === $captured && '0.00' === sprintf( '%0.2f', $amount ?? 0 ) ) {
 			return true;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -122,5 +122,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Prevent styles from non-checkout pages affecting the appearance of Stripe element.
 * Fix - Send correct attribute when setting the default payment method.
 * Dev - Build dynamic WordPress and WooCommerce dependencies for unit tests.
+* Fix - Void intent when cancelling an uncaptured order
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -744,6 +744,77 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that process_refund voids pre-authorization on cancel (uncaptured charge).
+	 */
+	public function test_process_refund_voids_pre_auth_on_cancel() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_transaction_id( 'ch_123' );
+		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$this->updateOrderMeta( $order, '_stripe_intent_id', 'pi_123' );
+		$order->save();
+		$order_id = $order->get_id();
+
+		// Mock the Stripe API to simulate a successful void/cancel
+		$callback = function ( $preempt, $request_args, $url ) {
+			// Simulate a PaymentIntent cancel or charge refund for pre-auth
+			if ( strpos( $url, 'payment_intents' ) !== false || strpos( $url, 'cancel' ) !== false ) {
+				$response = [
+					'headers'  => [],
+					'body'     => wp_json_encode(
+						[
+							'id'            => 'pi_123',
+							'object'        => 'payment_intent',
+							'status'        => 'requires_capture',
+							'latest_charge' => 'ch_123',
+						]
+					),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				];
+				return $response;
+			}
+			if ( strpos( $url, 'charges' ) !== false ) {
+				$response = [
+					'headers'  => [],
+					'body'     => wp_json_encode(
+						[
+							'id'      => 'ch_123',
+							'object'  => 'charge',
+							'status'  => 'succeeded',
+							'refunds' => [
+								'data' => [
+									[
+										'id'     => 're_123',
+										'amount' => 1000,
+										'status' => 'succeeded',
+									],
+								],
+							],
+						]
+					),
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+				];
+				return $response;
+			}
+			return $preempt;
+		};
+		add_filter( 'pre_http_request', $callback, 10, 3 );
+
+		// Should not return early, should attempt to void pre-auth
+		$result = $this->gateway->process_refund( $order_id );
+
+		// For uncaptured charges, process_refund returns false if refund was initiated by changing order status
+		$this->assertFalse( $result );
+
+		remove_filter( 'pre_http_request', $callback );
+	}
+
+	/**
 	 * Tests for `payment_icons`.
 	 *
 	 * @param bool   $optimized_checkout_enabled Whether Optimized Checkout is enabled.

--- a/tests/phpunit/test-wc-stripe-payment-gateway.php
+++ b/tests/phpunit/test-wc-stripe-payment-gateway.php
@@ -679,6 +679,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_process_refund_on_zero_amount() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( 'ch_123' ); // Set the charge ID as transaction ID
+		$this->updateOrderMeta( $order, '_stripe_charge_captured', 'yes' );
 		$order->save();
 		$order_id = $order->get_id();
 
@@ -749,7 +750,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	public function test_process_refund_voids_pre_auth_on_cancel() {
 		$order = WC_Helper_Order::create_order();
 		$order->set_transaction_id( 'ch_123' );
-		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$this->updateOrderMeta( $order, '_stripe_charge_captured', 'no' );
 		$this->updateOrderMeta( $order, '_stripe_intent_id', 'pi_123' );
 		$order->save();
 		$order_id = $order->get_id();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-456

## Changes proposed in this Pull Request:

This PR ensures that uncaptured Stripe PaymentIntents are voided when the associated order is canceled.

Previously, `process_refund()` treated all zero-amount refund requests as no-ops. However, for uncaptured payments (pre-authorizations), the correct behavior is to void the PaymentIntent rather than return early. This change updates the logic so that zero-amount refunds will only be skipped if the charge was already captured. For uncaptured charges, the method now proceeds to void the intent.

Ideally, we'd want to decouple voiding and refunding into separate methods and [cancel_payment](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/d547ff3ab28ddf394e004f3d3314fe6a5a482716/includes/class-wc-stripe-order-handler.php#L394) should call the correct method (refund vs void) appropriately. That's left as an exercise for another time :)  

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->


1. As a merchant, ensure that Stripe is set to authorize first and capture later from settings panel `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
2. As a customer, go through the purchase process and complete checkout.
3. As a merchant, in the edit order screen, change the order status to cancelled.
4. Order notes should indicate that the order was voided.
![CleanShot 2025-05-23 at 12 33 55](https://github.com/user-attachments/assets/93eee7fd-c7fa-436b-be06-56b0f53668ef)
6. View the transaction in the Stripe dashboard and ensure the payment intent was cancelled
![CleanShot 2025-05-23 at 13 37 25](https://github.com/user-attachments/assets/8798f5ef-7c45-4679-83bd-a05e0d9a7cef)




---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
