### PR TITLE
Fix fatal error caused by type mismatch

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Dev - Removes three unused NPM script commands: `test`, `test:grep`, and `test:single`
 * Dev - Upgrades the Babel-related packages
 * Dev - Consolidate component used for unavailable payment methods
+* Fix - Fatal error caused by type mismatch when processing webhooks
 
 = 9.9.0 - 2025-09-08 =
 * Dev - Adds PMC setting information to the Payment Intent object metadata

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1470,6 +1470,9 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	private function run_webhook_received_action( string $webhook_type, object $notification ): void {
 		try {
+			// Ensure we have an order or null.
+			$resolved_order = $this->resolved_order ? $this->resolved_order : null;
+
 			/**
 			 * Fires after a webhook has been processed, but before we respond to Stripe.
 			 * This allows for custom processing of the webhook after it has been processed.
@@ -1482,7 +1485,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			 * @param object $notification The webhook data sent from Stripe.
 			 * @param WC_Order|null $order The order being processed by the webhook.
 			 */
-			do_action( 'wc_stripe_webhook_received', $webhook_type, $notification, $this->resolved_order );
+			do_action( 'wc_stripe_webhook_received', $webhook_type, $notification, $resolved_order );
 		} catch ( Throwable $e ) {
 			WC_Stripe_Logger::error( 'Error in wc_stripe_webhook_received action: ' . $e->getMessage(), [ 'error' => $e ] );
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -721,17 +721,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
+			WC_Stripe_Logger::debug( 'Could not find order via refund ID: ' . $refund_object->id );
 			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
+		}
+
+		if ( ! $order ) {
+			WC_Stripe_Logger::warning( "Could not find order via refund ID ({$refund_object->id}) or charge ID ({$notification->data->object->id})" );
+			return;
 		}
 
 		// Set the order being processed for the `wc_stripe_webhook_received` action later.
 		$this->resolved_order = $order;
-
-		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
-			return;
-		}
 
 		$order_id = $order->get_id();
 
@@ -1470,9 +1470,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	private function run_webhook_received_action( string $webhook_type, object $notification ): void {
 		try {
-			// Ensure we have an order or null.
-			$resolved_order = $this->resolved_order ? $this->resolved_order : null;
-
 			/**
 			 * Fires after a webhook has been processed, but before we respond to Stripe.
 			 * This allows for custom processing of the webhook after it has been processed.
@@ -1485,7 +1482,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			 * @param object $notification The webhook data sent from Stripe.
 			 * @param WC_Order|null $order The order being processed by the webhook.
 			 */
-			do_action( 'wc_stripe_webhook_received', $webhook_type, $notification, $resolved_order );
+			do_action( 'wc_stripe_webhook_received', $webhook_type, $notification, $this->resolved_order );
 		} catch ( Throwable $e ) {
 			WC_Stripe_Logger::error( 'Error in wc_stripe_webhook_received action: ' . $e->getMessage(), [ 'error' => $e ] );
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1140,7 +1140,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$charge->is_webhook_response = true;
 					$this->process_response( $charge, $order );
 
-					$this->run_webhook_received_action( (string) $notification->type, $notification, $this->resolved_order );
+					$this->run_webhook_received_action( (string) $notification->type, $notification );
 				} else {
 					WC_Stripe_Logger::log( "Processing $notification->type ($intent->id) asynchronously for order $order_id." );
 
@@ -1322,7 +1322,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					break;
 			}
 
-			$this->run_webhook_received_action( (string) $webhook_type, $notification, $this->resolved_order );
+			$this->run_webhook_received_action( (string) $webhook_type, $notification );
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::log( 'Error processing deferred webhook: ' . $e->getMessage() );
 
@@ -1459,7 +1459,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			return;
 		}
 
-		$this->run_webhook_received_action( $notification->type, $notification, $this->resolved_order );
+		$this->run_webhook_received_action( $notification->type, $notification );
 	}
 
 	/**
@@ -1467,9 +1467,8 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 *
 	 * @param string $webhook_type The type of webhook that was processed.
 	 * @param object $notification The webhook data sent from Stripe.
-	 * @param WC_Order|null $order The order being processed by the webhook.
 	 */
-	private function run_webhook_received_action( string $webhook_type, object $notification, ?WC_Order $order = null ): void {
+	private function run_webhook_received_action( string $webhook_type, object $notification ): void {
 		try {
 			/**
 			 * Fires after a webhook has been processed, but before we respond to Stripe.

--- a/readme.txt
+++ b/readme.txt
@@ -118,5 +118,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Removes three unused NPM script commands: `test`, `test:grep`, and `test:single`
 * Dev - Upgrades the Babel-related packages
 * Dev - Consolidate component used for unavailable payment methods
+* Fix - Fatal error caused by type mismatch when processing webhooks
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->
Slack: p1757448726822629-slack-C055WHLA98D

## Changes proposed in this Pull Request:
This fixes the following fatal error

```
PHP Fatal error:  Uncaught TypeError: WC_Stripe_Webhook_Handler::run_webhook_received_action(): Argument #3 ($order) must be of type ?WC_Order, false given
```

`resolved_order` is given a `false` value, this doesn't match the type definition of the function parameter which causes the fatal error. `run_webhook_received_action` uses the `$this->resolved_order` directly instead of using the passed parameter, so in this PR we remove the parameter altogether.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
Code inspection should be sufficient
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)