### PR TITLE
Refactor handling of expand[] parameters

### DIFF
--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1743,7 +1743,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			throw new Exception( "Failed to get intent of type $intent_type. Type is not allowed" );
 		}
 
-		$response = WC_Stripe_API::request( [], "$intent_type/$intent_id?expand[]=payment_method", 'GET' );
+		$response = WC_Stripe_API::request( [ 'stripe_expand' => [ 'payment_method' ] ], "$intent_type/$intent_id", 'GET' );
 
 		if ( $response && isset( $response->{ 'error' } ) ) {
 			$error_response_message = print_r( $response, true );

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -202,7 +202,7 @@ class WC_Stripe_API {
 	 *
 	 * @since 3.1.0
 	 * @version 4.0.6
-	 * @param array  $request
+	 * @param array  $request Note that there is special handling for the `stripe_expand` parameter, which is expected to be an array of field names to expand.
 	 * @param string $api
 	 * @param string $method
 	 * @param bool   $with_headers To get the response with headers.
@@ -217,6 +217,11 @@ class WC_Stripe_API {
 			$headers['Idempotency-Key'] = $idempotency_key;
 		}
 
+		[
+			'request'       => $request,
+			'expand_params' => $expand_params,
+		] = self::extract_expand_params( $request );
+
 		$request = apply_filters_deprecated(
 			'woocommerce_stripe_request_body',
 			[ $request, $api ],
@@ -230,13 +235,23 @@ class WC_Stripe_API {
 		 *
 		 * @since 9.7.0
 		 *
-		 * @param array $request The default request body we will send to the Stripe API.
-		 * @param string $api The Stripe API endpoint.
+		 * @param array    $request       The default request body we will send to the Stripe API.
+		 * @param string   $api           The Stripe API endpoint.
+		 * @param string[] $expand_params The parameters to send as `expand[]` URL parameters in the request.
 		 */
-		$request = apply_filters( 'wc_stripe_request_body', $request, $api );
+		$request = apply_filters( 'wc_stripe_request_body', $request, $api, $expand_params );
+
+		$debug_params = [
+			'request'       => $request,
+		];
+		if ( is_array( $expand_params ) ) {
+			$debug_params['expand_params'] = $expand_params;
+		}
 
 		// Log the request after the filters have been applied.
-		WC_Stripe_Logger::debug( "Stripe API request: {$method} {$api}", [ 'request' => $request ] );
+		WC_Stripe_Logger::debug( "Stripe API request: {$method} {$api}", $debug_params );
+
+		$api = self::add_expand_params_to_api( $api, $expand_params );
 
 		$response = wp_safe_remote_post(
 			self::ENDPOINT . $api,
@@ -283,9 +298,10 @@ class WC_Stripe_API {
 	 *
 	 * @since 4.0.0
 	 * @version 4.0.0
-	 * @param string $api
+	 * @param string         $api           The Stripe API we want to call.
+	 * @param string[]|null  $expand_params The parameters to send as `expand[]` URL parameters in the request.
 	 */
-	public static function retrieve( $api ) {
+	public static function retrieve( $api, $expand_params = null ) {
 		// If keep count of consecutive 401 errors, and it exceeds INVALID_API_KEY_ERROR_COUNT_THRESHOLD,
 		// we return null until the cache expires (INVALID_API_KEY_ERROR_COUNT_CACHE_TIMEOUT) or the keys are updated.
 		$invalid_api_key_error_count = WC_Stripe_Database_Cache::get( self::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
@@ -300,7 +316,14 @@ class WC_Stripe_API {
 			return null;
 		}
 
-		WC_Stripe_Logger::debug( "Stripe API request: GET {$api}" );
+		$debug_params = [];
+		if ( is_array( $expand_params ) ) {
+			$debug_params['expand_params'] = $expand_params;
+		}
+
+		WC_Stripe_Logger::debug( "Stripe API request: GET {$api}", $debug_params );
+
+		$api = self::add_expand_params_to_api( $api, $expand_params );
 
 		$response = wp_safe_remote_get(
 			self::ENDPOINT . $api,
@@ -596,5 +619,36 @@ class WC_Stripe_API {
 			'payment_method_configurations/' . $id
 		);
 		return $response;
+	}
+
+	private static function extract_expand_params( array $request ): array {
+		if ( ! isset( $request['stripe_expand'] ) || ! is_array( $request['stripe_expand'] ) || [] === $request['stripe_expand'] ) {
+			return [
+				'request'       => $request,
+				'expand_params' => null,
+			];
+		}
+
+		$expand_params = $request['stripe_expand'];
+		unset( $request['stripe_expand'] );
+
+		return [
+			'request'       => $request,
+			'expand_params' => $expand_params,
+		];
+	}
+
+	private static function add_expand_params_to_api( string $api, ?array $expand_params ): string {
+		if ( ! is_array( $expand_params ) ) {
+			return $api;
+		}
+
+		$expand_url_param = 'expand[]=' . implode( '&expand[]=', array_map( 'rawurlencode', $expand_params ) );
+		// The API shouldn't include `?` already, but check just in case.
+		if ( str_contains( $api, '?' ) ) {
+			return $api . '&' . $expand_url_param;
+		}
+
+		return $api . '?' . $expand_url_param;
 	}
 }

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -714,14 +714,15 @@ class WC_Stripe_Customer {
 		$payment_methods = get_transient( self::PAYMENT_METHODS_TRANSIENT_KEY . $payment_method_type . $this->get_id() );
 
 		if ( false === $payment_methods ) {
-			$params   = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID === $payment_method_type ? '?expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt' : '';
-			$response = WC_Stripe_API::request(
+			$expand_params = WC_Stripe_UPE_Payment_Method_Sepa::STRIPE_ID === $payment_method_type ? [ 'data.sepa_debit.generated_from.charge', 'data.sepa_debit.generated_from.setup_attempt' ] : null;
+			$response      = WC_Stripe_API::request(
 				[
-					'customer' => $this->get_id(),
-					'type'     => $payment_method_type,
-					'limit'    => self::PAYMENT_METHODS_API_LIMIT,
+					'customer'      => $this->get_id(),
+					'type'          => $payment_method_type,
+					'limit'         => self::PAYMENT_METHODS_API_LIMIT,
+					'stripe_expand' => $expand_params,
 				],
-				'payment_methods' . $params,
+				'payment_methods',
 				'GET'
 			);
 
@@ -769,15 +770,19 @@ class WC_Stripe_Customer {
 
 			do {
 				$request_params = [
-					'customer' => $this->get_id(),
-					'limit'    => self::PAYMENT_METHODS_API_LIMIT,
+					'customer'      => $this->get_id(),
+					'limit'         => self::PAYMENT_METHODS_API_LIMIT,
+					'stripe_expand' => [
+						'data.sepa_debit.generated_from.charge',
+						'data.sepa_debit.generated_from.setup_attempt',
+					],
 				];
 
 				if ( $last_payment_method_id ) {
 					$request_params['starting_after'] = $last_payment_method_id;
 				}
 
-				$response = WC_Stripe_API::request( $request_params, 'payment_methods?expand[]=data.sepa_debit.generated_from.charge&expand[]=data.sepa_debit.generated_from.setup_attempt', 'GET' );
+				$response = WC_Stripe_API::request( $request_params, 'payment_methods', 'GET' );
 
 				if ( ! empty( $response->error ) ) {
 					if (

--- a/includes/class-wc-stripe-order-handler.php
+++ b/includes/class-wc-stripe-order-handler.php
@@ -314,8 +314,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 						$level3_data = $this->get_level3_data_from_order( $order );
 						$result      = WC_Stripe_API::request_with_level3_data(
 							[
-								'amount'   => WC_Stripe_Helper::get_stripe_amount( $order_total ),
-								'expand[]' => 'charges.data.balance_transaction',
+								'amount'         => WC_Stripe_Helper::get_stripe_amount( $order_total ),
+								'stripe_expand'  => [ 'charges.data.balance_transaction' ],
 							],
 							'payment_intents/' . $intent->id . '/capture',
 							$level3_data,
@@ -345,8 +345,8 @@ class WC_Stripe_Order_Handler extends WC_Stripe_Payment_Gateway {
 						$level3_data = $this->get_level3_data_from_order( $order );
 						$result      = WC_Stripe_API::request_with_level3_data(
 							[
-								'amount'   => WC_Stripe_Helper::get_stripe_amount( $order_total ),
-								'expand[]' => 'balance_transaction',
+								'amount'         => WC_Stripe_Helper::get_stripe_amount( $order_total ),
+								'stripe_expand'  => [ 'balance_transaction' ],
 							],
 							'charges/' . $charge . '/capture',
 							$level3_data,

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1558,7 +1558,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			return false;
 		}
 
-		$intent = $this->stripe_request( 'setup_intents/' . $intent_id . '?expand[]=payment_method.billing_details' );
+		$intent = $this->stripe_request( 'setup_intents/' . $intent_id, [ 'stripe_expand' => [ 'payment_method.billing_details' ] ] );
 		if ( ! $intent ) {
 			return false;
 		}
@@ -1646,10 +1646,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Get payment intent to confirm status.
 		if ( $payment_needed ) {
-			$intent = $this->stripe_request( 'payment_intents/' . $intent_id . '?expand[]=payment_method' );
+			$intent = $this->stripe_request( 'payment_intents/' . $intent_id, [ 'stripe_expand' => [ 'payment_method' ] ] );
 			$error  = isset( $intent->last_payment_error ) ? $intent->last_payment_error : false;
 		} else {
-			$intent = $this->stripe_request( 'setup_intents/' . $intent_id . '?expand[]=payment_method&expand[]=latest_attempt' );
+			$intent = $this->stripe_request( 'setup_intents/' . $intent_id, [ 'stripe_expand' => [ 'payment_method', 'latest_attempt' ] ] );
 			$error  = isset( $intent->last_setup_error ) ? $intent->last_setup_error : false;
 		}
 
@@ -2166,7 +2166,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function create_token_from_setup_intent( $setup_intent_id, $user ) {
 		try {
-			$setup_intent = $this->stripe_request( 'setup_intents/' . $setup_intent_id . '?&expand[]=latest_attempt' );
+			$setup_intent = $this->stripe_request( 'setup_intents/' . $setup_intent_id, [ 'stripe_expand' => [ 'latest_attempt' ] ] );
 			if ( ! empty( $setup_intent->last_payment_error ) ) {
 				throw new WC_Stripe_Exception( __( "We're not able to add this payment method. Please try again later.", 'woocommerce-gateway-stripe' ) );
 			}
@@ -2227,6 +2227,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		if ( is_null( $params ) ) {
 			return WC_Stripe_API::retrieve( $path );
 		}
+
+		if ( is_array( $params ) && [ 'stripe_expand' ] === array_keys( $params ) ) {
+			return WC_Stripe_API::retrieve( $path, $params['stripe_expand'] );
+		}
+
 		if ( ! is_null( $order ) ) {
 			$level3_data = $this->get_level3_data_from_order( $order );
 			return WC_Stripe_API::request_with_level3_data( $params, $path, $level3_data, $order );

--- a/tests/phpunit/Helpers/WC_Helper_Stripe_Api.php
+++ b/tests/phpunit/Helpers/WC_Helper_Stripe_Api.php
@@ -62,11 +62,12 @@ class WC_Helper_Stripe_Api extends WC_Stripe_API {
 	/**
 	 * Retrieve data. This is the equivalent mock for WC_Stripe_API::retrieve
 	 *
-	 * @param string data type
+	 * @param string         $key           The Stripe API we want to call.
+	 * @param string[]|null  $expand_params The parameters to send as `expand[]` URL parameters in the request.
 	 *
 	 * @return array retrieved data mock
 	 */
-	public static function retrieve( $key = 'account' ) {
+	public static function retrieve( $key = 'account', $expand_params = null ) {
 		return self::$retrieve_response;
 	}
 

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -954,7 +954,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			);
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'stripe_request' )
-			->with( "payment_intents/$payment_intent_id?expand[]=payment_method" )
+			->with( "payment_intents/$payment_intent_id", [ 'stripe_expand' => [ 'payment_method' ] ] )
 			->will(
 				$this->returnValue(
 					$this->array_to_object( $payment_intent_mock )
@@ -1017,7 +1017,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'stripe_request' )
-			->with( "payment_intents/$payment_intent_id?expand[]=payment_method" )
+			->with( "payment_intents/$payment_intent_id", [ 'stripe_expand' => [ 'payment_method' ] ] )
 			->will(
 				$this->returnValue(
 					$this->array_to_object( $payment_intent_mock )
@@ -1102,7 +1102,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		// Expect the process to bail early.
 		$this->mock_gateway->expects( $this->never() )
 			->method( 'stripe_request' )
-			->with( "payment_intents/$payment_intent_id?expand[]=payment_method" );
+			->with( "payment_intents/$payment_intent_id", [ 'stripe_expand' => [ 'payment_method' ] ] );
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $payment_intent_id, false );
 	}
@@ -1139,7 +1139,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			);
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'stripe_request' )
-			->with( "setup_intents/$setup_intent_id?expand[]=payment_method&expand[]=latest_attempt" )
+			->with( "setup_intents/$setup_intent_id", [ 'stripe_expand' => [ 'payment_method', 'latest_attempt' ] ] )
 			->will(
 				$this->returnValue(
 					$this->array_to_object( $setup_intent_mock )
@@ -1190,7 +1190,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			);
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'stripe_request' )
-			->with( "payment_intents/$payment_intent_id?expand[]=payment_method" )
+			->with( "payment_intents/$payment_intent_id", [ 'stripe_expand' => [ 'payment_method' ] ] )
 			->will(
 				$this->returnValue(
 					$this->array_to_object( $payment_intent_mock )
@@ -2280,7 +2280,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'stripe_request' )
-			->with( "payment_intents/$payment_intent_id?expand[]=payment_method" )
+			->with( "payment_intents/$payment_intent_id", [ 'stripe_expand' => [ 'payment_method' ] ] )
 			->will(
 				$this->returnValue(
 					$this->array_to_object( $payment_intent_mock )
@@ -2369,7 +2369,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->expects( $this->once() )
 			->method( 'stripe_request' )
-			->with( "setup_intents/$setup_intent_id?expand[]=payment_method&expand[]=latest_attempt" )
+			->with( "setup_intents/$setup_intent_id", [ 'stripe_expand' => [ 'payment_method', 'latest_attempt' ] ] )
 			->will(
 				$this->returnValue(
 					$this->array_to_object( $setup_intent_mock )


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR explores one way of refactoring how we handle the `expand[]` parameters supported by Stripe's APIs. I am still not sure I like the approach, but it feels better than the mixed implementation that we had before.

One minor concern I have is that the `WC_Stripe_API::retrieve()` API shape has changed, which might impact code that extends from the plugin, but I think that's not something many (if any) plugins would do due to the methods being called statically using the current class name.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
TBD
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
