### PR TITLE
Use current composer and remove legacy PHP compatibility code

### DIFF
--- a/bin/run-ci-tests.bash
+++ b/bin/run-ci-tests.bash
@@ -7,18 +7,11 @@ IFS=$'\n\t'
 # set environment variables
 WC_STRIPE_DIR="$GITHUB_WORKSPACE"
 
-echo 'Updating composer version & Install dependencies...'
-composer self-update 2.0.6 && composer install --no-progress
+echo 'Install composer dependencies...'
+composer install --no-progress
 
 echo 'Starting MySQL service...'
 sudo systemctl start mysql.service
-
-# On GitHub actions, set MySQL authentication to mysql_native_password instead of caching_sha2_password
-# to prevent DB connection problems with PHP versions less than 7.4
-if [[ -n $CI ]]; then
-	echo "Configuring MySQL to use mysql_native_password"
-	mysql -uroot -proot -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
-fi
 
 echo 'Setting up test environment...'
 bash bin/install-wp-tests.sh woocommerce_test root root localhost $WP_VERSION $WC_VERSION false


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR explores cleaning up the `bin/run-ci-tests.sh` script used by our automated tests. The changes are as follows:
 * Stop manually installing `composer 2.0.6` and rely on composer from the environment
   - The older composer version was generating PHP warnings on newer PHP versions, and the specific version install was only making ongoing maintenance work
 * Remove some code that was adding compatibility for PHP <7.4, as the lowest version we test on is 7.4

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Verify that all PHP unit test runs succeed. You can also inspect the actual logs for a recent PHP version to verify that we're not generating warnings from the composer dependencies.
 * Note that tests targeting WordPress L-2 and WooCommerce L-2 are currently failing -- that's being addressed in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4582
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR only modifies some internals of how our PHP unit tests are run in GitHub. There is no impact on the plugin on any sites.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
