### PR TITLE
Use platform PMC Id constants for the Checkout rendering

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@
 * Dev - Fix failing optimized checkout e2e test due to incorrect order of operations
 * Tweak - Remove Payment Method Configurations fallback cache
 * Fix - Show correct price in express checkout for zero decimal currencies
+* Fix - Prevent PMC fetch when rendering the checkout if settings sync is disabled
 
 = 9.5.2 - 2025-05-22 =
 * Add - Implement custom database cache for persistent caching with in-memory optimization.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -139,12 +139,12 @@ class WC_Stripe_Payment_Method_Configurations {
 	}
 
 	/**
-	 * Get the parent configuration ID.
+	 * Get the WooCommerce Platform payment method configuration id.
 	 *
-	 * @return string|null
+	 * @return string
 	 */
 	public static function get_parent_configuration_id() {
-		return self::get_primary_configuration()->parent ?? null;
+		return WC_Stripe_Mode::is_test() ? self::TEST_MODE_CONFIGURATION_PARENT_ID : self::LIVE_MODE_CONFIGURATION_PARENT_ID;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -149,5 +149,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Fix failing optimized checkout e2e test due to incorrect order of operations
 * Tweak - Remove Payment Method Configurations fallback cache
 * Fix - Show correct price in express checkout for zero decimal currencies
+* Fix - Prevent PMC fetch when rendering the checkout if settings sync is disabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-533

## Changes proposed in this Pull Request:

The parameter `paymentMethodConfigurationParentId` is only used for the Smart Checkout. Still, it's always present, which causes the checkout page to try fetching the PMC list even when the PMC flag is false.

This PR replaces the `get_parent_configuration_id` implementation with the constant for each mode (test or live), to avoid.

## Testing instructions

1. Disable settings sync (PMC)
    `wp option patch update woocommerce_stripe_settings pmc_enabled 'no'`
2. Checkout the `develop` branch
3. In the store, add a product to the cart and go to the checkout
4. Go to in the DevTools' Database Cache tab and check that the `wcstripe_cache_test_payment_method_configuration` entry was just updated (TTL == Expires):
    ![Screenshot 2025-06-17 at 17 25 45](https://github.com/user-attachments/assets/b7699b34-8d06-4b27-80ec-6de4383a08f8)
5. Delete the entry, refresh the checkout, and check that a new cache entry was created.
6. Checkout this branch (`fix/533-use-pmc-constants-for-checkout-rendering`)
7. Wait a couple of minutes and refresh the checkout, check that the cache entry was not updated (TTL and Expires dont match)
    ![Screenshot 2025-06-17 at 17 29 25](https://github.com/user-attachments/assets/64679960-2861-4bfe-b567-3ceb2036ef8f)
8. Delete the `wcstripe_cache_test_payment_method_configuration` entry (again) and reload the checkout.
9. Check that the cache entry was not created.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
