### PR TITLE
Introducing new filters to control the subscription detached tool parameters

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.7.0 - xxxx-xx-xx =
+* Add - Adds two new safety filters to the subscriptions detached debug tool: `wc_stripe_detached_subscriptions_maximum_time` and `wc_stripe_detached_subscriptions_maximum_count`
 * Fix - Fixes a possible fatal error when trying to generate the order signature for a `WC_Order_Refund` object
 * Add - New WooCommerce Debug Tool to list subscriptions without a payment method attached
 * Fix - Fixes a possible error notice when the `payment_request` Stripe setting key is not defined

--- a/includes/class-wc-stripe-status.php
+++ b/includes/class-wc-stripe-status.php
@@ -10,6 +10,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class WC_Stripe_Status {
 	/**
+	 * Maximum number of subscriptions to process in the detached subscriptions tool.
+	 *
+	 * @var int
+	 */
+	private const SUBSCRIPTIONS_DETACHED_LIST_LIMIT = 1000;
+
+	/**
 	 * Instance of WC_Gateway_Stripe
 	 *
 	 * @var WC_Gateway_Stripe
@@ -240,7 +247,14 @@ class WC_Stripe_Status {
 	 * @return void
 	 */
 	public function list_detached_subscriptions() {
-		$subscriptions     = WC_Stripe_Subscriptions_Helper::get_detached_subscriptions( 1000 ); // Limiting to 1000 subscriptions for safety.
+		/**
+		 * Maximum number of subscriptions to process.
+		 *
+		 * @since 9.6.0
+		 * @param int $max_count The maximum number of subscriptions to process.
+		 */
+		$max_count         = apply_filters( 'wc_stripe_detached_subscriptions_maximum_count', self::SUBSCRIPTIONS_DETACHED_LIST_LIMIT ); // Limit the number of subscriptions to process for safety.
+		$subscriptions     = WC_Stripe_Subscriptions_Helper::get_detached_subscriptions( $max_count );
 		$detached_messages = WC_Stripe_Subscriptions_Helper::build_subscriptions_detached_messages( $subscriptions );
 		echo '<div class="wrap woocommerce">';
 			echo '<h1>' . esc_html__( 'List Detached Stripe Subscriptions', 'woocommerce-gateway-stripe' ) . '</h1>';

--- a/includes/class-wc-stripe-status.php
+++ b/includes/class-wc-stripe-status.php
@@ -250,7 +250,7 @@ class WC_Stripe_Status {
 		/**
 		 * Maximum number of subscriptions to process.
 		 *
-		 * @since 9.6.0
+		 * @since 9.7.0
 		 * @param int $max_count The maximum number of subscriptions to process.
 		 */
 		$max_count         = apply_filters( 'wc_stripe_detached_subscriptions_maximum_count', self::SUBSCRIPTIONS_DETACHED_LIST_LIMIT ); // Limit the number of subscriptions to process for safety.

--- a/includes/compat/class-wc-stripe-subscriptions-helper.php
+++ b/includes/compat/class-wc-stripe-subscriptions-helper.php
@@ -23,8 +23,17 @@ class WC_Stripe_Subscriptions_Helper {
 
 	/**
 	 * Maximum number of subscriptions to load per page.
+	 *
+	 * @var int
 	 */
 	private const MAX_SUBSCRIPTIONS_PER_PAGE = 50;
+
+	/**
+	 * Fallback maximum execution time in seconds.
+	 *
+	 * @var int
+	 */
+	private const MAX_EXECUTION_TIME_FALLBACK = 30;
 
 	/**
 	 * Checks if subscriptions are enabled on the site.
@@ -60,11 +69,36 @@ class WC_Stripe_Subscriptions_Helper {
 			return $cached_subscriptions;
 		}
 
-		$subscriptions = [];
-		$page          = 1;
-		$per_page      = self::MAX_SUBSCRIPTIONS_PER_PAGE;
+		$subscriptions     = [];
+		$num_subscriptions = 0;
+		$page              = 1;
+		$per_page          = self::MAX_SUBSCRIPTIONS_PER_PAGE;
+		$start_time        = time();
+
+		// Defaults maximum execution time to server's `max_execution_time` (when available, or 30 if not) minus 5 seconds.
+		$default_max_time = ( ini_get( 'max_execution_time' ) ? ini_get( 'max_execution_time' ) : self::MAX_EXECUTION_TIME_FALLBACK ) - 5;
+
+		/**
+		 * Filter the maximum time allowed for fetching detached subscriptions.
+		 *
+		 * @since 9.6.0
+		 * @param int $max_time The maximum time allowed in seconds. Default is server's `max_execution_time` (when available, or 30 if not) minus 5 seconds.
+		 */
+		$max_time = apply_filters( 'wc_stripe_detached_subscriptions_maximum_time', $default_max_time );
 
 		do {
+			if ( ( time() - $start_time ) > $max_time ) {
+				// If we have been running for more than the default limit, stop to avoid long execution times.
+				WC_Stripe_Logger::error(
+					sprintf(
+						/* translators: %d is the maximum time allowed for fetching detached subscriptions */
+						__( 'Stopped fetching detached subscriptions before the %d seconds limit for safety.', 'woocommerce-gateway-stripe' ),
+						$max_time
+					)
+				);
+				break;
+			}
+
 			$batch             = wcs_get_subscriptions(
 				[
 					'subscriptions_per_page' => $per_page,

--- a/includes/compat/class-wc-stripe-subscriptions-helper.php
+++ b/includes/compat/class-wc-stripe-subscriptions-helper.php
@@ -89,7 +89,7 @@ class WC_Stripe_Subscriptions_Helper {
 		do {
 			if ( ( time() - $start_time ) > $max_time ) {
 				// If we have been running for more than the default limit, stop to avoid long execution times.
-				WC_Stripe_Logger::error(
+				WC_Stripe_Logger::log(
 					sprintf(
 						/* translators: %d is the maximum time allowed for fetching detached subscriptions */
 						__( 'Stopped fetching detached subscriptions before the %d seconds limit for safety.', 'woocommerce-gateway-stripe' ),

--- a/includes/compat/class-wc-stripe-subscriptions-helper.php
+++ b/includes/compat/class-wc-stripe-subscriptions-helper.php
@@ -81,7 +81,7 @@ class WC_Stripe_Subscriptions_Helper {
 		/**
 		 * Filter the maximum time allowed for fetching detached subscriptions.
 		 *
-		 * @since 9.6.0
+		 * @since 9.7.0
 		 * @param int $max_time The maximum time allowed in seconds. Default is server's `max_execution_time` (when available, or 30 if not) minus 5 seconds.
 		 */
 		$max_time = apply_filters( 'wc_stripe_detached_subscriptions_maximum_time', $default_max_time );

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.7.0 - xxxx-xx-xx =
+* Add - Adds two new safety filters to the subscriptions detached debug tool: `wc_stripe_detached_subscriptions_maximum_time` and `wc_stripe_detached_subscriptions_maximum_count`
 * Fix - Fixes a possible fatal error when trying to generate the order signature for a `WC_Order_Refund` object
 * Update - Improvements to custom checkout fields support for express checkout
 * Tweak - Use the Database Cache for the Stripe Account Data


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-502

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As suggested in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4391#pullrequestreview-2904306325, I am introducing two new filters serving as safety measures for the subscriptions detached identifier tool:
- `wc_stripe_detached_subscriptions_maximum_time` - controls the maximum execution time
- `wc_stripe_detached_subscriptions_maximum_count` - controls the maximum number of subscriptions to return

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout this branch on your test environment (`add/subscription-detached-tool-filters`)
- Connect your Stripe account
- Install the subscriptions extension
- Delete any existing database cache entries for the tool (`wcstripe_cache_test_detached_subscriptions_1000` key in `wp-admin/admin.php?page=wc-stripe-dev&tab=database-cache` if you are using the Stripe Dev extension)
- As a shopper, purchase more than one subscription
- Make all subscriptions identified as detached by editing `includes/compat/class-wc-stripe-subscriptions-helper.php#132` like:
```php
//			$source_id = $subscription->get_meta( '_stripe_source_id' );
//			if ( $source_id ) {
//				$payment_method = WC_Stripe_Database_Cache::get( 'payment_method_for_source_' . $source_id );
//				if ( ! $payment_method ) {
//					$payment_method = WC_Stripe_API::get_payment_method( $source_id );
//					WC_Stripe_Database_Cache::set( 'payment_method_for_source_' . $source_id, $payment_method, HOUR_IN_SECONDS );
//				}
				if ( true ) {
					$detached_subscriptions[] = [
						'id'                        => $subscription->get_id(),
						'customer_id'               => $subscription->get_meta( '_stripe_customer_id' ),
						'change_payment_method_url' => $subscription->get_change_payment_method_url(),
					];
				}
//			}
```

#### `wc_stripe_detached_subscriptions_maximum_time`

- Add the following snippet:
```php
add_filter( 'wc_stripe_detached_subscriptions_maximum_time', function () {
    return -1;
} );
```
- Go to WooCommerce -> Status -> Tools and click "List Stripe subscriptions with detached payment method"
- Check your Stripe logs and confirm you can see the entry:
<img width="936" alt="Screenshot 2025-07-09 at 09 41 34" src="https://github.com/user-attachments/assets/c8927398-8645-438a-8ffe-1cf4be4dda12" />

#### `wc_stripe_detached_subscriptions_maximum_count`

- Remove the previous snippet
- Delete the database cache entry again if it exists
- Add the following snippet:
```php
add_filter( 'wc_stripe_detached_subscriptions_maximum_count', function () {
    return 1;
} );
```
- Go to WooCommerce -> Status -> Tools and click "List Stripe subscriptions with detached payment method"
- Confirm that only a single subscription is listed inside the notice

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
