### PR TITLE
Fix booking multiple slots with ECE

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
+* Fix - Fixes issues related to booking multiple slots with express checkout payment methods enabled
 * Add - Adds a new bulk action option to the subscriptions listing screen to check for detached payment methods
 * Dev - Use product type constants that were added in WooCommerce 9.7
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -649,6 +649,7 @@ jQuery( function ( $ ) {
 		 */
 		addToCart: async () => {
 			let productId = $( '.single_add_to_cart_button' ).val();
+			let emptyCartParams = {};
 
 			const data = {
 				qty: $( quantityInputSelector ).val(),
@@ -663,6 +664,9 @@ jQuery( function ( $ ) {
 
 			if ( $( '.wc-bookings-booking-form' ).length ) {
 				productId = $( '.wc-booking-product-id' ).val();
+				emptyCartParams = {
+					bookingId: productId,
+				};
 			}
 
 			// Add extension data to the POST body
@@ -701,7 +705,7 @@ jQuery( function ( $ ) {
 			//  do not interfere with computed totals.
 			// Use the non-StoreAPI method as it is faster; Stripe requires
 			// the click event to be resolved within 1 second.
-			await api.expressCheckoutEmptyCartLegacy( {} );
+			await api.expressCheckoutEmptyCartLegacy( emptyCartParams );
 
 			return api.expressCheckoutAddToCart( data );
 		},

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -902,48 +902,4 @@ jQuery( function ( $ ) {
 	$( document.body ).on( 'updated_checkout', () => {
 		wcStripeECE.init();
 	} );
-
-	// Handle bookable products on the product page.
-	let wcBookingFormChanged = false;
-
-	$( document.body )
-		.off( 'wc_booking_form_changed' )
-		.on( 'wc_booking_form_changed', () => {
-			wcBookingFormChanged = true;
-		} );
-
-	// Listen for the WC Bookings wc_bookings_calculate_costs event to complete
-	// and add the bookable product to the cart, using the response to update the
-	// payment request request params with correct totals.
-	$( document ).ajaxComplete( function ( event, xhr, settings ) {
-		if ( wcBookingFormChanged ) {
-			if (
-				settings.url === window.booking_form_params.ajax_url &&
-				settings.data.includes( 'wc_bookings_calculate_costs' ) &&
-				xhr.responseText.includes( 'SUCCESS' )
-			) {
-				wcStripeECE.blockExpressCheckoutButton();
-				wcBookingFormChanged = false;
-
-				return wcStripeECE.addToCart().then( ( response ) => {
-					getExpressCheckoutData( 'product' ).total = response.total;
-					getExpressCheckoutData( 'product' ).displayItems =
-						response.displayItems;
-
-					// Empty the cart to avoid having 2 products in the cart when payment request is not used.
-					if ( useLegacyCartEndpoints ) {
-						api.expressCheckoutEmptyCartLegacy( {
-							bookingId: response.bookingId,
-						} );
-					} else {
-						api.expressCheckoutEmptyCart( response.bookingId );
-					}
-
-					wcStripeECE.init();
-
-					wcStripeECE.unblockExpressCheckoutButton();
-				} );
-			}
-		}
-	} );
 } );

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -143,7 +143,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		if ( $booking_id ) {
 			// When a bookable product is added to the cart, a 'booking' is created with status 'in-cart'.
 			// This status is used to prevent the booking from being booked by another customer
-			// and should be removed when the cart is emptied for ECE purposes.
+			// and should be removed when the cart is emptied for express checkout purposes.
 			do_action( 'wc-booking-remove-inactive-cart', $booking_id ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -103,8 +103,10 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		// When a bookable product is added to the cart, a 'booking' is created with status 'in-cart'.
 		// This status is used to prevent the booking from being booked by another customer
 		// and should be removed when the cart is emptied for ECE purposes.
-		foreach ( $booking_ids as $booking_id ) {
-			do_action( 'wc-booking-remove-inactive-cart', $booking_id ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		if ( has_action( 'wc-booking-remove-inactive-cart' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+			foreach ( $booking_ids as $booking_id ) {
+				do_action( 'wc-booking-remove-inactive-cart', $booking_id ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+			}
 		}
 
 		if ( ( ProductType::VARIABLE === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -92,8 +92,20 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		$product      = wc_get_product( $product_id );
 		$product_type = $product->get_type();
 
+		$booking_ids = [];
+		if ( 'booking' === $product_type ) {
+			$booking_ids = $this->express_checkout_helper->get_booking_ids_from_cart();
+		}
+
 		// First empty the cart to prevent wrong calculation.
 		WC()->cart->empty_cart();
+
+		// When a bookable product is added to the cart, a 'booking' is created with status 'in-cart'.
+		// This status is used to prevent the booking from being booked by another customer
+		// and should be removed when the cart is emptied for ECE purposes.
+		foreach ( $booking_ids as $booking_id ) {
+			do_action( 'wc-booking-remove-inactive-cart', $booking_id ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+		}
 
 		if ( ( ProductType::VARIABLE === $product_type || 'variable-subscription' === $product_type ) && isset( $_POST['attributes'] ) ) {
 			$attributes = wc_clean( wp_unslash( $_POST['attributes'] ) );
@@ -112,14 +124,6 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		$data          += $this->express_checkout_helper->build_display_items();
 		$data['result'] = 'success';
 
-		if ( 'booking' === $product_type ) {
-			$booking_id = $this->express_checkout_helper->get_booking_id_from_cart();
-
-			if ( ! empty( $booking_id ) ) {
-				$data['bookingId'] = $booking_id;
-			}
-		}
-
 		// @phpstan-ignore-next-line (return statement is added)
 		wp_send_json( $data );
 	}
@@ -135,9 +139,9 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		WC()->cart->empty_cart();
 
 		if ( $booking_id ) {
-			// When a bookable product is added to the cart, a 'booking' is create with status 'in-cart'.
+			// When a bookable product is added to the cart, a 'booking' is created with status 'in-cart'.
 			// This status is used to prevent the booking from being booked by another customer
-			// and should be removed when the cart is emptied for PRB purposes.
+			// and should be removed when the cart is emptied for ECE purposes.
 			do_action( 'wc-booking-remove-inactive-cart', $booking_id ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1669,16 +1669,36 @@ class WC_Stripe_Express_Checkout_Helper {
 	 * Used to remove the booking from WC Bookings in-cart status.
 	 *
 	 * @return int|false
+	 *
+	 * @deprecated 9.8.0 Use `get_booking_ids_from_cart()` instead.
 	 */
 	public function get_booking_id_from_cart() {
-		$cart      = WC()->cart->get_cart();
-		$cart_item = reset( $cart );
-
-		if ( $cart_item && isset( $cart_item['booking']['_booking_id'] ) ) {
-			return $cart_item['booking']['_booking_id'];
+		$booking_ids = $this->get_booking_ids_from_cart();
+		if ( ! empty( $booking_ids ) ) {
+			return $booking_ids[0];
 		}
 
 		return false;
+	}
+
+	/**
+	 * Gets a list of booking ids from the cart.
+	 *
+	 * Used to remove the booking from WC Bookings in-cart status.
+	 *
+	 * @return array
+	 */
+	public function get_booking_ids_from_cart() {
+		$cart        = WC()->cart->get_cart();
+		$booking_ids = [];
+
+		foreach ( $cart as $item ) {
+			if ( isset( $item['booking']['_booking_id'] ) ) {
+				$booking_ids[] = $item['booking']['_booking_id'];
+			}
+		}
+
+		return ! empty( $booking_ids ) ? array_unique( $booking_ids ) : [];
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1698,7 +1698,7 @@ class WC_Stripe_Express_Checkout_Helper {
 			}
 		}
 
-		return ! empty( $booking_ids ) ? array_unique( $booking_ids ) : [];
+		return array_unique( $booking_ids );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1693,7 +1693,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		$booking_ids = [];
 
 		foreach ( $cart as $item ) {
-			if ( isset( $item['booking']['_booking_id'] ) ) {
+			if ( ! empty( $item['booking']['_booking_id'] ) ) {
 				$booking_ids[] = $item['booking']['_booking_id'];
 			}
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
+* Fix - Fixes issues related to booking multiple slots with express checkout payment methods enabled
 * Add - Adds a new bulk action option to the subscriptions listing screen to check for detached payment methods
 * Dev - Use product type constants that were added in WooCommerce 9.7
 * Dev - Removes the inclusion of the deprecated WC_Stripe_Order class

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -698,8 +698,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		$product->save();
 
 		WC()->cart->cart_contents = [
-			'booking' => [
-				'_booking_id' => $product->get_id(),
+			[
+				'booking' => [
+					'_booking_id' => $product->get_id(),
+				],
 			],
 		];
 

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -685,25 +685,17 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	/**
 	 * Tests for `get_booking_ids_from_cart`.
 	 *
+	 * @param array $cart_contents Cart contents.
+	 * @param array $expected Expected booking IDs.
 	 * @return void
+	 *
+	 * @dataProvider provide_test_get_booking_ids_from_cart
 	 */
-	public function test_get_booking_ids_from_cart() {
+	public function test_get_booking_ids_from_cart( $cart_contents, $expected ) {
 		WC()->session->init();
 		WC()->cart->empty_cart();
 
-		// Add a booking product to the cart.
-		$product = WC_Helper_Product::create_simple_product();
-		$product->set_virtual( false );
-		$product->set_tax_status( 'none' );
-		$product->save();
-
-		WC()->cart->cart_contents = [
-			[
-				'booking' => [
-					'_booking_id' => $product->get_id(),
-				],
-			],
-		];
+		WC()->cart->cart_contents = $cart_contents;
 
 		$helper = new WC_Stripe_Express_Checkout_Helper();
 		$actual = $helper->get_booking_ids_from_cart();
@@ -712,6 +704,104 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		WC()->session->cleanup_sessions();
 		WC()->cart->empty_cart();
 
-		$this->assertSame( [ $product->get_id() ], $actual );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Provider for `test_get_booking_ids_from_cart`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_booking_ids_from_cart() {
+		$product_1 = WC_Helper_Product::create_simple_product();
+		$product_1->save();
+
+		$product_2 = WC_Helper_Product::create_simple_product();
+		$product_2->save();
+
+		$product_3 = WC_Helper_Product::create_simple_product();
+		$product_3->save();
+
+		return [
+			'no products'                => [
+				'cart contents' => [],
+				'expected'      => [],
+			],
+			'single product'             => [
+				'cart contents' => [
+					[
+						'product_id' => $product_1->get_id(),
+						'booking'    => [
+							'_booking_id' => $product_1->get_id(),
+						],
+					],
+				],
+				'expected'      => [
+					$product_1->get_id(),
+				],
+			],
+			'multiple products'          => [
+				'cart contents' => [
+					[
+						'product_id' => $product_1->get_id(),
+						'booking'    => [
+							'_booking_id' => $product_1->get_id(),
+						],
+					],
+					[
+						'product_id' => $product_2->get_id(),
+						'booking'    => [
+							'_booking_id' => $product_2->get_id(),
+						],
+					],
+				],
+				'expected'      => [
+					$product_1->get_id(),
+					$product_2->get_id(),
+				],
+			],
+			'multiple products, same ID' => [
+				'cart contents' => [
+					[
+						'product_id' => $product_1->get_id(),
+						'booking'    => [
+							'_booking_id' => $product_1->get_id(),
+						],
+					],
+					[
+						'product_id' => $product_1->get_id(),
+						'booking'    => [
+							'_booking_id' => $product_1->get_id(),
+						],
+					],
+				],
+				'expected'      => [
+					$product_1->get_id(),
+				],
+			],
+			'mixed products (booking data not always present)' => [
+				'cart contents' => [
+					[
+						'product_id' => $product_1->get_id(),
+						'booking'    => [
+							'_booking_id' => $product_1->get_id(),
+						],
+					],
+					[
+						'product_id' => $product_2->get_id(),
+					],
+					[
+						'product_id' => $product_3->get_id(),
+						'booking'    => [
+							'_booking_id' => $product_3->get_id(),
+						],
+					],
+				],
+				'expected'      => [
+					$product_1->get_id(),
+					$product_3->get_id(),
+				],
+			],
+		];
 	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -544,7 +544,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_is_express_checkout_context() {
 		return [
-			'Not Store API request' => [
+			'Not Store API request'                 => [
 				'is_store_api'       => false,
 				'has_express_header' => true,
 				'has_nonce_header'   => true,
@@ -619,11 +619,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_is_request_to_store_api() {
 		return [
-			'No rest_route set' => [
+			'No rest_route set'         => [
 				'rest_route' => '',
 				'expected'   => false,
 			],
-			'Store API checkout route' => [
+			'Store API checkout route'  => [
 				'rest_route' => '/wc/store/v1/checkout',
 				'expected'   => true,
 			],
@@ -631,7 +631,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'rest_route' => '/wc/store/v1/cart',
 				'expected'   => false,
 			],
-			'Non-Store API route' => [
+			'Non-Store API route'       => [
 				'rest_route' => '/wp/v2/posts',
 				'expected'   => false,
 			],
@@ -661,7 +661,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	public function provide_test_get_stripe_currency_decimals() {
 		return [
 			// No decimal currencies - should return 0
-			'Japanese Yen (no decimals)' => [
+			'Japanese Yen (no decimals)'      => [
 				'currency' => 'JPY',
 				'expected' => 0,
 			],
@@ -671,14 +671,45 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'expected' => 3,
 			],
 			// Default currencies - should return 2
-			'US Dollar (default)' => [
+			'US Dollar (default)'             => [
 				'currency' => 'USD',
 				'expected' => 2,
 			],
-			'Euro (default)' => [
+			'Euro (default)'                  => [
 				'currency' => 'EUR',
 				'expected' => 2,
 			],
 		];
+	}
+
+	/**
+	 * Tests for `get_booking_ids_from_cart`.
+	 *
+	 * @return void
+	 */
+	public function test_get_booking_ids_from_cart() {
+		WC()->session->init();
+		WC()->cart->empty_cart();
+
+		// Add a booking product to the cart.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_virtual( false );
+		$product->set_tax_status( 'none' );
+		$product->save();
+
+		WC()->cart->cart_contents = [
+			'booking' => [
+				'_booking_id' => $product->get_id(),
+			],
+		];
+
+		$helper = new WC_Stripe_Express_Checkout_Helper();
+		$actual = $helper->get_booking_ids_from_cart();
+
+		// Clean up.
+		WC()->session->cleanup_sessions();
+		WC()->cart->empty_cart();
+
+		$this->assertSame( [ $product->get_id() ], $actual );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-623

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR fixes issues with the Bookings extension when trying to add multiple slots to the cart. Currently, it is not possible to add more than one slot when the express checkout payment methods are enabled. This is because of the way we handle buttons on the product page. Also, some slots are not properly freed from cart when purchase using the product page.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`fix/booking-multiple-slots-with-ece`)
- Connect your Stripe account
- Enable express payment methods (Google Pay, Apple Pay, Link)
- Install the [Bookings extension](https://woocommerce.com/products/woocommerce-bookings/)
- Add a booking product

### Adding multiple slots

- As a shopper, attempt to add multiple days to your cart
- Go to your cart and confirm all of them are there

### Product page purchase after adding slots to the cart

- As a shopper, add multiple days to your cart
- Go to the bookings product page again
- Complete a purchase there using an express payment method
- Confirm the days you added previously to your cart are free again

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
