### PR TITLE
Fix/632 show generic error to customers when invalid keys

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Fix - 3DS authentication modal not shown when using Google Pay
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Require credit cards to be enabled before Apple Pay and Google Pay can be enabled in PMC
+* Tweak - Update checkout error message for invalid API key to be more generic and user-friendly
 
 = 9.7.0 - 2025-07-21 =
 * Update - Removes BNPL payment methods (Klarna and Affirm) when other official plugins are active

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1283,6 +1283,13 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			$e->getLocalizedMessage()
 		);
 
+		// If the error message is 'Invalid API Key...', we want to show a more generic error message,
+		// as the user won't not be able to do anything about it.
+		// The log and the order note will still show the full error message for debugging purposes.
+		if ( 0 === strpos( $e->getLocalizedMessage(), 'Invalid API Key' ) ) {
+			$error_message = __( "We're not able to process this payment. This may be an error on our side. Please contact us if you need any help placing your order.", 'woocommerce-gateway-stripe' );
+		}
+
 		wc_add_notice( $error_message, 'error' );
 
 		WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1284,7 +1284,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		);
 
 		// If the error message is 'Invalid API Key...', we want to show a more generic error message,
-		// as the user won't not be able to do anything about it.
+		// as the user won't be able to do anything about it.
 		// The log and the order note will still show the full error message for debugging purposes.
 		if ( 0 === strpos( $e->getLocalizedMessage(), 'Invalid API Key' ) ) {
 			$error_message = __( "We're not able to process this payment. This may be an error on our side. Please contact us if you need any help placing your order.", 'woocommerce-gateway-stripe' );

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - 3DS authentication modal not shown when using Google Pay
 * Update - Improve Stripe API connector logging to include request/response context
 * Fix - Require credit cards to be enabled before Apple Pay and Google Pay can be enabled in PMC
+* Tweak - Update checkout error message for invalid API key to be more generic and user-friendly
+
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-632

## Changes proposed in this Pull Request:

This PR replaces the error message displayed during checkout when the Stripe API Key is invalid; we specifically mention that the payment was not processed, and then use a message similar to what we use when no payment methods are available (as this is the same case, with an invalid API key all payment methods will fail).

<img width="1114" height="306" alt="Screenshot 2025-07-28 at 18 52 31" src="https://github.com/user-attachments/assets/22122691-b602-4433-8841-caccb870601e" />

The _logs entry_ and the _order note_ still show the full error message for debugging purposes.

---

For context, when there are no payment methods available during checkout, the message look like this:
<img width="703" height="170" alt="Screenshot 2025-07-28 at 19 07 22" src="https://github.com/user-attachments/assets/2d80592a-6c73-4d56-8500-6a15f01310bc" />

## Testing instructions

1. Checkout the `develop` branch
2. Replace the `secret_key` with an invalid value:
    `wp option patch update woocommerce_stripe_settings test_secret_key 'sk_test_INVALID'`
3. Go to the Store, add a product to the cart
4. Go to the Blocks Checkout, place the order, and check the error message mentions the API key:
    <img width="804" height="61" alt="Screenshot 2025-07-28 at 19 25 10" src="https://github.com/user-attachments/assets/a80235d6-c922-48be-b6cb-1cb6ffe9b029" />
5. Checkout this branch
6. Go to the Blocks Checkout, place the order again and check that the error message is now generic:
    <img width="1099" height="129" alt="Screenshot 2025-07-28 at 19 23 06" src="https://github.com/user-attachments/assets/949ff5d8-c949-4d98-8e25-e5c6e1014afc" />
8. Go to the Shortcode Checkout, attempt to place the order again, and check the message:
    <img width="762" height="64" alt="Screenshot 2025-07-28 at 19 25 22" src="https://github.com/user-attachments/assets/90f6d72c-5cdd-4754-8f32-b55c9e04fc0b" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
