### PR TITLE
Add PHP test exclusion: WooCommerce 9.9 requires WordPress >= 6.7

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -40,7 +40,7 @@ jobs:
       max-parallel: 16
       matrix:
         woocommerce_support_policy: [ 'L', 'L-1', 'L-2' ]
-        wordpress_support_policy:   [ 'L', 'L-1', 'L-2' ]
+        wordpress_support_policy:   [ 'L', 'L-1' ]
         php_support_policy:         [ 'L', 'L-1', 'L-2', 'L-3', '7.4' ]
         include:
           # WooCommerce
@@ -55,8 +55,8 @@ jobs:
             wordpress: ${{ fromJson(needs.get-wordpress-versions.outputs.wordpress-versions-json)[0] }}
           - wordpress_support_policy: L-1
             wordpress: ${{ fromJson(needs.get-wordpress-versions.outputs.wordpress-versions-json)[1] }}
-          - wordpress_support_policy: L-2
-            wordpress: ${{ fromJson(needs.get-wordpress-versions.outputs.wordpress-versions-json)[2] }}
+          #- wordpress_support_policy: L-2
+          #  wordpress: ${{ fromJson(needs.get-wordpress-versions.outputs.wordpress-versions-json)[2] }}
           # PHP
           - php_support_policy: L
             php: '8.3'
@@ -68,13 +68,6 @@ jobs:
             php: '8.0'
           - php_support_policy: '7.4'
             php: '7.4'
-        exclude: # incompatible versions of PHP, WordPress, and WooCommerce
-          - woocommerce_support_policy: L
-            wordpress_support_policy: L-2
-          - woocommerce_support_policy: L-1
-            wordpress_support_policy: L-2
-          - woocommerce_support_policy: L-2
-            wordpress_support_policy: L-2
 
     name: Stable (PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }})
     env:

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -73,6 +73,8 @@ jobs:
             wordpress_support_policy: L-2
           - woocommerce_support_policy: L-1
             wordpress_support_policy: L-2
+          - woocommerce_support_policy: L-2
+            wordpress_support_policy: L-2
 
     name: Stable (PHP=${{ matrix.php_support_policy }}, WP=${{ matrix.wordpress_support_policy }}, WC=${{ matrix.woocommerce_support_policy }})
     env:


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
With WooCommerce 10.1 being released yesterday, WooCommerce 9.9 is now the L-2 release, but it's not compatible with WordPress 6.6, which is currently the WordPress L-2 release. We need to drop the test cases that try to test that combination, and will need to look at this again when the next WordPress release comes out. Note that I have removed the WordPress L-2 option altogether, as it caused weird issues when excluding all combinations that include it.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Verify that the automated `PHP tests` workflows all pass, and we don't try to run tests for L-2/L-2 combinations of WordPress and WooCommerce.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This change only impacts our GitHub automated unit tests, and doesn't impact any code in the plugin itself.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
