### PR TITLE
Implement clickAddToCartButton() helper and update button for Subscription purchases

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 * Update - Show all available payment methods before unavailable payment methods
 * Tweak - Use smaller image for Optimized Checkout banner
 * Dev - Update WooCommerce Subscriptions e2e tests after 7.8.0 release
+* Dev - Make 'Add to cart' more robust in e2e tests
 
 = 9.8.1 - 2025-08-15 =
 * Fix - Remove connection type requirement from PMC sync migration attempt

--- a/readme.txt
+++ b/readme.txt
@@ -132,5 +132,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Show all available payment methods before unavailable payment methods
 * Tweak - Use smaller image for Optimized Checkout banner
 * Dev - Update WooCommerce Subscriptions e2e tests after 7.8.0 release
+* Dev - Make 'Add to cart' more robust in e2e tests
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/tests/checkout/blocks/pre-order-product.spec.js
+++ b/tests/e2e/tests/checkout/blocks/pre-order-product.spec.js
@@ -4,7 +4,11 @@ import config from 'config';
 import { api, payments, products } from '../../../utils';
 import { isPluginInstalled } from '../../../utils/plugin-utils';
 
-const { setupBlocksCheckout, fillCreditCardDetails } = payments;
+const {
+	setupBlocksCheckout,
+	fillCreditCardDetails,
+	clickAddToCartButton,
+} = payments;
 
 let productId;
 
@@ -28,7 +32,7 @@ test( 'customer can purchase a pre-order product @blocks @pre-orders', async ( {
 	page,
 } ) => {
 	await page.goto( `?p=${ productId }` );
-	await page.locator( 'button[name="add-to-cart"]' ).click();
+	await clickAddToCartButton( page, 'Pre-order now' );
 
 	const randomString = randomUUID();
 	// Subscriptions will create an account for this checkout, we need a random email.

--- a/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/blocks/subscription-product.spec.js
@@ -3,7 +3,11 @@ import { randomUUID } from 'crypto';
 import config from 'config';
 import { api, payments, products } from '../../../utils';
 
-const { setupBlocksCheckout, fillCreditCardDetails } = payments;
+const {
+	setupBlocksCheckout,
+	fillCreditCardDetails,
+	clickAddToCartButton,
+} = payments;
 
 let productId;
 
@@ -19,7 +23,7 @@ test( 'customer can purchase a subscription product @smoke @blocks @subscription
 	page,
 } ) => {
 	await page.goto( `?p=${ productId }` );
-	await page.locator( 'button[name="add-to-cart"]' ).click();
+	await clickAddToCartButton( page );
 
 	const randomString = randomUUID();
 	// Subscriptions will create an account for this checkout, we need a random email.
@@ -34,7 +38,7 @@ test( 'customer can purchase a subscription product @smoke @blocks @subscription
 	await setupBlocksCheckout( page, customerData );
 	await fillCreditCardDetails( page, config.get( 'cards.no-3ds' ) );
 
-	await page.locator( 'text=Add to cart' ).click();
+	await page.locator( 'text=Place order' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(

--- a/tests/e2e/tests/checkout/shortcode/pre-order-product.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/pre-order-product.spec.js
@@ -4,7 +4,11 @@ import config from 'config';
 import { api, payments, products } from '../../../utils';
 import { isPluginInstalled } from '../../../utils/plugin-utils';
 
-const { setupShortcodeCheckout, fillCreditCardDetailsShortcode } = payments;
+const {
+	setupShortcodeCheckout,
+	fillCreditCardDetailsShortcode,
+	clickAddToCartButton,
+} = payments;
 
 let productId;
 
@@ -28,7 +32,7 @@ test( 'customer can purchase a pre-order product @pre-orders', async ( {
 	page,
 } ) => {
 	await page.goto( `?p=${ productId }` );
-	await page.locator( 'button[name="add-to-cart"]' ).click();
+	await clickAddToCartButton( page, 'Pre-order now' );
 
 	const randomString = randomUUID();
 	// Subscriptions will create an account for this checkout, we need a random email.

--- a/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/subscription-product.spec.js
@@ -3,7 +3,11 @@ import { randomUUID } from 'crypto';
 import config from 'config';
 import { api, payments, products } from '../../../utils';
 
-const { setupShortcodeCheckout, fillCreditCardDetailsShortcode } = payments;
+const {
+	setupShortcodeCheckout,
+	fillCreditCardDetailsShortcode,
+	clickAddToCartButton,
+} = payments;
 
 let productId;
 
@@ -19,7 +23,7 @@ test( 'customer can purchase a subscription product @smoke @subscriptions', asyn
 	page,
 } ) => {
 	await page.goto( `?p=${ productId }` );
-	await page.locator( 'button[name="add-to-cart"]' ).click();
+	await clickAddToCartButton( page );
 
 	const randomString = randomUUID();
 	// Subscriptions will create an account for this checkout, we need a random email.
@@ -34,7 +38,7 @@ test( 'customer can purchase a subscription product @smoke @subscriptions', asyn
 	await setupShortcodeCheckout( page, customerData );
 	await fillCreditCardDetailsShortcode( page, config.get( 'cards.basic' ) );
 
-	await page.locator( 'text=Add to cart' ).click();
+	await page.locator( 'text=Place order' ).click();
 	await page.waitForURL( '**/checkout/order-received/**' );
 
 	await expect( page.locator( 'h1.entry-title' ) ).toHaveText(

--- a/tests/e2e/tests/express-checkout/express-checkout.spec.js
+++ b/tests/e2e/tests/express-checkout/express-checkout.spec.js
@@ -1,15 +1,13 @@
-const { test, expect } = require( '@playwright/test' );
+import { test, expect } from '@playwright/test';
+import { payments } from '../../utils';
+
+const { clickAddToCartButton } = payments;
 
 const addProductToCart = async ( page, productSlug = 'beanie' ) => {
 	// Add a product to the cart
 	await page.goto( `/product/${ productSlug }` );
 
-	const addToCartButton = await page.getByRole( 'button', {
-		name: 'Add to cart',
-		exact: true, // Needs to be exact, as there are other "Add to cart" buttons for other products in WooCommerce 10.1.
-	} );
-	await expect( addToCartButton ).toBeEnabled();
-	await addToCartButton.dispatchEvent( 'click' );
+	await clickAddToCartButton( page );
 
 	// Wait for the cart update to complete - look for success message or cart count update
 	await expect(

--- a/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
+++ b/tests/e2e/tests/subscriptions/subscription-renewal.spec.js
@@ -3,7 +3,11 @@ import { randomUUID } from 'crypto';
 import config from 'config';
 import { api, payments, products, user } from '../../utils';
 
-const { setupShortcodeCheckout, fillCreditCardDetailsShortcode } = payments;
+const {
+	setupShortcodeCheckout,
+	fillCreditCardDetailsShortcode,
+	clickAddToCartButton,
+} = payments;
 
 let productId;
 let username, userEmail;
@@ -43,7 +47,7 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 
 	await test.step( 'customer purchase a subscription product', async () => {
 		await page.goto( `?p=${ productId }` );
-		await page.locator( 'button[name="add-to-cart"]' ).click();
+		await clickAddToCartButton( page );
 
 		await setupShortcodeCheckout( page );
 		await fillCreditCardDetailsShortcode(
@@ -51,7 +55,7 @@ test( 'customer can renew a subscription @smoke @subscriptions', async ( {
 			config.get( 'cards.basic' )
 		);
 
-		await page.locator( 'text=Add to cart' ).click();
+		await page.locator( 'text=Place order' ).click();
 
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
 			'Order received'

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -2,6 +2,20 @@ import { expect } from '@playwright/test';
 import config from 'config';
 
 /**
+ * Click the primary add to cart button for the current page.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @returns {Locator} Playwright locator for the add to cart button.
+ */
+export async function clickAddToCartButton( page, label = 'Add to cart' ) {
+	const addToCartButton = await page
+		.getByRole( 'button', { name: label, exact: true } )
+		.first();
+	await expect( addToCartButton ).toBeEnabled();
+	await addToCartButton.click();
+}
+
+/**
  * Empty the WC cart.
  * @param {Page} page Playwright page fixture.
  */

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -4,8 +4,8 @@ import config from 'config';
 /**
  * Click the primary add to cart button for the current page.
  *
- * @param {Page} page Playwright page fixture.
- * @returns {Locator} Playwright locator for the add to cart button.
+ * @param {Page}   page  Playwright page fixture.
+ * @param {string} label The expected text for the "Add to cart" button.
  */
 export async function clickAddToCartButton( page, label = 'Add to cart' ) {
 	const addToCartButton = await page


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR implements a new `clickAddToCartButton()` helper method to make it simpler for e2e tests to semantically state that they want to click that button. The reason for the new helper is because WooCommerce 10.1 displays multiple buttons on the page with "Add to cart" in the text (or whatever the custom button text is for the product type, like "Pre-order now" for pre-orders). By using a central helper, we can make that logic consistent and avoid unnecessary code duplication, particularly because most tests are focused on the behaviour in checkout _after_ the product has been added to the cart.

This PR also updates the text for WooCommerce Subscriptions purchases, as the checkout button label was changed in 7.8.1, which was released in the last 24 hours.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Verify that the default e2e tests succeed
* If you want to test these locally, you should do the following:
  - Check out this branch: `git checkout fix/e2e-tests-with-multiple-add-to-cart-buttons`
  - Rebuild the JS: `npm run build`
  - Re-initialize your e2e configuration: `npm run test:e2e-cleanup && npm run test:e2e-setup`
  - Run the modified tests: `npm run test:e2e '.*(subscription|pre-order).*'`
  - Verify that they all pass

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)