### PR TITLE
Add filter to allow for manual payment method configuration (PMC) selection

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@
 * Update - Reduce settings Javascript file size by using smaller image
 * Dev - Update @wordpress/scripts to 30.24.0 and @wordpress/base-styles to 6.7.0
 * Fix - Prevent fatal error when third-party plugins check for non-existent methods in payment method classes
+* Add - Introduce wc_stripe_preselect_payment_method_configuration filter for manual payment method configuration selection
 
 = 9.9.2 - 2025-09-29 =
 * Fix - BACS instruction text appears twice on the Order Confirmation page

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -120,7 +120,16 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return object|null
 	 */
 	private static function get_payment_method_configuration_from_stripe() {
-		$preselected_pmc_id = apply_filters( 'wc_stripe_preselect_payment_method_configuration', null );
+		$is_test_mode       = WC_Stripe_Mode::is_test();
+		/**
+		 * Allows merchants to specify the ID of a Payment Method Configuration to use. This makes it possible for
+		 * merchants to create configurations for specific sites, e.g. when they operate sites in different countries
+		 * with different local payment methods.
+		 *
+		 * @param string|null $preselected_pmc_id The ID of the Payment Method Configuration to use. Null by default, but a string value may be returned.
+		 * @param bool        $is_test_mode       Whether the site is in test mode.
+		 */
+		$preselected_pmc_id = apply_filters( 'wc_stripe_preselect_payment_method_configuration', null, $is_test_mode );
 
 		if ( is_string( $preselected_pmc_id ) && str_starts_with( $preselected_pmc_id, 'pmc_' ) ) {
 			$configuration = WC_Stripe_API::retrieve( 'payment_method_configurations/' . $preselected_pmc_id );
@@ -149,7 +158,6 @@ class WC_Stripe_Payment_Method_Configurations {
 		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$configurations = $result->data ?? [];
 
-		$is_test_mode     = WC_Stripe_Mode::is_test();
 		$fallback_pmc_key = $is_test_mode ? 'woocommerce_stripe_pmc_fallback_id_test' : 'woocommerce_stripe_pmc_fallback_id_live';
 
 		// When connecting to the WooCommerce Platform account a new payment method configuration is created for the merchant.

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -121,6 +121,7 @@ class WC_Stripe_Payment_Method_Configurations {
 	 */
 	private static function get_payment_method_configuration_from_stripe() {
 		$is_test_mode       = WC_Stripe_Mode::is_test();
+
 		/**
 		 * Allows merchants to specify the ID of a Payment Method Configuration to use. This makes it possible for
 		 * merchants to create configurations for specific sites, e.g. when they operate sites in different countries

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -120,6 +120,32 @@ class WC_Stripe_Payment_Method_Configurations {
 	 * @return object|null
 	 */
 	private static function get_payment_method_configuration_from_stripe() {
+		$preselected_pmc_id = apply_filters( 'wc_stripe_preselect_payment_method_configuration', null );
+
+		if ( is_string( $preselected_pmc_id ) && str_starts_with( $preselected_pmc_id, 'pmc_' ) ) {
+			$configuration = WC_Stripe_API::retrieve( 'payment_method_configurations/' . $preselected_pmc_id );
+			$error = null;
+			if ( is_wp_error( $configuration ) ) {
+				$error = $configuration;
+			} elseif ( ! empty( $configuration->error ) ) {
+				$error = $configuration->error;
+			}
+
+			if ( null !== $error ) {
+				WC_Stripe_Logger::error(
+					'Error retrieving preselected Payment Method Configuration',
+					[
+						'pmc_id' => $preselected_pmc_id,
+						'error'  => $error,
+					]
+				);
+			} elseif ( ! empty( $configuration ) ) {
+				self::set_payment_method_configuration_cache( $configuration );
+				return $configuration;
+			}
+			// If the preselected Payment Method Configuration is not found, we continue with the default logic below.
+		}
+
 		$result         = WC_Stripe_API::get_instance()->get_payment_method_configurations();
 		$configurations = $result->data ?? [];
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,5 +140,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Reduce settings Javascript file size by using smaller image
 * Dev - Update @wordpress/scripts to 30.24.0 and @wordpress/base-styles to 6.7.0
 * Fix - Prevent fatal error when third-party plugins check for non-existent methods in payment method classes
+* Add - Introduce wc_stripe_preselect_payment_method_configuration filter for manual payment method configuration selection
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-735
Towards #4713

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
While I've kicked off a broader discussion for how we might want to allow for PMC selection (see pc4etw-1WV-p2 ), this PR tackles a much smaller piece of the puzzle: for more advanced setups, can we allow merchants to specify which PMC they want to use? The PR explores doing that by implementing a new `wc_stripe_preselect_payment_method_configuration` filter. If merchants hook into the filter and specify a valid PMC identifier of the form `pmc_*`, we will use that configuration by default, including caching the PMC. If we fail to fetch the PMC, we log an error and continue with the default logic.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->
### How might this break?

Merchants or developers could specify a PMC ID that doesn't exist, or is not valid in the current live/test environment. In those situations, we'll fall back on the default logic, which could be unexpected for the merchant.

Merchants may also create a PMC that adds payment methods we don't support in the plugin, especially if they're working within the Stripe dashboard to create a new PMC from scratch. However, that's already a possible issue with merchants making changes from the Stripe dashboard.

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Run the code from this branch on a test site
* Connect your site to Stripe using an account that you can use to access the Stripe dashboard -- a throwaway test account won't work that well for this use case, but you can use test or live mode for the connection.
* Ensure that logging is enabled for the Stripe plugin
* Make some changes to the enabled payment methods within the Stripe settings page -- make a note of which payment methods are enabled and disabled
* Navigate directly to the Stripe dashboard and navigate to _Settings_ -> _Payments_ -> _Payment methods_. Make sure you're in test/live mode to match your site's mode.
* Create a new payment method configuration within the dashboard, and enable some payment methods supported by the plugin, or even some we don't support if you want
* Copy the identifier for the PMC
* Add the following code snippet to your site to force selection of your new PMC with the `$is_test_mode` check set up to match your site configuration:
```php
function test_select_custom_stripe_pmc( $pmc_id, $is_test_mode ) {
	if ( $is_test_mode ) {
		return 'pmc_YOUR_PMC';
	}
	return $pmc_id;
}
add_filter( 'wc_stripe_preselect_payment_method_configuration', 'test_select_custom_stripe_pmc', 10, 2 );
```
* Reload the payment method settings page to force a reload of the payment configuration
* Verify that the PMC is your new PMC based on the payment methods
* Check the Stripe logs to verify that we're making an API call to `payment_method_configurations/pmc_YOUR_PMC` after the filter is added

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)