### PR TITLE
Update Javascript linting config to specify expected text domain

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -91,8 +91,8 @@ module.exports = {
 	ignorePatterns: [
 		'build/**',
 		'node_modules/**',
-		'vendor/**',
 		'phpunit-html/**',
 		'release/**',
+		'vendor/**',
 	],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,12 @@ module.exports = {
 		'testing-library/no-unnecessary-act': 'off',
 		'@typescript-eslint/no-empty-function': 'off',
 		'@typescript-eslint/no-var-requires': 'off',
+		'@wordpress/i18n-text-domain': [
+			'error',
+			{
+				allowedTextDomain: 'woocommerce-gateway-stripe',
+			},
+		],
 	},
 	settings: {
 		react: {
@@ -82,4 +88,5 @@ module.exports = {
 			'@wordpress/data',
 		],
 	},
+	ignorePatterns: [ 'phpunit-html/**' ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,5 +88,11 @@ module.exports = {
 			'@wordpress/data',
 		],
 	},
-	ignorePatterns: [ 'phpunit-html/**' ],
+	ignorePatterns: [
+		'build/**',
+		'node_modules/**',
+		'vendor/**',
+		'phpunit-html/**',
+		'release/**',
+	],
 };

--- a/changelog.txt
+++ b/changelog.txt
@@ -39,6 +39,7 @@
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
 * Fix - Add `get_icon_url()` to Payment Method base class
+* Fix - Ensure all Javascript strings use the correct text domain for translation
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Update - Increases the default font size for the Optimized Checkout payment element to match the rest of the checkout form
 * Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Dev - Implements WooCommerce constants for the tax statuses
+* Fix - Ensure all Javascript strings use the correct text domain for translation
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data
@@ -40,7 +41,6 @@
 * Fix - Handle missing customer when calling payment_methods API
 * Fix - Reduce number of calls to Stripe payment_methods API
 * Fix - Add `get_icon_url()` to Payment Method base class
-* Fix - Ensure all Javascript strings use the correct text domain for translation
 
 = 9.7.1 - 2025-07-28 =
 * Add - Add state mapping for Lithuania in express checkout

--- a/client/settings/general-settings-section/payment-method-checkbox.js
+++ b/client/settings/general-settings-section/payment-method-checkbox.js
@@ -100,7 +100,8 @@ const PaymentMethodCheckbox = ( {
 							{ sprintf(
 								/* translators: %s: a payment method name. */
 								__(
-									'%s cannot be enabled at checkout. Click to expand.'
+									'%s cannot be enabled at checkout. Click to expand.',
+									'woocommerce-gateway-stripe'
 								),
 								label
 							) }

--- a/client/settings/stripe-account-connected-notice/index.js
+++ b/client/settings/stripe-account-connected-notice/index.js
@@ -45,7 +45,7 @@ const StripeAccountConnectedNotice = () => {
 	if ( shouldShowNotice() ) {
 		localStorage.removeItem( LOCAL_STORAGE_KEY );
 		dispatch( 'core/notices' ).createSuccessNotice(
-			__( 'Stripe Account Connected', 'woocommerce' ),
+			__( 'Stripe Account Connected', 'woocommerce-gateway-stripe' ),
 			{
 				id: 'WOOCOMMERCE_STRIPE_ACCOUNT_CONNECTED_NOTICE',
 				actions: [

--- a/client/stripe-utils/cash-app-limit-notice-handler.js
+++ b/client/stripe-utils/cash-app-limit-notice-handler.js
@@ -11,7 +11,8 @@ const LIMIT_NOTICE_CLASSNAME = 'wc-block-checkout__payment-method-limit-notice';
 export const cashAppLimitNotice = document.createElement( 'div' );
 cashAppLimitNotice.classList.add( 'woocommerce-info', LIMIT_NOTICE_CLASSNAME );
 cashAppLimitNotice.textContent = __(
-	'Please note that, depending on your account and transaction history, Cash App Pay may reject your transaction due to its amount.'
+	'Please note that, depending on your account and transaction history, Cash App Pay may reject your transaction due to its amount.',
+	'woocommerce-gateway-stripe'
 );
 cashAppLimitNotice.setAttribute( 'data-testid', 'cash-app-limit-notice' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -148,5 +148,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Fix some e2e issues: timing, optional flows, and WooCommerce RC support
 * Fix - Reduce number of calls to Stripe payment_methods API
 * Fix - Add `get_icon_url()` to Payment Method base class
+* Fix - Ensure all Javascript strings use the correct text domain for translation
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-453

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR tackles three closely related linting improvements:
* We now include the `@wordpress/i18n-text-domain` rule in our Javascript linting configuration, and we have it configured to require the `woocommerce-gateway-stripe` text domain.
* Three locations that were not using the correct text domain have now been fixed
* We now exclude a few directories from Javascript linting -- these directories don't contain Javascript sources files, but may contain files that could otherwise be picked up by the linting checks. The directories are as follows:
  - `build/`
  - `node_modules/`
  - `phpunit-html/`
  - `release/`
  - `vendor/`

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Inspect the translation changes and verify that they look correct

* Check out this branch locally
* Run `npx eslint . --ext=js,jsx,ts,tsx` and verify that it completes quickly and no errors are reported
* Manually modify one call to `__()` in a Javascript file to specify no text domain, and another to specify an incorrect text domain
* Run `npx eslint . --ext=js,jsx,ts,tsx` and verify that both changes above are flagged due to the incorrect text domain.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
