### PR TITLE
Add filter to handle custom Klarna token name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@
 * Update - Reduce settings Javascript file size by using smaller image
 * Dev - Update @wordpress/scripts to 30.24.0 and @wordpress/base-styles to 6.7.0
 * Fix - Prevent fatal error when third-party plugins check for non-existent methods in payment method classes
+* Fix - Ensure Klarna payment tokens can be deleted and handled correctly
 
 = 9.9.2 - 2025-09-29 =
 * Fix - BACS instruction text appears twice on the Order Confirmation page

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -805,7 +805,8 @@ class WC_Stripe_Payment_Tokens {
 	}
 
 	/**
-	 * Filters the payment token class to override the credit card class with the extension's version.
+	 * Filters the payment token class to handle token classes that don't match the default
+	 * WooCommerce payment token class name.
 	 *
 	 * @param string $class Payment token class.
 	 * @param string $type Token type.
@@ -824,6 +825,11 @@ class WC_Stripe_Payment_Tokens {
 		if ( WC_Stripe_UPE_Payment_Method_Becs_Debit::STRIPE_ID === $type ) {
 			return WC_Payment_Token_Becs_Debit::class;
 		}
+		// Check for Klarna and make sure we don't override other plugins that may use `klarna` as the token ID.
+		if ( WC_Stripe_UPE_Payment_Method_Klarna::STRIPE_ID === $type && 'WC_Payment_Token_klarna' === $class ) {
+			return WC_Stripe_Klarna_Payment_Token::class;
+		}
+
 		return $class;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -140,5 +140,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Reduce settings Javascript file size by using smaller image
 * Dev - Update @wordpress/scripts to 30.24.0 and @wordpress/base-styles to 6.7.0
 * Fix - Prevent fatal error when third-party plugins check for non-existent methods in payment method classes
+* Fix - Ensure Klarna payment tokens can be deleted and handled correctly
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentTokens/WC_Stripe_Payment_Tokens_Test.php
+++ b/tests/phpunit/PaymentTokens/WC_Stripe_Payment_Tokens_Test.php
@@ -275,8 +275,8 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 	 * @return void
 	 * @dataProvider provide_test_woocommerce_payment_token_class
 	 */
-	public function test_woocommerce_payment_token_class( $class, $expected ) {
-		$actual = $this->stripe_payment_tokens->woocommerce_payment_token_class( $class, '' );
+	public function test_woocommerce_payment_token_class( $class, $expected, string $type = '' ) {
+		$actual = $this->stripe_payment_tokens->woocommerce_payment_token_class( $class, $type );
 		$this->assertSame( $expected, $actual );
 	}
 
@@ -302,6 +302,31 @@ class WC_Stripe_Payment_Tokens_Test extends WP_UnitTestCase {
 			WC_Payment_Token_Link::class    => [
 				'class'    => WC_Payment_Token_Link::class,
 				'expected' => WC_Payment_Token_Link::class,
+			],
+			WC_Payment_Token_ACH::class    => [
+				'class'    => 'test',
+				'expected' => WC_Payment_Token_ACH::class,
+				'type'     => WC_Stripe_UPE_Payment_Method_ACH::STRIPE_ID,
+			],
+			WC_Payment_Token_ACSS::class    => [
+				'class'    => 'test',
+				'expected' => WC_Payment_Token_ACSS::class,
+				'type'     => WC_Stripe_UPE_Payment_Method_ACSS::STRIPE_ID,
+			],
+			WC_Payment_Token_Becs_Debit::class    => [
+				'class'    => 'test',
+				'expected' => WC_Payment_Token_Becs_Debit::class,
+				'type'     => WC_Stripe_UPE_Payment_Method_Becs_Debit::STRIPE_ID,
+			],
+			'Klarna with overridden class'    => [
+				'class'    => 'test_klarna',
+				'expected' => 'test_klarna',
+				'type'     => \WC_Stripe_UPE_Payment_Method_Klarna::STRIPE_ID,
+			],
+			'Klarna with default class'    => [
+				'class'    => 'WC_Payment_Token_klarna',
+				'expected' => \WC_Stripe_Klarna_Payment_Token::class,
+				'type'     => \WC_Stripe_UPE_Payment_Method_Klarna::STRIPE_ID,
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-742
Fixes #4722

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4724

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR takes a slightly different approach to @Mayisha's approach in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4724. Rather than renaming the token class, this PR simply ensures that we add a case for the Klarna token classname to our existing logic that hooks into the `woocommerce_payment_token_class` filter. This also means we don't need to deprecate the current class name.

One thing to note is that I've added a check to allow other plugins to override the token class name before us. This may be overly defensive, but I thought it better to be wary on this rather than assume all `klarna` tokens necessarily belong to our plugin.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Verify that the unit tests are passing, both for Klarna and the other token classes implemented in `WC_Stripe_Payment_Tokens->woocommerce_payment_token_class()`
* Code review

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
