### PR TITLE
Fix undefined type key warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Fallback to text type if a custom field doesn't have the 'type' defined
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fallback to text type if a custom field doesn't have the 'type' defined
+* Fix - Fallback type if the custom field type is not defined
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,7 +17,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fallback type if the custom field type is not defined
+* Fix - Set default values for custom field options
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -226,12 +226,12 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 					if ( null === $type ) {
 						WC_Stripe_Logger::warning(
 							sprintf(
-								'Checkout field "%1$s" is missing a "type" key – falling back to "text".',
+								'Checkout field "%1$s" is missing a "type" key',
 								$field_key
 							)
 						);
 
-						$type = 'text';
+						$type = '';
 					}
 
 					$classic_custom_checkout_fields[ $field_key ] = [

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -198,9 +198,9 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 				foreach ( $additional_fields as $field_key => $field ) {
 					$block_custom_checkout_fields[ $field_key ] = [
 						'label'    => $field['label'],
-						'type'     => $field['type'],
+						'type'     => $field['type'] ?? 'text',
 						'location' => $checkout_fields->get_field_location( $field_key ),
-						'required' => $field['required'],
+						'required' => $field['required'] ?? false,
 					];
 				}
 
@@ -221,24 +221,11 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 						continue;
 					}
 
-					$type = $field['type'] ?? null;
-
-					if ( null === $type ) {
-						WC_Stripe_Logger::warning(
-							sprintf(
-								'Checkout field "%1$s" is missing a "type" key',
-								$field_key
-							)
-						);
-
-						$type = '';
-					}
-
 					$classic_custom_checkout_fields[ $field_key ] = [
 						'label'    => $field['label'],
-						'type'     => $type,
+						'type'     => $field['type'] ?? 'text',
 						'location' => $fieldset,
-						'required' => $field['required'],
+						'required' => $field['required'] ?? false,
 					];
 				}
 			}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -221,9 +221,22 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 						continue;
 					}
 
+					$type = $field['type'] ?? null;
+
+					if ( null === $type ) {
+						WC_Stripe_Logger::warning(
+							sprintf(
+								'Checkout field "%1$s" is missing a "type" key – falling back to "text".',
+								$field_key
+							)
+						);
+
+						$type = 'text';
+					}
+
 					$classic_custom_checkout_fields[ $field_key ] = [
 						'label'    => $field['label'],
-						'type'     => $field['type'],
+						'type'     => $type,
 						'location' => $fieldset,
 						'required' => $field['required'],
 					];

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fallback to text type if a custom field doesn't have the 'type' defined
+* Fix - Fallback type if the custom field type is not defined
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -127,5 +127,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Fallback to text type if a custom field doesn't have the 'type' defined
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -127,6 +127,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fallback type if the custom field type is not defined
+* Fix - Set default values for custom field options
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-577

## Changes proposed in this Pull Request:

- ~Log a warning if a custom field is missing the `type` field, along with the name of the field.~
- ~Fallback to an empty string type if it's not defined. I am not entirely sure if this could cause downstream issues or if assuming `type: text` would be better, everything seems to work when testing with an empty string.~

Set default values for optional fields based on [Blocks API guidelines ](https://developer.woocommerce.com/docs/block-development/cart-and-checkout-blocks/additional-checkout-fields/#using-the-api) (Thanks @annemirasol for the link)

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Add the snippet provided in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4455 to your store. 
2. Update the snippet to comment out the `type` field(s).
3. Visit the classic checkout page.
4. No warning should be printed on the checkout page.
5. In the logs (WC -> Status -> Logs), there should be an entry indicating the missing type

<img width="2072" height="178" alt="CleanShot 2025-07-11 at 15 35 57@2x" src="https://github.com/user-attachments/assets/07d1e70b-4670-403a-8620-31834f0372dc" />


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
