### PR TITLE
Fix Klarna not processing recurring payments with subscriptions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Dev - Improve Payment Method Configuration error logging
 * Dev - Add Stripe's request-id to API response logs
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
+* Fix - Klarna not processing recurring payments
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * The Klarna Payment Method class extending UPE base class
  */
 class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
+	use WC_Stripe_Subscriptions_Trait;
 
 	const STRIPE_ID = WC_Stripe_Payment_Methods::KLARNA;
 
@@ -45,6 +46,12 @@ class WC_Stripe_UPE_Payment_Method_Klarna extends WC_Stripe_UPE_Payment_Method {
 
 		// Klarna has complex rules around currencies and technically allows cross border transactions (like France to Norway). Currency and location rules will be enforced via checkout billing country validation.
 		$this->accept_only_domestic_payment = false;
+
+		// Init subscription so it can process subscription payments.
+		$this->maybe_init_subscriptions();
+
+		// Add support for pre-orders.
+		$this->maybe_init_pre_orders();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -121,5 +121,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Improve Payment Method Configuration error logging
 * Dev - Add Stripe's request-id to API response logs
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
+* Fix - Klarna not processing recurring payments
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-758

## Changes proposed in this Pull Request:

This PR adds Subscriptions and Pre-Order support initialization to the Klarna Payment Method class.

All the other recurrent payment methods call these initialization methods from their constructors.

## Testing instructions

1. Using the `develop` branch.
2. Purchase a Subscription with Klarna.
3. Navigate to the subscription (`WooCommerce > Subscriptions` and select the recently created subscription).
4. Verify that the subscription is created, but the only statuses it can be changed to are Active or Expired.
5. Verify there is no `Process renewal` option available:
    <img width="315" height="157" alt="Screenshot 2025-10-28 at 18 15 37" src="https://github.com/user-attachments/assets/47c6ee92-9ee7-4fe7-9d89-2a72fdc72435" />
6. Navigate to `Tools > Scheduled Actions`, look for the `woocommerce_scheduled_subscription_payment` with the associated subscription number, and run it.
7. Verify that it fails:
    <img width="1540" height="215" alt="Screenshot 2025-10-28 at 18 17 21" src="https://github.com/user-attachments/assets/eae18464-ac85-4e2c-b759-502e3fd27258" />
8. Checkout this branch `fix/758-klarna-not-processing-recurring-payments-with-subscriptions`
9. Navigate to the subscription (`WooCommerce > Subscriptions` and select the recently created subscription)
10. Check that now the `Process renewal` is available
11. Process the renewal (using the select or by manually running the scheduled action)
12. Check that the subscription was succesfully renewed:
    <img width="301" height="438" alt="Screenshot 2025-10-28 at 18 22 03" src="https://github.com/user-attachments/assets/670e0b4e-38ac-46aa-bfaf-38bbb8cff341" />


-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
