### PR TITLE
Fix No Such Customer error when adding a payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Tweak - Use the Database Cache for the Stripe Account Data
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
+* Fix - No such customer error when creating payment methods
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@
 * Tweak - Use the Database Cache for the Stripe Account Data
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
-* Fix - No such customer error when creating payment methods
+* Fix - No such customer error when creating a payment method with a new Stripe account
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -385,17 +385,16 @@ class WC_Stripe_Customer {
 	 * Updates existing Stripe customer or creates new customer for User through API.
 	 *
 	 * @param array $args     Additional arguments for the request (optional).
-	 * @param bool  $is_retry Whether the current call is a retry (optional, defaults to false). If true, then an exception will be thrown instead of further retries on error.
 	 *
 	 * @return string Customer ID
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function update_or_create_customer( $args = [], $is_retry = false ) {
+	public function update_or_create_customer( $args = [] ) {
 		if ( empty( $this->get_id() ) ) {
 			return $this->recreate_customer( $args );
 		} else {
-			return $this->update_customer( $args, true );
+			return $this->update_customer( $args );
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Use the Database Cache for the Stripe Account Data
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
+* Fix - No such customer error when creating payment methods
 
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Use the Database Cache for the Stripe Account Data
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
-* Fix - No such customer error when creating payment methods
+* Fix - No such customer error when creating a payment method with a new Stripe account
 
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-570

## Changes proposed in this Pull Request:

When a merchant switches Stripe accounts (e.g., moving from one Stripe account to another, or switching between test/live
environments), existing customer IDs stored in the db become invalid for the new account. The plugin was incorrectly
handling this scenario by passing `$is_retry = true` to the `update_customer()` method, which prevented the automatic customer recreation logic from executing.

- Removes the unused `$is_retry` parameter from the `update_or_create_customer()` method
- Ensures that when `update_customer()` encounters a "No such customer" error, it triggers the customer recreation logic.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. As a customer, log in and navigate to **My Account → Payment Methods**
2. Add a new payment method
3. Verify the payment method is saved successfully
4. As a merchant, go to **WooCommerce → Settings → Payments → Stripe**
5. Disconnect the current Stripe account
6. Connect a different Stripe account (or reconnect with different test/live keys)
7. As the same customer from step 1, navigate to **My Account → Payment Methods → Add Payment Method**
8. Try to add another payment method
9. In **develop:** The request fails with "No such customer" error.
10. In **this branch:** The payment method should be added successfully.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
