### PR TITLE
Prevent PMC migration to run when the plugin is not connected to Stripe

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Tweak - Use more specific selector in express checkout e2e tests
 * Fix - Relax customer validation that was preventing payments from the pay for order page
 * Fix - Remove connection type requirement from PMC sync migration attempt
+* Fix - Prevent the PMC migration to run when the plugin is not connected to Stripe
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1992,7 +1992,7 @@ class WC_Stripe_Helper {
 	 */
 	public static function is_connected( $mode = null ) {
 		// If the mode is not provided, we'll check the current mode.
-		if ( is_null( $mode ) ) {
+		if ( null === $mode ) {
 			$mode = WC_Stripe_Mode::is_test() ? 'test' : 'live';
 		}
 

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1983,4 +1983,24 @@ class WC_Stripe_Helper {
 
 		throw new Exception( __( "We're not able to process this request. Please try again later.", 'woocommerce-gateway-stripe' ) );
 	}
+
+	/**
+	 * Determines if the store is connected to Stripe.
+	 *
+	 * @param string $mode Optional. The mode to check. 'live' or 'test' - if not provided, the currently enabled mode will be checked.
+	 * @return bool True if connected, false otherwise.
+	 */
+	public static function is_connected( $mode = null ) {
+		// If the mode is not provided, we'll check the current mode.
+		if ( is_null( $mode ) ) {
+			$mode = WC_Stripe_Mode::is_test() ? 'test' : 'live';
+		}
+
+		$options = self::get_stripe_settings();
+		if ( 'test' === $mode ) {
+			return isset( $options['test_publishable_key'], $options['test_secret_key'] ) && trim( $options['test_publishable_key'] ) && trim( $options['test_secret_key'] );
+		} else {
+			return isset( $options['publishable_key'], $options['secret_key'] ) && trim( $options['publishable_key'] ) && trim( $options['secret_key'] );
+		}
+	}
 }

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -303,6 +303,11 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return bool
 	 */
 	public static function is_enabled() {
+		// Bail if account is not connected.
+		if ( ! WC_Stripe_Helper::is_connected() ) {
+			return false;
+		}
+
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 
 		// If we have the pmc_enabled flag, and it is set to no, we should not use the payment method configurations API.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -296,9 +296,7 @@ class WC_Stripe_Payment_Method_Configurations {
 
 	/**
 	 * Check if the payment method configurations API can be used to store enabled payment methods.
-	 * This requires the Stripe account to be connected to our platform ('connection_type' option to be 'connect').
-	 *
-	 * This is temporary until we finish the re-authentication campaign.
+	 * This requires the Stripe account to be connected to Stripe.
 	 *
 	 * @return bool
 	 */

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -269,17 +269,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		 * @return bool True if connected, false otherwise.
 		 */
 		public function is_connected( $mode = null ) {
-			// If the mode is not provided, we'll check the current mode.
-			if ( is_null( $mode ) ) {
-				$mode = WC_Stripe_Mode::is_test() ? 'test' : 'live';
-			}
-
-			$options = WC_Stripe_Helper::get_stripe_settings();
-			if ( 'test' === $mode ) {
-				return isset( $options['test_publishable_key'], $options['test_secret_key'] ) && trim( $options['test_publishable_key'] ) && trim( $options['test_secret_key'] );
-			} else {
-				return isset( $options['publishable_key'], $options['secret_key'] ) && trim( $options['publishable_key'] ) && trim( $options['secret_key'] );
-			}
+			return WC_Stripe_Helper::is_connected( $mode );
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -119,5 +119,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Use more specific selector in express checkout e2e tests
 * Fix - Relax customer validation that was preventing payments from the pay for order page
 * Fix - Remove connection type requirement from PMC sync migration attempt
+* Fix - Prevent the PMC migration to run when the plugin is not connected to Stripe
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
+++ b/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
@@ -24,8 +24,10 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 
 		$this->pmc = new WC_Stripe_Payment_Method_Configurations();
 
-		// Set up test connection type to enable PMC
+		// Set up test connection info to enable PMC
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
+		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
 		$stripe_settings['test_connection_type'] = 'connect';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 	}

--- a/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
@@ -107,11 +107,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	public function test_get_stripe_payment_method_configurations_settings( $enabled_payment_method_ids, $disabled_payment_method_ids ) {
 		$this->mock_payment_method_configurations( $enabled_payment_method_ids, $disabled_payment_method_ids );
 
-		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
-		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
 		$response = $this->controller->get_settings();
 		$this->assertEquals( 200, $response->get_status() );
 		foreach ( $enabled_payment_method_ids as $payment_method ) {
@@ -130,10 +125,8 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 		$this->mock_payment_method_configurations( [ 'card' ], [ 'amazon_pay', 'google_pay', 'apple_pay' ] );
 
 		// Set pmc_enabled to yes to prevent migration
-		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['pmc_enabled']          = 'yes';
-		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
-		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
+		$stripe_settings                = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['pmc_enabled'] = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$this->expect_payment_method_configurations_update( [ 'amazon_pay', 'card' ] );
@@ -386,11 +379,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 			[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
 		);
 
-		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
-		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
 		// After the update: card, Apple Pay, and Google Pay are enabled, CashApp is disabled
 		$this->expect_payment_method_configurations_update(
 			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ],
@@ -417,11 +405,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ],
 			[ WC_Stripe_Payment_Methods::CASHAPP_PAY ]
 		);
-
-		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
-		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		// After the update: CashApp is enabled, card, Apple Pay, and Google Pay are disabled
 		$this->expect_payment_method_configurations_update(
@@ -513,12 +496,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 			$enabled_payment_method_ids,
 			$disabled_payment_method_ids
 		);
-
-		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
-		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
 		$request  = new WP_REST_Request( 'GET', self::SETTINGS_ROUTE );
 		$response = $this->controller->get_settings( $request );
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
@@ -107,6 +107,11 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	public function test_get_stripe_payment_method_configurations_settings( $enabled_payment_method_ids, $disabled_payment_method_ids ) {
 		$this->mock_payment_method_configurations( $enabled_payment_method_ids, $disabled_payment_method_ids );
 
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
+		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
 		$response = $this->controller->get_settings();
 		$this->assertEquals( 200, $response->get_status() );
 		foreach ( $enabled_payment_method_ids as $payment_method ) {
@@ -125,8 +130,10 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 		$this->mock_payment_method_configurations( [ 'card' ], [ 'amazon_pay', 'google_pay', 'apple_pay' ] );
 
 		// Set pmc_enabled to yes to prevent migration
-		$stripe_settings                = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['pmc_enabled'] = 'yes';
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['pmc_enabled']          = 'yes';
+		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
+		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$this->expect_payment_method_configurations_update( [ 'amazon_pay', 'card' ] );
@@ -379,6 +386,11 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 			[ WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ]
 		);
 
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
+		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
 		// After the update: card, Apple Pay, and Google Pay are enabled, CashApp is disabled
 		$this->expect_payment_method_configurations_update(
 			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ],
@@ -405,6 +417,11 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 			[ WC_Stripe_Payment_Methods::CARD, WC_Stripe_Payment_Methods::APPLE_PAY, WC_Stripe_Payment_Methods::GOOGLE_PAY ],
 			[ WC_Stripe_Payment_Methods::CASHAPP_PAY ]
 		);
+
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
+		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		// After the update: CashApp is enabled, card, Apple Pay, and Google Pay are disabled
 		$this->expect_payment_method_configurations_update(
@@ -496,6 +513,12 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 			$enabled_payment_method_ids,
 			$disabled_payment_method_ids
 		);
+
+		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
+		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
 		$request  = new WP_REST_Request( 'GET', self::SETTINGS_ROUTE );
 		$response = $this->controller->get_settings( $request );
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/phpunit/Admin/WC_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Settings_Controller_Test.php
@@ -77,6 +77,8 @@ class WC_Stripe_Settings_Controller_Test extends WP_UnitTestCase {
 		$stripe_settings['testmode']             = 'yes';
 		$stripe_settings['test_publishable_key'] = '';
 		$stripe_settings['test_secret_key']      = '';
+		$stripe_settings['publishable_key']      = '';
+		$stripe_settings['secret_key']           = '';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		ob_start();

--- a/tests/phpunit/Helpers/UPE_Test_Helper.php
+++ b/tests/phpunit/Helpers/UPE_Test_Helper.php
@@ -48,7 +48,11 @@ class UPE_Test_Helper {
 		WC()->payment_gateways()->payment_gateways = [];
 		WC()->payment_gateways()->init();
 		$settings                         = WC_Stripe_Helper::get_stripe_settings();
+		$settings['publishable_key']      = 'pk_live_1234567890';
+		$settings['secret_key']           = 'sk_live_1234567890';
 		$settings['connection_type']      = 'connect';
+		$settings['test_publishable_key'] = 'pk_test_1234567890';
+		$settings['test_secret_key']      = 'sk_test_1234567890';
 		$settings['test_connection_type'] = 'connect';
 		$settings['pmc_enabled']          = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Test.php
@@ -931,6 +931,8 @@ class WC_Stripe_UPE_Payment_Method_Test extends WC_Mock_Stripe_API_Unit_Test_Cas
 	public function test_upe_method_enabled() {
 		$stripe_settings                         = WC_Stripe_Helper::get_stripe_settings();
 		$stripe_settings['enabled']              = 'yes';
+		$stripe_settings['test_publishable_key'] = 'pk_test_1234567890';
+		$stripe_settings['test_secret_key']      = 'sk_test_1234567890';
 		$stripe_settings['test_connection_type'] = 'connect';
 		$stripe_settings['pmc_enabled']          = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );

--- a/tests/phpunit/WC_REST_Stripe_Account_Keys_Controller_Test.php
+++ b/tests/phpunit/WC_REST_Stripe_Account_Keys_Controller_Test.php
@@ -42,7 +42,9 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 		// Setup existing keys
 		$settings                         = WC_Stripe_Helper::get_stripe_settings();
 		$settings['publishable_key']      = 'original-live-key-9999';
+		$settings['secret_key']           = '';
 		$settings['test_publishable_key'] = 'original-test-key-9999';
+		$settings['test_secret_key']      = '';
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 
 		$mock_account = $this->getMockBuilder( WC_Stripe_Account::class )

--- a/tests/phpunit/WC_REST_Stripe_Account_Keys_Controller_Test.php
+++ b/tests/phpunit/WC_REST_Stripe_Account_Keys_Controller_Test.php
@@ -176,7 +176,7 @@ class WC_REST_Stripe_Account_Keys_Controller_Test extends WC_Mock_Stripe_API_Uni
 
 		// Build request params
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
-		$request->set_param( 'publishable_key', '' );
+		$request->set_param( 'publishable_key', 'pk_live-key-updated' );
 
 		// Set initial payment methods
 		$this->set_stripe_account_data( [ 'country' => 'US' ] );

--- a/tests/phpunit/WC_Stripe_Account_Test.php
+++ b/tests/phpunit/WC_Stripe_Account_Test.php
@@ -37,6 +37,8 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$stripe_settings['testmode']             = 'yes';
 		$stripe_settings['test_publishable_key'] = 'pk_test_key';
 		$stripe_settings['test_secret_key']      = 'sk_test_key';
+		$stripe_settings['publishable_key']      = '';
+		$stripe_settings['secret_key']           = '';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$this->mock_connect = $this->getMockBuilder( WC_Stripe_Connect::class )


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

When instantiating the main Gateway class `WC_Stripe_UPE_Payment_Gateway`, the constructor lists all available payment methods (`get_upe_enabled_payment_method_ids()`), and that method attempts to migrate the local configuration to Stripe's PMC without checking if there is a connected account first.

This PR prevents the PMC migration from running when the store is not connected to Stripe.
It adds an `not is_connected()` bail out to the PMC `is_enabled()`

As the call originates from the `WC_Stripe_UPE_Payment_Gateway` constructor, we can't use the existing `WC_Stripe::get_instance()->connect->is_connected()`, so we extract the `is_connected` logic to the `WC_Stripe_Helper` so we can also call it from the `maybe_migrate_payment_methods_from_db_to_pmc()`.

## Testing instructions

1. Check out the `release/9.8.1` branch
2. Remove the plugin settings:
    `wp option delete woocommerce_stripe_settings`
3. Remove the Account cache:
    `wp option delete wcstripe_test_payment_method_configuration_cache`
4. Remove the API rate-limit count cache: 
    `wp option delete wcstripe_cache_live_invalid_api_key_error_count`
    `wp option delete wcstripe_cache_test_invalid_api_key_error_count`
5. Go to the plugin settings
6. Go to `WP Admin > WooCommerce > Status > Logs` and click `woocommerce-gateway-stripe` from the list
7. Check that there were multiple GETs to the payment method configuration API (which resulted in 401 errors):
    <img width="1255" height="377" alt="Screenshot 2025-08-14 at 22 46 31" src="https://github.com/user-attachments/assets/63110d11-dc7c-41ff-ae37-55f7b4d46844" />
8. Delete the log entry by clicking `Delete permanently`
    <img width="955" height="220" alt="Screenshot 2025-08-15 at 00 50 48" src="https://github.com/user-attachments/assets/a4fe5b9e-dddf-46ce-a0c8-a84da0af29a2" />
9. Checkout this branch (`fix/prevent-pmc-migration-when-not-connected`)
10. Remove the plugin settings:
    `wp option delete woocommerce_stripe_settings`
11. Remove the Account cache:
    `wp option delete wcstripe_test_payment_method_configuration_cache`
12. Remove the API rate-limit count cache: 
    `wp option delete wcstripe_cache_live_invalid_api_key_error_count`
    `wp option delete wcstripe_cache_test_invalid_api_key_error_count`
13. Go to the plugin settings
14. Go to `WP Admin > WooCommerce > Status > Logs` and click `woocommerce-gateway-stripe` from the list
15. Check that there were no attempts to fetch the payment method configurations

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
