### PR TITLE
Restricting BNPL promotional banner to target version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Fix - Restricts the BNPLs promotional banner to only be displayed after version 9.7.0.
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
-* Fix - Restricts the BNPLs promotional banner to only be displayed after version 9.7.0.
+* Fix - Restricts the BNPLs promotional banner to only be displayed after version 9.7.0
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/client/settings/payment-settings/promotional-banner/__tests__/get-promotional-banner-type.test.js
+++ b/client/settings/payment-settings/promotional-banner/__tests__/get-promotional-banner-type.test.js
@@ -31,6 +31,10 @@ describe( 'getPromotionalBannerType', () => {
 		).toBe( RECONNECT_BANNER );
 	} );
 	it( 'BNPL promotion banner', () => {
+		global.wc_stripe_settings_params = {
+			plugin_version: '9.7.0',
+		};
+
 		const accountData = {
 			testmode: false,
 			oauth_connections: {

--- a/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
+++ b/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
@@ -40,7 +40,8 @@ export const getPromotionalBannerType = (
 		isUpeEnabled &&
 		! hasBNPLEnabled &&
 		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params.plugin_version >= '9.7.0'
+		wc_stripe_settings_params?.plugin_version &&
+		parseFloat( String( wc_stripe_settings_params.plugin_version ).split( '.' ).slice( 0, 2 ).join( '.' ) ) >= 9.7
 	) {
 		return BNPL_PROMOTION_BANNER;
 	} else if ( ! isUpeEnabled ) {

--- a/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
+++ b/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
@@ -41,7 +41,13 @@ export const getPromotionalBannerType = (
 		! hasBNPLEnabled &&
 		// eslint-disable-next-line camelcase
 		wc_stripe_settings_params?.plugin_version &&
-		parseFloat( String( wc_stripe_settings_params.plugin_version ).split( '.' ).slice( 0, 2 ).join( '.' ) ) >= 9.7
+		parseFloat(
+			// eslint-disable-next-line camelcase
+			String( wc_stripe_settings_params.plugin_version )
+				.split( '.' )
+				.slice( 0, 2 )
+				.join( '.' )
+		) >= 9.7
 	) {
 		return BNPL_PROMOTION_BANNER;
 	} else if ( ! isUpeEnabled ) {

--- a/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
+++ b/client/settings/payment-settings/promotional-banner/get-promotional-banner-type.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 import {
 	BNPL_PROMOTION_BANNER,
 	NEW_CHECKOUT_EXPERIENCE_APMS_BANNER,
@@ -35,7 +36,12 @@ export const getPromotionalBannerType = (
 
 	if ( oauthConnected === false ) {
 		return RECONNECT_BANNER;
-	} else if ( isUpeEnabled && ! hasBNPLEnabled ) {
+	} else if (
+		isUpeEnabled &&
+		! hasBNPLEnabled &&
+		// eslint-disable-next-line camelcase
+		wc_stripe_settings_params.plugin_version >= '9.7.0'
+	) {
 		return BNPL_PROMOTION_BANNER;
 	} else if ( ! isUpeEnabled ) {
 		if ( hasAPMEnabled ) {

--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
-* Fix - Restricts the BNPLs promotional banner to only be displayed after version 9.7.0.
+* Fix - Restricts the BNPLs promotional banner to only be displayed after version 9.7.0
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Fix - Restricts the BNPLs promotional banner to only be displayed after version 9.7.0.
 * Add - Adds a new promotional banner to promote the BNPL payment methods (Klarna, Afterpay, and Affirm) on the settings page.
 * Fix - Adds an exception to be thrown when the order item quantity is zero, during the retrieval of level 3 data from an order.
 * Dev - Deprecates the WC_Stripe_Order class and removes its inclusion call.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-531
Base PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4328
See pcUrMV-b0q-p2#comment-32417

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The banner promoting BNPLs will now go out with the 9.7.0 version. This PR checks the current extension version when deciding whether the banner will be shown.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

Code review should be enough. You can play with lowering the current extension version on the backend (`includes/admin/class-wc-stripe-settings-controller.php#253`) and checking if the banner shows up by following the testing steps of [this PR](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4328).

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
