### PR TITLE
Normalise intent metadata values to yes/no/null

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@
 * Dev - Ensure e2e tests enable or disable Optimized Checkout during setup
 * Fix - Fix some PHP warnings
 * Dev - Consolidate component used for unavailable payment methods
+* Dev - Normalize intent metadata to yes/no/null values
 
 = 9.8.1 - 2025-08-15 =
 * Fix - Remove connection type requirement from PMC sync migration attempt

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2185,12 +2185,16 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	public function add_bnpl_debug_metadata( $metadata, $order ) {
 		// The following parameters are used to debug BNPL display issues.
+		$pmc_enabled = $this->get_option( 'pmc_enabled', 'null' );
+		if ( ! is_string( $pmc_enabled ) ) {
+			$pmc_enabled = $pmc_enabled ? 'yes' : 'no';
+		}
 		return array_merge(
 			$metadata,
 			[
-				'is_legacy_checkout_enabled' => ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
-				'is_oc_enabled'              => $this->is_oc_enabled(),
-				'pmc_enabled'                => $this->get_option( 'pmc_enabled' ),
+				'is_legacy_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ? 'no' : 'yes',
+				'is_oc_enabled'              => $this->is_oc_enabled() ? 'yes' : 'no',
+				'pmc_enabled'                => $pmc_enabled,
 			]
 		);
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -150,5 +150,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Ensure e2e tests enable or disable Optimized Checkout during setup
 * Fix - Fix some PHP warnings
 * Dev - Consolidate component used for unavailable payment methods
+* Dev - Normalize intent metadata to yes/no/null values
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3131,9 +3131,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			$this->mock_gateway->settings['pmc_enabled'] = $pmc_enabled;
 		}
 
-		$mock_upe_enabled = function () use ( $upe_enabled ) {
-			return $upe_enabled;
-		};
+		$mock_upe_enabled = $upe_enabled ? '__return_true' : '__return_false';
 		add_filter( 'wc_stripe_is_upe_checkout_enabled', $mock_upe_enabled, 999 );
 
 		$order = WC_Helper_Order::create_order();

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -301,8 +301,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			'payment_type'               => 'single',
 			'signature'                  => sprintf( '%d:%s', $order->get_id(), md5( implode( '-', [ absint( $order->get_id() ), $order->get_order_key(), $order->get_customer_id(), $amount ] ) ) ),
 			'tax_amount'                 => WC_Stripe_Helper::get_stripe_amount( $total_tax, strtolower( $currency ) ),
-			'is_legacy_checkout_enabled' => false,
-			'is_oc_enabled'              => false,
+			'is_legacy_checkout_enabled' => 'no',
+			'is_oc_enabled'              => 'no',
 			'pmc_enabled'                => 'no',
 		];
 		return [ $amount, $description, $metadata, strtolower( $currency ) ];
@@ -3086,5 +3086,78 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	public function test_get_payment_method_instance() {
 		$actual = $this->mock_gateway->get_payment_method_instance( WC_Stripe_Payment_Methods::CARD );
 		$this->assertInstanceOf( WC_Stripe_UPE_Payment_Method_CC::class, $actual );
+	}
+
+	/**
+	 * Data provider for {@see test_add_bnpl_debug_metadata()}.
+	 */
+	public function provide_test_add_bnpl_debug_metadata(): array {
+		return [
+			'All disabled)' => [
+				'upe_enabled' => false,
+				'oc_enabled'  => false,
+				'pmc_enabled' => false,
+			],
+			'All disabled with null pmc_enabled' => [
+				'upe_enabled' => false,
+				'oc_enabled'  => false,
+				'pmc_enabled' => null,
+			],
+			'All enabled' => [
+				'upe_enabled' => true,
+				'oc_enabled'  => true,
+				'pmc_enabled' => true,
+			],
+		];
+	}
+
+	/**
+	 * Test for `add_bnpl_debug_metadata`.
+	 *
+	 * @dataProvider provide_test_add_bnpl_debug_metadata
+	 * @param bool $upe_enabled Whether the UPE feature flag is enabled.
+	 * @param bool $oc_enabled Whether the OC feature is enabled.
+	 * @param bool|null $pmc_enabled Whether the PMC feature is enabled, disabled, or not specified.
+	 * @return void
+	 */
+	public function test_add_bnpl_debug_metadata( bool $upe_enabled, bool $oc_enabled, ?bool $pmc_enabled = null ) {
+		$init_oc_enabled  = $this->mock_gateway->oc_enabled;
+		$init_pmc_enabled = $this->mock_gateway->settings['pmc_enabled'] ?? null;
+
+		$this->mock_gateway->oc_enabled = $oc_enabled;
+		if ( null === $pmc_enabled ) {
+			unset( $this->mock_gateway->settings['pmc_enabled'] );
+		} else {
+			$this->mock_gateway->settings['pmc_enabled'] = $pmc_enabled;
+		}
+
+		$mock_upe_enabled = function () use ( $upe_enabled ) {
+			return $upe_enabled;
+		};
+		add_filter( 'wc_stripe_is_upe_checkout_enabled', $mock_upe_enabled, 999 );
+
+		$order = WC_Helper_Order::create_order();
+
+		$result = apply_filters( 'wc_stripe_intent_metadata', [], $order );
+
+		// Reset all variables and filters.
+		remove_filter( 'wc_stripe_is_upe_checkout_enabled', $mock_upe_enabled, 999 );
+		$this->mock_gateway->oc_enabled = $init_oc_enabled;
+		if ( null === $init_pmc_enabled ) {
+			unset( $this->mock_gateway->settings['pmc_enabled'] );
+		} else {
+			$this->mock_gateway->settings['pmc_enabled'] = $init_pmc_enabled ? 'yes' : 'no';
+		}
+
+		$this->assertArrayHasKey( 'is_legacy_checkout_enabled', $result );
+		$this->assertEquals( $upe_enabled ? 'no' : 'yes', $result['is_legacy_checkout_enabled'] );
+		$this->assertArrayHasKey( 'is_oc_enabled', $result );
+		$this->assertEquals( $oc_enabled ? 'yes' : 'no', $result['is_oc_enabled'] );
+		$this->assertArrayHasKey( 'pmc_enabled', $result );
+		if ( null === $pmc_enabled ) {
+			$this->assertEquals( 'null', $result['pmc_enabled'] );
+		} else {
+			$this->assertEquals( $pmc_enabled ? 'yes' : 'no', $result['pmc_enabled'] );
+		}
 	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3093,7 +3093,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 */
 	public function provide_test_add_bnpl_debug_metadata(): array {
 		return [
-			'All disabled)' => [
+			'All disabled' => [
 				'upe_enabled' => false,
 				'oc_enabled'  => false,
 				'pmc_enabled' => false,


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to:
 * https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4647
 * https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4650

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates the logging from https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4647 and https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4650 to ensure we log either `'yes'`, `'no'`, or `'null'` for the intent metadata values that were added by those PRs, as well as adding some light unit tests to ensure we're normalising the values as expected.

This PR implements [this suggestion](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4650#pullrequestreview-3195509923) from @Mayisha so we can get consistent and easier-to-query values in the data.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Check out and build this branch on your test environment - `git checkout update/format-for-custom-intent-meta-fields && npm run build`
* Connect your Stripe account
* As a shopper, add any product to your cart
* Go to any checkout page and complete the purchase
* Go to your Stripe dashboard, inspect the new transaction and confirm all three metadata keys are present and have either `'yes'`, `'no'`, or `'null'` as their value (though only `pmc_enabled` may have `'null'` as a value).
 * Feel free to manually modify any of the following values/options to get different behaviour:
   - Add a filter that disables UPE: `add_filter( 'wc_stripe_is_upe_checkout_enabled', '__return_false', 999 );`
   - Toggle Optimized Checkout via the Stripe settings UI
   - Manually modify the `pmc_enabled` subsetting:
     - `wp option patch update pmc_enabled no`
     - `wp option patch update pmc_enabled yes`
     - Deleting the option will simply re-try the PMC checks, so it won't be an effective test, though the unit tests do cover this case.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
