### PR TITLE
Increase onboarding notice localstorage expiration time to 1hr

### DIFF
--- a/client/settings/stripe-account-connected-notice/index.js
+++ b/client/settings/stripe-account-connected-notice/index.js
@@ -8,6 +8,8 @@ import {
 } from 'wcstripe/stripe-utils/utils';
 
 const LOCAL_STORAGE_KEY = 'wc_stripe_is_onboarding_through_wc_setup';
+const EXPIRATION_TIME = 60 * 60 * 1000; // 1 hour in milliseconds
+
 const query = new URLSearchParams( window.location.search );
 const from = query.get( 'from' );
 
@@ -27,7 +29,7 @@ if (
 	newAccountContainer &&
 	! isPaymentOnboardingTaskComplete
 ) {
-	setStorageWithExpiration( LOCAL_STORAGE_KEY, 'true', 60000 );
+	setStorageWithExpiration( LOCAL_STORAGE_KEY, 'true', EXPIRATION_TIME );
 }
 
 const shouldShowNotice = () => {


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-591

## Changes proposed in this Pull Request:
This increases the expiration time of the local storage key that's used to identify a new merchant entering the onboarding flow. The previous expiration time (1 minute) was not sufficient for merchants going through the entire KYC flow, so the notice was never displayed to them.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Create a build of this branch.
2. Create a new Jurassic Ninja site and upload and activate the build.
3. Install WooCommerce and go through the guided onboarding process.
4. Click on the "Get paid" onboarding task
![CleanShot 2025-07-02 at 15 59 48@2x](https://github.com/user-attachments/assets/c695c894-8539-4eee-8f29-e2e938df7e42)
5. Click the "Complete setup" option next to Stripe.
6. Go through Stripe onboarding flow.
7. In *develop*, if you wait more than 1 minute between entering the Stripe KYC flow and exiting it, the notice will not be displayed. In this branch, it should be displayed as long as you complete it within an hour.

![CleanShot 2025-07-02 at 15 37 03@2x](https://github.com/user-attachments/assets/eb44a64c-8ac1-4db6-a9a6-278c7259db83)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### This change tweaks a feature that has not yet been released publicly.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
