### PR TITLE
Fix more e2e test issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
+* Tweak - Use more specific selector in express checkout e2e tests
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
 * Tweak - Use more specific selector in express checkout e2e tests
+* Tweak - Small improvements to e2e tests
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/readme.txt
+++ b/readme.txt
@@ -116,5 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Checks for the subscription payment method (if it is Stripe) when verifying for the payment method detachment
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
+* Tweak - Use more specific selector in express checkout e2e tests
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -117,5 +117,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Implements WooCommerce constants for the tax statuses
 * Fix - Ensure all Javascript strings use the correct text domain for translation
 * Tweak - Use more specific selector in express checkout e2e tests
+* Tweak - Small improvements to e2e tests
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/blocks/sca-card.spec.js
+++ b/tests/e2e/tests/checkout/blocks/sca-card.spec.js
@@ -7,6 +7,7 @@ const {
 	setupCart,
 	setupBlocksCheckout,
 	fillCreditCardDetails,
+	handleCheckout3DSChallenge,
 } = payments;
 
 test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
@@ -21,23 +22,7 @@ test( 'customer can checkout with a SCA card @smoke @blocks', async ( {
 	await fillCreditCardDetails( page, config.get( 'cards.3ds' ) );
 	await page.locator( 'text=Place order' ).click();
 
-	// Wait until the SCA frame is available
-	while (
-		! page.frame( {
-			name: 'stripe-challenge-frame',
-		} )
-	) {
-		await page.waitForTimeout( 1000 );
-	}
-	// Not ideal, but the iframe body gets repalced after load, so a waitFor does not work here.
-	await page.waitForTimeout( 2000 );
-
-	await page
-		.frame( {
-			name: 'stripe-challenge-frame',
-		} )
-		.getByRole( 'button', { name: 'Complete' } )
-		.click();
+	await handleCheckout3DSChallenge( page );
 
 	await page.waitForURL( '**/checkout/order-received/**' );
 

--- a/tests/e2e/tests/express-checkout/express-checkout.spec.js
+++ b/tests/e2e/tests/express-checkout/express-checkout.spec.js
@@ -6,6 +6,7 @@ const addProductToCart = async ( page, productSlug = 'beanie' ) => {
 
 	const addToCartButton = await page.getByRole( 'button', {
 		name: 'Add to cart',
+		exact: true, // Needs to be exact, as there are other "Add to cart" buttons for other products in WooCommerce 10.1.
 	} );
 	await expect( addToCartButton ).toBeEnabled();
 	await addToCartButton.dispatchEvent( 'click' );

--- a/tests/e2e/tests/express-checkout/express-checkout.spec.js
+++ b/tests/e2e/tests/express-checkout/express-checkout.spec.js
@@ -102,6 +102,9 @@ test.describe( 'express checkout and variable products', () => {
 		page,
 	} ) => {
 		await page.goto( '/product/hoodie' );
+		await page
+			.getByLabel( 'color', { exact: true } )
+			.selectOption( 'Blue' );
 		await page.getByLabel( 'Logo', { exact: true } ).selectOption( 'Yes' );
 		const linkButton = await getLinkButton( page );
 		await expect( linkButton ).toBeVisible();

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -677,12 +677,11 @@ export async function handleCheckout3DSChallenge( page, action = 'authorize' ) {
 		outerFrameLocator.locator( '.LightboxModalLoadingIndicator' )
 	).toBeHidden();
 
-	const buttonId =
-		action === 'authorize'
-			? '#test-source-authorize-3ds'
-			: '#test-source-fail-3ds';
-	await expect( innerFrameLocator.locator( buttonId ) ).toBeVisible();
-	await innerFrameLocator.locator( buttonId ).click();
+	const buttonName = action === 'authorize' ? 'Complete' : 'Fail';
+	await expect(
+		innerFrameLocator.getByRole( 'button', { name: buttonName } )
+	).toBeVisible();
+	await innerFrameLocator.getByRole( 'button', { name: buttonName } ).click();
 
 	if ( action === 'fail' ) {
 		await expect( innerFrameLocator.owner() ).toBeHidden();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR builds on https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4591 to make some of our e2e tests a bit more robust. In particular, this PR includes the following changes:
 * `tests/e2e/tests/checkout/blocks/sca-card.spec.js` now relies on the `handleCheckout3DSChallenge()` helper function from `tests/e2e/utils/payments.js`, which has more robust handling for the expected 3DS modal
 * I have updated the `handleCheckout3DSChallenge()` helper function to use `getByRole()` so it is a more user-like action
 * I have updated the variable product test in `tests/e2e/tests/express-checkout/express-checkout.spec.js` to specify the `color` attribute for the variable product
   - I am not sure why the label is `color` with a lower-case `c`, but it is. 🤷 

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Verify that the default e2e tests pass successfully.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
