### PR TITLE
Adding a filter to enable the optimized checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Add - Adds a new filter (`wc_stripe_is_optimized_checkout_available`) to allow merchants to test the Optimized Checkout feature earlier.
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
-* Add - Adds a new filter (`wc_stripe_is_optimized_checkout_available`) to allow merchants to test the Optimized Checkout feature earlier.
+* Add - Adds a new filter (`wc_stripe_is_optimized_checkout_available`) to allow merchants to test the Optimized Checkout feature earlier
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -187,11 +187,11 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_oc_available() {
-		$feature_flag_value = self::get_option_with_default( self::OC_FEATURE_FLAG_NAME );
+		$default_value = self::get_option_with_default( self::OC_FEATURE_FLAG_NAME );
 		return apply_filters(
 			'wc_stripe_is_optimized_checkout_available',
-			'yes' === $feature_flag_value,
-			$feature_flag_value
+			'yes' === $default_value,
+			$default_value
 		);
 	}
 }

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -188,7 +188,7 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_oc_available() {
 		return apply_filters(
-			'wc_stripe_is_oc_available',
+			'wc_stripe_is_optimized_checkout_available',
 			'yes' === self::get_option_with_default( self::OC_FEATURE_FLAG_NAME ),
 			self::get_option_with_default( self::OC_FEATURE_FLAG_NAME )
 		);

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -187,10 +187,11 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_oc_available() {
+		$feature_flag_value = self::get_option_with_default( self::OC_FEATURE_FLAG_NAME );
 		return apply_filters(
 			'wc_stripe_is_optimized_checkout_available',
-			'yes' === self::get_option_with_default( self::OC_FEATURE_FLAG_NAME ),
-			self::get_option_with_default( self::OC_FEATURE_FLAG_NAME )
+			'yes' === $feature_flag_value,
+			$feature_flag_value
 		);
 	}
 }

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -187,6 +187,10 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_oc_available() {
-		return 'yes' === self::get_option_with_default( self::OC_FEATURE_FLAG_NAME );
+		return apply_filters(
+			'wc_stripe_is_oc_available',
+			'yes' === self::get_option_with_default( self::OC_FEATURE_FLAG_NAME ),
+			self::get_option_with_default( self::OC_FEATURE_FLAG_NAME )
+		);
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Add - Adds a new filter (`wc_stripe_is_optimized_checkout_available`) to allow merchants to test the Optimized Checkout feature earlier.
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
-* Add - Adds a new filter (`wc_stripe_is_optimized_checkout_available`) to allow merchants to test the Optimized Checkout feature earlier.
+* Add - Adds a new filter (`wc_stripe_is_optimized_checkout_available`) to allow merchants to test the Optimized Checkout feature earlier
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -24,13 +24,15 @@ class WC_Stripe_Feature_Flags_Test extends WP_UnitTestCase {
 	 */
 	public function test_is_oc_available( $option_value, $filter_function, $expected ) {
 		if ( ! empty( $filter_function ) ) {
-			add_filter( 'wc_stripe_is_optimized_checkout_available', '__return_true' );
+			add_filter( 'wc_stripe_is_optimized_checkout_available', $filter_function );
 		}
 
 		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $option_value );
 		$this->assertSame( $expected, WC_Stripe_Feature_Flags::is_oc_available() );
 
-		remove_filter( 'wc_stripe_is_optimized_checkout_available', '__return_true' );
+		if ( ! empty( $filter_function ) ) {
+			remove_filter( 'wc_stripe_is_optimized_checkout_available', $filter_function );
+		}
 	}
 
 	/**
@@ -40,17 +42,25 @@ class WC_Stripe_Feature_Flags_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_is_oc_available() {
 		return [
-			'available'          => [
-				'option value' => 'yes',
-				'expected'     => true,
+			'available'           => [
+				'option value'    => 'yes',
+				'filter function' => '',
+				'expected'        => true,
 			],
-			'not available'      => [
-				'option value' => 'no',
-				'expected'     => false,
+			'not available'       => [
+				'option value'    => 'no',
+				'filter function' => '',
+				'expected'        => false,
 			],
-			'filter set to true' => [
-				'option value' => 'no',
-				'expected'     => true,
+			'filter set to true'  => [
+				'option value'    => 'no',
+				'filter function' => '__return_true',
+				'expected'        => true,
+			],
+			'filter set to false' => [
+				'option value'    => 'yes',
+				'filter function' => '__return_false',
+				'expected'        => false,
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -17,13 +17,20 @@ class WC_Stripe_Feature_Flags_Test extends WP_UnitTestCase {
 	 * Test for `is_oc_available`.
 	 *
 	 * @param string $option_value The value of the feature flag option.
+	 * @param string $filter_function The filter function to apply.
 	 * @param bool   $expected     The expected result.
 	 * @return void
 	 * @dataProvider provide_test_is_oc_available
 	 */
-	public function test_is_oc_available( $option_value, $expected ) {
+	public function test_is_oc_available( $option_value, $filter_function, $expected ) {
+		if ( ! empty( $filter_function ) ) {
+			add_filter( 'wc_stripe_is_optimized_checkout_available', '__return_true' );
+		}
+
 		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $option_value );
 		$this->assertSame( $expected, WC_Stripe_Feature_Flags::is_oc_available() );
+
+		remove_filter( 'wc_stripe_is_optimized_checkout_available', '__return_true' );
 	}
 
 	/**
@@ -33,13 +40,17 @@ class WC_Stripe_Feature_Flags_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_is_oc_available() {
 		return [
-			'available'     => [
+			'available'          => [
 				'option value' => 'yes',
 				'expected'     => true,
 			],
-			'not available' => [
+			'not available'      => [
 				'option value' => 'no',
 				'expected'     => false,
+			],
+			'filter set to true' => [
+				'option value' => 'no',
+				'expected'     => true,
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-525

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

We are introducing a new filter (`wc_stripe_is_optimized_checkout_available`) to allow merchants to test the Optimized Checkout earlier if they want to.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/filter-to-enable-optimized-checkout`)
- Connect your Stripe account
- Go to the settings tab and confirm the Optimized Checkout option is not shown
<img width="1058" alt="Screenshot 2025-06-16 at 18 49 41" src="https://github.com/user-attachments/assets/9435fbb0-6401-4038-9332-040f4b846ff1" />

- Add the following code snippet to the main extension file (`woocommerce-gateway-stripe.php`)
```php
add_filter( 'wc_stripe_is_optimized_checkout_available', '__return_true' );
```
- Confirm the option is now shown:
<img width="786" alt="Screenshot 2025-06-16 at 18 52 27" src="https://github.com/user-attachments/assets/7df7422d-637f-4d9a-8d0a-4697d8bbea67" />

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
