### PR TITLE
Only clear customer cache when an action has been performed

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -21,6 +21,7 @@
 * Fix - Free trial subscription orders with payment methods that require redirection (eg: iDeal, Bancontact)
 * Tweak - Update checkout error message for invalid API key to be more generic and user-friendly
 * Tweak - Disable Amazon Pay in the merchant's Payment Method Configuration object if it is still behind a feature flag
+* Fix - Only clear customer cache when an action has been performed
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -744,9 +744,8 @@ class WC_Stripe_Customer {
 
 		$response = WC_Stripe_API::detach_payment_method_from_customer( $this->get_id(), $source_id );
 
-		$this->clear_cache( $source_id );
-
 		if ( empty( $response->error ) ) {
+			$this->clear_cache( $source_id );
 			do_action( 'wc_stripe_delete_source', $this->get_id(), $response );
 
 			return true;
@@ -767,9 +766,8 @@ class WC_Stripe_Customer {
 
 		$response = WC_Stripe_API::detach_payment_method_from_customer( $this->get_id(), $payment_method_id );
 
-		$this->clear_cache( $payment_method_id );
-
 		if ( empty( $response->error ) ) {
+			$this->clear_cache( $payment_method_id );
 			do_action( 'wc_stripe_detach_payment_method', $this->get_id(), $response );
 
 			return true;
@@ -792,9 +790,8 @@ class WC_Stripe_Customer {
 			'POST'
 		);
 
-		$this->clear_cache();
-
 		if ( empty( $response->error ) ) {
+			$this->clear_cache();
 			do_action( 'wc_stripe_set_default_source', $this->get_id(), $response );
 
 			return true;
@@ -819,9 +816,8 @@ class WC_Stripe_Customer {
 			'POST'
 		);
 
-		$this->clear_cache();
-
 		if ( empty( $response->error ) ) {
+			$this->clear_cache();
 			do_action( 'wc_stripe_set_default_payment_method', $this->get_id(), $response );
 
 			return true;

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -560,9 +560,6 @@ class WC_Stripe_Payment_Tokens {
 	 * @return  WC_Payment_Token   The WC object for the payment token.
 	 */
 	private function add_token_to_user( $payment_method, WC_Stripe_Customer $customer, $payment_method_ids = [] ) {
-		// Clear cached payment methods.
-		$customer->clear_cache();
-
 		$payment_method_type = $this->get_original_payment_method_type( $payment_method );
 		$gateway_id          = self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD[ $payment_method_type ];
 
@@ -570,11 +567,16 @@ class WC_Stripe_Payment_Tokens {
 		if ( $found_token ) {
 			// Update the token with the new payment method ID if the current payment method ID is not in the list of payment method IDs retrieved from Stripe.
 			if ( ! in_array( $found_token->get_token(), $payment_method_ids, true ) ) {
+				// Clear cached payment methods.
+		        $customer->clear_cache();
 				$found_token->set_token( $payment_method->id );
 				$found_token->save();
 			}
 			return $found_token;
 		}
+
+		// Clear cached payment methods.
+		$customer->clear_cache();
 
 		switch ( $payment_method_type ) {
 			case WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID:

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -568,7 +568,7 @@ class WC_Stripe_Payment_Tokens {
 			// Update the token with the new payment method ID if the current payment method ID is not in the list of payment method IDs retrieved from Stripe.
 			if ( ! in_array( $found_token->get_token(), $payment_method_ids, true ) ) {
 				// Clear cached payment methods.
-		        $customer->clear_cache();
+				$customer->clear_cache();
 				$found_token->set_token( $payment_method->id );
 				$found_token->save();
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Free trial subscription orders with payment methods that require redirection (eg: iDeal, Bancontact)
 * Tweak - Update checkout error message for invalid API key to be more generic and user-friendly
 * Tweak - Disable Amazon Pay in the merchant's Payment Method Configuration object if it is still behind a feature flag
+* Fix - Only clear customer cache when an action has been performed
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

If we skip updating a payment token or get an error response from stripe, we don't want to clear the customer cache as nothing has changed.

Prevents endless loops of clearing the cache and then reloading the customer data.

Discovered when using the same stripe test card twice on the same customer. Different expiration dates, but the same card number return the same fingerprint and are detected by Woo as a duplicate. 

Endless loop of:
1. Retrieve tokens from stripe.
2. Store tokens in transient.
3. Add payment method is triggered for the second token with the same fingerprint.
4. Cache is cleared, clearing the transient from step 2.
5. Duplicate payment method is detected.
6. Update is skipped due to token existing from list of stripe tokens.
7. Update is skipped.
8. Repeats on every request.

## Testing instructions

1. As a customer, add a test payment method.
2. As the same customer, update the payment method using credit card form in My Account settings. Use the same card but a different expiration date.
3. Go to the My Account -> Payment Methods are on the site.
4. Refresh the page.
5. Verify the Stripe API was not called on the second load.


---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Does not apply to mobile.

### Changelog entry

<details>

<summary>Only clear the customer cache when the data has been updated.</summary>

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
