### PR TITLE
Fix "undefined array key 'label' warning"

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Add - Add state mapping for Lithuania in express checkout
 * Tweak - Use wp_ajax prefix for its built-in security for Add Payment Method action
 * Dev - Fix WooCommerce version fetching in GitHub workflows
+* Fix - Fix PHP warning about undefined labels for custom checkout fields
 
 = 9.7.0 - 2025-07-21 =
 * Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,7 +10,7 @@
 * Tweak - Use wp_ajax prefix for its built-in security for Add Payment Method action
 * Dev - Fix WooCommerce version fetching in GitHub workflows
 * Dev - Fix failing test cases associated with WooCommerce 10.0.x
-* Fix - Fix PHP warning about undefined labels for custom checkout fields
+* Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
 
 = 9.7.0 - 2025-07-21 =
 * Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -59,7 +59,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 				$required_field_errors[] = sprintf(
 					/* translators: %s: field name */
 					__( '%s is a required field.', 'woocommerce-gateway-stripe' ),
-					$field['label']
+					empty( $field['label'] ) ? $key : $field['label']
 				);
 			}
 		}
@@ -197,7 +197,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 				$additional_fields            = $checkout_fields->get_additional_fields();
 				foreach ( $additional_fields as $field_key => $field ) {
 					$block_custom_checkout_fields[ $field_key ] = [
-						'label'    => $field['label'],
+						'label'    => $field['label'] ?? '',
 						'type'     => $field['type'] ?? 'text',
 						'location' => $checkout_fields->get_field_location( $field_key ),
 						'required' => $field['required'] ?? false,
@@ -222,7 +222,7 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 					}
 
 					$classic_custom_checkout_fields[ $field_key ] = [
-						'label'    => $field['label'],
+						'label'    => $field['label'] ?? '',
 						'type'     => $field['type'] ?? 'text',
 						'location' => $fieldset,
 						'required' => $field['required'] ?? false,

--- a/readme.txt
+++ b/readme.txt
@@ -120,6 +120,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Use wp_ajax prefix for its built-in security for Add Payment Method action
 * Dev - Fix WooCommerce version fetching in GitHub workflows
 * Dev - Fix failing test cases associated with WooCommerce 10.0.x
-* Fix - Fix PHP warning about undefined labels for custom checkout fields
+* Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -119,5 +119,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add state mapping for Lithuania in express checkout
 * Tweak - Use wp_ajax prefix for its built-in security for Add Payment Method action
 * Dev - Fix WooCommerce version fetching in GitHub workflows
+* Fix - Fix PHP warning about undefined labels for custom checkout fields
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Some custom checkout fields have no labels. This PR adds a safety check to remove the PHP warning `PHP Notice:  Undefined index: label in /var/www/html/wp-content/plugins/woocommerce-gateway-stripe/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php on line 225`

## Testing instructions

1. Add this snippet, which will add a classic custom checkout field that has no label.
```
// Enable ECE support for custom checkout fields
add_filter( 'wc_stripe_express_checkout_enable_classic_checkout_custom_fields', '__return_true' );

// Display custom checkout fields for classic checkout.
add_filter( 'woocommerce_checkout_fields', 'custom_add_checkout_field' );
function custom_add_checkout_field( $fields ) {
	$fields['billing']['preferred_contact'] = [
		'type'     => 'radio',
		'options'  => [
			'email' => 'Email',
			'phone' => 'Phone',
		],
		'required' => true,
		'class'   => array( 'form-row-wide' ),
		'priority' => 2,
	];

    return $fields;
}
```
2. As a shopper, add a product to cart and go to classic checkout.
   - In `develop`, you will see the PHP warning.
   - In this branch, there should be no warning.
3. Without filling out the custom fields, use Google Pay to complete the purchase. You will see the validation error message "preferred_contact is a required field."

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
