### PR TITLE
Fix payment_request Stripe settings key is undefined

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Fix - Fixes a possible error notice when the `payment_request` Stripe setting key is not defined
 * Update - Removes the change display order feature from the settings page when the Optimized Checkout is enabled
 * Update - Removes the customization of individual payment method titles and descriptions
 * Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests

--- a/includes/admin/class-wc-stripe-payment-gateways-controller.php
+++ b/includes/admin/class-wc-stripe-payment-gateways-controller.php
@@ -19,7 +19,7 @@ class WC_Stripe_Payment_Gateways_Controller {
 		// If UPE is enabled and there are enabled payment methods, we need to load the disable Stripe confirmation modal.
 		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
 		$enabled_upe_payment_methods  = WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids();
-		$upe_payment_requests_enabled = 'yes' === $stripe_settings['payment_request'];
+		$upe_payment_requests_enabled = 'yes' === ( $stripe_settings['payment_request'] ?? 'no' );
 
 		if ( ( is_array( $enabled_upe_payment_methods ) && count( $enabled_upe_payment_methods ) > 0 ) || $upe_payment_requests_enabled ) {
 			add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_payments_scripts' ] );

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Fix - Fixes a possible error notice when the `payment_request` Stripe setting key is not defined
 * Update - Removes the change display order feature from the settings page when the Optimized Checkout is enabled
 * Update - Removes the customization of individual payment method titles and descriptions
 * Fix - Fixes some inconsistencies related to the Optimized Checkout feature and improves its unit tests


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes an issue that might happen when attempting to access wp-admin on a fresh store. The `payment_request` Stripe setting key might not be initialized yet, and a notice can be shown:
```
Notice: Undefined index: payment_request in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/admin/class-wc-stripe-payment-gateways-controller.php on line 22 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/admin/class-wc-stripe-payment-gateways-controller.php:22) in /var/www/html/wp-includes/pluggable.php on line 1450 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/admin/class-wc-stripe-payment-gateways-controller.php:22) in /var/www/html/wp-includes/pluggable.php on line 1453
```
<img width="1859" alt="Screenshot 2025-07-03 at 17 54 42" src="https://github.com/user-attachments/assets/0a186126-b8b5-4a27-808d-386dd9a85529" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

The way I got this error was by:
- Deleting my whole Docker local environment for the extension (`npm run down`, deleted the `data`, `logs`, and `wordpress` folders inside the `docker` folder)
- Starting it from scratch (`npm run up`)
- Attempting to log in to wp-admin

Not sure how consistent it is. But if you cannot reproduce it, code review should be enough.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
