### PR TITLE
Upgrading the WC dependency extraction package

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.10.0 - xxxx-xx-xx =
+* Dev - Upgrades  the @woocommerce/dependency-extraction-webpack-plugin package
 * Dev - Renaming the Klarna payment token class to WC_Stripe_Klarna_Payment_Token
 * Dev - Upgrades Node to v20
 * Add - Allow the purchase of free trials using the Express Payment methods when the product does not require shipping

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@typescript-eslint/parser": "^6.21.0",
         "@woocommerce/currency": "^3.2.0",
         "@woocommerce/data": "^1.4.0",
-        "@woocommerce/dependency-extraction-webpack-plugin": "3.1.0",
+        "@woocommerce/dependency-extraction-webpack-plugin": "^4.0.0",
         "@woocommerce/eslint-plugin": "^2.2.0",
         "@woocommerce/navigation": "^6.1.0",
         "@woocommerce/woocommerce-rest-api": "^1.0.2",
@@ -7120,17 +7120,16 @@
       }
     },
     "node_modules/@woocommerce/dependency-extraction-webpack-plugin": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.1.0.tgz",
-      "integrity": "sha512-e/hOgJlLpisEqc0CjtNmK5eso1U4NaURIxFIgrH5AAFQbS1XN8BP6/SaTcWEfnNnoGqOSfn5p6hQFL6lz7OSrA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.0.0.tgz",
+      "integrity": "sha512-2vw9c9IsWhGPraEehkbzl8rmx1gArQ2PZQFVXj3LQ8Etgr/mM/hsxF/inG8+2bL7hFXYOtUYgwXuofLD2ozLxA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dependency-extraction-webpack-plugin": "^3.7.0"
+        "@wordpress/dependency-extraction-webpack-plugin": "next"
       },
       "engines": {
-        "node": "^20.11.1",
-        "pnpm": "9.1.3"
+        "node": "^20.11.1"
       }
     },
     "node_modules/@woocommerce/eslint-plugin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@typescript-eslint/parser": "^6.21.0",
         "@woocommerce/currency": "^3.2.0",
         "@woocommerce/data": "^1.4.0",
-        "@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
+        "@woocommerce/dependency-extraction-webpack-plugin": "3.1.0",
         "@woocommerce/eslint-plugin": "^2.2.0",
         "@woocommerce/navigation": "^6.1.0",
         "@woocommerce/woocommerce-rest-api": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "woocommerce-gateway-stripe",
-      "version": "9.9.0",
+      "version": "9.9.1",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
@@ -39,7 +39,7 @@
         "@typescript-eslint/parser": "^6.21.0",
         "@woocommerce/currency": "^3.2.0",
         "@woocommerce/data": "^1.4.0",
-        "@woocommerce/dependency-extraction-webpack-plugin": "^4.0.0",
+        "@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
         "@woocommerce/eslint-plugin": "^2.2.0",
         "@woocommerce/navigation": "^6.1.0",
         "@woocommerce/woocommerce-rest-api": "^1.0.2",
@@ -7120,16 +7120,17 @@
       }
     },
     "node_modules/@woocommerce/dependency-extraction-webpack-plugin": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.0.0.tgz",
-      "integrity": "sha512-2vw9c9IsWhGPraEehkbzl8rmx1gArQ2PZQFVXj3LQ8Etgr/mM/hsxF/inG8+2bL7hFXYOtUYgwXuofLD2ozLxA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@woocommerce/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-3.1.0.tgz",
+      "integrity": "sha512-e/hOgJlLpisEqc0CjtNmK5eso1U4NaURIxFIgrH5AAFQbS1XN8BP6/SaTcWEfnNnoGqOSfn5p6hQFL6lz7OSrA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/dependency-extraction-webpack-plugin": "next"
+        "@wordpress/dependency-extraction-webpack-plugin": "^3.7.0"
       },
       "engines": {
-        "node": "^20.11.1"
+        "node": "^20.11.1",
+        "pnpm": "9.1.3"
       }
     },
     "node_modules/@woocommerce/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@woocommerce/currency": "^3.2.0",
     "@woocommerce/data": "^1.4.0",
-    "@woocommerce/dependency-extraction-webpack-plugin": "^4.0.0",
+    "@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
     "@woocommerce/eslint-plugin": "^2.2.0",
     "@woocommerce/navigation": "^6.1.0",
     "@woocommerce/woocommerce-rest-api": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@woocommerce/currency": "^3.2.0",
     "@woocommerce/data": "^1.4.0",
-    "@woocommerce/dependency-extraction-webpack-plugin": "3.1.0",
+    "@woocommerce/dependency-extraction-webpack-plugin": "^4.0.0",
     "@woocommerce/eslint-plugin": "^2.2.0",
     "@woocommerce/navigation": "^6.1.0",
     "@woocommerce/woocommerce-rest-api": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@typescript-eslint/parser": "^6.21.0",
     "@woocommerce/currency": "^3.2.0",
     "@woocommerce/data": "^1.4.0",
-    "@woocommerce/dependency-extraction-webpack-plugin": "^3.1.0",
+    "@woocommerce/dependency-extraction-webpack-plugin": "3.1.0",
     "@woocommerce/eslint-plugin": "^2.2.0",
     "@woocommerce/navigation": "^6.1.0",
     "@woocommerce/woocommerce-rest-api": "^1.0.2",

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.10.0 - xxxx-xx-xx =
+* Dev - Upgrades  the @woocommerce/dependency-extraction-webpack-plugin package
 * Dev - Renaming the Klarna payment token class to WC_Stripe_Klarna_Payment_Token
 * Dev - Upgrades Node to v20
 * Add - Allow the purchase of free trials using the Express Payment methods when the product does not require shipping


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4670#discussion_r2348232421

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As requested by @daledupreez [here](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4670#discussion_r2348232421), I am upgrading the `@woocommerce/dependency-extraction-webpack-plugin` version here to the latest (working) available version.

I tried to use the actual latest version (4.0.0), but that broke our build script. I have then used the prior version instead (3.0.1).

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout to this branch on your test environment
- Confirm you can build the frontend files (`npm run build:webpack`)
- Confirm the frontend unit tests are still passing (`npm run test:js`)

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)

cc @daledupreez 