### PR TITLE
Remove connection type check from PMC sync

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@
 * Update - Increases the default font size for the Optimized Checkout payment element to match the rest of the checkout form
 * Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Dev - Implements WooCommerce constants for the tax statuses
+* Fix - Allow PMC sync migration attempt even when connection type is not present
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
 * Tweak - Use more specific selector in express checkout e2e tests
-* Fix - Allow PMC sync migration attempt even when connection type is not present
+* Fix - Remove connection type requirement from PMC sync migration attempt
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -376,6 +376,7 @@ class WC_Stripe_Payment_Method_Configurations {
 				}
 			}
 
+			WC_Stripe_Logger::error( 'Switching to Stripe-hosted payment method configuration', [ 'pmc_id' => $merchant_payment_method_configuration->id, 'enabled_payment_methods' => $enabled_payment_methods ] );
 			self::update_payment_method_configuration(
 				$enabled_payment_methods,
 				$available_payment_method_ids

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -303,7 +303,13 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings     = WC_Stripe_Helper::get_stripe_settings();
+		$connection_type_key = WC_Stripe_Mode::is_test() ? 'test_connection_type' : 'connection_type';
+
+		// If the account is known to be something other than a Connect OAuth account, we can't use the payment method configurations API.
+		if ( isset( $stripe_settings[ $connection_type_key ] ) && 'connect' !== $stripe_settings[ $connection_type_key ] ) {
+			return false;
+		}
 
 		// If we have the pmc_enabled flag, and it is set to no, we should not use the payment method configurations API.
 		// We only disable the PMC if the flag is set to no explicitly, an empty value means the migration has not been attempted yet.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -303,13 +303,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		$stripe_settings     = WC_Stripe_Helper::get_stripe_settings();
-		$connection_type_key = WC_Stripe_Mode::is_test() ? 'test_connection_type' : 'connection_type';
-
-		// If the account is known to be something other than a Connect OAuth account, we can't use the payment method configurations API.
-		if ( isset( $stripe_settings[ $connection_type_key ] ) && 'connect' !== $stripe_settings[ $connection_type_key ] ) {
-			return false;
-		}
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		// If we have the pmc_enabled flag, and it is set to no, we should not use the payment method configurations API.
 		// We only disable the PMC if the flag is set to no explicitly, an empty value means the migration has not been attempted yet.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -376,7 +376,15 @@ class WC_Stripe_Payment_Method_Configurations {
 				}
 			}
 
-			WC_Stripe_Logger::error( 'Switching to Stripe-hosted payment method configuration', [ 'pmc_id' => $merchant_payment_method_configuration->id, 'enabled_payment_methods' => $enabled_payment_methods ] );
+			WC_Stripe_Logger::error(
+				'Switching to Stripe-hosted payment method configuration',
+				[
+					'pmc_id'                       => $merchant_payment_method_configuration->id,
+					'enabled_payment_methods'      => $enabled_payment_methods,
+					'available_payment_method_ids' => $available_payment_method_ids,
+				]
+			);
+
 			self::update_payment_method_configuration(
 				$enabled_payment_methods,
 				$available_payment_method_ids

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -362,9 +362,8 @@ class WC_Stripe_Payment_Method_Configurations {
 			);
 		}
 
-		// Update the PMC if there are any enabled payment methods
+		// Update the PMC if there are locally enabled payment methods
 		if ( ! empty( $enabled_payment_methods ) ) {
-
 			// Get all available payment method IDs from the configuration.
 			// We explicitly disable all payment methods that are not in the enabled_payment_methods array
 			$available_payment_method_ids = [];
@@ -373,10 +372,9 @@ class WC_Stripe_Payment_Method_Configurations {
 					$available_payment_method_ids[] = $payment_method_id;
 				}
 
-				// Handle migrating from DB to PMC for BNPL default-on: if the payment method is enabled in
-				// the PMC, make sure to include it in the list enabled payment methods to push back.
+				// We want to also include payment methods enabled in the PMC, except for express payment methods.
 				if (
-					in_array( $payment_method_id, [ WC_Stripe_Payment_Methods::KLARNA, WC_Stripe_Payment_Methods::AFFIRM ], true ) &&
+					! in_array( $payment_method_id, WC_Stripe_Payment_Methods::EXPRESS_PAYMENT_METHODS, true ) &&
 					! in_array( $payment_method_id, $enabled_payment_methods, true ) &&
 					isset( $payment_method->display_preference->value ) && 'on' === $payment_method->display_preference->value
 				) {

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -372,6 +372,16 @@ class WC_Stripe_Payment_Method_Configurations {
 				if ( isset( $payment_method->display_preference ) ) {
 					$available_payment_method_ids[] = $payment_method_id;
 				}
+
+				// Handle migrating from DB to PMC for BNPL default-on: if the payment method is enabled in
+				// the PMC, make sure to include it in the list enabled payment methods to push back.
+				if (
+					in_array( $payment_method_id, [ WC_Stripe_Payment_Methods::KLARNA, WC_Stripe_Payment_Methods::AFFIRM ], true ) &&
+					! in_array( $payment_method_id, $enabled_payment_methods, true ) &&
+					isset( $payment_method->display_preference->value ) && 'on' === $payment_method->display_preference->value
+				) {
+					$enabled_payment_methods[] = $payment_method_id;
+				}
 			}
 
 			self::update_payment_method_configuration(

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -303,13 +303,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return bool
 	 */
 	public static function is_enabled() {
-		$stripe_settings     = WC_Stripe_Helper::get_stripe_settings();
-		$connection_type_key = WC_Stripe_Mode::is_test() ? 'test_connection_type' : 'connection_type';
-
-		// If the account is not a Connect OAuth account, we can't use the payment method configurations API.
-		if ( ! isset( $stripe_settings[ $connection_type_key ] ) || 'connect' !== $stripe_settings[ $connection_type_key ] ) {
-			return false;
-		}
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		// If we have the pmc_enabled flag, and it is set to no, we should not use the payment method configurations API.
 		// We only disable the PMC if the flag is set to no explicitly, an empty value means the migration has not been attempted yet.
@@ -395,7 +389,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * This is called when no Payment Method Configuration is found that inherits from the WooCommerce Platform.
 	 */
 	private static function disable_payment_method_configuration_sync() {
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings                = WC_Stripe_Helper::get_stripe_settings();
 		$stripe_settings['pmc_enabled'] = 'no';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -79,6 +79,13 @@ class WC_Stripe_Payment_Methods {
 		self::WECHAT_PAY,
 	];
 
+	const EXPRESS_PAYMENT_METHODS = [
+		self::AMAZON_PAY,
+		self::APPLE_PAY,
+		self::GOOGLE_PAY,
+		self::LINK,
+	];
+
 	/**
 	 * List of express payment methods labels. Amazon Pay and Link are not included,
 	 * as they have their own payment method classes.

--- a/readme.txt
+++ b/readme.txt
@@ -117,6 +117,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
 * Tweak - Use more specific selector in express checkout e2e tests
-* Fix - Allow PMC sync migration attempt even when connection type is not present
+* Fix - Remove connection type requirement from PMC sync migration attempt
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -115,5 +115,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Increases the default font size for the Optimized Checkout payment element to match the rest of the checkout form
 * Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Dev - Implements WooCommerce constants for the tax statuses
+* Fix - Allow PMC sync migration attempt even when connection type is not present
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -38,13 +38,6 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'test' => 'test',
 			]
 		);
-		$this->mock_payment_method_configurations(
-			[
-				WC_Stripe_Payment_Methods::CARD,
-				WC_Stripe_Payment_Methods::BANCONTACT,
-				WC_Stripe_Payment_Methods::EPS,
-			]
-		);
 	}
 
 	/**
@@ -131,22 +124,24 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			}
 		);
 		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
-		WC_Stripe_Helper::update_main_stripe_settings(
-			[
-				'enabled'                         => 'yes',
-				'testmode'                        => 'no',
-				'publishable_key'                 => 'pk_live_valid_test_key',
-				'secret_key'                      => 'sk_live_valid_test_key',
-				'upe_checkout_experience_enabled' => 'yes',
-				'connection_type'                 => 'connect',
-			]
-		);
 
 		$this->mock_payment_method_configurations(
 			[
+				WC_Stripe_Payment_Methods::CARD,
 				WC_Stripe_Payment_Methods::GIROPAY,
 				WC_Stripe_Payment_Methods::BANCONTACT,
 				WC_Stripe_Payment_Methods::EPS,
+			]
+		);
+
+		WC_Stripe_Helper::update_main_stripe_settings(
+			[
+				'enabled'                         => 'yes',
+				'testmode'                        => 'yes',
+				'test_publishable_key'            => 'pk_test_valid_test_key',
+				'test_secret_key'                 => 'sk_test_valid_test_key',
+				'upe_checkout_experience_enabled' => 'yes',
+				'connection_type'                 => 'connect',
 			]
 		);
 

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
@@ -925,78 +925,90 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	}
 
 	/**
-	 * Tests that UPE methods are enabled if Stripe is enabled and the account is connected to the platform.
+	 * Tests that UPE methods are enabled if Stripe is enabled and the method is enabled in the PMC,
+	 * for accounts with PMC sync.
 	 */
 	public function test_upe_method_enabled() {
 		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
 		$stripe_settings['enabled']              = 'yes';
 		$stripe_settings['test_connection_type'] = 'connect';
+		$stripe_settings['pmc_enabled']          = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::LINK ], [] );
-
-		$link_upe_method = new WC_Stripe_UPE_Payment_Method_Link();
+		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::LINK, WC_Stripe_Payment_Methods::CASHAPP_PAY ], [] );
+		$link_upe_method    = new WC_Stripe_UPE_Payment_Method_Link();
+		$cashapp_upe_method = new WC_Stripe_UPE_Payment_Method_Cash_App_Pay();
+		$wechat_upe_method  = new WC_Stripe_UPE_Payment_Method_Wechat_Pay();
 		$this->assertTrue( $link_upe_method->is_enabled() );
+		$this->assertTrue( $cashapp_upe_method->is_enabled() );
+		$this->assertFalse( $wechat_upe_method->is_enabled() );
 	}
 
 	/**
-	 * Tests that UPE methods are not enabled if Stripe is disabled.
+	 * Tests that UPE methods are not enabled if Stripe is disabled,
+	 * for accounts with PMC sync.
 	 */
 	public function test_upe_method_disabled() {
-		$stripe_settings            = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['enabled'] = 'no';
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['enabled']              = 'no';
+		$stripe_settings['test_connection_type'] = 'connect';
+		$stripe_settings['pmc_enabled']          = 'no';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::LINK ], [] );
-
-		$link_upe_method = new WC_Stripe_UPE_Payment_Method_Link();
+		$this->mock_payment_method_configurations( [ WC_Stripe_Payment_Methods::LINK, WC_Stripe_Payment_Methods::CASHAPP_PAY ], [] );
+		$link_upe_method    = new WC_Stripe_UPE_Payment_Method_Link();
+		$cashapp_upe_method = new WC_Stripe_UPE_Payment_Method_Cash_App_Pay();
+		$wechat_upe_method  = new WC_Stripe_UPE_Payment_Method_Wechat_Pay();
 		$this->assertFalse( $link_upe_method->is_enabled() );
+		$this->assertFalse( $cashapp_upe_method->is_enabled() );
+		$this->assertFalse( $wechat_upe_method->is_enabled() );
 	}
 
 	/**
-	 * Tests that UPE methods are only enabled if Stripe is enabled and the account is not connected to the platform.
+	 * Tests that UPE methods are only enabled if Stripe is enabled and the method is enabled in the local settings,
+	 * for accounts with no PMC sync.
 	 */
-	public function test_upe_method_enabled_for_non_connected_accounts() {
+	public function test_upe_method_enabled_no_pmc_sync() {
 		// Enable Stripe and reset the accepted payment methods.
-		$stripe_settings            = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['enabled'] = 'yes';
-		$stripe_settings['upe_checkout_experience_accepted_payments'] = [];
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['enabled']              = 'yes';
+		$stripe_settings['test_connection_type'] = 'connect';
+		$stripe_settings['pmc_enabled']          = 'no';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [
+			WC_Stripe_Payment_Methods::LINK,
+			WC_Stripe_Payment_Methods::CASHAPP_PAY,
+		];
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		// For each method we'll test the following combinations:
-		$stripe_enabled_settings    = [ 'yes', 'no', '' ];
-		$upe_method_enabled_options = [ true, false ];
+		$link_upe_method    = new WC_Stripe_UPE_Payment_Method_Link();
+		$cashapp_upe_method = new WC_Stripe_UPE_Payment_Method_Cash_App_Pay();
+		$wechat_upe_method  = new WC_Stripe_UPE_Payment_Method_Wechat_Pay();
+		$this->assertTrue( $link_upe_method->is_enabled() );
+		$this->assertTrue( $cashapp_upe_method->is_enabled() );
+		$this->assertFalse( $wechat_upe_method->is_enabled() );
+	}
 
-		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $payment_method ) {
-			foreach ( $stripe_enabled_settings as $stripe_enabled ) {
-				foreach ( $upe_method_enabled_options as $upe_method_enabled_option ) {
-					// CARD is always enabled for UPE and non connected accounts.
-					if ( WC_Stripe_Payment_Methods::CARD === $payment_method::STRIPE_ID && ! $upe_method_enabled_option ) {
-						continue;
-					}
+	/**
+	 * Tests that UPE methods are only enabled if Stripe is enabled and the method is enabled in the local settings,
+	 * for accounts with no PMC sync.
+	 */
+	public function test_upe_method_disabled_no_pmc_sync() {
+		// Enable Stripe and reset the accepted payment methods.
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['enabled']              = 'yes';
+		$stripe_settings['test_connection_type'] = 'connect';
+		$stripe_settings['pmc_enabled']          = 'no';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [
+			WC_Stripe_Payment_Methods::LINK,
+			WC_Stripe_Payment_Methods::CASHAPP_PAY,
+		];
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-					// Update the settings.
-					$stripe_settings['enabled'] = $stripe_enabled;
-
-					$payment_method_index = array_search( $payment_method::STRIPE_ID, $stripe_settings['upe_checkout_experience_accepted_payments'] );
-					if ( $upe_method_enabled_option && false === $payment_method_index ) {
-						$stripe_settings['upe_checkout_experience_accepted_payments'][] = $payment_method::STRIPE_ID;
-					} elseif ( ! $upe_method_enabled_option && false !== $payment_method_index ) {
-						unset( $stripe_settings['upe_checkout_experience_accepted_payments'][ $payment_method_index ] );
-					}
-
-					WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
-					// Verify that the payment method is enabled/disabled.
-					$payment_method_instance = new $payment_method();
-					// The UPE method is only enabled if Stripe is enabled and the method is enabled in the settings.
-					if ( 'yes' === $stripe_enabled && $upe_method_enabled_option ) {
-						$this->assertTrue( $payment_method_instance->is_enabled() );
-					} else {
-						$this->assertFalse( $payment_method_instance->is_enabled() );
-					}
-				}
-			}
-		}
+		$link_upe_method    = new WC_Stripe_UPE_Payment_Method_Link();
+		$cashapp_upe_method = new WC_Stripe_UPE_Payment_Method_Cash_App_Pay();
+		$wechat_upe_method  = new WC_Stripe_UPE_Payment_Method_Wechat_Pay();
+		$this->assertTrue( $link_upe_method->is_enabled() );
+		$this->assertTrue( $cashapp_upe_method->is_enabled() );
+		$this->assertFalse( $wechat_upe_method->is_enabled() );
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Fixes the issue where PMC sync does not get enabled for merchants who oAuth'ed before `connection_type` was introduced.

- We will remove the connection type requirement for PMC migration, and just rely on [this PMC check](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/e53c477e378b491dce8522c572724c4a9a000874/includes/class-wc-stripe-payment-method-configurations.php#L137) to disable incompatible merchants.
- We also introduce code to handle merchants who migrate after BNPL default-on was launched.

## Testing instructions
1. While still on `develop`, in wp-admin:
   - Connect your Stripe account.
   - `wp option patch delete woocommerce_stripe_settings test_connection_type` to simulate an oAuthed merchant with no connection type meta.
   - `wp option patch delete woocommerce_stripe_settings pmc_enabled` to simulate a merchant that has not yet been migrated.
   - `wp option delete wcstripe_cache_test_payment_method_configuration` to clear the cache.
   - Enable Cards and Cash App.
   - Disable Klarna and Affirm.
   - Disable express checkout methods.
2. Go to your Stripe dashboard PMC:
    - Enable Cards, Klarna, Affirm, Google Pay, Apple Pay and Link.
    - Disable Cash App.
4. Checkout this branch.
5. Verify that merchants with no `connection_type` will still get PMC sync'ing enabled.
   - Refresh wp-admin.
   - `wp option get woocommerce_stripe_settings` and verify `pmc_enabled` is `yes`
6. Verify in wp-admin that Cards, Cash App, Klarna, and Affirm are enabled, but express checkout methods are still disabled.
7. Verify that PMC sync gets disabled for merchants with incompatible PMCs.
   - Go to `includes/class-wc-stripe-payment-method-configurations.php` and edit the const `TEST_MODE_CONFIGURATION_PARENT_ID` to some random string.
   - `wp option patch delete woocommerce_stripe_settings test_connection_type`
   - `wp option patch delete woocommerce_stripe_settings pmc_enabled`
   - `wp option delete wcstripe_cache_test_payment_method_configuration`
   - Refresh wp-admin.
   - `wp option get woocommerce_stripe_settings` and verify `pmc_enabled` is `no`

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
