### PR TITLE
Fix Stripe customer creation with no email

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Tweak - Small improvements to e2e tests
 * Fix - Prevent the PMC migration to run when the plugin is not connected to Stripe
 * Fix - Fixes a fatal error in the OC inbox note when the new checkout is disabled
+* Fix - Allow checkout for logged-in users without an email in their account when a billing email is provided
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,13 +11,13 @@
 * Tweak - Small improvements to e2e tests
 * Fix - Fix unnecessary Stripe API calls when rendering subscription details
 * Add - Adds a new action (`wc_stripe_webhook_received`) to allow additional actions to be taken for webhook notifications from Stripe
+* Fix - Allow checkout for logged-in users without an email in their account when a billing email is provided
 
 = 9.8.1 - 2025-08-15 =
 * Fix - Remove connection type requirement from PMC sync migration attempt
 * Fix - Relax customer validation that was preventing payments from the pay for order page
 * Fix - Prevent the PMC migration to run when the plugin is not connected to Stripe
 * Fix - Fixes a fatal error in the OC inbox note when the new checkout is disabled
-* Fix - Allow checkout for logged-in users without an email in their account when a billing email is provided
 
 = 9.8.0 - 2025-08-11 =
 * Add - Adds the current setting value for the Optimized Checkout to the Stripe System Status Report data

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -159,6 +159,8 @@ class WC_Stripe_Customer {
 			$billing_first_name = get_user_meta( $user->ID, 'billing_first_name', true );
 			$billing_last_name  = get_user_meta( $user->ID, 'billing_last_name', true );
 
+			$email = $user->user_email;
+
 			// If billing first name does not exists try the user first name.
 			if ( empty( $billing_first_name ) ) {
 				$billing_first_name = get_user_meta( $user->ID, 'first_name', true );
@@ -169,11 +171,16 @@ class WC_Stripe_Customer {
 				$billing_last_name = get_user_meta( $user->ID, 'last_name', true );
 			}
 
+			// If the user email is not set, use the billing email.
+			if ( empty( $email ) ) {
+				$email = $this->get_billing_data_field( 'billing_email', $args );
+			}
+
 			// translators: %1$s First name, %2$s Second name, %3$s Username.
 			$description = sprintf( __( 'Name: %1$s %2$s, Username: %3$s', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name, $user->user_login );
 
 			$defaults = [
-				'email'       => $user->user_email,
+				'email'       => $email,
 				'description' => $description,
 			];
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -159,8 +159,6 @@ class WC_Stripe_Customer {
 			$billing_first_name = get_user_meta( $user->ID, 'billing_first_name', true );
 			$billing_last_name  = get_user_meta( $user->ID, 'billing_last_name', true );
 
-			$email = $user->user_email;
-
 			// If billing first name does not exists try the user first name.
 			if ( empty( $billing_first_name ) ) {
 				$billing_first_name = get_user_meta( $user->ID, 'first_name', true );
@@ -170,6 +168,8 @@ class WC_Stripe_Customer {
 			if ( empty( $billing_last_name ) ) {
 				$billing_last_name = get_user_meta( $user->ID, 'last_name', true );
 			}
+
+			$email = $user->user_email;
 
 			// If the user email is not set, use the billing email.
 			if ( empty( $email ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -123,5 +123,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Small improvements to e2e tests
 * Fix - Prevent the PMC migration to run when the plugin is not connected to Stripe
 * Fix - Fixes a fatal error in the OC inbox note when the new checkout is disabled
+* Fix - Allow checkout for logged-in users without an email in their account when a billing email is provided
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-673

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR fixes an edge case where logged-in users without an email address in their profile cannot complete checkout, even when they enter a valid email in the checkout form. For logged-in users, we use their profile email when creating the Stripe customer. Although it is not allowed via the UI, it is possible to have user accounts with empty emails created through custom scripts. In v9.7.0, we introduced validation to prevent Stripe customer creation with empty values which surfaced this issue.

This PR addresses this issue by falling back to using the billing email address if the user's email is empty for a logged-in user.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

### Setup
Create a test user without an email address using this SQL:
 ```sql
 INSERT INTO wp_users (ID, user_login, user_pass, user_nicename, user_email, user_url,
user_registered, user_activation_key, user_status, display_name)
 VALUES (NULL, 'nomail', MD5('password'), 'nomail', '', '', '2024-01-01 00:00:00', '', '0', 'No
Email User');
```

#### Test the issue on Develop

1. Log in as the user created above (`username: nomail`, `password: password`)
2. Add a product to the cart and proceed to checkout.
3. Fill in all required fields including a valid email address.
4. Attempt to complete the order.
5. Expected bug: You'll see an error "Missing required customer field: email"

#### Test the fix on this branch

1. Apply the changes from this PR.
2. Repeat steps 1-4 from above.
3. Order should be placed successfully.
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
