### PR TITLE
Add method to fetch and cache all saved payment methods for a customer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -35,6 +35,7 @@
 * Dev - Update SCSS to replace @import with @use and @forward
 * Fix - Handle missing customer when calling payment_methods API
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
+* Fix - Reduce number of calls to Stripe payment_methods API
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -940,6 +940,7 @@ class WC_Stripe_Customer {
 		foreach ( self::STRIPE_PAYMENT_METHODS as $payment_method_type ) {
 			delete_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id() );
 		}
+		delete_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . '__all_' . $this->get_id() );
 		// Clear cache for the specific payment method if provided.
 		if ( $payment_method_id ) {
 			WC_Stripe_Database_Cache::delete( 'payment_method_for_source_' . $payment_method_id );

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -775,8 +775,7 @@ class WC_Stripe_Customer {
 					$request_params['starting_after'] = $last_payment_method_id;
 				}
 
-				// TODO: work out how we can add the SEPA `expand[]` parameters to the request. Will that work when all types are being returned?
-				$response = WC_Stripe_API::request( $request_params, 'payment_methods', 'GET' );
+				$response = WC_Stripe_API::request( $request_params, 'payment_methods?expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt', 'GET' );
 
 				if ( ! empty( $response->error ) ) {
 					if (

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -31,6 +31,11 @@ class WC_Stripe_Customer {
 	];
 
 	/**
+	 * The maximum value for the `limit` argument in the Stripe payment_methods API.
+	 */
+	protected const PAYMENT_METHODS_API_LIMIT = 100;
+
+	/**
 	 * Stripe customer ID
 	 *
 	 * @var string
@@ -712,7 +717,7 @@ class WC_Stripe_Customer {
 				[
 					'customer' => $this->get_id(),
 					'type'     => $payment_method_type,
-					'limit'    => 100, // Maximum allowed value.
+					'limit'    => self::PAYMENT_METHODS_API_LIMIT,
 				],
 				'payment_methods' . $params,
 				'GET'
@@ -739,6 +744,95 @@ class WC_Stripe_Customer {
 		}
 
 		return empty( $payment_methods ) ? [] : $payment_methods;
+	}
+
+	/**
+	 * Get all payment methods for a customer.
+	 *
+	 * @param string[] $payment_method_types The payment method types to look for using Stripe method IDs. If the array is empty, it implies all payment method types.
+	 * @param int      $limit                The maximum number of payment methods to return. If the value is -1, no limit is applied.
+	 * @return array
+	 */
+	public function get_all_payment_methods( array $payment_method_types = [], int $limit = -1 ) {
+		if ( ! $this->get_id() ) {
+			return [];
+		}
+
+		$cache_key = self::PAYMENT_METHODS_TRANSIENT_KEY . '__all_' . $this->get_id();
+		$all_payment_methods = get_transient( $cache_key );
+
+		if ( false === $all_payment_methods || ! is_array( $all_payment_methods ) ) {
+			$all_payment_methods    = [];
+			$last_payment_method_id = null;
+
+			do {
+				$request_params = [
+					'customer' => $this->get_id(),
+					'limit'    => self::PAYMENT_METHODS_API_LIMIT,
+				];
+
+				if ( $last_payment_method_id ) {
+					$request_params['starting_after'] = $last_payment_method_id;
+				}
+
+				// TODO: work out how we can add the SEPA `expand[]` parameters to the request. Will that work when all types are being returned?
+				$response = WC_Stripe_API::request( $request_params, 'payment_methods', 'GET' );
+
+				if ( ! empty( $response->error ) ) {
+					if (
+						isset( $response->error->code )
+						&& isset( $response->error->param )
+						&& 'customer' === $response->error->param
+						&& 'resource_missing' === $response->error->code
+					) {
+						// If the customer doesn't exist, cache an empty array.
+						set_transient( $cache_key, [], DAY_IN_SECONDS );
+					}
+					return [];
+				}
+
+				if ( ! is_array( $response->data ) || [] === $response->data ) {
+					break;
+				}
+
+				$all_payment_methods = array_merge( $all_payment_methods, $response->data );
+
+				// Reset the last payment method ID so we can paginate correctly.
+				$last_payment_method_id = null;
+				if ( isset( $response->has_more ) && $response->has_more ) {
+					$last_payment_method = end( $response->data );
+
+					if ( $last_payment_method && ! empty( $last_payment_method->id ) ) {
+						$last_payment_method_id = $last_payment_method->id;
+					}
+				}
+			} while ( null !== $last_payment_method_id );
+
+			// Always cache the result without any filters applied.
+			set_transient( $cache_key, $all_payment_methods, DAY_IN_SECONDS );
+		}
+
+		// If there are no payment methods, no need to apply any filters below.
+		if ( [] === $all_payment_methods ) {
+			return $all_payment_methods;
+		}
+
+		// Only apply the limit and type filters after fetching and caching all payment methods.
+		$filtered_payment_methods = $all_payment_methods;
+		if ( [] !== $payment_method_types ) {
+			$filtered_payment_methods = array_filter(
+				$filtered_payment_methods,
+				function ( $payment_method ) use ( $payment_method_types ) {
+					return in_array( $payment_method->type, $payment_method_types, true );
+				}
+			);
+		}
+
+		if ( $limit > 0 ) {
+			return array_slice( $filtered_payment_methods, 0, $limit );
+		}
+
+		return $filtered_payment_methods;
 	}
 
 	/**

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -781,8 +781,7 @@ class WC_Stripe_Customer {
 
 				if ( ! empty( $response->error ) ) {
 					if (
-						isset( $response->error->code )
-						&& isset( $response->error->param )
+						isset( $response->error->param, $response->error->code )
 						&& 'customer' === $response->error->param
 						&& 'resource_missing' === $response->error->code
 					) {

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -32,6 +32,8 @@ class WC_Stripe_Customer {
 
 	/**
 	 * The maximum value for the `limit` argument in the Stripe payment_methods API.
+	 *
+	 * @see https://docs.stripe.com/api/payment_methods/customer_list#list_customer_payment_methods-limit
 	 */
 	protected const PAYMENT_METHODS_API_LIMIT = 100;
 

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -1013,72 +1013,12 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		$stripe_customer->set_id( $stripe_customer_id );
 
-		$payment_method_to_display = __( 'N/A', 'woocommerce-gateway-stripe' );
-
 		try {
-			// Retrieve all possible payment methods for subscriptions.
-			foreach ( WC_Stripe_Customer::STRIPE_PAYMENT_METHODS as $payment_method_type ) {
-				foreach ( $stripe_customer->get_payment_methods( $payment_method_type ) as $source ) {
-					if ( $source->id !== $stripe_source_id ) {
-						continue;
-					}
+			$customer_payment_methods = $stripe_customer->get_all_payment_methods();
 
-					// Legacy handling for Stripe Card objects. ref: https://docs.stripe.com/api/cards/object
-					if ( isset( $source->object ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
-						/* translators: 1) card brand 2) last 4 digits */
-						$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->brand ) ? wc_get_credit_card_type_label( $source->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->last4 );
-						break 2;
-					}
-
-					switch ( $source->type ) {
-						case WC_Stripe_Payment_Methods::CARD:
-							/* translators: 1) card brand 2) last 4 digits */
-							$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->card->brand ) ? wc_get_credit_card_type_label( $source->card->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->card->last4 );
-							break 3;
-						case WC_Stripe_Payment_Methods::SEPA_DEBIT:
-							/* translators: 1) last 4 digits of SEPA Direct Debit */
-							$payment_method_to_display = sprintf( __( 'Via SEPA Direct Debit ending in %1$s', 'woocommerce-gateway-stripe' ), $source->sepa_debit->last4 );
-							break 3;
-						case WC_Stripe_Payment_Methods::CASHAPP_PAY:
-							/* translators: 1) Cash App Cashtag */
-							$payment_method_to_display = sprintf( __( 'Via Cash App Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->cashapp->cashtag );
-							break 3;
-						case WC_Stripe_Payment_Methods::LINK:
-							/* translators: 1) email address associated with the Stripe Link payment method */
-							$payment_method_to_display = sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
-							break 3;
-						case WC_Stripe_Payment_Methods::ACH:
-							$payment_method_to_display = sprintf(
-								/* translators: 1) account type (checking, savings), 2) last 4 digits of account. */
-								__( 'Via %1$s Account ending in %2$s', 'woocommerce-gateway-stripe' ),
-								ucfirst( $source->us_bank_account->account_type ),
-								$source->us_bank_account->last4
-							);
-							break 3;
-						case WC_Stripe_Payment_Methods::BECS_DEBIT:
-							$payment_method_to_display = sprintf(
-								/* translators: last 4 digits of account. */
-								__( 'BECS Direct Debit ending in %s', 'woocommerce-gateway-stripe' ),
-								$source->au_becs_debit->last4
-							);
-							break 3;
-						case WC_Stripe_Payment_Methods::ACSS_DEBIT:
-							$payment_method_to_display = sprintf(
-								/* translators: 1) bank name, 2) last 4 digits of account. */
-								__( 'Via %1$s ending in %2$s', 'woocommerce-gateway-stripe' ),
-								$source->acss_debit->bank_name,
-								$source->acss_debit->last4
-							);
-							break 3;
-						case WC_Stripe_Payment_Methods::BACS_DEBIT:
-							/* translators: 1) the Bacs Direct Debit payment method's last 4 numbers */
-							$payment_method_to_display = sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
-							break 3;
-						case WC_Stripe_Payment_Methods::AMAZON_PAY:
-							/* translators: 1) the Amazon Pay payment method's email */
-							$payment_method_to_display = sprintf( __( 'Via Amazon Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->billing_details->email ?? '' );
-							break 3;
-					}
+			foreach ( $customer_payment_methods as $payment_method ) {
+				if ( $payment_method->id === $stripe_source_id ) {
+					return $this->get_payment_method_to_display_for_payment_method( $payment_method );
 				}
 			}
 		} catch ( WC_Stripe_Exception $e ) {
@@ -1086,7 +1026,72 @@ trait WC_Stripe_Subscriptions_Trait {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 		}
 
-		return $payment_method_to_display;
+		return __( 'N/A', 'woocommerce-gateway-stripe' );
+	}
+
+	/**
+	 * Helper function to get the descriptive text for a payment method or source.
+	 *
+	 * @param object $source The payment method or source object.
+	 * @return string The descriptive text for the payment method or source.
+	 */
+	protected function get_payment_method_to_display_for_payment_method( object $source ): string {
+		// Legacy handling for Stripe Card objects. ref: https://docs.stripe.com/api/cards/object
+		if ( isset( $source->object ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
+			return sprintf(
+				/* translators: 1) card brand 2) last 4 digits */
+				__( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ),
+				( isset( $source->brand ) ? wc_get_credit_card_type_label( $source->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ),
+				$source->last4
+			);
+		}
+
+		switch ( $source->type ) {
+			case WC_Stripe_Payment_Methods::CARD:
+				return sprintf(
+					/* translators: 1) card brand 2) last 4 digits */
+					__( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ),
+					( isset( $source->card->brand ) ? wc_get_credit_card_type_label( $source->card->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ),
+					$source->card->last4
+				);
+			case WC_Stripe_Payment_Methods::SEPA_DEBIT:
+				/* translators: 1) last 4 digits of SEPA Direct Debit */
+				return sprintf( __( 'Via SEPA Direct Debit ending in %1$s', 'woocommerce-gateway-stripe' ), $source->sepa_debit->last4 );
+			case WC_Stripe_Payment_Methods::CASHAPP_PAY:
+				/* translators: 1) Cash App Cashtag */
+				return sprintf( __( 'Via Cash App Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->cashapp->cashtag );
+			case WC_Stripe_Payment_Methods::LINK:
+				/* translators: 1) email address associated with the Stripe Link payment method */
+				return sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
+			case WC_Stripe_Payment_Methods::ACH:
+				return sprintf(
+					/* translators: 1) account type (checking, savings), 2) last 4 digits of account. */
+					__( 'Via %1$s Account ending in %2$s', 'woocommerce-gateway-stripe' ),
+					ucfirst( $source->us_bank_account->account_type ),
+					$source->us_bank_account->last4
+				);
+			case WC_Stripe_Payment_Methods::BECS_DEBIT:
+				return sprintf(
+					/* translators: last 4 digits of account. */
+					__( 'BECS Direct Debit ending in %s', 'woocommerce-gateway-stripe' ),
+					$source->au_becs_debit->last4
+				);
+			case WC_Stripe_Payment_Methods::ACSS_DEBIT:
+				return sprintf(
+					/* translators: 1) bank name, 2) last 4 digits of account. */
+					__( 'Via %1$s ending in %2$s', 'woocommerce-gateway-stripe' ),
+					$source->acss_debit->bank_name,
+					$source->acss_debit->last4
+				);
+			case WC_Stripe_Payment_Methods::BACS_DEBIT:
+				/* translators: 1) the Bacs Direct Debit payment method's last 4 numbers */
+				return sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
+			case WC_Stripe_Payment_Methods::AMAZON_PAY:
+				/* translators: 1) the Amazon Pay payment method's email */
+				return sprintf( __( 'Via Amazon Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->billing_details->email ?? '' );
+		}
+
+		return __( 'N/A', 'woocommerce-gateway-stripe' );
 	}
 
 	/**

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -1013,12 +1013,72 @@ trait WC_Stripe_Subscriptions_Trait {
 
 		$stripe_customer->set_id( $stripe_customer_id );
 
-		try {
-			$customer_payment_methods = $stripe_customer->get_all_payment_methods();
+		$payment_method_to_display = __( 'N/A', 'woocommerce-gateway-stripe' );
 
-			foreach ( $customer_payment_methods as $payment_method ) {
-				if ( $payment_method->id === $stripe_source_id ) {
-					return $this->get_payment_method_to_display_for_payment_method( $payment_method );
+		try {
+			// Retrieve all possible payment methods for subscriptions.
+			foreach ( WC_Stripe_Customer::STRIPE_PAYMENT_METHODS as $payment_method_type ) {
+				foreach ( $stripe_customer->get_payment_methods( $payment_method_type ) as $source ) {
+					if ( $source->id !== $stripe_source_id ) {
+						continue;
+					}
+
+					// Legacy handling for Stripe Card objects. ref: https://docs.stripe.com/api/cards/object
+					if ( isset( $source->object ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
+						/* translators: 1) card brand 2) last 4 digits */
+						$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->brand ) ? wc_get_credit_card_type_label( $source->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->last4 );
+						break 2;
+					}
+
+					switch ( $source->type ) {
+						case WC_Stripe_Payment_Methods::CARD:
+							/* translators: 1) card brand 2) last 4 digits */
+							$payment_method_to_display = sprintf( __( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ), ( isset( $source->card->brand ) ? wc_get_credit_card_type_label( $source->card->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ), $source->card->last4 );
+							break 3;
+						case WC_Stripe_Payment_Methods::SEPA_DEBIT:
+							/* translators: 1) last 4 digits of SEPA Direct Debit */
+							$payment_method_to_display = sprintf( __( 'Via SEPA Direct Debit ending in %1$s', 'woocommerce-gateway-stripe' ), $source->sepa_debit->last4 );
+							break 3;
+						case WC_Stripe_Payment_Methods::CASHAPP_PAY:
+							/* translators: 1) Cash App Cashtag */
+							$payment_method_to_display = sprintf( __( 'Via Cash App Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->cashapp->cashtag );
+							break 3;
+						case WC_Stripe_Payment_Methods::LINK:
+							/* translators: 1) email address associated with the Stripe Link payment method */
+							$payment_method_to_display = sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
+							break 3;
+						case WC_Stripe_Payment_Methods::ACH:
+							$payment_method_to_display = sprintf(
+								/* translators: 1) account type (checking, savings), 2) last 4 digits of account. */
+								__( 'Via %1$s Account ending in %2$s', 'woocommerce-gateway-stripe' ),
+								ucfirst( $source->us_bank_account->account_type ),
+								$source->us_bank_account->last4
+							);
+							break 3;
+						case WC_Stripe_Payment_Methods::BECS_DEBIT:
+							$payment_method_to_display = sprintf(
+								/* translators: last 4 digits of account. */
+								__( 'BECS Direct Debit ending in %s', 'woocommerce-gateway-stripe' ),
+								$source->au_becs_debit->last4
+							);
+							break 3;
+						case WC_Stripe_Payment_Methods::ACSS_DEBIT:
+							$payment_method_to_display = sprintf(
+								/* translators: 1) bank name, 2) last 4 digits of account. */
+								__( 'Via %1$s ending in %2$s', 'woocommerce-gateway-stripe' ),
+								$source->acss_debit->bank_name,
+								$source->acss_debit->last4
+							);
+							break 3;
+						case WC_Stripe_Payment_Methods::BACS_DEBIT:
+							/* translators: 1) the Bacs Direct Debit payment method's last 4 numbers */
+							$payment_method_to_display = sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
+							break 3;
+						case WC_Stripe_Payment_Methods::AMAZON_PAY:
+							/* translators: 1) the Amazon Pay payment method's email */
+							$payment_method_to_display = sprintf( __( 'Via Amazon Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->billing_details->email ?? '' );
+							break 3;
+					}
 				}
 			}
 		} catch ( WC_Stripe_Exception $e ) {
@@ -1026,72 +1086,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 		}
 
-		return __( 'N/A', 'woocommerce-gateway-stripe' );
-	}
-
-	/**
-	 * Helper function to get the descriptive text for a payment method or source.
-	 *
-	 * @param object $source The payment method or source object.
-	 * @return string The descriptive text for the payment method or source.
-	 */
-	protected function get_payment_method_to_display_for_payment_method( object $source ): string {
-		// Legacy handling for Stripe Card objects. ref: https://docs.stripe.com/api/cards/object
-		if ( isset( $source->object ) && WC_Stripe_Payment_Methods::CARD === $source->object ) {
-			return sprintf(
-				/* translators: 1) card brand 2) last 4 digits */
-				__( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ),
-				( isset( $source->brand ) ? wc_get_credit_card_type_label( $source->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ),
-				$source->last4
-			);
-		}
-
-		switch ( $source->type ) {
-			case WC_Stripe_Payment_Methods::CARD:
-				return sprintf(
-					/* translators: 1) card brand 2) last 4 digits */
-					__( 'Via %1$s card ending in %2$s', 'woocommerce-gateway-stripe' ),
-					( isset( $source->card->brand ) ? wc_get_credit_card_type_label( $source->card->brand ) : __( 'N/A', 'woocommerce-gateway-stripe' ) ),
-					$source->card->last4
-				);
-			case WC_Stripe_Payment_Methods::SEPA_DEBIT:
-				/* translators: 1) last 4 digits of SEPA Direct Debit */
-				return sprintf( __( 'Via SEPA Direct Debit ending in %1$s', 'woocommerce-gateway-stripe' ), $source->sepa_debit->last4 );
-			case WC_Stripe_Payment_Methods::CASHAPP_PAY:
-				/* translators: 1) Cash App Cashtag */
-				return sprintf( __( 'Via Cash App Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->cashapp->cashtag );
-			case WC_Stripe_Payment_Methods::LINK:
-				/* translators: 1) email address associated with the Stripe Link payment method */
-				return sprintf( __( 'Via Stripe Link (%1$s)', 'woocommerce-gateway-stripe' ), $source->link->email );
-			case WC_Stripe_Payment_Methods::ACH:
-				return sprintf(
-					/* translators: 1) account type (checking, savings), 2) last 4 digits of account. */
-					__( 'Via %1$s Account ending in %2$s', 'woocommerce-gateway-stripe' ),
-					ucfirst( $source->us_bank_account->account_type ),
-					$source->us_bank_account->last4
-				);
-			case WC_Stripe_Payment_Methods::BECS_DEBIT:
-				return sprintf(
-					/* translators: last 4 digits of account. */
-					__( 'BECS Direct Debit ending in %s', 'woocommerce-gateway-stripe' ),
-					$source->au_becs_debit->last4
-				);
-			case WC_Stripe_Payment_Methods::ACSS_DEBIT:
-				return sprintf(
-					/* translators: 1) bank name, 2) last 4 digits of account. */
-					__( 'Via %1$s ending in %2$s', 'woocommerce-gateway-stripe' ),
-					$source->acss_debit->bank_name,
-					$source->acss_debit->last4
-				);
-			case WC_Stripe_Payment_Methods::BACS_DEBIT:
-				/* translators: 1) the Bacs Direct Debit payment method's last 4 numbers */
-				return sprintf( __( 'Via Bacs Direct Debit ending in (%1$s)', 'woocommerce-gateway-stripe' ), $source->bacs_debit->last4 );
-			case WC_Stripe_Payment_Methods::AMAZON_PAY:
-				/* translators: 1) the Amazon Pay payment method's email */
-				return sprintf( __( 'Via Amazon Pay (%1$s)', 'woocommerce-gateway-stripe' ), $source->billing_details->email ?? '' );
-		}
-
-		return __( 'N/A', 'woocommerce-gateway-stripe' );
+		return $payment_method_to_display;
 	}
 
 	/**

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -301,19 +301,20 @@ class WC_Stripe_Payment_Tokens {
 
 			// Retrieve the payment methods for the enabled reusable gateways.
 			$payment_methods = [];
+
+			$reusable_payment_method_types = array_keys( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD );
+			$active_payment_method_types = [];
+
 			if ( $gateway->is_oc_enabled() ) {
-				// For OC, get all available payment method types
-				foreach ( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD as $payment_method_type => $reausable_gateway_id ) {
+				// For Optimized Checkout, get all available payment method types.
+				foreach ( $reusable_payment_method_types as $payment_method_type ) {
 					$payment_method_instance = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $payment_method_type );
 					if ( $payment_method_instance ) {
-						$retrieved_methods = $customer->get_payment_methods( $payment_method_type );
-						if ( ! empty( $retrieved_methods ) ) {
-							$payment_methods[] = $retrieved_methods;
-						}
+						$active_payment_method_types[] = $payment_method_type;
 					}
 				}
 			} else {
-				foreach ( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD as $payment_method_type => $reausable_gateway_id ) {
+				foreach ( $reusable_payment_method_types as $payment_method_type ) {
 					// The payment method type doesn't match the ones we use. Nothing to do here.
 					if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
 						continue;
@@ -321,22 +322,12 @@ class WC_Stripe_Payment_Tokens {
 
 					$payment_method_instance = $gateway->payment_methods[ $payment_method_type ];
 					if ( $payment_method_instance->is_enabled() ) {
-						$payment_methods[] = $customer->get_payment_methods( $payment_method_type );
+						$active_payment_method_types[] = $payment_method_type;
 					}
 				}
 			}
 
-			// Add SEPA if it is disabled and iDEAL or Bancontact are enabled. iDEAL and Bancontact tokens are saved as SEPA tokens.
-			if ( $gateway->is_sepa_tokens_for_other_methods_enabled() ) {
-				if ( $gateway->is_oc_enabled() ) {
-					$payment_methods[] = $customer->get_payment_methods( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID );
-				} elseif ( ! $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID ]->is_enabled()
-						&& ( $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID ]->is_enabled()
-							|| $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID ]->is_enabled() ) ) {
-
-						$payment_methods[] = $customer->get_payment_methods( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID );
-				}
-			}
+			$payment_methods = $customer->get_all_payment_methods( $active_payment_method_types );
 
 			$payment_methods    = array_merge( ...$payment_methods );
 			$payment_method_ids = array_map(

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -303,45 +303,21 @@ class WC_Stripe_Payment_Tokens {
 			$payment_methods = [];
 
 			$reusable_payment_method_types = array_keys( self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD );
-			$active_payment_method_types = [];
 
-			if ( $gateway->is_oc_enabled() ) {
-				// For Optimized Checkout, get all available payment method types.
-				foreach ( $reusable_payment_method_types as $payment_method_type ) {
-					$payment_method_instance = WC_Stripe_UPE_Payment_Gateway::get_payment_method_instance( $payment_method_type );
-					if ( $payment_method_instance ) {
-						$active_payment_method_types[] = $payment_method_type;
-					}
-				}
-			} else {
-				foreach ( $reusable_payment_method_types as $payment_method_type ) {
-					// The payment method type doesn't match the ones we use. Nothing to do here.
-					if ( ! isset( $gateway->payment_methods[ $payment_method_type ] ) ) {
-						continue;
-					}
-
-					$payment_method_instance = $gateway->payment_methods[ $payment_method_type ];
-					if ( $payment_method_instance->is_enabled() ) {
-						$active_payment_method_types[] = $payment_method_type;
-					}
-				}
-			}
+			$enabled_payment_methods = $gateway->get_upe_enabled_payment_method_ids();
+			$active_reusable_payment_method_types = array_intersect( $enabled_payment_methods, $reusable_payment_method_types );
 
 			// Add SEPA if it is disabled and iDEAL or Bancontact are enabled. iDEAL and Bancontact tokens are saved as SEPA tokens.
-			if ( $gateway->is_sepa_tokens_for_other_methods_enabled() ) {
-				if ( $gateway->is_oc_enabled() ) {
-					if ( ! in_array( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID, $active_payment_method_types, true ) ) {
-						$active_payment_method_types[] = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
-					}
-				} elseif ( ! $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID ]->is_enabled()
-						&& ( $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID ]->is_enabled()
-							|| $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID ]->is_enabled() ) ) {
-
-						$active_payment_method_types[] = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
+			if ( $gateway->is_sepa_tokens_for_other_methods_enabled() && ! in_array( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID, $active_reusable_payment_method_types, true ) ) {
+				if (
+					in_array( WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID, $active_reusable_payment_method_types, true )
+					|| in_array( WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID, $active_reusable_payment_method_types, true )
+				) {
+					$active_reusable_payment_method_types[] = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
 				}
 			}
 
-			$payment_methods = $customer->get_all_payment_methods( $active_payment_method_types );
+			$payment_methods = $customer->get_all_payment_methods( $active_reusable_payment_method_types );
 
 			$payment_method_ids = array_map(
 				function ( $payment_method ) {

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -327,6 +327,20 @@ class WC_Stripe_Payment_Tokens {
 				}
 			}
 
+			// Add SEPA if it is disabled and iDEAL or Bancontact are enabled. iDEAL and Bancontact tokens are saved as SEPA tokens.
+			if ( $gateway->is_sepa_tokens_for_other_methods_enabled() ) {
+				if ( $gateway->is_oc_enabled() ) {
+					if ( ! in_array( WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID, $active_payment_method_types, true ) ) {
+						$active_payment_method_types[] = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
+					}
+				} elseif ( ! $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID ]->is_enabled()
+						&& ( $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Ideal::STRIPE_ID ]->is_enabled()
+							|| $gateway->payment_methods[ WC_Stripe_UPE_Payment_Method_Bancontact::STRIPE_ID ]->is_enabled() ) ) {
+
+						$active_payment_method_types[] = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID;
+				}
+			}
+
 			$payment_methods = $customer->get_all_payment_methods( $active_payment_method_types );
 
 			$payment_methods    = array_merge( ...$payment_methods );

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -343,7 +343,6 @@ class WC_Stripe_Payment_Tokens {
 
 			$payment_methods = $customer->get_all_payment_methods( $active_payment_method_types );
 
-			$payment_methods    = array_merge( ...$payment_methods );
 			$payment_method_ids = array_map(
 				function ( $payment_method ) {
 					return $payment_method->id;

--- a/readme.txt
+++ b/readme.txt
@@ -144,5 +144,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Update SCSS to replace @import with @use and @forward
 * Fix - Handle missing customer when calling payment_methods API
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
+* Fix - Reduce number of calls to Stripe payment_methods API
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4560

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This change introduces a new `get_all_payment_methods()` method to the `WC_Stripe_Customer` class as a way to perform fewer overall API calls when trying to load all saved payment methods for a customer. The basic approach mimics the implementation in the existing `get_payment_methods()` method, but removes the query parameter to limit the accepted payment method types. Due to Stripe's API limiting the result page size to 100 rows, the new logic will fetch in a loop. The new code also fetches all the data and caches it before applying any filtering. That way the cached data can be re-used as needed, even if filters are re-applied. It's worth noting that we're using the same underlying mechanism for the cache as for specific payment methods, including the method responsible for clearing the customer cache.

The PR also updates the logic in `WC_Stripe_Payment_Tokens->woocommerce_get_customer_upe_payment_tokens()` to use the new method to fetch all saved tokens for a user across the set of currently enabled payment methods. The key improvement here is that we will now make at most 1 request per customer (or 2, if they have >100 saved payment methods!), and then cache the result. Previously, we would make an API call per enabled payment method, and we'd make more API calls when Optimized Checkout was enabled, as we weren't filtering on active payment methods. The code also makes an important code change to use a more recently introduced function to identify which payment methods are currently active, which also simplifies the code for identifying the active payment methods.

From an implementation perspective, it's worth noting that the new code always includes `expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt` as URL parameters, just in case we have any SEPA debits created from other payment methods like Bancontact or iDEAL.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

### Basic setup

* Create a store with a location in Europe and using EUR as the currency
* Connect to a Stripe test account
* Ensure you install and activate WooCommerce Subscriptions and a tool like [Debug Bar](https://wordpress.org/plugins/debug-bar/)  that allows you to see API calls made from the server
* Ensure you have a subscription product available
* Ensure that you enable iDEAL or Bancontact as payment methods, keep SEPA disabled, and that the `Enable SEPA Direct Debit tokens for other methods` setting for the Stripe gateway is enabled

### Steps

* Log in to the site as a user (or ensure your site will auto-create a user for you during checkout)
* Work through the flow to purchase a subscription product
* When you get to checkout, pick either iDEAL or Bancontact as your payment method
* Place your order, and confirm the purchase via the Stripe UI
* After confirming the payment, verify that you're taken to the order summary page
* Navigate to _My Account_ and then to _Payment methods_
* Verify that your subscription payment method is listed as a SEPA payment method
* Now clear all transients for your site, which can be done as follows in a dev environment:
```bash
npm run wp transient delete -- --all
```
* Refresh the page, and verify that only one API call was made to `https://api.stripe.com/v1/payment_methods` (though it will have additional URL parameters).
* Refresh the page again, and verify that we don't make another outbound HTTP call
  - For extra credit, you can also check out `develop`, clear transients and repeat the steps to see how many API requests we make 😬 

* Now add a simple product to your cart and navigate to checkout
* Use a card to pay for the product, and save your card details
* Navigate to _My Account_ -> _Payment Methods_
* Verify that your saved card is listed
* Clear transients and refresh the page
* Verify there is only one `payment_methods` API call
* Refresh the page, and verify that we don't trigger another API call

* Now add a product to your cart and navigate to checkout.
* Clear transients again, and reload checkout.
* Verify that you only see one API call to the Stripe `payment_methods` API
* Reload checkout, and verify that you don't see any calls to the `payment_methods` API

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
