### PR TITLE
Fix handling for "no such customer" response for customer payment_methods query

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@
 * Dev - Move some testing and compiler node dependencies to devDependencies
 * Dev - Minor CSS change to comply with a SASS rule deprecation
 * Dev - Update SCSS to replace @import with @use and @forward
+* Fix - Handle missing customer when calling payment_methods API
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -719,6 +719,15 @@ class WC_Stripe_Customer {
 			);
 
 			if ( ! empty( $response->error ) ) {
+				if (
+					isset( $response->error->code, $response->error->param, $response->error->type )
+					&& 'customer' === $response->error->param
+					&& 'resource_missing' === $response->error->code
+					&& 'invalid_request_error' === $response->error->type
+				) {
+					// If the customer doesn't exist, cache an empty array as a result.
+					set_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id(), [], DAY_IN_SECONDS );
+				}
 				return [];
 			}
 

--- a/readme.txt
+++ b/readme.txt
@@ -138,5 +138,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Move some testing and compiler node dependencies to devDependencies
 * Dev - Minor CSS change to comply with a SASS rule deprecation
 * Dev - Update SCSS to replace @import with @use and @forward
+* Fix - Handle missing customer when calling payment_methods API
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4560

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that when we receive an HTTP error from the Stripe `payment_methods` API, we now check if the customer doesn't exist based on the `error.type`, `error.param`, and `error.code` fields in the response from Stripe. If the customer doesn't exist, we now populate the cached data with an empty array to prevent unnecessary repeat calls to Stripe.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Set up a test site that uses a test connection to Stripe using the code from trunk
  - To _really_ see the problem, you can also enable Optimized Checkout and ensure you're using block checkout
* While logged in as a user, make a purchase (or perform another action) to get a Stripe customer ID assigned to your user
* Install a plugin like [Debug Bar](https://wordpress.org/plugins/debug-bar/) so you can see what HTTP requests are being made from PHP during page loads
* Add another product to your cart, and navigate to checkout -- keep this tab open
* Use Debug Bar to inspect the outbound HTTP requests for the site -- you may or may not see a number of HTTP requests to the Stripe `payment_methods` API
* Now reconnect Stripe and use a different test Stripe account
* Reload your checkout tab
* Inspect the outbound HTTP requests -- you should see a number of calls to the Stripe `payment_methods` API that all return 400 statuses
* Reload your checkout tab again, and verify that all the `payment_methods` API calls are repeated
* Now load the code from this branch
* Reload your checkout tab, and verify that all the `payment_methods` API calls are repeated
* Now load the checkout tab again, and verify that no `payment_methods` API calls are made, as we now have the data cached

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)