### PR TITLE
OC: Prevent title reset while typing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -63,6 +63,7 @@
 * Add - A notice to take user back to WC onboarding flow after connecting the Stripe account
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages
 * Tweak - Deprecate wc_connect_* filters
+* Fix - Prevent text field reset while editing Optimized Checkout title
 
 = 9.5.3 - 2025-06-23 =
 * Fix - Reimplement mapping of Express Checkout state values to align with WooCommerce's expected state formats

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -5,7 +5,7 @@ import {
 	ExternalLink,
 	TextControl,
 } from '@wordpress/components';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useIsOCEnabled, useIsUpeEnabled, useOCTitle } from '../../data';
 
 const SinglePaymentElementFeature = () => {
@@ -18,6 +18,28 @@ const SinglePaymentElementFeature = () => {
 			setIsOCEnabled( false );
 		}
 	}, [ isUpeEnabled, setIsOCEnabled ] );
+
+	// Local state for the title input to prevent value reset during typing
+	const [ localOCTitle, setLocalOCTitle ] = useState( OCTitle );
+
+	// Update local state when store value changes
+	useEffect( () => {
+		setLocalOCTitle( OCTitle );
+	}, [ OCTitle ] );
+
+	const handleTitleChange = ( value ) => {
+		setLocalOCTitle( value );
+	};
+
+	const handleTitleBlur = () => {
+		setOCTitle( localOCTitle );
+	};
+
+	const handleTitleKeyDown = ( event ) => {
+		if ( event.key === 'Enter' ) {
+			setOCTitle( localOCTitle );
+		}
+	};
 
 	return (
 		<>
@@ -55,8 +77,10 @@ const SinglePaymentElementFeature = () => {
 						'woocommerce-gateway-stripe'
 					) }
 					label={ __( 'Title', 'woocommerce-gateway-stripe' ) }
-					value={ OCTitle }
-					onChange={ setOCTitle }
+					value={ localOCTitle }
+					onChange={ handleTitleChange }
+					onBlur={ handleTitleBlur }
+					onKeyDown={ handleTitleKeyDown }
 				/>
 			) }
 		</>

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -32,12 +32,14 @@ const SinglePaymentElementFeature = () => {
 	};
 
 	const handleTitleBlur = () => {
-		setOCTitle( localOCTitle );
+		const finalTitle = localOCTitle.trim() || OCTitle;
+		setOCTitle( finalTitle );
+		setLocalOCTitle( finalTitle );
 	};
 
 	const handleTitleKeyDown = ( event ) => {
 		if ( event.key === 'Enter' ) {
-			setOCTitle( localOCTitle );
+			handleTitleBlur();
 		}
 	};
 

--- a/readme.txt
+++ b/readme.txt
@@ -174,5 +174,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - A notice to take user back to WC onboarding flow after connecting the Stripe account
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages
 * Tweak - Deprecate wc_connect_* filters
+* Fix - Prevent text field reset while editing Optimized Checkout title
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-569

## Changes proposed in this Pull Request:

Fixes a UI bug where the default title, i.e. "Stripe", can interfere with the user as they are typing in a new title.


https://github.com/user-attachments/assets/6109ead7-a218-4de1-bbd1-7e2de0c40be3

## Testing instructions
1. Enable the OC feature flag.
2. Go to Stripe settings and enable OC.
3. Change OC payment element title.
   - In `develop`, if while typing the field becomes empty, e.g. backspace everything, the default title "Stripe" will appear in the text box.
   - In this branch, the default title will only appear when the field is empty on blur. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
