### PR TITLE
Fix rate limit for failed add payment method attempts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Fix rate limiter for failed add payment method attempts
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fix rate limiter for failed add payment method attempts
+* Fix - Enforce rate limiter for failed add payment method attempts
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1116,9 +1116,10 @@ class WC_Stripe_Intent_Controller {
 	 * @throws Exception If the AJAX request is missing the required data or if there's an error creating and confirming the setup intent.
 	 */
 	public function create_and_confirm_setup_intent_ajax() {
+		$wc_add_payment_method_rate_limit_id = 'add_payment_method_' . get_current_user_id();
+
 		try {
 			// similar rate limiter is present in WC Core, but it's executed on page submission (and not on AJAX calls).
-			$wc_add_payment_method_rate_limit_id = 'add_payment_method_' . get_current_user_id();
 			if ( WC_Rate_Limiter::retried_too_soon( $wc_add_payment_method_rate_limit_id ) ) {
 				throw new WC_Stripe_Exception( 'Failed to save payment method.', __( 'You cannot add a new payment method so soon after the previous one.', 'woocommerce-gateway-stripe' ) );
 			}
@@ -1173,6 +1174,17 @@ class WC_Stripe_Intent_Controller {
 			);
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Failed to create and confirm setup intent. ' . $e->getMessage() );
+
+			/**
+			 * Filter the rate limit delay when adding a payment method.
+			 *
+			 * @since 9.7.0
+			 *
+			 * @param int $rate_limit_delay The rate limit delay in seconds.
+			 */
+			$rate_limit_delay = apply_filters( 'wc_stripe_add_payment_method_rate_limit_delay', 10 );
+
+			WC_Rate_Limiter::set_rate_limit( $wc_add_payment_method_rate_limit_id, $rate_limit_delay );
 
 			// Send back error so it can be displayed to the customer.
 			wp_send_json_error(

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1176,13 +1176,14 @@ class WC_Stripe_Intent_Controller {
 			WC_Stripe_Logger::log( 'Failed to create and confirm setup intent. ' . $e->getMessage() );
 
 			/**
-			 * Filter the rate limit delay when adding a payment method.
+			 * Filter the rate limit delay after a failure adding a payment method.
 			 *
 			 * @since 9.7.0
 			 *
 			 * @param int $rate_limit_delay The rate limit delay in seconds.
+			 * @param WC_Stripe_Exception $e The exception that occurred.
 			 */
-			$rate_limit_delay = apply_filters( 'wc_stripe_add_payment_method_rate_limit_delay', 10 );
+			$rate_limit_delay = apply_filters( 'wc_stripe_add_payment_method_on_error_rate_limit_delay', 10, $e );
 
 			WC_Rate_Limiter::set_rate_limit( $wc_add_payment_method_rate_limit_id, $rate_limit_delay );
 

--- a/readme.txt
+++ b/readme.txt
@@ -128,6 +128,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
-* Fix - Fix rate limiter for failed add payment method attempts
+* Fix - Enforce rate limiter for failed add payment method attempts
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -128,5 +128,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - No such customer error when creating a payment method with a new Stripe account
 * Fix - Validate create customer payload against required billing fields before sending to Stripe
 * Update - Enhanced logging system with support for all log levels and improved context handling
+* Fix - Fix rate limiter for failed add payment method attempts
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Intent_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Intent_Controller_Test.php
@@ -546,4 +546,59 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'succeeded', $result->status );
 	}
+
+	/**
+	 * Test that rate limiting works after a failed attempt.
+	 */
+	public function test_rate_limiting_on_consecutive_failed_calls() {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ $this, 'wp_ajax_halt_handler_filter' ] );
+
+		wp_set_current_user( 1 );
+		$_POST['wc-stripe-payment-method'] = 'pm_test_123';
+		$_POST['wc-stripe-payment-type']   = WC_Stripe_Payment_Methods::CARD;
+		// First call with invalid nonce - should fail and trigger rate limiting
+		$_POST['_ajax_nonce'] = 'invalid_nonce';
+
+		ob_start();
+		$this->mock_controller->create_and_confirm_setup_intent_ajax();
+		$output = ob_get_clean();
+		$response = json_decode( $output, true );
+		$this->assertFalse( $response['success'] );
+		$this->assertArrayHasKey( 'error', $response['data'] );
+		$this->assertEquals( 'Unable to verify your request. Please refresh the page and try again.', $response['data']['error']['message'] );
+
+		// Second call should fail due to rate limiting, regardless of nonce.
+		$_POST['_ajax_nonce'] = wp_create_nonce( 'wc_stripe_create_and_confirm_setup_intent_nonce' );
+
+		ob_start();
+		$this->mock_controller->create_and_confirm_setup_intent_ajax();
+		$output = ob_get_clean();
+
+		$response = json_decode( $output, true );
+		$this->assertFalse( $response['success'] );
+		$this->assertArrayHasKey( 'error', $response['data'] );
+		$this->assertEquals( 'You cannot add a new payment method so soon after the previous one.', $response['data']['error']['message'] );
+
+		remove_filter( 'wp_die_ajax_handler', [ $this, 'wp_ajax_halt_handler_filter' ] );
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+	}
+
+	/**
+	 * Filter to return a custom handler for AJAX requests.
+	 *
+	 * @return callable The custom handler function.
+	 */
+	public function wp_ajax_halt_handler_filter() {
+		return [ $this, 'wp_ajax_print_handler' ];
+	}
+
+	/**
+	 * Custom handler function to output the message.
+	 *
+	 * @param string $message The message to print.
+	 */
+	public function wp_ajax_print_handler( $message ) {
+		echo wp_kses_post( $message );
+	}
 }


### PR DESCRIPTION
Fixes STRIPE-582

## Changes proposed in this Pull Request:

This PR fixes the rate-limiting check when adding a new payment method.

## Testing instructions

1. Go to the `My account` page in your `Store`
2. Click the `Payment methods` option in the sidebar
3. Click `Add payment method`
4. Select `Credit / Debit Card` and try to add the card `4000 0000 0000 0002`
5. Check that the error message `Your card was declined.` is displayed:
    <img width="830" height="188" alt="Screenshot 2025-07-14 at 15 23 44" src="https://github.com/user-attachments/assets/98175495-f512-4876-a7f8-cb3a3eccf977" />
6. Re-try to add the same card within 10 seconds (click the button again)
7. Check that the error message is now `You cannot add a new payment method so soon after the previous one.`: 
    <img width="827" height="182" alt="Screenshot 2025-07-14 at 15 23 58" src="https://github.com/user-attachments/assets/4b3b088e-fc26-4067-b183-d1a888897d62" />

**Test the custom delay filter:**
1. Add the following filter:
    ```
    add_filter( 'wc_stripe_add_payment_method_on_error_rate_limit_delay', 'wc_stripe_custom_test', 10, 2 );
    function wc_stripe_custom_test( $rate_limit_delay, $exception ) {
        return 1;
    }
    ```
2. Try to add the same declined card as before (`4000 0000 0000 0002`)
3. Check that the delay is now 1 second

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
