### PR TITLE
Update Subscriptions CTA in e2e tests

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Fix - Allow checkout for logged-in users without an email in their account when a billing email is provided
 * Update - Show all available payment methods before unavailable payment methods
 * Tweak - Use smaller image for Optimized Checkout banner
+* Dev - Update WooCommerce Subscriptions e2e tests after 7.8.0 release
 
 = 9.8.1 - 2025-08-15 =
 * Fix - Remove connection type requirement from PMC sync migration attempt

--- a/readme.txt
+++ b/readme.txt
@@ -125,5 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Allow checkout for logged-in users without an email in their account when a billing email is provided
 * Update - Show all available payment methods before unavailable payment methods
 * Tweak - Use smaller image for Optimized Checkout banner
+* Dev - Update WooCommerce Subscriptions e2e tests after 7.8.0 release
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
@@ -34,7 +34,7 @@ test( 'customer can purchase a subscription product @smoke @blocks @subscription
 	await setupBlocksCheckout( page, customerData );
 	await fillCreditCardDetails( page, config.get( 'cards.no-3ds' ) );
 
-	await page.locator( 'text=Sign up now' ).click();
+	await page.locator( 'text=Add to cart' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(

--- a/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
@@ -34,7 +34,7 @@ test( 'customer can purchase a subscription product @smoke @subscriptions', asyn
 	await setupShortcodeCheckout( page, customerData );
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
 
-	await page.locator( 'text=Sign up now' ).click();
+	await page.locator( 'text=Add to cart' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(

--- a/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
@@ -51,7 +51,7 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 			config.get( 'cards.basic' )
 		);
 
-		await page.locator( 'text=Sign up now' ).click();
+		await page.locator( 'text=Add to cart' ).click();
 
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

In WooCommerce Subscriptions 7.8.0, the CTA for subscription purchases has been changed from "Sign up now" to "Add to cart". This PR updates our default e2e tests to reflect this change.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Verify that the Default e2e tests succeed for the PR
  - There are some unrelated issues with the Optimized Checkout tests at the moment
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [N/A] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [N/A] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [N/A] Included this PR in the Release Thread scope (or does not apply)
