### PR TITLE
Hardcoding ECE feature flag to be always enabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.0.0 - xxxx-xx-xx =
+* Update - Hardcodes the Express Checkout feature flag to be always enabled
 * Dev - Expands the Stripe Order Helper class to handle source ID, refund ID, intent ID, and setup intent ID metas
 * Update - Removing the `wc_stripe_is_upe_checkout_enabled` filter, as Legacy Checkout is no longer supported
 * Dev - Upgrades `jest` to version 29.7.0, `@wordpress/scripts` to 26.19.0, and adds `axios`(version 1.12.2) to the JavaScript development dependencies

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.0.0 - xxxx-xx-xx =
-* Update - Hardcodes the Express Checkout feature flag to be always enabled
+* Update - Disable Payment Request Buttons and ensure Express Checkout is used when express checkout buttons are enabled
 * Dev - Expands the Stripe Order Helper class to handle source ID, refund ID, intent ID, and setup intent ID metas
 * Update - Removing the `wc_stripe_is_upe_checkout_enabled` filter, as Legacy Checkout is no longer supported
 * Dev - Upgrades `jest` to version 29.7.0, `@wordpress/scripts` to 26.19.0, and adds `axios`(version 1.12.2) to the JavaScript development dependencies

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -13,7 +13,7 @@ class WC_Stripe_Feature_Flags {
 	 *
 	 * @var string
 	 *
-	 * @deprecated This feature flag will be removed in version 10.0.0. ECE will be permanently enabled.
+	 * @deprecated This feature flag will be removed in version 10.1.0. ECE will be permanently enabled.
 	 */
 	const ECE_FEATURE_FLAG_NAME = '_wcstripe_feature_ece';
 

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -5,8 +5,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_Stripe_Feature_Flags {
 	const UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME = 'upe_checkout_experience_enabled';
-	const ECE_FEATURE_FLAG_NAME               = '_wcstripe_feature_ece';
 	const AMAZON_PAY_FEATURE_FLAG_NAME        = '_wcstripe_feature_amazon_pay';
+
+	/**
+	 * Feature flag for Stripe ECE (Express Checkout Element).
+	 * This feature flag controls whether the new Express Checkout Element (ECE) or the legacy Payment Request Button (PRB) is used to render express checkout buttons.
+	 *
+	 * @var string
+	 *
+	 * @deprecated This feature flag will be removed in version 10.0.0. ECE will be permanently enabled.
+	 */
+	const ECE_FEATURE_FLAG_NAME = '_wcstripe_feature_ece';
 
 	/**
 	 * Feature flag for Optimized Checkout (OC).
@@ -25,7 +34,6 @@ class WC_Stripe_Feature_Flags {
 	 */
 	protected static $feature_flags = [
 		'_wcstripe_feature_upe'                => 'yes',
-		self::ECE_FEATURE_FLAG_NAME            => 'yes',
 		self::AMAZON_PAY_FEATURE_FLAG_NAME     => 'no',
 		self::OC_FEATURE_FLAG_NAME             => 'no',
 	];
@@ -65,9 +73,11 @@ class WC_Stripe_Feature_Flags {
 	 * Express checkout buttons are rendered with either ECE or PRB depending on this feature flag.
 	 *
 	 * @return bool
+	 *
+	 * @deprecated 10.0.0 ECE is always enabled. This method will be removed in a future release.
 	 */
 	public static function is_stripe_ece_enabled() {
-		return 'yes' === self::get_option_with_default( self::ECE_FEATURE_FLAG_NAME );
+		return true;
 	}
 
 	/**

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -177,9 +177,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			unset( $options['account_id'] );
 			unset( $options['test_account_id'] );
 
-			// Enable ECE for new connections.
-			$this->enable_ece_in_new_accounts();
-
 			WC_Stripe_Database_Cache::delete( WC_Stripe_API::INVALID_API_KEY_ERROR_COUNT_CACHE_KEY );
 			WC_Stripe_Helper::update_main_stripe_settings( $options );
 
@@ -230,17 +227,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			}
 
 			return 'yes';
-		}
-
-		/**
-		 * Enable Stripe express checkout element for new connections.
-		 */
-		private function enable_ece_in_new_accounts() {
-			$existing_stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-
-			if ( empty( $existing_stripe_settings ) ) {
-				update_option( WC_Stripe_Feature_Flags::ECE_FEATURE_FLAG_NAME, 'yes' );
-			}
 		}
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.0.0 - xxxx-xx-xx =
-* Update - Hardcodes the Express Checkout feature flag to be always enabled
+* Update - Disable Payment Request Buttons and ensure Express Checkout is used when express checkout buttons are enabled
 * Dev - Expands the Stripe Order Helper class to handle source ID, refund ID, intent ID, and setup intent ID metas
 * Update - Removing the `wc_stripe_is_upe_checkout_enabled` filter, as Legacy Checkout is no longer supported
 * Dev - Upgrades `jest` to version 29.7.0, `@wordpress/scripts` to 26.19.0, and adds `axios`(version 1.12.2) to the JavaScript development dependencies

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.0.0 - xxxx-xx-xx =
+* Update - Hardcodes the Express Checkout feature flag to be always enabled
 * Dev - Expands the Stripe Order Helper class to handle source ID, refund ID, intent ID, and setup intent ID metas
 * Update - Removing the `wc_stripe_is_upe_checkout_enabled` filter, as Legacy Checkout is no longer supported
 * Dev - Upgrades `jest` to version 29.7.0, `@wordpress/scripts` to 26.19.0, and adds `axios`(version 1.12.2) to the JavaScript development dependencies


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-733
See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4687#discussion_r2399736177

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, I am hardcoding the Express Checkout feature flag to be always enabled. This will force ECE for all merchants, even those that, for some reason, changed the default flag value, making it safe to remove all code related to Payment Request Buttons.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review is enough.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
