### PR TITLE
[ECE] Fix state mapping for Lithuania

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Update - Add the number of pending webhooks to the Account status section
 * Fix - Prevent "Undefined array key charges_enabled" PHP warning when determining live‑mode status
 * Update - Deprecate `wc_gateway_stripe_process_payment`, `wc_gateway_stripe_process_redirect_payment` and `wc_gateway_stripe_process_webhook_payment` actions in favour of `wc_gateway_stripe_process_payment_charge`
+* Add - Add state mapping for Lithuania in express checkout
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/includes/constants/class-wc-stripe-payment-request-button-states.php
+++ b/includes/constants/class-wc-stripe-payment-request-button-states.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *    1. WC provides a dropdown list of states, but there's no state field in Chrome for the following countries:
  *        AO (Angola), BD (Bangladesh), BG (Bulgaria), BJ (Benin), BO (Bolivia), DO (Dominican Republic),
  *        DZ (Algeria), GH (Ghana), GT (Guatemala), HU (Hungary), KE (Kenya), LA (Laos),
- *        LR (Liberia), MD (Moldova), NA (Namibia), NP (Nepal), PK (Pakistan),
+ *        LR (Liberia), LT (Lithuania), MD (Moldova), NA (Namibia), NP (Nepal), PK (Pakistan),
  *        PY (Paraguay), RO (Romania), TZ (Tanzania), UG (Uganda), UM (United States Minor Outlying Islands),
  *        ZA (South Africa), ZM (Zambia).
  *    2. Chrome does not provide a dropdown list of states for 161 countries in total, out of the 249 countries WC supports,
@@ -648,6 +648,8 @@ class WC_Stripe_Payment_Request_Button_States {
 		'LK' => [],
 		// Liberia.
 		'LR' => [],
+		// Lithuania.
+		'LT' => [],
 		// Luxembourg.
 		'LU' => [],
 		// Moldova.

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Add the number of pending webhooks to the Account status section
 * Fix - Prevent "Undefined array key charges_enabled" PHP warning when determining live‑mode status
 * Update - Deprecate `wc_gateway_stripe_process_payment`, `wc_gateway_stripe_process_redirect_payment` and `wc_gateway_stripe_process_webhook_payment` actions in favour of `wc_gateway_stripe_process_payment_charge`
+* Add - Add state mapping for Lithuania in express checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Reported in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4451#issuecomment-3078801734

## Changes proposed in this Pull Request:
The mapping for Lithuania was missing in `includes/constants/class-wc-stripe-payment-request-button-states.php`. The state field is not required for Lithuania in Google/Apple Pay. 

## Testing instructions
- Enable express checkout in your Stripe settings page.
- In your Google account, add a new address based in Lithuania but leave the `Province` field empty (it is optional)
- As a shopper, add a product to your cart and go to the checkout page.
- Click Google Pay and select the address in Lithuania as the shipping address.
- Click the `Pay` button.
- In `develop`, the checkout will fail with the following error.

<img width="1024" height="88" alt="Screenshot 2025-07-17 at 11 38 38 AM" src="https://github.com/user-attachments/assets/305c8e2a-a481-4bec-87aa-a5418af18a39" />


- In this branch, checkout should be successful. Confirm that the shipping address is correct in your order details page. 