### PR TITLE
Remove redundant secret key management when configuring webhooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,7 +7,7 @@
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
-* Tweak - Remove redundant secret management logic when configuring webhooks
+* Fix - Remove redundant secret management logic when configuring webhooks
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,6 +6,7 @@
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
+* Tweak - Remove redundant secret management logic when configuring webhooks
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -405,6 +405,9 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 			$response = $this->account->configure_webhooks( $environment );
 		} catch ( Exception $e ) {
 			return new WP_REST_Response( [ 'message' => $e->getMessage() ], 400 );
+		} finally {
+			// Ensure we reset the key before we do anything else.
+			WC_Stripe_API::set_secret_key( '' );
 		}
 
 		return new WP_REST_Response(

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -390,17 +390,6 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 
 		WC_Rate_Limiter::set_rate_limit( $rate_limit_key, 60 );
 
-		$settings     = WC_Stripe_Helper::get_stripe_settings();
-		$secret       = wc_clean( wp_unslash( $request->get_param( 'secret' ) ) );
-		$saved_secret = $settings[ $live_mode ? 'secret_key' : 'test_secret_key' ];
-
-		// If the secret received is masked and it matches the saved secret, use the raw saved secret.
-		if ( $secret === $this->mask_key_value( $saved_secret ) ) {
-			$secret = $saved_secret;
-		}
-
-		WC_Stripe_API::set_secret_key( $secret );
-
 		try {
 			$response = $this->account->configure_webhooks( $environment );
 		} catch ( Exception $e ) {

--- a/includes/admin/class-wc-rest-stripe-account-keys-controller.php
+++ b/includes/admin/class-wc-rest-stripe-account-keys-controller.php
@@ -399,8 +399,10 @@ class WC_REST_Stripe_Account_Keys_Controller extends WC_Stripe_REST_Base_Control
 			$secret = $saved_secret;
 		}
 
+		WC_Stripe_API::set_secret_key( $secret );
+
 		try {
-			$response = $this->account->configure_webhooks( $environment, $secret );
+			$response = $this->account->configure_webhooks( $environment );
 		} catch ( Exception $e ) {
 			return new WP_REST_Response( [ 'message' => $e->getMessage() ], 400 );
 		}

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -277,7 +277,10 @@ class WC_Stripe_Account {
 	/**
 	 * Configures webhooks for the account.
 	 *
+	 * Note: The caller is responsible for setting the appropriate API secret key before calling this method.
+	 *
 	 * @param string $mode The mode to configure webhooks for. Either 'live' or 'test'. Default is 'live'.
+	 * @param string $secret_key The secret key to save in webhook settings.
 	 *
 	 * @throws Exception If there was a problem setting up the webhooks.
 	 * @return object The response from the API.
@@ -288,12 +291,6 @@ class WC_Stripe_Account {
 			'url'            => WC_Stripe_Helper::get_webhook_url(),
 			'api_version'    => WC_Stripe_API::STRIPE_API_VERSION,
 		];
-
-		// If a secret key is provided, use it to configure the webhooks.
-		if ( $secret_key ) {
-			$previous_secret = WC_Stripe_API::get_secret_key();
-			WC_Stripe_API::set_secret_key( $secret_key );
-		}
 
 		$response = WC_Stripe_API::request( $request, 'webhook_endpoints', 'POST' );
 
@@ -309,11 +306,6 @@ class WC_Stripe_Account {
 		// Delete any previously configured webhooks. Exclude the current webhook ID from the deletion.
 		$this->delete_previously_configured_webhooks( $response->id );
 
-		// Restore the previous secret key if we changed it.
-		if ( $secret_key && isset( $previous_secret ) ) {
-			WC_Stripe_API::set_secret_key( $previous_secret );
-		}
-
 		$settings = WC_Stripe_Helper::get_stripe_settings();
 
 		$webhook_secret_setting = 'live' === $mode ? 'webhook_secret' : 'test_webhook_secret';
@@ -324,7 +316,7 @@ class WC_Stripe_Account {
 		$settings[ $webhook_data_setting ]   = [
 			'id'     => wc_clean( $response->id ),
 			'url'    => wc_clean( $response->url ),
-			'secret' => WC_Stripe_API::get_secret_key(),
+			'secret' => $secret_key,
 		];
 
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -285,7 +285,11 @@ class WC_Stripe_Account {
 	 * @throws Exception If there was a problem setting up the webhooks.
 	 * @return object The response from the API.
 	 */
-	public function configure_webhooks( $mode = 'live', $secret_key = '' ) {
+	public function configure_webhooks( $mode = 'live', $secret_key ) {
+		if ( empty( $secret_key ) ) {
+			throw new Exception( __( 'Secret key is required to configure webhooks.', 'woocommerce-gateway-stripe' ) );
+		}
+
 		$request = [
 			'enabled_events' => self::WEBHOOK_EVENTS,
 			'url'            => WC_Stripe_Helper::get_webhook_url(),

--- a/includes/class-wc-stripe-account.php
+++ b/includes/class-wc-stripe-account.php
@@ -277,18 +277,12 @@ class WC_Stripe_Account {
 	/**
 	 * Configures webhooks for the account.
 	 *
-	 * Note: The caller is responsible for setting the appropriate API secret key before calling this method.
-	 *
 	 * @param string $mode The mode to configure webhooks for. Either 'live' or 'test'. Default is 'live'.
-	 * @param string $secret_key The secret key to save in webhook settings.
 	 *
 	 * @throws Exception If there was a problem setting up the webhooks.
 	 * @return object The response from the API.
 	 */
-	public function configure_webhooks( $mode = 'live', $secret_key ) {
-		if ( empty( $secret_key ) ) {
-			throw new Exception( __( 'Secret key is required to configure webhooks.', 'woocommerce-gateway-stripe' ) );
-		}
+	public function configure_webhooks( $mode = 'live' ) {
 
 		$request = [
 			'enabled_events' => self::WEBHOOK_EVENTS,
@@ -320,7 +314,7 @@ class WC_Stripe_Account {
 		$settings[ $webhook_data_setting ]   = [
 			'id'     => wc_clean( $response->id ),
 			'url'    => wc_clean( $response->url ),
-			'secret' => $secret_key,
+			'secret' => WC_Stripe_API::get_secret_key(),
 		];
 
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
@@ -487,7 +481,7 @@ class WC_Stripe_Account {
 
 				// Events differ, reconfigure webhook
 				WC_Stripe_Logger::log( "Webhook events need updating for {$mode} mode - reconfiguring." );
-				$this->configure_webhooks( $mode, $secret_key );
+				$this->configure_webhooks( $mode );
 				WC_Stripe_Logger::log( "Successfully reconfigured webhooks for {$mode} mode after plugin update." );
 
 			} catch ( Exception $e ) {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -199,6 +199,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				WC_Stripe::get_instance()->account->configure_webhooks( $is_test ? 'test' : 'live' );
 			} catch ( Exception $e ) {
 				return new WP_Error( 'wc_stripe_webhook_error', $e->getMessage() );
+			} finally {
+				// Ensure we reset the key before we do anything else.
+				WC_Stripe_API::set_secret_key( '' );
 			}
 
 			// For new installs the legacy gateway gets instantiated because there is no settings in the DB yet,

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -196,7 +196,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			try {
 				// Automatically configure webhooks for the account now that we have the keys.
-				WC_Stripe::get_instance()->account->configure_webhooks( $is_test ? 'test' : 'live', $secret_key );
+				WC_Stripe::get_instance()->account->configure_webhooks( $is_test ? 'test' : 'live' );
 			} catch ( Exception $e ) {
 				return new WP_Error( 'wc_stripe_webhook_error', $e->getMessage() );
 			}

--- a/readme.txt
+++ b/readme.txt
@@ -116,5 +116,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
+* Tweak - Remove redundant secret management logic when configuring webhooks
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -117,7 +117,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
-* Tweak - Remove redundant secret management logic when configuring webhooks
+* Fix - Remove redundant secret management logic when configuring webhooks
 * Dev - Improve Payment Method Configuration error logging
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Account_Test.php
+++ b/tests/phpunit/WC_Stripe_Account_Test.php
@@ -468,8 +468,7 @@ class WC_Stripe_Account_Test extends WP_UnitTestCase {
 		$this->account->expects( $this->once() )
 			->method( 'configure_webhooks' )
 			->with(
-				$this->equalTo( 'test' ),
-				$this->equalTo( 'sk_test_key' )
+				$this->equalTo( 'test' )
 			);
 
 		// Run the update


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

`configure_webhooks` method was managing API key state (setting/restoring) even though all callers already handle this responsibility. This PR simplifies things by removing that logic completely.
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

1. Test onboarding flow
2. Test Webhook reconfiguration.
 - Go to the Stripe settings page.
 - Click Account Details -> Configure connection -> Reconfigure webooks
 - Make no errors are logged
3. Test a payment method that involves webhooks (eg: SEPA)



<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
