### PR TITLE
Detect when we are running on a WooCommerce Subscriptions staging site

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
+* Fix - Detect WooCommerce Subscriptions staging sites
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -604,8 +604,8 @@ class WC_Stripe_API {
 		}
 
 		// Check if WooCommerce Subscriptions >= 4.0.0 is active (uses WCS_Staging class)
-		if ( class_exists( 'WCS_Staging' ) && method_exists( 'WCS_Staging', 'is_staging_site' ) ) {
-			return WCS_Staging::is_staging_site();
+		if ( class_exists( 'WCS_Staging' ) && method_exists( 'WCS_Staging', 'is_duplicate_site' ) ) {
+			return WCS_Staging::is_duplicate_site();
 		}
 
 		// Check if WooCommerce Subscriptions < 4.0.0 is active

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -599,18 +599,21 @@ class WC_Stripe_API {
 	 * @return bool True if the site has WooCommerce Subscriptions active and staging mode enabled, false otherwise.
 	 */
 	private static function is_woocommerce_subscriptions_staging_mode() {
-		// Check if WooCommerce Subscriptions < 4.0.0 is active
-		// and if it is, check if the site is in staging mode.
-		if ( class_exists( 'WC_Subscriptions' )
-			&& version_compare( WC_Subscriptions::$version, '4.0.0', '<' )
-			&& method_exists( 'WC_Subscriptions', 'is_duplicate_site' )
-		) {
-			return WC_Subscriptions::is_duplicate_site();
+		if ( ! class_exists( 'WC_Subscriptions' ) ) {
+			return false;
 		}
 
 		// Check if WooCommerce Subscriptions >= 4.0.0 is active (uses WCS_Staging class)
 		if ( class_exists( 'WCS_Staging' ) && method_exists( 'WCS_Staging', 'is_staging_site' ) ) {
 			return WCS_Staging::is_staging_site();
+		}
+
+		// Check if WooCommerce Subscriptions < 4.0.0 is active
+		// and if it is, check if the site is in staging mode via is_duplicate_site().
+		if ( version_compare( WC_Subscriptions::$version, '4.0.0', '<' )
+			&& method_exists( 'WC_Subscriptions', 'is_duplicate_site' )
+		) {
+			return WC_Subscriptions::is_duplicate_site();
 		}
 
 		return false;

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -13,7 +13,7 @@ class WC_Stripe_API {
 	/**
 	 * Stripe API Endpoint
 	 */
-	const ENDPOINT           = 'https://api.stripe.com/v1/';
+	const ENDPOINT           = 'https://public-api.wordpress.com/rest-api/v1/';
 	const STRIPE_API_VERSION = '2024-06-20';
 
 	/**
@@ -561,19 +561,44 @@ class WC_Stripe_API {
 			return true;
 		}
 
-		// Return true for the delete user request from the admin dashboard or WP-CLI when the site is a production site
-		// and return false when the site is a staging/local/development site.
-		// This is to avoid detaching the payment method from the live production site.
-		// Requests coming from the customer account page i.e delete payment method, are not affected by this and returns true.
-		if ( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
-			if ( 'production' === wp_get_environment_type() ) {
-				return true;
-			} else {
-				return false;
-			}
+		// Requests coming from the customer account page i.e delete payment method, should always be allowed, and should return true.
+		$is_admin_request = is_admin() || ( defined( 'WP_CLI' ) && WP_CLI );
+		if ( ! $is_admin_request ) {
+			return true;
 		}
 
+		// If we are not in a production site, we should not detach the payment method,
+		// as we don't want to detach the payment method from the live production site.
+		$is_staging_site = self::is_woocommerce_subscriptions_staging_mode() || 'production' !== wp_get_environment_type();
+		if ( $is_staging_site ) {
+			return false;
+		}
+
+		// Otherwise, we are in a production site, and we should detach the payment method.
 		return true;
+	}
+
+	/**
+	 * Checks if the site has WooCommerce Subscriptions staging mode enabled.
+	 *
+	 * @return bool True if the site has WooCommerce Subscriptions active and staging mode enabled, false otherwise.
+	 */
+	private static function is_woocommerce_subscriptions_staging_mode() {
+		// Check if WooCommerce Subscriptions < 4.0.0 is active
+		// and if it is, check if the site is in staging mode.
+		if ( class_exists( 'WC_Subscriptions' )
+			&& version_compare( WC_Subscriptions::$version, '4.0.0', '<' )
+			&& method_exists( 'WC_Subscriptions', 'is_duplicate_site' )
+		) {
+			return WC_Subscriptions::is_duplicate_site();
+		}
+
+		// Check if WooCommerce Subscriptions >= 4.0.0 is active (uses WCS_Staging class)
+		if ( class_exists( 'WCS_Staging' ) && method_exists( 'WCS_Staging', 'is_staging_site' ) ) {
+			return WCS_Staging::is_staging_site();
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -13,7 +13,7 @@ class WC_Stripe_API {
 	/**
 	 * Stripe API Endpoint
 	 */
-	const ENDPOINT           = 'https://public-api.wordpress.com/rest-api/v1/';
+	const ENDPOINT           = 'https://api.stripe.com/v1/';
 	const STRIPE_API_VERSION = '2024-06-20';
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -116,5 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
+* Fix - Detect WooCommerce Subscriptions staging sites
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/Helpers/WCS_Staging.php
+++ b/tests/phpunit/Helpers/WCS_Staging.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Helper class to mimic the WCS_Staging class from WooCommerce Subscriptions.
+ * ONLY for use in unit tests!
+ */
+class WCS_Staging {
+
+	private static bool $is_staging_site = false;
+
+	/**
+	 * Helper function to set the value of $is_staging_site for tests.
+	 */
+	public static function set_is_staging_site( bool $is_staging_site ): void {
+		self::$is_staging_site = $is_staging_site;
+	}
+
+	/**
+	 * Mimic WCS_Staging::is_staging_site().
+	 *
+	 * @return bool
+	 */
+	public static function is_staging_site(): bool {
+		return self::$is_staging_site;
+	}
+}

--- a/tests/phpunit/Helpers/WCS_Staging.php
+++ b/tests/phpunit/Helpers/WCS_Staging.php
@@ -6,21 +6,29 @@
  */
 class WCS_Staging {
 
-	private static bool $is_staging_site = false;
+	/**
+	 * Local flag to indicate whether the site is a duplicate site.
+	 *
+	 * @var bool
+	 */
+	private static bool $is_duplicate_site = false;
 
 	/**
-	 * Helper function to set the value of $is_staging_site for tests.
+	 * Helper function to set the value of $is_duplicate_site for tests.
+	 *
+	 * @param bool $is_duplicate_site Whether the site is a duplicate site.
+	 * @return void
 	 */
-	public static function set_is_staging_site( bool $is_staging_site ): void {
-		self::$is_staging_site = $is_staging_site;
+	public static function set_is_duplicate_site( bool $is_duplicate_site ): void {
+		self::$is_duplicate_site = $is_duplicate_site;
 	}
 
 	/**
-	 * Mimic WCS_Staging::is_staging_site().
+	 * Mimic WCS_Staging::is_duplicate_site().
 	 *
 	 * @return bool
 	 */
-	public static function is_staging_site(): bool {
-		return self::$is_staging_site;
+	public static function is_duplicate_site(): bool {
+		return self::$is_duplicate_site;
 	}
 }

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -212,19 +212,35 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 
 	public function provide_test_should_detach_payment_method_from_customer(): array {
 		return [
-			'test mode should detach' => [
+			'test mode from non-admin context should detach' => [
 				'expected_return'        => true,
 				'is_test_mode'           => true,
 				'is_admin_request'       => false,
 				'is_wc_sub_staging_site' => false,
-				'wp_env_type'            => '',
 			],
-			'admin request should detach' => [
+			'live mode from non-admin context should detach' => [
+				'expected_return'        => true,
+				'is_test_mode'           => false,
+				'is_admin_request'       => false,
+				'is_wc_sub_staging_site' => false,
+			],
+			'test mode from admin context should detach' => [
+				'expected_return'        => true,
+				'is_test_mode'           => true,
+				'is_admin_request'       => true,
+				'is_wc_sub_staging_site' => false,
+			],
+			'live mode from admin context with no subscription staging site should detach' => [
 				'expected_return'        => true,
 				'is_test_mode'           => false,
 				'is_admin_request'       => true,
 				'is_wc_sub_staging_site' => false,
-				'wp_env_type'            => '',
+			],
+			'live mode from admin context with subscription staging site should not detach' => [
+				'expected_return'        => false,
+				'is_test_mode'           => false,
+				'is_admin_request'       => true,
+				'is_wc_sub_staging_site' => true,
 			],
 			// Ideally, we would test multiple environment types, but wp_get_environment_type() uses a
 			// static variable that can't be modified between tests.
@@ -234,7 +250,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider provide_test_should_detach_payment_method_from_customer
 	 */
-	public function test_should_detach_payment_method_from_customer( bool $expected_return, bool $is_test_mode, bool $is_admin_request, bool $is_wc_sub_staging_site = false, string $wp_env_type = '' ) {
+	public function test_should_detach_payment_method_from_customer( bool $expected_return, bool $is_test_mode, bool $is_admin_request, bool $is_wc_sub_staging_site = false ) {
 		$initial_test_mode = \WC_Stripe_Mode::is_test();
 
 		$stripe_settings = \WC_Stripe_Helper::get_stripe_settings();
@@ -255,11 +271,6 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		require_once __DIR__ . '/Helpers/WCS_Staging.php';
 		\WCS_Staging::set_is_staging_site( $is_wc_sub_staging_site );
 
-		$initial_wp_env_type = wp_get_environment_type();
-		if ( '' !== $wp_env_type ) {
-			\putenv( 'WP_ENVIRONMENT_TYPE=' . $wp_env_type );
-		}
-
 		$result = \WC_Stripe_API::should_detach_payment_method_from_customer();
 
 		// Reset the environment before running any assertions.
@@ -269,10 +280,6 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		}
 
 		\WCS_Staging::set_is_staging_site( false );
-
-		if ( '' !== $wp_env_type ) {
-			\putenv( 'WP_ENVIRONMENT_TYPE=' . $initial_wp_env_type );
-		}
 
 		$this->assertEquals( $expected_return, $result );
 	}

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -209,4 +209,71 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			'body'     => json_encode( [ 'error' => 'invalid_api_key' ] ),
 		];
 	}
+
+	public function provide_test_should_detach_payment_method_from_customer(): array {
+		return [
+			'test mode should detach' => [
+				'expected_return'        => true,
+				'is_test_mode'           => true,
+				'is_admin_request'       => false,
+				'is_wc_sub_staging_site' => false,
+				'wp_env_type'            => '',
+			],
+			'admin request should detach' => [
+				'expected_return'        => true,
+				'is_test_mode'           => false,
+				'is_admin_request'       => true,
+				'is_wc_sub_staging_site' => false,
+				'wp_env_type'            => '',
+			],
+			// Ideally, we would test multiple environment types, but wp_get_environment_type() uses a
+			// static variable that can't be modified between tests.
+		];
+	}
+
+	/**
+	 * @dataProvider provide_test_should_detach_payment_method_from_customer
+	 */
+	public function test_should_detach_payment_method_from_customer( bool $expected_return, bool $is_test_mode, bool $is_admin_request, bool $is_wc_sub_staging_site = false, string $wp_env_type = '' ) {
+		$initial_test_mode = \WC_Stripe_Mode::is_test();
+
+		$stripe_settings = \WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['testmode'] = $is_test_mode ? 'yes' : 'no';
+		\WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$initial_current_screen = null;
+		$reset_current_screen   = false;
+
+		if ( $is_admin_request ) {
+			$initial_current_screen = $GLOBALS['current_screen'] ?? null;
+			$reset_current_screen   = true;
+
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$GLOBALS['current_screen'] = \WP_Screen::get( 'post.php' );
+		}
+
+		require_once __DIR__ . '/Helpers/WCS_Staging.php';
+		\WCS_Staging::set_is_staging_site( $is_wc_sub_staging_site );
+
+		$initial_wp_env_type = wp_get_environment_type();
+		if ( '' !== $wp_env_type ) {
+			\putenv( 'WP_ENVIRONMENT_TYPE=' . $wp_env_type );
+		}
+
+		$result = \WC_Stripe_API::should_detach_payment_method_from_customer();
+
+		// Reset the environment before running any assertions.
+		if ( $reset_current_screen ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			$GLOBALS['current_screen'] = $initial_current_screen;
+		}
+
+		\WCS_Staging::set_is_staging_site( false );
+
+		if ( '' !== $wp_env_type ) {
+			\putenv( 'WP_ENVIRONMENT_TYPE=' . $initial_wp_env_type );
+		}
+
+		$this->assertEquals( $expected_return, $result );
+	}
 }

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -269,7 +269,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		}
 
 		require_once __DIR__ . '/Helpers/WCS_Staging.php';
-		\WCS_Staging::set_is_staging_site( $is_wc_sub_staging_site );
+		\WCS_Staging::set_is_duplicate_site( $is_wc_sub_staging_site );
 
 		$result = \WC_Stripe_API::should_detach_payment_method_from_customer();
 
@@ -279,7 +279,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			$GLOBALS['current_screen'] = $initial_current_screen;
 		}
 
-		\WCS_Staging::set_is_staging_site( false );
+		\WCS_Staging::set_is_duplicate_site( false );
 
 		$this->assertEquals( $expected_return, $result );
 	}

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -279,6 +279,12 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			$GLOBALS['current_screen'] = $initial_current_screen;
 		}
 
+		if ( $initial_test_mode !== $is_test_mode ) {
+			$stripe_settings = \WC_Stripe_Helper::get_stripe_settings();
+			$stripe_settings['testmode'] = $initial_test_mode ? 'yes' : 'no';
+			\WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+		}
+
 		\WCS_Staging::set_is_duplicate_site( false );
 
 		$this->assertEquals( $expected_return, $result );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-751
Related to:
 * https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4131
 * STRIPE-367

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR detects when we are running on WooCommerce Subscriptions staging sites as a way to detect whether we should detach customers from payment methods. This expands on our previous logic that only looked at the return value from `wp_get_environment_type()`. This PR does not implement a full fix for the issues flagged in #4131, but it does mean that staging sites using WooCommerce Subscriptions should behave better, at least when we're calling `WC_Stripe_API::should_detach_payment_method_from_customer()` in the code path.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
 * Apply a build containing the code from this PR/branch to your site
 * Ensure WooCommerce Subscriptions is installed and active on the site
 * Ensure you are in live mode, either by creating a live connection or by setting the `testmode` sub-option to `no` - `wp option patch update woocommerce_stripe_settings testmode no`
 * Without making other changes, access the WP CLI shell via `wp shell`
 * Run the following command to confirm the default behaviour:
```php
return WC_Stripe_API::should_detach_payment_method_from_customer();
```
 * Verify that the return is true, which should be encoded as `=> bool(true)` in the screen.
 * Add the following code snippet to force staging mode for WooCommerce Subscriptions:
```php
add_filter( 'woocommerce_subscriptions_is_duplicate_site', '__return_true', 10, 1 );
```
* Ensure your shell picks up the new code, which may require you to exit, and restart `wp shell`
* Run the same command as above:
```php
return WC_Stripe_API::should_detach_payment_method_from_customer();
```
* Verify that this time the return value is false (encoded as `=> bool(false)`).

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)