### PR TITLE
Add optional chaining as safety check in 'showError' 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -46,6 +46,7 @@
 * Update - Express Checkout: introduce new WP actions for supporting custom checkout fields for classic, shortcode-based checkout
 * Fix - Fix payment processing for $0 subscription with recurring coupon
 * Dev - Add e2e tests to cover Affirm purchase flow
+* Fix - Add safety check when checking error object
 
 = 9.5.3 - 2025-06-23 =
 * Fix - Reimplement mapping of Express Checkout state values to align with WooCommerce's expected state formats

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -69,12 +69,13 @@ jQuery( function ( $ ) {
 			! ( errorMessage instanceof String )
 		) {
 			if (
-				errorMessage.code &&
-				getStripeServerData()[ errorMessage.code ]
+				errorMessage?.code &&
+				getStripeServerData()[ errorMessage?.code ]
 			) {
-				errorMessage = getStripeServerData()[ errorMessage.code ];
+				errorMessage = getStripeServerData()[ errorMessage?.code ];
 			} else {
-				errorMessage = errorMessage.message;
+				errorMessage =
+					errorMessage?.message || 'An unknown error occurred.';
 			}
 		}
 

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -482,10 +482,14 @@ export const showErrorCheckout = ( errorMessage ) => {
 		typeof errorMessage !== 'string' &&
 		! ( errorMessage instanceof String )
 	) {
-		if ( errorMessage.code && getStripeServerData()[ errorMessage.code ] ) {
-			errorMessage = getStripeServerData()[ errorMessage.code ];
+		if (
+			errorMessage?.code &&
+			getStripeServerData()[ errorMessage?.code ]
+		) {
+			errorMessage = getStripeServerData()[ errorMessage?.code ];
 		} else {
-			errorMessage = errorMessage.message;
+			errorMessage =
+				errorMessage?.message || 'An unknown error occurred.';
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -159,5 +159,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fixes page crash when Klarna payment method is not supported in the merchant's country by returning an empty array instead of throwing an error
 * Fix - Fix payment processing for $0 subscription with recurring coupon
 * Dev - Add e2e tests to cover Affirm purchase flow
+* Fix - Add safety check when checking error object
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes part of STRIPE-559
Fixes part of #4440 

## Changes proposed in this Pull Request:
The report mentioned that shoppers are not redirected to the `thank you` page on checkout and the following console error is observed `TypeError: Cannot read properties of undefined (reading 'code')`. 

This PR just adds a safety check around that part of the code. The main underlying issue is being fixed in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4432

## Testing instructions
- Code review.
