### PR TITLE
Prevent "Undefined array key charges_enabled" PHP warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Fix - Set default values for custom field options
 * Fix - Enforce rate limiter for failed add payment method attempts
 * Update - Add the number of pending webhooks to the Account status section
+* Fix - Prevent "Undefined array key charges_enabled" PHP warning when determining live‑mode status
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -134,7 +134,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 					'supported' => $this->account->get_supported_store_currencies(),
 				],
 				'country'                  => $account['country'] ?? WC()->countries->get_base_country(),
-				'is_live'                  => WC_Stripe_Mode::is_live() && $account['charges_enabled'] ?? false,
+				'is_live'                  => WC_Stripe_Mode::is_live() && ( $account['charges_enabled'] ?? false ),
 				'test_mode'                => WC_Stripe_Mode::is_test(),
 			]
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -131,5 +131,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Set default values for custom field options
 * Fix - Enforce rate limiter for failed add payment method attempts
 * Update - Add the number of pending webhooks to the Account status section
+* Fix - Prevent "Undefined array key charges_enabled" PHP warning when determining live‑mode status
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-585

## Changes proposed in this Pull Request:
A simple fix to prevent the `Undefined array key charges_enabled` warning.

`$account['charges_enabled']` was being evaluated before the `?? false` fallback can kick in because of the operator‑precedence order (`&&` takes precedence over `??`).

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

A code review is sufficient.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
