### PR TITLE
Blocking disabling of cards when OC is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
-* Fix - Require credit cards to be enabled when the Optimized Checkout is active
+* Fix - Force the card payment method to be enabled when the Optimized Checkout is enabled in the merchant's Payment Method Configuration
 * Update - Deactivates Affirm or Klarna when other official plugins are active in merchant's Payment Method Configuration
 * Fix - Fixes issues related to booking multiple slots with express checkout payment methods enabled
 * Fix - Update the Optimized Checkout promotional inbox note to link to the relevant section in the Stripe settings page

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
+* Fix - Require credit cards to be enabled when the Optimized Checkout is active
 * Update - Deactivates Affirm or Klarna when other official plugins are active in merchant's Payment Method Configuration
 * Fix - Fixes issues related to booking multiple slots with express checkout payment methods enabled
 * Fix - Update the Optimized Checkout promotional inbox note to link to the relevant section in the Stripe settings page

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -298,17 +298,23 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	private function get_payment_method_ids_to_enable( WP_REST_Request $request ) {
 		$payment_method_ids_to_enable = $request->get_param( 'enabled_payment_method_ids' );
 		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
+		$is_oc_enabled                = $request->get_param( 'is_oc_enabled' );
 		$is_payment_request_enabled   = $request->get_param( 'is_payment_request_enabled' );
 
-		// Card is required for Apple Pay and Google Pay.
-		if ( $is_upe_enabled &&
-			 $is_payment_request_enabled &&
-			 in_array( WC_Stripe_Payment_Methods::CARD, $payment_method_ids_to_enable, true )
-		) {
-			$payment_method_ids_to_enable = array_merge(
-				$payment_method_ids_to_enable,
-				[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
-			);
+		// Card is required for Apple Pay, Google Pay and the Optimized Checkout.
+		if ( $is_upe_enabled ) {
+			if ( $is_oc_enabled ) {
+				$payment_method_ids_to_enable = array_merge( $payment_method_ids_to_enable, [ WC_Stripe_Payment_Methods::CARD ] );
+			}
+
+			if ( $is_payment_request_enabled &&
+				in_array( WC_Stripe_Payment_Methods::CARD, $payment_method_ids_to_enable, true )
+			) {
+				$payment_method_ids_to_enable = array_merge(
+					$payment_method_ids_to_enable,
+					[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
+				);
+			}
 		}
 
 		return $payment_method_ids_to_enable;

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -298,23 +298,17 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	private function get_payment_method_ids_to_enable( WP_REST_Request $request ) {
 		$payment_method_ids_to_enable = $request->get_param( 'enabled_payment_method_ids' );
 		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
-		$is_oc_enabled                = $request->get_param( 'is_oc_enabled' );
 		$is_payment_request_enabled   = $request->get_param( 'is_payment_request_enabled' );
 
-		// Card is required for Apple Pay, Google Pay and the Optimized Checkout.
-		if ( $is_upe_enabled ) {
-			if ( $is_oc_enabled ) {
-				$payment_method_ids_to_enable = array_merge( $payment_method_ids_to_enable, [ WC_Stripe_Payment_Methods::CARD ] );
-			}
-
-			if ( $is_payment_request_enabled &&
-				in_array( WC_Stripe_Payment_Methods::CARD, $payment_method_ids_to_enable, true )
-			) {
-				$payment_method_ids_to_enable = array_merge(
-					$payment_method_ids_to_enable,
-					[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
-				);
-			}
+		// Card is required for Apple Pay and Google Pay.
+		if ( $is_upe_enabled &&
+			 $is_payment_request_enabled &&
+			 in_array( WC_Stripe_Payment_Methods::CARD, $payment_method_ids_to_enable, true )
+		) {
+			$payment_method_ids_to_enable = array_merge(
+				$payment_method_ids_to_enable,
+				[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
+			);
 		}
 
 		return $payment_method_ids_to_enable;

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -282,9 +282,10 @@ class WC_Stripe {
 
 		add_action( 'init', [ $this, 'initialize_apple_pay_registration' ] );
 
-		// Check for payment methods that should be deactivated, e.g. unreleased,
-		// BNPLs when official plugins are active, etc.
-		add_action( 'init', [ $this, 'maybe_deactivate_payment_methods' ] );
+		// Check for payment methods that should be toggled, e.g. unreleased,
+		// BNPLs when official plugins are active,
+		// cards when the Optimized Checkout is enabled, etc.
+		add_action( 'init', [ $this, 'maybe_toggle_payment_methods' ] );
 	}
 
 	/**
@@ -863,18 +864,20 @@ class WC_Stripe {
 	}
 
 	/**
-	 * Deactivate payment methods that should be deactivated, e.g. unreleased,
-	 * BNPLs when other official plugins are active, etc.
+	 * Toggle payment methods that should be enabled/disabled, e.g. unreleased,
+	 * BNPLs when other official plugins are active,
+	 * cards when the Optimized Checkout is enabled, etc.
 	 *
 	 * @return void
 	 */
-	public function maybe_deactivate_payment_methods() {
+	public function maybe_toggle_payment_methods() {
 		$gateway = $this->get_main_stripe_gateway();
 		if ( ! is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
 			return;
 		}
 
 		$payment_method_ids_to_disable = [];
+		$payment_method_ids_to_enable  = [];
 		$enabled_payment_methods       = $gateway->get_upe_enabled_payment_method_ids();
 
 		// Check for BNPLs that should be deactivated.
@@ -889,9 +892,21 @@ class WC_Stripe {
 			$this->maybe_deactivate_amazon_pay( $enabled_payment_methods )
 		);
 
-		if ( [] === $payment_method_ids_to_disable ) {
+		// Check if cards should be activated.
+		// TODO: Remove this once card is not a requirement for the Optimized Checkout.
+		if ( $gateway->is_oc_enabled()
+			&& ! in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ) ) {
+			$payment_method_ids_to_enable[] = WC_Stripe_Payment_Methods::CARD;
+		}
+
+		if ( [] === $payment_method_ids_to_disable && [] === $payment_method_ids_to_enable ) {
 			return;
 		}
+
+		$enabled_payment_methods = array_merge(
+			$enabled_payment_methods,
+			$payment_method_ids_to_enable
+		);
 
 		$gateway->update_enabled_payment_methods(
 			array_diff( $enabled_payment_methods, $payment_method_ids_to_disable )

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
+* Fix - Require credit cards to be enabled when the Optimized Checkout is active
 * Update - Deactivates Affirm or Klarna when other official plugins are active in merchant's Payment Method Configuration
 * Fix - Fixes issues related to booking multiple slots with express checkout payment methods enabled
 * Fix - Update the Optimized Checkout promotional inbox note to link to the relevant section in the Stripe settings page

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
-* Fix - Require credit cards to be enabled when the Optimized Checkout is active
+* Fix - Force the card payment method to be enabled when the Optimized Checkout is enabled in the merchant's Payment Method Configuration
 * Update - Deactivates Affirm or Klarna when other official plugins are active in merchant's Payment Method Configuration
 * Fix - Fixes issues related to booking multiple slots with express checkout payment methods enabled
 * Fix - Update the Optimized Checkout promotional inbox note to link to the relevant section in the Stripe settings page

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -6,7 +6,6 @@ use WC_Stripe;
 use WC_Stripe_Helper;
 use WC_Stripe_Payment_Methods;
 use WC_Stripe_UPE_Payment_Gateway;
-use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 
 /**
  * These tests make assertions against the class WC_Stripe.

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -6,6 +6,7 @@ use WC_Stripe;
 use WC_Stripe_Helper;
 use WC_Stripe_Payment_Methods;
 use WC_Stripe_UPE_Payment_Gateway;
+use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 
 /**
  * These tests make assertions against the class WC_Stripe.
@@ -49,6 +50,10 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$upe_payment_gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$upe_payment_gateway->expects( $this->once() )
+			->method( 'is_oc_enabled' )
+			->willReturn( $oc_enabled );
 
 		$upe_payment_gateway->expects( $this->once() )
 			->method( 'get_upe_enabled_payment_method_ids' )

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -25,15 +25,20 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests for `maybe_deactivate_payment_methods`.
+	 * Tests for `maybe_toggle_payment_methods`.
 	 *
+	 * @param array $active_gateways The active payment gateways.
+	 * @param array $enabled_payment_method_ids The enabled payment method IDs.
+	 * @param bool $oc_enabled Whether the one-click payment methods are enabled.
+	 * @param int $update_enable_payment_methods_calls The number of times `update_enabled_payment_methods` should be called.
 	 * @return void
 	 *
-	 * @dataProvider provide_test_maybe_deactivate_payment_methods
+	 * @dataProvider provide_test_maybe_toggle_payment_methods
 	 */
-	public function test_maybe_deactivate_payment_methods(
+	public function test_maybe_toggle_payment_methods(
 		$active_gateways,
 		$enabled_payment_method_ids,
+		$oc_enabled,
 		$update_enable_payment_methods_calls
 	) {
 		$original_payment_gateways = WC()->payment_gateways->payment_gateways;
@@ -61,7 +66,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$wc_stripe->method( 'get_main_stripe_gateway' )
 			->willReturn( $upe_payment_gateway );
 
-		$wc_stripe->maybe_deactivate_payment_methods();
+		$wc_stripe->maybe_toggle_payment_methods();
 
 		// Clean up.
 		WC()->payment_gateways->payment_gateways = $original_payment_gateways;
@@ -72,13 +77,14 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 *
 	 * @return array
 	 */
-	public function provide_test_maybe_deactivate_payment_methods() {
+	public function provide_test_maybe_toggle_payment_methods() {
 		return [
 			'none active'                                 => [
 				'active gateways'                     => [],
 				'enabled payment method IDs'          => [
 					WC_Stripe_Payment_Methods::CARD,
 				],
+				'OC enabled'                          => false,
 				'update enable payment methods calls' => 0,
 			],
 			'affirm'                                      => [
@@ -92,6 +98,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					WC_Stripe_Payment_Methods::CARD,
 					WC_Stripe_Payment_Methods::AFFIRM,
 				],
+				'OC enabled'                          => false,
 				'update enable payment methods calls' => 1,
 			],
 			'klarna'                                      => [
@@ -105,6 +112,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					WC_Stripe_Payment_Methods::CARD,
 					WC_Stripe_Payment_Methods::KLARNA,
 				],
+				'OC enabled'                          => false,
 				'update enable payment methods calls' => 1,
 			],
 			'klarna and affirm active, but not on Stripe' => [
@@ -121,6 +129,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'enabled payment method IDs'          => [
 					WC_Stripe_Payment_Methods::CARD,
 				],
+				'OC enabled'                          => false,
 				'update enable payment methods calls' => 0,
 			],
 			'klarna and affirm active in both'            => [
@@ -139,6 +148,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					WC_Stripe_Payment_Methods::AFFIRM,
 					WC_Stripe_Payment_Methods::KLARNA,
 				],
+				'OC enabled'                          => false,
 				'update enable payment methods calls' => 1,
 			],
 			'amazon pay'                                  => [
@@ -147,6 +157,13 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					WC_Stripe_Payment_Methods::CARD,
 					WC_Stripe_Payment_Methods::AMAZON_PAY,
 				],
+				'OC enabled'                          => false,
+				'update enable payment methods calls' => 1,
+			],
+			'card, OC enabled'                            => [
+				'active gateways'                     => [],
+				'enabled payment method IDs'          => [],
+				'OC enabled'                          => true,
 				'update enable payment methods calls' => 1,
 			],
 		];


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-644

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Currently, the credit card payment method is required to display the single payment element when the Optimized Checkout is enabled. Since cards are no longer needed for the extension to work, that would break OC.

This PR follows a similar pattern to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4531, requiring cards to be enabled when OC is active.

Follow-up issues:
- STRIPE-645 - Block the checkbox and add a new pill to inform merchants of the limitation. This will go before 9.8
- STRIPE-646 - Make OC work without the need for the credit card payment method to be enabled. This will take time, probably after 9.8

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout to this branch on your test environment (`fix/block-disabling-of-cards-when-oc-is-enabled`)
- Connect your Stripe account
- Make OC available (you can use the `wc_stripe_is_optimized_checkout_available` filter for that)
- Enable OC
- Attempt to disable the credit card payment method
- Save your settings
- Refresh the page
- Confirm credit card is still enabled

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
