### PR TITLE
Fix Link availability when OC is enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.9.0 - xxxx-xx-xx =
+* Fix - The availability of the Link payment method when the Optimized Checkout is enabled
 * Dev - Replaces some payment method instantiation logic for the Optimized Checkout with calls to the `get_payment_method_instance` method
 * Dev - Multiple lint fixes in preparation for the Node 20 upgrade
 * Dev - Introduces a new helper method to identify Stripe orders

--- a/client/settings/payment-request-section/__tests__/index.test.js
+++ b/client/settings/payment-request-section/__tests__/index.test.js
@@ -5,6 +5,7 @@ import {
 	useGetAvailablePaymentMethodIds,
 	usePaymentRequestEnabledSettings,
 	useAmazonPayEnabledSettings,
+	useIsOCEnabled,
 } from 'wcstripe/data';
 import {
 	PAYMENT_METHOD_CARD,
@@ -17,6 +18,7 @@ jest.mock( 'wcstripe/data', () => ( {
 	useGetAvailablePaymentMethodIds: jest.fn(),
 	useEnabledPaymentMethodIds: jest.fn(),
 	useAmazonPayEnabledSettings: jest.fn(),
+	useIsOCEnabled: jest.fn(),
 } ) );
 
 const getMockPaymentRequestEnabledSettings = (
@@ -41,6 +43,7 @@ describe( 'PaymentRequestSection', () => {
 			PAYMENT_METHOD_AMAZON_PAY,
 		] );
 		useAmazonPayEnabledSettings.mockReturnValue( [ false, jest.fn() ] );
+		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
 		global.wc_stripe_settings_params = {
 			...globalValues,
 			is_amazon_pay_available: true,

--- a/client/settings/payment-request-section/__tests__/index.test.js
+++ b/client/settings/payment-request-section/__tests__/index.test.js
@@ -62,7 +62,7 @@ describe( 'PaymentRequestSection', () => {
 		expect( label ).toBeInTheDocument();
 	} );
 
-	it( 'hide link payment if card payment method is inactive', () => {
+	it( 'hide link payment if card payment method is inactive (OC disabled)', () => {
 		useGetAvailablePaymentMethodIds.mockReturnValue( [
 			PAYMENT_METHOD_LINK,
 			PAYMENT_METHOD_CARD,
@@ -76,7 +76,7 @@ describe( 'PaymentRequestSection', () => {
 		expect( screen.queryByText( 'Link by Stripe' ) ).toBeNull();
 	} );
 
-	it( 'show link payment if card payment method is active', () => {
+	it( 'show link payment if card payment method is active (OC disabled)', () => {
 		useGetAvailablePaymentMethodIds.mockReturnValue( [
 			PAYMENT_METHOD_LINK,
 			PAYMENT_METHOD_CARD,
@@ -84,6 +84,21 @@ describe( 'PaymentRequestSection', () => {
 		useEnabledPaymentMethodIds.mockReturnValue( [
 			[ PAYMENT_METHOD_CARD, PAYMENT_METHOD_LINK ],
 		] );
+
+		render( <PaymentRequestSection /> );
+
+		expect( screen.queryByText( 'Link by Stripe' ) ).toBeInTheDocument();
+	} );
+
+	it( 'show link payment if card payment method is inactive (OC enabled)', () => {
+		useGetAvailablePaymentMethodIds.mockReturnValue( [
+			PAYMENT_METHOD_LINK,
+			PAYMENT_METHOD_CARD,
+		] );
+		useEnabledPaymentMethodIds.mockReturnValue( [
+			[ PAYMENT_METHOD_LINK ],
+		] );
+		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
 
 		render( <PaymentRequestSection /> );
 

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -13,6 +13,7 @@ import {
 	useAmazonPayEnabledSettings,
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,
+	useIsOCEnabled,
 } from '../../data';
 import './styles.scss';
 import AmazonPayIcon from '../../payment-method-icons/amazon-pay';
@@ -41,6 +42,8 @@ const PaymentRequestSection = () => {
 		updateEnabledMethodIds,
 	] = useEnabledPaymentMethodIds();
 
+	const [ isOCEnabled ] = useIsOCEnabled();
+
 	const updateStripeLinkCheckout = ( isEnabled ) => {
 		// Add/remove Stripe Link from the list of enabled payment methods.
 		if ( isEnabled ) {
@@ -61,7 +64,7 @@ const PaymentRequestSection = () => {
 		PAYMENT_METHOD_CARD
 	);
 	const displayLinkPaymentMethod =
-		enabledMethodIds.includes( PAYMENT_METHOD_CARD ) &&
+		( enabledMethodIds.includes( PAYMENT_METHOD_CARD ) || isOCEnabled ) &&
 		availablePaymentMethodIds.includes( PAYMENT_METHOD_LINK );
 	const isStripeLinkEnabled = enabledMethodIds.includes(
 		PAYMENT_METHOD_LINK
@@ -91,6 +94,17 @@ const PaymentRequestSection = () => {
 								<div>
 									{ __(
 										'Credit card / debit card must be enabled as a payment method in order to use Express Checkout.',
+										'woocommerce-gateway-stripe'
+									) }
+								</div>
+							</li>
+						) }
+					{ ! displayExpressPaymentMethods &&
+						displayLinkPaymentMethod && (
+							<li className="express-checkout">
+								<div>
+									{ __(
+										'Credit card / debit card must be enabled as a payment method in order to use Google Pay and Apple Pay.',
 										'woocommerce-gateway-stripe'
 									) }
 								</div>

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.9.0 - xxxx-xx-xx =
+* Fix - The availability of the Link payment method when the Optimized Checkout is enabled
 * Dev - Replaces some payment method instantiation logic for the Optimized Checkout with calls to the `get_payment_method_instance` method
 * Dev - Multiple lint fixes in preparation for the Node 20 upgrade
 * Dev - Introduces a new helper method to identify Stripe orders


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-678

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

When the Optimized Checkout is enabled, the card payment method is no longer a requirement for the Link payment method to be available. But this is not reflected in the Stripe settings UI.

This PR fixes that by checking if OC is enabled before deciding to hide the Link method.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`fix/link-availability-with-oc`)
- Enable the Optimized Checkout
- Disable the card payment method in settings
- Confirm you see the Link payment method option in the payment method list
- As a shopper, add any product to your cart
- Go to the checkout page
- Confirm you see Link and complete a payment with it

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
