### PR TITLE
Update branch descriptions for e2e test workflows

### DIFF
--- a/.github/workflows/manual-e2e-tests.yml
+++ b/.github/workflows/manual-e2e-tests.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: Branch, Tag or SHA to checkout. Leave empty to use the default branch.
+        description: Branch, Tag or SHA to checkout. Leave empty to use the same commit/branch as the workflow branch.
         type: string
       wordpress-version:
         description: WordPress version number. Defaults to 'latest' (the latest version).

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -13,7 +13,7 @@ on:
         type: string
         default: '7.4'
       branch:
-        description: Branch, Tag or SHA to checkout. Leave empty to use the default branch.
+        description: Branch, Tag or SHA to checkout. Leave empty to use the same branch/commit as the calling workflow.
         type: string
 
 jobs:


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR is a follow-up to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4727, which added a new workflow to manually trigger e2e tests across branches. However, @diegocurbelo [flagged some concerns](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4727#discussion_r2430409274) with the descriptive text and the fact that we have two branch variables.

This PR addresses one aspect of the comment now that we have some runs in place. At present, I am still keeping the custom branch input, as I think we may have situations where we want to run workflow code from one branch (such as for a PR), but target code from another branch (generally the e2e tests). Regardless, the changes in this PR only update the description for the `branch` input to reflect that the code will default to the same branch as the workflow branch if no other value is specified.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Inspection should be sufficient.
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
No need for a changelog entry as this only impacts the field descriptions for manually running workflows in the GitHub UI.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
