### PR TITLE
Fix OC promotional inbox note CTA

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
-* Fix - Fixes the CTA button on the Optimized Checkout promotional inbox note to correctly link to the Stripe settings page
+* Fix - Update the Optimized Checkout promotional inbox note to link to the relevant section in the Stripe settings page
 * Add - Adds a new bulk action option to the subscriptions listing screen to check for detached payment methods
 * Dev - Use product type constants that were added in WooCommerce 9.7
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.7.0 - xxxx-xx-xx =
+* Fix - Fixes the CTA button on the Optimized Checkout promotional banner to correctly link to the Stripe settings page
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class
 * Add - Introduces a new banner to promote the Optimized Checkout feature in the Stripe settings page for versions 9.8 and above
 * Add - Introduces a new inbox note to promote the Optimized Checkout feature on version 9.8 and later

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.7.0 - xxxx-xx-xx =
-* Fix - Fixes the CTA button on the Optimized Checkout promotional banner to correctly link to the Stripe settings page
+* Fix - Fixes the CTA button on the Optimized Checkout promotional inbox note to correctly link to the Stripe settings page
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class
 * Add - Introduces a new banner to promote the Optimized Checkout feature in the Stripe settings page for versions 9.8 and above
 * Add - Introduces a new inbox note to promote the Optimized Checkout feature on version 9.8 and later

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -1,14 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import React, { useContext } from 'react';
 import userEvent from '@testing-library/user-event';
-import SinglePaymentElementFeature from 'wcstripe/settings/advanced-settings-section/single-payment-element-feature';
+import OptimizedCheckoutFeature from 'wcstripe/settings/advanced-settings-section/optimized-checkout-feature';
 import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 
 jest.useFakeTimers();
 
 describe( 'Single Payment Element feature setting', () => {
 	it( 'should render', () => {
-		render( <SinglePaymentElementFeature /> );
+		render( <OptimizedCheckoutFeature /> );
 
 		expect(
 			screen.queryByText(
@@ -29,7 +29,7 @@ describe( 'Single Payment Element feature setting', () => {
 		render(
 			<div>
 				<UpdateUpeDisabledFlagMock />
-				<SinglePaymentElementFeature />
+				<OptimizedCheckoutFeature />
 			</div>
 		);
 

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -6,7 +6,7 @@ import SettingsSection from '../settings-section';
 import CardBody from '../card-body';
 import DebugMode from './debug-mode';
 import LoadableSettingsSection from 'wcstripe/settings/loadable-settings-section';
-import SinglePaymentElementFeature from 'wcstripe/settings/advanced-settings-section/single-payment-element-feature';
+import OptimizedCheckoutFeature from 'wcstripe/settings/advanced-settings-section/optimized-checkout-feature';
 
 const AdvancedSettingsDescription = () => (
 	<>
@@ -28,7 +28,7 @@ const AdvancedSettings = () => {
 				<Card>
 					<CardBody>
 						<DebugMode />
-						{ isOcAvailable && <SinglePaymentElementFeature /> }
+						{ isOcAvailable && <OptimizedCheckoutFeature /> }
 					</CardBody>
 				</Card>
 			</LoadableSettingsSection>

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -41,7 +41,7 @@ const OptimizedCheckoutFeature = () => {
 				block: 'start',
 			} );
 		}
-	}, [] );
+	}, [ headingRef ] );
 
 	const handleTitleChange = ( value ) => {
 		setLocalOCTitle( value );

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -35,7 +35,7 @@ const OptimizedCheckoutFeature = () => {
 		}
 
 		const { highlight } = getQuery();
-		if ( highlight === 'enable-oc' ) {
+		if ( highlight === 'enable-optimized-checkout' ) {
 			headingRef.current.scrollIntoView( {
 				behavior: 'smooth',
 				block: 'start',

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -9,7 +9,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { getQuery } from '@woocommerce/navigation';
 import { useIsOCEnabled, useIsUpeEnabled, useOCTitle } from '../../data';
 
-const SinglePaymentElementFeature = () => {
+const OptimizedCheckoutFeature = () => {
 	const [ isOCEnabled, setIsOCEnabled ] = useIsOCEnabled();
 	const [ OCTitle, setOCTitle ] = useOCTitle();
 	const [ isUpeEnabled ] = useIsUpeEnabled();
@@ -105,4 +105,4 @@ const SinglePaymentElementFeature = () => {
 	);
 };
 
-export default SinglePaymentElementFeature;
+export default OptimizedCheckoutFeature;

--- a/client/settings/advanced-settings-section/single-payment-element-feature.js
+++ b/client/settings/advanced-settings-section/single-payment-element-feature.js
@@ -5,13 +5,15 @@ import {
 	ExternalLink,
 	TextControl,
 } from '@wordpress/components';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { getQuery } from '@woocommerce/navigation';
 import { useIsOCEnabled, useIsUpeEnabled, useOCTitle } from '../../data';
 
 const SinglePaymentElementFeature = () => {
 	const [ isOCEnabled, setIsOCEnabled ] = useIsOCEnabled();
 	const [ OCTitle, setOCTitle ] = useOCTitle();
 	const [ isUpeEnabled ] = useIsUpeEnabled();
+	const headingRef = useRef( null );
 
 	useEffect( () => {
 		if ( ! isUpeEnabled ) {
@@ -26,6 +28,20 @@ const SinglePaymentElementFeature = () => {
 	useEffect( () => {
 		setLocalOCTitle( OCTitle );
 	}, [ OCTitle ] );
+
+	useEffect( () => {
+		if ( ! headingRef.current ) {
+			return;
+		}
+
+		const { highlight } = getQuery();
+		if ( highlight === 'enable-oc' ) {
+			headingRef.current.scrollIntoView( {
+				behavior: 'smooth',
+				block: 'start',
+			} );
+		}
+	}, [] );
 
 	const handleTitleChange = ( value ) => {
 		setLocalOCTitle( value );
@@ -45,7 +61,7 @@ const SinglePaymentElementFeature = () => {
 
 	return (
 		<>
-			<h4>
+			<h4 ref={ headingRef }>
 				{ __(
 					'Enable Optimized Checkout Suite (recommended)',
 					'woocommerce-gateway-stripe'

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -25,7 +25,7 @@ class WC_Stripe_OC_Promotion_Note {
 	/**
 	 * Link to activate OC in store.
 	 */
-	const ACTIVATE_NOW_LINK = '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-oc';
+	private const ACTIVATE_NOW_LINK = '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-oc';
 
 	/**
 	 * Get the note.

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -23,9 +23,9 @@ class WC_Stripe_OC_Promotion_Note {
 	const NOTE_NAME = 'wc-stripe-oc-promotion-note';
 
 	/**
-	 * Link to learn more about OC.
+	 * Link to activate OC in store.
 	 */
-	const LEARN_MORE_LINK = 'https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/';
+	const ACTIVATE_NOW_LINK = '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-oc';
 
 	/**
 	 * Get the note.
@@ -41,8 +41,8 @@ class WC_Stripe_OC_Promotion_Note {
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			self::NOTE_NAME,
-			__( 'Learn more', 'woocommerce-gateway-stripe' ),
-			self::LEARN_MORE_LINK,
+			__( 'Activate now', 'woocommerce-gateway-stripe' ),
+			self::ACTIVATE_NOW_LINK,
 			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -25,7 +25,7 @@ final class WC_Stripe_OC_Promotion_Note {
 	/**
 	 * Link to activate OC in store.
 	 */
-	private const ACTIVATE_NOW_LINK = '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-oc';
+	private const ACTIVATE_NOW_LINK = '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-optimized-checkout';
 
 	/**
 	 * Get the note.

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class WC_Stripe_OC_Promotion_Note
  */
-class WC_Stripe_OC_Promotion_Note {
+final class WC_Stripe_OC_Promotion_Note {
 	use NoteTraits;
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
-* Fix - Fixes the CTA button on the Optimized Checkout promotional inbox note to correctly link to the Stripe settings page
+* Fix - Update the Optimized Checkout promotional inbox note to link to the relevant section in the Stripe settings page
 * Add - Adds a new bulk action option to the subscriptions listing screen to check for detached payment methods
 * Dev - Use product type constants that were added in WooCommerce 9.7
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.7.0 - xxxx-xx-xx =
-* Fix - Fixes the CTA button on the Optimized Checkout promotional banner to correctly link to the Stripe settings page
+* Fix - Fixes the CTA button on the Optimized Checkout promotional inbox note to correctly link to the Stripe settings page
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class
 * Add - Introduces a new banner to promote the Optimized Checkout feature in the Stripe settings page for versions 9.8 and above
 * Add - Introduces a new inbox note to promote the Optimized Checkout feature on version 9.8 and later

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.7.0 - xxxx-xx-xx =
+* Fix - Fixes the CTA button on the Optimized Checkout promotional banner to correctly link to the Stripe settings page
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class
 * Add - Introduces a new banner to promote the Optimized Checkout feature in the Stripe settings page for versions 9.8 and above
 * Add - Introduces a new inbox note to promote the Optimized Checkout feature on version 9.8 and later

--- a/tests/phpunit/Notes/WC_Stripe_OC_Promotion_Note_Test.php
+++ b/tests/phpunit/Notes/WC_Stripe_OC_Promotion_Note_Test.php
@@ -26,6 +26,6 @@ class WC_Stripe_OC_Promotion_Note_Test extends WP_UnitTestCase {
 		list( $learn_more_action ) = $note->get_actions();
 		$this->assertSame( 'wc-stripe-oc-promotion-note', $learn_more_action->name );
 		$this->assertSame( 'Activate now', $learn_more_action->label );
-		$this->assertSame( '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-oc', $learn_more_action->query );
+		$this->assertSame( '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-optimized-checkout', $learn_more_action->query );
 	}
 }

--- a/tests/phpunit/Notes/WC_Stripe_OC_Promotion_Note_Test.php
+++ b/tests/phpunit/Notes/WC_Stripe_OC_Promotion_Note_Test.php
@@ -25,7 +25,7 @@ class WC_Stripe_OC_Promotion_Note_Test extends WP_UnitTestCase {
 
 		list( $learn_more_action ) = $note->get_actions();
 		$this->assertSame( 'wc-stripe-oc-promotion-note', $learn_more_action->name );
-		$this->assertSame( 'Learn more', $learn_more_action->label );
-		$this->assertSame( 'https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/', $learn_more_action->query );
+		$this->assertSame( 'Activate now', $learn_more_action->label );
+		$this->assertSame( '?page=wc-settings&tab=checkout&section=stripe&panel=settings&highlight=enable-oc', $learn_more_action->query );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-633
Base PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4493
Figma nFI8jCCAQnd19PNwScqVU6-fi

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes the Optimized Checkout promotional inbox note CTA to match the Figma designs. In the original implementation, the CTA would open a new window with the specific documentation for OC. Now, it goes to the settings screen and scrolls down to the OC heading (following the behavior we had to UPE).

I am also taking the opportunity to rename the `SinglePaymentElementFeature` component to `OptimizedCheckoutFeature`.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Same as https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4493. Check that the CTA will send you to the settings screen, scrolling down until you reach the OC heading.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
