### PR TITLE
Fix webhook handler action fatals

### DIFF
--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1470,9 +1470,6 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 	 */
 	private function run_webhook_received_action( string $webhook_type, object $notification ): void {
 		try {
-			// Ensure we have an order or null.
-			$resolved_order = $this->resolved_order ? $this->resolved_order : null;
-
 			/**
 			 * Fires after a webhook has been processed, but before we respond to Stripe.
 			 * This allows for custom processing of the webhook after it has been processed.
@@ -1485,7 +1482,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			 * @param object $notification The webhook data sent from Stripe.
 			 * @param WC_Order|null $order The order being processed by the webhook.
 			 */
-			do_action( 'wc_stripe_webhook_received', $webhook_type, $notification, $resolved_order );
+			do_action( 'wc_stripe_webhook_received', $webhook_type, $notification, $this->resolved_order );
 		} catch ( Throwable $e ) {
 			WC_Stripe_Logger::error( 'Error in wc_stripe_webhook_received action: ' . $e->getMessage(), [ 'error' => $e ] );
 		}

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -721,17 +721,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		$order         = WC_Stripe_Helper::get_order_by_refund_id( $refund_object->id );
 
 		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via refund ID: ' . $refund_object->id );
+			WC_Stripe_Logger::debug( 'Could not find order via refund ID: ' . $refund_object->id );
 			$order = WC_Stripe_Helper::get_order_by_charge_id( $notification->data->object->id );
+		}
+
+		if ( ! $order ) {
+			WC_Stripe_Logger::warning( "Could not find order via refund ID ({$refund_object->id}) or charge ID ({$notification->data->object->id})" );
+			return;
 		}
 
 		// Set the order being processed for the `wc_stripe_webhook_received` action later.
 		$this->resolved_order = $order;
-
-		if ( ! $order ) {
-			WC_Stripe_Logger::log( 'Could not find order via charge ID: ' . $notification->data->object->id );
-			return;
-		}
 
 		$order_id = $order->get_id();
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR addresses the root cause of the type mismatch being addressed in #4660, which occurs because we were setting `$this->resolved_order` to a value before checking it when handling `charge.refund` webhooks. The specific issue occurred when we can't identify the order for the refund, as we hit a situation where we set `$this->resolved_order` and then return. The PR simply changes the order of operations so we return early when we don't find an order.

As a follow-up, this PR also removes the normalisation logic I pushed into #4660 in 4608e5269198c392debc4024dcd7e79c3a65e2ba, as we should now have no situations where we have `false` as a value.

The PR also tweaks the logging slightly:
 * When we fail to identify the order based on the refund ID, we now call the `debug()` method instead of the deprecated `log()` method on the `WC_Stripe_Logger` class
 * When we also fail to identify the order based on the charge ID, we now call the `warning()` method and include both the refund ID and the charge ID in the log message.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
This is a particularly tricky one to test, and the change is really meant to build on top of #4660. I _think_ inspection should be sufficient.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This PR is intended to be folded into #4660, so that PR should contain our changelog.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
