### PR TITLE
Payment methods notice when connecting an account

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
+* Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection
 * Add - Add a new filter allowing third-party plugins to hook captcha solutions when creating and confirming setup intents
 * Dev - Add track events when clicking the "Reconnect to Stripe" button (both in the settings page and the admin notice)
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -95,6 +95,12 @@ const ConnectStripeAccount = ( { oauthUrl, testOauthUrl } ) => {
 								},
 							} ) }
 						</TermsOfServiceText>
+						<p className="woocommerce-stripe-auth__help">
+							{ __(
+								'Some payment methods are automatically enabled when you connect your account. Review your Payment Methods settings for details.',
+								'woocommerce-gateway-stripe'
+							) }
+						</p>
 						<ButtonWrapper>
 							{ oauthUrl && (
 								<Button

--- a/client/settings/stripe-auth-account/index.js
+++ b/client/settings/stripe-auth-account/index.js
@@ -87,6 +87,12 @@ const StripeAuthAccount = ( { testMode } ) => {
 			<p className="woocommerce-stripe-auth__help">
 				{ getHelpText( testMode ) }
 			</p>
+			<p className="woocommerce-stripe-auth__help">
+				{ __(
+					'Some payment methods are automatically enabled when you connect your account. Review your Payment Methods settings for details.',
+					'woocommerce-gateway-stripe'
+				) }
+			</p>
 			<StripeAuthActions
 				testMode={ testMode }
 				displayWebhookConfigure={ displayWebhookConfigure }

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.1.0 - xxxx-xx-xx =
+* Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection
 * Add - Add a new filter allowing third-party plugins to hook captcha solutions when creating and confirming setup intents
 * Dev - Add track events when clicking the "Reconnect to Stripe" button (both in the settings page and the admin notice)
 * Update - Removes unnecessary legacy checkout gateway instantiations and UPE disablement code


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-752

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, I am adding a new paragraph to our connection modals to notify merchants about some payment methods that are automatically enabled. This is to avoid confusion when those methods appear automtically during the checkout process.

Initial account connection modal:
<img width="600" height="412" alt="Screenshot 2025-10-23 at 17 13 29" src="https://github.com/user-attachments/assets/c95641eb-79a6-47ed-bd25-1c23a45e1a15" />

Configure connection modal:
<img width="662" height="616" alt="Screenshot 2025-10-23 at 17 06 26" src="https://github.com/user-attachments/assets/88c4368e-d219-4b7e-89f6-59b2d21ea46a" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/payment-methods-notice-when-connecting-an-account`)
- When attempting to connect your Stripe account, confirm the new paraphraph was added as part of the modal (see preview above)
- Connect your Stripe account
- Go to the settings page
- Click the "Configure connection" button
- Confirm there's also a new paragraph there just like the preview above

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
