### PR TITLE
Fix Express Checkout error with free trial subscription on blocks cart/checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@
 * Dev - Improve Payment Method Configuration error logging
 * Dev - Add Stripe's request-id to API response logs
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
+* Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/client/blocks/express-checkout/index.js
+++ b/client/blocks/express-checkout/index.js
@@ -84,6 +84,11 @@ const expressCheckoutElement = ( expressPaymentMethod, api ) => {
 	);
 	const edit = getEditorElement( expressPaymentMethod );
 	const canMakePayment = ( { cart } ) => {
+		// eslint-disable-next-line camelcase
+		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
+			return false;
+		}
+
 		if (
 			parseFloat( cart.cartTotals.total_price ) === 0.0 &&
 			! getExpressCheckoutData( 'has_free_trial' )
@@ -92,11 +97,6 @@ const expressCheckoutElement = ( expressPaymentMethod, api ) => {
 		}
 
 		if ( ! getBlocksConfiguration()?.shouldShowExpressCheckoutButton ) {
-			return false;
-		}
-
-		// eslint-disable-next-line camelcase
-		if ( typeof wc_stripe_express_checkout_params === 'undefined' ) {
 			return false;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -123,5 +123,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Improve Payment Method Configuration error logging
 * Dev - Add Stripe's request-id to API response logs
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
+* Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-755

## Changes proposed in this Pull Request:

When there is a free trial subscription in the cart:
  1. The [scripts() method](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/995aff930bc29541004b06a4df7aa586959c8cc3/includes/payment-methods/class-wc-stripe-express-checkout-element.php#L394-L396) does not enqueue the script
  3. The script is never loaded, so `wc_stripe_express_checkout_params` is never defined
  4. And when we try to call `getExpressCheckoutData('has_free_trial')` a ReferenceError is thrown

This PR moves the check to the top of the function to avoid the `ReferenceError`.

_NOTE_: The issue also mentions that the buttons are not present in either the shortcode or blocks versions of the cart and checkout; that's intentional, when a subscription with a free trial requires shipping, then the buttons are not shown:
https://github.com/woocommerce/woocommerce-gateway-stripe/blob/48d5adb1d89c3611daf043e7e4b11f8362d3d214/includes/payment-methods/class-wc-stripe-express-checkout-helper.php#L484-L490

## Testing instructions

1. Create a Simple subscription with a free trial
2. Add it to the `cart` and go to the blocks `checkout`
3. In `develop`, the following error is triggered on page load:
    <img width="1540" height="255" alt="Screenshot 2025-10-29 at 16 24 02" src="https://github.com/user-attachments/assets/b5e1eb94-2ae4-419d-a71d-d310e37b7f33" />
4. In this branch (`fix/755-express-checkout-doesnt-work-with-free-trial-subscription`), there is no error.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
