### PR TITLE
Add extra guard in saved payment method filter

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Fix - Fix subscription renewal error caused by passing both mandate ID and mandate data
 * Fix - Avoid instantiating WC_Payment_Gateways too early when checking for Klarna and Affirm plugins
 * Fix - Fatal error caused by type mismatch when processing webhooks
+* Fix - Prevent type collisions for saved payment methods
 
 = 9.9.0 - 2025-09-08 =
 * Dev - Adds PMC setting information to the Payment Intent object metadata

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -410,6 +410,11 @@ class WC_Stripe_Payment_Tokens {
 	 * @return array $item Modified list item.
 	 */
 	public function get_account_saved_payment_methods_list_item( $item, $payment_token ) {
+		// If this isn't a Stripe payment token, take no action.
+		if ( ! $payment_token instanceof WC_Stripe_Payment_Method_Comparison_Interface ) {
+			return $item;
+		}
+
 		switch ( strtolower( $payment_token->get_type() ) ) {
 			case WC_Stripe_Payment_Methods::SEPA:
 				$item['method']['last4'] = $payment_token->get_last4();

--- a/readme.txt
+++ b/readme.txt
@@ -122,5 +122,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix subscription renewal error caused by passing both mandate ID and mandate data
 * Fix - Avoid instantiating WC_Payment_Gateways too early when checking for Klarna and Affirm plugins
 * Fix - Fatal error caused by type mismatch when processing webhooks
+* Fix - Prevent type collisions for saved payment methods
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentTokens/WC_Stripe_Payment_Tokens_Test.php
+++ b/tests/phpunit/PaymentTokens/WC_Stripe_Payment_Tokens_Test.php
@@ -305,4 +305,135 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 			],
 		];
 	}
+
+	/**
+	 * Data provider for {@see test_get_account_saved_payment_methods_list_item()}.
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_account_saved_payment_methods_list_item(): array {
+		$mock_sepa_collision_token = $this->getMockBuilder( WC_Payment_Token_CC::class )->getMock();
+
+		$mock_sepa_collision_token->method( 'get_type' )->willReturn( WC_Stripe_Payment_Methods::SEPA );
+
+		$sepa_token = new \WC_Payment_Token_SEPA();
+		$sepa_token->set_last4( '1234' );
+
+		$bacs_debit_token = new \WC_Payment_Token_Bacs_Debit();
+		$bacs_debit_token->set_last4( '2345' );
+
+		$ach_token = new \WC_Payment_Token_ACH();
+		$ach_token->set_last4( '3456' );
+		$ach_token->set_bank_name( 'Test ACH Bank' );
+
+		$acss_token = new \WC_Payment_Token_ACSS();
+		$acss_token->set_last4( '4567' );
+		$acss_token->set_bank_name( 'Test ACSS Bank' );
+
+		$becs_debit_token = new \WC_Payment_Token_Becs_Debit();
+		$becs_debit_token->set_last4( '5678' );
+
+		$link_token = new \WC_Payment_Token_Link();
+		$link_token->set_email( 'link.test@example.com' );
+
+		$amazon_pay_token = new \WC_Payment_Token_Amazon_Pay();
+		$amazon_pay_token->set_email( 'amazon.test@example.com' );
+
+		return [
+			'Non-Stripe payment token' => [
+				'payment_token'   => new \WC_Payment_Token_CC(),
+				'expected_result' => [],
+			],
+			'Non-Stripe payment token with SEPA type collision' => [
+				'payment_token'   => $mock_sepa_collision_token,
+				'expected_result' => [],
+			],
+			'Stripe payment token with unhandled type' => [
+				'payment_token'   => new \WC_Stripe_Payment_Token_CC(),
+				'expected_result' => [],
+			],
+			'SEPA token' => [
+				'payment_token'   => $sepa_token,
+				'expected_result' => [
+					'last4' => '1234',
+					'brand' => 'SEPA IBAN',
+				],
+			],
+			'BACS Debit token' => [
+				'payment_token'   => $bacs_debit_token,
+				'expected_result' => [
+					'last4' => '2345',
+					'brand' => 'Bacs Direct Debit',
+				],
+			],
+			'CashApp token' => [
+				'payment_token'   => new \WC_Payment_Token_CashApp(),
+				'expected_result' => [
+					'brand' => 'Cash App Pay',
+				],
+			],
+			'ACH token' => [
+				'payment_token'   => $ach_token,
+				'expected_result' => [
+					'last4' => '3456',
+					'brand' => 'Test ACH Bank',
+				],
+			],
+			'ACSS token' => [
+				'payment_token'   => $acss_token,
+				'expected_result' => [
+					'last4' => '4567',
+					'brand' => 'Test ACSS Bank',
+				],
+			],
+			'BECS Debit token' => [
+				'payment_token'   => $becs_debit_token,
+				'expected_result' => [
+					'last4' => '5678',
+					'brand' => 'BECS Direct Debit',
+				],
+			],
+			'Link token' => [
+				'payment_token'   => $link_token,
+				'expected_result' => [
+					'brand' => 'Stripe Link (link.test@example.com)',
+				],
+			],
+			'Amazon Pay token' => [
+				'payment_token'   => $amazon_pay_token,
+				'expected_result' => [
+					'brand' => 'Amazon Pay (amazon.test@example.com)',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test `get_account_saved_payment_methods_list_item()`.
+	 *
+	 * @param WC_Payment_Token $payment_token   Payment token.
+	 * @param array            $expected_result Expected result.
+	 * @return void
+	 * @dataProvider provide_test_get_account_saved_payment_methods_list_item
+	 */
+	public function test_get_account_saved_payment_methods_list_item( WC_Payment_Token $payment_token, array $expected_result ): void {
+		$initial_item = [
+			'method' => [],
+		];
+
+		$result = $this->stripe_payment_tokens->get_account_saved_payment_methods_list_item( $initial_item, $payment_token );
+
+		if ( [] === $expected_result ) {
+			$this->assertEquals( $expected_result, $result['method'] );
+			$this->assertEquals( $initial_item, $result );
+			return;
+		}
+
+		$this->assertCount( count( $expected_result ), $expected_result );
+
+		foreach ( $expected_result as $expected_key => $expected_value ) {
+			$this->assertArrayHasKey( $expected_key, $result['method'] );
+			$this->assertEquals( $expected_value, $result['method'][ $expected_key ] );
+		}
+	}
 }

--- a/tests/phpunit/PaymentTokens/WC_Stripe_Payment_Tokens_Test.php
+++ b/tests/phpunit/PaymentTokens/WC_Stripe_Payment_Tokens_Test.php
@@ -429,7 +429,7 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 			return;
 		}
 
-		$this->assertCount( count( $expected_result ), $expected_result );
+		$this->assertCount( count( $expected_result ), $result['method'] );
 
 		foreach ( $expected_result as $expected_key => $expected_value ) {
 			$this->assertArrayHasKey( $expected_key, $result['method'] );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to #4658

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR implements a guard that ensures we are operating on a token specific to the Stripe plugin in `WC_Stripe_Payment_Tokens->get_account_saved_payment_methods_list_item()`, which is hooked into the `woocommerce_payment_methods_list_item` filter from WooCommerce core. The specific guard is to check whether the token is an instance of `WC_Stripe_Payment_Method_Comparison_Interface`, our interface for comparing tokens and payment methods.
* If an incoming token doesn't implement the interface, we return from the method without taking any action.
* Otherwise we proceed as we did before.

The change ensures that if another saved payment method returns a type value from `get_type()` that matches one of our known values, we don't assume it implements the methods we are calling in the code.

The PR also adds unit tests to validate this behaviour.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

### Concerns/Questions

We _could_ also check whether `$payment_token->get_gateway_id()` matches the Stripe gateway ID, but that feels like it would be a much weaker check.
Alternatively, we could implement more specific `instanceof` checks for specific classes instead of the type checks, but I think the current implementation feels a bit cleaner. That said, the current approach requires us to implement the `WC_Stripe_Payment_Method_Comparison_Interface` interface for all of our token classes.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

The unit tests mostly cover the changes. I don't think we need additional testing, nor am I sure how we'd test this beyond confirming that My Account -> Payment Methods continues to work when Stripe and non-Stripe saved payment methods exist.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
