### PR TITLE
Checking for the subscription detached payment method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.8.0 - xxxx-xx-xx =
+* Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Update - Removes the ability to change the title for the Optimized Checkout payment element, as it is now set to "Stripe" by default
 * Update - Copy for the Optimized Checkout settings and notices
 * Dev - Implements WooCommerce constants for the tax statuses

--- a/includes/compat/class-wc-stripe-subscriptions-helper.php
+++ b/includes/compat/class-wc-stripe-subscriptions-helper.php
@@ -151,6 +151,11 @@ class WC_Stripe_Subscriptions_Helper {
 			return false;
 		}
 
+		if ( 'stripe' !== substr( (string) $subscription->get_payment_method(), 0, 6 ) ) {
+			// If the payment method is not a Stripe method, we don't need to check further.
+			return false;
+		}
+
 		$source_id = $subscription->get_meta( '_stripe_source_id' );
 		if ( ! $source_id ) {
 			return false;

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.8.0 - xxxx-xx-xx =
+* Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Update - Removes the ability to change the title for the Optimized Checkout payment element, as it is now set to "Stripe" by default
 * Update - Copy for the Optimized Checkout settings and notices
 * Dev - Implements WooCommerce constants for the tax statuses

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -646,6 +646,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$subscription = new WC_Subscription();
 		$subscription->set_id( 123 );
 		$subscription->set_status( 'active' );
+		$subscription->set_payment_method( 'stripe_klarna' );
 		$subscription->save();
 
 		$subscription->update_meta_data( '_stripe_source_id', $source_id );

--- a/tests/phpunit/Admin/WC_Stripe_Subscription_Detached_Bulk_Action_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Subscription_Detached_Bulk_Action_Test.php
@@ -80,6 +80,7 @@ class WC_Stripe_Subscription_Detached_Bulk_Action_Test extends WP_UnitTestCase {
 		$source_id             = 'src_123';
 		$subscription_detached = new WC_Subscription();
 		$subscription_detached->set_id( 2 );
+		$subscription_detached->set_payment_method( 'stripe_klarna' );
 		$subscription_detached->update_meta_data( '_stripe_source_id', $source_id );
 
 		$payment_method = (object) [

--- a/tests/phpunit/Compat/WC_Stripe_Subscriptions_Helper_Test.php
+++ b/tests/phpunit/Compat/WC_Stripe_Subscriptions_Helper_Test.php
@@ -60,6 +60,7 @@ class WC_Stripe_Subscriptions_Helper_Test extends WP_UnitTestCase {
 		$subscription = new WC_Subscription();
 		$subscription->set_id( $subscription_id );
 		$subscription->set_status( 'active' );
+		$subscription->set_payment_method( 'stripe_klarna' );
 		$subscription->set_time( 'next_payment_date', strtotime( '+1 week' ) );
 		$subscription->save();
 

--- a/tests/phpunit/Compat/WC_Stripe_Subscriptions_Helper_Test.php
+++ b/tests/phpunit/Compat/WC_Stripe_Subscriptions_Helper_Test.php
@@ -178,6 +178,7 @@ class WC_Stripe_Subscriptions_Helper_Test extends WP_UnitTestCase {
 	/**
 	 * Tests for {@see WC_Stripe_Subscriptions_Helper::is_subscription_payment_method_detached()}.
 	 *
+	 * @param string $payment_method The payment method type for the subscription.
 	 * @param array|null $source_meta The source meta data for the subscription.
 	 * @param array|\WP_Error $mocked_response The mocked response from the Stripe API.
 	 * @param bool $expected The expected result of the check.
@@ -185,12 +186,13 @@ class WC_Stripe_Subscriptions_Helper_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider provide_test_is_subscription_payment_method_detached
 	 */
-	public function test_is_subscription_payment_method_detached( $source_meta, $mocked_response, $expected ) {
+	public function test_is_subscription_payment_method_detached( $payment_method, $source_meta, $mocked_response, $expected ) {
 		WC_Stripe_Database_Cache::delete( 'payment_method_for_source_' . $source_meta );
 
 		$subscription = new WC_Subscription();
 		$subscription->set_id( 1 );
 		$subscription->set_status( 'active' );
+		$subscription->set_payment_method( $payment_method );
 		$subscription->save();
 
 		if ( ! is_null( $source_meta ) ) {
@@ -223,17 +225,26 @@ class WC_Stripe_Subscriptions_Helper_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_is_subscription_payment_method_detached() {
 		return [
+			'not a Stripe subscription'               => [
+				'payment method' => 'not_stripe',
+				'source meta'     => null,
+				'mocked response' => null,
+				'expected'        => false,
+			],
 			'missing meta'                            => [
+				'payment method'  => 'stripe_klarna',
 				'source meta'     => null,
 				'mocked response' => null,
 				'expected'        => false,
 			],
 			'wp error response, assumed detached'     => [
+				'payment method'  => 'stripe_klarna',
 				'source meta'     => 'src_123',
 				'mocked response' => new \WP_Error( 'error', 'An error occurred.' ),
 				'expected'        => true,
 			],
 			'Stripe error response, assumed detached' => [
+				'payment method'  => 'stripe_klarna',
 				'source meta'     => 'src_123',
 				'mocked response' => [
 					'response' => 400,
@@ -250,6 +261,7 @@ class WC_Stripe_Subscriptions_Helper_Test extends WP_UnitTestCase {
 				'expected'        => true,
 			],
 			'existing customer data'                  => [
+				'payment method'  => 'stripe_klarna',
 				'source meta'     => 'src_123',
 				'mocked response' => [
 					'response' => 200,
@@ -263,6 +275,7 @@ class WC_Stripe_Subscriptions_Helper_Test extends WP_UnitTestCase {
 				'expected'        => false,
 			],
 			'detached payment method'                 => [
+				'payment method'  => 'stripe_klarna',
 				'source meta'     => 'src_123',
 				'mocked response' => [
 					'response' => 200,

--- a/tests/phpunit/WC_Stripe_Status_Test.php
+++ b/tests/phpunit/WC_Stripe_Status_Test.php
@@ -115,6 +115,7 @@ class WC_Stripe_Status_Test extends WP_UnitTestCase {
 				$subscription = new WC_Subscription();
 				$subscription->set_id( $subscription_data['id'] );
 				$subscription->set_status( 'active' );
+				$subscription->set_payment_method( 'stripe_klarna' );
 				$subscription->save();
 
 				$subscription->update_meta_data( '_stripe_customer_id', $subscription_data['customer_id'] );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-661
Thread https://wordpress.org/support/topic/removing-unwanted-detached-payment-method-notices/

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Currently, the subscription detached notice displayed in the admin interface for subscriptions without payment methods does not verify the gateway. This causes notices to be shown erroneously for merchants with multiple gateways.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Same as https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4393. You can also install another gateway (e.g., Square), create some subscriptions with it, and confirm that the notice is no longer shown when viewing those.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
