### PR TITLE
Fix Optimized Checkout inconsistencies

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests.
 * Fix - Throws a specific exception on an edge case where a saved payment method could not be found when processing an order in the new checkout experience
 * Fix - Checks if the store has other BNPL extensions installed before displaying the promotional banner
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
-* Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests.
+* Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests
 * Fix - Throws a specific exception on an edge case where a saved payment method could not be found when processing an order in the new checkout experience
 * Fix - Checks if the store has other BNPL extensions installed before displaying the promotional banner
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -367,9 +367,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			'cards'                                => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/cards.svg" class="stripe-cards-icon stripe-icon" alt="' . __( 'Credit / Debit Card', 'woocommerce-gateway-stripe' ) . '" />',
 			WC_Stripe_Payment_Methods::CASHAPP_PAY => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/cashapp.svg" class="stripe-cashapp-icon stripe-icon" alt="Cash App Pay" />',
 		];
-		$settings   = WC_Stripe_Helper::get_stripe_settings();
-		$oc_setting = $settings['optimized_checkout_element'] ?? null;
-		if ( 'yes' === $oc_setting ) {
+		if ( 'yes' === $this->get_option( 'optimized_checkout_element' ) ) {
 			$icon_list['cards'] = '';
 		}
 		return apply_filters( 'wc_stripe_payment_icons', $icon_list );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -791,7 +791,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 			<?php
 			if ( $this->testmode ) :
-				if ( $this->spe_enabled ) :
+				if ( $this->oc_enabled ) :
 					echo wp_kses_post( self::get_testing_instructions_for_optimized_checkout() );
 				else :
 					?>
@@ -1972,7 +1972,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @deprecated 9.5.0 Use is_oc_enabled() instead.
 	 */
 	public function is_spe_enabled() {
-		return $this->spe_enabled;
+		return $this->oc_enabled;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -157,8 +157,8 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		$this->testmode                 = WC_Stripe_Mode::is_test();
 		$this->supports                 = [ 'products', 'refunds' ];
 		$this->supports_deferred_intent = true;
-		$this->oc_enabled               = WC_Stripe_Feature_Flags::is_oc_available() && 'yes' === $this->get_option( 'optimized_checkout_element' );
-		$this->oc_title                 = $this->get_option( 'optimized_checkout_element_title', __( 'Stripe', 'woocommerce-gateway-stripe' ) );
+		$this->oc_enabled               = WC_Stripe_Feature_Flags::is_oc_available() && 'yes' === get_option( 'optimized_checkout_element' );
+		$this->oc_title                 = get_option( 'optimized_checkout_element_title', __( 'Stripe', 'woocommerce-gateway-stripe' ) );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -157,8 +157,8 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		$this->testmode                 = WC_Stripe_Mode::is_test();
 		$this->supports                 = [ 'products', 'refunds' ];
 		$this->supports_deferred_intent = true;
-		$this->oc_enabled               = WC_Stripe_Feature_Flags::is_oc_available() && 'yes' === get_option( 'optimized_checkout_element' );
-		$this->oc_title                 = get_option( 'optimized_checkout_element_title', __( 'Stripe', 'woocommerce-gateway-stripe' ) );
+		$this->oc_enabled               = WC_Stripe_Feature_Flags::is_oc_available() && 'yes' === $this->get_option( 'optimized_checkout_element' );
+		$this->oc_title                 = $this->get_option( 'optimized_checkout_element_title', __( 'Stripe', 'woocommerce-gateway-stripe' ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -112,7 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
-* Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests.
+* Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests
 * Fix - Throws a specific exception on an edge case where a saved payment method could not be found when processing an order in the new checkout experience
 * Fix - Checks if the store has other BNPL extensions installed before displaying the promotional banner
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status.

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests.
 * Fix - Throws a specific exception on an edge case where a saved payment method could not be found when processing an order in the new checkout experience
 * Fix - Checks if the store has other BNPL extensions installed before displaying the promotional banner
 * Fix - Correctly notifies customers and merchants of a failed refund and reverts the refunded status.

--- a/tests/phpunit/Helpers/OC_Test_Helper.php
+++ b/tests/phpunit/Helpers/OC_Test_Helper.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests\Helpers;
+
+use WC_Stripe_Feature_Flags;
+use WC_Stripe_Helper;
+
+/**
+ * Provides methods useful when testing logic related to the Optimized Checkout.
+ */
+class OC_Test_Helper {
+	/**
+	 * Enables the Optimized Checkout feature flag and sets the corresponding setting.
+	 *
+	 * @return void
+	 */
+	public static function enable_oc() {
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+	}
+
+	/**
+	 * Disables the Optimized Checkout feature flag and sets the corresponding setting.
+	 *
+	 * @return void
+	 */
+	public static function disable_oc() {
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'no' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+	}
+}

--- a/tests/phpunit/Helpers/OC_Test_Helper.php
+++ b/tests/phpunit/Helpers/OC_Test_Helper.php
@@ -6,7 +6,7 @@ use WC_Stripe_Feature_Flags;
 use WC_Stripe_Helper;
 
 /**
- * Provides methods useful when testing logic related to the Optimized Checkout.
+ * Provides useful methods to test logic related to the Optimized Checkout.
  */
 class OC_Test_Helper {
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -4,6 +4,7 @@ namespace WooCommerce\Stripe\Tests\PaymentMethods;
 
 use Automattic\WooCommerce\Enums\OrderStatus;
 use Exception;
+use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 use WC_Data_Exception;
 use WC_Order;
@@ -2899,21 +2900,15 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 * @dataProvider provide_test_is_oc_enabled
 	 */
 	public function test_is_oc_enabled( $option_enabled, $expected ) {
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' ); // Not testing the feature flag.
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = $option_enabled ? 'yes' : 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		if ( $option_enabled ) {
+			OC_Test_Helper::enable_oc();
+		}
 
 		$gateway = new WC_Stripe_UPE_Payment_Gateway();
 		$actual  = $gateway->is_oc_enabled();
 
 		// Clean up
-		delete_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		OC_Test_Helper::disable_oc();
 
 		$this->assertSame( $expected, $actual );
 	}

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -2892,17 +2892,17 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	/**
 	 * Test that a failed payment intent is not reused and a new one is created instead.
 	 *
-	 * @param string $option_value The value of the 'optimized_checkout_element' option.
+	 * @param bool $option_enabled Whether the optimized checkout option is enabled.
 	 * @param bool $expected The expected result of the `is_oc_enabled` method.
 	 * @return void
 	 *
 	 * @dataProvider provide_test_is_oc_enabled
 	 */
-	public function test_is_oc_enabled( $option_value, $expected ) {
+	public function test_is_oc_enabled( $option_enabled, $expected ) {
 		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' ); // Not testing the feature flag.
 
 		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = $option_value;
+		$stripe_settings['optimized_checkout_element'] = $option_enabled ? 'yes' : 'no';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$gateway = new WC_Stripe_UPE_Payment_Gateway();
@@ -2926,11 +2926,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	public function provide_test_is_oc_enabled() {
 		return [
 			'Disabled' => [
-				'option value' => 'no',
+				'option value' => false,
 				'expected'     => false,
 			],
 			'Enabled'  => [
-				'option value' => 'yes',
+				'option value' => true,
 				'expected'     => true,
 			],
 		];

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -2893,14 +2893,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	/**
 	 * Test that a failed payment intent is not reused and a new one is created instead.
 	 *
-	 * @param bool $option_enabled Whether the optimized checkout option is enabled.
+	 * @param bool $setting_enabled Whether the optimized checkout setting is enabled.
 	 * @param bool $expected The expected result of the `is_oc_enabled` method.
 	 * @return void
 	 *
 	 * @dataProvider provide_test_is_oc_enabled
 	 */
-	public function test_is_oc_enabled( $option_enabled, $expected ) {
-		if ( $option_enabled ) {
+	public function test_is_oc_enabled( $setting_enabled, $expected ) {
+		if ( $setting_enabled ) {
 			OC_Test_Helper::enable_oc();
 		}
 
@@ -2921,11 +2921,11 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	public function provide_test_is_oc_enabled() {
 		return [
 			'Disabled' => [
-				'option value' => false,
-				'expected'     => false,
+				'setting value' => false,
+				'expected'      => false,
 			],
 			'Enabled'  => [
-				'option value' => true,
+				'setting value' => true,
 				'expected'     => true,
 			],
 		];

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -2892,24 +2892,48 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	/**
 	 * Test that a failed payment intent is not reused and a new one is created instead.
 	 *
+	 * @param string $option_value The value of the 'optimized_checkout_element' option.
+	 * @param bool $expected The expected result of the `is_oc_enabled` method.
 	 * @return void
+	 *
+	 * @dataProvider provide_test_is_oc_enabled
 	 */
-	public function test_is_oc_enabled() {
-		// Disabled
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'no' );
-
-		$gateway = new WC_Stripe_UPE_Payment_Gateway();
-		$this->assertFalse( $gateway->is_oc_enabled() );
-
-		// Enabled
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
+	public function test_is_oc_enabled( $option_value, $expected ) {
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' ); // Not testing the feature flag.
 
 		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = 'yes';
+		$stripe_settings['optimized_checkout_element'] = $option_value;
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$gateway = new WC_Stripe_UPE_Payment_Gateway();
-		$this->assertTrue( $gateway->is_oc_enabled() );
+		$actual  = $gateway->is_oc_enabled();
+
+		// Clean up
+		delete_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Data provider for `test_is_oc_enabled`.
+	 *
+	 * @return array[]
+	 */
+	public function provide_test_is_oc_enabled() {
+		return [
+			'Disabled' => [
+				'option value' => 'no',
+				'expected'     => false,
+			],
+			'Enabled'  => [
+				'option value' => 'yes',
+				'expected'     => true,
+			],
+		];
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
@@ -112,14 +112,14 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	/**
 	 * Test for `get_testing_instructions`.
 	 *
-	 * @param bool   $optimized_checkout_option Optimized Checkout option.
+	 * @param bool   $optimized_checkout_setting Optimized Checkout setting.
 	 * @param string $expected Expected instructions.
 	 * @return void
 	 *
 	 * @dataProvider provide_test_get_testing_instructions
 	 */
-	public function test_get_testing_instructions( $optimized_checkout_option, $expected ) {
-		if ( $optimized_checkout_option ) {
+	public function test_get_testing_instructions( $optimized_checkout_setting, $expected ) {
+		if ( $optimized_checkout_setting ) {
 			OC_Test_Helper::enable_oc();
 		}
 
@@ -140,12 +140,12 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	public function provide_test_get_testing_instructions() {
 		return [
 			'Optimized Checkout enabled'  => [
-				'optimized checkout option' => true,
-				'expected'                  => '<div id="wc-stripe-payment-method-instructions-card" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.</div><div id="wc-stripe-payment-method-instructions-blik" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use any 6-digit number to authorize payment.</div><div id="wc-stripe-payment-method-instructions-sepa_debit" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test account number AT611904300234573201. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">here</a>.</div>',
+				'optimized checkout setting' => true,
+				'expected'                   => '<div id="wc-stripe-payment-method-instructions-card" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.</div><div id="wc-stripe-payment-method-instructions-blik" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use any 6-digit number to authorize payment.</div><div id="wc-stripe-payment-method-instructions-sepa_debit" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test account number AT611904300234573201. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">here</a>.</div>',
 			],
 			'Optimized Checkout disabled' => [
-				'optimized checkout option' => false,
-				'expected'                  => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.',
+				'optimized checkout setting' => false,
+				'expected'                   => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.',
 			],
 		];
 	}

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
@@ -26,10 +26,7 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_title( $settings, $payment_details, $optimized_checkout_flag, $query_params, $expected ) {
 		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $optimized_checkout_flag ? 'yes' : 'no' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_flag ? 'yes' : 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		update_option( 'optimized_checkout_element', $optimized_checkout_flag ? 'yes' : 'no' );
 
 		if ( is_array( $payment_details ) ) {
 			$payment_details = json_decode( wp_json_encode( $payment_details ) );
@@ -109,22 +106,23 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	/**
 	 * Test for `get_testing_instructions`.
 	 *
-	 * @param bool   $optimized_checkout_flag Optimized Checkout flag.
+	 * @param bool   $optimized_checkout_option Optimized Checkout option.
 	 * @param string $expected Expected instructions.
 	 * @return void
 	 *
 	 * @dataProvider provide_test_get_testing_instructions
 	 */
-	public function test_get_testing_instructions( $optimized_checkout_flag, $expected ) {
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $optimized_checkout_flag ? 'yes' : 'no' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_flag ? 'yes' : 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+	public function test_get_testing_instructions( $optimized_checkout_option, $expected ) {
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' ); // Ensure the feature flag is enabled.
+		update_option( 'optimized_checkout_element', $optimized_checkout_option ? 'yes' : 'no' );
 
 		$payment_method = new WC_Stripe_UPE_Payment_Method_CC();
 
 		$this->assertEquals( $expected, $payment_method->get_testing_instructions() );
+
+		// Clean up
+		delete_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME );
+		delete_option( 'optimized_checkout_element' );
 	}
 
 	/**
@@ -135,12 +133,12 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	public function provide_test_get_testing_instructions() {
 		return [
 			'Optimized Checkout enabled'  => [
-				'optimized checkout flag' => true,
-				'expected'                => '<div id="wc-stripe-payment-method-instructions-card" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.</div><div id="wc-stripe-payment-method-instructions-blik" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use any 6-digit number to authorize payment.</div><div id="wc-stripe-payment-method-instructions-sepa_debit" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test account number AT611904300234573201. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">here</a>.</div>',
+				'optimized checkout option' => true,
+				'expected'                  => '<div id="wc-stripe-payment-method-instructions-card" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.</div><div id="wc-stripe-payment-method-instructions-blik" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use any 6-digit number to authorize payment.</div><div id="wc-stripe-payment-method-instructions-sepa_debit" class="wc-stripe-payment-method-instruction" style="display: none;"><strong>Test mode:</strong> use the test account number AT611904300234573201. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing?payment-method=sepa-direct-debit#non-card-payments" target="_blank">here</a>.</div>',
 			],
 			'Optimized Checkout disabled' => [
-				'optimized checkout flag' => false,
-				'expected'                => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.',
+				'optimized checkout option' => false,
+				'expected'                  => '<strong>Test mode:</strong> use the test VISA card 4242424242424242 with any expiry date and CVC. Other payment methods may redirect to a Stripe test page to authorize payment. More test card numbers are listed <a href="https://docs.stripe.com/testing" target="_blank">here</a>.',
 			],
 		];
 	}

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
@@ -17,16 +17,19 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	 *
 	 * @param array      $settings Settings.
 	 * @param array|bool $payment_details Payment details.
-	 * @param bool       $optimized_checkout_flag Optimized Checkout flag.
+	 * @param bool       $optimized_checkout_setting Optimized Checkout flag.
 	 * @param array      $query_params Query parameters.
 	 * @param string     $expected Expected title.
 	 * @return void
 	 *
 	 * @dataProvider provide_test_get_title
 	 */
-	public function test_get_title( $settings, $payment_details, $optimized_checkout_flag, $query_params, $expected ) {
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $optimized_checkout_flag ? 'yes' : 'no' );
-		update_option( 'optimized_checkout_element', $optimized_checkout_flag ? 'yes' : 'no' );
+	public function test_get_title( $settings, $payment_details, $optimized_checkout_setting, $query_params, $expected ) {
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $optimized_checkout_setting ? 'yes' : 'no' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_setting ? 'yes' : 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		if ( is_array( $payment_details ) ) {
 			$payment_details = json_decode( wp_json_encode( $payment_details ) );

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
@@ -6,6 +6,7 @@ use WC_Stripe_Feature_Flags;
 use WC_Stripe_Helper;
 use WC_Stripe_Payment_Methods;
 use WC_Stripe_UPE_Payment_Method_CC;
+use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WP_UnitTestCase;
 
 /**
@@ -25,11 +26,9 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_get_title
 	 */
 	public function test_get_title( $settings, $payment_details, $optimized_checkout_setting, $query_params, $expected ) {
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $optimized_checkout_setting ? 'yes' : 'no' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_setting ? 'yes' : 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		if ( $optimized_checkout_setting ) {
+			OC_Test_Helper::enable_oc();
+		}
 
 		if ( is_array( $payment_details ) ) {
 			$payment_details = json_decode( wp_json_encode( $payment_details ) );
@@ -42,8 +41,12 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 		}
 
 		$payment_method = new WC_Stripe_UPE_Payment_Method_CC();
+		$actual         = $payment_method->get_title( $payment_details );
 
-		$this->assertEquals( $expected, $payment_method->get_title( $payment_details ) );
+		// Clean up.
+		OC_Test_Helper::disable_oc();
+
+		$this->assertEquals( $expected, $actual );
 	}
 
 	/**
@@ -116,22 +119,17 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_get_testing_instructions
 	 */
 	public function test_get_testing_instructions( $optimized_checkout_option, $expected ) {
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' ); // Ensure the feature flag is enabled.
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_option ? 'yes' : 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		if ( $optimized_checkout_option ) {
+			OC_Test_Helper::enable_oc();
+		}
 
 		$payment_method = new WC_Stripe_UPE_Payment_Method_CC();
-
-		$this->assertEquals( $expected, $payment_method->get_testing_instructions() );
+		$actual         = $payment_method->get_testing_instructions();
 
 		// Clean up
-		delete_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME );
+		OC_Test_Helper::disable_oc();
 
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		$this->assertEquals( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_CC_Test.php
@@ -117,7 +117,10 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_testing_instructions( $optimized_checkout_option, $expected ) {
 		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' ); // Ensure the feature flag is enabled.
-		update_option( 'optimized_checkout_element', $optimized_checkout_option ? 'yes' : 'no' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_option ? 'yes' : 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$payment_method = new WC_Stripe_UPE_Payment_Method_CC();
 
@@ -125,7 +128,10 @@ class WC_Stripe_UPE_Payment_Method_CC_Test extends WP_UnitTestCase {
 
 		// Clean up
 		delete_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME );
-		delete_option( 'optimized_checkout_element' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
@@ -154,9 +154,9 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	 * Base template for Stripe AU BECS Debit Pay payment method.
 	 */
 	const MOCK_BECS_DEBIT_PAYMENT_METHOD_TEMPLATE = [
-		'id'                                        => 'pm_mock_payment_method_id',
-		'type'                                      => WC_Stripe_Payment_Methods::BECS_DEBIT,
-		WC_Stripe_Payment_Methods::BECS_DEBIT        => [
+		'id'                                  => 'pm_mock_payment_method_id',
+		'type'                                => WC_Stripe_Payment_Methods::BECS_DEBIT,
+		WC_Stripe_Payment_Methods::BECS_DEBIT => [
 			'last4'       => '4321',
 			'fingerprint' => 'F1ng3rpr1n7',
 		],
@@ -879,7 +879,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 			)
 			->getMock();
 
-		$actual = $mocked_payment_method->get_title();
+		$actual = $mocked_payment_method->get_description();
 
 		// Clean up.
 		OC_Test_Helper::disable_oc();

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
@@ -27,6 +27,7 @@ use WC_Stripe_UPE_Payment_Method_Cash_App_Pay;
 use WC_Stripe_UPE_Payment_Method_CC;
 use WC_Stripe_UPE_Payment_Method_Link;
 use WC_Stripe_UPE_Payment_Method_Wechat_Pay;
+use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\WC_Mock_Stripe_API_Unit_Test_Case;
 
 /**
@@ -857,11 +858,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 		}
 
 		// Test custom description when OC is enabled. Should be always empty.
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = 'yes';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		OC_Test_Helper::enable_oc();
 
 		$payment_method_id                       = WC_Stripe_Payment_Methods::CARD;
 		$custom_description                      = 'Custom description for ' . $payment_method_id;
@@ -882,16 +879,13 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 			)
 			->getMock();
 
-		$this->assertEmpty( $mocked_payment_method->get_description() );
+		$actual = $mocked_payment_method->get_title();
 
 		// Clean up.
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = 'yes';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
+		OC_Test_Helper::disable_oc();
 		update_option( 'woocommerce_stripe_' . $payment_method_id . '_settings', $original_payment_settings );
+
+		$this->assertEmpty( $actual );
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
@@ -856,9 +856,12 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 			update_option( 'woocommerce_stripe_' . $payment_method_id . '_settings', $original_payment_settings );
 		}
 
-		// Test custom description when SPE is enabled. Should be always empty.
+		// Test custom description when OC is enabled. Should be always empty.
 		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
-		update_option( 'optimized_checkout_element', 'yes' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$payment_method_id                       = WC_Stripe_Payment_Methods::CARD;
 		$custom_description                      = 'Custom description for ' . $payment_method_id;
@@ -880,6 +883,15 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 			->getMock();
 
 		$this->assertEmpty( $mocked_payment_method->get_description() );
+
+		// Clean up.
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		update_option( 'woocommerce_stripe_' . $payment_method_id . '_settings', $original_payment_settings );
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
@@ -858,10 +858,7 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 
 		// Test custom description when SPE is enabled. Should be always empty.
 		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = 'yes';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		update_option( 'optimized_checkout_element', 'yes' );
 
 		$payment_method_id                       = WC_Stripe_Payment_Methods::CARD;
 		$custom_description                      = 'Custom description for ' . $payment_method_id;

--- a/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
+++ b/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
@@ -8,7 +8,6 @@ use WC_Gateway_Stripe;
 use WC_Gateway_Stripe_Giropay;
 use WC_Stripe_Customer;
 use WC_Stripe_Exception;
-use WC_Stripe_Feature_Flags;
 use WC_Stripe_Helper;
 use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\OCTest_Helper;

--- a/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
+++ b/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
@@ -838,7 +838,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_payment_icons
 	 */
 	public function test_payment_icons( $optimized_checkout_enabled, $filter, $expected ) {
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, $optimized_checkout_enabled ? 'yes' : 'no' );
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
 
 		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
 		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_enabled ? 'yes' : 'no';
@@ -846,11 +846,21 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 
 		if ( $filter ) {
 			add_filter( 'wc_stripe_payment_icons', $filter );
-		} else {
-			remove_filter( 'wc_stripe_payment_icons', [] );
 		}
 
-		$this->assertSame( $expected, $this->gateway->payment_icons() );
+		$gateway = new WC_Gateway_Stripe();
+		$this->assertSame( $expected, $gateway->payment_icons() );
+
+		// Clean up
+		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'no' );
+
+		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['optimized_checkout_element'] = 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		if ( $filter ) {
+			remove_filter( 'wc_stripe_payment_icons', $filter );
+		}
 	}
 
 	/**

--- a/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
+++ b/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
@@ -10,6 +10,8 @@ use WC_Stripe_Customer;
 use WC_Stripe_Exception;
 use WC_Stripe_Feature_Flags;
 use WC_Stripe_Helper;
+use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
+use WooCommerce\Stripe\Tests\Helpers\OCTest_Helper;
 use WooCommerce\Stripe\Tests\Helpers\WC_Helper_Order;
 use WP_Error;
 use WP_UnitTestCase;
@@ -838,29 +840,23 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_payment_icons
 	 */
 	public function test_payment_icons( $optimized_checkout_enabled, $filter, $expected ) {
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'yes' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = $optimized_checkout_enabled ? 'yes' : 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		if ( $optimized_checkout_enabled ) {
+			OC_Test_Helper::enable_oc();
+		}
 
 		if ( $filter ) {
 			add_filter( 'wc_stripe_payment_icons', $filter );
 		}
 
 		$gateway = new WC_Gateway_Stripe();
-		$this->assertSame( $expected, $gateway->payment_icons() );
-
+		$actual  = $gateway->payment_icons();
 		// Clean up
-		update_option( WC_Stripe_Feature_Flags::OC_FEATURE_FLAG_NAME, 'no' );
-
-		$stripe_settings                               = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['optimized_checkout_element'] = 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
+		OC_Test_Helper::disable_oc();
 		if ( $filter ) {
 			remove_filter( 'wc_stripe_payment_icons', $filter );
 		}
+
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**
@@ -874,7 +870,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		};
 
 		return [
-			'default'                => [
+			'default'                    => [
 				'optimized checkout enabled' => false,
 				'filter'                     => null,
 				'expected'                   => [
@@ -902,8 +898,8 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 			],
 			'Optimized Checkout enabled' => [
 				'optimized checkout enabled' => true,
-				'filter'                 => null,
-				'expected'               => [
+				'filter'                     => null,
+				'expected'                   => [
 					'us_bank_account' => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/bank-debit.svg" class="stripe-ach-icon stripe-icon" alt="ACH" />',
 					'acss_debit'      => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/bank-debit.svg" class="stripe-ach-icon stripe-icon" alt="Pre-Authorized Debit" />',
 					'alipay'          => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/alipay.svg" class="stripe-alipay-icon stripe-icon" alt="Alipay" />',
@@ -926,10 +922,10 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 					'cashapp'         => '<img src="' . WC_STRIPE_PLUGIN_URL . '/assets/images/cashapp.svg" class="stripe-cashapp-icon stripe-icon" alt="Cash App Pay" />',
 				],
 			],
-			'filter applied'         => [
+			'filter applied'             => [
 				'optimized checkout enabled' => false,
-				'filter'                 => $mocked_filter,
-				'expected'               => [],
+				'filter'                     => $mocked_filter,
+				'expected'                   => [],
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes some inconsistencies related to the Optimized Checkout I found when developing https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4444. Basically:
- Added cleaning up logic to all tests
- Added a new unit test helper specific to OC (to enable/disable it)
- Some minor PHPCS fixes
- Fixed some references in the shortcode checkout (`oc_enabled` property instead of `spe_enabled)

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review should be enough. Check if the tests are still passing. You can also test the fix for the instructions in the shortcode checkout:
- Checkout to this branch on your test environment (`fix/oc-source-of-truth`)
- Connect your Stripe account
- Enable the `_wcstripe_feature_oc` feature flag (you can now use the `wc_stripe_is_optimized_checkout_available` filter)
- Enable the Optimized Checkout feature in `wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings`
- As a shopper, add a product to your cart
- Go to the shortcode checkout page
- Confirm the testing instructions are correctly displayed when selecting cards (or SEPA if you enabled it)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
