### PR TITLE
Fix buggy unsaved changes warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -37,6 +37,7 @@
 * Update - Support block checkout custom fields when using express payment methods like Apple Pay and Google Pay
 * Dev - Fix failing optimized checkout e2e test due to incorrect order of operations
 * Tweak - Remove Payment Mehtod Configurations fallback cache
+* Fix - Fix buggy unsaved changes warning in settings page
 
 = 9.5.2 - 2025-05-22 =
 * Add - Implement custom database cache for persistent caching with in-memory optimization.

--- a/client/settings/general-settings-section/customize-payment-method.js
+++ b/client/settings/general-settings-section/customize-payment-method.js
@@ -94,6 +94,8 @@ const CustomizePaymentMethod = ( { method, onClose } ) => {
 					) }
 				/>
 			) }
+			{ /* The 'submit' class is used by WC core to clear unsaved changes warnings.
+				See https://github.com/woocommerce/woocommerce/blob/fc7ffce309662758c0d3383de8cc8e8c6a57a167/plugins/woocommerce/client/legacy/js/admin/settings.js#L139 */ }
 			<ButtonWrapper className="submit">
 				<Button
 					variant="tertiary"

--- a/client/settings/general-settings-section/customize-payment-method.js
+++ b/client/settings/general-settings-section/customize-payment-method.js
@@ -94,7 +94,7 @@ const CustomizePaymentMethod = ( { method, onClose } ) => {
 					) }
 				/>
 			) }
-			<ButtonWrapper>
+			<ButtonWrapper className="submit">
 				<Button
 					variant="tertiary"
 					disabled={ isCustomizing }

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -20,7 +20,7 @@ const SaveSettingsSection = ( { onSettingsSave } ) => {
 	};
 
 	return (
-		<SaveSettingsSectionWrapper>
+		<SaveSettingsSectionWrapper className="submit">
 			<Button
 				isPrimary
 				isBusy={ isSaving }

--- a/client/settings/save-settings-section/index.js
+++ b/client/settings/save-settings-section/index.js
@@ -20,6 +20,8 @@ const SaveSettingsSection = ( { onSettingsSave } ) => {
 	};
 
 	return (
+		// The 'submit' class is used by WC core to clear unsaved changes warnings.
+		// See https://github.com/woocommerce/woocommerce/blob/fc7ffce309662758c0d3383de8cc8e8c6a57a167/plugins/woocommerce/client/legacy/js/admin/settings.js#L139
 		<SaveSettingsSectionWrapper className="submit">
 			<Button
 				isPrimary

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -4,13 +4,12 @@ import React, { useState } from 'react';
 import { TabPanel } from '@wordpress/components';
 import { getQuery, updateQueryString } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
-import { isEmpty, isEqual } from 'lodash';
+import { isEmpty } from 'lodash';
 import SettingsLayout from '../settings-layout';
 import PaymentSettingsPanel from '../payment-settings';
 import PaymentMethodsPanel from '../payment-methods';
 import SaveSettingsSection from '../save-settings-section';
 import { useSettings } from '../../data';
-import useConfirmNavigation from 'utils/use-confirm-navigation';
 
 const StyledTabPanel = styled( TabPanel )`
 	.components-tab-panel__tabs {
@@ -50,18 +49,6 @@ const SettingsManager = () => {
 			[ key ]: data,
 		} );
 	};
-
-	const isPristine =
-		! isEmpty( initialSettings ) && isEqual( initialSettings, settings );
-	const displayPrompt = ! isPristine;
-	const confirmationNavigationCallback = useConfirmNavigation(
-		displayPrompt
-	);
-
-	useEffect( confirmationNavigationCallback, [
-		displayPrompt,
-		confirmationNavigationCallback,
-	] );
 
 	// This grabs the "panel" URL query string value to allow for opening a specific tab.
 	const { panel } = getQuery();

--- a/readme.txt
+++ b/readme.txt
@@ -148,5 +148,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Support block checkout custom fields when using express payment methods like Apple Pay and Google Pay
 * Dev - Fix failing optimized checkout e2e test due to incorrect order of operations
 * Tweak - Remove Payment Mehtod Configurations fallback cache
+* Fix - Fix buggy unsaved changes warning in settings page
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Partly fixes https://github.com/woocommerce/woocommerce/issues/50936

## Changes proposed in this Pull Request:

1. Fixes a bug where the "Changes you made may not be saved." warning pops up even when all changes have been saved, by using [the required classname that resets the behavior](https://github.com/woocommerce/woocommerce/blob/ba53abb7bfef20509dd8e683d956430b6d766adc/plugins/woocommerce/client/legacy/js/admin/settings.js#L139) to the "Save changes" button container.
2. Removes now-redundant code where we implement our own "unsaved changes" detection.

### Details
Why it only started manifesting after WooCommerce 9.2.0: https://github.com/woocommerce/woocommerce/pull/47444 introduced fixes that enabled "unsaved changes" detection even for dynamically added form fields.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Go to the Stripe settings page, and make a change by checking/unchecking a payment method checkbox. Do not click the "Save changes" button.
2. Try to navigate to a different wp-admin page.
3. You should see the "unsaved changes" warning. Click `Cancel` to close the warning and stay on the page.
4. Click `Save changes`.
5. Try to navigate to a different wp-admin page.
   - In `develop`, you will still see the warning.
   - In this branch, there should be no more warning.
6. Perform the same test, but for customizing the name or description of a payment method. There should be no inappropriate "unsaved changes" warning.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
