### PR TITLE
Fix warning in Klarna unit test

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 9.10.0 - xxxx-xx-xx =
+* Dev - Fixes a warning thrown when running Klarna payment token PHP Unit tests
 * Dev - Fixes some possible warnings shown in the browser console when the Optimized Checkout payment element is instantiated with invalid parameters
 * Dev - Renaming the Klarna payment token class to WC_Stripe_Klarna_Payment_Token
 * Fix - Minor fixes and code improvements for the saved payment methods comparison logic

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 9.10.0 - xxxx-xx-xx =
+* Dev - Fixes a warning thrown when running Klarna payment token PHP Unit tests
 * Dev - Fixes some possible warnings shown in the browser console when the Optimized Checkout payment element is instantiated with invalid parameters
 * Dev - Renaming the Klarna payment token class to WC_Stripe_Klarna_Payment_Token
 * Fix - Minor fixes and code improvements for the saved payment methods comparison logic

--- a/tests/phpunit/PaymentTokens/WC_Stripe_Klarna_Payment_Token_Test.php
+++ b/tests/phpunit/PaymentTokens/WC_Stripe_Klarna_Payment_Token_Test.php
@@ -86,7 +86,6 @@ class WC_Stripe_Klarna_Payment_Token_Test extends WP_UnitTestCase {
 		$this->assertTrue( $this->token->is_equal_payment_method( $payment_method ) );
 
 		// Different DOB.
-		$this->token->set_type( WC_Stripe_Payment_Methods::KLARNA );
 		$payment_method->id = 'pm_123';
 		$payment_method->klarna->dob->day = 2;
 		$this->assertFalse( $this->token->is_equal_payment_method( $payment_method ) );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

The setting of the `type` property for a payment token is deprecated. This is causing tests for the Klarna payment token to throw a warning message. In this PR, I am removing the unnecessary line in the test that is causing the issue.

Deprecated message:
<img width="1401" height="55" alt="Screenshot 2025-09-18 at 10 51 33" src="https://github.com/user-attachments/assets/1bd027bb-181d-4ffc-ab80-558462d61ad0" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review is enough. Check if the tests are still passing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
