### PR TITLE
Show notification to return to WC onboarding flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -57,6 +57,7 @@
 * Fix - Correctly handle countries without states when using the express payment methods
 * Update - Include extension data from block checkout when submitting an express checkout order
 * Fix - Add order locking when processing payment redirects, to mitigate cases of double status updates
+* Add - A notice to take user back to WC onboarding flow after connecting the Stripe account
 
 = 9.5.3 - 2025-06-23 =
 * Fix - Reimplement mapping of Express Checkout state values to align with WooCommerce's expected state formats

--- a/client/settings/index.js
+++ b/client/settings/index.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ConnectStripeAccount from './connect-stripe-account';
+import StripeAccountConnectedNotice from './stripe-account-connected-notice';
 import SettingsManager from './settings-manager';
 import PaymentGatewayManager from './payment-gateway-manager';
 import UpeToggleContextProvider from './upe-toggle/provider';
@@ -27,6 +28,7 @@ if ( settingsContainer ) {
 				wc_stripe_settings_params.is_upe_checkout_enabled === '1'
 			}
 		>
+			<StripeAccountConnectedNotice />
 			<SettingsManager />
 		</UpeToggleContextProvider>,
 		settingsContainer

--- a/client/settings/stripe-account-connected-notice/__tests__/index.test.js
+++ b/client/settings/stripe-account-connected-notice/__tests__/index.test.js
@@ -1,0 +1,114 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+const mockGetStorageWithExpiration = jest.fn();
+const mockSetStorageWithExpiration = jest.fn();
+const mockGetQuery = jest.fn();
+const mockCreateSuccessNotice = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: () => ( {
+		createSuccessNotice: mockCreateSuccessNotice,
+	} ),
+} ) );
+
+jest.mock( '@woocommerce/navigation', () => ( {
+	getQuery: ( ...args ) => mockGetQuery( ...args ),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: ( path ) => `/wp-admin/${ path }`,
+} ) );
+
+jest.mock( 'wcstripe/stripe-utils/utils', () => ( {
+	getStorageWithExpiration: ( ...args ) =>
+		mockGetStorageWithExpiration( ...args ),
+	setStorageWithExpiration: ( ...args ) =>
+		mockSetStorageWithExpiration( ...args ),
+} ) );
+
+const LOCAL_STORAGE_KEY = 'wc_stripe_is_onboarding_through_wc_setup';
+
+const flushPromises = () =>
+	new Promise( ( resolve ) => setImmediate( resolve ) );
+
+describe( 'StripeAccountConnectedNotice', () => {
+	const originalLocation = window.location;
+	const originalLocalStorage = window.localStorage;
+	const mockRemoveItem = jest.fn();
+
+	beforeAll( () => {
+		// Replace global objects once for all specs; restore in afterAll.
+		Object.defineProperty( window, 'localStorage', {
+			value: { removeItem: mockRemoveItem },
+			writable: true,
+		} );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		// Default values for every test.
+		mockGetQuery.mockReturnValue( {} );
+		mockGetStorageWithExpiration.mockReturnValue( null );
+
+		// Ensure we have a predictable window.location for query parsing.
+		delete window.location;
+		window.location = { search: '' };
+
+		global.wc_stripe_settings_params = {
+			is_payments_onboarding_task_completed: '0',
+		};
+	} );
+
+	afterAll( () => {
+		window.location = originalLocation;
+		window.localStorage = originalLocalStorage;
+	} );
+
+	const renderNotice = async () => {
+		const StripeAccountConnectedNotice = ( await import( '..' ) ).default;
+		render( <StripeAccountConnectedNotice /> );
+		await flushPromises();
+	};
+
+	it( 'shows success notice when Stripe is connected and user is onboarding via WC', async () => {
+		mockGetQuery.mockReturnValue( { wc_stripe_connected: 'true' } );
+		mockGetStorageWithExpiration.mockReturnValue( 'true' );
+
+		await renderNotice();
+
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledWith(
+			'Stripe Account Connected',
+			{
+				id: 'WOOCOMMERCE_STRIPE_ACCOUNT_CONNECTED_NOTICE',
+				actions: [
+					{
+						url: '/wp-admin/admin.php?page=wc-admin',
+						label: 'Continue setting up your store',
+					},
+				],
+			}
+		);
+
+		expect( mockRemoveItem ).toHaveBeenCalledWith( LOCAL_STORAGE_KEY );
+	} );
+
+	it( 'does not show notice when Stripe is not connected', async () => {
+		mockGetStorageWithExpiration.mockReturnValue( 'true' );
+
+		await renderNotice();
+
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+		expect( mockRemoveItem ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not show notice when the user is not onboarding via WC', async () => {
+		mockGetQuery.mockReturnValue( { wc_stripe_connected: 'true' } );
+
+		await renderNotice();
+
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+		expect( mockRemoveItem ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/settings/stripe-account-connected-notice/index.js
+++ b/client/settings/stripe-account-connected-notice/index.js
@@ -1,0 +1,65 @@
+import { __ } from '@wordpress/i18n';
+import { dispatch } from '@wordpress/data';
+import { getAdminLink } from '@woocommerce/settings';
+import { getQuery } from '@woocommerce/navigation';
+import {
+	getStorageWithExpiration,
+	setStorageWithExpiration,
+} from 'wcstripe/stripe-utils/utils';
+
+const LOCAL_STORAGE_KEY = 'wc_stripe_is_onboarding_through_wc_setup';
+const query = new URLSearchParams( window.location.search );
+const from = query.get( 'from' );
+
+const newAccountContainer = document.getElementById(
+	'wc-stripe-new-account-container'
+);
+
+// If the new merchant is onboarding through WC Setup wizard and coming to Stripe Settings page
+// from the WC payments settings page, set a flag in local storage
+// to take them back to the onboarding flow after connecting their account.
+// This flag is needed because, when the merchant return back from Stripe, we lose the `from` query param.
+const isPaymentOnboardingTaskComplete =
+	window.wc_stripe_settings_params?.is_payments_onboarding_task_completed ===
+	'1';
+if (
+	from === 'WCADMIN_PAYMENT_SETTINGS' &&
+	newAccountContainer &&
+	! isPaymentOnboardingTaskComplete
+) {
+	setStorageWithExpiration( LOCAL_STORAGE_KEY, 'true', 60000 );
+}
+
+const shouldShowNotice = () => {
+	const { wc_stripe_connected: stripeAccountConnected } = getQuery();
+	const isOnboardingThroughWCSetup = getStorageWithExpiration(
+		LOCAL_STORAGE_KEY
+	);
+
+	return stripeAccountConnected && isOnboardingThroughWCSetup;
+};
+
+const StripeAccountConnectedNotice = () => {
+	if ( shouldShowNotice() ) {
+		localStorage.removeItem( LOCAL_STORAGE_KEY );
+		dispatch( 'core/notices' ).createSuccessNotice(
+			__( 'Stripe Account Connected', 'woocommerce' ),
+			{
+				id: 'WOOCOMMERCE_ONBOARDING_LOAD_SAMPLE_PRODUCTS_NOTICE',
+				actions: [
+					{
+						url: getAdminLink( 'admin.php?page=wc-admin' ),
+						label: __(
+							'Continue setting up your store',
+							'woocommerce'
+						),
+					},
+				],
+			}
+		);
+	}
+
+	return null;
+};
+
+export default StripeAccountConnectedNotice;

--- a/client/settings/stripe-account-connected-notice/index.js
+++ b/client/settings/stripe-account-connected-notice/index.js
@@ -45,7 +45,7 @@ const StripeAccountConnectedNotice = () => {
 		dispatch( 'core/notices' ).createSuccessNotice(
 			__( 'Stripe Account Connected', 'woocommerce' ),
 			{
-				id: 'WOOCOMMERCE_ONBOARDING_LOAD_SAMPLE_PRODUCTS_NOTICE',
+				id: 'WOOCOMMERCE_STRIPE_ACCOUNT_CONNECTED_NOTICE',
 				actions: [
 					{
 						url: getAdminLink( 'admin.php?page=wc-admin' ),

--- a/client/settings/stripe-account-connected-notice/index.js
+++ b/client/settings/stripe-account-connected-notice/index.js
@@ -51,7 +51,7 @@ const StripeAccountConnectedNotice = () => {
 						url: getAdminLink( 'admin.php?page=wc-admin' ),
 						label: __(
 							'Continue setting up your store',
-							'woocommerce'
+							'woocommerce-gateway-stripe'
 						),
 					},
 				],

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\WooCommerce\Admin\Features\OnboardingTasks\TaskLists;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -116,6 +118,25 @@ class WC_Stripe_Settings_Controller {
 
 		$account_data_exists = ( ! empty( $settings['publishable_key'] ) && ! empty( $settings['secret_key'] ) ) || ( ! empty( $settings['test_publishable_key'] ) && ! empty( $settings['test_secret_key'] ) );
 		echo $account_data_exists ? '<div id="wc-stripe-account-settings-container"></div>' : '<div id="wc-stripe-new-account-container"></div>';
+	}
+
+	/**
+	 * Determines if the payments task is completed in WooCommerce onboarding flow.
+	 *
+	 * @return bool True if the payments task is completed, false otherwise.
+	 */
+	private function is_payments_onboarding_task_completed(): bool {
+		$task_list = TaskLists::get_list( 'setup' );
+		if ( empty( $task_list ) ) {
+			return false;
+		}
+
+		$payments_task = $task_list->get_task( 'payments' );
+		if ( empty( $payments_task ) ) {
+			return false;
+		}
+
+		return $payments_task->is_complete();
 	}
 
 	/**
@@ -246,27 +267,28 @@ class WC_Stripe_Settings_Controller {
 		}
 
 		$params = [
-			'time'                         => time(),
-			'i18n_out_of_sync'             => $message,
-			'is_upe_checkout_enabled'      => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
-			'is_ach_enabled'               => WC_Stripe_Feature_Flags::is_ach_lpm_enabled(),
-			'is_acss_enabled'              => WC_Stripe_Feature_Flags::is_acss_lpm_enabled(),
-			'is_bacs_enabled'              => WC_Stripe_Feature_Flags::is_bacs_lpm_enabled(),
-			'is_blik_enabled'              => WC_Stripe_Feature_Flags::is_blik_lpm_enabled(),
-			'is_becs_debit_enabled'        => WC_Stripe_Feature_Flags::is_becs_debit_lpm_enabled(),
-			'stripe_oauth_url'             => $oauth_url,
-			'stripe_test_oauth_url'        => $test_oauth_url,
-			'show_customization_notice'    => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
-			'show_bnpl_promotional_banner' => $show_bnpl_promotion_banner,
-			'is_test_mode'                 => $this->get_gateway()->is_in_test_mode(),
-			'plugin_version'               => WC_STRIPE_VERSION,
-			'account_country'              => $this->account->get_account_country(),
-			'are_apms_deprecated'          => WC_Stripe_Feature_Flags::are_apms_deprecated(),
-			'is_amazon_pay_available'      => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
-			'is_oc_available'              => WC_Stripe_Feature_Flags::is_oc_available(),
-			'oauth_nonce'                  => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
-			'is_sepa_tokens_enabled'       => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_other_methods', 'no' ),
-			'has_other_bnpl_plugins'       => $has_other_bnpl_plugins_active,
+			'time'                                  => time(),
+			'i18n_out_of_sync'                      => $message,
+			'is_upe_checkout_enabled'               => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+			'is_ach_enabled'                        => WC_Stripe_Feature_Flags::is_ach_lpm_enabled(),
+			'is_acss_enabled'                       => WC_Stripe_Feature_Flags::is_acss_lpm_enabled(),
+			'is_bacs_enabled'                       => WC_Stripe_Feature_Flags::is_bacs_lpm_enabled(),
+			'is_blik_enabled'                       => WC_Stripe_Feature_Flags::is_blik_lpm_enabled(),
+			'is_becs_debit_enabled'                 => WC_Stripe_Feature_Flags::is_becs_debit_lpm_enabled(),
+			'stripe_oauth_url'                      => $oauth_url,
+			'stripe_test_oauth_url'                 => $test_oauth_url,
+			'show_customization_notice'             => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
+			'show_bnpl_promotional_banner'          => $show_bnpl_promotion_banner,
+			'is_test_mode'                          => $this->get_gateway()->is_in_test_mode(),
+			'plugin_version'                        => WC_STRIPE_VERSION,
+			'account_country'                       => $this->account->get_account_country(),
+			'are_apms_deprecated'                   => WC_Stripe_Feature_Flags::are_apms_deprecated(),
+			'is_amazon_pay_available'               => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
+			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
+			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
+			'is_sepa_tokens_enabled'                => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_other_methods', 'no' ),
+			'has_other_bnpl_plugins'                => $has_other_bnpl_plugins_active,
+			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -127,7 +127,11 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 				$this->record_account_connect_track_event( is_wp_error( $response ) );
 
-				wp_safe_redirect( esc_url_raw( remove_query_arg( [ 'wcs_stripe_state', 'wcs_stripe_code', 'wcs_stripe_type', 'wcs_stripe_mode' ] ) ) );
+				$redirect_url = remove_query_arg( [ 'wcs_stripe_state', 'wcs_stripe_code', 'wcs_stripe_type', 'wcs_stripe_mode' ] );
+				if ( ! is_wp_error( $response ) ) {
+					$redirect_url = add_query_arg( [ 'wc_stripe_connected' => 'true' ], $redirect_url );
+				}
+				wp_safe_redirect( esc_url_raw( $redirect_url ) );
 				exit;
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -168,5 +168,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Correctly handle countries without states when using the express payment methods
 * Update - Include extension data from block checkout when submitting an express checkout order
 * Fix - Add order locking when processing payment redirects, to mitigate cases of double status updates
+* Add - A notice to take user back to WC onboarding flow after connecting the Stripe account
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-510

## Changes proposed in this Pull Request:

When merchants are setting up WooCommerce and reach the payments step, and if they choose to setup Stripe, they will be directed to Stripe onboarding flow to connect their account. After connecting, this PR adds a notification to lead them back to the WooCommerce onboarding tasks. 

This change:

  - Detects when a merchant arrives at Stripe settings from the WC onboarding flow
  - Stores this state temporarily in local storage (with 60-second expiration)
  - Shows a success notice with a link to WC onboarding steps after Stripe account connection
  - Adds a wc_stripe_connected query parameter to track successful connections
  - Checks if the payments onboarding task is already completed to avoid showing the notice unnecessarily

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Create a build of this branch.
2. Create a new Jurassic Ninja site and upload and activate the build.
3. Install WooCommerce and go through the guided onboarding process.
4. Click on the "Get paid" onboarding task
![CleanShot 2025-07-02 at 15 59 48@2x](https://github.com/user-attachments/assets/c695c894-8539-4eee-8f29-e2e938df7e42)
5. Click the "Complete setup" option next to Stripe.
6. Go through Stripe onboarding flow.
7. When you are back on the Stripe settings page after onboarding is complete, there should be a new toast notification.
![CleanShot 2025-07-02 at 15 37 03@2x](https://github.com/user-attachments/assets/eb44a64c-8ac1-4db6-a9a6-278c7259db83)
8. Click the "Continue setting up your store" button, and you should be directed back to WooCommerce home with the onboarding tasks.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
