### PR TITLE
Fix code coverage WC version

### DIFF
--- a/.github/workflows/php-code-coverage.yml
+++ b/.github/workflows/php-code-coverage.yml
@@ -13,11 +13,11 @@ jobs:
   test:
     if: ${{ ! contains( github.event.head_commit.message, 'Merge branch' ) }}
     runs-on: ubuntu-22.04
-    name: PHP=8.1, WP=6.7, WC=9.5.2
+    name: PHP=8.1, WP=6.7, WC=9.6
     env:
       PHP_VERSION: '8.1'
       WP_VERSION: '6.7'
-      WC_VERSION: '9.5.2'
+      WC_VERSION: '9.6'
     steps:
       - name: Get Changed Files
         id: get-changed-files

--- a/.github/workflows/php-code-coverage.yml
+++ b/.github/workflows/php-code-coverage.yml
@@ -13,11 +13,11 @@ jobs:
   test:
     if: ${{ ! contains( github.event.head_commit.message, 'Merge branch' ) }}
     runs-on: ubuntu-22.04
-    name: PHP=8.1, WP=6.7, WC=9.6
+    name: PHP=8.1, WP=6.7, WC=9.6.0
     env:
       PHP_VERSION: '8.1'
       WP_VERSION: '6.7'
-      WC_VERSION: '9.6'
+      WC_VERSION: '9.6.0'
     steps:
       - name: Get Changed Files
         id: get-changed-files

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Dev - Updates the code coverage WooCommerce version to 9.6.0.
 * Fix - Makes payment methods dynamically available on the shortcode checkout when the Optimized Checkout is enabled depending on the saving method checkbox value.
 * Fix - Fixes a possible fatal error with Multibanco purchases when generating the email instructions.
 * Fix - Fixes a fatal error when the fingerprint property is not available for a card payment method.

--- a/includes/class-wc-stripe-mode.php
+++ b/includes/class-wc-stripe-mode.php
@@ -35,4 +35,13 @@ class WC_Stripe_Mode {
 	public static function random_method() {
 		return true;
 	}
+
+	/**
+	 * Random method to test the code coverage action.
+	 *
+	 * @return bool Whether the method executed successfully.
+	 */
+	public static function random_method2() {
+		return true;
+	}
 }

--- a/includes/class-wc-stripe-mode.php
+++ b/includes/class-wc-stripe-mode.php
@@ -26,4 +26,13 @@ class WC_Stripe_Mode {
 		$settings = WC_Stripe_Helper::get_stripe_settings();
 		return 'yes' === ( $settings['testmode'] ?? 'no' );
 	}
+
+	/**
+	 * Random method to test the code coverage action.
+	 *
+	 * @return bool Whether the method executed successfully.
+	 */
+	public static function random_method() {
+		return true;
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Dev - Updates the code coverage WooCommerce version to 9.6.0.
 * Fix - Makes payment methods dynamically available on the shortcode checkout when the Optimized Checkout is enabled depending on the saving method checkbox value.
 * Fix - Fixes a possible fatal error with Multibanco purchases when generating the email instructions.
 * Fix - Fixes a fatal error when the fingerprint property is not available for a card payment method.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The minimum supported WooCommerce version that the Stripe extension now supports is 9.6. Because of it, the PHP code coverage GitHub action is falling, as the bootstrap is not loading the classes properly for this version (returning early in `woocommerce_gateway_stripe_init`).

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Code review. Check if the tests are still passing. Confirm the code review action executed on this branch successfully.

The fake methods introduced here to test the action will be removed before merging the PR.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
