### PR TITLE
Onboarding to Jetpack upon saving the settings or upgrading the extension

### DIFF
--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -310,7 +310,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			return;
 		}
 
-		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$transact_account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$transact_account_manager->do_onboarding();
 	}
 

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -293,7 +293,25 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$this->update_is_debug_log_enabled( $request );
 		$this->update_oc_settings( $request );
 
+		$this->maybe_onboard_with_transact();
+
 		return new WP_REST_Response( [], 200 );
+	}
+
+	/**
+	 * Maybe onboard with the Transact Platform.
+	 *
+	 * @return void
+	 */
+	public function maybe_onboard_with_transact() {
+		wc_get_logger()->info( 'maybe_onboard_with_transact' );
+		// Do not run if Stripe is not enabled.
+		if ( 'yes' !== $this->gateway->enabled ) {
+			return;
+		}
+
+		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$transact_account_manager->do_onboarding();
 	}
 
 	/**

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -996,6 +996,10 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 	/**
 	 * Checks whether new keys are being entered when saving options.
+	 *
+	 * @return bool was anything saved?
+	 *
+	 * @todo Move this to the UPE class.
 	 */
 	public function process_admin_options() {
 		// Load all old values before the new settings get saved.
@@ -1004,7 +1008,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$old_test_publishable_key = $this->get_option( 'test_publishable_key' );
 		$old_test_secret_key      = $this->get_option( 'test_secret_key' );
 
-		parent::process_admin_options();
+		// Trigger Transact onboarding when settings are saved.
+		$saved = parent::process_admin_options();
 
 		// Load all old values after the new settings have been saved.
 		$new_publishable_key      = $this->get_option( 'publishable_key' );
@@ -1026,6 +1031,8 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		) {
 			update_option( 'wc_stripe_show_changed_keys_notice', 'yes' );
 		}
+
+		return $saved;
 	}
 
 	public function validate_publishable_key_field( $key, $value ) {

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -996,10 +996,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 
 	/**
 	 * Checks whether new keys are being entered when saving options.
-	 *
-	 * @return bool was anything saved?
-	 *
-	 * @todo Move this to the UPE class.
 	 */
 	public function process_admin_options() {
 		// Load all old values before the new settings get saved.
@@ -1008,8 +1004,7 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		$old_test_publishable_key = $this->get_option( 'test_publishable_key' );
 		$old_test_secret_key      = $this->get_option( 'test_secret_key' );
 
-		// Trigger Transact onboarding when settings are saved.
-		$saved = parent::process_admin_options();
+		parent::process_admin_options();
 
 		// Load all old values after the new settings have been saved.
 		$new_publishable_key      = $this->get_option( 'publishable_key' );
@@ -1031,8 +1026,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 		) {
 			update_option( 'wc_stripe_show_changed_keys_notice', 'yes' );
 		}
-
-		return $saved;
 	}
 
 	public function validate_publishable_key_field( $key, $value ) {

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -318,11 +318,11 @@ final class WC_Stripe_Transact_Account_Manager {
 	 * Get the transact account (merchant or provider) from the database cache.
 	 *
 	 * @param string $cache_key The cache key to get the account.
-	 * @return bool|null The transact account data, or null if the cache is
+	 * @return array|null The transact account data, or null if the cache is
 	 *                    empty or expired.
 	 */
-	private function get_transact_account_from_cache( $cache_key ): ?bool {
-		$transact_account = get_option( $cache_key, null );
+	private function get_transact_account_from_cache( $cache_key ): ?array {
+		$transact_account = WC_Stripe_Database_Cache::get( $cache_key );
 
 		if ( empty( $transact_account ) || ( isset( $transact_account['expiry'] ) && $transact_account['expiry'] < time() ) ) {
 			return null;
@@ -345,7 +345,7 @@ final class WC_Stripe_Transact_Account_Manager {
 			$endpoint .= '?' . http_build_query( $request_body );
 		}
 
-		$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
+		$response = \Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
 			$endpoint,
 			self::WPCOM_PROXY_ENDPOINT_API_VERSION,
 			[

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -130,9 +130,9 @@ final class WC_Stripe_Transact_Account_Manager {
 	 * is not in cache or expired.
 	 *
 	 * @param string $account_type The type of account to get (merchant or provider).
-	 * @return array|null Returns null if the transact account cannot be retrieved.
+	 * @return array|bool|null Returns null if the transact account cannot be retrieved.
 	 */
-	public function get_transact_account_data( $account_type ): ?array {
+	public function get_transact_account_data( $account_type ) {
 		$cache_key = $this->get_cache_key( $account_type );
 
 		// Get transact account from cache. If not found, fetch/create it.
@@ -318,10 +318,10 @@ final class WC_Stripe_Transact_Account_Manager {
 	 * Get the transact account (merchant or provider) from the database cache.
 	 *
 	 * @param string $cache_key The cache key to get the account.
-	 * @return array|null The transact account data, or null if the cache is
+	 * @return array|bool|null The transact account data, or null if the cache is
 	 *                    empty or expired.
 	 */
-	private function get_transact_account_from_cache( $cache_key ): ?array {
+	private function get_transact_account_from_cache( $cache_key ) {
 		$transact_account = WC_Stripe_Database_Cache::get( $cache_key );
 
 		if ( empty( $transact_account ) || ( isset( $transact_account['expiry'] ) && $transact_account['expiry'] < time() ) ) {

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -25,7 +25,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @var string
 	 */
-	private const TRANSACT_PROVIDER_TYPE = 'stripe';
+	private const TRANSACT_PROVIDER_TYPE = 'wc_stripe';
 
 	/**
 	 * Cache keys for the merchant and provider accounts.
@@ -106,6 +106,8 @@ final class WC_Stripe_Transact_Account_Manager {
 			);
 		}
 
+		wc_get_logger()->info( 'merchant_account_data: ' . wc_print_r( $merchant_account_data, true ) );
+
 		$provider_account_data = $this->get_transact_account_data( 'provider' );
 		if ( empty( $provider_account_data ) ) {
 			$provider_account = $this->create_provider_account();
@@ -120,6 +122,8 @@ final class WC_Stripe_Transact_Account_Manager {
 				$provider_account
 			);
 		}
+
+		wc_get_logger()->info( 'provider_account_data: ' . wc_print_r( $provider_account_data, true ) );
 
 		// Set an extra flag to indicate that we've completed onboarding.
 		$this->gateway->set_transact_onboarding_complete();

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -5,7 +5,7 @@
  *
  * Handles transact account management for WooCommerce Stripe integration.
  */
-final class WC_Stripe_Transact_Account_Manager {
+class WC_Stripe_Transact_Account_Manager {
 	/**
 	 * The API version for the proxy endpoint.
 	 *
@@ -63,7 +63,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @param WC_Stripe_UPE_Payment_Gateway $gateway Stripe gateway instance.
 	 */
-	private function __construct( WC_Stripe_UPE_Payment_Gateway $gateway ) {
+	public function __construct( WC_Stripe_UPE_Payment_Gateway $gateway ) {
 		$this->gateway = $gateway;
 	}
 

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -342,7 +342,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @return array|null The API response body, or null if the request fails.
 	 */
-	private function send_transact_api_request( $method, $endpoint, $request_body ): ?array {
+	private function send_transact_api_request( $method, $endpoint, $request_body ) {
 		if ( 'GET' === $method ) {
 			$endpoint .= '?' . http_build_query( $request_body );
 		}

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -67,7 +67,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @return void
 	 */
-	public function do_onboarding() {
+	public function do_onboarding(): void {
 		$stripe_connect  = woocommerce_gateway_stripe()->connect;
 		$mode            = WC_Stripe_Mode::is_test() ? 'test' : 'live';
 		$oauth_connected = (bool) $stripe_connect->is_connected_via_oauth( $mode );
@@ -134,7 +134,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 * @param string $account_type The type of account to get (merchant or provider).
 	 * @return array|null Returns null if the transact account cannot be retrieved.
 	 */
-	public function get_transact_account_data( $account_type ) {
+	public function get_transact_account_data( $account_type ): ?array {
 		$cache_key = $this->get_cache_key( $account_type );
 
 		// Get transact account from cache. If not found, fetch/create it.
@@ -160,7 +160,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 * @param string $account_type The type of account to get (merchant or provider).
 	 * @return string|null The cache key, or null if the account type is invalid.
 	 */
-	private function get_cache_key( $account_type ) {
+	private function get_cache_key( $account_type ): ?string {
 		if ( 'merchant' === $account_type ) {
 			return WC_Stripe_Mode::is_test() ? self::TRANSACT_MERCHANT_ACCOUNT_CACHE_KEY_TEST : self::TRANSACT_MERCHANT_ACCOUNT_CACHE_KEY_LIVE;
 		}
@@ -177,7 +177,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @return array|null The API response body, or null if the request fails.
 	 */
-	private function fetch_merchant_account() {
+	private function fetch_merchant_account(): ?array {
 		$site_id = \Jetpack_Options::get_option( 'id' );
 		if ( ! $site_id ) {
 			return null;
@@ -210,7 +210,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @return bool True if the provider account exists, false otherwise.
 	 */
-	private function fetch_provider_account() {
+	private function fetch_provider_account(): bool {
 		$site_id = \Jetpack_Options::get_option( 'id' );
 		if ( ! $site_id ) {
 			return false;
@@ -241,7 +241,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @return array|null The API response body, or null if the request fails.
 	 */
-	private function create_merchant_account() {
+	private function create_merchant_account(): ?array {
 		$site_id = \Jetpack_Options::get_option( 'id' );
 		if ( ! $site_id ) {
 			return null;
@@ -273,7 +273,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @return bool True if the provider account creation was successful, false otherwise.
 	 */
-	private function create_provider_account() {
+	private function create_provider_account(): bool {
 		$site_id = \Jetpack_Options::get_option( 'id' );
 		if ( ! $site_id ) {
 			return false;
@@ -304,7 +304,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 * @param string $cache_key The cache key to update.
 	 * @param array  $account_data The transact account data.
 	 */
-	private function update_transact_account_cache( $cache_key, $account_data ) {
+	private function update_transact_account_cache( $cache_key, $account_data ): void {
 		$expires = time() + self::TRANSACT_ACCOUNT_CACHE_EXPIRY;
 		WC_Stripe_Database_Cache::set(
 			$cache_key,
@@ -323,7 +323,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 * @return bool|null The transact account data, or null if the cache is
 	 *                    empty or expired.
 	 */
-	private function get_transact_account_from_cache( $cache_key ) {
+	private function get_transact_account_from_cache( $cache_key ): ?bool {
 		$transact_account = get_option( $cache_key, null );
 
 		if ( empty( $transact_account ) || ( isset( $transact_account['expiry'] ) && $transact_account['expiry'] < time() ) ) {
@@ -342,7 +342,7 @@ final class WC_Stripe_Transact_Account_Manager {
 	 *
 	 * @return array|null The API response body, or null if the request fails.
 	 */
-	private function send_transact_api_request( $method, $endpoint, $request_body ) {
+	private function send_transact_api_request( $method, $endpoint, $request_body ): ?array {
 		if ( 'GET' === $method ) {
 			$endpoint .= '?' . http_build_query( $request_body );
 		}

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -1,0 +1,364 @@
+<?php
+
+use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
+
+/**
+ * Class WC_Stripe_Transact_Account_Manager.
+ *
+ * Handles transact account management for WooCommerce Stripe integration.
+ */
+final class WC_Stripe_Transact_Account_Manager {
+	/**
+	 * The API version for the proxy endpoint.
+	 *
+	 * @var int
+	 */
+	private const WPCOM_PROXY_ENDPOINT_API_VERSION = 2;
+
+	/**
+	 * The timeout for requests to the WPCOM proxy endpoint.
+	 *
+	 * @var int
+	 */
+	private const WPCOM_PROXY_REQUEST_TIMEOUT = 60;
+
+	/**
+	 * Transact provider type, for provider onboarding.
+	 *
+	 * @var string
+	 */
+	private const TRANSACT_PROVIDER_TYPE = 'stripe';
+
+	/**
+	 * Cache keys for the merchant and provider accounts.
+	 *
+	 * @var string
+	 */
+	private const TRANSACT_MERCHANT_ACCOUNT_CACHE_KEY_LIVE = 'transact_merchant_account_live';
+	private const TRANSACT_MERCHANT_ACCOUNT_CACHE_KEY_TEST = 'transact_merchant_account_test';
+	private const TRANSACT_PROVIDER_ACCOUNT_CACHE_KEY_LIVE = 'transact_provider_account_live';
+	private const TRANSACT_PROVIDER_ACCOUNT_CACHE_KEY_TEST = 'transact_provider_account_test';
+
+	/**
+	 * The expiry time for the Transact account cache.
+	 *
+	 * @var int
+	 */
+	private const TRANSACT_ACCOUNT_CACHE_EXPIRY = 60 * 60 * 24; // 24 hours.
+
+	/**
+	 * Stripe gateway object.
+	 *
+	 * @var WC_Stripe_UPE_Payment_Gateway
+	 */
+	private $gateway;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param WC_Stripe_UPE_Payment_Gateway $gateway Stripe gateway instance.
+	 */
+	public function __construct( WC_Stripe_UPE_Payment_Gateway $gateway ) {
+		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Onboard the merchant with the Transact platform.
+	 *
+	 * @return void
+	 */
+	public function do_onboarding() {
+		$stripe_connect  = woocommerce_gateway_stripe()->connect;
+		$mode            = WC_Stripe_Mode::is_test() ? 'test' : 'live';
+		$oauth_connected = (bool) $stripe_connect->is_connected_via_oauth( $mode );
+
+		// Check that the merchant is connected via OAuth. Only begin onboarding if this minimum requirement is met.
+		if ( ! $oauth_connected ) {
+			return;
+		}
+
+		// Register with Jetpack if not already connected.
+		$jetpack_connection_manager = $this->gateway->get_jetpack_connection_manager();
+		if ( ! $jetpack_connection_manager ) {
+			WC_Stripe_Logger::error( 'Jetpack connection manager not found.' );
+			return;
+		}
+
+		if ( ! $jetpack_connection_manager->is_connected() ) {
+			$result = $jetpack_connection_manager->try_registration();
+			if ( is_wp_error( $result ) ) {
+				WC_Stripe_Logger::error( 'Jetpack registration failed: ' . $result->get_error_message() );
+				return;
+			}
+		}
+
+		// Fetch (cached) or create the Transact merchant and provider accounts.
+		$merchant_account_data = $this->get_transact_account_data( 'merchant' );
+		if ( empty( $merchant_account_data ) ) {
+			$merchant_account = $this->create_merchant_account();
+			if ( empty( $merchant_account ) ) {
+				WC_Stripe_Logger::error( 'Transact merchant onboarding failed.' );
+				return;
+			}
+
+			// Cache the merchant account data.
+			$this->update_transact_account_cache(
+				$this->get_cache_key( 'merchant' ),
+				$merchant_account
+			);
+		}
+
+		$provider_account_data = $this->get_transact_account_data( 'provider' );
+		if ( empty( $provider_account_data ) ) {
+			$provider_account = $this->create_provider_account();
+			if ( ! $provider_account ) {
+				WC_Stripe_Logger::error( 'Transact provider onboarding failed.' );
+				return;
+			}
+
+			// Cache the provider account data.
+			$this->update_transact_account_cache(
+				$this->get_cache_key( 'provider' ),
+				$provider_account
+			);
+		}
+
+		// Set an extra flag to indicate that we've completed onboarding.
+		$this->gateway->set_transact_onboarding_complete();
+	}
+
+	/**
+	 * Get the Transact account (merchant or provider) data. Performs a fetch if the account
+	 * is not in cache or expired.
+	 *
+	 * @param string $account_type The type of account to get (merchant or provider).
+	 * @return array|null Returns null if the transact account cannot be retrieved.
+	 */
+	public function get_transact_account_data( $account_type ) {
+		$cache_key = $this->get_cache_key( $account_type );
+
+		// Get transact account from cache. If not found, fetch/create it.
+		$transact_account = $this->get_transact_account_from_cache( $cache_key );
+		if ( empty( $transact_account ) ) {
+			$transact_account = 'merchant' === $account_type ? $this->fetch_merchant_account() : $this->fetch_provider_account();
+
+			// Fetch failed.
+			if ( empty( $transact_account ) ) {
+				return null;
+			}
+
+			// Update cache.
+			$this->update_transact_account_cache( $cache_key, $transact_account );
+		}
+
+		return $transact_account;
+	}
+
+	/**
+	 * Get the cache key for the transact account.
+	 *
+	 * @param string $account_type The type of account to get (merchant or provider).
+	 * @return string|null The cache key, or null if the account type is invalid.
+	 */
+	private function get_cache_key( $account_type ) {
+		if ( 'merchant' === $account_type ) {
+			return WC_Stripe_Mode::is_test() ? self::TRANSACT_MERCHANT_ACCOUNT_CACHE_KEY_TEST : self::TRANSACT_MERCHANT_ACCOUNT_CACHE_KEY_LIVE;
+		}
+
+		if ( 'provider' === $account_type ) {
+			return WC_Stripe_Mode::is_test() ? self::TRANSACT_PROVIDER_ACCOUNT_CACHE_KEY_TEST : self::TRANSACT_PROVIDER_ACCOUNT_CACHE_KEY_LIVE;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Fetch the merchant account from the Transact platform.
+	 *
+	 * @return array|null The API response body, or null if the request fails.
+	 */
+	private function fetch_merchant_account() {
+		$site_id = \Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return null;
+		}
+
+		$request_body = [
+			'test_mode' => WC_Stripe_Mode::is_test(),
+		];
+
+		$response = $this->send_transact_api_request(
+			'GET',
+			sprintf( '/sites/%d/transact/account', $site_id ),
+			$request_body
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$response_data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( empty( $response_data['public_id'] ) ) {
+			return null;
+		}
+
+		return [ 'public_id' => $response_data['public_id'] ];
+	}
+
+	/**
+	 * Fetch the provider account from the Transact platform.
+	 *
+	 * @return bool True if the provider account exists, false otherwise.
+	 */
+	private function fetch_provider_account() {
+		$site_id = \Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return false;
+		}
+
+		$request_body = [
+			'test_mode'     => WC_Stripe_Mode::is_test(),
+			'provider_type' => self::TRANSACT_PROVIDER_TYPE,
+		];
+
+		$response = $this->send_transact_api_request(
+			'GET',
+			sprintf( '/sites/%d/transact/account/%s', $site_id, self::TRANSACT_PROVIDER_TYPE ),
+			$request_body
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		// Provider account response only returns an empty onboarding link,
+		// which we do not need.
+		return true;
+	}
+
+	/**
+	 * Create the merchant account with the Transact platform.
+	 *
+	 * @return array|null The API response body, or null if the request fails.
+	 */
+	private function create_merchant_account() {
+		$site_id = \Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return null;
+		}
+
+		$request_body = [ 'test_mode' => WC_Stripe_Mode::is_test() ];
+
+		$response = $this->send_transact_api_request(
+			'POST',
+			sprintf( '/sites/%d/transact/account', $site_id ),
+			$request_body
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$response_data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( empty( $response_data['public_id'] ) ) {
+			WC_Stripe_Logger::error( 'Transact merchant account creation failed. Response body: ' . wc_print_r( $response_data, true ) );
+			return null;
+		}
+
+		return [ 'public_id' => $response_data['public_id'] ];
+	}
+
+	/**
+	 * Create the provider account with the Transact platform.
+	 *
+	 * @return bool True if the provider account creation was successful, false otherwise.
+	 */
+	private function create_provider_account() {
+		$site_id = \Jetpack_Options::get_option( 'id' );
+		if ( ! $site_id ) {
+			return false;
+		}
+
+		$request_body = [
+			'test_mode'     => WC_Stripe_Mode::is_test(),
+			'provider_type' => self::TRANSACT_PROVIDER_TYPE,
+		];
+		$response     = $this->send_transact_api_request(
+			'POST',
+			sprintf( '/sites/%d/transact/account/%s/onboard', $site_id, self::TRANSACT_PROVIDER_TYPE ),
+			$request_body
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return false;
+		}
+
+		// Provider account response only returns an empty onboarding link,
+		// which we do not need.
+		return true;
+	}
+
+	/**
+	 * Update the transact account (merchant or provider) cache.
+	 *
+	 * @param string $cache_key The cache key to update.
+	 * @param array  $account_data The transact account data.
+	 */
+	private function update_transact_account_cache( $cache_key, $account_data ) {
+		$expires = time() + self::TRANSACT_ACCOUNT_CACHE_EXPIRY;
+		WC_Stripe_Database_Cache::set(
+			$cache_key,
+			[
+				'account' => $account_data,
+				'expiry'  => $expires,
+			],
+			self::TRANSACT_ACCOUNT_CACHE_EXPIRY
+		);
+	}
+
+	/**
+	 * Get the transact account (merchant or provider) from the database cache.
+	 *
+	 * @param string $cache_key The cache key to get the account.
+	 * @return bool|null The transact account data, or null if the cache is
+	 *                    empty or expired.
+	 */
+	private function get_transact_account_from_cache( $cache_key ) {
+		$transact_account = get_option( $cache_key, null );
+
+		if ( empty( $transact_account ) || ( isset( $transact_account['expiry'] ) && $transact_account['expiry'] < time() ) ) {
+			return null;
+		}
+
+		return $transact_account['account'] ?? null;
+	}
+
+	/**
+	 * Send a request to the Transact platform.
+	 *
+	 * @param string $method The HTTP method to use.
+	 * @param string $endpoint The endpoint to request.
+	 * @param array  $request_body The request body.
+	 *
+	 * @return array|null The API response body, or null if the request fails.
+	 */
+	private function send_transact_api_request( $method, $endpoint, $request_body ) {
+		if ( 'GET' === $method ) {
+			$endpoint .= '?' . http_build_query( $request_body );
+		}
+
+		$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+			$endpoint,
+			self::WPCOM_PROXY_ENDPOINT_API_VERSION,
+			[
+				'headers' => [ 'Content-Type' => 'application/json' ],
+				'method'  => $method,
+				'timeout' => self::WPCOM_PROXY_REQUEST_TIMEOUT,
+			],
+			'GET' === $method ? null : wp_json_encode( $request_body ),
+			'wpcom'
+		);
+
+		return $response;
+	}
+}

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -1,7 +1,5 @@
 <?php
 
-use Automattic\Jetpack\Connection\Client as Jetpack_Connection_Client;
-
 /**
  * Class WC_Stripe_Transact_Account_Manager.
  *
@@ -347,7 +345,7 @@ final class WC_Stripe_Transact_Account_Manager {
 			$endpoint .= '?' . http_build_query( $request_body );
 		}
 
-		$response = Jetpack_Connection_Client::wpcom_json_api_request_as_blog(
+		$response = Automattic\Jetpack\Connection\Client::wpcom_json_api_request_as_blog(
 			$endpoint,
 			self::WPCOM_PROXY_ENDPOINT_API_VERSION,
 			[

--- a/includes/class-wc-stripe-transact-account-manager.php
+++ b/includes/class-wc-stripe-transact-account-manager.php
@@ -52,12 +52,43 @@ final class WC_Stripe_Transact_Account_Manager {
 	private $gateway;
 
 	/**
+	 * Singleton instance of the class.
+	 *
+	 * @var null|WC_Stripe_Transact_Account_Manager
+	 */
+	private static ?WC_Stripe_Transact_Account_Manager $instance = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param WC_Stripe_UPE_Payment_Gateway $gateway Stripe gateway instance.
 	 */
-	public function __construct( WC_Stripe_UPE_Payment_Gateway $gateway ) {
+	private function __construct( WC_Stripe_UPE_Payment_Gateway $gateway ) {
 		$this->gateway = $gateway;
+	}
+
+	/**
+	 * Gets the singleton instance of the class.
+	 *
+	 * @param WC_Stripe_UPE_Payment_Gateway $gateway Stripe gateway instance.
+	 * @return WC_Stripe_Transact_Account_Manager|null
+	 */
+	public static function get_instance( WC_Stripe_UPE_Payment_Gateway $gateway ): ?self {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self( $gateway );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Sets the singleton instance of the class.
+	 *
+	 * @param WC_Stripe_Transact_Account_Manager|null $instance
+	 * @return void
+	 */
+	public static function set_instance( ?self $instance ) {
+		self::$instance = $instance;
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -938,7 +938,7 @@ class WC_Stripe {
 			return;
 		}
 
-		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $gateway );
+		$transact_account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $gateway );
 		$transact_account_manager->do_onboarding();
 	}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -131,6 +131,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-database-cache-prefetch.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-api.php';
 		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-mode.php';
+		include_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-transact-account-manager.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/class-wc-stripe-subscriptions-helper.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/trait-wc-stripe-subscriptions-utilities.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/compat/trait-wc-stripe-subscriptions.php';

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -924,6 +924,27 @@ class WC_Stripe {
 	}
 
 	/**
+	 * Maybe onboard with the Transact Platform.
+	 *
+	 * @return void
+	 */
+	public function maybe_onboard_with_transact(): void {
+		if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		$gateway = $this->get_main_stripe_gateway();
+
+		// Do not run if Stripe is not enabled.
+		if ( 'yes' !== $gateway->enabled ) {
+			return;
+		}
+
+		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $gateway );
+		$transact_account_manager->do_onboarding();
+	}
+
+	/**
 	 * Deactivate Affirm or Klarna payment methods if other official plugins are active.
 	 *
 	 * @param array $available_payment_gateways The available payment gateways.
@@ -977,26 +998,5 @@ class WC_Stripe {
 
 		// Disable Amazon Pay.
 		return [ WC_Stripe_Payment_Methods::AMAZON_PAY ];
-	}
-
-	/**
-	 * Maybe onboard with the Transact Platform.
-	 *
-	 * @return void
-	 */
-	private function maybe_onboard_with_transact(): void {
-		if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
-			return;
-		}
-
-		$gateway = $this->get_main_stripe_gateway();
-
-		// Do not run if Stripe is not enabled.
-		if ( 'yes' !== $gateway->enabled ) {
-			return;
-		}
-
-		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $gateway );
-		$transact_account_manager->do_onboarding();
 	}
 }

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -600,8 +600,6 @@ class WC_Stripe {
 			return $settings;
 		}
 
-		$this->maybe_onboard_with_transact();
-
 		return $this->toggle_upe( $settings, $old_settings );
 	}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -299,6 +299,9 @@ class WC_Stripe {
 
 		// Handle the async cache prefetch action.
 		add_action( WC_Stripe_Database_Cache_Prefetch::ASYNC_PREFETCH_ACTION, [ WC_Stripe_Database_Cache_Prefetch::get_instance(), 'handle_prefetch_action' ], 10, 1 );
+
+		// Hook for plugin upgrades.
+		add_action( 'woocommerce_updated', [ $this, 'maybe_onboard_with_transact' ] );
 	}
 
 	/**
@@ -596,6 +599,8 @@ class WC_Stripe {
 		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
 			return $settings;
 		}
+
+		$this->maybe_onboard_with_transact();
 
 		return $this->toggle_upe( $settings, $old_settings );
 	}
@@ -972,5 +977,26 @@ class WC_Stripe {
 
 		// Disable Amazon Pay.
 		return [ WC_Stripe_Payment_Methods::AMAZON_PAY ];
+	}
+
+	/**
+	 * Maybe onboard with the Transact Platform.
+	 *
+	 * @return void
+	 */
+	private function maybe_onboard_with_transact(): void {
+		if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		$gateway = $this->get_main_stripe_gateway();
+
+		// Do not run if Stripe is not enabled.
+		if ( 'yes' !== $gateway->enabled ) {
+			return;
+		}
+
+		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $gateway );
+		$transact_account_manager->do_onboarding();
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3431,11 +3431,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Get the Jetpack Connection Manager instance.
 	 *
-	 * @return Automattic\Jetpack\Connection\Manager
+	 * @return \Automattic\Jetpack\Connection\Manager
 	 */
-	public function get_jetpack_connection_manager(): Automattic\Jetpack\Connection\Manager {
+	public function get_jetpack_connection_manager(): \Automattic\Jetpack\Connection\Manager {
 		if ( ! $this->jetpack_connection_manager ) {
-			$this->jetpack_connection_manager = new Automattic\Jetpack\Connection\Manager( 'woocommerce' );
+			$this->jetpack_connection_manager = new \Automattic\Jetpack\Connection\Manager( 'woocommerce' );
 		}
 		return $this->jetpack_connection_manager;
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3461,11 +3461,40 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @inheritDoc
 	 */
 	public function process_admin_options() {
+		// Load all old values before the new settings get saved.
+		$old_publishable_key      = $this->get_option( 'publishable_key' );
+		$old_secret_key           = $this->get_option( 'secret_key' );
+		$old_test_publishable_key = $this->get_option( 'test_publishable_key' );
+		$old_test_secret_key      = $this->get_option( 'test_secret_key' );
+
 		// Trigger Transact onboarding when settings are saved.
 		$saved = parent::process_admin_options();
 		if ( $saved ) {
 			$this->maybe_onboard_with_transact();
 		}
+
+		// Load all old values after the new settings have been saved.
+		$new_publishable_key      = $this->get_option( 'publishable_key' );
+		$new_secret_key           = $this->get_option( 'secret_key' );
+		$new_test_publishable_key = $this->get_option( 'test_publishable_key' );
+		$new_test_secret_key      = $this->get_option( 'test_secret_key' );
+
+		// Checks whether a value has transitioned from a non-empty value to a new one.
+		$has_changed = function ( $old_value, $new_value ) {
+			return ! empty( $old_value ) && ( $old_value !== $new_value );
+		};
+
+		// Look for updates.
+		if (
+			$has_changed( $old_publishable_key, $new_publishable_key )
+			|| $has_changed( $old_secret_key, $new_secret_key )
+			|| $has_changed( $old_test_publishable_key, $new_test_publishable_key )
+			|| $has_changed( $old_test_secret_key, $new_test_secret_key )
+		) {
+			update_option( 'wc_stripe_show_changed_keys_notice', 'yes' );
+		}
+
+		return $saved;
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1,7 +1,6 @@
 <?php
 
 use Automattic\WooCommerce\Enums\OrderStatus;
-use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -185,7 +184,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Jetpack connection manager.
 	 *
-	 * @var Jetpack_Connection_Manager
+	 * @var Automattic\Jetpack\Connection\Manager
 	 */
 	private $jetpack_connection_manager;
 
@@ -3432,11 +3431,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	/**
 	 * Get the Jetpack Connection Manager instance.
 	 *
-	 * @return Jetpack_Connection_Manager
+	 * @return Automattic\Jetpack\Connection\Manager
 	 */
-	public function get_jetpack_connection_manager(): Jetpack_Connection_Manager {
+	public function get_jetpack_connection_manager(): Automattic\Jetpack\Connection\Manager {
 		if ( ! $this->jetpack_connection_manager ) {
-			$this->jetpack_connection_manager = new Jetpack_Connection_Manager( 'woocommerce' );
+			$this->jetpack_connection_manager = new Automattic\Jetpack\Connection\Manager( 'woocommerce' );
 		}
 		return $this->jetpack_connection_manager;
 	}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -1,6 +1,7 @@
 <?php
 
 use Automattic\WooCommerce\Enums\OrderStatus;
+use Automattic\Jetpack\Connection\Manager as Jetpack_Connection_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -180,6 +181,20 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 * @var WC_Stripe_UPE_Payment_Method[]
 	 */
 	public $payment_methods = [];
+
+	/**
+	 * Jetpack connection manager.
+	 *
+	 * @var Jetpack_Connection_Manager
+	 */
+	private $jetpack_connection_manager;
+
+	/**
+	 * Whether the Transact onboarding is complete.
+	 *
+	 * @var bool
+	 */
+	private $transact_onboarding_complete;
 
 	/**
 	 * Constructor
@@ -3409,5 +3424,31 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		// considered enabled if either is enabled in Stripe.
 		return in_array( WC_Stripe_Payment_Methods::APPLE_PAY, $enabled_payment_method_ids, true ) ||
 			in_array( WC_Stripe_Payment_Methods::GOOGLE_PAY, $enabled_payment_method_ids, true );
+	}
+
+	/**
+	 * Get the Jetpack Connection Manager instance.
+	 *
+	 * @return Jetpack_Connection_Manager
+	 */
+	public function get_jetpack_connection_manager(): Jetpack_Connection_Manager {
+		if ( ! $this->jetpack_connection_manager ) {
+			$this->jetpack_connection_manager = new Jetpack_Connection_Manager( 'woocommerce' );
+		}
+		return $this->jetpack_connection_manager;
+	}
+
+	/**
+	 * Set the Transact onboarding as complete.
+	 *
+	 * @return void
+	 */
+	public function set_transact_onboarding_complete(): void {
+		if ( $this->transact_onboarding_complete ) {
+			return;
+		}
+
+		$this->update_option( 'transact_onboarding_complete', 'yes' );
+		$this->transact_onboarding_complete = true;
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -312,9 +312,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Add metadata to Stripe intents for easier debugging of BNPL issues.
 		add_filter( 'wc_stripe_intent_metadata', [ $this, 'add_bnpl_debug_metadata' ], 10, 2 );
-
-		// Hook for plugin upgrades.
-		add_action( 'woocommerce_updated', [ $this, 'maybe_onboard_with_transact' ] );
 	}
 
 	/**
@@ -3452,66 +3449,5 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		$this->update_option( 'transact_onboarding_complete', 'yes' );
 		$this->transact_onboarding_complete = true;
-	}
-
-	/**
-	 * Checks whether new keys are being entered when saving options.
-	 *
-	 * @inheritDoc
-	 */
-	public function process_admin_options() {
-		// Load all old values before the new settings get saved.
-		$old_publishable_key      = $this->get_option( 'publishable_key' );
-		$old_secret_key           = $this->get_option( 'secret_key' );
-		$old_test_publishable_key = $this->get_option( 'test_publishable_key' );
-		$old_test_secret_key      = $this->get_option( 'test_secret_key' );
-
-		// Trigger Transact onboarding when settings are saved.
-		$saved = parent::process_admin_options();
-		if ( $saved ) {
-			$this->maybe_onboard_with_transact();
-		}
-
-		// Load all old values after the new settings have been saved.
-		$new_publishable_key      = $this->get_option( 'publishable_key' );
-		$new_secret_key           = $this->get_option( 'secret_key' );
-		$new_test_publishable_key = $this->get_option( 'test_publishable_key' );
-		$new_test_secret_key      = $this->get_option( 'test_secret_key' );
-
-		// Checks whether a value has transitioned from a non-empty value to a new one.
-		$has_changed = function ( $old_value, $new_value ) {
-			return ! empty( $old_value ) && ( $old_value !== $new_value );
-		};
-
-		// Look for updates.
-		if (
-			$has_changed( $old_publishable_key, $new_publishable_key )
-			|| $has_changed( $old_secret_key, $new_secret_key )
-			|| $has_changed( $old_test_publishable_key, $new_test_publishable_key )
-			|| $has_changed( $old_test_secret_key, $new_test_secret_key )
-		) {
-			update_option( 'wc_stripe_show_changed_keys_notice', 'yes' );
-		}
-
-		return $saved;
-	}
-
-	/**
-	 * Maybe onboard with the Transact Platform.
-	 *
-	 * @return void
-	 */
-	private function maybe_onboard_with_transact(): void {
-		if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
-			return;
-		}
-
-		// Do not run if Stripe is not enabled.
-		if ( 'yes' !== $this->enabled ) {
-			return;
-		}
-
-		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $this );
-		$transact_account_manager->do_onboarding();
 	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -313,6 +313,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Add metadata to Stripe intents for easier debugging of BNPL issues.
 		add_filter( 'wc_stripe_intent_metadata', [ $this, 'add_bnpl_debug_metadata' ], 10, 2 );
+
+		// Hook for plugin upgrades.
+		add_action( 'woocommerce_updated', [ $this, 'maybe_onboard_with_transact' ] );
 	}
 
 	/**
@@ -3450,5 +3453,37 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		$this->update_option( 'transact_onboarding_complete', 'yes' );
 		$this->transact_onboarding_complete = true;
+	}
+
+	/**
+	 * Checks whether new keys are being entered when saving options.
+	 *
+	 * @inheritDoc
+	 */
+	public function process_admin_options() {
+		// Trigger Transact onboarding when settings are saved.
+		$saved = parent::process_admin_options();
+		if ( $saved ) {
+			$this->maybe_onboard_with_transact();
+		}
+	}
+
+	/**
+	 * Maybe onboard with the Transact Platform.
+	 *
+	 * @return void
+	 */
+	private function maybe_onboard_with_transact(): void {
+		if ( ! is_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
+		// Do not run if Stripe is not enabled.
+		if ( 'yes' !== $this->enabled ) {
+			return;
+		}
+
+		$transact_account_manager = new WC_Stripe_Transact_Account_Manager( $this );
+		$transact_account_manager->do_onboarding();
 	}
 }

--- a/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
@@ -4,6 +4,7 @@ namespace WooCommerce\Stripe\Tests\Admin;
 
 use Automattic\WooCommerce\Blocks\Package;
 use Exception;
+use WC_Stripe_Transact_Account_Manager;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 use WC_Stripe_UPE_Payment_Gateway;
 use WC_REST_Stripe_Settings_Controller;
@@ -512,7 +513,6 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	 * @dataProvider is_payment_request_enabled_legacy_provider
 	 */
 	public function test_is_payment_request_enabled_legacy( $is_enabled, $option_value ) {
-		// Settings controller with non-UPE gateway.
 		$gateway = new WC_Stripe_UPE_Payment_Gateway();
 		$gateway->update_option( 'payment_request', $option_value );
 		$controller = new WC_REST_Stripe_Settings_Controller( $gateway );
@@ -590,6 +590,55 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 				'tabs',
 				'foo',
 				true, // is_upe_enabled
+			],
+		];
+	}
+
+	/**
+	 * Tests for `maybe_onboard_with_transact`.
+	 *
+	 * @param bool $gateway_enabled     Whether the gateway is enabled.
+	 * @param bool $expected_to_onboard Whether onboarding is expected to occur.
+	 * @return void
+	 *
+	 * @dataProvider provide_test_maybe_onboard_with_transact
+	 */
+	public function test_maybe_onboard_with_transact( bool $gateway_enabled = true, bool $expected_to_onboard = false ): void {
+		$gateway          = $this->get_gateway();
+		$gateway->enabled = $gateway_enabled ? 'yes' : 'no';
+
+		$transact_account_manager = $this->getMockBuilder( WC_Stripe_Transact_Account_Manager::class )
+			->onlyMethods( [ 'do_onboarding' ] )
+			->setConstructorArgs( [ $gateway ] )
+			->getMock();
+
+		$transact_account_manager
+			->expects( $expected_to_onboard ? $this->once() : $this->never() )
+			->method( 'do_onboarding' );
+
+		WC_Stripe_Transact_Account_Manager::set_instance( $transact_account_manager );
+
+		$controller = new WC_REST_Stripe_Settings_Controller( $gateway );
+		$controller->maybe_onboard_with_transact();
+
+		// Clean up
+		$gateway->enabled = 'yes';
+	}
+
+	/**
+	 * Provider for `test_maybe_onboard_with_transact`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_maybe_onboard_with_transact(): array {
+		return [
+			'gateway not enabled' => [
+				'gateway enabled'     => false,
+				'expected to onboard' => false,
+			],
+			'gateway enabled'     => [
+				'gateway enabled'     => true,
+				'expected to onboard' => true,
 			],
 		];
 	}

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3132,4 +3132,26 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$this->assertArrayHasKey( 'pmc_enabled', $result );
 		$this->assertEquals( 'yes', $result['pmc_enabled'] );
 	}
+
+	/**
+	 * Tests for `get_jetpack_connection_manager`.
+	 *
+	 * @return void
+	 */
+	public function test_get_jetpack_connection_manager(): void {
+		$this->assertInstanceOf(
+			\Automattic\Jetpack\Connection\Manager::class,
+			$this->mock_gateway->get_jetpack_connection_manager()
+		);
+	}
+
+	/**
+	 * Tests for `set_transact_onboarding_complete`.
+	 *
+	 * @return void
+	 */
+	public function test_set_transact_onboarding_complete(): void {
+		$this->mock_gateway->set_transact_onboarding_complete();
+		$this->assertEquals( 'yes', $this->mock_gateway->get_option( 'transact_onboarding_complete' ) );
+	}
 }

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -5,6 +5,7 @@ namespace WooCommerce\Stripe\Tests;
 use WC_Stripe;
 use WC_Stripe_Helper;
 use WC_Stripe_Payment_Methods;
+use WC_Stripe_Transact_Account_Manager;
 use WC_Stripe_UPE_Payment_Gateway;
 
 /**
@@ -151,6 +152,90 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					WC_Stripe_Payment_Methods::AMAZON_PAY,
 				],
 				'update enable payment methods calls' => 1,
+			],
+		];
+	}
+
+	/**
+	 * Tests for `maybe_onboard_with_transact`.
+	 *
+	 * @param bool $can_manage_woocommerce Whether the user can manage WooCommerce.
+	 * @param bool $gateway_enabled        Whether the gateway is enabled.
+	 * @param bool $onboarding_called      Whether onboarding is expected to be called.
+	 * @return void
+	 *
+	 * @dataProvider provide_test_maybe_onboard_with_transact
+	 */
+	public function test_maybe_onboard_with_transact( $can_manage_woocommerce = false, $gateway_enabled = true, $onboarding_called = false ): void {
+		// Mock the GLOBALS to return `true` for `is_admin`
+		$current_screen = $this->getMockBuilder( \stdClass::class )
+			->addMethods( [ 'in_admin' ] )
+			->getMock();
+
+		$current_screen->expects( $this->any() )
+			->method( 'in_admin' )
+			->willReturn( true );
+
+		$GLOBALS['current_screen'] = $current_screen; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+
+		$user_cap_filter = function ( $allcaps ) use ( $can_manage_woocommerce ) {
+			$allcaps['manage_woocommerce'] = $can_manage_woocommerce;
+			return $allcaps;
+		};
+		add_filter( 'user_has_cap', $user_cap_filter );
+
+		$transact_account_manager = $this->getMockBuilder( WC_Stripe_Transact_Account_Manager::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'do_onboarding' ] )
+			->getMock();
+
+		$transact_account_manager->expects( $onboarding_called ? $this->once() : $this->never() )
+			->method( 'do_onboarding' );
+
+		WC_Stripe_Transact_Account_Manager::set_instance( $transact_account_manager );
+
+		$upe_payment_gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$upe_payment_gateway->enabled = $gateway_enabled ? 'yes' : 'no';
+
+		$wc_stripe = $this->getMockBuilder( WC_Stripe::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_main_stripe_gateway' ] )
+			->getMock();
+
+		$wc_stripe->method( 'get_main_stripe_gateway' )
+			->willReturn( $upe_payment_gateway );
+
+		$wc_stripe->maybe_onboard_with_transact();
+
+		// Clean up.
+		remove_filter( 'user_has_cap', $user_cap_filter );
+		unset( $GLOBALS['current_screen'] );
+	}
+
+	/**
+	 * Provider for `test_maybe_onboard_with_transact`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_maybe_onboard_with_transact(): array {
+		return [
+			'user cannot manage woocommerce' => [
+				'user can manage woocommerce' => false,
+				'gateway is enabled'          => true,
+				'onboarding called'           => false,
+			],
+			'gateway is not enabled'         => [
+				'user can manage woocommerce' => true,
+				'gateway is enabled'          => false,
+				'onboarding called'           => false,
+			],
+			'onboarding called successfully' => [
+				'user can manage woocommerce' => true,
+				'gateway is enabled'          => true,
+				'onboarding called'           => true,
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
+++ b/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
@@ -289,7 +289,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 
 		// Check that the cache was updated.
 		$cached_data = WC_Stripe_Database_Cache::get( 'transact_merchant_account_test' );
-		$this->assertEquals( $expected_merchant_account, $cached_data['account'] );
+		$this->assertNull( $cached_data );
 	}
 
 
@@ -356,7 +356,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Check that the cache was updated.
 		WC_Stripe_Database_Cache::delete( 'transact_provider_account_test' );
 		$cached_data = WC_Stripe_Database_Cache::get( 'transact_provider_account_test' );
-		$this->assertTrue( $cached_data['account'] );
+		$this->assertNull( $cached_data );
 	}
 
 	/**

--- a/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
+++ b/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
@@ -96,7 +96,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 	 * Test constructor sets gateway.
 	 */
 	public function test_constructor_sets_gateway() {
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 
 		// Use reflection to access the private gateway property.
 		$reflection       = new \ReflectionClass( $account_manager );

--- a/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
+++ b/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
@@ -1,0 +1,741 @@
+<?php
+/**
+ * Class WC_Stripe_Transact_Account_Manager_Test file.
+ *
+ * @package WooCommerce_Stripe/Tests
+ */
+
+declare(strict_types=1);
+
+namespace WooCommerce\Stripe\Tests;
+
+use WC_Stripe_Connect;
+use WC_Stripe_Database_Cache;
+use WC_Stripe_Helper;
+use WC_Stripe_UPE_Payment_Gateway;
+use WC_Stripe_Transact_Account_Manager;
+use WP_UnitTestCase;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Stripe_Transact_Account_Manager_Test class.
+ *
+ * @package WooCommerce_Stripe/Tests
+ */
+class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
+	/**
+	 * Mock Stripe gateway.
+	 *
+	 * @var WC_Stripe_UPE_Payment_Gateway
+	 */
+	private $gateway;
+
+	/**
+	 * Account manager instance.
+	 *
+	 * @var WC_Stripe_Transact_Account_Manager
+	 */
+	private $account_manager;
+
+	/**
+	 * The original `WC_Stripe_Connect` instance, to be restored after tests.
+	 *
+	 * @var WC_Stripe_Connect
+	 */
+	private WC_Stripe_Connect $stripe_connect_original;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Create mock Stripe gateway.
+		$this->gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Set default properties.
+		$stripe_settings             = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['testmode'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		// overriding the `WC_Stripe_Connect` in woocommerce_gateway_stripe(),
+		$stripe_connect_mock = $this->createPartialMock(
+			WC_Stripe_Connect::class,
+			[ 'is_connected_via_oauth' ]
+		);
+		$stripe_connect_mock
+			->expects( $this->any() )
+			->method( 'is_connected_via_oauth' )
+			->willReturn( true );
+
+		$this->stripe_connect_original        = woocommerce_gateway_stripe()->connect;
+		woocommerce_gateway_stripe()->connect = $stripe_connect_mock;
+
+		// Create account manager instance.
+		$this->account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		parent::tear_down();
+
+		// Restoring the original `WC_Stripe_Connect` instance.
+		woocommerce_gateway_stripe()->connect = $this->stripe_connect_original;
+	}
+
+	/**
+	 * Test constructor sets gateway.
+	 */
+	public function test_constructor_sets_gateway() {
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+
+		// Use reflection to access the private gateway property.
+		$reflection       = new \ReflectionClass( $account_manager );
+		$gateway_property = $reflection->getProperty( 'gateway' );
+		$gateway_property->setAccessible( true );
+
+		$this->assertSame( $this->gateway, $gateway_property->getValue( $account_manager ) );
+	}
+
+	/**
+	 * Test do_onboarding when not connected via OAuth.
+	 */
+	public function test_do_onboarding_when_not_connected_via_oauth() {
+		// overriding the `WC_Stripe_Connect` in woocommerce_gateway_stripe(),
+		$stripe_connect_mock = $this->createPartialMock(
+			WC_Stripe_Connect::class,
+			[ 'is_connected_via_oauth' ]
+		);
+		$stripe_connect_mock
+			->expects( $this->any() )
+			->method( 'is_connected_via_oauth' )
+			->willReturn( false );
+
+		$this->stripe_connect_original        = woocommerce_gateway_stripe()->connect;
+		woocommerce_gateway_stripe()->connect = $stripe_connect_mock;
+
+		// Should not throw any errors and should return early.
+		$this->account_manager->do_onboarding();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test do_onboarding when Jetpack registration fails.
+	 */
+	public function test_do_onboarding_when_jetpack_registration_fails() {
+		// Mock the gateway to return a mock Jetpack connection manager.
+		$jetpack_manager = $this->getMockBuilder( \Automattic\Jetpack\Connection\Manager::class )
+			->onlyMethods( [ 'is_connected', 'try_registration' ] )
+			->getMock();
+
+		$jetpack_manager->method( 'is_connected' )
+			->willReturn( false );
+
+		$jetpack_manager->method( 'try_registration' )
+			->willReturn( new \WP_Error( 'registration_failed', 'Registration failed' ) );
+
+		$this->gateway->method( 'get_jetpack_connection_manager' )
+			->willReturn( $jetpack_manager );
+
+		// Should not throw any errors and should return early.
+		$this->account_manager->do_onboarding();
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test do_onboarding when merchant account creation fails.
+	 */
+	public function test_do_onboarding_when_merchant_account_creation_fails() {
+		// Mock the gateway to return a mock Jetpack connection manager.
+		$jetpack_manager = $this->getMockBuilder( \Automattic\Jetpack\Connection\Manager::class )
+			->onlyMethods( [ 'is_connected' ] )
+			->getMock();
+
+		$jetpack_manager->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->gateway->method( 'get_jetpack_connection_manager' )
+			->willReturn( $jetpack_manager );
+
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return an error.
+		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		// Should do nothing. Should not throw any errors.
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager->do_onboarding();
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test do_onboarding when provider account creation fails.
+	 */
+	public function test_do_onboarding_when_provider_account_creation_fails() {
+		// Mock the gateway to return a mock Jetpack connection manager.
+		$jetpack_manager = $this->getMockBuilder( \Automattic\Jetpack\Connection\Manager::class )
+			->onlyMethods( [ 'is_connected' ] )
+			->getMock();
+
+		$jetpack_manager->method( 'is_connected' )
+			->willReturn( true );
+
+		$this->gateway->method( 'get_jetpack_connection_manager' )
+			->willReturn( $jetpack_manager );
+
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return an error.
+		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		// Should do nothing. Should not throw any errors.
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager->do_onboarding();
+
+		// Check that it returns true.
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test get_merchant_account_data returns cached data when available.
+	 */
+	public function test_get_merchant_account_data_returns_cached_data() {
+		// Return valid cache data.
+		WC_Stripe_Database_Cache::set( 'transact_merchant_account_test', $this->return_valid_merchant_account_cache() );
+
+		$result = $this->account_manager->get_transact_account_data( 'merchant' );
+
+		// Clean up the filter.
+		WC_Stripe_Database_Cache::delete( 'transact_merchant_account_test' );
+
+		$expected_merchant_account = $this->return_valid_merchant_account_cache();
+		$this->assertEquals( $expected_merchant_account['account'], $result );
+	}
+
+	/**
+	 * Test get_merchant_account_data returns null when cache is expired.
+	 */
+	public function test_get_merchant_account_data_returns_null_when_cache_expired() {
+		// Mock cache to return expired data.
+		WC_Stripe_Database_Cache::set( 'transact_merchant_account_test', $this->return_expired_merchant_account_cache() );
+
+		$result = $this->account_manager->get_transact_account_data( 'merchant' );
+
+		// Clean up the filter.
+		WC_Stripe_Database_Cache::delete( 'transact_merchant_account_test' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test get_merchant_account_data fetches when cache is empty and caches fetched data.
+	 */
+	public function test_get_merchant_account_data_fetches_and_caches_data() {
+		// Return empty cache.
+		WC_Stripe_Database_Cache::set( 'transact_merchant_account_test', $this->return_empty_merchant_account_cache() );
+
+		// Return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Return a successful response, with the merchant account data.
+		add_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
+
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$result          = $account_manager->get_transact_account_data( 'merchant' );
+
+		// Clean up the filters and cache.
+		WC_Stripe_Database_Cache::delete( 'transact_merchant_account_test' );
+
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
+
+		// Check that it returns the data.
+		$response_data             = json_decode( $this->return_merchant_account_api_success()['body'], true );
+		$expected_merchant_account = [ 'public_id' => $response_data['public_id'] ];
+		$this->assertEquals( $expected_merchant_account, $result );
+
+		// Check that the cache was updated.
+		$cached_data = WC_Stripe_Database_Cache::get( 'transact_merchant_account_test' );
+		$this->assertEquals( $expected_merchant_account, $cached_data['account'] );
+	}
+
+
+	/**
+	 * Test get_provider_account_data returns cached data when available.
+	 */
+	public function test_get_provider_account_data_returns_cached_data() {
+		// Return valid cache data.
+		WC_Stripe_Database_Cache::set( 'transact_provider_account_test', $this->return_valid_provider_account_cache() );
+
+		$result = $this->account_manager->get_transact_account_data( 'provider' );
+
+		// Clean up the cache.
+		WC_Stripe_Database_Cache::delete( 'transact_provider_account_test' );
+
+		$expected_provider_account = $this->return_valid_provider_account_cache();
+		$this->assertEquals( $expected_provider_account['account'], $result );
+	}
+
+	/**
+	 * Test get_provider_account_data returns null when cache is expired.
+	 */
+	public function test_get_provider_account_data_returns_null_when_cache_expired() {
+		// Mock cache to return expired data.
+		WC_Stripe_Database_Cache::set( 'transact_provider_account_test', $this->return_expired_provider_account_cache() );
+
+		$result = $this->account_manager->get_transact_account_data( 'provider' );
+
+		// Clean up the cache.
+		WC_Stripe_Database_Cache::delete( 'transact_provider_account_test' );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test get_provider_account_data fetches when cache is empty and caches fetched data.
+	 */
+	public function test_get_provider_account_data_fetches_and_caches_data() {
+		// Return empty cache.
+		WC_Stripe_Database_Cache::set( 'transact_provider_account_test', $this->return_empty_provider_account_cache() );
+
+		// Return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Return a successful response, with the provider account data.
+		add_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
+
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$result          = $account_manager->get_transact_account_data( 'provider' );
+
+		// Clean up the filters and cache.
+		WC_Stripe_Database_Cache::delete( 'transact_provider_account_test' );
+
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
+
+		// Check that it returns the data.
+		$this->assertTrue( $result );
+
+		// Check that the cache was updated.
+		WC_Stripe_Database_Cache::delete( 'transact_provider_account_test' );
+		$cached_data = WC_Stripe_Database_Cache::get( 'transact_provider_account_test' );
+		$this->assertTrue( $cached_data['account'] );
+	}
+
+	/**
+	 * Test fetch_merchant_account when API request fails.
+	 */
+	public function test_fetch_merchant_account_when_api_request_fails() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return an error.
+		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$reflection      = new \ReflectionClass( $account_manager );
+		$method          = $reflection->getMethod( 'fetch_merchant_account' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test fetch_merchant_account when API response is successful.
+	 */
+	public function test_fetch_merchant_account_when_api_response_successful() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return a successful response.
+		add_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
+
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$reflection      = new \ReflectionClass( $account_manager );
+		$method          = $reflection->getMethod( 'fetch_merchant_account' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
+
+		$this->assertEquals( [ 'public_id' => 'test_public_id' ], $result );
+	}
+
+	/**
+	 * Test fetch_provider_account when API request fails.
+	 */
+	public function test_fetch_provider_account_when_api_request_fails() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return an error.
+		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		// Create a real account manager instance.
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+
+		// Use reflection to access the private fetch_provider_account method.
+		$reflection = new \ReflectionClass( $account_manager );
+		$method     = $reflection->getMethod( 'fetch_provider_account' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test fetch_provider_account when API response is successful.
+	 */
+	public function test_fetch_provider_account_when_api_response_successful() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return a successful response.
+		add_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
+
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$reflection      = new \ReflectionClass( $account_manager );
+		$method          = $reflection->getMethod( 'fetch_provider_account' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
+
+		// Check that it returns true.
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test create_merchant_account when API request fails.
+	 */
+	public function test_create_merchant_account_when_api_request_fails() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return an error.
+		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		// Create a real account manager instance.
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+
+		// Use reflection to access the private create_merchant_account method.
+		$reflection    = new \ReflectionClass( $account_manager );
+		$create_method = $reflection->getMethod( 'create_merchant_account' );
+		$create_method->setAccessible( true );
+
+		$result = $create_method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		// The method should return null when API fails.
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test create_merchant_account when API response is successful.
+	 */
+	public function test_create_merchant_account_when_api_response_successful() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return a successful response.
+		add_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
+
+		// Create a real account manager instance.
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+
+		// Use reflection to access the private create_merchant_account method.
+		$reflection = new \ReflectionClass( $account_manager );
+		$method     = $reflection->getMethod( 'create_merchant_account' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
+
+		// Check that it returns the data.
+		$this->assertEquals( [ 'public_id' => 'test_public_id' ], $result );
+	}
+
+	/**
+	 * Test create_provider_account when API request fails.
+	 */
+	public function test_create_provider_account_when_api_request_fails() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return an error.
+		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$reflection      = new \ReflectionClass( $account_manager );
+		$method          = $reflection->getMethod( 'create_provider_account' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Check that it returns false.
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test create_provider_account when API response is successful.
+	 */
+	public function test_create_provider_account_when_api_response_successful() {
+		// Mock Jetpack options to return a valid site ID.
+		add_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+
+		// Return a Jetpack blog token.
+		add_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+
+		// Mock the HTTP request to return a successful response.
+		add_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
+
+		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$reflection      = new \ReflectionClass( $account_manager );
+		$method          = $reflection->getMethod( 'create_provider_account' );
+		$method->setAccessible( true );
+		$result = $method->invoke( $account_manager );
+
+		// Clean up the filters.
+		remove_filter( 'pre_option_jetpack_private_options', [ $this, 'return_blog_token' ] );
+		remove_filter( 'pre_option_jetpack_options', [ $this, 'return_valid_site_id' ] );
+		remove_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
+
+		// Check that it returns true.
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Helper method to return API error response.
+	 *
+	 * @return \WP_Error Error response.
+	 */
+	public function return_api_error() {
+		return new \WP_Error( 'api_error', 'API request failed' );
+	}
+
+	/**
+	 * Helper method to return successful merchant account API response.
+	 *
+	 * @return array Success response.
+	 */
+	public function return_merchant_account_api_success() {
+		return [
+			'response' => [ 'code' => 200 ],
+			'body'     => wp_json_encode(
+				[
+					'public_id' => 'test_public_id',
+				]
+			),
+		];
+	}
+
+	/**
+	 * Helper method to return successful provider account API response.
+	 *
+	 * @return array Success response.
+	 */
+	public function return_provider_account_api_success() {
+		return [ 'response' => [ 'code' => 200 ] ];
+	}
+
+	/**
+	 * Helper method to return null site ID for Jetpack options.
+	 *
+	 * @param mixed $value The option value.
+	 *
+	 * @return null
+	 */
+	public function return_null_site_id( $value ) {
+		return [ 'id' => null ];
+	}
+
+	/**
+	 * Helper method to return valid site ID for Jetpack options.
+	 *
+	 * @param mixed $value The option value.
+	 *
+	 * @return int
+	 */
+	public function return_valid_site_id( $value ) {
+		return [ 'id' => 12345 ];
+	}
+
+	/**
+	 * Helper method to return empty merchant account cache.
+	 *
+	 * @return false
+	 */
+	public function return_empty_merchant_account_cache() {
+		return false;
+	}
+
+	/**
+	 * Helper method to return expired merchant account cache.
+	 *
+	 * @return array
+	 */
+	public function return_expired_merchant_account_cache() {
+		return [
+			'account' => [ 'public_id' => 'test_public_id' ],
+			'expiry'  => time() - 3600, // Expired 1 hour ago.
+		];
+	}
+
+	/**
+	 * Helper method to return valid merchant account cache.
+	 *
+	 * @return array
+	 */
+	public function return_valid_merchant_account_cache() {
+		return [
+			'account' => [ 'public_id' => 'test_public_id' ],
+			'expiry'  => time() + 3600, // Expires in 1 hour.
+		];
+	}
+
+	/**
+	 * Helper method to return empty provider account cache.
+	 *
+	 * @return false
+	 */
+	public function return_empty_provider_account_cache() {
+		return false;
+	}
+
+	/**
+	 * Helper method to return expired provider account cache.
+	 *
+	 * @return array
+	 */
+	public function return_expired_provider_account_cache() {
+		return [
+			'account' => true,
+			'expiry'  => time() - 3600, // Expired 1 hour ago.
+		];
+	}
+
+	/**
+	 * Helper method to return valid provider account cache.
+	 *
+	 * @return array
+	 */
+	public function return_valid_provider_account_cache() {
+		return [
+			'account' => true,
+			'expiry'  => time() + 3600, // Expires in 1 hour.
+		];
+	}
+
+	/**
+	 * Helper method to return valid blog token for Jetpack options.
+	 *
+	 * @param mixed $value The option value.
+	 *
+	 * @return array
+	 */
+	public function return_blog_token( $value ) {
+		return [ 'blog_token' => 'IAM.AJETPACKBLOGTOKEN' ];
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tearDown(): void {
+		// Clean up any options we created.
+		WC_Stripe_Database_Cache::delete( 'transact_merchant_account_live' );
+		WC_Stripe_Database_Cache::delete( 'transact_merchant_account_test' );
+		WC_Stripe_Database_Cache::delete( 'transact_provider_account_live' );
+		WC_Stripe_Database_Cache::delete( 'transact_provider_account_test' );
+
+		parent::tearDown();
+	}
+}

--- a/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
+++ b/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
@@ -93,9 +93,9 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test constructor sets gateway.
+	 * Test `get_instance` sets gateway.
 	 */
-	public function test_constructor_sets_gateway() {
+	public function test_get_instance_sets_gateway() {
 		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 
 		// Use reflection to access the private gateway property.

--- a/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
+++ b/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
@@ -95,15 +95,18 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 	/**
 	 * Test `get_instance` sets gateway.
 	 */
-	public function test_get_instance_sets_gateway() {
+	public function test_get_instance_set_instance() {
 		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
+		$this->assertInstanceOf( WC_Stripe_Transact_Account_Manager::class, $account_manager );
 
-		// Use reflection to access the private gateway property.
-		$reflection       = new \ReflectionClass( $account_manager );
-		$gateway_property = $reflection->getProperty( 'gateway' );
-		$gateway_property->setAccessible( true );
+		// Test setting a custom instance.
+		$custom_transaction_manager = new class( $this->gateway ) extends WC_Stripe_Transact_Account_Manager {
+			public string $test_property = 'foo';
+		};
 
-		$this->assertSame( $this->gateway, $gateway_property->getValue( $account_manager ) );
+		WC_Stripe_Transact_Account_Manager::set_instance( $custom_transaction_manager );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
+		$this->assertEquals( 'foo', $account_manager->test_property );
 	}
 
 	/**

--- a/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
+++ b/tests/phpunit/WC_Stripe_Transact_Account_Manager_Test.php
@@ -77,7 +77,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		woocommerce_gateway_stripe()->connect = $stripe_connect_mock;
 
 		// Create account manager instance.
-		$this->account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$this->account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 	}
 
 	/**
@@ -178,7 +178,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
 
 		// Should do nothing. Should not throw any errors.
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$account_manager->do_onboarding();
 
 		// Clean up the filters.
@@ -214,7 +214,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
 
 		// Should do nothing. Should not throw any errors.
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$account_manager->do_onboarding();
 
 		// Check that it returns true.
@@ -272,7 +272,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Return a successful response, with the merchant account data.
 		add_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
 
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$result          = $account_manager->get_transact_account_data( 'merchant' );
 
 		// Clean up the filters and cache.
@@ -340,7 +340,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Return a successful response, with the provider account data.
 		add_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
 
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$result          = $account_manager->get_transact_account_data( 'provider' );
 
 		// Clean up the filters and cache.
@@ -372,7 +372,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Mock the HTTP request to return an error.
 		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
 
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$reflection      = new \ReflectionClass( $account_manager );
 		$method          = $reflection->getMethod( 'fetch_merchant_account' );
 		$method->setAccessible( true );
@@ -400,7 +400,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Mock the HTTP request to return a successful response.
 		add_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
 
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$reflection      = new \ReflectionClass( $account_manager );
 		$method          = $reflection->getMethod( 'fetch_merchant_account' );
 		$method->setAccessible( true );
@@ -429,7 +429,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
 
 		// Create a real account manager instance.
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 
 		// Use reflection to access the private fetch_provider_account method.
 		$reflection = new \ReflectionClass( $account_manager );
@@ -458,7 +458,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Mock the HTTP request to return a successful response.
 		add_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
 
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$reflection      = new \ReflectionClass( $account_manager );
 		$method          = $reflection->getMethod( 'fetch_provider_account' );
 		$method->setAccessible( true );
@@ -487,7 +487,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
 
 		// Create a real account manager instance.
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 
 		// Use reflection to access the private create_merchant_account method.
 		$reflection    = new \ReflectionClass( $account_manager );
@@ -519,7 +519,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $this, 'return_merchant_account_api_success' ] );
 
 		// Create a real account manager instance.
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 
 		// Use reflection to access the private create_merchant_account method.
 		$reflection = new \ReflectionClass( $account_manager );
@@ -550,7 +550,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Mock the HTTP request to return an error.
 		add_filter( 'pre_http_request', [ $this, 'return_api_error' ] );
 
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$reflection      = new \ReflectionClass( $account_manager );
 		$method          = $reflection->getMethod( 'create_provider_account' );
 		$method->setAccessible( true );
@@ -578,7 +578,7 @@ class WC_Stripe_Transact_Account_Manager_Test extends WP_UnitTestCase {
 		// Mock the HTTP request to return a successful response.
 		add_filter( 'pre_http_request', [ $this, 'return_provider_account_api_success' ] );
 
-		$account_manager = new WC_Stripe_Transact_Account_Manager( $this->gateway );
+		$account_manager = WC_Stripe_Transact_Account_Manager::get_instance( $this->gateway );
 		$reflection      = new \ReflectionClass( $account_manager );
 		$method          = $reflection->getMethod( 'create_provider_account' );
 		$method->setAccessible( true );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See peNR48-1Qg#comment-1095-p2

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, we are introducing a mechanism to onboard plugin merchants to the Jetpack Transact Platform. It follows the same standard [we have in PayPal](https://github.com/woocommerce/woocommerce/pull/60238), with most of the code ported from there.

The onboarding logic is triggered upon saving the Stripe settings or by performing a plugin upgrade.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Apply the 194549-ghe-Automattic/wpcom to your WPCOM Sandbox
- Checkout to this branch on your test environment (`dev/jetpack-onboarding-class`)
- Make sure it is externally accessible
- And that the `/etc/hosts` file contains an entry for your WPCOM sandbox:
```
<WPCOM Sandbox IP> public-api.wordpress.com
```
- Connect your Stripe account
- Attempt to save any Stripe setting, like toggling OCS on/off
- Check the value of the Stripe settings option on your database (`wp_options`, `woocommerce_stripe_settings` key)
- Confirm `transact_onboarding_complete` is present with the `yes` value

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
