### PR TITLE
Show number of pending webhooks in the warning section of the Account status

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,7 +14,7 @@
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
 * Fix - No such customer error when creating a payment method with a new Stripe account
-* Update - Add the number of pending webhooks to the Account status secction
+* Update - Add the number of pending webhooks to the Account status section
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
 * Fix - No such customer error when creating a payment method with a new Stripe account
+* Update - Add the number of pending webhooks to the Account status secction
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -100,6 +100,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		WC_Stripe_Logger::debug( 'Webhook received: ' . $event_type );
 
+		WC_Stripe_Webhook_State::set_pending_webhooks_count( $event->pending_webhooks );
+
 		// Validate it to make sure it is legit.
 		$request_headers   = array_change_key_case( $this->get_request_headers(), CASE_UPPER );
 		$validation_result = $this->validate_request( $request_headers, $request_body );

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -272,9 +272,11 @@ class WC_Stripe_Webhook_State {
 
 		$date_format = 'Y-m-d H:i:s e';
 
+		$meesage = '';
+
 		switch ( $code ) {
 			case 1: // Case 1 (Nominal case): Most recent = success
-				return sprintf(
+				$meesage = sprintf(
 					$test_mode ?
 						/* translators: 1) date and time of last webhook received, e.g. 2020-06-28 10:30:50 UTC */
 						__( 'The most recent test webhook, timestamped %s, was processed successfully.', 'woocommerce-gateway-stripe' ) :
@@ -282,8 +284,9 @@ class WC_Stripe_Webhook_State {
 						__( 'The most recent live webhook, timestamped %s, was processed successfully.', 'woocommerce-gateway-stripe' ),
 					gmdate( $date_format, $last_success_at )
 				);
+				break;
 			case 2: // Case 2: No webhooks received yet
-				return sprintf(
+				$meesage = sprintf(
 					$test_mode ?
 						/* translators: 1) date and time webhook monitoring began, e.g. 2020-06-28 10:30:50 UTC */
 						__( 'No test webhooks have been received since monitoring began at %s.', 'woocommerce-gateway-stripe' ) :
@@ -291,49 +294,62 @@ class WC_Stripe_Webhook_State {
 						__( 'No live webhooks have been received since monitoring began at %s.', 'woocommerce-gateway-stripe' ),
 					gmdate( $date_format, $monitoring_began_at )
 				);
+				break;
 			case 3: // Case 3: Failure after success
-				return sprintf(
+				$meesage = sprintf(
 					$test_mode ?
 						/*
 						 * translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
-						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (The last test webhook to process successfully was timestamped %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ) :
+						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (The last test webhook to process successfully was timestamped %3$s.)', 'woocommerce-gateway-stripe' ) :
 						/*
 						 * translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
-						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (The last live webhook to process successfully was timestamped %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ),
+						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (The last live webhook to process successfully was timestamped %3$s.)', 'woocommerce-gateway-stripe' ),
 					gmdate( $date_format, $last_failure_at ),
 					$last_error,
 					gmdate( $date_format, $last_success_at ),
 					$pending_webhooks,
 				);
+				break;
 			default: // Case 4: Failure with no prior success
-				return sprintf(
+				$meesage = sprintf(
 					$test_mode ?
 						/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
-						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (No test webhooks have been processed successfully since monitoring began at %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ) :
+						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (No test webhooks have been processed successfully since monitoring began at %3$s.)', 'woocommerce-gateway-stripe' ) :
 						/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
-						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (No live webhooks have been processed successfully since monitoring began at %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ),
+						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (No live webhooks have been processed successfully since monitoring began at %3$s.)', 'woocommerce-gateway-stripe' ),
 					gmdate( $date_format, $last_failure_at ),
 					$last_error,
 					gmdate( $date_format, $monitoring_began_at ),
 					$pending_webhooks,
 				);
 		}
+
+		if ( $pending_webhooks > 0 ) {
+			$meesage .= '. ' . sprintf(
+				/* translators: 1) number of pending webhooks */
+				_n(
+					'There is at least %d webhook pending.',
+					'There are approximately %d webhooks pending.',
+					$pending_webhooks,
+					'woocommerce-gateway-stripe'
+				),
+				$pending_webhooks
+			);
+		}
+
+		return $meesage;
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -15,11 +15,13 @@ class WC_Stripe_Webhook_State {
 	const OPTION_LIVE_LAST_SUCCESS_AT     = 'wc_stripe_wh_last_success_at';
 	const OPTION_LIVE_LAST_FAILURE_AT     = 'wc_stripe_wh_last_failure_at';
 	const OPTION_LIVE_LAST_ERROR          = 'wc_stripe_wh_last_error';
+	const OPTION_LIVE_PENDING_WEBHOOKS    = 'wc_stripe_wh_live_pending_webhooks';
 
 	const OPTION_TEST_MONITORING_BEGAN_AT = 'wc_stripe_wh_test_monitor_began_at';
 	const OPTION_TEST_LAST_SUCCESS_AT     = 'wc_stripe_wh_test_last_success_at';
 	const OPTION_TEST_LAST_FAILURE_AT     = 'wc_stripe_wh_test_last_failure_at';
 	const OPTION_TEST_LAST_ERROR          = 'wc_stripe_wh_test_last_error';
+	const OPTION_TEST_PENDING_WEBHOOKS    = 'wc_stripe_wh_test_pending_webhooks';
 
 	const VALIDATION_SUCCEEDED                 = 'validation_succeeded';
 	const VALIDATION_FAILED_EMPTY_HEADERS      = 'empty_headers';
@@ -57,6 +59,7 @@ class WC_Stripe_Webhook_State {
 			delete_option( self::OPTION_LIVE_LAST_SUCCESS_AT );
 			delete_option( self::OPTION_LIVE_LAST_FAILURE_AT );
 			delete_option( self::OPTION_LIVE_LAST_ERROR );
+			delete_option( self::OPTION_LIVE_PENDING_WEBHOOKS );
 		}
 
 		if ( 'all' === $mode || 'test' === $mode ) {
@@ -64,6 +67,7 @@ class WC_Stripe_Webhook_State {
 			delete_option( self::OPTION_TEST_LAST_SUCCESS_AT );
 			delete_option( self::OPTION_TEST_LAST_FAILURE_AT );
 			delete_option( self::OPTION_TEST_LAST_ERROR );
+			delete_option( self::OPTION_TEST_PENDING_WEBHOOKS );
 		}
 	}
 
@@ -228,6 +232,30 @@ class WC_Stripe_Webhook_State {
 	}
 
 	/**
+	 * Sets the number of pending webhooks.
+	 *
+	 * @since 9.7.0
+	 *
+	 * @param int $pending_webhooks The number of pending webhooks.
+	 */
+	public static function set_pending_webhooks_count( $pending_webhooks ) {
+		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_PENDING_WEBHOOKS : self::OPTION_LIVE_PENDING_WEBHOOKS;
+		update_option( $option, $pending_webhooks );
+	}
+
+	/**
+	 * Gets the number of pending webhooks.
+	 *
+	 * @since 9.7.0
+	 *
+	 * @return int The number of pending webhooks.
+	 */
+	public static function get_pending_webhooks_count() {
+		$option = WC_Stripe_Mode::is_test() ? self::OPTION_TEST_PENDING_WEBHOOKS : self::OPTION_LIVE_PENDING_WEBHOOKS;
+		return get_option( $option, 0 );
+	}
+
+	/**
 	 * Gets the state of webhook processing in a human readable format.
 	 *
 	 * @since 5.0.0
@@ -240,6 +268,7 @@ class WC_Stripe_Webhook_State {
 		$last_error          = self::get_last_error_reason();
 		$test_mode           = WC_Stripe_Mode::is_test();
 		$code                = self::get_webhook_status_code();
+		$pending_webhooks    = self::get_pending_webhooks_count();
 
 		$date_format = 'Y-m-d H:i:s e';
 
@@ -269,17 +298,20 @@ class WC_Stripe_Webhook_State {
 						 * translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
+						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (The last test webhook to process successfully was timestamped %3$s.)', 'woocommerce-gateway-stripe' ) :
+						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (The last test webhook to process successfully was timestamped %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ) :
 						/*
 						 * translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time of last successful webhook e.g. 2020-05-28 10:30:50 UTC
+						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (The last live webhook to process successfully was timestamped %3$s.)', 'woocommerce-gateway-stripe' ),
+						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (The last live webhook to process successfully was timestamped %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ),
 					gmdate( $date_format, $last_failure_at ),
 					$last_error,
-					gmdate( $date_format, $last_success_at )
+					gmdate( $date_format, $last_success_at ),
+					$pending_webhooks,
 				);
 			default: // Case 4: Failure with no prior success
 				return sprintf(
@@ -287,16 +319,19 @@ class WC_Stripe_Webhook_State {
 						/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
+						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (No test webhooks have been processed successfully since monitoring began at %3$s.)', 'woocommerce-gateway-stripe' ) :
+						__( 'Warning: The most recent test webhook, received at %1$s, could not be processed. Reason: %2$s. (No test webhooks have been processed successfully since monitoring began at %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ) :
 						/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
 						 * translators: 3) date and time webhook monitoring began e.g. 2020-05-28 10:30:50 UTC
+						 * translators: 4) number of pending webhooks
 						 */
-						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (No live webhooks have been processed successfully since monitoring began at %3$s.)', 'woocommerce-gateway-stripe' ),
+						__( 'Warning: The most recent live webhook, received at %1$s, could not be processed. Reason: %2$s. (No live webhooks have been processed successfully since monitoring began at %3$s, and there are approximately %4$d webhooks pending)', 'woocommerce-gateway-stripe' ),
 					gmdate( $date_format, $last_failure_at ),
 					$last_error,
-					gmdate( $date_format, $monitoring_began_at )
+					gmdate( $date_format, $monitoring_began_at ),
+					$pending_webhooks,
 				);
 		}
 	}

--- a/includes/class-wc-stripe-webhook-state.php
+++ b/includes/class-wc-stripe-webhook-state.php
@@ -272,11 +272,11 @@ class WC_Stripe_Webhook_State {
 
 		$date_format = 'Y-m-d H:i:s e';
 
-		$meesage = '';
+		$message = '';
 
 		switch ( $code ) {
 			case 1: // Case 1 (Nominal case): Most recent = success
-				$meesage = sprintf(
+				$message = sprintf(
 					$test_mode ?
 						/* translators: 1) date and time of last webhook received, e.g. 2020-06-28 10:30:50 UTC */
 						__( 'The most recent test webhook, timestamped %s, was processed successfully.', 'woocommerce-gateway-stripe' ) :
@@ -286,7 +286,7 @@ class WC_Stripe_Webhook_State {
 				);
 				break;
 			case 2: // Case 2: No webhooks received yet
-				$meesage = sprintf(
+				$message = sprintf(
 					$test_mode ?
 						/* translators: 1) date and time webhook monitoring began, e.g. 2020-06-28 10:30:50 UTC */
 						__( 'No test webhooks have been received since monitoring began at %s.', 'woocommerce-gateway-stripe' ) :
@@ -296,7 +296,7 @@ class WC_Stripe_Webhook_State {
 				);
 				break;
 			case 3: // Case 3: Failure after success
-				$meesage = sprintf(
+				$message = sprintf(
 					$test_mode ?
 						/*
 						 * translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
@@ -313,11 +313,10 @@ class WC_Stripe_Webhook_State {
 					gmdate( $date_format, $last_failure_at ),
 					$last_error,
 					gmdate( $date_format, $last_success_at ),
-					$pending_webhooks,
 				);
 				break;
 			default: // Case 4: Failure with no prior success
-				$meesage = sprintf(
+				$message = sprintf(
 					$test_mode ?
 						/* translators: 1) date and time of last failed webhook e.g. 2020-06-28 10:30:50 UTC
 						 * translators: 2) reason webhook failed
@@ -332,12 +331,11 @@ class WC_Stripe_Webhook_State {
 					gmdate( $date_format, $last_failure_at ),
 					$last_error,
 					gmdate( $date_format, $monitoring_began_at ),
-					$pending_webhooks,
 				);
 		}
 
 		if ( $pending_webhooks > 0 ) {
-			$meesage .= '. ' . sprintf(
+			$message .= '. ' . sprintf(
 				/* translators: 1) number of pending webhooks */
 				_n(
 					'There is at least %d webhook pending.',
@@ -349,7 +347,7 @@ class WC_Stripe_Webhook_State {
 			);
 		}
 
-		return $meesage;
+		return $message;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
 * Fix - No such customer error when creating a payment method with a new Stripe account
-* Update - Add the number of pending webhooks to the Account status secction
+* Update - Add the number of pending webhooks to the Account status section
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -124,6 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
 * Fix - No such customer error when creating a payment method with a new Stripe account
-
+* Update - Add the number of pending webhooks to the Account status secction
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Webhook_State_Test.php
+++ b/tests/phpunit/WC_Stripe_Webhook_State_Test.php
@@ -129,9 +129,11 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		if ( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED === $validation_result ) {
 			$notification = json_decode( $this->request_body );
 			WC_Stripe_Webhook_State::set_last_webhook_success_at( $notification->created );
+			WC_Stripe_Webhook_State::set_pending_webhooks_count( 0 );
 		} else {
 			WC_Stripe_Webhook_State::set_last_webhook_failure_at( time() );
 			WC_Stripe_Webhook_State::set_last_error_reason( $validation_result );
+			WC_Stripe_Webhook_State::set_pending_webhooks_count( 3 );
 		}
 	}
 
@@ -169,7 +171,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Case 3: Failure after success.
 	public function test_get_webhook_status_message_failure_after_success() {
 		$this->set_valid_request_data();
-		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(The last [mode] webhook to process successfully was timestamped (.*), and there are approximately (\d+) webhooks pending\)/';
+		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(The last [mode] webhook to process successfully was timestamped (.*).\). There are approximately (\d+) webhooks pending./';
 		// Live
 		$this->set_testmode( 'no' );
 		// Process successful webhook.
@@ -195,7 +197,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Case 4: Failure with no prior success.
 	public function test_get_webhook_status_message_failure_with_no_prior_success() {
 		$this->set_valid_request_data();
-		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(No [mode] webhooks have been processed successfully since monitoring began at (.*), and there are approximately (\d+) webhooks pending\)/';
+		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(No [mode] webhooks have been processed successfully since monitoring began at (.*).\). There are approximately (\d+) webhooks pending./';
 		// Live
 		$this->set_testmode( 'no' );
 		// Fail webhook.
@@ -210,6 +212,12 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		$this->process_webhook();
 		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
 		$this->assertMatchesRegularExpression( str_replace( '[mode]', 'test', $expected_message ), $message );
+
+		// Test that when pending webhooks count is 1 the message is singular.
+		$expected_message = '/Warning: (.*).\). There is at least 1 webhook pending./';
+		WC_Stripe_Webhook_State::set_pending_webhooks_count( 1 );
+		$message = WC_Stripe_Webhook_State::get_webhook_status_message();
+		$this->assertMatchesRegularExpression( $expected_message, $message );
 	}
 
 	// Test failure reason: no error.

--- a/tests/phpunit/WC_Stripe_Webhook_State_Test.php
+++ b/tests/phpunit/WC_Stripe_Webhook_State_Test.php
@@ -70,11 +70,13 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_LAST_SUCCESS_AT );
 		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_LAST_FAILURE_AT );
 		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_LAST_ERROR );
+		delete_option( WC_Stripe_Webhook_State::OPTION_LIVE_PENDING_WEBHOOKS );
 
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_MONITORING_BEGAN_AT );
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_SUCCESS_AT );
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_FAILURE_AT );
 		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_LAST_ERROR );
+		delete_option( WC_Stripe_Webhook_State::OPTION_TEST_PENDING_WEBHOOKS );
 
 		parent::tear_down();
 	}
@@ -167,7 +169,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Case 3: Failure after success.
 	public function test_get_webhook_status_message_failure_after_success() {
 		$this->set_valid_request_data();
-		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(The last [mode] webhook to process successfully was timestamped/';
+		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(The last [mode] webhook to process successfully was timestamped (.*), and there are approximately (\d+) webhooks pending\)/';
 		// Live
 		$this->set_testmode( 'no' );
 		// Process successful webhook.
@@ -193,7 +195,7 @@ class WC_Stripe_Webhook_State_Test extends WP_UnitTestCase {
 	// Case 4: Failure with no prior success.
 	public function test_get_webhook_status_message_failure_with_no_prior_success() {
 		$this->set_valid_request_data();
-		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(No [mode] webhooks have been processed successfully since monitoring began at/';
+		$expected_message = '/Warning: The most recent [mode] webhook, received at (.*), could not be processed. Reason: (.*) \(No [mode] webhooks have been processed successfully since monitoring began at (.*), and there are approximately (\d+) webhooks pending\)/';
 		// Live
 		$this->set_testmode( 'no' );
 		// Fail webhook.


### PR DESCRIPTION
Fixes STRIPE-27
Fixes #1225

## Changes proposed in this Pull Request:

This PR adds the number of pending webhooks to the warning message displayed when a webhook processing error occurs

It also relates to STRIPE-372, as it detects unexpected configuration problems, and with the new automatic webhook configuration during account connection (and the `Reconfigure webhooks` button in the connection modal it can be fixed from the UI. 

**NORMAL / NO WEBHOOK ERRORS**
<img width="771" height="253" alt="Screenshot 2025-07-10 at 17 18 19" src="https://github.com/user-attachments/assets/8e4ac4f5-73fc-47e9-bbd3-81c823206875" />

**WEBHOOK ERRORS**
<img width="1486" height="312" alt="image-2" src="https://github.com/user-attachments/assets/8f434f29-8a51-4ec3-ae06-7fe2f2edabf2" />

## Testing instructions

0. Make sure the webhooks are properly configured
1. Change the webhook secret ('test_webhook_secret') in the settings to an invalid value (using the Dev Tools or WP-CLI)
    `wp option patch update woocommerce_stripe_settings test_webhook_secret 'whsec_INVALID'`
2. In the plugin settings, enable CashApp
3. Add a product to the cart, and go to the `Checkout page`
4. Select `CashApp` as the payment method, and click `Place Order` (no need to complete it, loading the modal is enough to trigger a couple of webhooks)
5. In the plugin settings, go to the `Settings` tab, and check that the warning message is displayed, and it includes the pending webhooks:
    <img width="769" height="332" alt="Screenshot 2025-07-10 at 18 20 41" src="https://github.com/user-attachments/assets/8e8cdf8d-ab88-4ed1-bf7c-de34efd63889" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
