### PR TITLE
Avoid instantiating WC_Payment_Gateways too early

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Dev - Removes three unused NPM script commands: `test`, `test:grep`, and `test:single`
 * Dev - Upgrades the Babel-related packages
 * Dev - Consolidate component used for unavailable payment methods
+* Fix - Avoid instantiating WC_Payment_Gateways too early when checking for Klarna and Affirm plugins
 
 = 9.9.0 - 2025-09-08 =
 * Dev - Adds PMC setting information to the Payment Intent object metadata

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -288,7 +288,7 @@ class WC_Stripe {
 		// Check for payment methods that should be toggled, e.g. unreleased,
 		// BNPLs when official plugins are active,
 		// cards when the Optimized Checkout is enabled, etc.
-		add_action( 'init', [ $this, 'maybe_toggle_payment_methods' ] );
+		add_action( 'wc_payment_gateways_initialized', [ $this, 'maybe_toggle_payment_methods' ] );
 
 		add_action( WC_Stripe_Database_Cache::ASYNC_CLEANUP_ACTION, [ WC_Stripe_Database_Cache::class, 'delete_all_stale_entries_async' ], 10, 2 );
 		add_action( 'action_scheduler_run_recurring_actions_schedule_hook', [ WC_Stripe_Database_Cache::class, 'maybe_schedule_daily_async_cleanup' ], 10, 0 );

--- a/readme.txt
+++ b/readme.txt
@@ -118,5 +118,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Removes three unused NPM script commands: `test`, `test:grep`, and `test:single`
 * Dev - Upgrades the Babel-related packages
 * Dev - Consolidate component used for unavailable payment methods
+* Fix - Avoid instantiating WC_Payment_Gateways too early when checking for Klarna and Affirm plugins
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-710

## Changes proposed in this Pull Request:

h/t @shohanhossainnab for the analysis 🕵️‍♂️ 

When we check whether Klarna or Affirm official plugins are active on `init`, we call `WC()->payment_gateways->payment_gateways()`, which instantiates the `WC_Payment_Gateways` class and loads and caches payment gateways. This can cause other payment plugins to hook in too late into the `woocommerce_payment_gateways` filter.

This PR moves the check from `init` to `wc_payment_gateways_initialized`, to make sure we are not triggering the initialization of payment gateways, but merely responding to the event.

## Testing instructions
1. Install and activate Angell EYE's WooCommerce for PayPal: https://github.com/angelleye/paypal-woocommerce/releases
2. Install, activate and enable the official Klarna plugin: https://wordpress.org/plugins/klarna-payments-for-woocommerce/
3. Go to your Stripe dashboard PMC, and enable Klarna and Affirm.
4. Delete your PMC cache: `wp option delete wcstripe_cache_test_payment_method_configuration`
6. Go to WooCommerce > Settings > Payments (refresh, if necessary).
   - In `develop`, notice that Angell EYE's WooCommerce for PayPal doesn't appear in the list of gateways.
   - In this branch, you will see all their gateways/payment methods -- there are a lot.
7. Go back to your Stripe dashboard PMC, and notice that Klarna has been disabled but Affirm is still enabled.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
