### PR TITLE
Introducing a note to promote OC

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.7.0 - xxxx-xx-xx =
+* Add - Introduces a new inbox note to promote the Optimized Checkout feature on version 9.8 and later
 * Fix - Moves the existing order lock functionality earlier in the order processing flow to prevent duplicate processing requests
 * Add - Adds two new safety filters to the subscriptions detached debug tool: `wc_stripe_detached_subscriptions_maximum_time` and `wc_stripe_detached_subscriptions_maximum_count`
 * Add - Show a notice when editing an active subscription that has no payment method attached

--- a/includes/admin/class-wc-stripe-inbox-notes.php
+++ b/includes/admin/class-wc-stripe-inbox-notes.php
@@ -64,6 +64,9 @@ class WC_Stripe_Inbox_Notes {
 
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-bnpl-promotion-note.php';
 		WC_Stripe_BNPL_Promotion_Note::init( $gateway );
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-oc-promotion-note.php';
+		WC_Stripe_OC_Promotion_Note::init( $gateway );
 	}
 
 	public static function get_campaign_2020_cutoff() {

--- a/includes/notes/class-wc-stripe-bnpl-promotion-note.php
+++ b/includes/notes/class-wc-stripe-bnpl-promotion-note.php
@@ -23,7 +23,7 @@ class WC_Stripe_BNPL_Promotion_Note {
 	const NOTE_NAME = 'wc-stripe-bnpl-promotion-note';
 
 	/**
-	 * Link to enable the UPE in store.
+	 * Link to learn more about BNPLs.
 	 */
 	const LEARN_MORE_LINK = 'https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/';
 

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -94,4 +94,13 @@ class WC_Stripe_OC_Promotion_Note {
 
 		self::possibly_add_note();
 	}
+
+	/**
+	 * Should this note exist?
+	 *
+	 * @inheritDoc
+	 */
+	public static function is_applicable() {
+		return ! WC_Stripe::get_instance()->get_main_stripe_gateway()->is_oc_enabled();
+	}
 }

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -23,9 +23,9 @@ class WC_Stripe_OC_Promotion_Note {
 	const NOTE_NAME = 'wc-stripe-oc-promotion-note';
 
 	/**
-	 * Link to activate OC.
+	 * Link to learn more about OC.
 	 */
-	const ACTIVATE_NOW_LINK = 'https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/';
+	const LEARN_MORE_LINK = 'https://href.li/?https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/';
 
 	/**
 	 * Get the note.
@@ -41,8 +41,8 @@ class WC_Stripe_OC_Promotion_Note {
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			self::NOTE_NAME,
-			__( 'Activate now', 'woocommerce-gateway-stripe' ),
-			self::ACTIVATE_NOW_LINK,
+			__( 'Learn more', 'woocommerce-gateway-stripe' ),
+			self::LEARN_MORE_LINK,
 			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Display a notice to merchants to promote OC (Optimized Checkout).
+ *
+ * @package WooCommerce\Payments\Admin
+ */
+
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class WC_Stripe_OC_Promotion_Note
+ */
+class WC_Stripe_OC_Promotion_Note {
+	use NoteTraits;
+
+	/**
+	 * Name of the note for use in the database.
+	 */
+	const NOTE_NAME = 'wc-stripe-oc-promotion-note';
+
+	/**
+	 * Link to activate OC.
+	 */
+	const ACTIVATE_NOW_LINK = 'https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/';
+
+	/**
+	 * Get the note.
+	 */
+	public static function get_note() {
+		$note_class = self::get_note_class();
+		$note       = new $note_class();
+
+		$note->set_title( __( 'Increase conversions with Stripe\'s Optimized Checkout Suite', 'woocommerce-gateway-stripe' ) );
+		$note->set_content( __( 'Optimize your checkout for more sales by automatically displaying the most relevant payment methods for each customer.', 'woocommerce-gateway-stripe' ) );
+		$note->set_type( $note_class::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_source( 'woocommerce-gateway-stripe' );
+		$note->add_action(
+			self::NOTE_NAME,
+			__( 'Activate now', 'woocommerce-gateway-stripe' ),
+			self::ACTIVATE_NOW_LINK,
+			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
+			true
+		);
+
+		return $note;
+	}
+
+	/**
+	 * Get the class type to be used for the note.
+	 *
+	 * @return string
+	 */
+	private static function get_note_class() {
+		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
+			return Note::class;
+		} else {
+			return WC_Admin_Note::class;
+		}
+	}
+
+	/**
+	 * Init OC promotion notification
+	 *
+	 * @param WC_Stripe_Payment_Gateway $gateway
+	 *
+	 * @return void
+	 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException
+	 */
+	public static function init( WC_Stripe_Payment_Gateway $gateway ) {
+		/**
+		 * No need to display the admin inbox note when
+		 * - Below version 9.8
+		 * - OC is already enabled
+		 * - Stripe is not enabled
+		 */
+		if ( ! defined( 'WC_STRIPE_VERSION' ) || version_compare( WC_STRIPE_VERSION, '9.8', '<' ) ) {
+			return;
+		}
+
+		if ( $gateway->is_oc_enabled() ) {
+			return;
+		}
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_enabled  = isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
+		if ( ! $stripe_enabled ) {
+			return;
+		}
+
+		self::possibly_add_note();
+	}
+}

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -25,7 +25,7 @@ class WC_Stripe_OC_Promotion_Note {
 	/**
 	 * Link to learn more about OC.
 	 */
-	const LEARN_MORE_LINK = 'https://href.li/?https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/';
+	const LEARN_MORE_LINK = 'https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/';
 
 	/**
 	 * Get the note.

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.7.0 - xxxx-xx-xx =
+* Add - Introduces a new inbox note to promote the Optimized Checkout feature on version 9.8 and later
 * Fix - Moves the existing order lock functionality earlier in the order processing flow to prevent duplicate processing requests
 * Add - Adds two new safety filters to the subscriptions detached debug tool: `wc_stripe_detached_subscriptions_maximum_time` and `wc_stripe_detached_subscriptions_maximum_count`
 * Add - Show a notice when editing an active subscription that has no payment method attached

--- a/tests/phpunit/Notes/WC_Stripe_BNPL_Promotion_Note_Test.php
+++ b/tests/phpunit/Notes/WC_Stripe_BNPL_Promotion_Note_Test.php
@@ -23,9 +23,9 @@ class WC_Stripe_BNPL_Promotion_Note_Test extends WP_UnitTestCase {
 		$this->assertSame( 'wc-stripe-bnpl-promotion-note', $note->get_name() );
 		$this->assertSame( 'woocommerce-gateway-stripe', $note->get_source() );
 
-		list( $enable_upe_action ) = $note->get_actions();
-		$this->assertSame( 'wc-stripe-bnpl-promotion-note', $enable_upe_action->name );
-		$this->assertSame( 'Learn more', $enable_upe_action->label );
-		$this->assertSame( 'https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/', $enable_upe_action->query );
+		list( $learn_more_action ) = $note->get_actions();
+		$this->assertSame( 'wc-stripe-bnpl-promotion-note', $learn_more_action->name );
+		$this->assertSame( 'Learn more', $learn_more_action->label );
+		$this->assertSame( 'https://woocommerce.com/document/stripe/setup-and-configuration/additional-payment-methods/', $learn_more_action->query );
 	}
 }

--- a/tests/phpunit/Notes/WC_Stripe_OC_Promotion_Note_Test.php
+++ b/tests/phpunit/Notes/WC_Stripe_OC_Promotion_Note_Test.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests\Notes;
+
+use WC_Stripe_OC_Promotion_Note;
+use WP_UnitTestCase;
+
+/**
+ * Class WC_Stripe_OC_Promotion_Note_Test
+ *
+ * @package WooCommerce/Stripe/WC_Stripe_OC_Promotion_Note
+ *
+ * Class WC_Stripe_OC_Promotion_Note tests.
+ */
+class WC_Stripe_OC_Promotion_Note_Test extends WP_UnitTestCase {
+	public function test_get_note() {
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-oc-promotion-note.php';
+		$note = WC_Stripe_OC_Promotion_Note::get_note();
+
+		$this->assertSame( 'Increase conversions with Stripe\'s Optimized Checkout Suite', $note->get_title() );
+		$this->assertSame( 'Optimize your checkout for more sales by automatically displaying the most relevant payment methods for each customer.', $note->get_content() );
+		$this->assertSame( 'marketing', $note->get_type() );
+		$this->assertSame( 'wc-stripe-oc-promotion-note', $note->get_name() );
+		$this->assertSame( 'woocommerce-gateway-stripe', $note->get_source() );
+
+		list( $learn_more_action ) = $note->get_actions();
+		$this->assertSame( 'wc-stripe-oc-promotion-note', $learn_more_action->name );
+		$this->assertSame( 'Learn more', $learn_more_action->label );
+		$this->assertSame( 'https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/', $learn_more_action->query );
+	}
+}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-547
Figma nFI8jCCAQnd19PNwScqVU6-fi
P2 changing the "Activate now" to "Learn more" pcUrMV-b1m-p2#comment-33344

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR introduces a new note to be displayed on the WooCommerce admin home, promoting OC (Optimized Checkout). The note is added when the Stripe extension is enabled, the version is above 9.8, and OC is not enabled.

<img width="716" height="225" alt="Screenshot 2025-07-15 at 11 29 50" src="https://github.com/user-attachments/assets/199f2e26-9e8c-4f51-84ca-f80a8042c8fc" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout to this branch on your test environment (`add/oc-promotional-inbox-note`)
- Connect your Stripe account
- Hardcode the minimum required extension version to `9.6` in `/includes/notes/class-wc-stripe-oc-promotion-note.php#81`
- Make sure the OC flag is enabled (`_wcstripe_feature_oc` or the `wc_stripe_is_optimized_checkout_available` filter), but the feature disabled
- Confirm the note is added and is correctly displayed on your inbox (`wp-admin/admin.php?page=wc-admin`)
- Check if it matches the Figma design contents
- Confirm that by clicking "Learn more" you are sent to `https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/`
- Confirm that by clicking "Dismiss" the note is gone
- You can make additional tests for the conditions by deleting the note in the `wp_wc_admin_notes ` database table and enabling OC to confirm the note is not added

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
