### PR TITLE
Add get_icon_url() to payment method classes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -38,6 +38,7 @@
 * Fix - Handle missing customer when calling payment_methods API
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
+* Fix - Add `get_icon_url()` to Payment Method base class
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -236,6 +236,16 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 	}
 
 	/**
+	 * Gets the payment method's icon url.
+	 * Each payment method should override this method to return the specific icon url.
+	 *
+	 * @return string The icon url.
+	 */
+	public function get_icon_url() {
+		return '';
+	}
+
+	/**
 	 * Returns boolean dependent on whether payment method
 	 * can be used at checkout
 	 *

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -237,11 +237,12 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 
 	/**
 	 * Gets the payment method's icon url.
+	 * Each payment method should override this method to return the icon url.
 	 *
 	 * @return string The icon url.
 	 */
 	public function get_icon_url() {
-		return $this->get_icon();
+		return '';
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method.php
@@ -237,12 +237,11 @@ abstract class WC_Stripe_UPE_Payment_Method extends WC_Payment_Gateway {
 
 	/**
 	 * Gets the payment method's icon url.
-	 * Each payment method should override this method to return the specific icon url.
 	 *
 	 * @return string The icon url.
 	 */
 	public function get_icon_url() {
-		return '';
+		return $this->get_icon();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -147,5 +147,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Handle missing customer when calling payment_methods API
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
+* Fix - Add `get_icon_url()` to Payment Method base class
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-664

## Changes proposed in this Pull Request:


WooCommerce 10.1.0 in [Blocks: Add Payment Method Icons Block #57181](https://github.com/woocommerce/woocommerce/pull/57181), started using `$gateway->get_icon_url()` to get the gateway icon:
```
if ( is_callable( array( $gateway, 'get_icon_url' ) ) ){
	$icon_url = $gateway->get_icon_url();
}
```

For most gateways, this is not a problem; if the gateway does not implement the method, it doesn't show any icon.

But in the case of the Stripe Gateway, `$gateway` is a payment method instance that inherits from `WC_Stripe_UPE_Payment_Method`, which doesn't have a `get_icon_url()` method, but it has a `__cal()`  [implementation](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e0d8375b7fdc870cd6d9ce9f47a5cc95bd516986/includes/payment-methods/class-wc-stripe-upe-payment-method.php#L152), it makes `is_callable()` to always return `true`.

This PR adds a `get_icon_url()` that calls the existing `get_icon()` method that already returns the icon_url.

NOTE: Should we add the individual icons in this PR? or add them as part of 9.9?, it feels that we should also refactor get_icon so we dont have the icons URLs hardrcoded in different palces.

## Testing instructions
0. Update WooCommerce to `10.1.0-rc.4` (manually or using the [beta tester plugin](https://woocommerce.com/products/woocommerce-beta-tester/))
1. Go to `WP-Admin > Pages` and edit the `Checkout` page
2. In the `development` branch, that will trigger an uncaught error:
    <img width="716" height="475" alt="Screenshot 2025-08-11 at 15 23 06" src="https://github.com/user-attachments/assets/7942c77d-f744-4856-aceb-cbfaff5757b0" />
3. With this branch (`fix/undefined-method-get-icon-url`), it loads without triggering any errors.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
