### PR TITLE
Adding a promotional note for BNPLs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Add - Introduces a new marketing note to promote BNPLs (Buy Now Pay Later) payment methods (Klarna, Afterpay, and Affirm) on WooCommerce admin home page
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status
 * Update - Legacy checkout experience has been deprecated, new checkout experience is now the default for all sites
 * Fix - Fixes an edge case where the express payment method buttons would not be displayed on the checkout if taxes used to be enabled

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
-* Add - Introduces a new marketing note to promote BNPLs (Buy Now Pay Later) payment methods (Klarna, Afterpay, and Affirm) on WooCommerce admin home page
+* Add - Introduces a new marketing note to promote BNPLs (Buy Now Pay Later) payment methods (Klarna and Affirm) on WooCommerce admin home page
 * Fix - Throws a specific exception on an edge case where a saved payment method could not be found when processing an order in the new checkout experience
 * Fix - Checks if the store has other BNPL extensions installed before displaying the promotional banner
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -46,6 +46,9 @@ class WC_Stripe_Inbox_Notes {
 		return trait_exists( 'Automattic\WooCommerce\Admin\Notes\NoteTraits' ) && class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' );
 	}
 
+	/**
+	 * Create UPE notes.
+	 */
 	public static function create_upe_notes() {
 		if ( ! self::are_inbox_notes_supported() ) {
 			return;
@@ -54,8 +57,13 @@ class WC_Stripe_Inbox_Notes {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-upe-availability-note.php';
 		WC_Stripe_UPE_Availability_Note::init();
 
+		$gateway = WC_Stripe::get_instance()->get_main_stripe_gateway();
+
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-upe-stripelink-note.php';
-		WC_Stripe_UPE_StripeLink_Note::init( WC_Stripe::get_instance()->get_main_stripe_gateway() );
+		WC_Stripe_UPE_StripeLink_Note::init( $gateway );
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-bnpl-promotion-note.php';
+		WC_Stripe_BNPL_Promotion_Note::init( $gateway );
 	}
 
 	public static function get_campaign_2020_cutoff() {

--- a/includes/notes/class-wc-stripe-bnpl-promotion-note.php
+++ b/includes/notes/class-wc-stripe-bnpl-promotion-note.php
@@ -95,8 +95,9 @@ class WC_Stripe_BNPL_Promotion_Note {
 
 		$has_other_bnpl_plugins_active = false;
 		$available_payment_gateways    = WC()->payment_gateways->payment_gateways;
+		$other_bnpl_gateway_ids        = [ 'affirm', 'klarna_payments' ];
 		foreach ( $available_payment_gateways as $available_payment_gateway ) {
-			if ( ( 'affirm' === $available_payment_gateway->id || 'klarna_payments' === $available_payment_gateway->id ) && 'yes' === $available_payment_gateway->enabled ) {
+			if ( in_array( $available_payment_gateway->id, $other_bnpl_gateway_ids, true ) && 'yes' === $available_payment_gateway->enabled ) {
 				$has_other_bnpl_plugins_active = true;
 				break;
 			}

--- a/includes/notes/class-wc-stripe-bnpl-promotion-note.php
+++ b/includes/notes/class-wc-stripe-bnpl-promotion-note.php
@@ -95,8 +95,8 @@ class WC_Stripe_BNPL_Promotion_Note {
 
 		$has_other_bnpl_plugins_active = false;
 		$available_payment_gateways    = WC()->payment_gateways->payment_gateways;
-		foreach ( $available_payment_gateways as $gateway ) {
-			if ( ( 'affirm' === $gateway->id || 'klarna_payments' === $gateway->id ) && 'yes' === $gateway->enabled ) {
+		foreach ( $available_payment_gateways as $available_payment_gateway ) {
+			if ( ( 'affirm' === $available_payment_gateway->id || 'klarna_payments' === $available_payment_gateway->id ) && 'yes' === $available_payment_gateway->enabled ) {
 				$has_other_bnpl_plugins_active = true;
 				break;
 			}

--- a/includes/notes/class-wc-stripe-bnpl-promotion-note.php
+++ b/includes/notes/class-wc-stripe-bnpl-promotion-note.php
@@ -86,7 +86,7 @@ class WC_Stripe_BNPL_Promotion_Note {
 			return;
 		}
 
-		$available_upe_payment_methods = $gateway->get_upe_available_payment_methods();
+		$available_upe_payment_methods = $gateway->get_upe_enabled_payment_method_ids();
 		foreach ( WC_Stripe_Payment_Methods::BNPL_PAYMENT_METHODS as $bnpl_payment_method ) {
 			if ( in_array( $bnpl_payment_method, $available_upe_payment_methods, true ) ) {
 				return;

--- a/includes/notes/class-wc-stripe-bnpl-promotion-note.php
+++ b/includes/notes/class-wc-stripe-bnpl-promotion-note.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Display a notice to merchants to promote BNPL (Buy Now Pay Later) payment methods.
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Stripe_BNPL_Promotion_Note
+ */
+class WC_Stripe_BNPL_Promotion_Note {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-stripe-bnpl-promotion-note';
+
+	/**
+	 * Link to enable the UPE in store.
+	 */
+	const LEARN_MORE_LINK = 'https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note_class = self::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Offer more ways to pay with Buy Now, Pay Later', 'woocommerce-gateway-stripe' ) );
+		$message  = __( 'Flexible pay-over-time options can boost revenue by up to 14%.* Affirm and Klarna payments are auto-enabled with Stripe for eligible merchants.', 'woocommerce-gateway-stripe' );
+		$message .= '<br /><br />';
+		$message .= __( '*Source: Stripe 2024', 'woocommerce-gateway-stripe' );
+		$note->set_content( $message );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-gateway-stripe' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Learn more', 'woocommerce-gateway-stripe' ),
+			self::LEARN_MORE_LINK,
+			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
+			true
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Get the class type to be used for the note.
+	 *
+	 * @return string
+	 */
+	private static function get_note_class() {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+			return Note::class;
+		} else {
+			return WC_Admin_Note::class;
+		}
+	}
+
+	/**
+	 * Init BNPL promotion notification
+	 *
+	 * @param WC_Stripe_Payment_Gateway $gateway
+	 *
+	 * @return void
+	 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException
+	 */
+	public static function init( WC_Stripe_Payment_Gateway $gateway ) {
+		/**
+		 * No need to display the admin inbox note when
+		 * - Below version 9.7
+		 * - Store has any BNPLs enabled
+		 * - Other BNPL extensions are active
+		 * - Stripe is not enabled
+		 */
+		if ( ! defined( 'WC_STRIPE_VERSION' ) || version_compare( WC_STRIPE_VERSION, '9.7', '<' ) ) {
+			return;
+		}
+
+		$available_upe_payment_methods = $gateway->get_upe_available_payment_methods();
+		foreach ( WC_Stripe_Payment_Methods::BNPL_PAYMENT_METHODS as $bnpl_payment_method ) {
+			if ( in_array( $bnpl_payment_method, $available_upe_payment_methods, true ) ) {
+				return;
+			}
+		}
+
+		$has_other_bnpl_plugins_active = false;
+		$available_payment_gateways    = WC()->payment_gateways->payment_gateways;
+		foreach ( $available_payment_gateways as $gateway ) {
+			if ( ( 'affirm' === $gateway->id || 'klarna_payments' === $gateway->id ) && 'yes' === $gateway->enabled ) {
+				$has_other_bnpl_plugins_active = true;
+				break;
+			}
+		}
+		if ( $has_other_bnpl_plugins_active ) {
+			return;
+		}
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_enabled  = isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
+		if ( ! $stripe_enabled ) {
+			return;
+		}
+
+		self::possibly_add_note();
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
-* Add - Introduces a new marketing note to promote BNPLs (Buy Now Pay Later) payment methods (Klarna, Afterpay, and Affirm) on WooCommerce admin home page
+* Add - Introduces a new marketing note to promote BNPLs (Buy Now Pay Later) payment methods (Klarna and Affirm) on WooCommerce admin home page
 * Fix - Throws a specific exception on an edge case where a saved payment method could not be found when processing an order in the new checkout experience
 * Fix - Checks if the store has other BNPL extensions installed before displaying the promotional banner
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status.

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Add - Introduces a new marketing note to promote BNPLs (Buy Now Pay Later) payment methods (Klarna, Afterpay, and Affirm) on WooCommerce admin home page
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status.
 * Update - Legacy checkout experience has been deprecated, new checkout experience is now the default for all sites
 * Fix - Fixes an edge case where the express payment method buttons would not be displayed on the checkout if taxes used to be enabled

--- a/tests/phpunit/Notes/WC_Stripe_BNPL_Promotion_Note_Test.php
+++ b/tests/phpunit/Notes/WC_Stripe_BNPL_Promotion_Note_Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests\Notes;
+
+use WC_Stripe_BNPL_Promotion_Note;
+use WP_UnitTestCase;
+
+/**
+ * Class WC_Stripe_BNPL_Promotion_Note_Test
+ *
+ * @package WooCommerce/Stripe/WC_Stripe_BNPL_Promotion_Note
+ *
+ * Class WC_Stripe_BNPL_Promotion_Note tests.
+ */
+class WC_Stripe_BNPL_Promotion_Note_Test extends WP_UnitTestCase {
+	public function test_get_note() {
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-bnpl-promotion-note.php';
+		$note = WC_Stripe_BNPL_Promotion_Note::get_note();
+
+		$this->assertSame( 'Offer more ways to pay with Buy Now, Pay Later', $note->get_title() );
+		$this->assertSame( 'Flexible pay-over-time options can boost revenue by up to 14%.* Affirm and Klarna payments are auto-enabled with Stripe for eligible merchants.<br /><br />*Source: Stripe 2024', $note->get_content() );
+		$this->assertSame( 'marketing', $note->get_type() );
+		$this->assertSame( 'wc-stripe-bnpl-promotion-note', $note->get_name() );
+		$this->assertSame( 'woocommerce-gateway-stripe', $note->get_source() );
+
+		list( $enable_upe_action ) = $note->get_actions();
+		$this->assertSame( 'wc-stripe-bnpl-promotion-note', $enable_upe_action->name );
+		$this->assertSame( 'Learn more', $enable_upe_action->label );
+		$this->assertSame( 'https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/', $enable_upe_action->query );
+	}
+}

--- a/tests/phpunit/Notes/WC_Stripe_UPE_Availability_Note_Test.php
+++ b/tests/phpunit/Notes/WC_Stripe_UPE_Availability_Note_Test.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace WooCommerce\Stripe\Tests;
+namespace WooCommerce\Stripe\Tests\Notes;
 
 use WC_Stripe_UPE_Availability_Note;
 use WP_UnitTestCase;


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-548
Figma 0fiyiUe18lGU6kGyQNmXxE?node-id=871-22237&t=qYzLLyDitMTNKLt0-0-fi

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR introduces a new note to be displayed on the WooCommerce admin home, promoting BNPLs (Klarna and Affirm). The note is added when the Stripe extension is enabled, version is above 9.7, and BNPLs are not enabled (within the extension itself or by using the other official extensions).

The logic to check for other extensions was suggested by @diegocurbelo [here](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4438#discussion_r2169622041). I will make the block shareable on the last PR to land.

<img width="712" alt="Screenshot 2025-06-26 at 17 55 57" src="https://github.com/user-attachments/assets/37b41172-d591-4579-bb47-522ff199f128" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout to this branch on your test environment (`add/bnpl-promotional-note`)
- Connect your Stripe account
- Hardcode the minimum required extension version to `9.5` in `/includes/notes/class-wc-stripe-bnpl-promotion-note.php#85`
- Make sure BNPLs are not enabled and the other official extensions are not installed
- Confirm the note is added and is correctly displayed on your inbox (`wp-admin/admin.php?page=wc-admin`)
- Check if it matches the Figma design contents
- Confirm that by clicking "Learn more" you are sent to `https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/`
- Confirm that by clicking "Dismiss" the note is gone
- You can make additional tests for the conditions by deleting the note in the `wp_wc_admin_notes ` database table and enabling BNPLs and/or the other official extensions (Affirm, Klarna) to confirm the notes are not added

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
