### PR TITLE
Remove @testing-library/react-hooks for compatibility with React 18

### DIFF
--- a/client/data/account-keys/__tests__/hooks.test.js
+++ b/client/data/account-keys/__tests__/hooks.test.js
@@ -1,5 +1,5 @@
 import { useSelect, useDispatch } from '@wordpress/data';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import { useAccountKeys, useAccountKeysPublishableKey } from '../hooks';
 import { STORE_NAME } from '../../constants';
 

--- a/client/data/account/__tests__/hooks.test.js
+++ b/client/data/account/__tests__/hooks.test.js
@@ -1,5 +1,5 @@
 import { useSelect, useDispatch } from '@wordpress/data';
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react';
 import { useGetCapabilities, useAccount } from '../hooks';
 
 jest.mock( '@wordpress/data' );

--- a/client/data/payment-gateway/__tests__/hooks.test.js
+++ b/client/data/payment-gateway/__tests__/hooks.test.js
@@ -1,5 +1,5 @@
 import { useSelect, useDispatch } from '@wordpress/data';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import {
 	usePaymentGateway,
 	useEnabledPaymentGateway,

--- a/client/data/settings/__tests__/hooks.js
+++ b/client/data/settings/__tests__/hooks.js
@@ -1,5 +1,5 @@
 import { useSelect, useDispatch } from '@wordpress/data';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react';
 import {
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "@playwright/test": "^1.40.1",
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^14.3.1",
-        "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^13.2.1",
         "@types/react": "16.9.56",
         "@types/react-dom": "^18.3.7",
@@ -5194,36 +5193,6 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
-      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@types/react": "^16.9.0 || ^17.0.0",
-        "react": "^16.9.0 || ^17.0.0",
-        "react-dom": "^16.9.0 || ^17.0.0",
-        "react-test-renderer": "^16.9.0 || ^17.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        },
-        "react-test-renderer": {
-          "optional": true
-        }
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -31396,22 +31365,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "react": ">=16.13.1"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -41172,16 +41125,6 @@
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^9.0.0",
         "@types/react-dom": "^18.0.0"
-      }
-    },
-    "@testing-library/react-hooks": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
-      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "react-error-boundary": "^3.1.0"
       }
     },
     "@testing-library/user-event": {
@@ -61899,15 +61842,6 @@
             "loose-envify": "^1.1.0"
           }
         }
-      }
-    },
-    "react-error-boundary": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
-      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.12.5"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@playwright/test": "^1.40.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^14.3.1",
-    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^13.2.1",
     "@types/react": "16.9.56",
     "@types/react-dom": "^18.3.7",


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-451

## Changes proposed in this Pull Request:

This PR builds on @wjrosa's work in #4617 to update the plugin to React 18. This PR tackles some issues that I found while running tests for the code in that PR, mostly due to `@testing-library/react-hooks` triggering warnings when we ran `renderHook` and `act` imported from the library. I confirmed that the implementation for `renderHook` is using a deprecated `act` imported from elsewhere, and I then went to the package repo, only to find [this handy notice](https://github.com/testing-library/react-hooks-testing-library?tab=readme-ov-file#a-note-about-react-18-support):

> ### A Note about React 18 Support
>
> If you are using the current version of react-testing-library, replace
> 
> ```js
> import { renderHook } from '@testing-library/react-hooks'
> ```
> with
> ```js
> import { renderHook } from '@testing-library/react'
> ```
> Once replaced, `@testing-library/react-hooks` can be uninstalled.

This PR does just that, and removes a number of warnings related to test rendering. There are still a few related to initial values for some components, but those are quite distinct from this shift from `@testing-library/react-hooks` to `@testing-library/react`.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Check out this branch
* Run `npm run test:js`
* Verify that there are no console errors mentioning any of the following:
  - `Warning: ReactDOM.render is no longer supported in React 18. Use createRoot instead.`
  - `Warning: unmountComponentAtNode is deprecated and will be removed in the next major release. Switch to the createRoot API.`
  - `Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`.`

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR is building on top of #4617 and should be merged into that PR. We don't need separate documentation for the changes.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
