### PR TITLE
Add missing changelog entries to readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -112,6 +112,12 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 = 9.7.0 - xxxx-xx-xx =
 * Fix - Fixes a possible fatal error when trying to generate the order signature for a `WC_Order_Refund` object
+* Add - New WooCommerce Debug Tool to list subscriptions without a payment method attached
+* Fix - Fixes a possible error notice when the `payment_request` Stripe setting key is not defined
+* Fix - Prevent irrelevant payment method update requests to Stripe during checkout
+* Add - A notice to take user back to WC onboarding flow after connecting the Stripe account
+* Tweak - Deprecate wc_connect_* filters
+* Fix - Prevent text field reset while editing Optimized Checkout title
 * Update - Improvements to custom checkout fields support for express checkout
 * Tweak - Use the Database Cache for the Stripe Account Data
 * Update - Update filter names to use the wc_stripe_* prefix


### PR DESCRIPTION


## Changes proposed in this Pull Request:

Looks like we missed adding some of the changelog entries to the readme in https://github.com/woocommerce/woocommerce-gateway-stripe/commit/81e087615c356eac2bfc96b5a60128b47ad06e46

This PR adds those.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Inspect the changelog.txt and readme.txt and make sure they are the same.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment This adds some of the missing changelog entries to readme.txt

</details>

**Post merge**

-   [N/A] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [N/A] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [N/A] Included this PR in the Release Thread scope (or does not apply)
