### PR TITLE
Fix attempt to retrieve the order key from a order refund object

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.6.0 - xxxx-xx-xx =
+* Fix - Fixes a possible fatal error when trying to generate the order signature for a `WC_Order_Refund` object
 * Add - New WooCommerce Debug Tool to list subscriptions without a payment method attached
 * Fix - Fixes a possible error notice when the `payment_request` Stripe setting key is not defined
 * Update - Removes the change display order feature from the settings page when the Optimized Checkout is enabled

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2523,7 +2523,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	 * @return string The order's unique signature. Format: order_id:md5(order_id-order_key-customer_id-order_total).
 	 */
 	protected function get_order_signature( $order ) {
-		$order = ! is_a( $order, 'WC_Order' ) ? wc_get_order( $order ) : $order;
+		if ( is_a( $order, 'WC_Order_Refund' ) ) {
+			$order = wc_get_order( $order->get_parent_id() );
+		}
 
 		$signature = [
 			absint( $order->get_id() ),

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -2525,6 +2525,8 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	protected function get_order_signature( $order ) {
 		if ( is_a( $order, 'WC_Order_Refund' ) ) {
 			$order = wc_get_order( $order->get_parent_id() );
+		} elseif ( ! is_a( $order, 'WC_Order' ) ) {
+			$order = wc_get_order( $order );
 		}
 
 		$signature = [

--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.6.0 - xxxx-xx-xx =
 
+* Fix - Fixes a possible fatal error when trying to generate the order signature for a `WC_Order_Refund` object
 * Add - New WooCommerce Debug Tool to list subscriptions without a payment method attached
 * Fix - Fixes a possible error notice when the `payment_request` Stripe setting key is not defined
 * Update - Removes the change display order feature from the settings page when the Optimized Checkout is enabled


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See aebzv00zugsu8b-grafana

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes a possible fatal error that occasionally happens when we try to generate the order signature (`get_order_signature`) while passing a `WC_Order_Refund` object as a parameter:
```
PHP Fatal error:  Uncaught Error: Call to undefined method Automattic\WooCommerce\Admin\Overrides\OrderRefund::get_order_key() in /srv/htdocs/wp-content/plugins/woocommerce-gateway-stripe/includes/abstracts/abstract-wc-stripe-payment-gateway.php:2403
```

`get_parent_id` returns the order ID, which we can use to retrieve the base `WC_Order` object ([docs](https://woocommerce.github.io/code-reference/classes/WC-Order-Refund.html#method_get_parent_id)).

This error was found in our Grafana dashboards.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review should be enough.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
