### PR TITLE
Fix multiple PHP warnings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -33,6 +33,7 @@
 * Update - Add nightly task and WooCommerce tool to remove stale entries from our database cache
 * Dev - Make 'Add to cart' more robust in e2e tests
 * Dev - Ensure e2e tests enable or disable Optimized Checkout during setup
+* Fix - Fix some PHP warnings
 
 = 9.8.1 - 2025-08-15 =
 * Fix - Remove connection type requirement from PMC sync migration attempt

--- a/includes/admin/class-wc-rest-stripe-account-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-controller.php
@@ -116,7 +116,7 @@ class WC_REST_Stripe_Account_Controller extends WC_Stripe_REST_Base_Controller {
 		// Use statement descriptor from settings, falling back to Stripe account statement descriptor if needed.
 		$statement_descriptor = WC_Stripe_Helper::clean_statement_descriptor( $this->gateway->get_option( 'statement_descriptor' ) );
 		if ( empty( $statement_descriptor ) ) {
-			$statement_descriptor = $account['settings']['payments']['statement_descriptor'];
+			$statement_descriptor = $account['settings']['payments']['statement_descriptor'] ?? null;
 		}
 		if ( empty( $statement_descriptor ) ) {
 			$statement_descriptor = null;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
@@ -215,6 +215,11 @@ class WC_Stripe_Express_Checkout_Custom_Fields {
 			$classic_custom_checkout_fields = [];
 			$standard_checkout_fields       = $this->get_standard_checkout_fields();
 			$all_fields                     = WC()->checkout()->get_checkout_fields();
+
+			if ( empty( $all_fields ) ) {
+				return $classic_custom_checkout_fields;
+			}
+
 			foreach ( $all_fields as $fieldset => $fields ) {
 				foreach ( $fields as $field_key => $field ) {
 					if ( in_array( $field_key, $standard_checkout_fields, true ) ) {

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -193,10 +193,14 @@ class WC_Stripe_Express_Checkout_Element {
 	 * @return array  The settings used for the Stripe express checkout element in JavaScript.
 	 */
 	public function javascript_params() {
+		$publishable_key = WC_Stripe_Mode::is_test()
+			? ( $this->stripe_settings['test_publishable_key'] ?? '' )
+			: ( $this->stripe_settings['publishable_key'] ?? '' );
+
 		return [
 			'ajax_url'                   => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 			'stripe'                     => [
-				'publishable_key'             => WC_Stripe_Mode::is_test() ? $this->stripe_settings['test_publishable_key'] : $this->stripe_settings['publishable_key'],
+				'publishable_key'             => $publishable_key,
 				'allow_prepaid_card'          => apply_filters( 'wc_stripe_allow_prepaid_card', true ) ? 'yes' : 'no',
 				'locale'                      => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
 				'is_link_enabled'             => $this->express_checkout_helper->is_link_enabled(),

--- a/readme.txt
+++ b/readme.txt
@@ -143,5 +143,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Add nightly task and WooCommerce tool to remove stale entries from our database cache
 * Dev - Make 'Add to cart' more robust in e2e tests
 * Dev - Ensure e2e tests enable or disable Optimized Checkout during setup
+* Fix - Fix some PHP warnings
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR fixes three code locations that can generate warnings in at least some cases. They definitely feel like edge cases, but we can make our code more robust regardless. The three fixes are as follows:
 * In the code responsible for building data for Javascript execution, we are now protecting against the case where no publishable keys are present
   - It's worth noting that the fallback value for this case is `''` rather than null, as the client code uses `''` as the fallback value at present (based on [this code](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/671721f51a73bfdc5605b74e0543472fa0f797b7/client/data/account-keys/hooks.js#L84))
 * In the code responsible for finding custom checkout fields, we detect when there aren't any checkout fields to process
 * In the code responsible for getting the statement descriptor, we now handle the case where we don't have the expected account data

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

In general, inspection should be sufficient, as the code changes are pretty small and add explicit fallback values for array accesses.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
