### PR TITLE
Add the Stripe's request-id header value to the API error/response logs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
+* Dev - Add Stripe's request-id to API error logs.
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
-* Dev - Add Stripe's request-id to API error logs.
+* Dev - Add Stripe's request-id to API error logs
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -255,9 +255,10 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: {$method} {$api}",
 				[
-					'request'         => $request,
-					'idempotency_key' => $idempotency_key,
-					'response'        => $response,
+					'request'           => $request,
+					'stripe_request_id' => self::get_stripe_request_id( $response ),
+					'idempotency_key'   => $idempotency_key,
+					'response'          => $response,
 				]
 			);
 
@@ -266,7 +267,13 @@ class WC_Stripe_API {
 
 		$response_body = json_decode( $response['body'] );
 
-		WC_Stripe_Logger::debug( "Stripe API response: {$method} {$api}", [ 'response' => $response_body ] );
+		WC_Stripe_Logger::debug(
+			"Stripe API response: {$method} {$api}",
+			[
+				'stripe_request_id' => self::get_stripe_request_id( $response ),
+				'response'          => $response_body,
+			]
+		);
 
 		if ( $with_headers ) {
 			return [
@@ -317,7 +324,8 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: GET {$api} returned a 401",
 				[
-					'response' => json_decode( $response['body'] ),
+					'stripe_request_id' => self::get_stripe_request_id( $response ),
+					'response'          => json_decode( $response['body'] ),
 				]
 			);
 
@@ -350,7 +358,8 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: GET {$api}",
 				[
-					'response' => $response,
+					'stripe_request_id' => self::get_stripe_request_id( $response ),
+					'response'          => $response,
 				]
 			);
 			return new WP_Error( 'stripe_error', __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ) );
@@ -358,7 +367,13 @@ class WC_Stripe_API {
 
 		$response_body = json_decode( $response['body'] );
 
-		WC_Stripe_Logger::debug( "Stripe API response: GET {$api}", [ 'response' => $response_body ] );
+		WC_Stripe_Logger::debug(
+			"Stripe API response: GET {$api}",
+			[
+				'stripe_request_id' => self::get_stripe_request_id( $response ),
+				'response'          => $response_body,
+			]
+		);
 
 		return $response_body;
 	}
@@ -596,5 +611,20 @@ class WC_Stripe_API {
 			'payment_method_configurations/' . $id
 		);
 		return $response;
+	}
+
+	/**
+	 * Returns the Stripe's request_id associated with the response.
+	 *
+	 * @param array|WP_Error $response HTTP response.
+	 *
+	 * @return string The Stripe's request_id associated with the response or null if not present.
+	 */
+	private static function get_stripe_request_id( $response ) {
+		$headers = wp_remote_retrieve_headers( $response );
+		if ( ! empty( $headers ) ) {
+			return $headers->getAll()['request-id'];
+		}
+		return '';
 	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -622,8 +622,11 @@ class WC_Stripe_API {
 	 */
 	private static function get_stripe_request_id( $response ) {
 		$headers = wp_remote_retrieve_headers( $response );
-		if ( ! empty( $headers ) ) {
-			return $headers->getAll()['request-id'];
+		if ( is_array( $headers ) ) {
+			return $headers['request-id'] ?? '';
+		}
+		if ( is_object( $headers ) && $headers instanceof \WpOrg\Requests\Utility\CaseInsensitiveDictionary ) {
+			return $headers->getAll()['request-id'] ?? '';
 		}
 		return '';
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -116,6 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
-* Dev - Add Stripe's request-id to API error logs.
+* Dev - Add Stripe's request-id to API error logs
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -116,5 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
+* Dev - Add Stripe's request-id to API error logs.
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

This PR adds the `request-id` from the Stripe API response headers to the structured data of every log in the Stripe API class.

This allows tracking down specific requests in the Stripe Dashboard and/or sharing the Request ID with Stripe Support.

## Testing instructions

1. Navigate to the plugin settings
2. Update the enabled payment methods
3. Go to the Logs (WooCommerce > Status > Logs and oprn the `woocommerce-gateway-stripe` file
4. Expand the additional context of any response and check that `stripe_request_id` is present:
    <img width="741" height="324" alt="Screenshot 2025-10-23 at 16 15 47" src="https://github.com/user-attachments/assets/e45d38a4-f809-4c01-8d1f-75fe6e4b0842" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
