### PR TITLE
Update an entry in readme.txt to match changelog.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -115,7 +115,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Check for checkout validation error before creating a payment method in Stripe
 * Fix - Prevent multiple save appearance AJAX calls on Block Checkout
 * Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
-* Fix - Fix fatal when processing Boleto setup intents via webhooks
+* Fix - Fix fatal when processing setup intents for free subscriptions via webhooks
 * Dev - Fix WooCommerce version fetching in GitHub workflows
 * Dev - Fix failing test cases associated with WooCommerce 10.0.x
 


### PR DESCRIPTION
I missed updating the `readme.txt` in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4518 following the [suggested](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4518#discussion_r2226443755) update. This makes sure we have the same changelog entry in both readme and changelog.