### PR TITLE
Fix wrong price formatting in Apple/Google Pay

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Fixes wrong price formatting in express checkout
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -306,7 +306,7 @@ class WC_Stripe_Helper {
 	 *
 	 * @return array $currencies
 	 */
-	private static function three_decimal_currencies() {
+	public static function three_decimal_currencies() {
 		return [
 			'bhd', // Bahraini Dinar
 			'jod', // Jordanian Dinar

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -315,6 +315,22 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
+	 * Get the number of decimals supported by Stripe for the currency.
+	 *
+	 * @return int
+	 */
+	public static function get_stripe_currency_decimals() {
+		$currency = get_woocommerce_currency();
+		if ( in_array( $currency, WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
+			return 0;
+		} elseif ( in_array( $currency, WC_Stripe_Helper::three_decimal_currencies(), true ) ) {
+			return 3;
+		} else {
+			return 2;
+		}
+	}
+
+	/**
 	 * JS params data used by cart and checkout pages.
 	 *
 	 * @param array $data
@@ -323,7 +339,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		$data = [
 			'url'                     => wc_get_checkout_url(),
 			'currency_code'           => strtolower( get_woocommerce_currency() ),
-			'currency_decimals'       => wc_get_price_decimals(),
+			'currency_decimals'       => $this->get_stripe_currency_decimals(),
 			'country_code'            => substr( get_option( 'woocommerce_default_country' ), 0, 2 ),
 			'needs_shipping'          => 'no',
 			'needs_payer_phone'       => 'required' === get_option( 'woocommerce_checkout_phone_field', 'required' ),

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -320,7 +320,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * @return int
 	 */
 	public static function get_stripe_currency_decimals() {
-		$currency = get_woocommerce_currency();
+		$currency = strtolower( get_woocommerce_currency() );
 		if ( in_array( $currency, WC_Stripe_Helper::no_decimal_currencies(), true ) ) {
 			return 0;
 		} elseif ( in_array( $currency, WC_Stripe_Helper::three_decimal_currencies(), true ) ) {

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -325,9 +325,9 @@ class WC_Stripe_Express_Checkout_Helper {
 			return 0;
 		} elseif ( in_array( $currency, WC_Stripe_Helper::three_decimal_currencies(), true ) ) {
 			return 3;
-		} else {
-			return 2;
 		}
+
+		return 2;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -127,5 +127,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Fixes wrong price formatting in express checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -637,4 +637,48 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Test for `get_stripe_currency_decimals`.
+	 *
+	 * @param string $currency Currency code.
+	 * @param int    $expected Expected number of decimals.
+	 *
+	 * @dataProvider provide_test_get_stripe_currency_decimals
+	 */
+	public function test_get_stripe_currency_decimals( $currency, $expected ) {
+		update_option( 'woocommerce_currency', $currency );
+
+		$actual = WC_Stripe_Express_Checkout_Helper::get_stripe_currency_decimals();
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Provider for `test_get_stripe_currency_decimals`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_stripe_currency_decimals() {
+		return [
+			// No decimal currencies - should return 0
+			'Japanese Yen (no decimals)' => [
+				'currency' => 'JPY',
+				'expected' => 0,
+			],
+			// Three decimal currencies - should return 3
+			'Bahraini Dinar (three decimals)' => [
+				'currency' => 'BHD',
+				'expected' => 3,
+			],
+			// Default currencies - should return 2
+			'US Dollar (default)' => [
+				'currency' => 'USD',
+				'expected' => 2,
+			],
+			'Euro (default)' => [
+				'currency' => 'EUR',
+				'expected' => 2,
+			],
+		];
+	}
 }


### PR DESCRIPTION
Fixes STRIPE-573
Fixes #4479 

## Changes proposed in this Pull Request:
- Returning Stripe's expected currency decimal value in `currency_decimals` instead of what's saved in the WooCommerce settings.

## Testing instructions

- Go to **WooCommerce > Settings > General** and scroll to Currency options
- Set `USD` as the store currency
- Set `0` as the **Number of decimals**
- Enable express checkout in your Stripe settings page
- As a shopper, add a product priced $18 to your cart and go to the checkout page.
    - In `develop`, notice that Google/Apple Pay is not present
    - In this branch the Google/Apple Pay button should be present
- Go to your cart and increase the number of products to 5 so that the cart total becomes $90.
    - In `develop`, notice that, Google/Apple Pay is now present on the checkout page. But when you click the express checkout button, notice that the displayed price is wrong.
    - In this branch, the Google/Apple pay button should be present and display the correct amount.
- Now set the store currency to `JPY` and confirm that the price is correct on Google/Apple Pay and Link modals for JPY.
