### PR TITLE
Fix 'Invalid Configuration' error when disabling card

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Fix fatal when processing setup intents for free subscriptions via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
+* Fix - Require credit cards to be enabled before Apple Pay and Google Pay can be enabled in PMC
 
 = 9.7.0 - 2025-07-21 =
 * Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -300,8 +300,11 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
 		$is_payment_request_enabled   = $request->get_param( 'is_payment_request_enabled' );
 
-		if ( $is_upe_enabled && $is_payment_request_enabled &&
-			in_array( WC_Stripe_Payment_Methods::CARD, $payment_method_ids_to_enable, true ) ) {
+		// Card is required for Apple Pay and Google Pay.
+		if ( $is_upe_enabled &&
+			 $is_payment_request_enabled &&
+			 in_array( WC_Stripe_Payment_Methods::CARD, $payment_method_ids_to_enable, true )
+		) {
 			$payment_method_ids_to_enable = array_merge(
 				$payment_method_ids_to_enable,
 				[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -300,7 +300,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
 		$is_payment_request_enabled   = $request->get_param( 'is_payment_request_enabled' );
 
-		if ( $is_upe_enabled && $is_payment_request_enabled ) {
+		if ( $is_upe_enabled && $is_payment_request_enabled &&
+			in_array( WC_Stripe_Payment_Methods::CARD, $payment_method_ids_to_enable, true ) ) {
 			$payment_method_ids_to_enable = array_merge(
 				$payment_method_ids_to_enable,
 				[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]

--- a/readme.txt
+++ b/readme.txt
@@ -125,5 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
 * Fix - Fix fatal when processing Boleto setup intents via webhooks
 * Fix - Prevent Stripe API calls after several consecutive 401 (Unauthorized) responses
+* Fix - Require credit cards to be enabled before Apple Pay and Google Pay can be enabled in PMC
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
@@ -376,6 +376,53 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 		remove_filter( 'user_has_cap', $cb );
 	}
 
+	public function test_update_settings_enables_apple_pay_google_pay() {
+		// Before the update: card and CashApp are enabled, Apple Pay and Google Pay are disabled
+		$this->mock_payment_method_configurations(
+			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::CASHAPP_PAY ],
+			[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
+		);
+
+		// After the update: card, Apple Pay, and Google Pay are enabled, CashApp is disabled
+		$this->expect_payment_method_configurations_update(
+			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ],
+			[ WC_Stripe_Payment_Methods::CASHAPP_PAY ]
+		);
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		// Disable CashApp, keep card enabled.
+		$request->set_param( 'enabled_payment_method_ids', [ WC_Stripe_Payment_Methods::CARD ] );
+		$request->set_param( 'is_upe_enabled', true );
+		// Enable Apple Pay and Google Pay.
+		$request->set_param( 'is_payment_request_enabled', true );
+
+		$response = $this->controller->update_settings( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	public function test_update_settings_enforces_apple_pay_google_pay_requires_card() {
+		// Before the update: card, Apple Pay, and Google Pay are enabled, CashApp is disabled
+		$this->mock_payment_method_configurations(
+			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ],
+			[ WC_Stripe_Payment_Methods::CASHAPP_PAY ]
+		);
+
+		// After the update: CashApp is enabled, card, Apple Pay, and Google Pay are disabled
+		$this->expect_payment_method_configurations_update(
+			[ WC_Stripe_Payment_Methods::CASHAPP_PAY ],
+			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
+		);
+
+		$request = new WP_REST_Request( 'POST', self::SETTINGS_ROUTE );
+		// Disable card, enable CashApp.
+		$request->set_param( 'enabled_payment_method_ids', [ WC_Stripe_Payment_Methods::CASHAPP_PAY ] );
+		$request->set_param( 'is_upe_enabled', true );
+		// Enable Apple Pay and Google Pay -- this will be ignored because card is disabled
+		$request->set_param( 'is_payment_request_enabled', true );
+
+		$response = $this->controller->update_settings( $request );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
 	/**
 	 * Tests for the dismiss notice endpoint.
 	 *

--- a/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
@@ -376,6 +376,10 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 		remove_filter( 'user_has_cap', $cb );
 	}
 
+	/**
+	 * Tests that Apple Pay and Google Pay can be enabled in the PMC
+	 * when payment request is enabled, and card is enabled.
+	 */
 	public function test_update_settings_enables_apple_pay_google_pay() {
 		// Before the update: card and CashApp are enabled, Apple Pay and Google Pay are disabled
 		$this->mock_payment_method_configurations(
@@ -399,6 +403,10 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 		$this->assertEquals( 200, $response->get_status() );
 	}
 
+	/**
+	 * Tests that Apple Pay and Google Pay can only be enabled in the PMC
+	 * when payment request is enabled, and card is enabled.
+	 */
 	public function test_update_settings_enforces_apple_pay_google_pay_requires_card() {
 		// Before the update: card, Apple Pay, and Google Pay are enabled, CashApp is disabled
 		$this->mock_payment_method_configurations(


### PR DESCRIPTION
## Changes proposed in this Pull Request:
When you attempt to disable **Credit card / debit card** as a payment method while Apple Pay and Google Pay are enabled, you will get the following error in your logs:

```
Error: Invalid configuration. Apple Pay and Google Pay require Card to be enabled.: https://dashboard.stripe.com/acct_...
``` 

This PR enforces the card requirement before including Apple Pay and Google Pay in the PMC update.

## Testing instructions
1. Ensure your test site is PMC-enabled: `wp option patch update woocommerce_stripe_settings pmc_enabled 'yes'`
2. Enable cards, Apple Pay/Google Pay, and another payment method like CashApp.
3. Refresh the settings page.
4. Uncheck cards. Notice that the express checkout section gets hidden as cards are a requirement.
5. Click "Save changes."
   - In `develop`, you get the error described in your logs. On page refresh, you will see cards and Apple Pay/Google Pay are still enabled.
   - In this branch, no log errors and your changes should persist.

Note: a separate issue I noticed is that when PMC updates fail, we do not get any indication in the settings page. We get the same "Settings saved" success message, but on page refresh, the changes were not persisted. Documented in STRIPE-643

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
