### PR TITLE
Fix address validation for manually entered orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
 * Fix - Add `get_icon_url()` to Payment Method base class
+* Fix - Relax customer validation that was preventing payments from the pay for order page"
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/changelog.txt
+++ b/changelog.txt
@@ -39,7 +39,7 @@
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
 * Fix - Add `get_icon_url()` to Payment Method base class
-* Fix - Relax customer validation that was preventing payments from the pay for order page"
+* Fix - Relax customer validation that was preventing payments from the pay for order page
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -16,7 +16,7 @@ class WC_Stripe_Customer {
 	public const CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD = 'add_payment_method';
 
 	/**
-	 * Constant for the customer context when paying for an order via the "Pay for Order" page..
+	 * Constant for the customer context when paying for an order via the "Pay for Order" page.
 	 */
 	public const CUSTOMER_CONTEXT_PAY_FOR_ORDER = 'pay_for_order';
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -209,19 +209,19 @@ class WC_Stripe_Customer {
 	/**
 	 * Validate that we have valid data before we try to create a customer.
 	 *
-	 * @param array $create_customer_request
-	 * @param bool  $is_add_payment_method_page
+	 * @param array       $create_customer_request The base data to build the customer request.
+	 * @param null|string $current_context         Flag to indicate whether we are in a context where limited details are permitted.
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	private function validate_create_customer_request( $create_customer_request, $is_add_payment_method_page = false ) {
+	private function validate_create_customer_request( $create_customer_request, ?string $current_context = null ) {
 		/**
 		 * Filters the required customer fields when creating a customer in Stripe.
 		 *
 		 * @since 9.7.0
-		 * @param array $required_fields The required customer fields as derived from the required billing fields in checkout.
+		 * @param array $required_fields The required customer fields as derived from the required billing fields in checkout. In some contexts, like adding a payment method, we allow minimal details to be provided.
 		 */
-		$required_fields = apply_filters( 'wc_stripe_create_customer_required_fields', $this->get_create_customer_required_fields( $is_add_payment_method_page ) );
+		$required_fields = apply_filters( 'wc_stripe_create_customer_required_fields', $this->get_create_customer_required_fields( $current_context ) );
 
 		foreach ( $required_fields as $field => $field_requirements ) {
 			if ( true === $field_requirements ) {
@@ -258,13 +258,17 @@ class WC_Stripe_Customer {
 	/**
 	 * Get the list of required fields for the create customer request.
 	 *
-	 * @param bool $is_add_payment_method_page
+	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
 	 *
 	 * @return array
 	 */
-	private function get_create_customer_required_fields( $is_add_payment_method_page = false ) {
-		// If we are on the add payment method page, we need to check just for the email field.
-		if ( $is_add_payment_method_page ) {
+	private function get_create_customer_required_fields( ?string $current_context = null ) {
+		// If we are on the add payment method page or the pay for order page, we need to check just for the email field.
+		$contexts_with_minimal_details = [
+			'add_payment_method',
+			'pay_for_order',
+		];
+		if ( in_array( $current_context, $contexts_with_minimal_details, true ) ) {
 			return [
 				'email' => true,
 			];
@@ -422,12 +426,12 @@ class WC_Stripe_Customer {
 	 * Create a customer via API.
 	 *
 	 * @param array $args
-	 * @param bool  $is_add_payment_method_page Whether the request is for the add payment method page.
+	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
 	 * @return WP_Error|int
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function create_customer( $args = [], $is_add_payment_method_page = false ) {
+	public function create_customer( $args = [], $current_context = null ) {
 		$args = $this->generate_customer_request( $args );
 
 		// For guest users, check if a customer already exists with the same email and name in Stripe account before creating a new one.
@@ -445,7 +449,7 @@ class WC_Stripe_Customer {
 			 */
 			$create_customer_args = apply_filters( 'wc_stripe_create_customer_args', $args );
 
-			$this->validate_create_customer_request( $create_customer_args, $is_add_payment_method_page );
+			$this->validate_create_customer_request( $create_customer_args, $current_context );
 
 			$response = WC_Stripe_API::request( $create_customer_args, 'customers' );
 		} else {
@@ -523,14 +527,15 @@ class WC_Stripe_Customer {
 	 * Updates existing Stripe customer or creates new customer for User through API.
 	 *
 	 * @param array $args     Additional arguments for the request (optional).
+	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
 	 *
 	 * @return string Customer ID
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function update_or_create_customer( $args = [], $is_add_payment_method_page = false ) {
+	public function update_or_create_customer( $args = [], $current_context = null ) {
 		if ( empty( $this->get_id() ) ) {
-			return $this->recreate_customer( $args, $is_add_payment_method_page );
+			return $this->recreate_customer( $args, $current_context );
 		} else {
 			return $this->update_customer( $args );
 		}
@@ -978,13 +983,13 @@ class WC_Stripe_Customer {
 	 * Recreates the customer for this user.
 	 *
 	 * @param array $args Additional arguments for the request (optional).
-	 * @param bool  $is_add_payment_method_page Whether the request is for the add payment method page.
+	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
 	 *
 	 * @return string ID of the new Customer object.
 	 */
-	private function recreate_customer( $args = [], $is_add_payment_method_page = false ) {
+	private function recreate_customer( $args = [], $current_context = null ) {
 		$this->delete_id_from_meta();
-		return $this->create_customer( $args, $is_add_payment_method_page );
+		return $this->create_customer( $args, $current_context );
 	}
 
 	/**

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -11,6 +11,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Stripe_Customer {
 
 	/**
+	 * Constant for the customer context when adding a payment method.
+	 */
+	public const CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD = 'add_payment_method';
+
+	/**
+	 * Constant for the customer context when paying for an order via the "Pay for Order" page..
+	 */
+	public const CUSTOMER_CONTEXT_PAY_FOR_ORDER = 'pay_for_order';
+
+	/**
+	 * Constants for the customer contexts where minimal billing details are permitted.
+	 */
+	protected const MINIMAL_BILLING_DETAILS_CONTEXTS = [
+		self::CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD,
+		self::CUSTOMER_CONTEXT_PAY_FOR_ORDER,
+	];
+
+	/**
 	 * String prefix for Stripe payment methods request transient.
 	 */
 	const PAYMENT_METHODS_TRANSIENT_KEY = 'stripe_payment_methods_';
@@ -258,17 +276,12 @@ class WC_Stripe_Customer {
 	/**
 	 * Get the list of required fields for the create customer request.
 	 *
-	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
+	 * @param string|null $current_context The context we are creating the customer in.
 	 *
 	 * @return array
 	 */
 	private function get_create_customer_required_fields( ?string $current_context = null ) {
-		// If we are on the add payment method page or the pay for order page, we need to check just for the email field.
-		$contexts_with_minimal_details = [
-			'add_payment_method',
-			'pay_for_order',
-		];
-		if ( in_array( $current_context, $contexts_with_minimal_details, true ) ) {
+		if ( in_array( $current_context, self::MINIMAL_BILLING_DETAILS_CONTEXTS, true ) ) {
 			return [
 				'email' => true,
 			];
@@ -426,7 +439,7 @@ class WC_Stripe_Customer {
 	 * Create a customer via API.
 	 *
 	 * @param array $args
-	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
+	 * @param string|null $current_context The context we are creating the customer in.
 	 * @return WP_Error|int
 	 *
 	 * @throws WC_Stripe_Exception
@@ -530,7 +543,7 @@ class WC_Stripe_Customer {
 	 * Updates existing Stripe customer or creates new customer for User through API.
 	 *
 	 * @param array $args     Additional arguments for the request (optional).
-	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
+	 * @param string|null $current_context The context we are creating the customer in.
 	 *
 	 * @return string Customer ID
 	 *
@@ -559,7 +572,7 @@ class WC_Stripe_Customer {
 		}
 
 		if ( is_bool( $current_context ) ) {
-			return $current_context ? 'add_payment_method' : null;
+			return $current_context ? self::CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD : null;
 		}
 
 		if ( is_string( $current_context ) ) {
@@ -1011,7 +1024,7 @@ class WC_Stripe_Customer {
 	 * Recreates the customer for this user.
 	 *
 	 * @param array $args Additional arguments for the request (optional).
-	 * @param string|null $current_context The context we are creating the customer in. We specifically care about 'pay_for_order' and 'add_payment_method', where minimal details are available.
+	 * @param string|null $current_context The context we are creating the customer in.
 	 *
 	 * @return string ID of the new Customer object.
 	 */

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -439,6 +439,9 @@ class WC_Stripe_Customer {
 			$response = $this->get_existing_customer( $args['email'], $args['name'] );
 		}
 
+		// $current_context was initially introduced as a boolean flag, so check for old callers.
+		$current_context = $this->normalize_current_context( $current_context );
+
 		if ( empty( $response ) ) {
 			/**
 			 * Filters the arguments used to create a customer.
@@ -535,10 +538,35 @@ class WC_Stripe_Customer {
 	 */
 	public function update_or_create_customer( $args = [], $current_context = null ) {
 		if ( empty( $this->get_id() ) ) {
+			// $current_context was initially introduced as a boolean flag, so check for old callers.
+			$current_context = $this->normalize_current_context( $current_context );
+
 			return $this->recreate_customer( $args, $current_context );
 		} else {
 			return $this->update_customer( $args );
 		}
+	}
+
+	/**
+	 * Normalize the current context to a string, as the argument was initially introduced as a boolean flag.
+	 *
+	 * @param string|bool|null $current_context The current context.
+	 * @return string|null The normalized context.
+	 */
+	private function normalize_current_context( $current_context ): ?string {
+		if ( null === $current_context ) {
+			return null;
+		}
+
+		if ( is_bool( $current_context ) ) {
+			return $current_context ? 'add_payment_method' : null;
+		}
+
+		if ( is_string( $current_context ) ) {
+			return $current_context;
+		}
+
+		return null;
 	}
 
 	/**
@@ -987,7 +1015,7 @@ class WC_Stripe_Customer {
 	 *
 	 * @return string ID of the new Customer object.
 	 */
-	private function recreate_customer( $args = [], $current_context = null ) {
+	private function recreate_customer( $args = [], ?string $current_context = null ) {
 		$this->delete_id_from_meta();
 		return $this->create_customer( $args, $current_context );
 	}

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -23,7 +23,7 @@ class WC_Stripe_Customer {
 	/**
 	 * Constants for the customer contexts where minimal billing details are permitted.
 	 */
-	protected const MINIMAL_BILLING_DETAILS_CONTEXTS = [
+	public const MINIMAL_BILLING_DETAILS_CONTEXTS = [
 		self::CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD,
 		self::CUSTOMER_CONTEXT_PAY_FOR_ORDER,
 	];

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1197,7 +1197,7 @@ class WC_Stripe_Intent_Controller {
 			// Manually create the payment information array to create & confirm the setup intent.
 			$payment_information = [
 				'payment_method'        => $payment_method,
-				'customer'              => $customer->update_or_create_customer( [], 'add_payment_method' ),
+				'customer'              => $customer->update_or_create_customer( [], WC_Stripe_Customer::CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD ),
 				'selected_payment_type' => $payment_type,
 				'return_url'            => wc_get_account_endpoint_url( 'payment-methods' ),
 				'use_stripe_sdk'        => 'true', // We want the user to complete the next steps via the JS elements. ref https://docs.stripe.com/api/setup_intents/create#create_setup_intent-use_stripe_sdk

--- a/includes/class-wc-stripe-intent-controller.php
+++ b/includes/class-wc-stripe-intent-controller.php
@@ -1149,7 +1149,7 @@ class WC_Stripe_Intent_Controller {
 			// Manually create the payment information array to create & confirm the setup intent.
 			$payment_information = [
 				'payment_method'        => $payment_method,
-				'customer'              => $customer->update_or_create_customer( [], true ),
+				'customer'              => $customer->update_or_create_customer( [], 'add_payment_method' ),
 				'selected_payment_type' => $payment_type,
 				'return_url'            => wc_get_account_endpoint_url( 'payment-methods' ),
 				'use_stripe_sdk'        => 'true', // We want the user to complete the next steps via the JS elements. ref https://docs.stripe.com/api/setup_intents/create#create_setup_intent-use_stripe_sdk

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2847,10 +2847,12 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$user     = $this->get_user_from_order( $order );
 		$customer = new WC_Stripe_Customer( $user->ID );
 
+		$current_context = $this->is_valid_pay_for_order_endpoint() ? 'pay_for_order' : null;
+
 		// Pass the order object so we can retrieve billing details
 		// in payment flows where it is not present in the request.
 		$args = [ 'order' => $order ];
-		return $customer->update_or_create_customer( $args );
+		return $customer->update_or_create_customer( $args, $current_context );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2858,7 +2858,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$user     = $this->get_user_from_order( $order );
 		$customer = new WC_Stripe_Customer( $user->ID );
 
-		$current_context = $this->is_valid_pay_for_order_endpoint() ? 'pay_for_order' : null;
+		$current_context = $this->is_valid_pay_for_order_endpoint() ? WC_Stripe_Customer::CUSTOMER_CONTEXT_PAY_FOR_ORDER : null;
 
 		// Pass the order object so we can retrieve billing details
 		// in payment flows where it is not present in the request.

--- a/readme.txt
+++ b/readme.txt
@@ -148,5 +148,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
 * Fix - Add `get_icon_url()` to Payment Method base class
+* Fix - Relax customer validation that was preventing payments from the pay for order page"
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -148,6 +148,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
 * Fix - Add `get_icon_url()` to Payment Method base class
-* Fix - Relax customer validation that was preventing payments from the pay for order page"
+* Fix - Relax customer validation that was preventing payments from the pay for order page
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Customer_Test.php
+++ b/tests/phpunit/WC_Stripe_Customer_Test.php
@@ -98,21 +98,61 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 				'expected_exception_message' => 'missing_required_customer_field: address->country',
 				'expected_exception_string'  => 'Missing required customer field: address->country',
 			],
-			'add payment method page, all fields present and required, no overrides' => [
+			'add payment method page with boolean, all fields present and required, no overrides' => [
 				'billing_fields'             => [], // only email is required
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => null,
 				'expected_exception_string'  => null,
-				'is_add_payment_method_page' => true,
+				'current_context'            => true,
 			],
-			'add payment method page, email is empty string' => [
+			'add payment method page with context, all fields present and required, no overrides' => [
+				'billing_fields'             => [], // only email is required
+				'woo_billing_fields'         => null,
+				'stripe_billing_fields'      => null,
+				'expected_exception_message' => null,
+				'expected_exception_string'  => null,
+				'current_context'            => \WC_Stripe_Customer::CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD,
+			],
+			'add payment method page with boolean, email is empty string' => [
 				'billing_fields'             => [ 'email' => '' ],
 				'woo_billing_fields'         => null,
 				'stripe_billing_fields'      => null,
 				'expected_exception_message' => 'missing_required_customer_field: email',
 				'expected_exception_string'  => 'Missing required customer field: email',
-				'is_add_payment_method_page' => true,
+				'current_context'            => true,
+			],
+			'add payment method page with context, email is empty string' => [
+				'billing_fields'             => [ 'email' => '' ],
+				'woo_billing_fields'         => null,
+				'stripe_billing_fields'      => null,
+				'expected_exception_message' => 'missing_required_customer_field: email',
+				'expected_exception_string'  => 'Missing required customer field: email',
+				'current_context'            => \WC_Stripe_Customer::CUSTOMER_CONTEXT_ADD_PAYMENT_METHOD,
+			],
+			'pay for order page, only email present and required, no overrides' => [
+				'billing_fields'             => [], // only email is required
+				'woo_billing_fields'         => null,
+				'stripe_billing_fields'      => null,
+				'expected_exception_message' => null,
+				'expected_exception_string'  => null,
+				'current_context'            => \WC_Stripe_Customer::CUSTOMER_CONTEXT_PAY_FOR_ORDER,
+			],
+			'pay for order page, only email is empty string' => [
+				'billing_fields'             => [ 'email' => '' ],
+				'woo_billing_fields'         => null,
+				'stripe_billing_fields'      => null,
+				'expected_exception_message' => 'missing_required_customer_field: email',
+				'expected_exception_string'  => 'Missing required customer field: email',
+				'current_context'            => \WC_Stripe_Customer::CUSTOMER_CONTEXT_PAY_FOR_ORDER,
+			],
+			'all fields present and required, no overrides, context is false' => [
+				'billing_fields'             => [],
+				'woo_billing_fields'         => null,
+				'stripe_billing_fields'      => null,
+				'expected_exception_message' => null,
+				'expected_exception_string'  => null,
+				'current_context'            => false,
 			],
 		];
 	}
@@ -126,9 +166,9 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 		?array $stripe_billing_fields = null,
 		?string $expected_exception_message = null,
 		?string $expected_exception_string = null,
-		?bool $is_add_payment_method_page = false
+		$current_context = null
 	) {
-		if ( $is_add_payment_method_page ) {
+		if ( true === $current_context || in_array( $current_context, \WC_Stripe_Customer::MINIMAL_BILLING_DETAILS_CONTEXTS, true ) ) {
 			$default_billing_data = [
 				'email'      => 'test@example.com',
 				'first_name' => '',
@@ -278,7 +318,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 		}
 
 		try {
-			$customer->create_customer( $args, $is_add_payment_method_page );
+			$customer->create_customer( $args, $current_context );
 		} catch ( \WC_Stripe_Exception $stripe_exception ) {
 			$was_exception_thrown = true;
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-659

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
The underlying driver for this PR is that the original code that made customer validation stricter, https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4464, _always_ required all fields. We previously shipped https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4489 to relax those restrictions when users are adding payment methods. This PR refactors some of the code from https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4489 to be a bit more generic so we can identify specific contexts in which we expect a smaller set of customer details to be available. The PR also relaxes customer validation for the "Pay for order" page, making it possible for manually entered orders to be handled with limited customer information.

At a technical level, the changes in this PR are as follows:
 * Change a number of functions to accept a nullable `$current_context` string parameter instead of a `$is_add_payment_method_page` boolean parameter.
   - The changes include a normalization step for all public method so callers of the previous API get the same behaviour.
      * This was only released in 9.7.1, but I still want to avoid unnecessary breakages
 * Update `WC_Stripe_Customer->get_create_customer_required_fields()` to require only an email address when we are on the pay for order page in addition to the case for adding a payment method.
 * Updating the two callers to specify the appropriate context string.
 
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Run a current version of the plugin (e.g. from 9.7.1, 9.8.0, or `develop)
* Ensure Stripe is connected in test mode and you have at least one product
* Navigate to _WooCommerce_ -> _Orders_ and then click on the "Add order" button
* Add some line items to the order
* For the billing details, enter only the user's email address
* Save the order
* Once the order is saved, find the "Customer payment page" link in the _General_ section of the order details and copy the link
* In an incognito window or different browser window, navigate to that link
* Try to make payment
* You should get a validation error
* Now switch to this branch, and re-submit the payment
* The payment should now be processed and you should be redirected to the order received page

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)