### PR TITLE
Allow non-reusable methods to be used with manual renewals

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
-* Add - Voucher payment methods (Boleto, Multibanco, and Oxxo) can now be used when purchasing subscriptions if manual renewals are enabled or required.
+* Add - Voucher payment methods (Boleto, Multibanco, and Oxxo) can now be used when purchasing subscriptions if manual renewals are enabled or required
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Add - Voucher payment methods (Boleto, Multibanco, and Oxxo) can now be used when purchasing subscriptions if manual renewals are enabled or required.
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/client/blocks/__tests__/utils.test.js
+++ b/client/blocks/__tests__/utils.test.js
@@ -57,7 +57,7 @@ describe( 'Blocks Utils', () => {
 			};
 		} );
 
-		test( 'has auto renewal subscription', () => {
+		test( 'cart has auto renewal subscription', () => {
 			mockGetSetting.mockReturnValue( {
 				cartContainsSubscription: true,
 				subscriptionManualRenewalEnabled: false,
@@ -65,11 +65,11 @@ describe( 'Blocks Utils', () => {
 			expect( shouldSetupOffSessionPayment( false, false ) ).toBeTruthy();
 		} );
 
-		test( 'shows save option', () => {
+		test( 'showSaveOption is true', () => {
 			expect( shouldSetupOffSessionPayment( true, true ) ).toBeTruthy();
 		} );
 
-		test( 'either', () => {
+		test( 'cart does not have auto renewal subscription and showSaveOption is false', () => {
 			expect( shouldSetupOffSessionPayment( false, false ) ).toBeFalsy();
 		} );
 	} );

--- a/client/blocks/__tests__/utils.test.js
+++ b/client/blocks/__tests__/utils.test.js
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import {
 	extractOrderAttributionData,
 	populateOrderAttributionInputs,
+	shouldSetupOffSessionPayment,
 } from 'wcstripe/blocks/utils';
 
 describe( 'Blocks Utils', () => {
@@ -41,6 +42,35 @@ describe( 'Blocks Utils', () => {
 			expect(
 				global.wc_order_attribution.setOrderTracking
 			).toHaveBeenCalledWith( true );
+		} );
+	} );
+
+	describe( 'shouldSetupOffSessionPayment', () => {
+		let mockGetSetting;
+
+		beforeEach( () => {
+			mockGetSetting = jest.fn().mockReturnValue( {} );
+			global.wc = {
+				wcSettings: {
+					getSetting: mockGetSetting,
+				},
+			};
+		} );
+
+		test( 'has auto renewal subscription', () => {
+			mockGetSetting.mockReturnValue( {
+				cartContainsSubscription: true,
+				subscriptionManualRenewalEnabled: false,
+			} );
+			expect( shouldSetupOffSessionPayment( false, false ) ).toBeTruthy();
+		} );
+
+		test( 'shows save option', () => {
+			expect( shouldSetupOffSessionPayment( true, true ) ).toBeTruthy();
+		} );
+
+		test( 'either', () => {
+			expect( shouldSetupOffSessionPayment( false, false ) ).toBeFalsy();
 		} );
 	} );
 } );

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -47,6 +47,7 @@ const PaymentElements = ( {
 		paymentProcessorLoadErrorMessage,
 		setPaymentProcessorLoadErrorMessage,
 	] = useState( null );
+	const paymentMethodsConfig = getBlocksConfiguration()?.paymentMethodsConfig;
 
 	useEffect( () => {
 		if ( supportsDeferredIntent || hasRequestedIntent ) {
@@ -157,7 +158,12 @@ const PaymentElements = ( {
 			};
 
 			// If the cart contains a auto-renewing subscription or the payment method supports saving, we need to use off_session setup so Stripe can display appropriate terms and conditions.
-			if ( shouldSetupOffSessionPayment( props.showSaveOption ) ) {
+			if (
+				shouldSetupOffSessionPayment(
+					props.showSaveOption,
+					paymentMethodsConfig[ paymentMethodId ].isReusable
+				)
+			) {
 				options = {
 					...options,
 					...{

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -20,14 +20,20 @@ export const getBlocksConfiguration = () => {
  * Determines if off-session payment should be set up.
  *
  * @param {boolean} showSaveOption - Whether to show the save option.
+ * @param {boolean} paymentMethodReusable - Whether the payment method is reusable.
  * @return {boolean} True if off-session payment should be set up, false otherwise.
  */
-export const shouldSetupOffSessionPayment = ( showSaveOption ) => {
+export const shouldSetupOffSessionPayment = (
+	showSaveOption,
+	paymentMethodReusable
+) => {
 	const config = getBlocksConfiguration();
+	const methodNotReusableButManualRenewalEnabled =
+		! paymentMethodReusable && config?.subscriptionManualRenewalEnabled;
 	const hasAutoRenewingSubscription =
 		config?.cartContainsSubscription &&
 		! config?.subscriptionRequiresManualRenewal &&
-		! config?.subscriptionManualRenewalEnabled;
+		! methodNotReusableButManualRenewalEnabled;
 	return hasAutoRenewingSubscription || showSaveOption;
 };
 

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -186,6 +186,10 @@ export const getStripeImageUrl = ( imageName ) => {
 /**
  * Whether manual renewal is required based on the payment method's reusability.
  *
+ * It is considered required if:
+ * - The payment method is not reusable and manual renewal is enabled in the configuration.
+ * - The configuration explicitly requires manual renewal.
+ *
  * @param {boolean} paymentMethodReusable
  * @return {boolean} True if manual renewal is required, false otherwise.
  */

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -28,12 +28,12 @@ export const shouldSetupOffSessionPayment = (
 	paymentMethodReusable
 ) => {
 	const config = getBlocksConfiguration();
-	const methodNotReusableButManualRenewalEnabled =
-		! paymentMethodReusable && config?.subscriptionManualRenewalEnabled;
+	const manualRenewalRequired =
+		( ! paymentMethodReusable &&
+			config?.subscriptionManualRenewalEnabled ) ||
+		config?.subscriptionRequiresManualRenewal;
 	const hasAutoRenewingSubscription =
-		config?.cartContainsSubscription &&
-		! config?.subscriptionRequiresManualRenewal &&
-		! methodNotReusableButManualRenewalEnabled;
+		config?.cartContainsSubscription && ! manualRenewalRequired;
 	return hasAutoRenewingSubscription || showSaveOption;
 };
 

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -26,7 +26,8 @@ export const shouldSetupOffSessionPayment = ( showSaveOption ) => {
 	const config = getBlocksConfiguration();
 	const hasAutoRenewingSubscription =
 		config?.cartContainsSubscription &&
-		! config?.subscriptionRequiresManualRenewal;
+		! config?.subscriptionRequiresManualRenewal &&
+		! config?.subscriptionManualRenewalEnabled;
 	return hasAutoRenewingSubscription || showSaveOption;
 };
 

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -19,16 +19,17 @@ export const getBlocksConfiguration = () => {
 /**
  * Determines if off-session payment should be set up.
  *
- * @param {boolean} showSaveOption - Whether to show the save option.
- * @param {boolean} paymentMethodReusable - Whether the payment method is reusable.
+ * @param {boolean} shouldShowSaveOption - Whether to show the save option.
+ * @param {boolean} isPaymentMethodReusable - Whether the payment method is reusable.
  * @return {boolean} True if off-session payment should be set up, false otherwise.
  */
 export const shouldSetupOffSessionPayment = (
-	showSaveOption,
-	paymentMethodReusable
+	shouldShowSaveOption,
+	isPaymentMethodReusable
 ) => {
 	return (
-		showSaveOption || hasAutoRenewingSubscription( paymentMethodReusable )
+		shouldShowSaveOption ||
+		hasAutoRenewingSubscription( isPaymentMethodReusable )
 	);
 };
 

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -28,7 +28,7 @@ export const shouldSetupOffSessionPayment = (
 	paymentMethodReusable
 ) => {
 	return (
-		hasAutoRenewingSubscription( paymentMethodReusable ) || showSaveOption
+		showSaveOption || hasAutoRenewingSubscription( paymentMethodReusable )
 	);
 };
 

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -27,14 +27,9 @@ export const shouldSetupOffSessionPayment = (
 	showSaveOption,
 	paymentMethodReusable
 ) => {
-	const config = getBlocksConfiguration();
-	const manualRenewalRequired =
-		( ! paymentMethodReusable &&
-			config?.subscriptionManualRenewalEnabled ) ||
-		config?.subscriptionRequiresManualRenewal;
-	const hasAutoRenewingSubscription =
-		config?.cartContainsSubscription && ! manualRenewalRequired;
-	return hasAutoRenewingSubscription || showSaveOption;
+	return (
+		hasAutoRenewingSubscription( paymentMethodReusable ) || showSaveOption
+	);
 };
 
 /**
@@ -186,4 +181,33 @@ export const addOrderAttributionInputsIfNotExists = () => {
 export const getStripeImageUrl = ( imageName ) => {
 	const config = getBlocksConfiguration();
 	return `${ config?.plugin_url }/assets/images/${ imageName }.svg`;
+};
+
+/**
+ * Whether manual renewal is required based on the payment method's reusability.
+ *
+ * @param {boolean} paymentMethodReusable
+ * @return {boolean} True if manual renewal is required, false otherwise.
+ */
+const isManualRenewalRequired = ( paymentMethodReusable ) => {
+	const config = getBlocksConfiguration();
+	return (
+		( ! paymentMethodReusable &&
+			config?.subscriptionManualRenewalEnabled ) ||
+		config?.subscriptionRequiresManualRenewal
+	);
+};
+
+/**
+ * Checks if the cart contains an auto-renewing subscription.
+ *
+ * @param {boolean} paymentMethodReusable Indicates if the payment method is reusable.
+ * @return {boolean} True if the cart contains an auto-renewing subscription, false otherwise.
+ */
+const hasAutoRenewingSubscription = ( paymentMethodReusable ) => {
+	const config = getBlocksConfiguration();
+	return (
+		config?.cartContainsSubscription &&
+		! isManualRenewalRequired( paymentMethodReusable )
+	);
 };

--- a/client/blocks/utils.js
+++ b/client/blocks/utils.js
@@ -191,13 +191,13 @@ export const getStripeImageUrl = ( imageName ) => {
  * - The payment method is not reusable and manual renewal is enabled in the configuration.
  * - The configuration explicitly requires manual renewal.
  *
- * @param {boolean} paymentMethodReusable
+ * @param {boolean} isReusablePaymentMethod
  * @return {boolean} True if manual renewal is required, false otherwise.
  */
-const isManualRenewalRequired = ( paymentMethodReusable ) => {
+const isManualRenewalRequired = ( isReusablePaymentMethod ) => {
 	const config = getBlocksConfiguration();
 	return (
-		( ! paymentMethodReusable &&
+		( ! isReusablePaymentMethod &&
 			config?.subscriptionManualRenewalEnabled ) ||
 		config?.subscriptionRequiresManualRenewal
 	);
@@ -206,13 +206,13 @@ const isManualRenewalRequired = ( paymentMethodReusable ) => {
 /**
  * Checks if the cart contains an auto-renewing subscription.
  *
- * @param {boolean} paymentMethodReusable Indicates if the payment method is reusable.
+ * @param {boolean} isReusablePaymentMethod Indicates if the payment method is reusable.
  * @return {boolean} True if the cart contains an auto-renewing subscription, false otherwise.
  */
-const hasAutoRenewingSubscription = ( paymentMethodReusable ) => {
+const hasAutoRenewingSubscription = ( isReusablePaymentMethod ) => {
 	const config = getBlocksConfiguration();
 	return (
 		config?.cartContainsSubscription &&
-		! isManualRenewalRequired( paymentMethodReusable )
+		! isManualRenewalRequired( isReusablePaymentMethod )
 	);
 };

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1034,8 +1034,8 @@ class WC_Stripe_Intent_Controller {
 		$payment_method                 = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $selected_payment_type );
 		$is_manual_renewal_required     = ( ! $payment_method->is_reusable() && WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled() )
 			|| WC_Stripe_Subscriptions_Helper::is_manual_renewal_required();
-		$has_sub_and_manual_renewal_off = ! empty( $payment_information['has_subscription'] ) && ! $is_manual_renewal_required;
-		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || $has_sub_and_manual_renewal_off ) ) {
+		$has_auto_renewing_subscription = ! empty( $payment_information['has_subscription'] ) && ! $is_manual_renewal_required;
+		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || $has_auto_renewing_subscription ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1029,8 +1029,13 @@ class WC_Stripe_Intent_Controller {
 		}
 
 		// If the customer is saving the payment method to the store or has a subscription, we should set the setup_future_usage to off_session.
-		// Only exception is when using a confirmation token. For confirmations tokens, the setup_future_usage is set within the payment method.
-		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || ! empty( $payment_information['has_subscription'] ) ) ) {
+		// Only exceptions are when using a confirmation token or manual renewal is required.
+		// For confirmations tokens, the setup_future_usage is set within the payment method.
+		$payment_method                 = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $selected_payment_type );
+		$is_manual_renewal_required     = ( ! $payment_method->is_reusable() && WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled() )
+			|| WC_Stripe_Subscriptions_Helper::is_manual_renewal_required();
+		$has_sub_and_manual_renewal_off = ! empty( $payment_information['has_subscription'] ) && ! $is_manual_renewal_required;
+		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || $has_sub_and_manual_renewal_off ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1032,9 +1032,7 @@ class WC_Stripe_Intent_Controller {
 		// Only exceptions are when using a confirmation token or manual renewal is required.
 		// For confirmations tokens, the setup_future_usage is set within the payment method.
 		$payment_method                 = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $selected_payment_type );
-		$is_manual_renewal_required     = ( ! $payment_method->is_reusable() && WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled() )
-			|| WC_Stripe_Subscriptions_Helper::is_manual_renewal_required();
-		$has_auto_renewing_subscription = ! empty( $payment_information['has_subscription'] ) && ! $is_manual_renewal_required;
+		$has_auto_renewing_subscription = ! empty( $payment_information['has_subscription'] ) && ! $this->is_manual_renewal_required( $payment_method->is_reusable() );
 		if ( ! $is_using_confirmation_token && ( $payment_information['save_payment_method_to_store'] || $has_auto_renewing_subscription ) ) {
 			$request['setup_future_usage'] = 'off_session';
 		}
@@ -1313,5 +1311,15 @@ class WC_Stripe_Intent_Controller {
 		if ( is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
 			$gateway->maybe_process_upe_redirect();
 		}
+	}
+
+	/**
+	 * Check if manual renewal is required for the payment method.
+	 *
+	 * @return bool
+	 */
+	private function is_manual_renewal_required( $is_payment_method_reusable ) {
+		return ( ! $is_payment_method_reusable && WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled() )
+			|| WC_Stripe_Subscriptions_Helper::is_manual_renewal_required();
 	}
 }

--- a/includes/compat/class-wc-stripe-subscriptions-helper.php
+++ b/includes/compat/class-wc-stripe-subscriptions-helper.php
@@ -75,4 +75,32 @@ class WC_Stripe_Subscriptions_Helper {
 
 		return $detached_subscriptions;
 	}
+
+	/**
+	 * Returns boolean on whether manual renewal is required for the subscriptions of this store.
+	 *
+	 * @since 9.6.0
+	 *
+	 * @return bool
+	 */
+	public static function is_manual_renewal_required() {
+		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
+			return function_exists( 'wcs_is_manual_renewal_required' ) && wcs_is_manual_renewal_required();
+		}
+		return false;
+	}
+
+	/**
+	 * Returns boolean on whether manual renewal is enabled for the subscriptions of this store.
+	 *
+	 * @since 9.6.0
+	 *
+	 * @return bool
+	 */
+	public static function is_manual_renewal_enabled() {
+		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
+			return function_exists( 'wcs_is_manual_renewal_enabled' ) && wcs_is_manual_renewal_enabled();
+		}
+		return false;
+	}
 }

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -118,10 +118,12 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	 * @since 9.6.0
 	 *
 	 * @return bool
+	 *
+	 * @deprecated 9.6.0 Use WC_Stripe_Subscriptions_Helper::is_manual_renewal_required instead.
 	 */
 	public function is_manual_renewal_required() {
 		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
-			return WC_Stripe_Subscriptions_Helper::is_manual_renewal_required() || $this->cart_contains_renewal();
+			return WC_Stripe_Subscriptions_Helper::is_manual_renewal_required();
 		}
 		return false;
 	}

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -127,6 +127,20 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	}
 
 	/**
+	 * Returns boolean on whether manual renewal is enabled for the subscriptions of this store.
+	 *
+	 * @since 9.6.0
+	 *
+	 * @return bool
+	 */
+	public function is_manual_renewal_enabled() {
+		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
+			return function_exists( 'wcs_is_manual_renewal_enabled' ) && wcs_is_manual_renewal_enabled();
+		}
+		return false;
+	}
+
+	/**
 	 * Checks the cart to see if it contains a subscription product renewal.
 	 *
 	 * @since 5.6.0

--- a/includes/compat/trait-wc-stripe-subscriptions-utilities.php
+++ b/includes/compat/trait-wc-stripe-subscriptions-utilities.php
@@ -121,21 +121,7 @@ trait WC_Stripe_Subscriptions_Utilities_Trait {
 	 */
 	public function is_manual_renewal_required() {
 		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
-			return ( class_exists( 'WCS_Manual_Renewal_Manager' ) && WCS_Manual_Renewal_Manager::is_manual_renewal_required() ) || $this->cart_contains_renewal();
-		}
-		return false;
-	}
-
-	/**
-	 * Returns boolean on whether manual renewal is enabled for the subscriptions of this store.
-	 *
-	 * @since 9.6.0
-	 *
-	 * @return bool
-	 */
-	public function is_manual_renewal_enabled() {
-		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
-			return function_exists( 'wcs_is_manual_renewal_enabled' ) && wcs_is_manual_renewal_enabled();
+			return WC_Stripe_Subscriptions_Helper::is_manual_renewal_required() || $this->cart_contains_renewal();
 		}
 		return false;
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -518,7 +518,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['addPaymentReturnURL']               = wc_get_account_endpoint_url( 'payment-methods' );
 		$stripe_params['enabledBillingFields']              = $enabled_billing_fields;
 		$stripe_params['cartContainsSubscription']          = $this->is_subscription_item_in_cart();
-		$stripe_params['subscriptionRequiresManualRenewal'] = $this->is_manual_renewal_required();
+		$stripe_params['subscriptionRequiresManualRenewal'] = WC_Stripe_Subscriptions_Helper::is_manual_renewal_required();
 		$stripe_params['subscriptionManualRenewalEnabled']  = WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled();
 		$stripe_params['accountCountry']                    = WC_Stripe::get_instance()->account->get_account_country();
 		$stripe_params['isPaymentRequestEnabled']           = $express_checkout_helper->is_payment_request_enabled();
@@ -2651,7 +2651,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Save it when paying for a subscription and manual renewal is not required.
 		if ( $this->has_subscription( $order_id ) ) {
-			return ! $this->is_manual_renewal_required();
+			return ! WC_Stripe_Subscriptions_Helper::is_manual_renewal_required();
 		}
 
 		// Unless it's paying for a subscription, don't save it when saving payment methods is disabled.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -519,6 +519,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['enabledBillingFields']              = $enabled_billing_fields;
 		$stripe_params['cartContainsSubscription']          = $this->is_subscription_item_in_cart();
 		$stripe_params['subscriptionRequiresManualRenewal'] = $this->is_manual_renewal_required();
+		$stripe_params['subscriptionManualRenewalEnabled']  = $this->is_manual_renewal_enabled();
 		$stripe_params['accountCountry']                    = WC_Stripe::get_instance()->account->get_account_country();
 		$stripe_params['isPaymentRequestEnabled']           = $express_checkout_helper->is_payment_request_enabled();
 		$stripe_params['isAmazonPayEnabled']                = $express_checkout_helper->is_amazon_pay_enabled();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -519,7 +519,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['enabledBillingFields']              = $enabled_billing_fields;
 		$stripe_params['cartContainsSubscription']          = $this->is_subscription_item_in_cart();
 		$stripe_params['subscriptionRequiresManualRenewal'] = $this->is_manual_renewal_required();
-		$stripe_params['subscriptionManualRenewalEnabled']  = $this->is_manual_renewal_enabled();
+		$stripe_params['subscriptionManualRenewalEnabled']  = WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled();
 		$stripe_params['accountCountry']                    = WC_Stripe::get_instance()->account->get_account_country();
 		$stripe_params['isPaymentRequestEnabled']           = $express_checkout_helper->is_payment_request_enabled();
 		$stripe_params['isAmazonPayEnabled']                = $express_checkout_helper->is_amazon_pay_enabled();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -314,7 +314,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 
 		// If cart or order contains subscription, enable payment method if it's reusable, or if manual renewals are enabled.
 		if ( $this->is_subscription_item_in_cart() || ( ! empty( $order_id ) && $this->has_subscription( $order_id ) ) ) {
-			return $this->is_reusable() || ( function_exists( 'wcs_is_manual_renewal_enabled' ) && wcs_is_manual_renewal_enabled() );
+			return $this->is_reusable() || $this->is_manual_renewal_enabled();
 		}
 
 		// If cart or order contains pre-order, enable payment method if it's reusable.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -314,7 +314,7 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 
 		// If cart or order contains subscription, enable payment method if it's reusable, or if manual renewals are enabled.
 		if ( $this->is_subscription_item_in_cart() || ( ! empty( $order_id ) && $this->has_subscription( $order_id ) ) ) {
-			return $this->is_reusable() || $this->is_manual_renewal_enabled();
+			return $this->is_reusable() || WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled();
 		}
 
 		// If cart or order contains pre-order, enable payment method if it's reusable.

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -312,9 +312,9 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 			return false;
 		}
 
-		// If cart or order contains subscription, enable payment method if it's reusable.
+		// If cart or order contains subscription, enable payment method if it's reusable, or if manual renewals are enabled.
 		if ( $this->is_subscription_item_in_cart() || ( ! empty( $order_id ) && $this->has_subscription( $order_id ) ) ) {
-			return $this->is_reusable();
+			return $this->is_reusable() || ( function_exists( 'wcs_is_manual_renewal_enabled' ) && wcs_is_manual_renewal_enabled() );
 		}
 
 		// If cart or order contains pre-order, enable payment method if it's reusable.

--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
-* Add - Voucher payment methods (Boleto, Multibanco, and Oxxo) can now be used when purchasing subscriptions if manual renewals are enabled or required.
+* Add - Voucher payment methods (Boleto, Multibanco, and Oxxo) can now be used when purchasing subscriptions if manual renewals are enabled or required
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Add - Voucher payment methods (Boleto, Multibanco, and Oxxo) can now be used when purchasing subscriptions if manual renewals are enabled or required.
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/tests/phpunit/Compat/WC_Stripe_Subscriptions_Helper_Test.php
+++ b/tests/phpunit/Compat/WC_Stripe_Subscriptions_Helper_Test.php
@@ -21,4 +21,26 @@ class WC_Stripe_Subscriptions_Helper_Test extends WP_UnitTestCase {
 	public function test_is_subscriptions_enabled() {
 		$this->assertTrue( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() );
 	}
+
+	/**
+	 * Test for `test_is_manual_renewal_required`.
+	 *
+	 * @return void
+	 */
+	public function test_is_manual_renewal_required() {
+		// This test assumes that manual renewal is not required.
+		// If the logic changes, this test should be updated accordingly.
+		$this->assertFalse( WC_Stripe_Subscriptions_Helper::is_manual_renewal_required() );
+	}
+
+	/**
+	 * Test for `is_manual_renewal_enabled`.
+	 *
+	 * @return void
+	 */
+	public function test_is_manual_renewal_enabled() {
+		// This test assumes that manual renewal is not enabled.
+		// If the logic changes, this test should be updated accordingly.
+		$this->assertFalse( WC_Stripe_Subscriptions_Helper::is_manual_renewal_enabled() );
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-403
Fixes #4217
Woo Doc https://woocommerce.com/document/subscriptions/store-manager-guide/#accept-manual-renewals

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Currently, voucher payment methods (Multibanco, Boleto, and Oxxo) cannot be used to pay for subscriptions. That's because they don't allow auto-renewal. According to the Woo docs, those should be accepted when manual renewals are enabled or required.

This PR fixes this behavior by checking for both settings when displaying and processing orders.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/allow-non-reusable-methods-to-be-used-with-manual-renewal`)
- Connect your Stripe account
- Install the subscriptions extension
- Add a subscription product
- Enable manual renewals in WooCommerce -> Settings -> Subscriptions -> "Accept Manual Renewals"
- Make sure the legacy checkout and the optimized checkout are disabled
- Configure your store to follow the specific rules for [Oxxo](https://docs.stripe.com/payments/oxxo), [Multibanco](https://docs.stripe.com/payments/multibanco), and [Boleto](https://docs.stripe.com/payments/boleto)
- As a shopper, add the subscription product to your cart
- Confirm the voucher payment methods are now available in both the block checkout and shortcode checkout
- Confirm you can complete the purchase

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
