### PR TITLE
Deactivates Affirm or Klarna in PMC when other extensions are active

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.7.0 - xxxx-xx-xx =
+* Update - Deactivates Affirm or Klarna when other official plugins are active in merchant's Payment Method Configuration
 * Dev - Use product type constants that were added in WooCommerce 9.7
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class
 * Add - Introduces a new banner to promote the Optimized Checkout feature in the Stripe settings page for versions 9.8 and above

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -877,10 +877,10 @@ class WC_Stripe {
 
 		$enabled_payment_methods       = $gateway->get_upe_enabled_payment_method_ids();
 		$payment_method_ids_to_disable = [];
-		if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true ) && $has_affirm_plugin_active ) {
+		if ( $has_affirm_plugin_active && in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true ) ) {
 			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
 		}
-		if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true ) && $has_klarna_plugin_active ) {
+		if ( $has_klarna_plugin_active && in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true ) ) {
 			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
 		}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -874,6 +874,9 @@ class WC_Stripe {
 		}
 
 		$gateway = $this->get_main_stripe_gateway();
+		if ( ! is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
+			return;
+		}
 
 		$enabled_payment_methods       = $gateway->get_upe_enabled_payment_method_ids();
 		$payment_method_ids_to_disable = [];

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -281,6 +281,9 @@ class WC_Stripe {
 		add_action( 'init', [ $this, 'initialize_status_page' ], 15 );
 
 		add_action( 'init', [ $this, 'initialize_apple_pay_registration' ] );
+
+		// Check if other official plugins are active for Klarna or Affirm and deactivate those BNPLs if so.
+		add_action( 'init', [ $this, 'maybe_deactivate_bnpls' ] );
 	}
 
 	/**
@@ -856,5 +859,40 @@ class WC_Stripe {
 
 		$wcstripe_status = new WC_Stripe_Status( self::get_main_stripe_gateway(), $this->account );
 		$wcstripe_status->init_hooks();
+	}
+
+	/**
+	 * Maybe deactivate Affirm or Klarna payment methods if other official plugins are active.
+	 *
+	 * @return void
+	 */
+	public function maybe_deactivate_bnpls() {
+		$has_affirm_plugin_active = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM );
+		$has_klarna_plugin_active = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA );
+		if ( ! $has_affirm_plugin_active && ! $has_klarna_plugin_active ) {
+			return;
+		}
+
+		$gateway = $this->get_main_stripe_gateway();
+
+		$enabled_payment_methods       = $gateway->get_upe_enabled_payment_method_ids();
+		$payment_method_ids_to_disable = [];
+		if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true ) && $has_affirm_plugin_active ) {
+			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
+		}
+		if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true ) && $has_klarna_plugin_active ) {
+			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
+		}
+
+		if ( [] === $payment_method_ids_to_disable ) {
+			return;
+		}
+
+		$gateway->update_enabled_payment_methods(
+			array_diff(
+				$enabled_payment_methods,
+				$payment_method_ids_to_disable
+			)
+		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3354,7 +3354,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
 				$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
 			}
-			if ( count( $payment_method_ids_to_disable ) > 0 ) {
+			if ( $payment_method_ids_to_disable !== [] ) {
 				$this->update_enabled_payment_methods(
 					array_diff(
 						$enabled_payment_methods,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3344,18 +3344,22 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		if ( WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
 			$enabled_payment_methods       = $this->get_upe_enabled_payment_method_ids();
 			$payment_method_ids_to_disable = [];
-			if ( WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
+			if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true )
+				&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
 				$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
 			}
-			if ( WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
+			if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true )
+				&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
 				$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
 			}
-			$this->update_enabled_payment_methods(
-				array_diff(
-					$enabled_payment_methods,
-					$payment_method_ids_to_disable
-				)
-			);
+			if ( count( $payment_method_ids_to_disable ) > 0 ) {
+				$this->update_enabled_payment_methods(
+					array_diff(
+						$enabled_payment_methods,
+						$payment_method_ids_to_disable
+					)
+				);
+			}
 		}
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3341,7 +3341,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return void
 	 */
 	private function maybe_deactivate_bnpls() {
-		if ( WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
+		if ( ! WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
+			return;
+		}
 			$enabled_payment_methods       = $this->get_upe_enabled_payment_method_ids();
 			$payment_method_ids_to_disable = [];
 			if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true )

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -238,9 +238,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Check if pre-orders are enabled and add support for them.
 		$this->maybe_init_pre_orders();
 
-		// Check if other official plugins are active for Klarna or Affirm and deactivate those BNPLs if so.
-		$this->maybe_deactivate_bnpls();
-
 		$this->title                         = $this->payment_methods['card']->get_title();
 		$this->description                   = $this->payment_methods['card']->get_description();
 		$this->enabled                       = $this->get_option( 'enabled' );
@@ -3333,38 +3330,5 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// considered enabled if either is enabled in Stripe.
 		return in_array( WC_Stripe_Payment_Methods::APPLE_PAY, $enabled_payment_method_ids, true ) ||
 			in_array( WC_Stripe_Payment_Methods::GOOGLE_PAY, $enabled_payment_method_ids, true );
-	}
-
-	/**
-	 * Maybe deactivate Affirm or Klarna payment methods if other official plugins are active.
-	 *
-	 * @return void
-	 */
-	private function maybe_deactivate_bnpls() {
-		$has_affirm_plugin_active = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM );
-		$has_klarna_plugin_active = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA );
-		if ( ! $has_affirm_plugin_active && ! $has_klarna_plugin_active ) {
-			return;
-		}
-
-		$enabled_payment_methods       = $this->get_upe_enabled_payment_method_ids();
-		$payment_method_ids_to_disable = [];
-		if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true ) && $has_affirm_plugin_active ) {
-			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
-		}
-		if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true ) && $has_klarna_plugin_active ) {
-			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
-		}
-
-		if ( [] === $payment_method_ids_to_disable ) {
-			return;
-		}
-
-		$this->update_enabled_payment_methods(
-			array_diff(
-				$enabled_payment_methods,
-				$payment_method_ids_to_disable
-			)
-		);
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3344,24 +3344,24 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		if ( ! WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
 			return;
 		}
-			$enabled_payment_methods       = $this->get_upe_enabled_payment_method_ids();
-			$payment_method_ids_to_disable = [];
-			if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true )
-				&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
-				$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
-			}
-			if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true )
-				&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
-				$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
-			}
-			if ( $payment_method_ids_to_disable !== [] ) {
-				$this->update_enabled_payment_methods(
-					array_diff(
-						$enabled_payment_methods,
-						$payment_method_ids_to_disable
-					)
-				);
-			}
+
+		$enabled_payment_methods       = $this->get_upe_enabled_payment_method_ids();
+		$payment_method_ids_to_disable = [];
+		if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true )
+			&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
+			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
+		}
+		if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true )
+			&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
+			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
+		}
+		if ( [] !== $payment_method_ids_to_disable ) {
+			$this->update_enabled_payment_methods(
+				array_diff(
+					$enabled_payment_methods,
+					$payment_method_ids_to_disable
+				)
+			);
 		}
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -238,6 +238,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// Check if pre-orders are enabled and add support for them.
 		$this->maybe_init_pre_orders();
 
+		// Check if other official plugins are active for Klarna or Affirm and deactivate those BNPLs if so.
+		$this->maybe_deactivate_bnpls();
+
 		$this->title                         = $this->payment_methods['card']->get_title();
 		$this->description                   = $this->payment_methods['card']->get_description();
 		$this->enabled                       = $this->get_option( 'enabled' );
@@ -3330,5 +3333,29 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// considered enabled if either is enabled in Stripe.
 		return in_array( WC_Stripe_Payment_Methods::APPLE_PAY, $enabled_payment_method_ids, true ) ||
 			in_array( WC_Stripe_Payment_Methods::GOOGLE_PAY, $enabled_payment_method_ids, true );
+	}
+
+	/**
+	 * Maybe deactivate Affirm or Klarna payment methods if other official plugins are active.
+	 *
+	 * @return void
+	 */
+	private function maybe_deactivate_bnpls() {
+		if ( WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
+			$enabled_payment_methods       = $this->get_upe_enabled_payment_method_ids();
+			$payment_method_ids_to_disable = [];
+			if ( WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
+				$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
+			}
+			if ( WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
+				$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
+			}
+			$this->update_enabled_payment_methods(
+				array_diff(
+					$enabled_payment_methods,
+					$payment_method_ids_to_disable
+				)
+			);
+		}
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3341,27 +3341,30 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @return void
 	 */
 	private function maybe_deactivate_bnpls() {
-		if ( ! WC_Stripe_Helper::has_other_bnpl_plugins_active() ) {
+		$has_affirm_plugin_active = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM );
+		$has_klarna_plugin_active = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA );
+		if ( ! $has_affirm_plugin_active && ! $has_klarna_plugin_active ) {
 			return;
 		}
 
 		$enabled_payment_methods       = $this->get_upe_enabled_payment_method_ids();
 		$payment_method_ids_to_disable = [];
-		if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true )
-			&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM ) ) {
+		if ( in_array( WC_Stripe_Payment_Methods::AFFIRM, $enabled_payment_methods, true ) && $has_affirm_plugin_active ) {
 			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::AFFIRM;
 		}
-		if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true )
-			&& WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ) ) {
+		if ( in_array( WC_Stripe_Payment_Methods::KLARNA, $enabled_payment_methods, true ) && $has_klarna_plugin_active ) {
 			$payment_method_ids_to_disable[] = WC_Stripe_Payment_Methods::KLARNA;
 		}
-		if ( [] !== $payment_method_ids_to_disable ) {
-			$this->update_enabled_payment_methods(
-				array_diff(
-					$enabled_payment_methods,
-					$payment_method_ids_to_disable
-				)
-			);
+
+		if ( [] === $payment_method_ids_to_disable ) {
+			return;
 		}
+
+		$this->update_enabled_payment_methods(
+			array_diff(
+				$enabled_payment_methods,
+				$payment_method_ids_to_disable
+			)
+		);
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.7.0 - xxxx-xx-xx =
+* Update - Deactivates Affirm or Klarna when other official plugins are active in merchant's Payment Method Configuration
 * Dev - Use product type constants that were added in WooCommerce 9.7
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class
 * Add - Introduces a new banner to promote the Optimized Checkout feature in the Stripe settings page for versions 9.8 and above

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -3,7 +3,9 @@
 namespace WooCommerce\Stripe\Tests;
 
 use WC_Stripe_Feature_Flags;
-use WP_UnitTestCase;
+use WC_Stripe_Helper;
+use WC_Stripe_UPE_Payment_Gateway;
+use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 
 /**
  * These tests make assertions against the class WC_Stripe_Feature_Flags
@@ -12,7 +14,18 @@ use WP_UnitTestCase;
  *
  * @package WooCommerce/Stripe/WC_Stripe_Feature_Flags
  */
-class WC_Stripe_Feature_Flags_Test extends WP_UnitTestCase {
+class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
+	/**
+	 * @var UPE_Test_Helper
+	 */
+	private $upe_helper;
+
+	public function set_up() {
+		parent::set_up();
+		$this->upe_helper = new UPE_Test_Helper();
+		$this->set_stripe_account_data( [ 'country' => 'US' ] );
+	}
+
 	/**
 	 * Test for `is_oc_available`.
 	 *
@@ -63,5 +76,31 @@ class WC_Stripe_Feature_Flags_Test extends WP_UnitTestCase {
 				'expected'        => false,
 			],
 		];
+	}
+
+	public function test_legacy_payment_methods_supported_by_upe_are_not_loaded_when_upe_is_enabled() {
+		$this->upe_helper->enable_upe_feature_flag();
+		$this->assertTrue( WC_Stripe_Feature_Flags::is_upe_preview_enabled() );
+
+		WC_Stripe_Helper::update_main_stripe_settings( [ 'upe_checkout_experience_enabled' => 'yes' ] );
+		$this->upe_helper->reload_payment_gateways();
+
+		$this->assertTrue( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() );
+
+		$loaded_gateway_classes = array_map(
+			function ( $gateway ) {
+				return get_class( $gateway );
+			},
+			WC()->payment_gateways->payment_gateways()
+		);
+
+		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $upe_method ) {
+			if ( ! defined( "$upe_method::LPM_GATEWAY_CLASS" ) ) {
+				continue;
+			}
+			$this->assertNotContains( $upe_method::LPM_GATEWAY_CLASS, $loaded_gateway_classes );
+		}
+
+		$this->assertContains( WC_Stripe_UPE_Payment_Gateway::class, $loaded_gateway_classes );
 	}
 }

--- a/tests/phpunit/WC_Stripe_Helper_Test.php
+++ b/tests/phpunit/WC_Stripe_Helper_Test.php
@@ -8,8 +8,8 @@ use WC_Order;
 use WC_Stripe_Currency_Code;
 use WC_Stripe_Helper;
 use WC_Stripe_Payment_Methods;
+use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\WC_Helper_Order;
-use WP_UnitTestCase;
 
 /**
  * These tests make assertions against class WC_Stripe_Helper.
@@ -18,7 +18,18 @@ use WP_UnitTestCase;
  *
  * WC_Stripe_Helper_Test class.
  */
-class WC_Stripe_Helper_Test extends WP_UnitTestCase {
+class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
+	/**
+	 * @var UPE_Test_Helper
+	 */
+	private $upe_helper;
+
+	public function set_up() {
+		parent::set_up();
+		$this->upe_helper = new UPE_Test_Helper();
+		$this->set_stripe_account_data( [ 'country' => 'US' ] );
+	}
+
 	public function test_convert_to_stripe_locale() {
 		$result = WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( 'en_GB' );
 		$this->assertEquals( 'en-GB', $result );
@@ -696,6 +707,192 @@ class WC_Stripe_Helper_Test extends WP_UnitTestCase {
 				],
 				'expected'         => false,
 			],
+		];
+	}
+
+	/**
+	 * Stripe requires price in the smallest dominations aka cents.
+	 * This test will see if we're indeed converting the price correctly.
+	 */
+	public function test_price_conversion_before_send_to_stripe() {
+		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 100.50, WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ) );
+		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 10050, WC_Stripe_Currency_Code::JAPANESE_YEN ) );
+		$this->assertEquals( 100, WC_Stripe_Helper::get_stripe_amount( 100.50, WC_Stripe_Currency_Code::JAPANESE_YEN ) );
+		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 100.50 ) );
+		$this->assertIsInt( WC_Stripe_Helper::get_stripe_amount( 100.50, WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ) );
+	}
+
+	/**
+	 * We store balance fee/net amounts coming from Stripe.
+	 * We need to make sure we format it correctly to be stored in WC.
+	 * These amounts are posted in lowest dominations.
+	 */
+	public function test_format_balance_fee() {
+		$balance_fee1           = new stdClass();
+		$balance_fee1->fee      = 10500;
+		$balance_fee1->net      = 10000;
+		$balance_fee1->currency = WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR;
+
+		$this->assertEquals( 105.00, WC_Stripe_Helper::format_balance_fee( $balance_fee1, 'fee' ) );
+
+		$balance_fee2           = new stdClass();
+		$balance_fee2->fee      = 10500;
+		$balance_fee2->net      = 10000;
+		$balance_fee2->currency = WC_Stripe_Currency_Code::JAPANESE_YEN;
+
+		$this->assertEquals( 10500, WC_Stripe_Helper::format_balance_fee( $balance_fee2, 'fee' ) );
+
+		$balance_fee3           = new stdClass();
+		$balance_fee3->fee      = 10500;
+		$balance_fee3->net      = 10000;
+		$balance_fee3->currency = WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR;
+
+		$this->assertEquals( 100.00, WC_Stripe_Helper::format_balance_fee( $balance_fee3, 'net' ) );
+
+		$balance_fee4           = new stdClass();
+		$balance_fee4->fee      = 10500;
+		$balance_fee4->net      = 10000;
+		$balance_fee4->currency = WC_Stripe_Currency_Code::JAPANESE_YEN;
+
+		$this->assertEquals( 10000, WC_Stripe_Helper::format_balance_fee( $balance_fee4, 'net' ) );
+
+		$balance_fee5           = new stdClass();
+		$balance_fee5->fee      = 10500;
+		$balance_fee5->net      = 10000;
+		$balance_fee5->currency = WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR;
+
+		$this->assertEquals( 105.00, WC_Stripe_Helper::format_balance_fee( $balance_fee5 ) );
+
+		$this->assertIsString( WC_Stripe_Helper::format_balance_fee( $balance_fee5 ) );
+	}
+
+	/**
+	 * Stripe requires statement_descriptor to be no longer than 22 characters.
+	 * In addition, it cannot contain <>"' special characters.
+	 *
+	 * @dataProvider statement_descriptor_sanitation_provider
+	 */
+	public function test_statement_descriptor_sanitation( $original, $expected ) {
+		$this->assertEquals( $expected, WC_Stripe_Helper::clean_statement_descriptor( $original ) );
+	}
+
+	public function statement_descriptor_sanitation_provider() {
+		return [
+			'removes \''             => [ 'Test\'s Store', 'Tests Store' ],
+			'removes "'              => [ 'Test " Store', 'Test  Store' ],
+			'removes <'              => [ 'Test < Store', 'Test  Store' ],
+			'removes >'              => [ 'Test > Store', 'Test  Store' ],
+			'removes /'              => [ 'Test / Store', 'Test  Store' ],
+			'removes ('              => [ 'Test ( Store', 'Test  Store' ],
+			'removes )'              => [ 'Test ) Store', 'Test  Store' ],
+			'removes {'              => [ 'Test { Store', 'Test  Store' ],
+			'removes }'              => [ 'Test } Store', 'Test  Store' ],
+			'removes \\'             => [ 'Test \\ Store', 'Test  Store' ],
+			'removes *'              => [ 'Test * Store', 'Test  Store' ],
+			'keeps at most 22 chars' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
+			'mixed length, \' and >' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
+			'mixed length, \' and <' => [ 'Test\'s Store < Driving Course Range', 'Tests Store  Driving C' ],
+			'mixed length, \' and "' => [ 'Test\'s Store " Driving Course Range', 'Tests Store  Driving C' ],
+			'removes non-Latin'      => [ 'Test-Storeシ Drהiving?12', 'Test-Store Driving?12' ],
+		];
+	}
+
+	public function test_turning_on_upe_with_no_stripe_legacy_payment_methods_enabled_will_not_turn_on_the_upe_gateway_and_default_to_card_and_link() {
+		$this->upe_helper->enable_upe_feature_flag();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertEquals( 'no', $stripe_settings['enabled'] );
+		$this->assertEquals( 'no', $stripe_settings['upe_checkout_experience_enabled'] );
+
+		$stripe_settings['upe_checkout_experience_enabled'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		// Because no Stripe LPM's were enabled when UPE was enabled, the Stripe gateway is not enabled yet.
+		$this->assertEquals( 'no', $stripe_settings['enabled'] );
+		$this->assertEquals( 'yes', $stripe_settings['upe_checkout_experience_enabled'] );
+	}
+
+	public function test_turning_on_upe_enables_the_correct_upe_methods_based_on_which_legacy_payment_methods_were_enabled() {
+		update_option( 'woocommerce_currency', 'EUR' );
+		$this->upe_helper->enable_upe_feature_flag();
+
+		// Enable sepa and iDEAL LPM gateways.
+		update_option( 'woocommerce_stripe_sepa_settings', [ 'enabled' => 'yes' ] );
+		update_option( 'woocommerce_stripe_ideal_settings', [ 'enabled' => 'yes' ] );
+		$this->upe_helper->reload_payment_gateways();
+
+		// Initialize default stripe settings, turn on UPE.
+		WC_Stripe_Helper::update_main_stripe_settings( [ 'upe_checkout_experience_enabled' => 'yes' ] );
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertEquals( 'yes', $stripe_settings['enabled'] );
+		$this->assertEquals( 'yes', $stripe_settings['upe_checkout_experience_enabled'] );
+
+		// Make sure the SEPA and iDEAL LPMs were disabled.
+		$sepa_settings = get_option( 'woocommerce_stripe_sepa_settings' );
+		$this->assertEquals( 'no', $sepa_settings['enabled'] );
+		$ideal_settings = get_option( 'woocommerce_stripe_ideal_settings' );
+		$this->assertEquals( 'no', $ideal_settings['enabled'] );
+	}
+
+	public function test_turning_off_upe_enables_the_correct_legacy_payment_methods_based_on_which_upe_payment_methods_were_enabled() {
+		$this->upe_helper->enable_upe_feature_flag();
+
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+
+		update_option( 'woocommerce_currency', 'EUR' );
+
+		// Disable sepa and iDEAL LPM gateways.
+		update_option( 'woocommerce_stripe_sepa_settings', [ 'enabled' => 'no' ] );
+		update_option( 'woocommerce_stripe_ideal_settings', [ 'enabled' => 'no' ] );
+
+		// Turn UPE on first.
+		$stripe_settings['upe_checkout_experience_enabled'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::SEPA_DEBIT, WC_Stripe_Payment_Methods::IDEAL ] );
+
+		// Turn UPE off.
+		$stripe_settings['upe_checkout_experience_enabled'] = 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		// Check that the main 'stripe' gateway was disabled because the 'card' UPE method was not enabled.
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertEquals( 'no', $stripe_settings['enabled'] );
+		// Check that the correct LPMs were re-enabled.
+		$sepa_settings = get_option( 'woocommerce_stripe_sepa_settings' );
+		$this->assertEquals( 'yes', $sepa_settings['enabled'] );
+		$ideal_settings = get_option( 'woocommerce_stripe_ideal_settings' );
+		$this->assertEquals( 'yes', $ideal_settings['enabled'] );
+	}
+
+	/**
+	 * Test that {@see WC_Stripe_Helper::is_webhook_url()} works as expected.
+	 *
+	 * @dataProvider is_webhook_url_provider
+	 * @covers WC_Stripe_Helper::is_webhook_url()
+	 */
+	public function test_is_webhook_url( $url, $webhook_url, $expected_result ) {
+		$this->assertEquals( $expected_result, WC_Stripe_Helper::is_webhook_url( $url, $webhook_url ) );
+	}
+
+	/**
+	 * Data provider for {@see test_is_webhook_url()}.
+	 *
+	 * @return array
+	 */
+	public function is_webhook_url_provider() {
+		return [
+			'webhook URLs with mismatched protocol should match'       => [ 'https://example.com/?wc-api=wc_stripe', 'http://example.com/?wc-api=wc_stripe', true ],
+			'webhook URLs with mismatched host should not match'       => [ 'https://example.com/?wc-api=wc_stripe', 'https://test.example.com/?wc-api=wc_stripe', false ],
+			'webhook URLs with mismatched path should not match'       => [ 'https://example.com/foo?wc-api=wc_stripe', 'https://example.com/bar?wc-api=wc_stripe', false ],
+			'webhook URL with empty path should match'                 => [ 'https://example.com/', 'https://example.com/?wc-api=wc_stripe', true ],
+			'webhook URL with empty query string should match'         => [ 'https://example.com/test/', 'https://example.com/test/', true ],
+			'webhook URL with empty comparison query should not match' => [ 'https://example.com/test/?foo=bar', 'https://example.com/test/', false ],
+			'webhook URL with missing parameter should not match'      => [ 'https://example.com/test/?wc-api=wc_stripe', 'https://example.com/test/?wc-api=wc_stripe&foo=bar', false ],
+			'webhook URL with wrong parameter should not match'        => [ 'https://example.com/test/?wc-api=wc_stripe_BAD', 'https://example.com/test/?wc-api=wc_stripe', false ],
+			'webhook URL with extra parameters should match'           => [ 'https://example.com/test/?wc-api=wc_stripe&foo=bar', 'https://example.com/test/?wc-api=wc_stripe', true ],
 		];
 	}
 }

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -7,6 +7,13 @@ use WC_Stripe_Helper;
 use WC_Stripe_Payment_Methods;
 use WC_Stripe_UPE_Payment_Gateway;
 
+/**
+ * These tests make assertions against the class WC_Stripe.
+ *
+ * Class WC_Stripe_Test
+ *
+ * @package WooCommerce/Stripe/WC_Stripe
+ */
 class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	public function test_constants_defined() {
 		$this->assertTrue( defined( 'WC_STRIPE_VERSION' ) );

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -2,27 +2,12 @@
 
 namespace WooCommerce\Stripe\Tests;
 
-use stdClass;
-use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
-use WC_Stripe_Currency_Code;
-use WC_Stripe_Feature_Flags;
+use WC_Stripe;
 use WC_Stripe_Helper;
 use WC_Stripe_Payment_Methods;
 use WC_Stripe_UPE_Payment_Gateway;
 
 class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
-
-	/**
-	 * @var UPE_Test_Helper
-	 */
-	private $upe_helper;
-
-	public function set_up() {
-		parent::set_up();
-		$this->upe_helper = new UPE_Test_Helper();
-		$this->set_stripe_account_data( [ 'country' => 'US' ] );
-	}
-
 	public function test_constants_defined() {
 		$this->assertTrue( defined( 'WC_STRIPE_VERSION' ) );
 		$this->assertTrue( defined( 'WC_STRIPE_MIN_PHP_VER' ) );
@@ -33,214 +18,128 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Stripe requires price in the smallest dominations aka cents.
-	 * This test will see if we're indeed converting the price correctly.
-	 */
-	public function test_price_conversion_before_send_to_stripe() {
-		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 100.50, WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ) );
-		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 10050, WC_Stripe_Currency_Code::JAPANESE_YEN ) );
-		$this->assertEquals( 100, WC_Stripe_Helper::get_stripe_amount( 100.50, WC_Stripe_Currency_Code::JAPANESE_YEN ) );
-		$this->assertEquals( 10050, WC_Stripe_Helper::get_stripe_amount( 100.50 ) );
-		$this->assertIsInt( WC_Stripe_Helper::get_stripe_amount( 100.50, WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ) );
-	}
-
-	/**
-	 * We store balance fee/net amounts coming from Stripe.
-	 * We need to make sure we format it correctly to be stored in WC.
-	 * These amounts are posted in lowest dominations.
-	 */
-	public function test_format_balance_fee() {
-		$balance_fee1           = new stdClass();
-		$balance_fee1->fee      = 10500;
-		$balance_fee1->net      = 10000;
-		$balance_fee1->currency = WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR;
-
-		$this->assertEquals( 105.00, WC_Stripe_Helper::format_balance_fee( $balance_fee1, 'fee' ) );
-
-		$balance_fee2           = new stdClass();
-		$balance_fee2->fee      = 10500;
-		$balance_fee2->net      = 10000;
-		$balance_fee2->currency = WC_Stripe_Currency_Code::JAPANESE_YEN;
-
-		$this->assertEquals( 10500, WC_Stripe_Helper::format_balance_fee( $balance_fee2, 'fee' ) );
-
-		$balance_fee3           = new stdClass();
-		$balance_fee3->fee      = 10500;
-		$balance_fee3->net      = 10000;
-		$balance_fee3->currency = WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR;
-
-		$this->assertEquals( 100.00, WC_Stripe_Helper::format_balance_fee( $balance_fee3, 'net' ) );
-
-		$balance_fee4           = new stdClass();
-		$balance_fee4->fee      = 10500;
-		$balance_fee4->net      = 10000;
-		$balance_fee4->currency = WC_Stripe_Currency_Code::JAPANESE_YEN;
-
-		$this->assertEquals( 10000, WC_Stripe_Helper::format_balance_fee( $balance_fee4, 'net' ) );
-
-		$balance_fee5           = new stdClass();
-		$balance_fee5->fee      = 10500;
-		$balance_fee5->net      = 10000;
-		$balance_fee5->currency = WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR;
-
-		$this->assertEquals( 105.00, WC_Stripe_Helper::format_balance_fee( $balance_fee5 ) );
-
-		$this->assertIsString( WC_Stripe_Helper::format_balance_fee( $balance_fee5 ) );
-	}
-
-	/**
-	 * Stripe requires statement_descriptor to be no longer than 22 characters.
-	 * In addition, it cannot contain <>"' special characters.
+	 * Tests for `maybe_deactivate_bnpls`.
 	 *
-	 * @dataProvider statement_descriptor_sanitation_provider
-	 */
-	public function test_statement_descriptor_sanitation( $original, $expected ) {
-		$this->assertEquals( $expected, WC_Stripe_Helper::clean_statement_descriptor( $original ) );
-	}
-
-	public function statement_descriptor_sanitation_provider() {
-		return [
-			'removes \''             => [ 'Test\'s Store', 'Tests Store' ],
-			'removes "'              => [ 'Test " Store', 'Test  Store' ],
-			'removes <'              => [ 'Test < Store', 'Test  Store' ],
-			'removes >'              => [ 'Test > Store', 'Test  Store' ],
-			'removes /'              => [ 'Test / Store', 'Test  Store' ],
-			'removes ('              => [ 'Test ( Store', 'Test  Store' ],
-			'removes )'              => [ 'Test ) Store', 'Test  Store' ],
-			'removes {'              => [ 'Test { Store', 'Test  Store' ],
-			'removes }'              => [ 'Test } Store', 'Test  Store' ],
-			'removes \\'             => [ 'Test \\ Store', 'Test  Store' ],
-			'removes *'              => [ 'Test * Store', 'Test  Store' ],
-			'keeps at most 22 chars' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
-			'mixed length, \' and >' => [ 'Test\'s Store > Driving Course Range', 'Tests Store  Driving C' ],
-			'mixed length, \' and <' => [ 'Test\'s Store < Driving Course Range', 'Tests Store  Driving C' ],
-			'mixed length, \' and "' => [ 'Test\'s Store " Driving Course Range', 'Tests Store  Driving C' ],
-			'removes non-Latin'      => [ 'Test-Storeシ Drהiving?12', 'Test-Store Driving?12' ],
-		];
-	}
-
-	public function test_legacy_payment_methods_supported_by_upe_are_not_loaded_when_upe_is_enabled() {
-		$this->upe_helper->enable_upe_feature_flag();
-		$this->assertTrue( WC_Stripe_Feature_Flags::is_upe_preview_enabled() );
-
-		WC_Stripe_Helper::update_main_stripe_settings( [ 'upe_checkout_experience_enabled' => 'yes' ] );
-		$this->upe_helper->reload_payment_gateways();
-
-		$this->assertTrue( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() );
-
-		$loaded_gateway_classes = array_map(
-			function ( $gateway ) {
-				return get_class( $gateway );
-			},
-			WC()->payment_gateways->payment_gateways()
-		);
-
-		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $upe_method ) {
-			if ( ! defined( "$upe_method::LPM_GATEWAY_CLASS" ) ) {
-				continue;
-			}
-			$this->assertNotContains( $upe_method::LPM_GATEWAY_CLASS, $loaded_gateway_classes );
-		}
-
-		$this->assertContains( WC_Stripe_UPE_Payment_Gateway::class, $loaded_gateway_classes );
-	}
-
-	public function test_turning_on_upe_with_no_stripe_legacy_payment_methods_enabled_will_not_turn_on_the_upe_gateway_and_default_to_card_and_link() {
-		$this->upe_helper->enable_upe_feature_flag();
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		$this->assertEquals( 'no', $stripe_settings['enabled'] );
-		$this->assertEquals( 'no', $stripe_settings['upe_checkout_experience_enabled'] );
-
-		$stripe_settings['upe_checkout_experience_enabled'] = 'yes';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		// Because no Stripe LPM's were enabled when UPE was enabled, the Stripe gateway is not enabled yet.
-		$this->assertEquals( 'no', $stripe_settings['enabled'] );
-		$this->assertEquals( 'yes', $stripe_settings['upe_checkout_experience_enabled'] );
-	}
-
-	public function test_turning_on_upe_enables_the_correct_upe_methods_based_on_which_legacy_payment_methods_were_enabled() {
-		update_option( 'woocommerce_currency', 'EUR' );
-		$this->upe_helper->enable_upe_feature_flag();
-
-		// Enable sepa and iDEAL LPM gateways.
-		update_option( 'woocommerce_stripe_sepa_settings', [ 'enabled' => 'yes' ] );
-		update_option( 'woocommerce_stripe_ideal_settings', [ 'enabled' => 'yes' ] );
-		$this->upe_helper->reload_payment_gateways();
-
-		// Initialize default stripe settings, turn on UPE.
-		WC_Stripe_Helper::update_main_stripe_settings( [ 'upe_checkout_experience_enabled' => 'yes' ] );
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		$this->assertEquals( 'yes', $stripe_settings['enabled'] );
-		$this->assertEquals( 'yes', $stripe_settings['upe_checkout_experience_enabled'] );
-
-		// Make sure the SEPA and iDEAL LPMs were disabled.
-		$sepa_settings = get_option( 'woocommerce_stripe_sepa_settings' );
-		$this->assertEquals( 'no', $sepa_settings['enabled'] );
-		$ideal_settings = get_option( 'woocommerce_stripe_ideal_settings' );
-		$this->assertEquals( 'no', $ideal_settings['enabled'] );
-	}
-
-	public function test_turning_off_upe_enables_the_correct_legacy_payment_methods_based_on_which_upe_payment_methods_were_enabled() {
-		$this->upe_helper->enable_upe_feature_flag();
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-
-		update_option( 'woocommerce_currency', 'EUR' );
-
-		// Disable sepa and iDEAL LPM gateways.
-		update_option( 'woocommerce_stripe_sepa_settings', [ 'enabled' => 'no' ] );
-		update_option( 'woocommerce_stripe_ideal_settings', [ 'enabled' => 'no' ] );
-
-		// Turn UPE on first.
-		$stripe_settings['upe_checkout_experience_enabled'] = 'yes';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
-		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::SEPA_DEBIT, WC_Stripe_Payment_Methods::IDEAL ] );
-
-		// Turn UPE off.
-		$stripe_settings['upe_checkout_experience_enabled'] = 'no';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
-		// Check that the main 'stripe' gateway was disabled because the 'card' UPE method was not enabled.
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		$this->assertEquals( 'no', $stripe_settings['enabled'] );
-		// Check that the correct LPMs were re-enabled.
-		$sepa_settings = get_option( 'woocommerce_stripe_sepa_settings' );
-		$this->assertEquals( 'yes', $sepa_settings['enabled'] );
-		$ideal_settings = get_option( 'woocommerce_stripe_ideal_settings' );
-		$this->assertEquals( 'yes', $ideal_settings['enabled'] );
-	}
-
-	/**
-	 * Test that {@see WC_Stripe_Helper::is_webhook_url()} works as expected.
+	 * @return void
 	 *
-	 * @dataProvider is_webhook_url_provider
-	 * @covers WC_Stripe_Helper::is_webhook_url()
+	 * @dataProvider provide_test_maybe_deactivate_bnpls
 	 */
-	public function test_is_webhook_url( $url, $webhook_url, $expected_result ) {
-		$this->assertEquals( $expected_result, WC_Stripe_Helper::is_webhook_url( $url, $webhook_url ) );
+	public function test_maybe_deactivate_bnpls(
+		$active_gateways,
+		$get_upe_payment_method_ids_calls,
+		$enabled_payment_method_ids,
+		$update_enable_payment_methods_calls
+	) {
+		$original_payment_gateways = WC()->payment_gateways->payment_gateways;
+
+		// Mock the available payment gateways.
+		WC()->payment_gateways->payment_gateways = $active_gateways;
+
+		$upe_payment_gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$upe_payment_gateway->expects( $this->exactly( $get_upe_payment_method_ids_calls ) )
+			->method( 'get_upe_enabled_payment_method_ids' )
+			->willReturn( $enabled_payment_method_ids );
+
+		$upe_payment_gateway->expects( $this->exactly( $update_enable_payment_methods_calls ) )
+			->method( 'update_enabled_payment_methods' )
+			->with( [ WC_Stripe_Payment_Methods::CARD ] );
+
+		$wc_stripe = $this->getMockBuilder( WC_Stripe::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_main_stripe_gateway' ] )
+			->getMock();
+
+		$wc_stripe->method( 'get_main_stripe_gateway' )
+			->willReturn( $upe_payment_gateway );
+
+		$wc_stripe->maybe_deactivate_bnpls();
+
+		// Clean up.
+		WC()->payment_gateways->payment_gateways = $original_payment_gateways;
 	}
 
 	/**
-	 * Data provider for {@see test_is_webhook_url()}.
+	 * Provider for `test_maybe_deactivate_bnpls`.
 	 *
 	 * @return array
 	 */
-	public function is_webhook_url_provider() {
+	public function provide_test_maybe_deactivate_bnpls() {
 		return [
-			'webhook URLs with mismatched protocol should match'       => [ 'https://example.com/?wc-api=wc_stripe', 'http://example.com/?wc-api=wc_stripe', true ],
-			'webhook URLs with mismatched host should not match'       => [ 'https://example.com/?wc-api=wc_stripe', 'https://test.example.com/?wc-api=wc_stripe', false ],
-			'webhook URLs with mismatched path should not match'       => [ 'https://example.com/foo?wc-api=wc_stripe', 'https://example.com/bar?wc-api=wc_stripe', false ],
-			'webhook URL with empty path should match'                 => [ 'https://example.com/', 'https://example.com/?wc-api=wc_stripe', true ],
-			'webhook URL with empty query string should match'         => [ 'https://example.com/test/', 'https://example.com/test/', true ],
-			'webhook URL with empty comparison query should not match' => [ 'https://example.com/test/?foo=bar', 'https://example.com/test/', false ],
-			'webhook URL with missing parameter should not match'      => [ 'https://example.com/test/?wc-api=wc_stripe', 'https://example.com/test/?wc-api=wc_stripe&foo=bar', false ],
-			'webhook URL with wrong parameter should not match'        => [ 'https://example.com/test/?wc-api=wc_stripe_BAD', 'https://example.com/test/?wc-api=wc_stripe', false ],
-			'webhook URL with extra parameters should match'           => [ 'https://example.com/test/?wc-api=wc_stripe&foo=bar', 'https://example.com/test/?wc-api=wc_stripe', true ],
+			'none active'                    => [
+				'active gateways'                     => [],
+				'get UPE payment method IDs calls'    => 0,
+				'enabled payment method IDs'          => [
+					WC_Stripe_Payment_Methods::CARD,
+				],
+				'update enable payment methods calls' => 0,
+			],
+			'affirm'                         => [
+				'active gateways'                     => [
+					WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM => (object) [
+						'id'      => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM,
+						'enabled' => 'yes',
+					],
+				],
+				'get UPE payment method IDs calls'    => 1,
+				'enabled payment method IDs'          => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::AFFIRM,
+				],
+				'update enable payment methods calls' => 1,
+			],
+			'klarna'                         => [
+				'active gateways'                     => [
+					WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA => (object) [
+						'id'      => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA,
+						'enabled' => 'yes',
+					],
+				],
+				'get UPE payment method IDs calls'    => 1,
+				'enabled payment method IDs'          => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'update enable payment methods calls' => 1,
+			],
+			'both active, but not on Stripe' => [
+				'active gateways'                     => [
+					WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM => (object) [
+						'id'      => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM,
+						'enabled' => 'yes',
+					],
+					WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA => (object) [
+						'id'      => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA,
+						'enabled' => 'yes',
+					],
+				],
+				'get UPE payment method IDs calls'    => 1,
+				'enabled payment method IDs'          => [
+					WC_Stripe_Payment_Methods::CARD,
+				],
+				'update enable payment methods calls' => 0,
+			],
+			'both active in both'            => [
+				'active gateways'                     => [
+					WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM => (object) [
+						'id'      => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM,
+						'enabled' => 'yes',
+					],
+					WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA => (object) [
+						'id'      => WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA,
+						'enabled' => 'yes',
+					],
+				],
+				'get UPE payment method IDs calls'    => 1,
+				'enabled payment method IDs'          => [
+					WC_Stripe_Payment_Methods::CARD,
+					WC_Stripe_Payment_Methods::AFFIRM,
+					WC_Stripe_Payment_Methods::KLARNA,
+				],
+				'update enable payment methods calls' => 1,
+			],
 		];
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-628

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4492, we filtered out Affirm and Klarna when other official plugins are active. Here, I am forcing the deactivation (under the same rules) directly on the merchant's Payment Method Configuration. This is needed to avoid these payment methods from showing up when the Optimized Checkout is enabled.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout to this branch on your test environment (`update/disable-bnpls-in-pmc-when-other-plugins-are-active`)
- Connect a US Stripe account
- Go to the Stripe dashboard and enable both Klarna and Affirm in the main PMC (the one with "WooCommerce Inc. configuration")
- Install the [Affirm](https://woocommerce.com/products/woocommerce-gateway-affirm/) or [Klarna](https://woocommerce.com/products/klarna-payments/) extensions (only one is enough)
- Go to the store's wp-admin
- Revisit the Stripe dashboard and confirm the related payment method was deactivated
- Enable the Optimized Checkout (you can use the `wc_stripe_is_optimized_checkout_available` filter and enable the setting)
- As a shopper, add any product to your cart
- Confirm the related payment method is not available in the checkout pages

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
