### PR TITLE
Fix Google Pay 3DS modal 

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,7 @@
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Fix fatal when processing setup intents for free subscriptions via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
-* Fix - 3DS authentication model not shown when using Google Pay
+* Fix - 3DS authentication modal not shown when using Google Pay
 
 = 9.7.0 - 2025-07-21 =
 * Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,7 @@
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Fix fatal when processing setup intents for free subscriptions via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
-* Fix - Google Pay 3DS authentication model not shown
+* Fix - 3DS authentication model not shown when using Google Pay
 
 = 9.7.0 - 2025-07-21 =
 * Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Fix fatal when processing setup intents for free subscriptions via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
+* Fix - Google Pay 3DS authentication model not shown
 
 = 9.7.0 - 2025-07-21 =
 * Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -616,5 +616,55 @@ describe( 'Express checkout event handlers', () => {
 			);
 			expect( completePayment ).not.toHaveBeenCalled();
 		} );
+
+		test( 'should extract redirect URL from payment_details when redirect_url is empty for 3DS authentication', async () => {
+			const threeDSRedirectUrl =
+				'#confirm-pi-pi_1234567890abcdef_secret_test1234567890abcdef:fake_nonce';
+
+			elements.submit.mockResolvedValue( {} );
+			stripe.createPaymentMethod.mockResolvedValue( {
+				paymentMethod: { id: 'pm_123' },
+			} );
+			api.expressCheckoutECECreateOrder.mockResolvedValue( {
+				payment_result: {
+					payment_status: 'success',
+					payment_details: [
+						{
+							key: 'result',
+							value: 'success',
+						},
+						{
+							key: 'redirect',
+							value: threeDSRedirectUrl,
+						},
+						{
+							key: 'payment_method',
+							value: 'pm_test1234567890abcdef',
+						},
+					],
+					redirect_url: '',
+				},
+			} );
+
+			api.confirmIntent.mockReturnValue( true );
+
+			await onConfirmHandler( {
+				api,
+				stripe,
+				elements,
+				completePayment,
+				abortPayment,
+				event,
+			} );
+
+			expect( api.expressCheckoutECECreateOrder ).toHaveBeenCalled();
+			expect( api.confirmIntent ).toHaveBeenCalledWith(
+				threeDSRedirectUrl
+			);
+			expect( completePayment ).toHaveBeenCalledWith(
+				threeDSRedirectUrl
+			);
+			expect( abortPayment ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -184,11 +184,20 @@ const processOrder = async ( {
 		);
 	}
 
+	// Extract redirect URL from payment_details if redirect_url is empty
+	let redirectUrl = orderResponse?.payment_result?.redirect_url;
+	if ( ! redirectUrl ) {
+		const redirectDetail = orderResponse?.payment_result?.payment_details?.find(
+			( detail ) => detail.key === 'redirect'
+		);
+		redirectUrl = redirectDetail?.value || '';
+	}
+
 	return {
 		result: orderResponse?.payment_result?.payment_status,
 		errorMessage: orderResponse?.payment_result?.payment_details?.find(
 			( detail ) => detail.key === 'errorMessage'
 		)?.value,
-		redirect: orderResponse?.payment_result?.redirect_url,
+		redirect: redirectUrl,
 	};
 };

--- a/readme.txt
+++ b/readme.txt
@@ -125,5 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
 * Fix - Fix fatal when processing Boleto setup intents via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
+* Fix - Google Pay 3DS authentication model not shown
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
 * Fix - Fix fatal when processing Boleto setup intents via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
-* Fix - Google Pay 3DS authentication model not shown
+* Fix - 3DS authentication model not shown when using Google Pay
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
 * Fix - Fix fatal when processing Boleto setup intents via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
-* Fix - 3DS authentication model not shown when using Google Pay
+* Fix - 3DS authentication modal not shown when using Google Pay
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-624

## Changes proposed in this Pull Request:

3D Secure verification dialog fails to appear when paying with 3DS test card using "Google Pay" button. This happens because we're looking for the redirect URL in `payment_result.redirect_url`, but for Google Pay, it's present in `payment_result.payment_details[]` with key `'redirect'`. This issue was recently fixed in WooPayments with https://github.com/Automattic/woocommerce-payments/pull/10958. This PR follows a similar approach.

Note: I am not entirely sure if the scenario this PR is fixing is possible with real cards, as digital wallets verify the card at the time it's added to the wallet. But since Google Pay provides test cards for 3DS, it's good to have it fixed.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Add a product to the cart and go to checkout page.
2. Select Google Pay.
3. Choose a card that requires 3ds verification (eg: "3DS out of band": Visa towards the bottom of the test card list)
4. In `develop` 3ds verification modal will not be shown.
5. On this branch, the modal should be shown and you should be able to simulate success and failure scenarios (if using a test account)

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
