### PR TITLE
Fix free trial subscription purchases with payment methods that require redirection

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,6 @@
 * Fix - 3DS authentication modal not shown when using Google Pay
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Require credit cards to be enabled before Apple Pay and Google Pay can be enabled in PMC
-* Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
 * Fix - Free trial subscription orders with payment methods that require redirection (eg: iDeal, Bancontact)
 
 = 9.7.1 - 2025-07-28 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,8 @@
 * Fix - 3DS authentication modal not shown when using Google Pay
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Require credit cards to be enabled before Apple Pay and Google Pay can be enabled in PMC
+* Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
+* Fix - Free trial subscription orders with payment methods that require redirection (eg: iDeal, Bancontact)
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1007,8 +1007,8 @@ class WC_Stripe_Intent_Controller {
 
 		$request = $this->maybe_add_mandate_options( $request, $payment_information['selected_payment_type'] );
 
-		// Does not set the return URL if Single Payment Element is enabled or if the request needs redirection.
-		if ( $this->get_upe_gateway()->is_oc_enabled() || $this->request_needs_redirection( $payment_method_types ) ) {
+		// Does not set the return URL if the request needs redirection.
+		if ( $this->request_needs_redirection( $payment_method_types ) ) {
 			$request['return_url'] = $payment_information['return_url'];
 		}
 
@@ -1097,8 +1097,8 @@ class WC_Stripe_Intent_Controller {
 			$request['confirm'] = 'false';
 		}
 
-		// Removes the return URL if Single Payment Element is not enabled or if the request doesn't need redirection.
-		if ( ( ! $this->get_upe_gateway()->is_oc_enabled() || ! $this->request_needs_redirection( $request['payment_method_types'] ) ) ) {
+		// Removes the return URL if the request doesn't need redirection.
+		if ( ( ! $this->request_needs_redirection( $request['payment_method_types'] ) ) ) {
 			unset( $request['return_url'] );
 		}
 

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1098,7 +1098,7 @@ class WC_Stripe_Intent_Controller {
 		}
 
 		// Removes the return URL if the request doesn't need redirection.
-		if ( ( ! $this->request_needs_redirection( $request['payment_method_types'] ) ) ) {
+		if ( ! $this->request_needs_redirection( $request['payment_method_types'] ) ) {
 			unset( $request['return_url'] );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - 3DS authentication modal not shown when using Google Pay
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Require credit cards to be enabled before Apple Pay and Google Pay can be enabled in PMC
+* Fix - Free trial subscription orders with payment methods that require redirection (eg: iDeal, Bancontact)
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-638

## Changes proposed in this Pull Request:

Remove Optimized Checkout related `return_url` handling to fix free-trial subscription purchases. It's not clear to me why these checks were needed originally, so I would appreciate additional regression checks with OC enabled.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. As a merchant, make sure the Subscriptions plugin is installed and active.
2. Go to WC -> Settings -> Subscriptions. Make sure "Allow $0 initial checkout without a payment method." setting is not enabled.
3. Create a free trial subscription.
4. As a shopper, try to purchase the subscription using iDeal or Bancontact.
5. In **develop**  there will be an error at checkout.
6. In this branch, you should be able to purchase the subscription. 



<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
