### PR TITLE
Fix the version placeholder

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -110,7 +110,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
-= 9.7.1 - xxxx-xx-xx
+= 9.7.1 - xxxx-xx-xx =
 * Fix - Fix fatal when processing setup intents for free subscriptions via webhooks
 * Fix - Fix required field error message and PHP warning for custom checkout fields that don't have a label
 * Add - Add state mapping for Lithuania in express checkout


### PR DESCRIPTION
Fix release version placeholder to make the `woorelease` validation.

```
WR [15:03:22] [ERROR] Can't find the changelog version declaration in the readme.txt for woocommerce-gateway-stripe
WR [15:03:22] [ERROR] Woorelease finished with errors! Please correct the error and retry.
WR [15:03:22] [ERROR] For more information on the error, please visit https://github.com/woocommerce/woorelease/wiki/Errors#error-43 or ping #woo-devs in Slack
```