### PR TITLE
Fix payment method detachment when deleting user via CLI

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Fix - Ensure that we migrate payment_request_button_size=medium on upgrade
 * Fix - Apply shipping country restrictions to Express Checkout
 * Dev - Prevent changelog entries with trailing periods
+* Fix - When the user is deleted via WP CLI, take into account the environment type before detaching their payment methods
 
 = 9.5.2 - 2025-05-22 =
 * Add - Implement custom database cache for persistent caching with in-memory optimization.

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -457,11 +457,11 @@ class WC_Stripe_API {
 			return true;
 		}
 
-		// Return true for the delete user request from the admin dashboard when the site is a production site
+		// Return true for the delete user request from the admin dashboard or WP-CLI when the site is a production site
 		// and return false when the site is a staging/local/development site.
 		// This is to avoid detaching the payment method from the live production site.
 		// Requests coming from the customer account page i.e delete payment method, are not affected by this and returns true.
-		if ( is_admin() ) {
+		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			if ( 'production' === wp_get_environment_type() ) {
 				return true;
 			} else {

--- a/readme.txt
+++ b/readme.txt
@@ -140,5 +140,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure that we migrate payment_request_button_size=medium on upgrade
 * Fix - Apply shipping country restrictions to Express Checkout
 * Dev - Prevent changelog entries with trailing periods
+* Fix - When the user is deleted via WP CLI, take into account the environment type before detaching their payment methods
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-466
Fixes #4335

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR addresses an issue where payment methods were detached from Stripe customers when deleting users via WP-CLI in non-production environments. Previously, the code only checked for `is_admin()` to determine if the request was coming from the admin interface, which meant WP-CLI requests would bypass the environment check and always detach payment methods.
The fix adds a check for WP-CLI requests using `defined( 'WP_CLI' ) && WP_CLI` alongside the existing `is_admin()` check. 

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Add `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` to your `wp-config.php`.
2. If your site is in test mode, disable [this](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ab4fbe62c431150882aaf658252a2cc4f22539b9/includes/class-wc-stripe-api.php#L456) check.
3. As a shopper, create a new account. 
4. Go to My Account -> Payment methods and add a new payment method.
5. On your Stripe dashboard, under Customers, make sure the customer shows up with their payment method.
6. Remove the user using wp cli `wp user delete USER_ID`
7. On your Stripe dashboard, the payment method should not be removed from the shopper.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
