### PR TITLE
Use more specific selector for express checkout e2e tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
+* Tweak - Use more specific selector in express checkout e2e tests
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/readme.txt
+++ b/readme.txt
@@ -116,5 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
+* Tweak - Use more specific selector in express checkout e2e tests
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/express-checkout/express-checkout.spec.js
+++ b/tests/e2e/tests/express-checkout/express-checkout.spec.js
@@ -6,6 +6,7 @@ const addProductToCart = async ( page, productSlug = 'beanie' ) => {
 
 	const addToCartButton = await page.getByRole( 'button', {
 		name: 'Add to cart',
+		exact: true, // Needs to be exact, as there are other "Add to cart" buttons for other products in WooCommerce 10.1.
 	} );
 	await expect( addToCartButton ).toBeEnabled();
 	await addToCartButton.dispatchEvent( 'click' );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR adds the `exact` flag to the `page.getByLabel()` call we're making on the product page for our express checkout e2e tests. The additional flag is needed because WooCommerce 10.1.0 now ensures that the "Add to cart" buttons for related products also have the button role, so the inexact match was finding multiple buttons. (The other "Add to cart" buttons all use more specific text that includes the product name.) This behaviour was added by https://github.com/woocommerce/woocommerce/pull/59628.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Verify that the express checkout e2e tests are mostly succeeding, and are not failing with the following error message:
```
    Error: expect.toBeEnabled: Error: strict mode violation: getByRole('button', { name: 'Add to cart' }) resolved to 4 elements:
        1) <button value="16" type="submit" name="add-to-cart" clas…>Add to cart</button> aka getByRole('button', { name: 'Add to cart', exact: true })
        2) <a role="button" rel="nofollow" data-quantity="1" d…>Add to cart</a> aka getByLabel('Add to cart: “Belt”')
        3) <a role="button" rel="nofollow" data-quantity="1" d…>Add to cart</a> aka getByLabel('Add to cart: “Beanie with')
        4) <a role="button" rel="nofollow" data-quantity="1" d…>Add to cart</a> aka getByLabel('Add to cart: “Sunglasses”')
```
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [N/A] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [N/A] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
