### PR TITLE
Request system report when creating an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,14 +28,15 @@ assignees: ''
 
 <!-- Please share any screenshots of the problem to help us understand what is happening. -->
 
-### Environment
+### System report
 
-<!-- Please share the following information with us. -->
-- WordPress Version
-- WooCommerce Version
-- Stripe Plugin Version
-- Browser [e.g. Chrome, Safari, Safari on iOS, Chrome on Android] and Version
-- Any other plugins installed
+<details>
+
+<summary></summary>
+
+<!-- Please share your system report. This can be obtained from WooCommerce -> Status -> System status -> Get system report -> Copy for Github -->
+
+</details>
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ assignees: ''
 
 <details>
 
-<summary></summary>
+<summary>System report</summary>
 
 <!-- Please share your system report. This can be obtained from WooCommerce -> Status -> System status -> Get system report -> Copy for Github -->
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR proposes replacing the Environment section in the bug template with a section requesting the system report. WooCommerce System Report is more comprehensive and contains all of the environment details that was requested in the previous template (except browser version), along with additional information like Stripe Account ID, which can be valuable when debugging issues in the payment flow. We've had a few recent bugs where we requested the system report after the issue was filed. We can avoid some of the back-and-forth discussions by requesting it early.


<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

A review of the template is sufficient.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
No code changes

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
