### PR TITLE
Adding the PMC enabled info to BNPL debug metadata

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.9.0 - xxxx-xx-xx =
+* Dev - Adds PMC setting information to the Payment Intent object metadata
 * Dev - Upgrades the Webpack-related packages
 * Dev - Adds debug information to the Payment Intent object metadata
 * Dev - Upgrade the cross-env and rimraf NPM packages; remove chromedriver NPM dependency

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2190,7 +2190,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			[
 				'is_legacy_checkout_enabled' => ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 				'is_oc_enabled'              => $this->is_oc_enabled(),
-				'pmc_enabled'                => 'yes' === $this->get_option( 'pmc_enabled' ),
+				'pmc_enabled'                => $this->get_option( 'pmc_enabled' ),
 			]
 		);
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2190,6 +2190,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			[
 				'is_legacy_checkout_enabled' => ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
 				'is_oc_enabled'              => $this->is_oc_enabled(),
+				'pmc_enabled'                => 'yes' === $this->get_option( 'pmc_enabled' ),
 			]
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.9.0 - xxxx-xx-xx =
+* Dev - Adds PMC setting information to the Payment Intent object metadata
 * Dev - Upgrades the Webpack-related packages
 * Dev - Adds debug information to the Payment Intent object metadata
 * Dev - Upgrade the cross-env and rimraf NPM packages; remove chromedriver NPM dependency

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -303,6 +303,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			'tax_amount'                 => WC_Stripe_Helper::get_stripe_amount( $total_tax, strtolower( $currency ) ),
 			'is_legacy_checkout_enabled' => false,
 			'is_oc_enabled'              => false,
+			'pmc_enabled'                => 'no',
 		];
 		return [ $amount, $description, $metadata, strtolower( $currency ) ];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4647#issuecomment-3257925517

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR just adds the `pmc_enabled` metadata to payment intents. The goal is to make it easier to debug when BNPLs are not showing up, allowing us to look directly in the Stripe dashboard instead of relying on the system status report.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`dev/add-pmc-enabled-info-to-bnpl-debug-metada`)
- Connect your Stripe account
- As a shopper, add any product to your cart
- Go to any checkout page and complete the purchase
- Go to your Stripe dashboard, inspect the new transaction and confirm the new metadata key is there (`pmc_enabled`)

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
