### PR TITLE
Fix Add Payment Method page and required Stripe customer field validation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Require email address only for Stripe customer validation when request is from the Add Payment Method page
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -249,7 +249,7 @@ class WC_Stripe_Customer {
 	}
 
 	/**
-	 * Get the list ofrequired fields for the create customer request.
+	 * Get the list of required fields for the create customer request.
 	 *
 	 * @param bool $is_add_payment_method_page
 	 *

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -203,55 +203,18 @@ class WC_Stripe_Customer {
 	 * Validate that we have valid data before we try to create a customer.
 	 *
 	 * @param array $create_customer_request
+	 * @param bool  $is_add_payment_method_page
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	private function validate_create_customer_request( $create_customer_request ) {
-		$checkout_billing_fields = WC_Checkout::instance()->get_checkout_fields( 'billing' );
-		$required_billing_fields = array_filter(
-			$checkout_billing_fields,
-			function ( $field_data ) {
-				return $field_data['required'] ?? false;
-			}
-		);
-
-		$required_fields = [];
-
-		if ( isset( $required_billing_fields['billing_email'] ) ) {
-			$required_fields['email'] = true;
-		}
-
-		if ( isset( $required_billing_fields['billing_first_name'] ) || isset( $required_billing_fields['billing_last_name'] ) ) {
-			$required_fields['name'] = true;
-		}
-
-		$required_address_fields = [];
-		$address_field_mapping = [
-			'billing_address_1' => 'line1',
-			'billing_address_2' => 'line2',
-			'billing_city'      => 'city',
-			'billing_country'   => 'country',
-			'billing_postcode'  => 'postal_code',
-			'billing_state'     => 'state',
-		];
-
-		foreach ( $address_field_mapping as $field => $stripe_field_name ) {
-			if ( isset( $required_billing_fields[ $field ] ) ) {
-				$required_address_fields[ $stripe_field_name ] = true;
-			}
-		}
-
-		if ( [] !== $required_address_fields ) {
-			$required_fields['address'] = $required_address_fields;
-		}
-
+	private function validate_create_customer_request( $create_customer_request, $is_add_payment_method_page = false ) {
 		/**
 		 * Filters the required customer fields when creating a customer in Stripe.
 		 *
 		 * @since 9.7.0
 		 * @param array $required_fields The required customer fields as derived from the required billing fields in checkout.
 		 */
-		$required_fields = apply_filters( 'wc_stripe_create_customer_required_fields', $required_fields );
+		$required_fields = apply_filters( 'wc_stripe_create_customer_required_fields', $this->get_create_customer_required_fields( $is_add_payment_method_page ) );
 
 		foreach ( $required_fields as $field => $field_requirements ) {
 			if ( true === $field_requirements ) {
@@ -283,6 +246,62 @@ class WC_Stripe_Customer {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Get the list ofrequired fields for the create customer request.
+	 *
+	 * @param bool $is_add_payment_method_page
+	 *
+	 * @return array
+	 */
+	private function get_create_customer_required_fields( $is_add_payment_method_page = false ) {
+		// If we are on the add payment method page, we need to check just for the email field.
+		if ( $is_add_payment_method_page ) {
+			return [
+				'email' => true,
+			];
+		}
+
+		$checkout_billing_fields = WC_Checkout::instance()->get_checkout_fields( 'billing' );
+		$required_billing_fields = array_filter(
+			$checkout_billing_fields,
+			function ( $field_data ) {
+				return $field_data['required'] ?? false;
+			}
+		);
+
+		$required_fields = [];
+
+		if ( isset( $required_billing_fields['billing_email'] ) ) {
+			$required_fields['email'] = true;
+		}
+
+		if ( isset( $required_billing_fields['billing_first_name'] ) || isset( $required_billing_fields['billing_last_name'] ) ) {
+			$required_fields['name'] = true;
+		}
+
+		$required_address_fields = [];
+		$address_field_mapping   = [
+			'billing_address_1' => 'line1',
+			'billing_address_2' => 'line2',
+			'billing_city'      => 'city',
+			'billing_country'   => 'country',
+			'billing_postcode'  => 'postal_code',
+			'billing_state'     => 'state',
+		];
+
+		foreach ( $address_field_mapping as $field => $stripe_field_name ) {
+			if ( isset( $required_billing_fields[ $field ] ) ) {
+				$required_address_fields[ $stripe_field_name ] = true;
+			}
+		}
+
+		if ( [] !== $required_address_fields ) {
+			$required_fields['address'] = $required_address_fields;
+		}
+
+		return $required_fields;
 	}
 
 	/**
@@ -418,7 +437,9 @@ class WC_Stripe_Customer {
 			 */
 			$create_customer_args = apply_filters( 'wc_stripe_create_customer_args', $args );
 
-			$this->validate_create_customer_request( $create_customer_args );
+			$is_add_payment_method_page = isset( $args['is_add_payment_method_page'] ) && true === $args['is_add_payment_method_page'];
+			unset( $create_customer_args['is_add_payment_method_page'] );
+			$this->validate_create_customer_request( $create_customer_args, $is_add_payment_method_page );
 
 			$response = WC_Stripe_API::request( $create_customer_args, 'customers' );
 		} else {
@@ -426,7 +447,7 @@ class WC_Stripe_Customer {
 			 * This filter is documented in includes/class-wc-stripe-customer.php.
 			 */
 			$update_customer_args = apply_filters( 'wc_stripe_update_customer_args', $args );
-			$response = WC_Stripe_API::request( $update_customer_args, 'customers/' . $response->id );
+			$response             = WC_Stripe_API::request( $update_customer_args, 'customers/' . $response->id );
 		}
 
 		if ( ! empty( $response->error ) ) {

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -415,11 +415,12 @@ class WC_Stripe_Customer {
 	 * Create a customer via API.
 	 *
 	 * @param array $args
+	 * @param bool  $is_add_payment_method_page Whether the request is for the add payment method page.
 	 * @return WP_Error|int
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function create_customer( $args = [] ) {
+	public function create_customer( $args = [], $is_add_payment_method_page = false ) {
 		$args = $this->generate_customer_request( $args );
 
 		// For guest users, check if a customer already exists with the same email and name in Stripe account before creating a new one.
@@ -437,8 +438,6 @@ class WC_Stripe_Customer {
 			 */
 			$create_customer_args = apply_filters( 'wc_stripe_create_customer_args', $args );
 
-			$is_add_payment_method_page = isset( $args['is_add_payment_method_page'] ) && true === $args['is_add_payment_method_page'];
-			unset( $create_customer_args['is_add_payment_method_page'] );
 			$this->validate_create_customer_request( $create_customer_args, $is_add_payment_method_page );
 
 			$response = WC_Stripe_API::request( $create_customer_args, 'customers' );
@@ -522,9 +521,9 @@ class WC_Stripe_Customer {
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function update_or_create_customer( $args = [] ) {
+	public function update_or_create_customer( $args = [], $is_add_payment_method_page = false ) {
 		if ( empty( $this->get_id() ) ) {
-			return $this->recreate_customer( $args );
+			return $this->recreate_customer( $args, $is_add_payment_method_page );
 		} else {
 			return $this->update_customer( $args );
 		}
@@ -879,12 +878,13 @@ class WC_Stripe_Customer {
 	 * Recreates the customer for this user.
 	 *
 	 * @param array $args Additional arguments for the request (optional).
+	 * @param bool  $is_add_payment_method_page Whether the request is for the add payment method page.
 	 *
 	 * @return string ID of the new Customer object.
 	 */
-	private function recreate_customer( $args = [] ) {
+	private function recreate_customer( $args = [], $is_add_payment_method_page = false ) {
 		$this->delete_id_from_meta();
-		return $this->create_customer( $args );
+		return $this->create_customer( $args, $is_add_payment_method_page );
 	}
 
 	/**

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1120,8 +1120,10 @@ class WC_Stripe_Intent_Controller {
 			// similar rate limiter is present in WC Core, but it's executed on page submission (and not on AJAX calls).
 			$wc_add_payment_method_rate_limit_id = 'add_payment_method_' . get_current_user_id();
 			if ( WC_Rate_Limiter::retried_too_soon( $wc_add_payment_method_rate_limit_id ) ) {
+				error_log( 'rate limit hit' );
 				throw new WC_Stripe_Exception( 'Failed to save payment method.', __( 'You cannot add a new payment method so soon after the previous one.', 'woocommerce-gateway-stripe' ) );
 			}
+			error_log( 'rate limit not hit' );
 
 			$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_and_confirm_setup_intent_nonce', false, false );
 
@@ -1140,6 +1142,7 @@ class WC_Stripe_Intent_Controller {
 			$user = wp_get_current_user();
 			// This page is only accessible to logged in users.
 			if ( ! $user->ID ) {
+				error_log( 'user not found' );
 				throw new WC_Stripe_Exception( 'User not found.', __( "We're not able to add this payment method. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
 			}
 			$customer = new WC_Stripe_Customer( $user->ID );

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1120,10 +1120,8 @@ class WC_Stripe_Intent_Controller {
 			// similar rate limiter is present in WC Core, but it's executed on page submission (and not on AJAX calls).
 			$wc_add_payment_method_rate_limit_id = 'add_payment_method_' . get_current_user_id();
 			if ( WC_Rate_Limiter::retried_too_soon( $wc_add_payment_method_rate_limit_id ) ) {
-				error_log( 'rate limit hit' );
 				throw new WC_Stripe_Exception( 'Failed to save payment method.', __( 'You cannot add a new payment method so soon after the previous one.', 'woocommerce-gateway-stripe' ) );
 			}
-			error_log( 'rate limit not hit' );
 
 			$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_and_confirm_setup_intent_nonce', false, false );
 
@@ -1142,7 +1140,6 @@ class WC_Stripe_Intent_Controller {
 			$user = wp_get_current_user();
 			// This page is only accessible to logged in users.
 			if ( ! $user->ID ) {
-				error_log( 'user not found' );
 				throw new WC_Stripe_Exception( 'User not found.', __( "We're not able to add this payment method. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
 			}
 			$customer = new WC_Stripe_Customer( $user->ID );

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1143,7 +1143,7 @@ class WC_Stripe_Intent_Controller {
 			// Manually create the payment information array to create & confirm the setup intent.
 			$payment_information = [
 				'payment_method'        => $payment_method,
-				'customer'              => $customer->update_or_create_customer(),
+				'customer'              => $customer->update_or_create_customer( [ 'is_add_payment_method_page' => true ] ),
 				'selected_payment_type' => $payment_type,
 				'return_url'            => wc_get_account_endpoint_url( 'payment-methods' ),
 				'use_stripe_sdk'        => 'true', // We want the user to complete the next steps via the JS elements. ref https://docs.stripe.com/api/setup_intents/create#create_setup_intent-use_stripe_sdk

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1137,7 +1137,11 @@ class WC_Stripe_Intent_Controller {
 			}
 
 			// Determine the customer managing the payment methods, create one if we don't have one already.
-			$user     = wp_get_current_user();
+			$user = wp_get_current_user();
+			// This page is only accessible to logged in users.
+			if ( ! $user->ID ) {
+				throw new WC_Stripe_Exception( 'User not found.', __( "We're not able to add this payment method. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
+			}
 			$customer = new WC_Stripe_Customer( $user->ID );
 
 			// Manually create the payment information array to create & confirm the setup intent.

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1147,7 +1147,7 @@ class WC_Stripe_Intent_Controller {
 			// Manually create the payment information array to create & confirm the setup intent.
 			$payment_information = [
 				'payment_method'        => $payment_method,
-				'customer'              => $customer->update_or_create_customer( [ 'is_add_payment_method_page' => true ] ),
+				'customer'              => $customer->update_or_create_customer( [], true ),
 				'selected_payment_type' => $payment_type,
 				'return_url'            => wc_get_account_endpoint_url( 'payment-methods' ),
 				'use_stripe_sdk'        => 'true', // We want the user to complete the next steps via the JS elements. ref https://docs.stripe.com/api/setup_intents/create#create_setup_intent-use_stripe_sdk

--- a/readme.txt
+++ b/readme.txt
@@ -128,5 +128,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Require email address only for Stripe customer validation when request is from the Add Payment Method page
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Customer_Test.php
+++ b/tests/phpunit/WC_Stripe_Customer_Test.php
@@ -46,38 +46,38 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 				'expected_exception_message' => null,
 				'expected_exception_string'  => null,
 			],
-			'email is empty string' => [
+			'email is empty string'             => [
 				'billing_fields'             => [ 'email' => '' ],
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => 'missing_required_customer_field: email',
 				'expected_exception_string'  => 'Missing required customer field: email',
 			],
-			'email is whitespace string' => [
+			'email is whitespace string'        => [
 				'billing_fields'             => [ 'email' => '   	  ' ],
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => 'missing_required_customer_field: email',
 				'expected_exception_string'  => 'Missing required customer field: email',
 			],
-			'name is null' => [
+			'name is null'                      => [
 				'billing_fields'             => [
 					'first_name' => null,
-					'last_name' => '',
+					'last_name'  => '',
 				],
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => 'missing_required_customer_field: name',
 				'expected_exception_string'  => 'Missing required customer field: name',
 			],
-			'address line1 is empty string' => [
+			'address line1 is empty string'     => [
 				'billing_fields'             => [ 'address_1' => '' ],
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => 'missing_required_customer_field: address->line1',
 				'expected_exception_string'  => 'Missing required customer field: address->line1',
 			],
-			'address city is empty string' => [
+			'address city is empty string'      => [
 				'billing_fields'             => [ 'city' => '' ],
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
@@ -91,12 +91,26 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 				'expected_exception_message' => 'missing_required_customer_field: address->city',
 				'expected_exception_string'  => 'Missing required customer field: address->city',
 			],
-			'address country is empty string' => [
+			'address country is empty string'   => [
 				'billing_fields'             => [ 'country' => '' ],
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => 'missing_required_customer_field: address->country',
 				'expected_exception_string'  => 'Missing required customer field: address->country',
+			],
+			'add payment method page, all fields present and required, no overrides' => [
+				'billing_fields'             => [],
+				'woo_billing_fields'         => null,
+				'stripe_billing_fields'      => null,
+				'expected_exception_message' => null,
+				'expected_exception_string'  => null,
+			],
+			'add payment method page, email is empty string' => [
+				'billing_fields'             => [ 'email' => '' ],
+				'woo_billing_fields'         => null,
+				'stripe_billing_fields'      => null,
+				'expected_exception_message' => 'missing_required_customer_field: email',
+				'expected_exception_string'  => 'Missing required customer field: email',
 			],
 		];
 	}
@@ -104,17 +118,30 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 	/**
 	 * @dataProvider provide_test_validate_create_customer_request_cases
 	 */
-	public function test_validate_create_customer_request( array $billing_fields = [], ?array $woo_billing_fields = null, ?array $stripe_billing_fields = null, ?string $expected_exception_message = null, ?string $expected_exception_string = null ) {
-		$default_billing_data = [
-			'email'      => 'test@example.com',
-			'first_name' => 'John',
-			'last_name'  => 'Doe',
-			'address_1'  => '123 Main St',
-			'city'       => 'Anytown',
-			'state'      => 'CA',
-			'postcode'   => '12345',
-			'country'    => 'US',
-		];
+	public function test_validate_create_customer_request(
+		array $billing_fields = [],
+		?array $woo_billing_fields = null,
+		?array $stripe_billing_fields = null,
+		?string $expected_exception_message = null,
+		?string $expected_exception_string = null,
+		?bool $is_add_payment_method_page = false
+	) {
+		if ( $is_add_payment_method_page ) {
+			$default_billing_data = [
+				'email' => 'test@example.com',
+			];
+		} else {
+			$default_billing_data = [
+				'email'      => 'test@example.com',
+				'first_name' => 'John',
+				'last_name'  => 'Doe',
+				'address_1'  => '123 Main St',
+				'city'       => 'Anytown',
+				'state'      => 'CA',
+				'postcode'   => '12345',
+				'country'    => 'US',
+			];
+		}
 
 		$billing_data = wp_parse_args( $billing_fields, $default_billing_data );
 
@@ -193,7 +220,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 		$mock_order->method( 'get_billing_postcode' )->willReturn( $billing_data['postcode'] );
 		$mock_order->method( 'get_billing_state' )->willReturn( $billing_data['state'] );
 
-		$args = [
+		$args     = [
 			'order' => $mock_order,
 		];
 		$customer = new \WC_Stripe_Customer();

--- a/tests/phpunit/WC_Stripe_Customer_Test.php
+++ b/tests/phpunit/WC_Stripe_Customer_Test.php
@@ -99,11 +99,12 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 				'expected_exception_string'  => 'Missing required customer field: address->country',
 			],
 			'add payment method page, all fields present and required, no overrides' => [
-				'billing_fields'             => [],
+				'billing_fields'             => [], // only email is required
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => null,
 				'expected_exception_string'  => null,
+				'is_add_payment_method_page' => true,
 			],
 			'add payment method page, email is empty string' => [
 				'billing_fields'             => [ 'email' => '' ],
@@ -111,6 +112,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => 'missing_required_customer_field: email',
 				'expected_exception_string'  => 'Missing required customer field: email',
+				'is_add_payment_method_page' => true,
 			],
 		];
 	}
@@ -128,7 +130,14 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 	) {
 		if ( $is_add_payment_method_page ) {
 			$default_billing_data = [
-				'email' => 'test@example.com',
+				'email'      => 'test@example.com',
+				'first_name' => '',
+				'last_name'  => '',
+				'address_1'  => '',
+				'city'       => '',
+				'state'      => '',
+				'postcode'   => '',
+				'country'    => '',
 			];
 		} else {
 			$default_billing_data = [
@@ -269,7 +278,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 		}
 
 		try {
-			$customer->create_customer( $args );
+			$customer->create_customer( $args, $is_add_payment_method_page );
 		} catch ( \WC_Stripe_Exception $stripe_exception ) {
 			$was_exception_thrown = true;
 


### PR DESCRIPTION
Towards STRIPE-562
## Changes proposed in this Pull Request:

h/t @kaushikasomaiya for finding the breakage, and the deep dive

Iterates on https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4464, where we introduced required field validation before creating a Stripe customer.
- Handle requests from Add Payment Method page, where only the customer's email address is available.
- Bail early when there is no logged in user triggering the Add Payment Method request

## Testing instructions
1. Fix: As a logged in user, make sure you can add a payment method via My Account > Payment methods.
2. Smoke test: as a shopper, make sure you can go through checkout without any problems.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
