### PR TITLE
Removing the ability to edit the OC container title

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
-* Update - Removes the ability to change the title for the Optimized Checkout payment element, and use "Stripe" as the title
+* Update - Removes the ability to change the title for the Optimized Checkout payment element, as it is now set to "Stripe" by default
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
+* Update - Removes the ability to change the title for the Optimized Checkout payment element, as it is now set to "Stripe" by default
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
-* Update - Removes the ability to change the title for the Optimized Checkout payment element, as it is now set to "Stripe" by default
+* Update - Removes the ability to change the title for the Optimized Checkout payment element, and use "Stripe" as the title
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import jQuery from 'jquery';
 import WCStripeAPI from '../../api';
 import {
@@ -318,9 +317,7 @@ jQuery( function ( $ ) {
 				getStripeServerData()?.isOCEnabled &&
 				$( 'input#payment_method_stripe' ).is( ':checked' )
 			) {
-				$( 'label[for=payment_method_stripe]' ).text(
-					__( 'Stripe', 'woocommerce-gateway-stripe' )
-				);
+				$( 'label[for=payment_method_stripe]' ).text( 'Stripe' );
 			}
 
 			maybeClearBlikCodeValidation();

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import jQuery from 'jquery';
 import WCStripeAPI from '../../api';
 import {
@@ -310,6 +311,16 @@ jQuery( function ( $ ) {
 				);
 			} else {
 				removeCashAppLimitNotice();
+			}
+
+			// Change the payment method container title when the Optimized Checkout is enabled
+			if (
+				getStripeServerData()?.isOCEnabled &&
+				$( 'input#payment_method_stripe' ).is( ':checked' )
+			) {
+				$( 'label[for=payment_method_stripe]' ).text(
+					__( 'Stripe', 'woocommerce-gateway-stripe' )
+				);
 			}
 
 			maybeClearBlikCodeValidation();

--- a/client/classic/upe/index.js
+++ b/client/classic/upe/index.js
@@ -312,17 +312,6 @@ jQuery( function ( $ ) {
 				removeCashAppLimitNotice();
 			}
 
-			// Change the payment method container title when the Optimized Checkout is enabled
-			if (
-				getStripeServerData()?.isOCEnabled &&
-				getStripeServerData()?.OCTitle &&
-				$( 'input#payment_method_stripe' ).is( ':checked' )
-			) {
-				$( 'label[for=payment_method_stripe]' ).text(
-					getStripeServerData()?.OCTitle
-				);
-			}
-
 			maybeClearBlikCodeValidation();
 		} );
 

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -166,7 +166,6 @@ export const useIsShortAccountStatementEnabled = makeSettingsHook(
 export const useDebugLog = makeSettingsHook( 'is_debug_log_enabled' );
 export const useIsUpeEnabled = makeSettingsHook( 'is_upe_enabled' );
 export const useIsOCEnabled = makeSettingsHook( 'is_oc_enabled' );
-export const useOCTitle = makeSettingsHook( 'oc_title', 'Stripe' );
 export const useIsPMCEnabled = makeReadOnlySettingsHook(
 	'is_pmc_enabled',
 	false

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -5,7 +5,6 @@ import AdvancedSettings from '..';
 import {
 	useDebugLog,
 	useIsUpeEnabled,
-	useOCTitle,
 	useGetSavingError,
 	useSettings,
 	useIsOCEnabled,
@@ -15,7 +14,6 @@ jest.mock( 'wcstripe/data', () => ( {
 	useDebugLog: jest.fn(),
 	useIsUpeEnabled: jest.fn(),
 	useIsOCEnabled: jest.fn(),
-	useOCTitle: jest.fn(),
 	useGetSavingError: jest.fn(),
 	useSettings: jest.fn(),
 } ) );
@@ -27,7 +25,6 @@ describe( 'AdvancedSettings', () => {
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useIsUpeEnabled.mockReturnValue( [ true, jest.fn() ] );
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
-		useOCTitle.mockReturnValue( 'Stripe' );
 		useGetSavingError.mockReturnValue( null );
 
 		// Set `isLoading` to false so `LoadableSettingsSection` can render.
@@ -78,20 +75,5 @@ describe( 'AdvancedSettings', () => {
 				'Enable Optimized Checkout Suite (recommended)'
 			)
 		).toBeInTheDocument();
-	} );
-
-	it( 'should display the Optimized Checkout title setting if the Optimized Checkout feature is enabled', () => {
-		global.wc_stripe_settings_params = { is_oc_available: true };
-
-		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
-
-		render( <AdvancedSettings /> );
-
-		expect(
-			screen.queryByText(
-				'This will appear as the title of the Optimized Checkout Suite payment element on checkout.'
-			)
-		).toBeInTheDocument();
-		expect( screen.queryByLabelText( 'Title' ) ).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -1,17 +1,12 @@
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement } from '@wordpress/element';
-import {
-	CheckboxControl,
-	ExternalLink,
-	TextControl,
-} from '@wordpress/components';
-import React, { useEffect, useRef, useState } from 'react';
+import { CheckboxControl, ExternalLink } from '@wordpress/components';
+import React, { useEffect, useRef } from 'react';
 import { getQuery } from '@woocommerce/navigation';
-import { useIsOCEnabled, useIsUpeEnabled, useOCTitle } from '../../data';
+import { useIsOCEnabled, useIsUpeEnabled } from '../../data';
 
 const OptimizedCheckoutFeature = () => {
 	const [ isOCEnabled, setIsOCEnabled ] = useIsOCEnabled();
-	const [ OCTitle, setOCTitle ] = useOCTitle();
 	const [ isUpeEnabled ] = useIsUpeEnabled();
 	const headingRef = useRef( null );
 
@@ -20,14 +15,6 @@ const OptimizedCheckoutFeature = () => {
 			setIsOCEnabled( false );
 		}
 	}, [ isUpeEnabled, setIsOCEnabled ] );
-
-	// Local state for the title input to prevent value reset during typing
-	const [ localOCTitle, setLocalOCTitle ] = useState( OCTitle );
-
-	// Update local state when store value changes
-	useEffect( () => {
-		setLocalOCTitle( OCTitle );
-	}, [ OCTitle ] );
 
 	useEffect( () => {
 		if ( ! headingRef.current ) {
@@ -42,22 +29,6 @@ const OptimizedCheckoutFeature = () => {
 			} );
 		}
 	}, [ headingRef ] );
-
-	const handleTitleChange = ( value ) => {
-		setLocalOCTitle( value );
-	};
-
-	const handleTitleBlur = () => {
-		const finalTitle = localOCTitle.trim() || OCTitle;
-		setOCTitle( finalTitle );
-		setLocalOCTitle( finalTitle );
-	};
-
-	const handleTitleKeyDown = ( event ) => {
-		if ( event.key === 'Enter' ) {
-			handleTitleBlur();
-		}
-	};
 
 	return (
 		<>
@@ -88,19 +59,6 @@ const OptimizedCheckoutFeature = () => {
 				onChange={ setIsOCEnabled }
 				disabled={ ! isUpeEnabled }
 			/>
-			{ isOCEnabled && (
-				<TextControl
-					help={ __(
-						'This will appear as the title of the Optimized Checkout Suite payment element on checkout.',
-						'woocommerce-gateway-stripe'
-					) }
-					label={ __( 'Title', 'woocommerce-gateway-stripe' ) }
-					value={ localOCTitle }
-					onChange={ handleTitleChange }
-					onBlur={ handleTitleBlur }
-					onKeyDown={ handleTitleKeyDown }
-				/>
-			) }
 		</>
 	);
 };

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -80,11 +80,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
-					'oc_title'                         => [
-						'description'       => __( 'The default title to show above the Optimized Checkout element.', 'woocommerce-gateway-stripe' ),
-						'type'              => 'string',
-						'validate_callback' => 'rest_validate_request_arg',
-					],
 					'amazon_pay_button_size'           => [
 						'description'       => __( 'Express checkout button sizes.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',
@@ -247,7 +242,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'is_debug_log_enabled'                     => 'yes' === $this->gateway->get_option( 'logging' ),
 				'is_upe_enabled'                           => $is_upe_enabled,
 				'is_oc_enabled'                            => 'yes' === $this->gateway->get_option( 'optimized_checkout_element' ),
-				'oc_title'                                 => $this->gateway->get_validated_option( 'optimized_checkout_element_title' ),
 				'is_pmc_enabled'                           => 'yes' === $this->gateway->get_option( 'pmc_enabled' ),
 			]
 		);
@@ -541,7 +535,6 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	private function update_oc_settings( WP_REST_Request $request ) {
 		$attributes = [
 			'is_oc_enabled' => 'optimized_checkout_element',
-			'oc_title'      => 'optimized_checkout_element_title',
 		];
 		foreach ( $attributes as $request_key => $attribute ) {
 			$value = $request->get_param( $request_key );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -516,7 +516,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Optimized Checkout feature flag + setting.
 		$stripe_params['isOCEnabled'] = $this->oc_enabled;
-		$stripe_params['OCTitle']     = $this->get_option( 'optimized_checkout_element_title', __( 'Stripe', 'woocommerce-gateway-stripe' ) );
 
 		// Single Payment Element payment method parent configuration ID
 		$stripe_params['paymentMethodConfigurationParentId'] = WC_Stripe_Payment_Method_Configurations::get_parent_configuration_id();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -166,7 +166,7 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 
 		// Block checkout and pay for order (checkout) page.
 		if ( ( has_block( 'woocommerce/checkout' ) || ! empty( $_GET['pay_for_order'] ) ) && ! is_wc_endpoint_url( 'order-received' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return __( 'Stripe', 'woocommerce-gateway-stripe' );
+			return 'Stripe';
 		}
 
 		return parent::get_title();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
@@ -166,7 +166,7 @@ class WC_Stripe_UPE_Payment_Method_CC extends WC_Stripe_UPE_Payment_Method {
 
 		// Block checkout and pay for order (checkout) page.
 		if ( ( has_block( 'woocommerce/checkout' ) || ! empty( $_GET['pay_for_order'] ) ) && ! is_wc_endpoint_url( 'order-received' ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			return $this->oc_title;
+			return __( 'Stripe', 'woocommerce-gateway-stripe' );
 		}
 
 		return parent::get_title();

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -120,13 +120,6 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	protected $oc_enabled;
 
 	/**
-	 * The default title for the Optimized Checkout element
-	 *
-	 * @var string
-	 */
-	protected $oc_title;
-
-	/**
 	 * Create instance of payment method
 	 */
 	public function __construct() {
@@ -140,7 +133,6 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 		$this->supports                 = [ 'products', 'refunds' ];
 		$this->supports_deferred_intent = true;
 		$this->oc_enabled               = WC_Stripe_Feature_Flags::is_oc_available() && 'yes' === $this->get_option( 'optimized_checkout_element' );
-		$this->oc_title                 = $this->get_option( 'optimized_checkout_element_title', __( 'Stripe', 'woocommerce-gateway-stripe' ) );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
+* Update - Removes the ability to change the title for the Optimized Checkout payment element, as it is now set to "Stripe" by default
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled
 * Add - Tracks the toggle of the Optimized Checkout feature in the promotional banner


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-656

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As requested by the Stripe team, we are removing here the ability to customize the Optimized Checkout element title (shown above the payment methods on the checkout page).

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`update/remove-the-ability-to-edit-oc-title`)
- Connect your Stripe account
- Enable the Optimized Checkout

### Setting

- Confirm that the input field to set the custom title is gone:
<img width="789" height="138" alt="Screenshot 2025-08-05 at 17 16 36" src="https://github.com/user-attachments/assets/8a1917d1-dbe1-4c17-9f24-e9bcee5d3b76" />

### Block checkout

- Confirm the container title is always shown as "Stripe"
<img width="916" height="197" alt="Screenshot 2025-08-05 at 17 18 14" src="https://github.com/user-attachments/assets/ff70054c-afa5-4eaf-ba9b-2bfc2d47d6c8" />

### Classic/shortcode

- Confirm the same:
<img width="471" height="370" alt="Screenshot 2025-08-05 at 17 17 36" src="https://github.com/user-attachments/assets/118c20c5-0551-423c-89d1-2ab87313f89b" />

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
