### PR TITLE
Refactor webhook handler to compute order or refund upfront

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -262,7 +262,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = WC_Stripe_Helper::get_order_by_source_id( $notification->data->object->id );
+		$order = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via source ID: ' . $notification->data->object->id );
@@ -395,7 +395,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_dispute( $notification ) {
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
+		$order = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->charge );
@@ -436,7 +436,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_dispute_closed( $notification ) {
-		$order  = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
+		$order  = $this->get_order_from_notification( $notification );
 		$status = $notification->data->object->status;
 
 		if ( ! $order ) {
@@ -488,7 +488,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_capture( $notification ) {
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
+		$order = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
@@ -560,7 +560,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $charge->id );
+		$order = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $charge->id );
@@ -618,7 +618,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_charge_failed( $notification ) {
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
+		$order = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
@@ -653,16 +653,11 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_source_canceled( $notification ) {
-		$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
+		$order = $this->get_order_from_notification( $notification );
 
-		// If can't find order by charge ID, try source ID.
 		if ( ! $order ) {
-			$order = WC_Stripe_Helper::get_order_by_source_id( $notification->data->object->id );
-
-			if ( ! $order ) {
-				WC_Stripe_Logger::log( 'Could not find order via charge/source ID: ' . $notification->data->object->id );
-				return;
-			}
+			WC_Stripe_Logger::log( 'Could not find order via charge/source ID: ' . $notification->data->object->id );
+			return;
 		}
 
 		// Don't proceed if payment method isn't Stripe.
@@ -689,18 +684,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_refund( $notification ) {
-		$refund_object = $this->get_refund_object( $notification );
-		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+		$order = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
-			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
-		}
-
-		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
+			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $notification->data->object->id );
 			return;
 		}
+
+		$refund_object = $this->get_refund_object( $notification );
 
 		$order_id = $order->get_id();
 
@@ -777,8 +768,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_webhook_refund_updated( $notification ) {
+		// Note that we avoid calling `get_refund_object()` as that code makes a call to Stripe.
 		$refund_object = $notification->data->object;
-		$order         = WC_Stripe_Helper::get_order_by_charge_id( $refund_object->charge );
+		$order         = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order to update refund via charge ID: ' . $refund_object->charge );
@@ -872,20 +864,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_review_opened( $notification ) {
-		if ( isset( $notification->data->object->payment_intent ) ) {
-			$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
+		$order = $this->get_order_from_notification( $notification );
 
-			if ( ! $order ) {
-				WC_Stripe_Logger::log( '[Review Opened] Could not find order via intent ID: ' . $notification->data->object->payment_intent );
-				return;
-			}
-		} else {
-			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
-
-			if ( ! $order ) {
-				WC_Stripe_Logger::log( '[Review Opened] Could not find order via charge ID: ' . $notification->data->object->charge );
-				return;
-			}
+		if ( ! $order ) {
+			$reference_type = isset( $notification->data->object->payment_intent ) ? 'payment_intent' : 'charge';
+			$reference      = 'payment_intent' === $reference_type ? $notification->data->object->payment_intent : $notification->data->object->charge ?? 'unknown';
+			WC_Stripe_Logger::log( '[Review Opened] Could not find order via ' . $reference_type . ': ' . $reference );
+			return;
 		}
 
 		$this->set_stripe_order_status_before_hold( $order, $order->get_status() );
@@ -913,20 +898,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @param object $notification
 	 */
 	public function process_review_closed( $notification ) {
-		if ( isset( $notification->data->object->payment_intent ) ) {
-			$order = WC_Stripe_Helper::get_order_by_intent_id( $notification->data->object->payment_intent );
+		$order = $this->get_order_from_notification( $notification );
 
-			if ( ! $order ) {
-				WC_Stripe_Logger::log( '[Review Closed] Could not find order via intent ID: ' . $notification->data->object->payment_intent );
-				return;
-			}
-		} else {
-			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->charge );
-
-			if ( ! $order ) {
-				WC_Stripe_Logger::log( '[Review Closed] Could not find order via charge ID: ' . $notification->data->object->charge );
-				return;
-			}
+		if ( ! $order ) {
+			$reference_type = isset( $notification->data->object->payment_intent ) ? 'payment_intent' : 'charge';
+			$reference      = 'payment_intent' === $reference_type ? $notification->data->object->payment_intent : $notification->data->object->charge ?? 'unknown';
+			WC_Stripe_Logger::log( '[Review Closed] Could not find order via ' . $reference_type . ': ' . $reference );
+			return;
 		}
 
 		/* translators: 1) The reason type. */
@@ -1030,7 +1008,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	public function process_payment_intent( $notification ) {
 		$intent = $notification->data->object;
-		$order  = $this->get_order_from_intent( $intent );
+		$order  = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via intent ID: ' . $intent->id );
@@ -1146,7 +1124,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 
 	public function process_setup_intent( $notification ) {
 		$intent = $notification->data->object;
-		$order  = WC_Stripe_Helper::get_order_by_setup_intent_id( $intent->id );
+		$order  = $this->get_order_from_notification( $notification );
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via setup intent ID: ' . $intent->id );
@@ -1334,6 +1312,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	public function process_webhook( $request_body ) {
 		$notification = json_decode( $request_body );
 
+		$order = $this->get_order_from_notification( $notification );
+
 		switch ( $notification->type ) {
 			case 'account.updated':
 				$this->process_account_updated( $notification );
@@ -1397,6 +1377,98 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$this->process_setup_intent( $notification );
 
 		}
+	}
+
+	protected function get_order_from_notification( $notification ) {
+		$object = $notification->data->object ?? new stdClass();
+		$order  = false;
+
+		// Handle different notification types based on their structure
+		switch ( $notification->type ) {
+			case 'source.chargeable':
+				// Source-based notifications
+				$order = WC_Stripe_Helper::get_order_by_source_id( $object->id );
+				break;
+
+			case 'source.canceled':
+				// Try charge ID first, then source ID as fallback
+				$order = WC_Stripe_Helper::get_order_by_charge_id( $object->id );
+				if ( ! $order ) {
+					$order = WC_Stripe_Helper::get_order_by_source_id( $object->id );
+				}
+				break;
+
+			case 'charge.succeeded':
+			case 'charge.failed':
+			case 'charge.expired':
+			case 'charge.captured':
+				// Charge-based notifications
+				$order = WC_Stripe_Helper::get_order_by_charge_id( $object->id );
+				break;
+
+			case 'charge.dispute.created':
+			case 'charge.dispute.closed':
+				// Dispute notifications - use charge ID from dispute object
+				$order = WC_Stripe_Helper::get_order_by_charge_id( $object->charge );
+				break;
+
+			case 'charge.refunded':
+				// Refund notifications - try refund ID first, then charge ID
+				$refund_object = $this->get_refund_object( $notification );
+				$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
+				if ( ! $order ) {
+					$order = WC_Stripe_Helper::get_order_by_charge_id( $object->id );
+				}
+				break;
+
+			case 'charge.refund.updated':
+				// Refund update notifications - use charge ID from refund object
+				$order = WC_Stripe_Helper::get_order_by_charge_id( $object->charge );
+				break;
+
+			case 'review.opened':
+			case 'review.closed':
+				// Review notifications - try payment intent first, then charge
+				if ( isset( $object->payment_intent ) ) {
+					$order = WC_Stripe_Helper::get_order_by_intent_id( $object->payment_intent );
+				} else {
+					$order = WC_Stripe_Helper::get_order_by_charge_id( $object->charge );
+				}
+				break;
+
+			case 'payment_intent.processing':
+			case 'payment_intent.succeeded':
+			case 'payment_intent.payment_failed':
+			case 'payment_intent.amount_capturable_updated':
+			case 'payment_intent.requires_action':
+				// Payment intent notifications - rely on get_order_from_intent()
+				$order = $this->get_order_from_intent( $object );
+				break;
+
+			case 'setup_intent.succeeded':
+			case 'setup_intent.setup_failed':
+				// Setup intent notifications
+				$order = WC_Stripe_Helper::get_order_by_setup_intent_id( $object->id );
+				break;
+
+			default:
+				// For unknown notification types, try common patterns
+				if ( isset( $object->payment_intent ) ) {
+					$order = WC_Stripe_Helper::get_order_by_intent_id( $object->payment_intent );
+				} elseif ( isset( $object->charge ) ) {
+					$order = WC_Stripe_Helper::get_order_by_charge_id( $object->charge );
+				} elseif ( isset( $object->id ) ) {
+					// Try as charge ID first
+					$order = WC_Stripe_Helper::get_order_by_charge_id( $object->id );
+					if ( ! $order ) {
+						// Try as source ID
+						$order = WC_Stripe_Helper::get_order_by_source_id( $object->id );
+					}
+				}
+				break;
+		}
+
+		return $order;
 	}
 
 	/**

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -253,16 +253,19 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param object $notification
-	 * @param bool   $retry
+	 * @param object              $notification The notification data from Stripe.
+	 * @param bool                $retry        Whether to retry the payment.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_payment( $notification, $retry = true ) {
+	public function process_webhook_payment( $notification, $retry = true, $order = null ) {
 		// The following 3 payment methods are synchronous so does not need to be handle via webhook.
 		if ( WC_Stripe_Payment_Methods::CARD === $notification->data->object->type || WC_Stripe_Payment_Methods::SEPA_DEBIT === $notification->data->object->type || 'three_d_secure' === $notification->data->object->type ) {
 			return;
 		}
 
-		$order = $this->get_order_from_notification( $notification );
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via source ID: ' . $notification->data->object->id );
@@ -328,13 +331,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 						// Don't do anymore retries after this.
 						if ( 5 <= $this->retry_interval ) {
 
-							return $this->process_webhook_payment( $notification, false );
+							return $this->process_webhook_payment( $notification, false, $order );
 						}
 
 						sleep( $this->retry_interval );
 
 						$this->retry_interval++;
-						return $this->process_webhook_payment( $notification, true );
+						return $this->process_webhook_payment( $notification, true, $order );
 					} else {
 						$localized_message = __( 'Sorry, we are unable to process your payment at this time. Please retry later.', 'woocommerce-gateway-stripe' );
 						$order->add_order_note( $localized_message );
@@ -392,10 +395,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * We want to put the order into on-hold and add an order note.
 	 *
 	 * @since 4.0.0
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_dispute( $notification ) {
-		$order = $this->get_order_from_notification( $notification );
+	public function process_webhook_dispute( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->charge );
@@ -433,10 +439,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Process webhook dispute that is closed.
 	 *
 	 * @since 4.4.1
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_dispute_closed( $notification ) {
-		$order  = $this->get_order_from_notification( $notification );
+	public function process_webhook_dispute_closed( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 		$status = $notification->data->object->status;
 
 		if ( ! $order ) {
@@ -485,10 +494,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_capture( $notification ) {
-		$order = $this->get_order_from_notification( $notification );
+	public function process_webhook_capture( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
@@ -537,9 +549,10 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_charge_succeeded( $notification ) {
+	public function process_webhook_charge_succeeded( $notification, $order = null ) {
 		if ( empty( $notification->data->object ) ) {
 			WC_Stripe_Logger::log( 'Missing charge object in charge.succeeded webhook, Event ID: %s', $notification->id ?? 'unknown' );
 			return;
@@ -560,7 +573,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$order = $this->get_order_from_notification( $notification );
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $charge->id );
@@ -615,10 +630,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * @since 4.0.0
 	 * @since 4.1.5 Can handle any fail payments from any methods.
 	 * @since 9.0.0 Can handle payment expiration.
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_charge_failed( $notification ) {
-		$order = $this->get_order_from_notification( $notification );
+	public function process_webhook_charge_failed( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
@@ -650,10 +668,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @since 4.1.15 Add check to make sure order is processed by Stripe.
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_source_canceled( $notification ) {
-		$order = $this->get_order_from_notification( $notification );
+	public function process_webhook_source_canceled( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via charge/source ID: ' . $notification->data->object->id );
@@ -681,10 +702,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @since 4.0.0
 	 * @version 4.9.0
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_webhook_refund( $notification ) {
-		$order = $this->get_order_from_notification( $notification );
+	public function process_webhook_refund( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $notification->data->object->id );
@@ -765,12 +789,15 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Process a refund update.
 	 *
-	 * @param object $notification
+	 * @param object                     $notification The notification data from Stripe.
+	 * @param WC_Order_Refund|false|null $refund       The refund object.
 	 */
-	public function process_webhook_refund_updated( $notification ) {
+	public function process_webhook_refund_updated( $notification, $order = null ) {
 		// Note that we avoid calling `get_refund_object()` as that code makes a call to Stripe.
 		$refund_object = $notification->data->object;
-		$order         = $this->get_order_from_notification( $notification );
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order to update refund via charge ID: ' . $refund_object->charge );
@@ -861,10 +888,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Process webhook reviews that are opened. i.e Radar.
 	 *
 	 * @since 4.0.6
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $refund       The related order.
 	 */
-	public function process_review_opened( $notification ) {
-		$order = $this->get_order_from_notification( $notification );
+	public function process_review_opened( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			$reference_type = isset( $notification->data->object->payment_intent ) ? 'payment_intent' : 'charge';
@@ -895,10 +925,13 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 * Process webhook reviews that are closed. i.e Radar.
 	 *
 	 * @since 4.0.6
-	 * @param object $notification
+	 * @param object              $notification The notification data from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_review_closed( $notification ) {
-		$order = $this->get_order_from_notification( $notification );
+	public function process_review_closed( $notification, $order = null ) {
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			$reference_type = isset( $notification->data->object->payment_intent ) ? 'payment_intent' : 'charge';
@@ -1004,11 +1037,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Handles the processing of a payment intent webhook.
 	 *
-	 * @param stdClass $notification The webhook notification from Stripe.
+	 * @param object              $notification The webhook notification from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
 	 */
-	public function process_payment_intent( $notification ) {
+	public function process_payment_intent( $notification, $order = null ) {
 		$intent = $notification->data->object;
-		$order  = $this->get_order_from_notification( $notification );
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via intent ID: ' . $intent->id );
@@ -1122,9 +1158,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$this->unlock_order_payment( $order );
 	}
 
-	public function process_setup_intent( $notification ) {
+	/**
+	 * Handles the processing of a setup intent webhook.
+	 *
+	 * @param object              $notification The webhook notification from Stripe.
+	 * @param WC_Order|false|null $order        The related order.
+	 */
+	public function process_setup_intent( $notification, $order = null ) {
 		$intent = $notification->data->object;
-		$order  = $this->get_order_from_notification( $notification );
+		if ( null === $order ) {
+			$order = $this->get_order_from_notification( $notification );
+		}
 
 		if ( ! $order ) {
 			WC_Stripe_Logger::log( 'Could not find order via setup intent ID: ' . $intent->id );
@@ -1320,48 +1364,48 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				break;
 
 			case 'source.chargeable':
-				$this->process_webhook_payment( $notification );
+				$this->process_webhook_payment( $notification, true, $order );
 				break;
 
 			case 'source.canceled':
-				$this->process_webhook_source_canceled( $notification );
+				$this->process_webhook_source_canceled( $notification, $order );
 				break;
 
 			case 'charge.succeeded':
-				$this->process_webhook_charge_succeeded( $notification );
+				$this->process_webhook_charge_succeeded( $notification, $order );
 				break;
 
 			case 'charge.failed':
 			case 'charge.expired':
-				$this->process_webhook_charge_failed( $notification );
+				$this->process_webhook_charge_failed( $notification, $order );
 				break;
 
 			case 'charge.captured':
-				$this->process_webhook_capture( $notification );
+				$this->process_webhook_capture( $notification, $order );
 				break;
 
 			case 'charge.dispute.created':
-				$this->process_webhook_dispute( $notification );
+				$this->process_webhook_dispute( $notification, $order );
 				break;
 
 			case 'charge.dispute.closed':
-				$this->process_webhook_dispute_closed( $notification );
+				$this->process_webhook_dispute_closed( $notification, $order );
 				break;
 
 			case 'charge.refunded':
-				$this->process_webhook_refund( $notification );
+				$this->process_webhook_refund( $notification, $order );
 				break;
 
 			case 'charge.refund.updated':
-				$this->process_webhook_refund_updated( $notification );
+				$this->process_webhook_refund_updated( $notification, $order );
 				break;
 
 			case 'review.opened':
-				$this->process_review_opened( $notification );
+				$this->process_review_opened( $notification, $order );
 				break;
 
 			case 'review.closed':
-				$this->process_review_closed( $notification );
+				$this->process_review_closed( $notification, $order );
 				break;
 
 			case 'payment_intent.processing':
@@ -1369,16 +1413,22 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			case 'payment_intent.payment_failed':
 			case 'payment_intent.amount_capturable_updated':
 			case 'payment_intent.requires_action':
-				$this->process_payment_intent( $notification );
+				$this->process_payment_intent( $notification, $order );
 				break;
 
 			case 'setup_intent.succeeded':
 			case 'setup_intent.setup_failed':
-				$this->process_setup_intent( $notification );
+				$this->process_setup_intent( $notification, $order );
 
 		}
 	}
 
+	/**
+	 * Helper method to centralize the logic for getting the order from a webhook notification.
+	 *
+	 * @param object $notification The webhook notification from Stripe.
+	 * @return WC_Order|WC_Order_Refund|false The order or refund object, or false if not found.
+	 */
 	protected function get_order_from_notification( $notification ) {
 		$object = $notification->data->object ?? new stdClass();
 		$order  = false;

--- a/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
+++ b/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
@@ -741,6 +741,7 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 		$refund_order->save();
 
 		$notification = (object) [
+			'type' => 'charge.refund.updated',
 			'data' => (object) [
 				'object' => (object) [
 					'id'             => $refund_id,


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-564
Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4466

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR explores refactoring our webhook handler in two specific ways:
 - Centralise the code responsible for looking up an order for the various notification types from Stripe
 - Call that code from `process_webhook()` and then pass in the order that was identified

The refactor stems from a discussion in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4466, where we're trying to build WordPress hooks for developers to process webhooks more easily.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
