### PR TITLE
Fix unnecessary payment method creation when checkout has validation errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Update - Add the number of pending webhooks to the Account status section
 * Fix - Prevent "Undefined array key charges_enabled" PHP warning when determining live‑mode status
 * Update - Deprecate `wc_gateway_stripe_process_payment`, `wc_gateway_stripe_process_redirect_payment` and `wc_gateway_stripe_process_webhook_payment` actions in favour of `wc_gateway_stripe_process_payment_charge`
+* Tweak - Check for checkout validation error before creating a payment method in Stripe
 
 = 9.6.0 - 2025-07-07 =
 * Fix - Register Express Checkout script before use to restore buttons on “order-pay” pages

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -194,11 +194,11 @@ const PaymentProcessor = ( {
 						};
 					}
 
-					const hasError = document.querySelector(
+					const hasValidationError = document.querySelector(
 						'.wc-block-components-validation-error'
 					);
 					// Return if there is a validation error on the checkout fields.
-					if ( hasError ) {
+					if ( hasValidationError ) {
 						return;
 					}
 

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -194,6 +194,14 @@ const PaymentProcessor = ( {
 						};
 					}
 
+					const hasError = document.querySelector(
+						'.wc-block-components-validation-error'
+					);
+					// Return if there is a validation error on the checkout fields.
+					if ( hasError ) {
+						return;
+					}
+
 					// BLIK is a special case which is not handled through the Stripe element.
 					if ( ! ( isPaymentElementComplete || isBlikSelected ) ) {
 						return {

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -3,6 +3,7 @@
  */
 import { getPaymentMethods } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
+import { select } from '@wordpress/data';
 import {
 	PaymentElement,
 	useElements,
@@ -194,12 +195,14 @@ const PaymentProcessor = ( {
 						};
 					}
 
-					const hasValidationError = document.querySelector(
-						'.wc-block-components-validation-error'
-					);
-					// Return if there is a validation error on the checkout fields.
-					if ( hasValidationError ) {
-						return;
+					const { validationStore } = window.wc?.wcBlocksData ?? {};
+					if ( validationStore ) {
+						const store = select( validationStore );
+						const hasValidationErrors = store.hasValidationErrors();
+						// Return if there is a validation error on the checkout fields.
+						if ( hasValidationErrors ) {
+							return;
+						}
 					}
 
 					// BLIK is a special case which is not handled through the Stripe element.

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -41,6 +41,20 @@ jQuery( function ( $ ) {
 	} );
 
 	$( 'form.checkout' ).on( generateCheckoutEventNames(), function () {
+		const $form = $( 'form.checkout' );
+		// Lose focus for all fields to trigger validation
+		$form
+			.find( '.input-text, select, input:checkbox' )
+			.trigger( 'validate' )
+			.trigger( 'blur' );
+
+		if (
+			$form.find( '.woocommerce-invalid' ).length > 0 &&
+			$form.find( '.woocommerce-invalid' ).is( ':visible' )
+		) {
+			return;
+		}
+
 		return processPaymentIfNotUsingSavedMethod( $( this ) );
 	} );
 

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -48,10 +48,12 @@ jQuery( function ( $ ) {
 			.trigger( 'validate' )
 			.trigger( 'blur' );
 
-		if (
+		const hasValidationErrors =
 			$form.find( '.woocommerce-invalid' ).length > 0 &&
-			$form.find( '.woocommerce-invalid' ).is( ':visible' )
-		) {
+			$form.find( '.woocommerce-invalid' ).is( ':visible' );
+
+		// Return if there is a validation error on the checkout fields
+		if ( hasValidationErrors ) {
 			return;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Add the number of pending webhooks to the Account status section
 * Fix - Prevent "Undefined array key charges_enabled" PHP warning when determining live‑mode status
 * Update - Deprecate `wc_gateway_stripe_process_payment`, `wc_gateway_stripe_process_redirect_payment` and `wc_gateway_stripe_process_webhook_payment` actions in favour of `wc_gateway_stripe_process_payment_charge`
+* Tweak - Check for checkout validation error before creating a payment method in Stripe
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-589

## Changes proposed in this Pull Request:
- Before calling `stripe.createPaymentMethod` checking the page for any validation error.

## Testing instructions
- Enable card in your Stripe settings
- As a shopper, open your browser in private/incognito mode and open the network tab of your developer console.
- Add a product to your cart and go to the block checkout page.
- Without filling in the email or billing details enter card details and click the place order button.
- In `develop`, 
    - Notice that a request is sent to Stripe to create a payment method but the checkout does not go through as there are missing required fields.
- In this branch, 
    - Confirm that no request is sent to Stripe to create a payment method.
    - Fill in all the required fields and click checkout again. Confirm that a request is sent to Stripe to create a payment method, this time and the checkout succeeds.
- Do the same test for the shortcode checkout.