### PR TITLE
Fix wc_gateway_stripe_process_payment action not called for sync payments

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fixes wc_gateway_stripe_process_payment action not being called for synchronous payments
+* Update - Depreacte `wc_gateway_stripe_process_payment` action in favor of `wc_gateway_stripe_process_payment_charge`
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Update - Depreacte `wc_gateway_stripe_process_payment` action in favor of `wc_gateway_stripe_process_payment_charge`
+* Update - Depreacte `wc_gateway_stripe_process_payment` action in favour of `wc_gateway_stripe_process_payment_charge`
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
 * Fix - No such customer error when creating a payment method with a new Stripe account
+* Fix - Fixes wc_gateway_stripe_process_payment action not being called for synchronous payments
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -559,7 +559,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		 * @param object $response The Charge response from Stripe.
 		 * @param WC_Order $order The Order object.
 		 */
-		do_action( 'wc_gateway_stripe_process_payment', $response, $order );
+		do_action( 'wc_gateway_stripe_process_payment_charge', $response, $order );
 
 		$order_id = $order->get_id();
 		$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -534,7 +534,12 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	}
 
 	/**
-	 * Store extra meta data for an order from a Stripe Response.
+	 * Store extra meta data for an order from a Stripe charge response.
+	 *
+	 * @param object $response The Charge response from Stripe.
+	 * @param WC_Order $order The Order object.
+	 *
+	 * @return object The Charge response from Stripe.
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
@@ -547,6 +552,14 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			$localized_message = __( 'Payment processing failed. Please retry.', 'woocommerce-gateway-stripe' );
 			throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 		}
+
+		/**
+		 * Allow third-party code to add custom logic before processing the charge data from Stripe.
+		 *
+		 * @param object $response The Charge response from Stripe.
+		 * @param WC_Order $order The Order object.
+		 */
+		do_action( 'wc_gateway_stripe_process_payment', $response, $order );
 
 		$order_id = $order->get_id();
 		$captured = ( isset( $response->captured ) && $response->captured ) ? 'yes' : 'no';

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -219,7 +219,13 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				return;
 			}
 
-			do_action( 'wc_gateway_stripe_process_redirect_payment', $response, $order );
+			do_action_deprecated(
+				'wc_gateway_stripe_process_redirect_payment',
+				[ $response, $order ],
+				'9.7.0',
+				'wc_gateway_stripe_process_payment',
+				'The wc_gateway_stripe_process_redirect_payment action is deprecated. Use wc_gateway_stripe_process_payment instead.'
+			);
 
 			$this->process_response( $response, $order );
 

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -223,8 +223,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 				'wc_gateway_stripe_process_redirect_payment',
 				[ $response, $order ],
 				'9.7.0',
-				'wc_gateway_stripe_process_payment',
-				'The wc_gateway_stripe_process_redirect_payment action is deprecated. Use wc_gateway_stripe_process_payment instead.'
+				'wc_gateway_stripe_process_payment_charge',
+				'The wc_gateway_stripe_process_redirect_payment action is deprecated. Use wc_gateway_stripe_process_payment_charge instead.'
 			);
 
 			$this->process_response( $response, $order );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -362,8 +362,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				'wc_gateway_stripe_process_webhook_payment',
 				[ $response, $order ],
 				'9.7.0',
-				'wc_gateway_stripe_process_payment',
-				'The wc_gateway_stripe_process_webhook_payment action is deprecated. Use wc_gateway_stripe_process_payment instead.'
+				'wc_gateway_stripe_process_payment_charge',
+				'The wc_gateway_stripe_process_webhook_payment action is deprecated. Use wc_gateway_stripe_process_payment_charge instead.'
 			);
 
 			$response->is_webhook_response = true;
@@ -1083,6 +1083,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				// Process the webhook now if it's for a voucher or wallet payment , or if filtered to process immediately and order is not awaiting action.
 				if ( $is_voucher_payment || $is_wallet_payment || ( ! $process_webhook_async && ! $is_awaiting_action ) ) {
 					$charge = $this->get_latest_charge_from_intent( $intent );
+
+					do_action_deprecated(
+						'wc_gateway_stripe_process_payment',
+						[ $charge, $order ],
+						'9.7.0',
+						'wc_gateway_stripe_process_payment_charge',
+						'The wc_gateway_stripe_process_payment action is deprecated. Use wc_gateway_stripe_process_payment_charge instead.'
+					);
+
 					$charge->is_webhook_response = true;
 					$this->process_response( $charge, $order );
 				} else {
@@ -1286,6 +1295,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		WC_Stripe_Logger::log( "Processing Stripe PaymentIntent {$intent_id} for order {$order->get_id()} via deferred webhook." );
+
+		do_action_deprecated(
+			'wc_gateway_stripe_process_payment',
+			[ $charge, $order ],
+			'9.7.0',
+			'wc_gateway_stripe_process_payment_charge',
+			'The wc_gateway_stripe_process_payment action is deprecated. Use wc_gateway_stripe_process_payment_charge instead.'
+		);
 
 		$charge->is_webhook_response = true;
 		$this->process_response( $charge, $order );

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -355,7 +355,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				return;
 			}
 
-			do_action( 'wc_gateway_stripe_process_webhook_payment', $response, $order );
+			do_action_deprecated(
+				'wc_gateway_stripe_process_webhook_payment',
+				[ $response, $order ],
+				'9.7.0',
+				'wc_gateway_stripe_process_payment',
+				'The wc_gateway_stripe_process_webhook_payment action is deprecated. Use wc_gateway_stripe_process_payment instead.'
+			);
 
 			$response->is_webhook_response = true;
 			$this->process_response( $response, $order );
@@ -1074,9 +1080,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				// Process the webhook now if it's for a voucher or wallet payment , or if filtered to process immediately and order is not awaiting action.
 				if ( $is_voucher_payment || $is_wallet_payment || ( ! $process_webhook_async && ! $is_awaiting_action ) ) {
 					$charge = $this->get_latest_charge_from_intent( $intent );
-
-					do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
-
 					$charge->is_webhook_response = true;
 					$this->process_response( $charge, $order );
 				} else {
@@ -1281,7 +1284,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 		WC_Stripe_Logger::log( "Processing Stripe PaymentIntent {$intent_id} for order {$order->get_id()} via deferred webhook." );
 
-		do_action( 'wc_gateway_stripe_process_payment', $charge, $order );
 		$charge->is_webhook_response = true;
 		$this->process_response( $charge, $order );
 	}

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -571,6 +571,14 @@ trait WC_Stripe_Subscriptions_Trait {
 				do_action( 'wc_gateway_stripe_process_payment_subscription_charge_attempt_delayed', $response, $renewal_order );
 			} else {
 				// The charge was successfully captured
+				do_action_deprecated(
+					'wc_gateway_stripe_process_payment',
+					[ $response, $renewal_order ],
+					'9.7.0',
+					'wc_gateway_stripe_process_payment_charge',
+					'The wc_gateway_stripe_process_payment action is deprecated. Use wc_gateway_stripe_process_payment_charge instead.'
+				);
+
 				// Use the last charge within the intent or the full response body in case of SEPA.
 				$latest_charge = $this->get_latest_charge_from_intent( $response );
 				$this->process_response( ( ! empty( $latest_charge ) ) ? $latest_charge : $response, $renewal_order );

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -571,8 +571,6 @@ trait WC_Stripe_Subscriptions_Trait {
 				do_action( 'wc_gateway_stripe_process_payment_subscription_charge_attempt_delayed', $response, $renewal_order );
 			} else {
 				// The charge was successfully captured
-				do_action( 'wc_gateway_stripe_process_payment', $response, $renewal_order );
-
 				// Use the last charge within the intent or the full response body in case of SEPA.
 				$latest_charge = $this->get_latest_charge_from_intent( $response );
 				$this->process_response( ( ! empty( $latest_charge ) ) ? $latest_charge : $response, $renewal_order );

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -373,6 +373,14 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 					throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 				}
 
+				do_action_deprecated(
+					'wc_gateway_stripe_process_payment',
+					[ $response, $order ],
+					'9.7.0',
+					'wc_gateway_stripe_process_payment_charge',
+					'The wc_gateway_stripe_process_payment action is deprecated. Use wc_gateway_stripe_process_payment_charge instead.'
+				);
+
 				// Process valid response.
 				$this->process_response( $response, $order );
 			} else {

--- a/includes/payment-methods/class-wc-gateway-stripe-sepa.php
+++ b/includes/payment-methods/class-wc-gateway-stripe-sepa.php
@@ -373,8 +373,6 @@ class WC_Gateway_Stripe_Sepa extends WC_Stripe_Payment_Gateway {
 					throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 				}
 
-				do_action( 'wc_gateway_stripe_process_payment', $response, $order );
-
 				// Process valid response.
 				$this->process_response( $response, $order );
 			} else {

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fixes wc_gateway_stripe_process_payment action not being called for synchronous payments
+* Update - Depreacte `wc_gateway_stripe_process_payment` action in favor of `wc_gateway_stripe_process_payment_charge`
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Update - Depreacte `wc_gateway_stripe_process_payment` action in favor of `wc_gateway_stripe_process_payment_charge`
+* Update - Depreacte `wc_gateway_stripe_process_payment` action in favour of `wc_gateway_stripe_process_payment_charge`
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Update filter names to use the wc_stripe_* prefix
 * Add - Show payment methods sync status on the UI
 * Fix - No such customer error when creating a payment method with a new Stripe account
-
+* Fix - Fixes wc_gateway_stripe_process_payment action not being called for synchronous payments
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -1460,7 +1460,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
-	 * Test that the wc_gateway_stripe_process_payment action is triggered when process_response() is called for synchronous payment paths.
+	 * Test that the wc_gateway_stripe_process_payment_charge action is triggered when process_response() is called for synchronous payment paths.
 	 */
 	public function test_process_response_triggers_wc_gateway_stripe_process_payment_action() {
 		$payment_method_id = 'pm_mock';
@@ -1481,7 +1481,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$mock_action_process_payment = new MockAction();
 		add_action(
-			'wc_gateway_stripe_process_payment',
+			'wc_gateway_stripe_process_payment_charge',
 			[ &$mock_action_process_payment, 'action' ]
 		);
 
@@ -2073,7 +2073,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		// by hooking into it.
 		$mock_action_process_payment = new MockAction();
 		add_action(
-			'wc_gateway_stripe_process_payment',
+			'wc_gateway_stripe_process_payment_charge',
 			[ &$mock_action_process_payment, 'action' ]
 		);
 
@@ -2122,7 +2122,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		// Assert: Our hook was called once.
 		$this->assertEquals( 1, $mock_action_process_payment->get_call_count() );
 		// Assert: Only our hook was called.
-		$this->assertEquals( [ 'wc_gateway_stripe_process_payment' ], $mock_action_process_payment->get_tags() );
+		$this->assertEquals( [ 'wc_gateway_stripe_process_payment_charge' ], $mock_action_process_payment->get_tags() );
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -1462,7 +1462,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	/**
 	 * Test that the wc_gateway_stripe_process_payment_charge action is triggered when process_response() is called for synchronous payment paths.
 	 */
-	public function test_process_response_triggers_wc_gateway_stripe_process_payment_action() {
+	public function test_process_response_triggers_wc_gateway_stripe_process_payment_charge_action() {
 		$payment_method_id = 'pm_mock';
 		$customer_id       = 'cus_mock';
 		$order             = WC_Helper_Order::create_order();

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -1460,6 +1460,45 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Test that the wc_gateway_stripe_process_payment action is triggered when process_response() is called for synchronous payment paths.
+	 */
+	public function test_process_response_triggers_wc_gateway_stripe_process_payment_action() {
+		$payment_method_id = 'pm_mock';
+		$customer_id       = 'cus_mock';
+		$order             = WC_Helper_Order::create_order();
+		$order_id          = $order->get_id();
+
+		$payment_method_mock                     = self::MOCK_CARD_PAYMENT_METHOD_TEMPLATE;
+		$payment_method_mock['id']               = $payment_method_id;
+		$payment_method_mock['customer']         = $customer_id;
+		$payment_method_mock['card']['exp_year'] = intval( gmdate( 'Y' ) ) + 1;
+
+		$charge_mock                           = self::MOCK_CARD_PAYMENT_INTENT_TEMPLATE['charges']['data'][0];
+		$charge_mock['payment_method_details'] = $payment_method_mock;
+		$charge_mock['captured']               = true;
+		$charge_mock['status']                 = 'succeeded';
+		$charge_mock['id']                     = 'ch_mock_success';
+
+		$mock_action_process_payment = new MockAction();
+		add_action(
+			'wc_gateway_stripe_process_payment',
+			[ &$mock_action_process_payment, 'action' ]
+		);
+
+		$this->mock_gateway->process_response( $this->array_to_object( $charge_mock ), wc_get_order( $order_id ) );
+
+		$final_order = wc_get_order( $order_id );
+
+		// Test the action was called only once.
+		$this->assertEquals( 1, $mock_action_process_payment->get_call_count() );
+
+		// Test the order was processed successfully.
+		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
+		$this->assertEquals( 'yes', $final_order->get_meta( '_stripe_charge_captured', true ) );
+		$this->assertEquals( $charge_mock['id'], $final_order->get_transaction_id() );
+	}
+
+	/**
 	 * TESTS FOR SAVED PAYMENTS.
 	 */
 

--- a/tests/phpunit/WC_Stripe_Subscription_Renewal_Test.php
+++ b/tests/phpunit/WC_Stripe_Subscription_Renewal_Test.php
@@ -224,7 +224,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		// by hooking into it.
 		$mock_action_process_payment = new MockAction();
 		add_action(
-			'wc_gateway_stripe_process_payment',
+			'wc_gateway_stripe_process_payment_charge',
 			[ &$mock_action_process_payment, 'action' ]
 		);
 
@@ -256,7 +256,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, $mock_action_process_payment->get_call_count() );
 
 		// Assert: Only our hook was called.
-		$this->assertEquals( [ 'wc_gateway_stripe_process_payment' ], $mock_action_process_payment->get_tags() );
+		$this->assertEquals( [ 'wc_gateway_stripe_process_payment_charge' ], $mock_action_process_payment->get_tags() );
 
 		// Clean up.
 		remove_filter( 'pre_http_request', [ $this, 'pre_http_request_response_success' ] );

--- a/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
+++ b/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
@@ -75,6 +75,18 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
 			->setMethods( $methods )
 			->getMock();
+
+		// Set process_response mock to use the real method.
+		// We need to mock this because several tests check that it's not called or called a specific number of times.
+		$this->mock_webhook_handler->expects( $this->any() )
+		->method( 'process_response' )
+		->willReturnCallback(
+			function ( $response, $order ) {
+				// Call the real method
+				$real_handler = new WC_Stripe_Webhook_Handler();
+				return $real_handler->process_response( $response, $order );
+			}
+		);
 	}
 
 	/**
@@ -439,17 +451,6 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 
 		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
 			->willReturn( (object) self::MOCK_PAYMENT_INTENT['charges']['data'][0] );
-
-		// // Mock process_response to trigger the action wc_gateway_stripe_process_payment
-		$this->mock_webhook_handler->expects( $this->any() )
-			->method( 'process_response' )
-			->willReturnCallback(
-				function ( $response, $order ) {
-					// Create a temporary instance to call the real method (that need to be mocked for the other tests)
-					$real_handler = new WC_Stripe_Webhook_Handler();
-					return $real_handler->process_response( $response, $order );
-				}
-			);
 
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( $order_status );

--- a/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
+++ b/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
@@ -440,6 +440,17 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$this->mock_webhook_handler->method( 'get_latest_charge_from_intent' )
 			->willReturn( (object) self::MOCK_PAYMENT_INTENT['charges']['data'][0] );
 
+		// // Mock process_response to trigger the action wc_gateway_stripe_process_payment
+		$this->mock_webhook_handler->expects( $this->any() )
+			->method( 'process_response' )
+			->willReturnCallback(
+				function ( $response, $order ) {
+					// Create a temporary instance to call the real method (that need to be mocked for the other tests)
+					$real_handler = new WC_Stripe_Webhook_Handler();
+					return $real_handler->process_response( $response, $order );
+				}
+			);
+
 		$order = WC_Helper_Order::create_order();
 		$order->set_status( $order_status );
 		if ( $order_locked ) {
@@ -590,7 +601,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 				'order locked'                   => false,
 				'payment type'                   => WC_Stripe_Payment_Methods::BOLETO,
 				'order status final'             => false,
-				'expected status'                => OrderStatus::PENDING,
+				'expected status'                => OrderStatus::PROCESSING,
 				'expected note'                  => '',
 				'expected process payment calls' => 1,
 				'expected process payment intent incomplete calls' => 0,

--- a/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
+++ b/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
@@ -439,7 +439,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	) {
 		$mock_action_process_payment = new MockAction();
 		add_action(
-			'wc_gateway_stripe_process_payment',
+			'wc_gateway_stripe_process_payment_charge',
 			[ &$mock_action_process_payment, 'action' ]
 		);
 


### PR DESCRIPTION
Fixes STRIPE-576

## Changes proposed in this Pull Request:

This PR deprecates the actions `wc_gateway_stripe_process_payment`, `wc_gateway_stripe_process_redirect_payment` and `wc_gateway_stripe_process_webhook_payment` and introduces a new one `wc_gateway_stripe_process_payment_charge` called from inside the `process_response()` method, that is called for all payments (synchronous and asynchronous)

## Testing instructions

1. Add the following snippet:
    ```
	add_action( 'wc_gateway_stripe_process_payment_charge', 'custom_info', 10, 2);
	function custom_info( $charge, $order ) {
		$logger = wc_get_logger();
		$logger->info( wc_print_r( $charge, true ), array( 'source' => 'ks-stripe' ) );
	}
    ```
2. Add a product to the cart, and go to the checkout
3. Select Credit Card as the payment method and use the card 4242424242424242
4. Click `Place Order`
5. Open the plugin logs (WooCommerce > Status > Logs, and select `test-stripe`
6. Check that the action was called:
    <img width="719" height="132" alt="Screenshot 2025-07-11 at 15 37 29" src="https://github.com/user-attachments/assets/7ea2af68-947a-405a-9007-58c5243c0fd6" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
