### PR TITLE
PoC: Use _x() to identify shopper-facing strings

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -1,5 +1,5 @@
 /* global Stripe */
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { applyFilters } from '@wordpress/hooks';
 import {
@@ -46,19 +46,22 @@ export default class WCStripeAPI {
 		// error is a jqXHR and statusText is one of "timeout", "error", "abort", and "parsererror".
 		switch ( error.statusText ) {
 			case 'timeout':
-				return __(
+				return _x(
 					'A timeout occurred while connecting to the server. Please try again.',
+					'shopper',
 					'woocommerce-gateway-stripe'
 				);
 			case 'abort':
-				return __(
+				return _x(
 					'The connection to the server was aborted. Please try again.',
+					'shopper',
 					'woocommerce-gateway-stripe'
 				);
 			case 'error':
 			default:
-				return __(
+				return _x(
 					'An error occurred while connecting to the server. Please try again.',
+					'shopper',
 					'woocommerce-gateway-stripe'
 				);
 		}

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -48,20 +48,20 @@ export default class WCStripeAPI {
 			case 'timeout':
 				return _x(
 					'A timeout occurred while connecting to the server. Please try again.',
-					'shopper',
+					'[shopper]',
 					'woocommerce-gateway-stripe'
 				);
 			case 'abort':
 				return _x(
 					'The connection to the server was aborted. Please try again.',
-					'shopper',
+					'[shopper]',
 					'woocommerce-gateway-stripe'
 				);
 			case 'error':
 			default:
 				return _x(
 					'An error occurred while connecting to the server. Please try again.',
-					'shopper',
+					'[shopper]',
 					'woocommerce-gateway-stripe'
 				);
 		}

--- a/client/blocks/credit-card/elements.js
+++ b/client/blocks/credit-card/elements.js
@@ -1,5 +1,5 @@
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import {
 	CardElement,
 	CardNumberElement,
@@ -49,8 +49,9 @@ export const InlineCard = ( {
 					onChange={ errorCallback }
 				/>
 				<label htmlFor="wc-stripe-inline-card-element">
-					{ __(
+					{ _x(
 						'Credit Card Information',
+						'shopper',
 						'woocommerce-gateway-stripe'
 					) }
 				</label>
@@ -115,7 +116,11 @@ export const CardElements = ( {
 					onBlur={ () => cardNumOnActive( isEmpty.cardNumber ) }
 				/>
 				<label htmlFor="wc-stripe-card-number-element">
-					{ __( 'Card Number', 'woocommerce-gateway-stripe' ) }
+					{ _x(
+						'Card Number',
+						'shopper',
+						'woocommerce-gateway-stripe'
+					) }
 				</label>
 				<ValidationInputError errorMessage={ cardNumError } />
 			</div>
@@ -132,7 +137,11 @@ export const CardElements = ( {
 					id="wc-stripe-card-expiry-element"
 				/>
 				<label htmlFor="wc-stripe-card-expiry-element">
-					{ __( 'Expiry Date', 'woocommerce-gateway-stripe' ) }
+					{ _x(
+						'Expiry Date',
+						'shopper',
+						'woocommerce-gateway-stripe'
+					) }
 				</label>
 				<ValidationInputError errorMessage={ cardExpiryError } />
 			</div>
@@ -146,7 +155,7 @@ export const CardElements = ( {
 					id="wc-stripe-card-code-element"
 				/>
 				<label htmlFor="wc-stripe-card-code-element">
-					{ __( 'CVV/CVC', 'woocommerce-gateway-stripe' ) }
+					{ _x( 'CVV/CVC', 'shopper', 'woocommerce-gateway-stripe' ) }
 				</label>
 				<ValidationInputError errorMessage={ cardCvcError } />
 			</div>

--- a/client/blocks/credit-card/elements.js
+++ b/client/blocks/credit-card/elements.js
@@ -51,7 +51,7 @@ export const InlineCard = ( {
 				<label htmlFor="wc-stripe-inline-card-element">
 					{ _x(
 						'Credit Card Information',
-						'shopper',
+						'[shopper]',
 						'woocommerce-gateway-stripe'
 					) }
 				</label>
@@ -118,7 +118,7 @@ export const CardElements = ( {
 				<label htmlFor="wc-stripe-card-number-element">
 					{ _x(
 						'Card Number',
-						'shopper',
+						'[shopper]',
 						'woocommerce-gateway-stripe'
 					) }
 				</label>
@@ -139,7 +139,7 @@ export const CardElements = ( {
 				<label htmlFor="wc-stripe-card-expiry-element">
 					{ _x(
 						'Expiry Date',
-						'shopper',
+						'[shopper]',
 						'woocommerce-gateway-stripe'
 					) }
 				</label>
@@ -155,7 +155,11 @@ export const CardElements = ( {
 					id="wc-stripe-card-code-element"
 				/>
 				<label htmlFor="wc-stripe-card-code-element">
-					{ _x( 'CVV/CVC', 'shopper', 'woocommerce-gateway-stripe' ) }
+					{ _x(
+						'CVV/CVC',
+						'[shopper]',
+						'woocommerce-gateway-stripe'
+					) }
 				</label>
 				<ValidationInputError errorMessage={ cardCvcError } />
 			</div>

--- a/client/blocks/credit-card/index.js
+++ b/client/blocks/credit-card/index.js
@@ -33,7 +33,7 @@ const StripeLabel = ( props ) => {
 
 	const labelText =
 		getBlocksConfiguration()?.title ??
-		_x( 'Credit / Debit Card', 'shopper', 'woocommerce-gateway-stripe' );
+		_x( 'Credit / Debit Card', '[shopper]', 'woocommerce-gateway-stripe' );
 
 	return <PaymentMethodLabel text={ labelText } />;
 };
@@ -60,7 +60,7 @@ const stripeCcPaymentMethod = {
 	canMakePayment: () => stripePromise,
 	ariaLabel: _x(
 		'Stripe Credit Card payment method',
-		'shopper',
+		'[shopper]',
 		'woocommerce-gateway-stripe'
 	),
 	supports,

--- a/client/blocks/credit-card/index.js
+++ b/client/blocks/credit-card/index.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { useEffect, useState } from '@wordpress/element';
 import { ThreeDSecurePaymentHandler } from '../three-d-secure';
 import { StripeCreditCard, getStripeCreditCardIcons } from './payment-method';
@@ -33,7 +33,7 @@ const StripeLabel = ( props ) => {
 
 	const labelText =
 		getBlocksConfiguration()?.title ??
-		__( 'Credit / Debit Card', 'woocommerce-gateway-stripe' );
+		_x( 'Credit / Debit Card', 'shopper', 'woocommerce-gateway-stripe' );
 
 	return <PaymentMethodLabel text={ labelText } />;
 };
@@ -58,8 +58,9 @@ const stripeCcPaymentMethod = {
 	),
 	icons: cardIcons,
 	canMakePayment: () => stripePromise,
-	ariaLabel: __(
+	ariaLabel: _x(
 		'Stripe Credit Card payment method',
+		'shopper',
 		'woocommerce-gateway-stripe'
 	),
 	supports,

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -1,5 +1,5 @@
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { useStripe, useElements } from '@stripe/react-stripe-js';
 import {
 	onAbortPaymentHandler,
@@ -113,8 +113,9 @@ export const useExpressCheckout = ( {
 
 			if ( getExpressCheckoutData( 'taxes_based_on_billing' ) ) {
 				displayExpressCheckoutNotice(
-					__(
+					_x(
 						'Final taxes charged can differ based on your actual billing address when using Express Checkout buttons (Link, Google Pay or Apple Pay).',
+						'shopper',
 						'woocommerce-gateway-stripe'
 					),
 					'info',

--- a/client/blocks/express-checkout/hooks.js
+++ b/client/blocks/express-checkout/hooks.js
@@ -115,7 +115,7 @@ export const useExpressCheckout = ( {
 				displayExpressCheckoutNotice(
 					_x(
 						'Final taxes charged can differ based on your actual billing address when using Express Checkout buttons (Link, Google Pay or Apple Pay).',
-						'shopper',
+						'[shopper]',
 						'woocommerce-gateway-stripe'
 					),
 					'info',

--- a/client/blocks/upe/upe-deferred-intent-creation/blik-code-element.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/blik-code-element.js
@@ -1,5 +1,5 @@
 import { ValidatedTextInput } from '@woocommerce/blocks-checkout';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { useState } from 'react';
 
 const BlikCodeElement = () => {
@@ -16,15 +16,17 @@ const BlikCodeElement = () => {
 				value={ blikCode }
 				customValidityMessage={ ( validity ) => {
 					if ( validity.valueMissing ) {
-						return __(
+						return _x(
 							'Please enter a valid BLIK code',
+							'shopper',
 							'woocommerce-gateway-stripe'
 						);
 					}
 
 					if ( validity.patternMismatch ) {
-						return __(
+						return _x(
 							'BLIK Code is invalid',
+							'shopper',
 							'woocommerce-gateway-stripe'
 						);
 					}
@@ -36,8 +38,9 @@ const BlikCodeElement = () => {
 					marginTop: 'var(--wp--preset--spacing--50)',
 				} }
 			>
-				{ __(
+				{ _x(
 					'After submitting your order, please authorize the payment in your mobile banking application.',
+					'shopper',
 					'woocommerce-gateway-stripe'
 				) }
 			</p>

--- a/client/blocks/upe/upe-deferred-intent-creation/blik-code-element.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/blik-code-element.js
@@ -18,7 +18,7 @@ const BlikCodeElement = () => {
 					if ( validity.valueMissing ) {
 						return _x(
 							'Please enter a valid BLIK code',
-							'shopper',
+							'[shopper]',
 							'woocommerce-gateway-stripe'
 						);
 					}
@@ -26,7 +26,7 @@ const BlikCodeElement = () => {
 					if ( validity.patternMismatch ) {
 						return _x(
 							'BLIK Code is invalid',
-							'shopper',
+							'[shopper]',
 							'woocommerce-gateway-stripe'
 						);
 					}
@@ -40,7 +40,7 @@ const BlikCodeElement = () => {
 			>
 				{ _x(
 					'After submitting your order, please authorize the payment in your mobile banking application.',
-					'shopper',
+					'[shopper]',
 					'woocommerce-gateway-stripe'
 				) }
 			</p>

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { _x, sprintf } from '@wordpress/i18n';
 import { StoreNotice } from '@woocommerce/blocks-checkout';
 import { Elements } from '@stripe/react-stripe-js';
 /**
@@ -75,8 +75,9 @@ const PaymentElements = ( {
 					error?.message ??
 						sprintf(
 							// translators: %s is the payment method title.
-							__(
+							_x(
 								'Failed to load %s payment method. Please refresh the page and try again.',
+								'shopper',
 								'woocommerce-gateway-stripe'
 							),
 							paymentMethodTitle
@@ -111,8 +112,9 @@ const PaymentElements = ( {
 			<LoadingMask
 				isLoading={ true }
 				showSpinner={ true }
-				screenReaderLabel={ __(
+				screenReaderLabel={ _x(
 					'Loading payment method…',
+					'shopper',
 					'woocommerce-gateway-stripe'
 				) }
 			/>

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -77,7 +77,7 @@ const PaymentElements = ( {
 							// translators: %s is the payment method title.
 							_x(
 								'Failed to load %s payment method. Please refresh the page and try again.',
-								'shopper',
+								'[shopper]',
 								'woocommerce-gateway-stripe'
 							),
 							paymentMethodTitle
@@ -114,7 +114,7 @@ const PaymentElements = ( {
 				showSpinner={ true }
 				screenReaderLabel={ _x(
 					'Loading payment method…',
-					'shopper',
+					'[shopper]',
 					'woocommerce-gateway-stripe'
 				) }
 			/>

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -190,7 +190,7 @@ const PaymentProcessor = ( {
 							type: 'error',
 							message: _x(
 								'Invalid or missing payment details. Please ensure the provided payment method is correctly entered.',
-								'shopper',
+								'[shopper]',
 								'woocommerce-gateway-stripe'
 							),
 						};
@@ -212,7 +212,7 @@ const PaymentProcessor = ( {
 							type: 'error',
 							message: _x(
 								'Your payment information is incomplete.',
-								'shopper',
+								'[shopper]',
 								'woocommerce-gateway-stripe'
 							),
 						};

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-processor.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getPaymentMethods } from '@woocommerce/blocks-registry';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
 import {
 	PaymentElement,
@@ -188,8 +188,9 @@ const PaymentProcessor = ( {
 					if ( hasLoadErrorRef.current ) {
 						return {
 							type: 'error',
-							message: __(
+							message: _x(
 								'Invalid or missing payment details. Please ensure the provided payment method is correctly entered.',
+								'shopper',
 								'woocommerce-gateway-stripe'
 							),
 						};
@@ -209,8 +210,9 @@ const PaymentProcessor = ( {
 					if ( ! ( isPaymentElementComplete || isBlikSelected ) ) {
 						return {
 							type: 'error',
-							message: __(
+							message: _x(
 								'Your payment information is incomplete.',
+								'shopper',
 								'woocommerce-gateway-stripe'
 							),
 						};

--- a/client/brand-logos/stripe-mark/index.js
+++ b/client/brand-logos/stripe-mark/index.js
@@ -17,7 +17,7 @@ const StripeMark = ( { className, ...restProps } ) => (
 		src={ mark }
 		width="64"
 		height="64"
-		alt={ _x( 'Stripe logo', 'shopper', 'woocommerce-gateway-stripe' ) }
+		alt={ _x( 'Stripe logo', '[shopper]', 'woocommerce-gateway-stripe' ) }
 		{ ...restProps }
 	/>
 );

--- a/client/brand-logos/stripe-mark/index.js
+++ b/client/brand-logos/stripe-mark/index.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import classNames from 'classnames';
 import mark from './mark.svg';
 
@@ -17,7 +17,7 @@ const StripeMark = ( { className, ...restProps } ) => (
 		src={ mark }
 		width="64"
 		height="64"
-		alt={ __( 'Stripe logo', 'woocommerce-gateway-stripe' ) }
+		alt={ _x( 'Stripe logo', 'shopper', 'woocommerce-gateway-stripe' ) }
 		{ ...restProps }
 	/>
 );

--- a/client/brand-logos/woo-white/index.js
+++ b/client/brand-logos/woo-white/index.js
@@ -20,7 +20,7 @@ const WooLogo = ( { className, ...restProps } ) => (
 		src={ logo }
 		width="64"
 		height="64"
-		alt={ _x( 'Woo logo', 'shopper', 'woocommerce-gateway-stripe' ) }
+		alt={ _x( 'Woo logo', '[shopper]', 'woocommerce-gateway-stripe' ) }
 		{ ...restProps }
 	/>
 );

--- a/client/brand-logos/woo-white/index.js
+++ b/client/brand-logos/woo-white/index.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import classNames from 'classnames';
 import logo from './logo.svg';
 
@@ -20,7 +20,7 @@ const WooLogo = ( { className, ...restProps } ) => (
 		src={ logo }
 		width="64"
 		height="64"
-		alt={ __( 'Woo logo', 'woocommerce-gateway-stripe' ) }
+		alt={ _x( 'Woo logo', 'shopper', 'woocommerce-gateway-stripe' ) }
 		{ ...restProps }
 	/>
 );

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { _x, sprintf } from '@wordpress/i18n';
 import {
 	appendPaymentMethodIdToForm,
 	appendPaymentIntentIdToForm,
@@ -118,8 +118,9 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 				error?.message ??
 					sprintf(
 						// translators: %s is the payment method title.
-						__(
+						_x(
 							'Failed to load %s payment method. Please refresh the page and try again.',
+							'shopper',
 							'woocommerce-gateway-stripe'
 						),
 						paymentMethodsConfig?.[ paymentMethodType ]?.title ?? ''
@@ -419,8 +420,9 @@ export const processPayment = (
 	blockUI( jQueryForm );
 
 	const getErrorMessage = ( err ) => {
-		const genericErrorMessage = __(
+		const genericErrorMessage = _x(
 			'Payment failed. Please try again.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		);
 		if ( ! err ) {
@@ -452,7 +454,11 @@ export const processPayment = (
 		};
 		return sprintf(
 			/* translators: %s is an input field name */
-			__( '%s is a required field.', 'woocommerce-gateway-stripe' ),
+			_x(
+				'%s is a required field.',
+				'shopper',
+				'woocommerce-gateway-stripe'
+			),
 			( section && section[ 1 ]
 				? toProperCase( section[ 1 ] ) + ' '
 				: '' ) + toProperCase( field[ 1 ] )
@@ -467,8 +473,9 @@ export const processPayment = (
 
 			if ( hasLoadError ) {
 				throw new Error(
-					__(
+					_x(
 						'Invalid or missing payment details. Please ensure the provided payment method is correctly entered.',
+						'shopper',
 						'woocommerce-gateway-stripe'
 					)
 				);
@@ -669,8 +676,9 @@ export const confirmVoucherPayment = async ( api, jQueryForm ) => {
 
 	if ( ! stripeServerData?.orderReceivedURL ) {
 		showErrorCheckout(
-			__(
+			_x(
 				'There was a problem processing the payment. Please refresh the page to try again.',
+				'shopper',
 				'woocommerce-gateway-stripe'
 			)
 		);

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -120,7 +120,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 						// translators: %s is the payment method title.
 						_x(
 							'Failed to load %s payment method. Please refresh the page and try again.',
-							'shopper',
+							'[shopper]',
 							'woocommerce-gateway-stripe'
 						),
 						paymentMethodsConfig?.[ paymentMethodType ]?.title ?? ''
@@ -422,7 +422,7 @@ export const processPayment = (
 	const getErrorMessage = ( err ) => {
 		const genericErrorMessage = _x(
 			'Payment failed. Please try again.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		);
 		if ( ! err ) {
@@ -456,7 +456,7 @@ export const processPayment = (
 			/* translators: %s is an input field name */
 			_x(
 				'%s is a required field.',
-				'shopper',
+				'[shopper]',
 				'woocommerce-gateway-stripe'
 			),
 			( section && section[ 1 ]
@@ -475,7 +475,7 @@ export const processPayment = (
 				throw new Error(
 					_x(
 						'Invalid or missing payment details. Please ensure the provided payment method is correctly entered.',
-						'shopper',
+						'[shopper]',
 						'woocommerce-gateway-stripe'
 					)
 				);
@@ -678,7 +678,7 @@ export const confirmVoucherPayment = async ( api, jQueryForm ) => {
 		showErrorCheckout(
 			_x(
 				'There was a problem processing the payment. Please refresh the page to try again.',
-				'shopper',
+				'[shopper]',
 				'woocommerce-gateway-stripe'
 			)
 		);

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -72,7 +72,7 @@ jQuery( function ( $ ) {
 	let wcStripeECEError = '';
 	const defaultErrorMessage = _x(
 		'There was an error getting the product information.',
-		'shopper',
+		'[shopper]',
 		'woocommerce-gateway-stripe'
 	);
 
@@ -130,7 +130,7 @@ jQuery( function ( $ ) {
 		if ( addToCartButton.classList.contains( 'disabled' ) ) {
 			const defaultMessage = _x(
 				'Please select your product options before proceeding.',
-				'shopper',
+				'[shopper]',
 				'woocommerce-gateway-stripe'
 			);
 			let message;
@@ -143,7 +143,7 @@ jQuery( function ( $ ) {
 					getAddToCartVariationParams( 'i18n_unavailable_text' ) ||
 					_x(
 						'Sorry, this product is unavailable. Please choose a different combination.',
-						'shopper',
+						'[shopper]',
 						'woocommerce-gateway-stripe'
 					);
 			}
@@ -383,7 +383,7 @@ jQuery( function ( $ ) {
 					displayExpressCheckoutNotice(
 						_x(
 							'Final taxes charged can differ based on your actual billing address when using Express Checkout buttons (Link, Google Pay or Apple Pay).',
-							'shopper',
+							'[shopper]',
 							'woocommerce-gateway-stripe'
 						),
 						'info',
@@ -432,7 +432,7 @@ jQuery( function ( $ ) {
 					if ( wcStripeECE.isAddToCartSuccessful === false ) {
 						const message = _x(
 							'There was an error adding the product to the cart.',
-							'shopper',
+							'[shopper]',
 							'woocommerce-gateway-stripe'
 						);
 						return wcStripeECE.abortPayment( event, message );

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -1,7 +1,7 @@
 /* global wcStripeExpressCheckoutPayForOrderParams */
 /* global wc_stripe_express_checkout_params */
 
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { debounce } from 'lodash';
 import jQuery from 'jquery';
 import WCStripeAPI from '../../api';
@@ -70,8 +70,9 @@ jQuery( function ( $ ) {
 	);
 
 	let wcStripeECEError = '';
-	const defaultErrorMessage = __(
+	const defaultErrorMessage = _x(
 		'There was an error getting the product information.',
+		'shopper',
 		'woocommerce-gateway-stripe'
 	);
 
@@ -127,8 +128,9 @@ jQuery( function ( $ ) {
 
 		// First check if product can be added to cart.
 		if ( addToCartButton.classList.contains( 'disabled' ) ) {
-			const defaultMessage = __(
+			const defaultMessage = _x(
 				'Please select your product options before proceeding.',
+				'shopper',
 				'woocommerce-gateway-stripe'
 			);
 			let message;
@@ -139,8 +141,9 @@ jQuery( function ( $ ) {
 			) {
 				message =
 					getAddToCartVariationParams( 'i18n_unavailable_text' ) ||
-					__(
+					_x(
 						'Sorry, this product is unavailable. Please choose a different combination.',
+						'shopper',
 						'woocommerce-gateway-stripe'
 					);
 			}
@@ -378,8 +381,9 @@ jQuery( function ( $ ) {
 
 				if ( getExpressCheckoutData( 'taxes_based_on_billing' ) ) {
 					displayExpressCheckoutNotice(
-						__(
+						_x(
 							'Final taxes charged can differ based on your actual billing address when using Express Checkout buttons (Link, Google Pay or Apple Pay).',
+							'shopper',
 							'woocommerce-gateway-stripe'
 						),
 						'info',
@@ -426,8 +430,9 @@ jQuery( function ( $ ) {
 					);
 
 					if ( wcStripeECE.isAddToCartSuccessful === false ) {
-						const message = __(
+						const message = _x(
 							'There was an error adding the product to the cart.',
+							'shopper',
 							'woocommerce-gateway-stripe'
 						);
 						return wcStripeECE.abortPayment( event, message );

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { getErrorMessageFromNotice, normalizeOrderData } from './utils';
 
 const handlePaymentFlowException = ( event, exception, abortPayment ) => {
@@ -19,8 +19,9 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 		}
 	}
 	if ( ! errorMessage ) {
-		errorMessage = __(
+		errorMessage = _x(
 			'There was a problem processing the order.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		);
 	}

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -21,7 +21,7 @@ const handlePaymentFlowException = ( event, exception, abortPayment ) => {
 	if ( ! errorMessage ) {
 		errorMessage = _x(
 			'There was a problem processing the order.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		);
 	}

--- a/client/express-checkout/transformers/wc-to-stripe.js
+++ b/client/express-checkout/transformers/wc-to-stripe.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { getExpressCheckoutData } from 'wcstripe/express-checkout/utils';
@@ -63,7 +63,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 	if ( taxAmount ) {
 		displayItems.push( {
 			amount: transformPrice( taxAmount, cartData.totals ),
-			name: __( 'Tax', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Tax', 'shopper', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 
@@ -78,7 +78,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 		displayItems.push( {
 			key: 'total_shipping',
 			amount: transformPrice( shippingAmount, cartData.totals ),
-			name: __( 'Shipping', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Shipping', 'shopper', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 
@@ -89,7 +89,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 	if ( discountAmount ) {
 		displayItems.push( {
 			amount: -transformPrice( discountAmount, cartData.totals ),
-			name: __( 'Discount', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Discount', 'shopper', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 
@@ -97,7 +97,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 	if ( refundAmount ) {
 		displayItems.push( {
 			amount: -transformPrice( refundAmount, cartData.totals ),
-			name: __( 'Refund', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Refund', 'shopper', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 

--- a/client/express-checkout/transformers/wc-to-stripe.js
+++ b/client/express-checkout/transformers/wc-to-stripe.js
@@ -63,7 +63,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 	if ( taxAmount ) {
 		displayItems.push( {
 			amount: transformPrice( taxAmount, cartData.totals ),
-			name: _x( 'Tax', 'shopper', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Tax', '[shopper]', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 
@@ -78,7 +78,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 		displayItems.push( {
 			key: 'total_shipping',
 			amount: transformPrice( shippingAmount, cartData.totals ),
-			name: _x( 'Shipping', 'shopper', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Shipping', '[shopper]', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 
@@ -89,7 +89,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 	if ( discountAmount ) {
 		displayItems.push( {
 			amount: -transformPrice( discountAmount, cartData.totals ),
-			name: _x( 'Discount', 'shopper', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Discount', '[shopper]', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 
@@ -97,7 +97,7 @@ export const transformCartDataForDisplayItems = ( rawCartData ) => {
 	if ( refundAmount ) {
 		displayItems.push( {
 			amount: -transformPrice( refundAmount, cartData.totals ),
-			name: _x( 'Refund', 'shopper', 'woocommerce-gateway-stripe' ),
+			name: _x( 'Refund', '[shopper]', 'woocommerce-gateway-stripe' ),
 		} );
 	}
 

--- a/client/stripe-utils/cash-app-limit-notice-handler.js
+++ b/client/stripe-utils/cash-app-limit-notice-handler.js
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { callWhenElementIsAvailable } from 'wcstripe/blocks/upe/call-when-element-is-available';
 import { CASH_APP_NOTICE_AMOUNT_THRESHOLD } from 'wcstripe/data/constants';
 
@@ -10,8 +10,10 @@ const LIMIT_NOTICE_CLASSNAME = 'wc-block-checkout__payment-method-limit-notice';
  */
 export const cashAppLimitNotice = document.createElement( 'div' );
 cashAppLimitNotice.classList.add( 'woocommerce-info', LIMIT_NOTICE_CLASSNAME );
-cashAppLimitNotice.textContent = __(
-	'Please note that, depending on your account and transaction history, Cash App Pay may reject your transaction due to its amount.'
+cashAppLimitNotice.textContent = _x(
+	'Please note that, depending on your account and transaction history, Cash App Pay may reject your transaction due to its amount.',
+	'shopper',
+	'woocommerce-gateway-stripe'
 );
 cashAppLimitNotice.setAttribute( 'data-testid', 'cash-app-limit-notice' );
 

--- a/client/stripe-utils/cash-app-limit-notice-handler.js
+++ b/client/stripe-utils/cash-app-limit-notice-handler.js
@@ -12,7 +12,7 @@ export const cashAppLimitNotice = document.createElement( 'div' );
 cashAppLimitNotice.classList.add( 'woocommerce-info', LIMIT_NOTICE_CLASSNAME );
 cashAppLimitNotice.textContent = _x(
 	'Please note that, depending on your account and transaction history, Cash App Pay may reject your transaction due to its amount.',
-	'shopper',
+	'[shopper]',
 	'woocommerce-gateway-stripe'
 );
 cashAppLimitNotice.setAttribute( 'data-testid', 'cash-app-limit-notice' );

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -1,6 +1,6 @@
 /* global wc_stripe_upe_params, wc, wc_stripe_express_checkout_params */
 import { dispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import ReactDOM from 'react-dom';
 import { getAppearance } from '../styles/upe';
 import {
@@ -55,64 +55,79 @@ const isNonFriendlyError = ( type ) =>
 
 const getErrorMessageForCode = ( code ) => {
 	const messages = {
-		[ errorCodes.INVALID_NUMBER ]: __(
+		[ errorCodes.INVALID_NUMBER ]: _x(
 			'The card number is not a valid credit card number.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INVALID_EXPIRY_MONTH ]: __(
+		[ errorCodes.INVALID_EXPIRY_MONTH ]: _x(
 			'The card expiration month is invalid.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INVALID_EXPIRY_YEAR ]: __(
+		[ errorCodes.INVALID_EXPIRY_YEAR ]: _x(
 			'The card expiration year is invalid.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INVALID_CVC ]: __(
+		[ errorCodes.INVALID_CVC ]: _x(
 			'The card security code is invalid.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INCORRECT_NUMBER ]: __(
+		[ errorCodes.INCORRECT_NUMBER ]: _x(
 			'The card number is incorrect.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INCOMPLETE_NUMBER ]: __(
+		[ errorCodes.INCOMPLETE_NUMBER ]: _x(
 			'The card number is incomplete.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INCOMPLETE_CVC ]: __(
+		[ errorCodes.INCOMPLETE_CVC ]: _x(
 			'The card security code is incomplete.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INCOMPLETE_EXPIRY ]: __(
+		[ errorCodes.INCOMPLETE_EXPIRY ]: _x(
 			'The card expiration date is incomplete.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.EXPIRED_CARD ]: __(
+		[ errorCodes.EXPIRED_CARD ]: _x(
 			'The card has expired.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INCORRECT_CVC ]: __(
+		[ errorCodes.INCORRECT_CVC ]: _x(
 			'The card security code is incorrect.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INCORRECT_ZIP ]: __(
+		[ errorCodes.INCORRECT_ZIP ]: _x(
 			'The card zip code failed validation.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.INVALID_EXPIRY_YEAR_PAST ]: __(
-			'The card expiration year is in the past',
+		[ errorCodes.INVALID_EXPIRY_YEAR_PAST ]: _x(
+			'The card expiration year is in the past.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.CARD_DECLINED ]: __(
+		[ errorCodes.CARD_DECLINED ]: _x(
 			'The card was declined.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.MISSING ]: __(
+		[ errorCodes.MISSING ]: _x(
 			'There is no card on a customer that is being charged.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
-		[ errorCodes.PROCESSING_ERROR ]: __(
+		[ errorCodes.PROCESSING_ERROR ]: _x(
 			'An error occurred while processing the card.',
+			'shopper',
 			'woocommerce-gateway-stripe'
 		),
 	};
@@ -122,13 +137,15 @@ const getErrorMessageForCode = ( code ) => {
 const getErrorMessageForTypeAndCode = ( type, code = '' ) => {
 	switch ( type ) {
 		case errorTypes.INVALID_EMAIL:
-			return __(
+			return _x(
 				'Invalid email address, please correct and try again.',
+				'shopper',
 				'woocommerce-gateway-stripe'
 			);
 		case isNonFriendlyError( type ):
-			return __(
+			return _x(
 				'Unable to process this payment, please try again or use alternative method.',
+				'shopper',
 				'woocommerce-gateway-stripe'
 			);
 		case errorTypes.CARD_ERROR:
@@ -821,7 +838,11 @@ export const validateBlikCode = ( jQueryForm = undefined ) => {
 
 	if ( ! /[0-9]{6}/.test( code ) ) {
 		throw new Error(
-			__( 'BLIK Code is invalid', 'woocommerce-gateway-stripe' )
+			_x(
+				'BLIK Code is invalid',
+				'shopper',
+				'woocommerce-gateway-stripe'
+			)
 		);
 	}
 };

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -57,77 +57,77 @@ const getErrorMessageForCode = ( code ) => {
 	const messages = {
 		[ errorCodes.INVALID_NUMBER ]: _x(
 			'The card number is not a valid credit card number.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INVALID_EXPIRY_MONTH ]: _x(
 			'The card expiration month is invalid.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INVALID_EXPIRY_YEAR ]: _x(
 			'The card expiration year is invalid.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INVALID_CVC ]: _x(
 			'The card security code is invalid.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INCORRECT_NUMBER ]: _x(
 			'The card number is incorrect.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INCOMPLETE_NUMBER ]: _x(
 			'The card number is incomplete.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INCOMPLETE_CVC ]: _x(
 			'The card security code is incomplete.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INCOMPLETE_EXPIRY ]: _x(
 			'The card expiration date is incomplete.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.EXPIRED_CARD ]: _x(
 			'The card has expired.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INCORRECT_CVC ]: _x(
 			'The card security code is incorrect.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INCORRECT_ZIP ]: _x(
 			'The card zip code failed validation.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.INVALID_EXPIRY_YEAR_PAST ]: _x(
 			'The card expiration year is in the past.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.CARD_DECLINED ]: _x(
 			'The card was declined.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.MISSING ]: _x(
 			'There is no card on a customer that is being charged.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 		[ errorCodes.PROCESSING_ERROR ]: _x(
 			'An error occurred while processing the card.',
-			'shopper',
+			'[shopper]',
 			'woocommerce-gateway-stripe'
 		),
 	};
@@ -139,13 +139,13 @@ const getErrorMessageForTypeAndCode = ( type, code = '' ) => {
 		case errorTypes.INVALID_EMAIL:
 			return _x(
 				'Invalid email address, please correct and try again.',
-				'shopper',
+				'[shopper]',
 				'woocommerce-gateway-stripe'
 			);
 		case isNonFriendlyError( type ):
 			return _x(
 				'Unable to process this payment, please try again or use alternative method.',
-				'shopper',
+				'[shopper]',
 				'woocommerce-gateway-stripe'
 			);
 		case errorTypes.CARD_ERROR:
@@ -840,7 +840,7 @@ export const validateBlikCode = ( jQueryForm = undefined ) => {
 		throw new Error(
 			_x(
 				'BLIK Code is invalid',
-				'shopper',
+				'[shopper]',
 				'woocommerce-gateway-stripe'
 			)
 		);


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR explores the idea of using translation with context via `_x()` to explicitly identify strings that will be shown to shoppers. The goal is to make it easier to identify which strings impact the shopper experience, and when they are not translated. For now, the PR uses `[shopper]` as the context to identify shopper-facing strings in the `client/` folder. It intentionally doesn't include any settings UI (i.e. merchant-facing screens), nor does it include any files for payment requests, which have been deprecated.

Additional surface areas that may be candidates include:
 * Email templates
 * Some server-generated error messages
 * Any server-generated HTML intended for display to shoppers

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

TBD
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
