### PR TITLE
Adding a notice to highlight OC

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
+* Add - Includes a new notice to highlight the Optimized Checkout feature above the payment methods list in the Stripe settings page
 * Dev - Implements WooCommerce constants for the tax statuses
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -7,8 +7,12 @@ import UpeToggleContext from 'wcstripe/settings/upe-toggle/context';
 jest.useFakeTimers();
 
 describe( 'Optimized Checkout Element feature setting', () => {
+	const setIsOCEnabled = jest.fn().mockImplementation();
+
 	it( 'should render', () => {
-		render( <OptimizedCheckoutFeature /> );
+		render(
+			<OptimizedCheckoutFeature setIsOCEnabled={ setIsOCEnabled } />
+		);
 
 		expect(
 			screen.queryByText(
@@ -29,7 +33,7 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		render(
 			<div>
 				<UpdateUpeDisabledFlagMock />
-				<OptimizedCheckoutFeature />
+				<OptimizedCheckoutFeature setIsOCEnabled={ setIsOCEnabled } />
 			</div>
 		);
 

--- a/client/settings/advanced-settings-section/index.js
+++ b/client/settings/advanced-settings-section/index.js
@@ -20,7 +20,7 @@ const AdvancedSettingsDescription = () => (
 	</>
 );
 
-const AdvancedSettings = () => {
+const AdvancedSettings = ( { isOCEnabled, setIsOCEnabled } ) => {
 	const isOcAvailable = wc_stripe_settings_params.is_oc_available; // eslint-disable-line camelcase
 	return (
 		<SettingsSection Description={ AdvancedSettingsDescription }>
@@ -28,7 +28,12 @@ const AdvancedSettings = () => {
 				<Card>
 					<CardBody>
 						<DebugMode />
-						{ isOcAvailable && <OptimizedCheckoutFeature /> }
+						{ isOcAvailable && (
+							<OptimizedCheckoutFeature
+								isOCEnabled={ isOCEnabled }
+								setIsOCEnabled={ setIsOCEnabled }
+							/>
+						) }
 					</CardBody>
 				</Card>
 			</LoadableSettingsSection>

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -3,10 +3,9 @@ import { createInterpolateElement } from '@wordpress/element';
 import { CheckboxControl, ExternalLink } from '@wordpress/components';
 import React, { useEffect, useRef } from 'react';
 import { getQuery } from '@woocommerce/navigation';
-import { useIsOCEnabled, useIsUpeEnabled } from '../../data';
+import { useIsUpeEnabled } from '../../data';
 
-const OptimizedCheckoutFeature = () => {
-	const [ isOCEnabled, setIsOCEnabled ] = useIsOCEnabled();
+const OptimizedCheckoutFeature = ( { isOCEnabled, setIsOCEnabled } ) => {
 	const [ isUpeEnabled ] = useIsUpeEnabled();
 	const headingRef = useRef( null );
 

--- a/client/settings/optimized-checkout-notice/__tests__/display-order-customization-notice.js
+++ b/client/settings/optimized-checkout-notice/__tests__/display-order-customization-notice.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import OptimizedCheckoutNotice from '..';
+import OCToggleContext from 'wcstripe/settings/oc-toggle/context';
+
+jest.mock( '@wordpress/api-fetch' );
+
+describe( 'OptimizedCheckoutNotice', () => {
+	it( 'should render the notice when UPE is enabled', () => {
+		render(
+			<OCToggleContext.Provider value={ { isOCEnabled: true } }>
+				<OptimizedCheckoutNotice />
+			</OCToggleContext.Provider>
+		);
+
+		const noticeText = screen.queryAllByText(
+			"You're using Stripe's Optimized Checkout Suite to dynamically display the most relevant payment methods you've enabled to each customer."
+		)?.[ 0 ];
+		expect( noticeText ).toBeInTheDocument();
+	} );
+
+	it( 'should not render the notice when OC is disabled', () => {
+		const { container } = render(
+			<OCToggleContext.Provider value={ { isOCEnabled: false } }>
+				<OptimizedCheckoutNotice />
+			</OCToggleContext.Provider>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+} );

--- a/client/settings/optimized-checkout-notice/__tests__/index.test.js
+++ b/client/settings/optimized-checkout-notice/__tests__/index.test.js
@@ -1,17 +1,10 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import OptimizedCheckoutNotice from '..';
-import OCToggleContext from 'wcstripe/settings/oc-toggle/context';
-
-jest.mock( '@wordpress/api-fetch' );
 
 describe( 'OptimizedCheckoutNotice', () => {
-	it( 'should render the notice when UPE is enabled', () => {
-		render(
-			<OCToggleContext.Provider value={ { isOCEnabled: true } }>
-				<OptimizedCheckoutNotice />
-			</OCToggleContext.Provider>
-		);
+	it( 'should render the notice when OC is enabled', () => {
+		render( <OptimizedCheckoutNotice isOCEnabled={ true } /> );
 
 		const noticeText = screen.queryAllByText(
 			"You're using Stripe's Optimized Checkout Suite to dynamically display the most relevant payment methods you've enabled to each customer."
@@ -21,9 +14,7 @@ describe( 'OptimizedCheckoutNotice', () => {
 
 	it( 'should not render the notice when OC is disabled', () => {
 		const { container } = render(
-			<OCToggleContext.Provider value={ { isOCEnabled: false } }>
-				<OptimizedCheckoutNotice />
-			</OCToggleContext.Provider>
+			<OptimizedCheckoutNotice isOCEnabled={ false } />
 		);
 
 		expect( container.firstChild ).toBeNull();

--- a/client/settings/optimized-checkout-notice/__tests__/index.test.js
+++ b/client/settings/optimized-checkout-notice/__tests__/index.test.js
@@ -1,8 +1,28 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { screen, render, act } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import userEvent from '@testing-library/user-event';
 import OptimizedCheckoutNotice from '..';
 
+jest.mock( '@wordpress/api-fetch' );
+
 describe( 'OptimizedCheckoutNotice', () => {
+	const globalValues = global.wc_stripe_settings_params;
+	beforeEach( () => {
+		apiFetch.mockImplementation(
+			jest.fn( () => Promise.resolve( { data: {} } ) )
+		);
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			show_optimized_checkout_notice: true,
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		global.wc_stripe_settings_params = globalValues;
+	} );
+
 	it( 'should render the notice when OC is enabled', () => {
 		render( <OptimizedCheckoutNotice isOCEnabled={ true } /> );
 
@@ -12,9 +32,40 @@ describe( 'OptimizedCheckoutNotice', () => {
 		expect( noticeText ).toBeInTheDocument();
 	} );
 
+	it( 'should make an API call to dismiss the banner on button click', async () => {
+		const dismissNoticeMock = jest.fn( () =>
+			Promise.resolve( { data: {} } )
+		);
+		apiFetch.mockImplementation( dismissNoticeMock );
+
+		render( <OptimizedCheckoutNotice isOCEnabled={ true } /> );
+
+		const dismissButton = screen.queryByRole( 'button', {
+			'aria-label': 'Dismiss the notice',
+		} );
+		expect( dismissButton ).toBeInTheDocument();
+		await act( async () => {
+			await userEvent.click( dismissButton );
+		} );
+		expect( dismissNoticeMock ).toHaveBeenCalled();
+	} );
+
 	it( 'should not render the notice when OC is disabled', () => {
 		const { container } = render(
 			<OptimizedCheckoutNotice isOCEnabled={ false } />
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should not render the notice when `show_optimized_checkout_notice` is false', () => {
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			show_optimized_checkout_notice: false,
+		};
+
+		const { container } = render(
+			<OptimizedCheckoutNotice isOCEnabled={ true } />
 		);
 
 		expect( container.firstChild ).toBeNull();

--- a/client/settings/optimized-checkout-notice/index.js
+++ b/client/settings/optimized-checkout-notice/index.js
@@ -1,10 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
-import React, { useContext } from 'react';
+import React from 'react';
 import { Icon, Notice } from '@wordpress/components';
 import { info } from '@wordpress/icons';
 import interpolateComponents from 'interpolate-components';
-import OCToggleContext from 'wcstripe/settings/oc-toggle/context';
 
 const NoticeWrapper = styled( Notice )`
 	margin: 0 0 24px 0;
@@ -20,8 +19,7 @@ const NoticeContent = styled.div`
 	}
 `;
 
-const OptimizedCheckoutNotice = () => {
-	const { isOCEnabled } = useContext( OCToggleContext );
+const OptimizedCheckoutNotice = ( { isOCEnabled } ) => {
 	if ( ! isOCEnabled ) {
 		return null;
 	}

--- a/client/settings/optimized-checkout-notice/index.js
+++ b/client/settings/optimized-checkout-notice/index.js
@@ -1,9 +1,11 @@
+/* global wc_stripe_settings_params */
 import { __ } from '@wordpress/i18n';
 import styled from '@emotion/styled';
-import React from 'react';
+import React, { useState } from 'react';
 import { Icon, Notice } from '@wordpress/components';
 import { info } from '@wordpress/icons';
 import interpolateComponents from 'interpolate-components';
+import apiFetch from '@wordpress/api-fetch';
 
 const NoticeWrapper = styled( Notice )`
 	margin: 0 0 24px 0;
@@ -20,12 +22,27 @@ const NoticeContent = styled.div`
 `;
 
 const OptimizedCheckoutNotice = ( { isOCEnabled } ) => {
-	if ( ! isOCEnabled ) {
+	const [ showNotice, setShowNotice ] = useState(
+		// eslint-disable-next-line camelcase
+		wc_stripe_settings_params.show_optimized_checkout_notice
+	);
+
+	if ( ! isOCEnabled || ! showNotice ) {
 		return null;
 	}
 
+	const handleDismissNotice = () => {
+		apiFetch( {
+			path: '/wc/v3/wc_stripe/settings/notice',
+			method: 'POST',
+			data: { wc_stripe_show_optimized_checkout_notice: 'no' },
+		} ).finally( () => {
+			setShowNotice( false );
+		} );
+	};
+
 	return (
-		<NoticeWrapper isDismissible={ false }>
+		<NoticeWrapper isDismissible={ true } onRemove={ handleDismissNotice }>
 			<NoticeContent>
 				<Icon icon={ info } size={ 24 } />
 				<div>

--- a/client/settings/optimized-checkout-notice/index.js
+++ b/client/settings/optimized-checkout-notice/index.js
@@ -1,0 +1,56 @@
+import { __ } from '@wordpress/i18n';
+import styled from '@emotion/styled';
+import React, { useContext } from 'react';
+import { Icon, Notice } from '@wordpress/components';
+import { info } from '@wordpress/icons';
+import interpolateComponents from 'interpolate-components';
+import OCToggleContext from 'wcstripe/settings/oc-toggle/context';
+
+const NoticeWrapper = styled( Notice )`
+	margin: 0 0 24px 0;
+`;
+
+const NoticeContent = styled.div`
+	display: inline-grid;
+	grid-template-columns: auto auto auto;
+	gap: 12px;
+
+	> svg {
+		fill: var( --wp-admin-theme-color );
+	}
+`;
+
+const OptimizedCheckoutNotice = () => {
+	const { isOCEnabled } = useContext( OCToggleContext );
+	if ( ! isOCEnabled ) {
+		return null;
+	}
+
+	return (
+		<NoticeWrapper isDismissible={ false }>
+			<NoticeContent>
+				<Icon icon={ info } size={ 24 } />
+				<div>
+					{ interpolateComponents( {
+						mixedString: __(
+							"You're using Stripe's Optimized Checkout Suite to dynamically display the most relevant payment methods you've enabled to each customer. {{docLink}}Learn more{{/docLink}}",
+							'woocommerce-gateway-stripe'
+						),
+						components: {
+							docLink: (
+								// eslint-disable-next-line jsx-a11y/anchor-has-content
+								<a
+									target="_blank"
+									rel="noreferrer"
+									href="https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/"
+								/>
+							),
+						},
+					} ) }
+				</div>
+			</NoticeContent>
+		</NoticeWrapper>
+	);
+};
+
+export default OptimizedCheckoutNotice;

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -53,6 +53,7 @@ const PaymentMethodsPanel = ( {
 	setShowPromotionalBanner,
 	showPromotionalBanner,
 	promotionalBannerType,
+	isOCEnabled,
 	setIsOCEnabled,
 	setIsUpeEnabled,
 } ) => {
@@ -78,7 +79,7 @@ const PaymentMethodsPanel = ( {
 			) }
 			<SettingsSection Description={ PaymentMethodsDescription }>
 				<DisplayOrderCustomizationNotice />
-				<OptimizedCheckoutNotice />
+				<OptimizedCheckoutNotice isOCEnabled={ isOCEnabled } />
 				<GeneralSettingsSection
 					onSaveChanges={ onSaveChanges }
 					showLegacyExperienceTransitionNotice={

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -9,6 +9,7 @@ import LoadableSettingsSection from '../loadable-settings-section';
 import DisplayOrderCustomizationNotice from '../display-order-customization-notice';
 import { NEW_CHECKOUT_EXPERIENCE_BANNER } from 'wcstripe/settings/payment-settings/constants';
 import PromotionalBanner from 'wcstripe/settings/payment-settings/promotional-banner';
+import OptimizedCheckoutNotice from 'wcstripe/settings/optimized-checkout-notice';
 
 const PaymentMethodsDescription = () => {
 	return (
@@ -77,6 +78,7 @@ const PaymentMethodsPanel = ( {
 			) }
 			<SettingsSection Description={ PaymentMethodsDescription }>
 				<DisplayOrderCustomizationNotice />
+				<OptimizedCheckoutNotice />
 				<GeneralSettingsSection
 					onSaveChanges={ onSaveChanges }
 					showLegacyExperienceTransitionNotice={

--- a/client/settings/payment-settings/index.js
+++ b/client/settings/payment-settings/index.js
@@ -70,6 +70,7 @@ const PaymentSettingsPanel = ( {
 	showPromotionalBanner,
 	setShowPromotionalBanner,
 	promotionalBannerType,
+	isOCEnabled,
 	setIsOCEnabled,
 	setIsUpeEnabled,
 } ) => {
@@ -145,7 +146,10 @@ const PaymentSettingsPanel = ( {
 					<PaymentsAndTransactionsSection />
 				</LoadableSettingsSection>
 			</SettingsSection>
-			<AdvancedSettingsSection />
+			<AdvancedSettingsSection
+				isOCEnabled={ isOCEnabled }
+				setIsOCEnabled={ setIsOCEnabled }
+			/>
 		</>
 	);
 };

--- a/client/settings/settings-manager/index.js
+++ b/client/settings/settings-manager/index.js
@@ -111,6 +111,7 @@ const SettingsManager = () => {
 									setShowPromotionalBanner
 								}
 								promotionalBannerType={ promotionalBannerType }
+								isOCEnabled={ isOCEnabled }
 								setIsOCEnabled={ setIsOCEnabled }
 								setIsUpeEnabled={ setIsUpeEnabled }
 							/>
@@ -122,6 +123,7 @@ const SettingsManager = () => {
 									setShowPromotionalBanner
 								}
 								promotionalBannerType={ promotionalBannerType }
+								isOCEnabled={ isOCEnabled }
 								setIsOCEnabled={ setIsOCEnabled }
 								setIsUpeEnabled={ setIsUpeEnabled }
 							/>

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -617,6 +617,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 */
 	public function dismiss_notice( WP_REST_Request $request ) {
 		if ( null === $request->get_param( 'wc_stripe_show_customization_notice' )
+			&& null === $request->get_param( 'wc_stripe_show_optimized_checkout_notice' )
 			&& null === $request->get_param( 'wc_stripe_show_bnpl_promotion_banner' )
 			&& null === $request->get_param( 'wc_stripe_show_oc_promotion_banner' ) ) {
 			return new WP_REST_Response( [], 200 );
@@ -624,6 +625,10 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 		if ( null !== $request->get_param( 'wc_stripe_show_customization_notice' ) ) {
 			update_option( 'wc_stripe_show_customization_notice', 'no' );
+		}
+
+		if ( null !== $request->get_param( 'wc_stripe_show_optimized_checkout_notice' ) ) {
+			update_option( 'wc_stripe_show_optimized_checkout_notice', 'no' );
 		}
 
 		if ( null !== $request->get_param( 'wc_stripe_show_bnpl_promotion_banner' ) ) {

--- a/includes/admin/class-wc-stripe-rest-oc-setting-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-rest-oc-setting-toggle-controller.php
@@ -95,7 +95,7 @@ class WC_Stripe_REST_OC_Setting_Toggle_Controller extends WC_Stripe_REST_Base_Co
 
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 
-		if ( $value !== $current_value ) {
+		if ( $is_oc_enabled !== $current_value ) {
 			wc_admin_record_tracks_event(
 				$is_oc_enabled ? 'wcstripe_oc_enabled' : 'wcstripe_oc_disabled',
 				[

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -270,6 +270,7 @@ class WC_Stripe_Settings_Controller {
 			'stripe_oauth_url'                      => $oauth_url,
 			'stripe_test_oauth_url'                 => $test_oauth_url,
 			'show_customization_notice'             => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
+			'show_optimized_checkout_notice'        => get_option( 'wc_stripe_show_optimized_checkout_notice', 'yes' ) === 'yes' ? true : false,
 			'show_bnpl_promotional_banner'          => $show_bnpl_promotion_banner,
 			'show_oc_promotional_banner'            => $show_oc_promotion_banner,
 			'is_test_mode'                          => $this->get_gateway()->is_in_test_mode(),

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
+* Add - Includes a new notice to highlight the Optimized Checkout feature above the payment methods list in the Stripe settings page
 * Dev - Implements WooCommerce constants for the tax statuses
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
 * Add - A new pill to the payment methods page to indicate the credit card requirement when the Optimized Checkout feature is enabled


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-658
Figma nFI8jCCAQnd19PNwScqVU6/Stripe-Payments--External-?node-id=2066-7573&t=9CgVqRH2lc08bHHB-0-fi

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

We are adding a new notice to highlight the Optimized Checkout feature above the payment method listing screen under Stripe settings. This is a simple notice, displayed with the standard notice visuals and linking to the main OC documentation (`https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/`).

Notice preview:
<img width="770" height="86" alt="Screenshot 2025-08-06 at 11 59 20" src="https://github.com/user-attachments/assets/042257f6-567d-4022-82e1-86a288f58f51" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/oc-inline-notice`)
- Connect your Stripe account
- Enable the Optimized Checkout
- Go to the payment methods listing screen (`wp-admin/admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods`)
- Confirm you can see the new notice and that it matches the preview and the Figma designs
- Confirm that clicking "Read more" sends you to `https://woocommerce.com/document/stripe/admin-experience/optimized-checkout-suite/`

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
