### PR TITLE
E2E: Test the basic Affirm payment flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@
 * Tweak - Remove Payment Method Configurations fallback cache
 * Tweak - Update deprecation notice message to specify that legacy checkout experience has been deprecated since version 9.6.0
 * Update - Remove legacy checkout checkbox from settings
+* Dev - Add e2e tests to cover Affirm purchase flow
 
 = 9.5.3 - 2025-06-23 =
 * Fix - Reimplement mapping of Express Checkout state values to align with WooCommerce's expected state formats

--- a/readme.txt
+++ b/readme.txt
@@ -151,5 +151,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Remove Payment Method Configurations fallback cache
 * Tweak - Update deprecation notice message to specify that legacy checkout experience has been deprecated since version 9.6.0
 * Update - Remove legacy checkout checkbox from settings
+* Dev - Add e2e tests to cover Affirm purchase flow
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/blocks/affirm.spec.js
+++ b/tests/e2e/tests/checkout/blocks/affirm.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { admin, payments } from '../../../utils';
+
+const { setupAffirmCheckout } = payments;
+
+test.describe( 'Affirm payment tests @blocks', () => {
+	test.beforeAll( async ( { browser } ) => {
+		await test.step( 'Setup test environment', async () => {
+			// Enable Klarna in admin
+			await admin.togglePaymentMethod( browser, 'Affirm', true );
+		} );
+	} );
+
+	test.describe.configure( { mode: 'parallel' } );
+
+	test( 'customer can pay with Affirm @smoke', async ( { page } ) => {
+		await setupAffirmCheckout( page, 'blocks' );
+		await page.locator( 'text=Place order' ).click();
+		// Since we don't have control over the Affirm payment flow,
+		// verifying the redirect is all we can do consistently without introducing a
+		// flaky test.
+		await expect( page ).toHaveURL( /.*affirm\.com/ );
+	} );
+} );

--- a/tests/e2e/tests/checkout/blocks/affirm.spec.js
+++ b/tests/e2e/tests/checkout/blocks/affirm.spec.js
@@ -6,7 +6,7 @@ const { setupAffirmCheckout } = payments;
 test.describe( 'Affirm payment tests @blocks', () => {
 	test.beforeAll( async ( { browser } ) => {
 		await test.step( 'Setup test environment', async () => {
-			// Enable Klarna in admin
+			// Enable Affirm in admin
 			await admin.togglePaymentMethod( browser, 'Affirm', true );
 		} );
 	} );

--- a/tests/e2e/tests/checkout/blocks/affirm.spec.js
+++ b/tests/e2e/tests/checkout/blocks/affirm.spec.js
@@ -19,6 +19,6 @@ test.describe( 'Affirm payment tests @blocks', () => {
 		// Since we don't have control over the Affirm payment flow,
 		// verifying the redirect is all we can do consistently without introducing a
 		// flaky test.
-		await expect( page ).toHaveURL( /.*affirm\.com/ );
+		await expect( page ).toHaveURL( /.*(affirm\.com|stripe\.com)/ );
 	} );
 } );

--- a/tests/e2e/tests/checkout/blocks/affirm.spec.js
+++ b/tests/e2e/tests/checkout/blocks/affirm.spec.js
@@ -17,8 +17,8 @@ test.describe( 'Affirm payment tests @blocks', () => {
 		await setupAffirmCheckout( page, 'blocks' );
 		await page.locator( 'text=Place order' ).click();
 		// Since we don't have control over the Affirm payment flow,
-		// verifying the redirect is all we can do consistently without introducing a
-		// flaky test.
+		// verifying the redirect to Stripe or Affirm is all we can do consistently
+		// without introducing a flaky test.
 		await expect( page ).toHaveURL( /.*(affirm\.com|stripe\.com)/ );
 	} );
 } );

--- a/tests/e2e/tests/checkout/shortcode/affirm.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/affirm.spec.js
@@ -17,8 +17,8 @@ test.describe( 'Affirm payment tests @shortcode', () => {
 		await setupAffirmCheckout( page, 'shortcode' );
 		await page.locator( 'text=Place order' ).click();
 		// Since we don't have control over the Affirm payment flow,
-		// verifying the redirect is all we can do consistently without introducing a
-		// flaky test.
-		await expect( page ).toHaveURL( /.*affirm\.com/ );
+		// verifying the redirect to Stripe or Affirm is all we can do consistently
+		// without introducing a flaky test.
+		await expect( page ).toHaveURL( /.*(affirm\.com|stripe\.com)/ );
 	} );
 } );

--- a/tests/e2e/tests/checkout/shortcode/affirm.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/affirm.spec.js
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { admin, payments } from '../../../utils';
+
+const { setupAffirmCheckout } = payments;
+
+test.describe( 'Affirm payment tests @shortcode', () => {
+	test.beforeAll( async ( { browser } ) => {
+		await test.step( 'Setup test environment', async () => {
+			// Enable Affirm in admin
+			await admin.togglePaymentMethod( browser, 'Affirm', true );
+		} );
+	} );
+
+	test.describe.configure( { mode: 'parallel' } );
+
+	test( 'customer can pay with Affirm @smoke', async ( { page } ) => {
+		await setupAffirmCheckout( page, 'shortcode' );
+		await page.locator( 'text=Place order' ).click();
+		// Since we don't have control over the Affirm payment flow,
+		// verifying the redirect is all we can do consistently without introducing a
+		// flaky test.
+		await expect( page ).toHaveURL( /.*affirm\.com/ );
+	} );
+} );

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -858,3 +858,43 @@ export const fillBECSDetails = async ( page, checkoutType = 'blocks' ) => {
 		.fill( '000123456' );
 	await stripeFrame.locator( '[name="auBsb"]' ).fill( '000000' );
 };
+
+/**
+ * Set up the checkout page for Affirm payment.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {string} checkoutType The type of checkout ('blocks' or 'shortcode').
+ */
+export const setupAffirmCheckout = async ( page, checkoutType = 'blocks' ) => {
+	// Affirm is only available when the price is above $50.
+	const lineItems = [ [ config.get( 'products.simple.name' ), 5 ] ];
+
+	await emptyCart( page );
+	await setupCart( page, lineItems );
+
+	const isBlocks = checkoutType === 'blocks';
+
+	// Fill billing details
+	const billingDetails = config.get( 'addresses.customer.billing' );
+	if ( isBlocks ) {
+		await setupBlocksCheckout( page, billingDetails );
+	} else {
+		await setupShortcodeCheckout( page, billingDetails );
+	}
+
+	await page.waitForTimeout( 1000 );
+
+	// Wait for the payment method selector to be available
+	if ( isBlocks ) {
+		await page
+			.locator( 'label', { hasText: 'Affirm' } )
+			.waitFor( { state: 'visible', timeout: 5000 } );
+		await page.locator( 'label' ).filter( { hasText: 'Affirm' } ).click();
+	} else {
+		await page
+			.getByText( 'Affirm' )
+			.waitFor( { state: 'visible', timeout: 5000 } );
+		await page.getByText( 'Affirm' ).click();
+	}
+	await page.waitForTimeout( 1000 );
+};


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-530

## Changes proposed in this Pull Request:

This adds an e2e test to cover the basic purchase flow with Affirm. Affirm has rate-limiting turned on even for sandbox accounts, and the KYC + payment flow on Affirm's end is quite lengthy. So I've opted to only check if we redirect to Affirm after clicking the "Place Order" button instead of introducing flaky tests that try to automate the entire flow.


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Make sure e2e tests on GH pass.
2. Optionally, run e2es locally with `npm run test:e2e -- affirm`  and make sure they pass.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [N/A] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [N/A] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [N/A] Included this PR in the Release Thread scope (or does not apply)