### PR TITLE
Update PMC cache keys, and remove fallback cache

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@
 * Fix - When the user is deleted via WP CLI, take into account the environment type before detaching their payment methods
 * Tweak - Add prefix to the custom database cache keys
 * Dev - Fix failing optimized checkout e2e test due to incorrect order of operations
+* Tweak - Remove Payment Mehtod Configurations fallback cache
 
 = 9.5.2 - 2025-05-22 =
 * Add - Implement custom database cache for persistent caching with in-memory optimization.

--- a/readme.txt
+++ b/readme.txt
@@ -146,5 +146,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - When the user is deleted via WP CLI, take into account the environment type before detaching their payment methods
 * Tweak - Add prefix to the custom database cache keys
 * Dev - Fix failing optimized checkout e2e test due to incorrect order of operations
+* Tweak - Remove Payment Mehtod Configurations fallback cache
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR removes the cache key prefix from the Payment_Method_Configurations class; it's no longer needed. https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4370 included that logic into the Database Cache.

It also removes the fallback cache; the new database cache uses the same `options` table to store data, making it redundant.


## Testing instructions

Code review.

Follow the original implementation testing instructions: https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4331

Also, this [Dev Tools plugin PR](https://github.com/woocommerce/woocommerce-gateway-stripe-dev-tools/pull/4) adds a way to see (and delete) the new database cache entries (with TTL and expiration), which makes things easier to test without manually checking the database with wp-cli:

![Screenshot 2025-06-08 at 13 10 36](https://github.com/user-attachments/assets/0c588ded-f27b-467f-bc13-658bb9c9a6e8)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [x] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [x] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [x] Included this PR in the Release Thread scope (or does not apply)
