### PR TITLE
Increase limit when listing available payment method configurations from the Stripe API

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
 * Dev - Improve Payment Method Configuration error logging
+* Fix - Increase limit when listing available payment method configurations from the Stripe API
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -582,7 +582,9 @@ class WC_Stripe_API {
 	 * @return array The response from the API request.
 	 */
 	public function get_payment_method_configurations() {
-		return self::retrieve( 'payment_method_configurations' );
+		// The default limit is 10, so we set it to 100 to get all configurations in a single request.
+		// @see https://stripe.com/docs/api/payment_method_configurations/list#list_payment_method_configurations-limit
+		return self::retrieve( 'payment_method_configurations?limit=100' );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -118,5 +118,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Renames previous Order Helper class methods to use the `_id` suffix
 * Dev - Expands the Stripe Order Helper class to handle customer ID, card ID, UPE payment type, and UPE redirect status metas
 * Dev - Improve Payment Method Configuration error logging
+* Fix - Increase limit when listing available payment method configurations from the Stripe API
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-753
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

Merchants reported that after re-authenticating Stripe, the plugin appears to redirect/complete the OAuth flow, but the Optimized Checkout Suite option does not appear in Stripe settings, and the "Sync" option remains disabled.

This might happen if the Stripe account has more than 10 payment method configurations, so this PR increases the limit so we return all configurations.

## Testing instructions

1. Go to your Stripe Dashboard and create more than 10 PMCs:
    <img width="1351" height="764" alt="Screenshot 2025-10-24 at 10 17 24" src="https://github.com/user-attachments/assets/96b9660f-0fca-4b95-98a7-adde9ee2fbdb" />
2. In your test store, clear the payment methods cache (use the Dev Tools or remove the option `wcstripe_cache_test_payment_method_configuration`)
3. Go to the Plugin settings > Payment methods
4. Go to the plugin logs and check that the payment method configuration list now includes the limit:
    <img width="900" height="157" alt="Screenshot 2025-10-24 at 10 29 54" src="https://github.com/user-attachments/assets/2710c3bf-a947-41e8-94ae-a70a4dd06a52" />
5. Expand the Additional Data of the repose and check that there are more than 10 payment method configurations and that `has_more` attribute is `false`:
    <img width="558" height="163" alt="Screenshot 2025-10-24 at 10 30 10" src="https://github.com/user-attachments/assets/4c6e1a55-53c1-4a1f-8887-202aeac6cd84" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
