### PR TITLE
Reduce number of payment_methods API calls

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -723,17 +723,20 @@ class WC_Stripe_Customer {
 		$all_payment_methods = get_transient( $cache_key );
 
 		if ( false === $all_payment_methods || ! is_array( $all_payment_methods ) ) {
-			$all_payment_methods  = [];
+			$all_payment_methods    = [];
+			$last_payment_method_id = null;
 
-			while ( true ) {
-				$response = WC_Stripe_API::request(
-					[
-						'customer' => $this->get_id(),
-						'limit'    => 100,
-					],
-					'payment_methods',
-					'GET'
-				);
+			do {
+				$request_params = [
+					'customer' => $this->get_id(),
+					'limit'    => 100,
+				];
+
+				if ( $last_payment_method_id ) {
+					$request_params['starting_after'] = $last_payment_method_id;
+				}
+
+				$response = WC_Stripe_API::request( $request_params, 'payment_methods', 'GET' );
 
 				if ( ! empty( $response->error ) ) {
 					if (
@@ -754,10 +757,16 @@ class WC_Stripe_Customer {
 
 				$all_payment_methods = array_merge( $all_payment_methods, $response->data );
 
-				if ( ! isset( $response->has_more ) || ! $response->has_more ) {
-					break;
+				// Reset the last payment method ID so we can paginate correctly.
+				$last_payment_method_id = null;
+				if ( isset( $response->has_more ) && $response->has_more ) {
+					$last_payment_method = end( $response->data );
+
+					if ( $last_payment_method && ! empty( $last_payment_method->id ) ) {
+						$last_payment_method_id = $last_payment_method->id;
+					}
 				}
-			}
+			} while ( null !== $last_payment_method_id );
 
 			// Always cache the result without any filters applied.
 			set_transient( $cache_key, $all_payment_methods, DAY_IN_SECONDS );

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -704,32 +704,81 @@ class WC_Stripe_Customer {
 			return [];
 		}
 
-		$payment_methods = get_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id() );
+		return $this->get_all_payment_methods( [ $payment_method_type ] );
+	}
 
-		if ( false === $payment_methods ) {
-			$params   = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID === $payment_method_type ? '?expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt' : '';
-			$response = WC_Stripe_API::request(
-				[
-					'customer' => $this->get_id(),
-					'type'     => $payment_method_type,
-					'limit'    => 100, // Maximum allowed value.
-				],
-				'payment_methods' . $params,
-				'GET'
-			);
-
-			if ( ! empty( $response->error ) ) {
-				return [];
-			}
-
-			if ( is_array( $response->data ) ) {
-				$payment_methods = $response->data;
-			}
-
-			set_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id(), $payment_methods, DAY_IN_SECONDS );
+	/**
+	 * Get all payment methods for a customer.
+	 *
+	 * @param string[] $payment_method_types The payment method types to look for using Stripe method IDs. If the array is empty, it implies all payment method types.
+	 * @param int      $limit                The maximum number of payment methods to return. If the value is -1, no limit is applied.
+	 * @return array
+	 */
+	public function get_all_payment_methods( array $payment_method_types = [], int $limit = -1 ) {
+		if ( ! $this->get_id() ) {
+			return [];
 		}
 
-		return empty( $payment_methods ) ? [] : $payment_methods;
+		$cache_key = self::PAYMENT_METHODS_TRANSIENT_KEY . '__all_' . $this->get_id();
+		$all_payment_methods = get_transient( $cache_key );
+
+		if ( false === $all_payment_methods || ! is_array( $all_payment_methods ) ) {
+			$all_payment_methods  = [];
+
+			while ( true ) {
+				$response = WC_Stripe_API::request(
+					[
+						'customer' => $this->get_id(),
+						'limit'    => 100,
+					],
+					'payment_methods',
+					'GET'
+				);
+
+				if ( ! empty( $response->error ) ) {
+					if (
+						isset( $response->error->code )
+						&& isset( $response->error->param )
+						&& 'customer' === $response->error->param
+						&& 'resource_missing' === $response->error->code
+					) {
+						// If the customer doesn't exist, cache an empty array.
+						set_transient( $cache_key, [], DAY_IN_SECONDS );
+					}
+					return [];
+				}
+
+				if ( ! is_array( $response->data ) || [] === $response->data ) {
+					break;
+				}
+
+				$all_payment_methods = array_merge( $all_payment_methods, $response->data );
+
+				if ( ! isset( $response->has_more ) || ! $response->has_more ) {
+					break;
+				}
+			}
+
+			// Always cache the result without any filters applied.
+			set_transient( $cache_key, $all_payment_methods, DAY_IN_SECONDS );
+		}
+
+		// Note that we only apply the limit and type filters after fetching and caching all payment methods.
+		$filtered_payment_methods = $all_payment_methods;
+		if ( [] !== $payment_method_types ) {
+			$filtered_payment_methods = array_filter(
+				$filtered_payment_methods,
+				function ( $payment_method ) use ( $payment_method_types ) {
+					return in_array( $payment_method->type, $payment_method_types, true );
+				}
+			);
+		}
+
+		if ( $limit > 0 ) {
+			return array_slice( $filtered_payment_methods, 0, $limit );
+		}
+
+		return $filtered_payment_methods;
 	}
 
 	/**
@@ -837,6 +886,7 @@ class WC_Stripe_Customer {
 		foreach ( self::STRIPE_PAYMENT_METHODS as $payment_method_type ) {
 			delete_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id() );
 		}
+		delete_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . '__all_' . $this->get_id() );
 		// Clear cache for the specific payment method if provided.
 		if ( $payment_method_id ) {
 			WC_Stripe_Database_Cache::delete( 'payment_method_for_source_' . $payment_method_id );

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -1016,69 +1016,69 @@ trait WC_Stripe_Subscriptions_Trait {
 		$payment_method_to_display = __( 'N/A', 'woocommerce-gateway-stripe' );
 
 		try {
-			// Retrieve all possible payment methods for subscriptions.
-			foreach ( WC_Stripe_Customer::STRIPE_PAYMENT_METHODS as $payment_method_type ) {
-				foreach ( $stripe_customer->get_payment_methods( $payment_method_type ) as $source ) {
-					if ( $source->id !== $stripe_source_id ) {
-						continue;
-					}
+			// Retrieve all possible payment methods for the customer so we make minimal API calls to Stripe.
+			$customer_payment_methods = $stripe_customer->get_all_payment_methods();
 
-					// Legacy handling for Stripe Card objects. ref: https://docs.stripe.com/api/cards/object
-					if ( isset( $source->object ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
+			foreach ( $customer_payment_methods as $source ) {
+				if ( $source->id !== $stripe_source_id ) {
+					continue;
+				}
+
+				// Legacy handling for Stripe Card objects. ref: https://docs.stripe.com/api/cards/object
+				if ( isset( $source->object ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
+					/* translators: 1) card brand 2) last 4 digits */
+					$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->brand ) ? wc_get_credit_card_type_label( $source->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->last4 );
+					break;
+				}
+
+				switch ( $source->type ) {
+					case WC_Stripe_Payment_Methods::CARD:
 						/* translators: 1) card brand 2) last 4 digits */
-						$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->brand ) ? wc_get_credit_card_type_label( $source->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->last4 );
+						$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->card->brand ) ? wc_get_credit_card_type_label( $source->card->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->card->last4 );
 						break 2;
-					}
-
-					switch ( $source->type ) {
-						case WC_Stripe_Payment_Methods::CARD:
-							/* translators: 1) card brand 2) last 4 digits */
-							$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->card->brand ) ? wc_get_credit_card_type_label( $source->card->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->card->last4 );
-							break 3;
-						case WC_Stripe_Payment_Methods::SEPA_DEBIT:
-							/* translators: 1) last 4 digits of SEPA Direct Debit */
-							$payment_method_to_display = sprintf( __( 'Via SEPA Direct Debit ending in %1$s', 'woocommerce-gateway-stripe' ), $source->sepa_debit->last4 );
-							break 3;
-						case WC_Stripe_Payment_Methods::CASHAPP_PAY:
-							/* translators: 1) Cash App Cashtag */
-							$payment_method_to_display = sprintf( __( 'Via Cash App Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->cashapp->cashtag );
-							break 3;
-						case WC_Stripe_Payment_Methods::LINK:
-							/* translators: 1) email address associated with the Stripe Link payment method */
-							$payment_method_to_display = sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
-							break 3;
-						case WC_Stripe_Payment_Methods::ACH:
-							$payment_method_to_display = sprintf(
-								/* translators: 1) account type (checking, savings), 2) last 4 digits of account. */
-								__( 'Via %1$s Account ending in %2$s', 'woocommerce-gateway-stripe' ),
-								ucfirst( $source->us_bank_account->account_type ),
-								$source->us_bank_account->last4
-							);
-							break 3;
-						case WC_Stripe_Payment_Methods::BECS_DEBIT:
-							$payment_method_to_display = sprintf(
-								/* translators: last 4 digits of account. */
-								__( 'BECS Direct Debit ending in %s', 'woocommerce-gateway-stripe' ),
-								$source->au_becs_debit->last4
-							);
-							break 3;
-						case WC_Stripe_Payment_Methods::ACSS_DEBIT:
-							$payment_method_to_display = sprintf(
-								/* translators: 1) bank name, 2) last 4 digits of account. */
-								__( 'Via %1$s ending in %2$s', 'woocommerce-gateway-stripe' ),
-								$source->acss_debit->bank_name,
-								$source->acss_debit->last4
-							);
-							break 3;
-						case WC_Stripe_Payment_Methods::BACS_DEBIT:
-							/* translators: 1) the Bacs Direct Debit payment method's last 4 numbers */
-							$payment_method_to_display = sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
-							break 3;
-						case WC_Stripe_Payment_Methods::AMAZON_PAY:
-							/* translators: 1) the Amazon Pay payment method's email */
-							$payment_method_to_display = sprintf( __( 'Via Amazon Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->billing_details->email ?? '' );
-							break 3;
-					}
+					case WC_Stripe_Payment_Methods::SEPA_DEBIT:
+						/* translators: 1) last 4 digits of SEPA Direct Debit */
+						$payment_method_to_display = sprintf( __( 'Via SEPA Direct Debit ending in %1$s', 'woocommerce-gateway-stripe' ), $source->sepa_debit->last4 );
+						break 2;
+					case WC_Stripe_Payment_Methods::CASHAPP_PAY:
+						/* translators: 1) Cash App Cashtag */
+						$payment_method_to_display = sprintf( __( 'Via Cash App Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->cashapp->cashtag );
+						break 2;
+					case WC_Stripe_Payment_Methods::LINK:
+						/* translators: 1) email address associated with the Stripe Link payment method */
+						$payment_method_to_display = sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
+						break 2;
+					case WC_Stripe_Payment_Methods::ACH:
+						$payment_method_to_display = sprintf(
+							/* translators: 1) account type (checking, savings), 2) last 4 digits of account. */
+							__( 'Via %1$s Account ending in %2$s', 'woocommerce-gateway-stripe' ),
+							ucfirst( $source->us_bank_account->account_type ),
+							$source->us_bank_account->last4
+						);
+						break 2;
+					case WC_Stripe_Payment_Methods::BECS_DEBIT:
+						$payment_method_to_display = sprintf(
+							/* translators: last 4 digits of account. */
+							__( 'BECS Direct Debit ending in %s', 'woocommerce-gateway-stripe' ),
+							$source->au_becs_debit->last4
+						);
+						break 2;
+					case WC_Stripe_Payment_Methods::ACSS_DEBIT:
+						$payment_method_to_display = sprintf(
+							/* translators: 1) bank name, 2) last 4 digits of account. */
+							__( 'Via %1$s ending in %2$s', 'woocommerce-gateway-stripe' ),
+							$source->acss_debit->bank_name,
+							$source->acss_debit->last4
+						);
+						break 2;
+					case WC_Stripe_Payment_Methods::BACS_DEBIT:
+						/* translators: 1) the Bacs Direct Debit payment method's last 4 numbers */
+						$payment_method_to_display = sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
+						break 2;
+					case WC_Stripe_Payment_Methods::AMAZON_PAY:
+						/* translators: 1) the Amazon Pay payment method's email */
+						$payment_method_to_display = sprintf( __( 'Via Amazon Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->billing_details->email ?? '' );
+						break 2;
 				}
 			}
 		} catch ( WC_Stripe_Exception $e ) {

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -301,19 +301,18 @@ class WC_Stripe_Payment_Tokens {
 
 			// Retrieve the payment methods for the enabled reusable gateways.
 			$payment_methods = [];
+			$reusable_payment_method_types = array_keys( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD );
+			$active_payment_method_types   = [];
 			if ( $gateway->is_oc_enabled() ) {
-				// For OC, get all available payment method types
-				foreach ( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD as $payment_method_type => $reausable_gateway_id ) {
+				// For Optimized Checkout, get all available payment method types.
+				foreach ( $reusable_payment_method_types as $payment_method_type ) {
 					$payment_method_instance = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $payment_method_type );
 					if ( $payment_method_instance ) {
-						$retrieved_methods = $customer->get_payment_methods( $payment_method_type );
-						if ( ! empty( $retrieved_methods ) ) {
-							$payment_methods[] = $retrieved_methods;
-						}
+						$active_payment_method_types[] = $payment_method_type;
 					}
 				}
 			} else {
-				foreach ( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD as $payment_method_type => $reausable_gateway_id ) {
+				foreach ( $reusable_payment_method_types as $payment_method_type ) {
 					// The payment method type doesn't match the ones we use. Nothing to do here.
 					if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
 						continue;
@@ -321,10 +320,11 @@ class WC_Stripe_Payment_Tokens {
 
 					$payment_method_instance = $gateway->payment_methods[ $payment_method_type ];
 					if ( $payment_method_instance->is_enabled() ) {
-						$payment_methods[] = $customer->get_payment_methods( $payment_method_type );
+						$active_payment_method_types[] = $payment_method_type;
 					}
 				}
 			}
+			$payment_methods = $customer->get_all_payment_methods( $active_payment_method_types );
 
 			// Add SEPA if it is disabled and iDEAL or Bancontact are enabled. iDEAL and Bancontact tokens are saved as SEPA tokens.
 			if ( $gateway->is_sepa_tokens_for_other_methods_enabled() ) {

--- a/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
+++ b/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
@@ -595,7 +595,7 @@ class WC_Stripe_Payment_Gateway_Test extends WP_UnitTestCase {
 		$mock_subscription->save();
 
 		// This is the key the customer's payment methods are stored under in the transient.
-		$transient_key = WC_Stripe_Customer::PAYMENT_METHODS_TRANSIENT_KEY . 'cardcus_mock';
+		$transient_key = WC_Stripe_Customer::PAYMENT_METHODS_TRANSIENT_KEY . '__all_cus_mock';
 
 		$mock_payment_method       = new stdClass();
 		$mock_payment_method->id   = 'src_mock';


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR tackles multiple pieces of code to try and reduce the number of API calls we make to the Stripe `payment_methods` API, which we may want to split up into smaller PRs:
 * Explicitly check for responses where the customer doesn't exist, and cache an empty result for that case
 * Refactor the code so we are fetching all payment methods for a customer, caching that result, while allowing for filtering on specific payment method types _after_ we fetch the result.
   - The vast majority (if not all) customers should have fewer than 100 saved payment methods, so this should result in 1 API call any time we have a cache miss, and at most 1 API call per request where we look for payment methods.
 * Refactor some loops that were fetching payment methods for each payment method until we found ones that we care about.

### Next steps and concerns

* **SEPA calls** - our logic for SEPA uses an undocumented `expand` URL parameter ([Stripe API docs for the API](https://docs.stripe.com/api/payment_methods/customer_list?lang=curl&api-version=2024-06-20)) -- I am not sure how this would (or would not) work across other payment methods
* **What can/should we include in 9.8.0?** - I _think_ we should add the "no customer" check for 9.8.0, as that should be an improvement that prevents nasty problems. I think we should seriously consider shipping only the `get_payment_methods()` API and the changes to callers that I have implemented in this change, but leave `get_payment_method()` untouched for now.
  - I am really open to feedback on what should (and should not) be included in 9.8.0!
* We may want to consider shifting to the database cache rather than transients for this data, but I haven't even looked at that yet.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
