### PR TITLE
Disabling BNPLs when other official plugins are active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.7.0 - xxxx-xx-xx =
+* Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active
 * Fix - Moves the existing order lock functionality earlier in the order processing flow to prevent duplicate processing requests
 * Add - Adds two new safety filters to the subscriptions detached debug tool: `wc_stripe_detached_subscriptions_maximum_time` and `wc_stripe_detached_subscriptions_maximum_count`
 * Add - Show a notice when editing an active subscription that has no payment method attached

--- a/client/blocks/upe/index.js
+++ b/client/blocks/upe/index.js
@@ -3,9 +3,11 @@ import {
 	registerExpressPaymentMethod,
 } from '@woocommerce/blocks-registry';
 import {
+	PAYMENT_METHOD_AFFIRM,
 	PAYMENT_METHOD_AMAZON_PAY,
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_GIROPAY,
+	PAYMENT_METHOD_KLARNA,
 	PAYMENT_METHOD_LINK,
 } from '../../stripe-utils/constants';
 import { updateTokenLabelsWhenLoaded } from './token-label-updater.js';
@@ -38,18 +40,26 @@ const api = new WCStripeAPI(
 const paymentMethodsConfig =
 	getBlocksConfiguration()?.paymentMethodsConfig ?? {};
 
-const methodsToFilter = [
-	PAYMENT_METHOD_AMAZON_PAY,
-	PAYMENT_METHOD_LINK,
-	PAYMENT_METHOD_GIROPAY, // Skip giropay as it was deprecated by Jun, 30th 2024.
-];
-
 // Register UPE Elements.
 if ( getBlocksConfiguration()?.isOCEnabled ) {
 	registerPaymentMethod(
 		upeElement( PAYMENT_METHOD_CARD, api, paymentMethodsConfig.card )
 	);
 } else {
+	const methodsToFilter = [
+		PAYMENT_METHOD_AMAZON_PAY,
+		PAYMENT_METHOD_LINK,
+		PAYMENT_METHOD_GIROPAY, // Skip giropay as it was deprecated by Jun, 30th 2024.
+	];
+
+	// Filter out some BNPLs when other official extensions are present.
+	if ( getBlocksConfiguration()?.hasAffirmGatewayPlugin ) {
+		methodsToFilter.push( PAYMENT_METHOD_AFFIRM );
+	}
+	if ( getBlocksConfiguration()?.hasKlarnaGatewayPlugin ) {
+		methodsToFilter.push( PAYMENT_METHOD_KLARNA );
+	}
+
 	Object.entries( paymentMethodsConfig )
 		.filter( ( [ method ] ) => ! methodsToFilter.includes( method ) )
 		.forEach( ( [ method, config ] ) => {

--- a/client/components/payment-method-unavailable-due-conflict-pill/__tests__/index.test.js
+++ b/client/components/payment-method-unavailable-due-conflict-pill/__tests__/index.test.js
@@ -1,28 +1,20 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import PaymentMethodUnavailableDueConflictPill from '..';
-import { usePaymentMethodCurrencies } from 'utils/use-payment-method-currencies';
-
-jest.mock( '../../../payment-methods-map', () => ( {
-	card: { currencies: [] },
-	giropay: { currencies: [ 'EUR' ] },
-} ) );
-
-jest.mock( 'utils/use-payment-method-currencies', () => ( {
-	usePaymentMethodCurrencies: jest.fn(),
-} ) );
+import { PAYMENT_METHOD_AFFIRM } from 'wcstripe/stripe-utils/constants';
 
 describe( 'PaymentMethodUnavailableDueConflictPill', () => {
 	beforeEach( () => {
-		global.wcSettings = { currency: { code: 'USD' } };
-		usePaymentMethodCurrencies.mockReturnValue( [ 'EUR' ] );
+		global.wc_stripe_settings_params = { has_affirm_gateway_plugin: false };
 	} );
 
-	it( 'should render the "Requires currency" text', () => {
+	it( 'should render the "Unavailable due conflict" text', () => {
+		global.wc_stripe_settings_params = { has_affirm_gateway_plugin: true };
+
 		render(
 			<PaymentMethodUnavailableDueConflictPill
-				id="giropay"
-				label="giropay"
+				id={ PAYMENT_METHOD_AFFIRM }
+				label="Affirm"
 			/>
 		);
 
@@ -31,28 +23,14 @@ describe( 'PaymentMethodUnavailableDueConflictPill', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should not render when currency matches', () => {
-		global.wcSettings = { currency: { code: 'EUR' } };
+	it( 'should not render when other extensions are not active', () => {
 		const { container } = render(
 			<PaymentMethodUnavailableDueConflictPill
-				id="giropay"
-				label="giropay"
+				id={ PAYMENT_METHOD_AFFIRM }
+				label="Affirm"
 			/>
 		);
 
 		expect( container.firstChild ).toBeNull();
-	} );
-
-	it( 'should render when currency differs', () => {
-		render(
-			<PaymentMethodUnavailableDueConflictPill
-				id="giropay"
-				label="giropay"
-			/>
-		);
-
-		expect(
-			screen.queryByText( 'Unavailable due conflict' )
-		).toBeInTheDocument();
 	} );
 } );

--- a/client/components/payment-method-unavailable-due-conflict-pill/__tests__/index.test.js
+++ b/client/components/payment-method-unavailable-due-conflict-pill/__tests__/index.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import PaymentMethodUnavailableDueConflictPill from '..';
+import { usePaymentMethodCurrencies } from 'utils/use-payment-method-currencies';
+
+jest.mock( '../../../payment-methods-map', () => ( {
+	card: { currencies: [] },
+	giropay: { currencies: [ 'EUR' ] },
+} ) );
+
+jest.mock( 'utils/use-payment-method-currencies', () => ( {
+	usePaymentMethodCurrencies: jest.fn(),
+} ) );
+
+describe( 'PaymentMethodUnavailableDueConflictPill', () => {
+	beforeEach( () => {
+		global.wcSettings = { currency: { code: 'USD' } };
+		usePaymentMethodCurrencies.mockReturnValue( [ 'EUR' ] );
+	} );
+
+	it( 'should render the "Requires currency" text', () => {
+		render(
+			<PaymentMethodUnavailableDueConflictPill
+				id="giropay"
+				label="giropay"
+			/>
+		);
+
+		expect(
+			screen.queryByText( 'Unavailable due conflict' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render when currency matches', () => {
+		global.wcSettings = { currency: { code: 'EUR' } };
+		const { container } = render(
+			<PaymentMethodUnavailableDueConflictPill
+				id="giropay"
+				label="giropay"
+			/>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should render when currency differs', () => {
+		render(
+			<PaymentMethodUnavailableDueConflictPill
+				id="giropay"
+				label="giropay"
+			/>
+		);
+
+		expect(
+			screen.queryByText( 'Unavailable due conflict' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/components/payment-method-unavailable-due-conflict-pill/__tests__/index.test.js
+++ b/client/components/payment-method-unavailable-due-conflict-pill/__tests__/index.test.js
@@ -8,7 +8,7 @@ describe( 'PaymentMethodUnavailableDueConflictPill', () => {
 		global.wc_stripe_settings_params = { has_affirm_gateway_plugin: false };
 	} );
 
-	it( 'should render the "Unavailable due conflict" text', () => {
+	it( 'should render the "Has plugin conflict" text', () => {
 		global.wc_stripe_settings_params = { has_affirm_gateway_plugin: true };
 
 		render(
@@ -19,7 +19,7 @@ describe( 'PaymentMethodUnavailableDueConflictPill', () => {
 		);
 
 		expect(
-			screen.queryByText( 'Unavailable due conflict' )
+			screen.queryByText( 'Has plugin conflict' )
 		).toBeInTheDocument();
 	} );
 

--- a/client/components/payment-method-unavailable-due-conflict-pill/index.js
+++ b/client/components/payment-method-unavailable-due-conflict-pill/index.js
@@ -59,10 +59,7 @@ const PaymentMethodUnavailableDueConflictPill = ( { id, label } ) => {
 	) {
 		return (
 			<StyledPill>
-				{ __(
-					'Has plugin conflict',
-					'woocommerce-gateway-stripe'
-				) }
+				{ __( 'Has plugin conflict', 'woocommerce-gateway-stripe' ) }
 				<Popover
 					BaseComponent={ IconComponent }
 					content={ interpolateComponents( {

--- a/client/components/payment-method-unavailable-due-conflict-pill/index.js
+++ b/client/components/payment-method-unavailable-due-conflict-pill/index.js
@@ -1,0 +1,99 @@
+/* global wc_stripe_settings_params */
+import { __, sprintf } from '@wordpress/i18n';
+import React from 'react';
+import styled from '@emotion/styled';
+import interpolateComponents from 'interpolate-components';
+import { Icon, info } from '@wordpress/icons';
+import Popover from 'wcstripe/components/popover';
+import {
+	PAYMENT_METHOD_AFFIRM,
+	PAYMENT_METHOD_KLARNA,
+} from 'wcstripe/stripe-utils/constants';
+
+const StyledPill = styled.span`
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 4px 8px;
+	border: 1px solid #fcf9e8;
+	border-radius: 2px;
+	background-color: #fcf9e8;
+	color: #674600;
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 16px;
+	width: fit-content;
+`;
+
+const StyledLink = styled.a`
+	&:focus,
+	&:visited {
+		box-shadow: none;
+	}
+`;
+
+const IconWrapper = styled.span`
+	height: 16px;
+	cursor: pointer;
+`;
+
+const AlertIcon = styled( Icon )`
+	fill: #674600;
+`;
+
+const IconComponent = ( { children, ...props } ) => (
+	<IconWrapper { ...props }>
+		<AlertIcon icon={ info } size="16" />
+		{ children }
+	</IconWrapper>
+);
+
+const PaymentMethodUnavailableDueConflictPill = ( { id, label } ) => {
+	if (
+		( id === PAYMENT_METHOD_AFFIRM &&
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.has_affirm_gateway_plugin ) ||
+		( id === PAYMENT_METHOD_KLARNA &&
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.has_klarna_gateway_plugin )
+	) {
+		return (
+			<StyledPill>
+				{ __(
+					'Unavailable due conflict',
+					'woocommerce-gateway-stripe'
+				) }
+				<Popover
+					BaseComponent={ IconComponent }
+					content={ interpolateComponents( {
+						mixedString: sprintf(
+							/* translators: $1: a payment method name */
+							__(
+								'%1$s is unavailable due to another official plugin being active.',
+								'woocommerce-gateway-stripe'
+							),
+							label
+						),
+						components: {
+							currencySettingsLink: (
+								<StyledLink
+									href="/wp-admin/admin.php?page=wc-settings&tab=general"
+									target="_blank"
+									rel="noreferrer"
+									onClick={ ( ev ) => {
+										// Stop propagation is necessary so it doesn't trigger the tooltip click event.
+										ev.stopPropagation();
+									} }
+								/>
+							),
+						},
+					} ) }
+				/>
+			</StyledPill>
+		);
+	}
+
+	return null;
+};
+
+export default PaymentMethodUnavailableDueConflictPill;

--- a/client/components/payment-method-unavailable-due-conflict-pill/index.js
+++ b/client/components/payment-method-unavailable-due-conflict-pill/index.js
@@ -60,7 +60,7 @@ const PaymentMethodUnavailableDueConflictPill = ( { id, label } ) => {
 		return (
 			<StyledPill>
 				{ __(
-					'Unavailable due conflict',
+					'Has plugin conflict',
 					'woocommerce-gateway-stripe'
 				) }
 				<Popover

--- a/client/settings/general-settings-section/payment-method-description.js
+++ b/client/settings/general-settings-section/payment-method-description.js
@@ -4,6 +4,7 @@ import PaymentMethodMissingCurrencyPill from '../../components/payment-method-mi
 import RecurringPaymentIcon from '../../components/recurring-payment-icon';
 import PaymentMethodCapabilityStatusPill from 'wcstripe/components/payment-method-capability-status-pill';
 import PaymentMethodDeprecationPill from 'wcstripe/components/payment-method-deprecation-pill';
+import PaymentMethodUnavailableDueConflictPill from 'wcstripe/components/payment-method-unavailable-due-conflict-pill';
 
 const Wrapper = styled.div`
 	display: flex;
@@ -66,6 +67,10 @@ const PaymentMethodDescription = ( {
 								label={ label }
 							/>
 							<PaymentMethodCapabilityStatusPill
+								id={ id }
+								label={ label }
+							/>
+							<PaymentMethodUnavailableDueConflictPill
 								id={ id }
 								label={ label }
 							/>

--- a/client/settings/general-settings-section/payment-method.js
+++ b/client/settings/general-settings-section/payment-method.js
@@ -12,6 +12,7 @@ import {
 	PAYMENT_METHOD_AFFIRM,
 	PAYMENT_METHOD_AFTERPAY_CLEARPAY,
 	PAYMENT_METHOD_CARD,
+	PAYMENT_METHOD_KLARNA,
 } from 'wcstripe/stripe-utils/constants';
 import PaymentMethodFeesPill from 'wcstripe/components/payment-method-fees-pill';
 import { usePaymentMethodCurrencies } from 'utils/use-payment-method-currencies';
@@ -127,8 +128,14 @@ const PaymentMethod = ( { method, data } ) => {
 
 	const storeCurrency = window?.wcSettings?.currency?.code;
 	const isDisabled =
-		paymentMethodCurrencies.length &&
-		! paymentMethodCurrencies.includes( storeCurrency );
+		( paymentMethodCurrencies.length &&
+			! paymentMethodCurrencies.includes( storeCurrency ) ) ||
+		( PAYMENT_METHOD_AFFIRM === method &&
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.has_affirm_gateway_plugin ) ||
+		( PAYMENT_METHOD_KLARNA === method &&
+			// eslint-disable-next-line camelcase
+			wc_stripe_settings_params.has_klarna_gateway_plugin );
 
 	return (
 		<div key={ method }>

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -21,6 +21,7 @@ import {
 	PAYMENT_METHOD_AFTERPAY_CLEARPAY,
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_GIROPAY,
+	PAYMENT_METHOD_KLARNA,
 	PAYMENT_METHOD_SOFORT,
 } from 'wcstripe/stripe-utils/constants';
 
@@ -182,6 +183,28 @@ const GeneralSettingsSection = ( { isChangingDisplayOrder } ) => {
 	) {
 		availablePaymentMethods.splice(
 			availablePaymentMethods.indexOf( PAYMENT_METHOD_SOFORT ),
+			1
+		);
+	}
+
+	// Remove Affirm and Klarna if other official plugins are active
+	if (
+		// eslint-disable-next-line camelcase
+		wc_stripe_settings_params?.has_affirm_gateway_plugin &&
+		availablePaymentMethods.includes( PAYMENT_METHOD_AFFIRM )
+	) {
+		availablePaymentMethods.splice(
+			availablePaymentMethods.indexOf( PAYMENT_METHOD_AFFIRM ),
+			1
+		);
+	}
+	if (
+		// eslint-disable-next-line camelcase
+		wc_stripe_settings_params?.has_klarna_gateway_plugin &&
+		availablePaymentMethods.includes( PAYMENT_METHOD_KLARNA )
+	) {
+		availablePaymentMethods.splice(
+			availablePaymentMethods.indexOf( PAYMENT_METHOD_KLARNA ),
 			1
 		);
 	}

--- a/client/settings/general-settings-section/payment-methods-list.js
+++ b/client/settings/general-settings-section/payment-methods-list.js
@@ -21,7 +21,6 @@ import {
 	PAYMENT_METHOD_AFTERPAY_CLEARPAY,
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_GIROPAY,
-	PAYMENT_METHOD_KLARNA,
 	PAYMENT_METHOD_SOFORT,
 } from 'wcstripe/stripe-utils/constants';
 
@@ -183,28 +182,6 @@ const GeneralSettingsSection = ( { isChangingDisplayOrder } ) => {
 	) {
 		availablePaymentMethods.splice(
 			availablePaymentMethods.indexOf( PAYMENT_METHOD_SOFORT ),
-			1
-		);
-	}
-
-	// Remove Affirm and Klarna if other official plugins are active
-	if (
-		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params?.has_affirm_gateway_plugin &&
-		availablePaymentMethods.includes( PAYMENT_METHOD_AFFIRM )
-	) {
-		availablePaymentMethods.splice(
-			availablePaymentMethods.indexOf( PAYMENT_METHOD_AFFIRM ),
-			1
-		);
-	}
-	if (
-		// eslint-disable-next-line camelcase
-		wc_stripe_settings_params?.has_klarna_gateway_plugin &&
-		availablePaymentMethods.includes( PAYMENT_METHOD_KLARNA )
-	) {
-		availablePaymentMethods.splice(
-			availablePaymentMethods.indexOf( PAYMENT_METHOD_KLARNA ),
 			1
 		);
 	}

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -278,8 +278,8 @@ class WC_Stripe_Settings_Controller {
 			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
 			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
 			'is_sepa_tokens_enabled'                => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_other_methods', 'no' ),
-			'has_affirm_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( 'affirm' ),
-			'has_klarna_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( 'klarna_payments' ),
+			'has_affirm_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ),
+			'has_klarna_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ),
 			'has_other_bnpl_plugins'                => WC_Stripe_Helper::has_other_bnpl_plugins_active(),
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 		];

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -257,15 +257,6 @@ class WC_Stripe_Settings_Controller {
 			// Show the BNPL promotional banner only if no BNPL payment methods are enabled.
 			&& ! array_intersect( WC_Stripe_Payment_Methods::BNPL_PAYMENT_METHODS, $enabled_payment_methods );
 
-		$has_other_bnpl_plugins_active = false;
-		$available_payment_gateways    = WC()->payment_gateways->payment_gateways;
-		foreach ( $available_payment_gateways as $gateway ) {
-			if ( ( 'affirm' === $gateway->id || 'klarna_payments' === $gateway->id ) && 'yes' === $gateway->enabled ) {
-				$has_other_bnpl_plugins_active = true;
-				break;
-			}
-		}
-
 		$params = [
 			'time'                                  => time(),
 			'i18n_out_of_sync'                      => $message,
@@ -287,7 +278,7 @@ class WC_Stripe_Settings_Controller {
 			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
 			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
 			'is_sepa_tokens_enabled'                => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_other_methods', 'no' ),
-			'has_other_bnpl_plugins'                => $has_other_bnpl_plugins_active,
+			'has_other_bnpl_plugins'                => WC_Stripe_Helper::has_other_bnpl_plugins_active(),
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 		];
 		wp_localize_script(

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -278,6 +278,8 @@ class WC_Stripe_Settings_Controller {
 			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
 			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),
 			'is_sepa_tokens_enabled'                => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_other_methods', 'no' ),
+			'has_affirm_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( 'affirm' ),
+			'has_klarna_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( 'klarna_payments' ),
 			'has_other_bnpl_plugins'                => WC_Stripe_Helper::has_other_bnpl_plugins_active(),
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 		];

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1858,7 +1858,7 @@ class WC_Stripe_Helper {
 	 * @return bool
 	 */
 	public static function has_other_bnpl_plugins_active() {
-		$available_payment_gateways = WC()->payment_gateways->payment_gateways;
+		$available_payment_gateways = WC()->payment_gateways->payment_gateways ?? [];
 		$other_bnpl_gateway_ids     = [ 'affirm', 'klarna_payments' ];
 		foreach ( $available_payment_gateways as $available_payment_gateway ) {
 			if ( in_array( $available_payment_gateway->id, $other_bnpl_gateway_ids, true ) && 'yes' === $available_payment_gateway->enabled ) {

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -21,6 +21,20 @@ class WC_Stripe_Helper {
 	const PAYMENT_AWAITING_ACTION_META = '_stripe_payment_awaiting_action';
 
 	/**
+	 * The identifier for the official Affirm gateway plugin.
+	 *
+	 * @var string
+	 */
+	const OFFICIAL_PLUGIN_ID_AFFIRM = 'affirm';
+
+	/**
+	 * The identifier for the official Klarna gateway plugin.
+	 *
+	 * @var string
+	 */
+	const OFFICIAL_PLUGIN_ID_KLARNA = 'klarna_payments';
+
+	/**
 	 * List of legacy Stripe gateways.
 	 *
 	 * @var array
@@ -1858,7 +1872,7 @@ class WC_Stripe_Helper {
 	 * @return bool
 	 */
 	public static function has_other_bnpl_plugins_active() {
-		$other_bnpl_gateway_ids = [ 'affirm', 'klarna_payments' ];
+		$other_bnpl_gateway_ids = [ self::OFFICIAL_PLUGIN_ID_AFFIRM, self::OFFICIAL_PLUGIN_ID_KLARNA ];
 		foreach ( $other_bnpl_gateway_ids as $bnpl_gateway_id ) {
 			if ( self::has_gateway_plugin_active( $bnpl_gateway_id ) ) {
 				return true;

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1851,4 +1851,20 @@ class WC_Stripe_Helper {
 				return __( 'Unknown reason', 'woocommerce-gateway-stripe' );
 		}
 	}
+
+	/**
+	 * Checks if there are other Buy Now Pay Later plugins active.
+	 *
+	 * @return bool
+	 */
+	public static function has_other_bnpl_plugins_active() {
+		$available_payment_gateways = WC()->payment_gateways->payment_gateways;
+		$other_bnpl_gateway_ids     = [ 'affirm', 'klarna_payments' ];
+		foreach ( $available_payment_gateways as $available_payment_gateway ) {
+			if ( in_array( $available_payment_gateway->id, $other_bnpl_gateway_ids, true ) && 'yes' === $available_payment_gateway->enabled ) {
+				return true;
+			}
+		}
+		return false;
+	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1858,10 +1858,25 @@ class WC_Stripe_Helper {
 	 * @return bool
 	 */
 	public static function has_other_bnpl_plugins_active() {
+		$other_bnpl_gateway_ids = [ 'affirm', 'klarna_payments' ];
+		foreach ( $other_bnpl_gateway_ids as $bnpl_gateway_id ) {
+			if ( self::has_gateway_plugin_active( $bnpl_gateway_id ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Checks if a given payment gateway plugin is active.
+	 *
+	 * @param string $plugin_id
+	 * @return bool
+	 */
+	public static function has_gateway_plugin_active( $plugin_id ) {
 		$available_payment_gateways = WC()->payment_gateways->payment_gateways ?? [];
-		$other_bnpl_gateway_ids     = [ 'affirm', 'klarna_payments' ];
 		foreach ( $available_payment_gateways as $available_payment_gateway ) {
-			if ( in_array( $available_payment_gateway->id, $other_bnpl_gateway_ids, true ) && 'yes' === $available_payment_gateway->enabled ) {
+			if ( $plugin_id === $available_payment_gateway->id && 'yes' === $available_payment_gateway->enabled ) {
 				return true;
 			}
 		}

--- a/includes/notes/class-wc-stripe-bnpl-promotion-note.php
+++ b/includes/notes/class-wc-stripe-bnpl-promotion-note.php
@@ -93,16 +93,7 @@ class WC_Stripe_BNPL_Promotion_Note {
 			}
 		}
 
-		$has_other_bnpl_plugins_active = false;
-		$available_payment_gateways    = WC()->payment_gateways->payment_gateways;
-		$other_bnpl_gateway_ids        = [ 'affirm', 'klarna_payments' ];
-		foreach ( $available_payment_gateways as $available_payment_gateway ) {
-			if ( in_array( $available_payment_gateway->id, $other_bnpl_gateway_ids, true ) && 'yes' === $available_payment_gateway->enabled ) {
-				$has_other_bnpl_plugins_active = true;
-				break;
-			}
-		}
-		if ( $has_other_bnpl_plugins_active ) {
+		if ( WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -220,10 +220,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 
 			// Disable BNPLs when other official plugins are installed and enabled.
-			if ( WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
-				if ( in_array( $payment_method_class, [ WC_Stripe_UPE_Payment_Method_Affirm::class, WC_Stripe_UPE_Payment_Method_Klarna::class ], true ) ) {
-					continue;
-				}
+			if ( WC_Stripe_UPE_Payment_Method_Affirm::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( 'affirm' ) ) {
+				continue;
+			}
+
+			if ( WC_Stripe_UPE_Payment_Method_Klarna::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( 'klarna_payments' ) ) {
+				continue;
 			}
 
 			$payment_method                                     = new $payment_method_class();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -219,7 +219,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				continue;
 			}
 
-			$payment_method                                     = new $payment_method_class();
+			$payment_method = new $payment_method_class();
+
+			// Disable BNPLs when other official plugins are installed and enabled.
+			if ( WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
+				if ( in_array( $payment_method_class, [ WC_Stripe_UPE_Payment_Method_Affirm::class, WC_Stripe_UPE_Payment_Method_Klarna::class ], true ) ) {
+					$payment_method->update_option( 'enabled', 'no' );
+				}
+			}
+
 			$this->payment_methods[ $payment_method->get_id() ] = $payment_method;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -566,6 +566,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Single Payment Element payment method parent configuration ID
 		$stripe_params['paymentMethodConfigurationParentId'] = WC_Stripe_Payment_Method_Configurations::get_parent_configuration_id();
 
+		// Checking for other BNPL extensions.
+		$stripe_params['hasAffirmGatewayPlugin'] = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM );
+		$stripe_params['hasKlarnaGatewayPlugin'] = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA );
+
 		$cart_total = ( WC()->cart ? WC()->cart->get_total( '' ) : 0 );
 		$currency   = get_woocommerce_currency();
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -219,15 +219,14 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				continue;
 			}
 
-			$payment_method = new $payment_method_class();
-
 			// Disable BNPLs when other official plugins are installed and enabled.
 			if ( WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
 				if ( in_array( $payment_method_class, [ WC_Stripe_UPE_Payment_Method_Affirm::class, WC_Stripe_UPE_Payment_Method_Klarna::class ], true ) ) {
-					$payment_method->update_option( 'enabled', 'no' );
+					continue;
 				}
 			}
 
+			$payment_method                                     = new $payment_method_class();
 			$this->payment_methods[ $payment_method->get_id() ] = $payment_method;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -219,15 +219,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				continue;
 			}
 
-			// Disable BNPLs when other official plugins are installed and enabled.
-			if ( WC_Stripe_UPE_Payment_Method_Affirm::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
-				continue;
-			}
-
-			if ( WC_Stripe_UPE_Payment_Method_Klarna::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
-				continue;
-			}
-
 			$payment_method                                     = new $payment_method_class();
 			$this->payment_methods[ $payment_method->get_id() ] = $payment_method;
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -220,11 +220,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 
 			// Disable BNPLs when other official plugins are installed and enabled.
-			if ( WC_Stripe_UPE_Payment_Method_Affirm::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( 'affirm' ) ) {
+			if ( WC_Stripe_UPE_Payment_Method_Affirm::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
 				continue;
 			}
 
-			if ( WC_Stripe_UPE_Payment_Method_Klarna::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( 'klarna_payments' ) ) {
+			if ( WC_Stripe_UPE_Payment_Method_Klarna::class === $payment_method_class && WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
 				continue;
 			}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-affirm.php
@@ -61,4 +61,18 @@ class WC_Stripe_UPE_Payment_Method_Affirm extends WC_Stripe_UPE_Payment_Method {
 	public function requires_automatic_capture() {
 		return false;
 	}
+
+	/**
+	 * Returns true if the UPE method is available.
+	 *
+	 * @inheritDoc
+	 */
+	public function is_available() {
+		// Affirm is only available if the official Affirm plugin is not active.
+		if ( WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
+			return false;
+		}
+
+		return parent::is_available();
+	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
@@ -156,4 +156,18 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 	public function requires_automatic_capture() {
 		return false;
 	}
+
+	/**
+	 * Returns true if the UPE method is available.
+	 *
+	 * @inheritDoc
+	 */
+	public function is_available() {
+		// Klarna is only available if the official Klarna plugin is not active.
+		if ( WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
+			return false;
+		}
+
+		return parent::is_available();
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.7.0 - xxxx-xx-xx =
+* Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active
 * Fix - Moves the existing order lock functionality earlier in the order processing flow to prevent duplicate processing requests
 * Add - Adds two new safety filters to the subscriptions detached debug tool: `wc_stripe_detached_subscriptions_maximum_time` and `wc_stripe_detached_subscriptions_maximum_count`
 * Add - Show a notice when editing an active subscription that has no payment method attached

--- a/tests/phpunit/WC_Stripe_Helper_Test.php
+++ b/tests/phpunit/WC_Stripe_Helper_Test.php
@@ -237,4 +237,58 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Tests for `has_gateway_plugin_active`.
+	 *
+	 * @param string $plugin_id The plugin ID to evaluate.
+	 * @param array $payment_gateways The available payment gateways.
+	 * @param bool $expected The expected result.
+	 * @return void
+	 *
+	 * @dataProvider provide_has_gateway_plugin_active
+	 */
+	public function test_has_gateway_plugin_active( $plugin_id, $payment_gateways, $expected ) {
+		$original_payment_gateways = WC()->payment_gateways->payment_gateways;
+
+		// Mock the available payment gateways.
+		WC()->payment_gateways->payment_gateways = $payment_gateways;
+
+		$actual = WC_Stripe_Helper::has_gateway_plugin_active( $plugin_id );
+
+		// Clean up.
+		WC()->payment_gateways->payment_gateways = $original_payment_gateways;
+
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Provider for `test_has_gateway_plugin_active`.
+	 *
+	 * @return array
+	 */
+	public function provide_has_gateway_plugin_active() {
+		return [
+			'has Klarna official plugin active'           => [
+				'plugin id'        => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA,
+				'payment gateways' => [
+					'klarna' => (object) [
+						'id'      => 'klarna_payments',
+						'enabled' => 'yes',
+					],
+				],
+				'expected'         => true,
+			],
+			'does not have Klarna official plugin active' => [
+				'plugin id'        => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA,
+				'payment gateways' => [
+					'affirm' => (object) [
+						'id'      => 'affirm',
+						'enabled' => 'yes',
+					],
+				],
+				'expected'         => false,
+			],
+		];
+	}
 }

--- a/tests/phpunit/WC_Stripe_Helper_Test.php
+++ b/tests/phpunit/WC_Stripe_Helper_Test.php
@@ -190,408 +190,50 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test for `get_order_by_intent_id`
+	 * Tests for `has_other_bnpl_plugins_active`.
 	 *
-	 * @param string $status              The order status to return.
-	 * @param bool   $success             Whether the order should be found.
-	 * @return void
-	 * @dataProvider provide_test_get_order_by_intent_id
-	 */
-	public function test_get_order_by_intent_id( $status, $success ) {
-		$order    = WC_Helper_Order::create_order();
-		$order_id = $order->get_id();
-
-		$order = wc_get_order( $order_id );
-		$order->set_status( $status );
-
-		$intent_id = 'pi_mock';
-		update_post_meta( $order_id, '_stripe_intent_id', $intent_id );
-
-		$order = WC_Stripe_Helper::get_order_by_intent_id( $intent_id );
-		if ( $success ) {
-			$this->assertInstanceOf( WC_Order::class, $order );
-		} else {
-			$this->assertFalse( $order );
-		}
-	}
-
-	/**
-	 * Data provider for `test_get_order_by_intent_id`
-	 *
-	 * @return array
-	 */
-	public function provide_test_get_order_by_intent_id(): array {
-		return [
-			'regular table' => [
-				'custom orders table' => false,
-				'status'              => OrderStatus::COMPLETED,
-				'success'             => true,
-			],
-			'trashed order' => [
-				'custom orders table' => false,
-				'status'              => OrderStatus::TRASH,
-				'success'             => false,
-			],
-		];
-	}
-
-	/**
-	 * Test for `get_stripe_amount`
-	 *
-	 * @param int    $total    The total amount.
-	 * @param string $currency The currency.
-	 * @param int    $expected The expected amount.
-	 * @dataProvider provide_test_get_stripe_amount
-	 */
-	public function test_get_stripe_amount( int $total, string $currency, int $expected, int $price_decimals_setting = 2 ): void {
-		if ( 2 !== $price_decimals_setting ) {
-			update_option( 'woocommerce_price_num_decimals', $price_decimals_setting );
-		}
-
-		$amount = WC_Stripe_Helper::get_stripe_amount( $total, $currency );
-		$this->assertEquals( $expected, $amount );
-	}
-
-	/**
-	 * Data provider for `test_get_stripe_amount`
-	 *
-	 * @return array
-	 */
-	public function provide_test_get_stripe_amount(): array {
-		return [
-			WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR => [
-				'total'    => 100,
-				'currency' => WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
-				'expected' => 10000,
-			],
-			WC_Stripe_Currency_Code::JAPANESE_YEN         => [
-				'total'    => 100,
-				'currency' => WC_Stripe_Currency_Code::JAPANESE_YEN,
-				'expected' => 100,
-			],
-			WC_Stripe_Currency_Code::EURO                 => [
-				'total'    => 100,
-				'currency' => WC_Stripe_Currency_Code::EURO,
-				'expected' => 10000,
-			],
-			WC_Stripe_Currency_Code::BAHRAINI_DINAR       => [
-				'total'    => 100,
-				'currency' => WC_Stripe_Currency_Code::BAHRAINI_DINAR,
-				'expected' => 100000,
-			],
-			WC_Stripe_Currency_Code::BAHRAINI_DINAR . ' (3 decimals)' => [
-				'total'                  => 100,
-				'currency'               => WC_Stripe_Currency_Code::BAHRAINI_DINAR,
-				'expected'               => 100000,
-				'price_decimals_setting' => 3,
-			],
-			WC_Stripe_Currency_Code::JORDANIAN_DINAR      => [
-				'total'    => 100,
-				'currency' => WC_Stripe_Currency_Code::JORDANIAN_DINAR,
-				'expected' => 100000,
-			],
-			WC_Stripe_Currency_Code::BURUNDIAN_FRANC      => [
-				'total'    => 100,
-				'currency' => WC_Stripe_Currency_Code::BURUNDIAN_FRANC,
-				'expected' => 100,
-			],
-		];
-	}
-
-	/**
-	 * Test for `payment_method_allows_manual_capture`
-	 *
-	 * @param string $payment_method The payment method.
-	 * @param bool   $expected       Whether manual capture is allowed.
-	 * @dataProvider provide_payment_method_allows_manual_capture
+	 * @param array $payment_gateways The available payment gateways.
+	 * @param bool  $expected         The expected result.
+	 * @dataProvider provide_test_has_other_bnpl_plugins_active
 	 * @return void
 	 */
-	public function test_payment_method_allows_manual_capture( $payment_method, $expected ): void {
-		$actual = WC_Stripe_Helper::payment_method_allows_manual_capture( $payment_method );
-		$this->assertEquals( $expected, $actual );
-	}
+	public function test_has_other_bnpl_plugins_active( $payment_gateways, $expected ) {
+		$original_payment_gateways = WC()->payment_gateways->payment_gateways;
 
-	/**
-	 * Provider for `test_payment_method_allows_manual_capture`
-	 *
-	 * @return array
-	 */
-	public function provide_payment_method_allows_manual_capture(): array {
-		return [
-			'Card'              => [
-				'payment_method' => 'stripe',
-				'expected'       => true,
-			],
-			'Affirm'            => [
-				'payment_method' => 'stripe_affirm',
-				'expected'       => true,
-			],
-			'Klarna'            => [
-				'payment_method' => 'stripe_klarna',
-				'expected'       => true,
-			],
-			'Afterpay/Clearpay' => [
-				'payment_method' => 'stripe_afterpay_clearpay',
-				'expected'       => true,
-			],
-			'EPS'               => [
-				'payment_method' => 'stripe_eps',
-				'expected'       => false,
-			],
-			'AmazonPay'         => [
-				'payment_method' => 'stripe_amazon_pay',
-				'expected'       => true,
-			],
-		];
-	}
+		// Mock the available payment gateways.
+		WC()->payment_gateways->payment_gateways = $payment_gateways;
 
-	public function provide_is_wallet_payment_method(): array {
-		return [
-			'Apple Pay'  => [
-				'apple_pay',
-				false,
-			],
-			'Google Pay' => [
-				'google_pay',
-				false,
-			],
-			'Alipay'     => [
-				WC_Stripe_Payment_Methods::ALIPAY,
-				false,
-			],
-			'Klarna'     => [
-				WC_Stripe_Payment_Methods::KLARNA,
-				false,
-			],
-			'EPS'        => [
-				WC_Stripe_Payment_Methods::EPS,
-				false,
-			],
-			'WeChat'     => [
-				WC_Stripe_Payment_Methods::WECHAT_PAY,
-				true,
-			],
-			'Cash App'   => [
-				WC_Stripe_Payment_Methods::CASHAPP_PAY,
-				true,
-			],
-		];
-	}
+		$actual = WC_Stripe_Helper::has_other_bnpl_plugins_active();
 
-	/**
-	 * Test for `update_main_stripe_settings`, `get_stripe_settings` and `delete_main_stripe_settings`.
-	 *
-	 * @return void
-	 */
-	public function test_handle_main_stripe_settings() {
-		WC_Stripe_Helper::update_main_stripe_settings( [ 'test' => 'abc' ] );
-		$current_settings = WC_Stripe_Helper::get_stripe_settings();
-		$this->assertSame( $current_settings['test'], 'abc' );
+		// Clean up.
+		WC()->payment_gateways->payment_gateways = $original_payment_gateways;
 
-		WC_Stripe_Helper::delete_main_stripe_settings();
-		$current_settings = WC_Stripe_Helper::get_stripe_settings();
-		$this->assertSame( [], $current_settings );
-	}
-
-	/**
-	 * Test for `get_klarna_preferred_locale`.
-	 * @return void
-	 */
-	public function test_get_klarna_preferred_locale() {
-		// Language is supported for the region (same region)
-		$store_locale    = 'en_US';
-		$billing_country = 'US';
-		$expected        = 'en-US';
-		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
 		$this->assertSame( $expected, $actual );
-
-		// Language is supported for the region (different region)
-		$store_locale    = 'en_US';
-		$billing_country = 'DE';
-		$expected        = 'en-DE';
-		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
-		$this->assertSame( $expected, $actual );
-
-		// Language is supported for the region (different region)
-		$store_locale    = 'es_ES';
-		$billing_country = 'US';
-		$expected        = 'es-US';
-		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
-		$this->assertSame( $expected, $actual );
-
-		// Language is not supported for the region
-		$store_locale    = 'fr_FR';
-		$billing_country = 'US';
-		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
-		$this->assertNull( $actual );
-
-		// Region is not supported, with supported locale
-		$store_locale    = 'pt_PT';
-		$billing_country = 'BR';
-		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
-		$this->assertNull( $actual );
-
-		// Region is not supported, with non-supported locale
-		$store_locale    = 'tl';
-		$billing_country = 'PH';
-		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
-		$this->assertNull( $actual );
 	}
 
 	/**
-	 * Test for `add_stripe_methods_in_woocommerce_gateway_order`.
-	 * @return void
-	 */
-	public function test_add_stripe_methods_in_woocommerce_gateway_order() {
-		// When the option is empty, i.e. fresh install, gateway ordering should still work.
-		$stripe_payment_methods = [
-			'stripe_klarna',
-			'card',
-			'stripe_alipay',
-		];
-		delete_option( 'woocommerce_gateway_order' );
-		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order( $stripe_payment_methods );
-		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
-		$this->assertArrayHasKey( 'stripe_klarna', $gateway_order );
-		$this->assertArrayHasKey( 'stripe', $gateway_order );
-		$this->assertArrayHasKey( 'stripe_alipay', $gateway_order );
-		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe'] );
-		$this->assertTrue( $gateway_order['stripe'] < $gateway_order['stripe_alipay'] );
-
-		// Further updates to gateway ordering should work.
-		$stripe_payment_methods = [
-			'stripe_klarna',
-			'stripe_alipay',
-			'card',
-		];
-		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order( $stripe_payment_methods );
-		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
-		$this->assertArrayHasKey( 'stripe_klarna', $gateway_order );
-		$this->assertArrayHasKey( 'stripe', $gateway_order );
-		$this->assertArrayHasKey( 'stripe_alipay', $gateway_order );
-		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe_alipay'] );
-		$this->assertTrue( $gateway_order['stripe_alipay'] < $gateway_order['stripe'] );
-
-		// Order with respect to other gateways is retained.
-		update_option(
-			'woocommerce_gateway_order',
-			[
-				'cod'           => 1,
-				'stripe_klarna' => 2,
-				'stripe'        => 3,
-				'stripe_alipay' => 4,
-				'cheque'        => 5,
-			]
-		);
-		$stripe_payment_methods = [
-			'stripe_alipay',
-			'stripe_klarna',
-			'card',
-			'stripe_affirm',
-		];
-		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order( $stripe_payment_methods );
-		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
-		$this->assertTrue( $gateway_order['cod'] < $gateway_order['stripe_alipay'] );
-		$this->assertTrue( $gateway_order['stripe_alipay'] < $gateway_order['stripe_klarna'] );
-		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe'] );
-		$this->assertTrue( $gateway_order['stripe'] < $gateway_order['stripe_affirm'] );
-		$this->assertTrue( $gateway_order['stripe_affirm'] < $gateway_order['cheque'] );
-	}
-
-	/**
-	 * Test for `add_mandate_data`.
-	 *
-	 * @param string $server_variable_key   The key of the server variable to set.
-	 * @param string $server_variable_value The value to set the server variable to.
-	 * @param string $expected_ip_address    The expected IP address.
-	 * @dataProvider provider_test_add_mandate_data
-	 * @return void
-	 */
-	public function test_add_mandate_data( $server_variable_key, $server_variable_value, $expected_ip_address ) {
-		unset( $_SERVER['REMOTE_ADDR'] );
-		unset( $_SERVER['HTTP_X_REAL_IP'] );
-		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
-
-		$_SERVER[ $server_variable_key ] = $server_variable_value;
-		$request                         = WC_Stripe_Helper::add_mandate_data( [] );
-		$this->assertTrue( isset( $request['mandate_data']['customer_acceptance']['online']['ip_address'] ) );
-		$ip_address = $request['mandate_data']['customer_acceptance']['online']['ip_address'];
-		$this->assertSame( $expected_ip_address, $ip_address );
-	}
-
-	/**
-	 * Data provider for `test_add_mandate_data`.
+	 * Provider for `test_has_other_bnpl_plugins_active`.
 	 *
 	 * @return array
 	 */
-	public function provider_test_add_mandate_data() {
+	public function provide_test_has_other_bnpl_plugins_active() {
 		return [
-			[ 'REMOTE_ADDR', '192.168.1.1', '192.168.1.1' ],
-			[ 'REMOTE_ADDR', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
-			[ 'HTTP_X_REAL_IP', '192.168.1.1', '192.168.1.1' ],
-			[ 'HTTP_X_REAL_IP', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
-			[ 'HTTP_X_FORWARDED_FOR', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
-			[ 'HTTP_X_FORWARDED_FOR', '192.168.1.1', '192.168.1.1' ],
-			[ 'HTTP_X_REAL_IP', 'invalid-ip-address', 'invalid-ip-address' ],
-			[ 'HTTP_X_REAL_IP', '', '' ],
-		];
-	}
-
-	/**
-	 * Tests for `get_refund_reason_description`.
-	 *
-	 * @param string $refund_reason_key The refund reason key to test.
-	 * @param string $expected          The expected description.
-	 * @return void
-	 *
-	 * @dataProvider provide_test_get_refund_reason_description
-	 */
-	public function test_get_refund_reason_description( $refund_reason_key, $expected ) {
-		$this->assertSame( $expected, WC_Stripe_Helper::get_refund_reason_description( $refund_reason_key ) );
-	}
-
-	/**
-	 * Data provider for `test_get_refund_reason_description`.
-	 *
-	 * @return array
-	 */
-	public function provide_test_get_refund_reason_description() {
-		return [
-			'The charge has been disputed'                 => [
-				'key'      => 'charge_for_pending_refund_disputed',
-				'expected' => 'The charge has been disputed',
+			'has other plugins'           => [
+				'payment gateways' => [
+					'klarna' => (object) [
+						'id'      => 'klarna_payments',
+						'enabled' => 'yes',
+					],
+					'affirm' => (object) [
+						'id'      => 'affirm',
+						'enabled' => 'yes',
+					],
+				],
+				'expected'         => true,
 			],
-			'The refund was declined'                      => [
-				'key'      => 'declined',
-				'expected' => 'The refund was declined',
-			],
-			'The original payment method has expired or was canceled' => [
-				'key'      => 'expired_or_canceled_card',
-				'expected' => 'The original payment method has expired or was canceled',
-			],
-			'We could not process the refund at this time' => [
-				'key'      => 'insufficient_funds',
-				'expected' => 'We could not process the refund at this time',
-			],
-			'The original payment method was lost or stolen' => [
-				'key'      => 'lost_or_stolen_card',
-				'expected' => 'The original payment method was lost or stolen',
-			],
-			'We stopped processing the refund'             => [
-				'key'      => 'merchant_request',
-				'expected' => 'We stopped processing the refund',
-			],
-			'Unknown reason (random)'                      => [
-				'key'      => 'random',
-				'expected' => 'Unknown reason',
-			],
-			'Unknown reason (null)'                        => [
-				'key'      => null,
-				'expected' => 'Unknown reason',
-			],
-			'Unknown reason (empty)'                       => [
-				'key'      => '',
-				'expected' => 'Unknown reason',
+			'does not have other plugins' => [
+				'payment gateways' => [],
+				'expected'         => false,
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Helper_Test.php
+++ b/tests/phpunit/WC_Stripe_Helper_Test.php
@@ -190,6 +190,413 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test for `get_order_by_intent_id`
+	 *
+	 * @param string $status              The order status to return.
+	 * @param bool   $success             Whether the order should be found.
+	 * @return void
+	 * @dataProvider provide_test_get_order_by_intent_id
+	 */
+	public function test_get_order_by_intent_id( $status, $success ) {
+		$order    = WC_Helper_Order::create_order();
+		$order_id = $order->get_id();
+
+		$order = wc_get_order( $order_id );
+		$order->set_status( $status );
+
+		$intent_id = 'pi_mock';
+		update_post_meta( $order_id, '_stripe_intent_id', $intent_id );
+
+		$order = WC_Stripe_Helper::get_order_by_intent_id( $intent_id );
+		if ( $success ) {
+			$this->assertInstanceOf( WC_Order::class, $order );
+		} else {
+			$this->assertFalse( $order );
+		}
+	}
+
+	/**
+	 * Data provider for `test_get_order_by_intent_id`
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_order_by_intent_id(): array {
+		return [
+			'regular table' => [
+				'custom orders table' => false,
+				'status'              => OrderStatus::COMPLETED,
+				'success'             => true,
+			],
+			'trashed order' => [
+				'custom orders table' => false,
+				'status'              => OrderStatus::TRASH,
+				'success'             => false,
+			],
+		];
+	}
+
+	/**
+	 * Test for `get_stripe_amount`
+	 *
+	 * @param int    $total    The total amount.
+	 * @param string $currency The currency.
+	 * @param int    $expected The expected amount.
+	 * @dataProvider provide_test_get_stripe_amount
+	 */
+	public function test_get_stripe_amount( int $total, string $currency, int $expected, int $price_decimals_setting = 2 ): void {
+		if ( 2 !== $price_decimals_setting ) {
+			update_option( 'woocommerce_price_num_decimals', $price_decimals_setting );
+		}
+
+		$amount = WC_Stripe_Helper::get_stripe_amount( $total, $currency );
+		$this->assertEquals( $expected, $amount );
+	}
+
+	/**
+	 * Data provider for `test_get_stripe_amount`
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_stripe_amount(): array {
+		return [
+			WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR => [
+				'total'    => 100,
+				'currency' => WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
+				'expected' => 10000,
+			],
+			WC_Stripe_Currency_Code::JAPANESE_YEN         => [
+				'total'    => 100,
+				'currency' => WC_Stripe_Currency_Code::JAPANESE_YEN,
+				'expected' => 100,
+			],
+			WC_Stripe_Currency_Code::EURO                 => [
+				'total'    => 100,
+				'currency' => WC_Stripe_Currency_Code::EURO,
+				'expected' => 10000,
+			],
+			WC_Stripe_Currency_Code::BAHRAINI_DINAR       => [
+				'total'    => 100,
+				'currency' => WC_Stripe_Currency_Code::BAHRAINI_DINAR,
+				'expected' => 100000,
+			],
+			WC_Stripe_Currency_Code::BAHRAINI_DINAR . ' (3 decimals)' => [
+				'total'                  => 100,
+				'currency'               => WC_Stripe_Currency_Code::BAHRAINI_DINAR,
+				'expected'               => 100000,
+				'price_decimals_setting' => 3,
+			],
+			WC_Stripe_Currency_Code::JORDANIAN_DINAR      => [
+				'total'    => 100,
+				'currency' => WC_Stripe_Currency_Code::JORDANIAN_DINAR,
+				'expected' => 100000,
+			],
+			WC_Stripe_Currency_Code::BURUNDIAN_FRANC      => [
+				'total'    => 100,
+				'currency' => WC_Stripe_Currency_Code::BURUNDIAN_FRANC,
+				'expected' => 100,
+			],
+		];
+	}
+
+	/**
+	 * Test for `payment_method_allows_manual_capture`
+	 *
+	 * @param string $payment_method The payment method.
+	 * @param bool   $expected       Whether manual capture is allowed.
+	 * @dataProvider provide_payment_method_allows_manual_capture
+	 * @return void
+	 */
+	public function test_payment_method_allows_manual_capture( $payment_method, $expected ): void {
+		$actual = WC_Stripe_Helper::payment_method_allows_manual_capture( $payment_method );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Provider for `test_payment_method_allows_manual_capture`
+	 *
+	 * @return array
+	 */
+	public function provide_payment_method_allows_manual_capture(): array {
+		return [
+			'Card'              => [
+				'payment_method' => 'stripe',
+				'expected'       => true,
+			],
+			'Affirm'            => [
+				'payment_method' => 'stripe_affirm',
+				'expected'       => true,
+			],
+			'Klarna'            => [
+				'payment_method' => 'stripe_klarna',
+				'expected'       => true,
+			],
+			'Afterpay/Clearpay' => [
+				'payment_method' => 'stripe_afterpay_clearpay',
+				'expected'       => true,
+			],
+			'EPS'               => [
+				'payment_method' => 'stripe_eps',
+				'expected'       => false,
+			],
+			'AmazonPay'         => [
+				'payment_method' => 'stripe_amazon_pay',
+				'expected'       => true,
+			],
+		];
+	}
+
+	public function provide_is_wallet_payment_method(): array {
+		return [
+			'Apple Pay'  => [
+				'apple_pay',
+				false,
+			],
+			'Google Pay' => [
+				'google_pay',
+				false,
+			],
+			'Alipay'     => [
+				WC_Stripe_Payment_Methods::ALIPAY,
+				false,
+			],
+			'Klarna'     => [
+				WC_Stripe_Payment_Methods::KLARNA,
+				false,
+			],
+			'EPS'        => [
+				WC_Stripe_Payment_Methods::EPS,
+				false,
+			],
+			'WeChat'     => [
+				WC_Stripe_Payment_Methods::WECHAT_PAY,
+				true,
+			],
+			'Cash App'   => [
+				WC_Stripe_Payment_Methods::CASHAPP_PAY,
+				true,
+			],
+		];
+	}
+
+	/**
+	 * Test for `update_main_stripe_settings`, `get_stripe_settings` and `delete_main_stripe_settings`.
+	 *
+	 * @return void
+	 */
+	public function test_handle_main_stripe_settings() {
+		WC_Stripe_Helper::update_main_stripe_settings( [ 'test' => 'abc' ] );
+		$current_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( $current_settings['test'], 'abc' );
+
+		WC_Stripe_Helper::delete_main_stripe_settings();
+		$current_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertSame( [], $current_settings );
+	}
+
+	/**
+	 * Test for `get_klarna_preferred_locale`.
+	 * @return void
+	 */
+	public function test_get_klarna_preferred_locale() {
+		// Language is supported for the region (same region)
+		$store_locale    = 'en_US';
+		$billing_country = 'US';
+		$expected        = 'en-US';
+		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
+		$this->assertSame( $expected, $actual );
+
+		// Language is supported for the region (different region)
+		$store_locale    = 'en_US';
+		$billing_country = 'DE';
+		$expected        = 'en-DE';
+		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
+		$this->assertSame( $expected, $actual );
+
+		// Language is supported for the region (different region)
+		$store_locale    = 'es_ES';
+		$billing_country = 'US';
+		$expected        = 'es-US';
+		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
+		$this->assertSame( $expected, $actual );
+
+		// Language is not supported for the region
+		$store_locale    = 'fr_FR';
+		$billing_country = 'US';
+		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
+		$this->assertNull( $actual );
+
+		// Region is not supported, with supported locale
+		$store_locale    = 'pt_PT';
+		$billing_country = 'BR';
+		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
+		$this->assertNull( $actual );
+
+		// Region is not supported, with non-supported locale
+		$store_locale    = 'tl';
+		$billing_country = 'PH';
+		$actual          = WC_Stripe_Helper::get_klarna_preferred_locale( $store_locale, $billing_country );
+		$this->assertNull( $actual );
+	}
+
+	/**
+	 * Test for `add_stripe_methods_in_woocommerce_gateway_order`.
+	 * @return void
+	 */
+	public function test_add_stripe_methods_in_woocommerce_gateway_order() {
+		// When the option is empty, i.e. fresh install, gateway ordering should still work.
+		$stripe_payment_methods = [
+			'stripe_klarna',
+			'card',
+			'stripe_alipay',
+		];
+		delete_option( 'woocommerce_gateway_order' );
+		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order( $stripe_payment_methods );
+		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
+		$this->assertArrayHasKey( 'stripe_klarna', $gateway_order );
+		$this->assertArrayHasKey( 'stripe', $gateway_order );
+		$this->assertArrayHasKey( 'stripe_alipay', $gateway_order );
+		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe'] );
+		$this->assertTrue( $gateway_order['stripe'] < $gateway_order['stripe_alipay'] );
+
+		// Further updates to gateway ordering should work.
+		$stripe_payment_methods = [
+			'stripe_klarna',
+			'stripe_alipay',
+			'card',
+		];
+		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order( $stripe_payment_methods );
+		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
+		$this->assertArrayHasKey( 'stripe_klarna', $gateway_order );
+		$this->assertArrayHasKey( 'stripe', $gateway_order );
+		$this->assertArrayHasKey( 'stripe_alipay', $gateway_order );
+		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe_alipay'] );
+		$this->assertTrue( $gateway_order['stripe_alipay'] < $gateway_order['stripe'] );
+
+		// Order with respect to other gateways is retained.
+		update_option(
+			'woocommerce_gateway_order',
+			[
+				'cod'           => 1,
+				'stripe_klarna' => 2,
+				'stripe'        => 3,
+				'stripe_alipay' => 4,
+				'cheque'        => 5,
+			]
+		);
+		$stripe_payment_methods = [
+			'stripe_alipay',
+			'stripe_klarna',
+			'card',
+			'stripe_affirm',
+		];
+		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order( $stripe_payment_methods );
+		$gateway_order = get_option( 'woocommerce_gateway_order', [] );
+		$this->assertTrue( $gateway_order['cod'] < $gateway_order['stripe_alipay'] );
+		$this->assertTrue( $gateway_order['stripe_alipay'] < $gateway_order['stripe_klarna'] );
+		$this->assertTrue( $gateway_order['stripe_klarna'] < $gateway_order['stripe'] );
+		$this->assertTrue( $gateway_order['stripe'] < $gateway_order['stripe_affirm'] );
+		$this->assertTrue( $gateway_order['stripe_affirm'] < $gateway_order['cheque'] );
+	}
+
+	/**
+	 * Test for `add_mandate_data`.
+	 *
+	 * @param string $server_variable_key   The key of the server variable to set.
+	 * @param string $server_variable_value The value to set the server variable to.
+	 * @param string $expected_ip_address    The expected IP address.
+	 * @dataProvider provider_test_add_mandate_data
+	 * @return void
+	 */
+	public function test_add_mandate_data( $server_variable_key, $server_variable_value, $expected_ip_address ) {
+		unset( $_SERVER['REMOTE_ADDR'] );
+		unset( $_SERVER['HTTP_X_REAL_IP'] );
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+
+		$_SERVER[ $server_variable_key ] = $server_variable_value;
+		$request                         = WC_Stripe_Helper::add_mandate_data( [] );
+		$this->assertTrue( isset( $request['mandate_data']['customer_acceptance']['online']['ip_address'] ) );
+		$ip_address = $request['mandate_data']['customer_acceptance']['online']['ip_address'];
+		$this->assertSame( $expected_ip_address, $ip_address );
+	}
+
+	/**
+	 * Data provider for `test_add_mandate_data`.
+	 *
+	 * @return array
+	 */
+	public function provider_test_add_mandate_data() {
+		return [
+			[ 'REMOTE_ADDR', '192.168.1.1', '192.168.1.1' ],
+			[ 'REMOTE_ADDR', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
+			[ 'HTTP_X_REAL_IP', '192.168.1.1', '192.168.1.1' ],
+			[ 'HTTP_X_REAL_IP', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
+			[ 'HTTP_X_FORWARDED_FOR', '192.168.1.1, 192.168.1.2, 192.168.1.3', '192.168.1.1' ],
+			[ 'HTTP_X_FORWARDED_FOR', '192.168.1.1', '192.168.1.1' ],
+			[ 'HTTP_X_REAL_IP', 'invalid-ip-address', 'invalid-ip-address' ],
+			[ 'HTTP_X_REAL_IP', '', '' ],
+		];
+	}
+
+	/**
+	 * Tests for `get_refund_reason_description`.
+	 *
+	 * @param string $refund_reason_key The refund reason key to test.
+	 * @param string $expected          The expected description.
+	 * @return void
+	 *
+	 * @dataProvider provide_test_get_refund_reason_description
+	 */
+	public function test_get_refund_reason_description( $refund_reason_key, $expected ) {
+		$this->assertSame( $expected, WC_Stripe_Helper::get_refund_reason_description( $refund_reason_key ) );
+	}
+
+	/**
+	 * Data provider for `test_get_refund_reason_description`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_refund_reason_description() {
+		return [
+			'The charge has been disputed'                 => [
+				'key'      => 'charge_for_pending_refund_disputed',
+				'expected' => 'The charge has been disputed',
+			],
+			'The refund was declined'                      => [
+				'key'      => 'declined',
+				'expected' => 'The refund was declined',
+			],
+			'The original payment method has expired or was canceled' => [
+				'key'      => 'expired_or_canceled_card',
+				'expected' => 'The original payment method has expired or was canceled',
+			],
+			'We could not process the refund at this time' => [
+				'key'      => 'insufficient_funds',
+				'expected' => 'We could not process the refund at this time',
+			],
+			'The original payment method was lost or stolen' => [
+				'key'      => 'lost_or_stolen_card',
+				'expected' => 'The original payment method was lost or stolen',
+			],
+			'We stopped processing the refund'             => [
+				'key'      => 'merchant_request',
+				'expected' => 'We stopped processing the refund',
+			],
+			'Unknown reason (random)'                      => [
+				'key'      => 'random',
+				'expected' => 'Unknown reason',
+			],
+			'Unknown reason (null)'                        => [
+				'key'      => null,
+				'expected' => 'Unknown reason',
+			],
+			'Unknown reason (empty)'                       => [
+				'key'      => '',
+				'expected' => 'Unknown reason',
+			],
+		];
+	}
+
+	/**
 	 * Tests for `has_other_bnpl_plugins_active`.
 	 *
 	 * @param array $payment_gateways The available payment gateways.


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-431

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

To prevent Affirm and Klarna from being displayed alongside other official plugins, we are now removing them when the other plugins are active. Instead of checking for any of the plugins, we are disabling each corresponding method.

I am also adding some new helper methods specific to this logic to reduce duplicate code.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout to the `develop` branch on your test environment
- Connect a US Stripe account
- Install [Affirm](https://woocommerce.com/products/woocommerce-gateway-affirm/) or [Klarna](https://woocommerce.com/products/klarna-payments/) extensions (only one is enough)
- Confirm you can see Klarna and Affirm in the payment methods settings page (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`)
- Enable both
- As a shopper, add at least 50 USD in products to your cart
- Go to the checkout page and confirm both methods are available
- Now checkout to this branch instead (`update/disable-bnpls-when-other-plugins-are-active`)
- As a shopper, confirm Klarna and Affirm are now gone from the payment methods settings page (depending on the official extension you installed, or both if you installed both)
- As a merchant, go to the checkout page and confirm that the same happened

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
