### PR TITLE
Fix flaky E2E tests

### DIFF
--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -18,12 +18,14 @@ const config = {
 	testDir: '../tests',
 
 	// Maximum time one test can run for
-	timeout: TIMEOUT ? Number( TIMEOUT ) : 90 * 1000,
+	// Increased from 90s to 120s to accommodate tests with multiple iframe interactions
+	timeout: TIMEOUT ? Number( TIMEOUT ) : 120 * 1000,
 
 	expect: {
 		// Maximum time expect() should wait for the condition to be met
 		// For example in `await expect(locator).toHaveText();`
-		timeout: 20 * 1000,
+		// Increased from 20s to 30s to reduce flakiness with Stripe API calls
+		timeout: 30 * 1000,
 	},
 
 	// Folder for test artifacts such as screenshots, videos, traces, etc
@@ -69,6 +71,10 @@ const config = {
 		video: 'on-first-retry',
 
 		viewport: { width: 1280, height: 720 },
+
+		// Maximum time for individual actions (click, fill, etc.)
+		// Added to reduce flakiness with slow-loading elements
+		actionTimeout: 15 * 1000,
 	},
 
 	projects: [

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -18,14 +18,12 @@ const config = {
 	testDir: '../tests',
 
 	// Maximum time one test can run for
-	// Increased from 90s to 120s to accommodate tests with multiple iframe interactions
-	timeout: TIMEOUT ? Number( TIMEOUT ) : 120 * 1000,
+	timeout: TIMEOUT ? Number( TIMEOUT ) : 90 * 1000,
 
 	expect: {
 		// Maximum time expect() should wait for the condition to be met
 		// For example in `await expect(locator).toHaveText();`
-		// Increased from 20s to 30s to reduce flakiness with Stripe API calls
-		timeout: 30 * 1000,
+		timeout: 20 * 1000,
 	},
 
 	// Folder for test artifacts such as screenshots, videos, traces, etc
@@ -73,7 +71,6 @@ const config = {
 		viewport: { width: 1280, height: 720 },
 
 		// Maximum time for individual actions (click, fill, etc.)
-		// Added to reduce flakiness with slow-loading elements
 		actionTimeout: 15 * 1000,
 	},
 

--- a/tests/e2e/config/playwright.config.js
+++ b/tests/e2e/config/playwright.config.js
@@ -18,12 +18,14 @@ const config = {
 	testDir: '../tests',
 
 	// Maximum time one test can run for
-	timeout: TIMEOUT ? Number( TIMEOUT ) : 90 * 1000,
+	// Increased from 90s to 120s to reduce flakiness with Stripe iframe/modal flow.
+	timeout: TIMEOUT ? Number( TIMEOUT ) : 120 * 1000,
 
 	expect: {
 		// Maximum time expect() should wait for the condition to be met
 		// For example in `await expect(locator).toHaveText();`
-		timeout: 20 * 1000,
+		// Increased from 20s to 30s to reduce flakiness with Stripe iframe/modal interactions.
+		timeout: 30 * 1000,
 	},
 
 	// Folder for test artifacts such as screenshots, videos, traces, etc

--- a/tests/e2e/tests/checkout/blocks/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/ach.spec.js
@@ -9,7 +9,6 @@ const {
 	setupBlocksCheckout,
 	fillACHBankDetails,
 	setupACHCheckout,
-	waitForPaymentFormStable,
 } = payments;
 
 test.describe( 'ACH payment tests @blocks', () => {
@@ -49,9 +48,6 @@ test.describe( 'ACH payment tests @blocks', () => {
 		await setupACHCheckout( page, 'blocks' );
 		await fillACHBankDetails( page );
 
-		// Wait for payment form to be stable before placing order
-		await waitForPaymentFormStable( page );
-
 		await page.locator( 'text=Place order' ).click();
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
@@ -77,9 +73,6 @@ test.describe( 'ACH payment tests @blocks', () => {
 				)
 				.click();
 
-			// Wait for payment form to be stable before placing order
-			await waitForPaymentFormStable( page );
-
 			await page.locator( 'text=Place order' ).click();
 			await page.waitForURL( '**/checkout/order-received/**' );
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
@@ -99,9 +92,6 @@ test.describe( 'ACH payment tests @blocks', () => {
 				.locator( 'label' )
 				.filter( { hasText: 'Checking account ending in' } )
 				.click();
-
-			// Wait for payment form to be stable before placing order
-			await waitForPaymentFormStable( page );
 
 			await page.locator( 'text=Place order' ).click();
 			await page.waitForURL( '**/checkout/order-received/**' );

--- a/tests/e2e/tests/checkout/blocks/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/blocks/lpms/ach.spec.js
@@ -9,6 +9,7 @@ const {
 	setupBlocksCheckout,
 	fillACHBankDetails,
 	setupACHCheckout,
+	waitForPaymentFormStable,
 } = payments;
 
 test.describe( 'ACH payment tests @blocks', () => {
@@ -47,6 +48,10 @@ test.describe( 'ACH payment tests @blocks', () => {
 	} ) => {
 		await setupACHCheckout( page, 'blocks' );
 		await fillACHBankDetails( page );
+
+		// Wait for payment form to be stable before placing order
+		await waitForPaymentFormStable( page );
+
 		await page.locator( 'text=Place order' ).click();
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
@@ -71,6 +76,10 @@ test.describe( 'ACH payment tests @blocks', () => {
 					'.wc-block-components-payment-methods__save-card-info'
 				)
 				.click();
+
+			// Wait for payment form to be stable before placing order
+			await waitForPaymentFormStable( page );
+
 			await page.locator( 'text=Place order' ).click();
 			await page.waitForURL( '**/checkout/order-received/**' );
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
@@ -90,6 +99,10 @@ test.describe( 'ACH payment tests @blocks', () => {
 				.locator( 'label' )
 				.filter( { hasText: 'Checking account ending in' } )
 				.click();
+
+			// Wait for payment form to be stable before placing order
+			await waitForPaymentFormStable( page );
+
 			await page.locator( 'text=Place order' ).click();
 			await page.waitForURL( '**/checkout/order-received/**' );
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(

--- a/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
@@ -9,6 +9,7 @@ const {
 	setupCart,
 	setupShortcodeCheckout,
 	setupACHCheckout,
+	fillACHBankDetails,
 } = payments;
 
 test.describe( 'ACH payment tests @shortcode', () => {
@@ -45,9 +46,7 @@ test.describe( 'ACH payment tests @shortcode', () => {
 	test( 'customer can pay with ACH using valid bank details @smoke', async ( {
 		page,
 	} ) => {
-		// Customer not logged-in
 		await setupACHCheckout( page, 'shortcode' );
-
 		const frame = page
 			.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
 			.first();
@@ -95,35 +94,7 @@ test.describe( 'ACH payment tests @shortcode', () => {
 				config.get( 'users.customer.password' )
 			);
 			await setupACHCheckout( page, 'shortcode' );
-
-			const frame = page
-				.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
-				.first();
-
-			// Click Agree and Continue button
-			let button = frame.getByTestId( 'agree-button' );
-			await expect( button ).toBeVisible();
-			await button.click();
-
-			// Click Not now button
-			button = frame.getByTestId( 'link-not-now-button' );
-			await expect( button ).toBeVisible();
-			await button.click();
-
-			// Click "Success ••••" account
-			button = frame.getByRole( 'button', { name: 'Success ••••' } );
-			await expect( button ).toBeVisible();
-			await button.click();
-
-			// Click Connect account button
-			button = frame.getByTestId( 'select-button' );
-			await expect( button ).toBeVisible();
-			await button.click();
-
-			// Click the done button with retry logic
-			button = frame.getByTestId( 'done-button' );
-			await expect( button ).toBeVisible();
-			await button.click();
+			await fillACHBankDetails( page );
 
 			await page
 				.getByRole( 'checkbox', {

--- a/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
@@ -10,6 +10,7 @@ const {
 	setupShortcodeCheckout,
 	fillACHBankDetails,
 	setupACHCheckout,
+	waitForPaymentFormStable,
 } = payments;
 
 test.describe( 'ACH payment tests @shortcode', () => {
@@ -48,6 +49,10 @@ test.describe( 'ACH payment tests @shortcode', () => {
 	} ) => {
 		await setupACHCheckout( page, 'shortcode' );
 		await fillACHBankDetails( page );
+
+		// Wait for payment form to be stable before placing order
+		await waitForPaymentFormStable( page );
+
 		await page.locator( 'text=Place order' ).click();
 		await page.waitForURL( '**/checkout/order-received/**' );
 		await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
@@ -72,6 +77,10 @@ test.describe( 'ACH payment tests @shortcode', () => {
 					name: 'Save payment information to',
 				} )
 				.click();
+
+			// Wait for payment form to be stable before placing order
+			await waitForPaymentFormStable( page );
+
 			await clickPlaceOrder( page );
 			await page.waitForURL( '**/checkout/order-received/**' );
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(
@@ -97,6 +106,10 @@ test.describe( 'ACH payment tests @shortcode', () => {
 				.locator( '.woocommerce-SavedPaymentMethods-token' )
 				.first()
 				.click();
+
+			// Wait for payment form to be stable before placing order
+			await waitForPaymentFormStable( page );
+
 			await clickPlaceOrder( page );
 			await page.waitForURL( '**/checkout/order-received/**' );
 			await expect( page.locator( 'h1.entry-title' ) ).toHaveText(

--- a/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
@@ -47,34 +47,7 @@ test.describe( 'ACH payment tests @shortcode', () => {
 		page,
 	} ) => {
 		await setupACHCheckout( page, 'shortcode' );
-		const frame = page
-			.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
-			.first();
-
-		// Click Agree and Continue button
-		let button = frame.getByTestId( 'agree-button' );
-		await expect( button ).toBeVisible();
-		await button.click();
-
-		// Click "Success ••••" account
-		button = frame.getByRole( 'button', { name: 'Success ••••' } );
-		await expect( button ).toBeVisible();
-		await button.click();
-
-		// Click Connect account button
-		button = frame.getByTestId( 'select-button' );
-		await expect( button ).toBeVisible();
-		await button.click();
-
-		// Click Not now button
-		button = frame.getByTestId( 'link-not-now-button' );
-		await expect( button ).toBeVisible();
-		await button.click();
-
-		// Click the done button with retry logic
-		button = frame.getByTestId( 'done-button' );
-		await expect( button ).toBeVisible();
-		await button.click();
+		await fillACHBankDetails( page );
 
 		await page.locator( 'text=Place order' ).click();
 		await page.waitForURL( '**/checkout/order-received/**' );

--- a/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
+++ b/tests/e2e/tests/checkout/shortcode/lpms/ach.spec.js
@@ -8,9 +8,7 @@ const {
 	emptyCart,
 	setupCart,
 	setupShortcodeCheckout,
-	fillACHBankDetails,
 	setupACHCheckout,
-	waitForPaymentFormStable,
 } = payments;
 
 test.describe( 'ACH payment tests @shortcode', () => {
@@ -47,11 +45,37 @@ test.describe( 'ACH payment tests @shortcode', () => {
 	test( 'customer can pay with ACH using valid bank details @smoke', async ( {
 		page,
 	} ) => {
+		// Customer not logged-in
 		await setupACHCheckout( page, 'shortcode' );
-		await fillACHBankDetails( page );
 
-		// Wait for payment form to be stable before placing order
-		await waitForPaymentFormStable( page );
+		const frame = page
+			.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
+			.first();
+
+		// Click Agree and Continue button
+		let button = frame.getByTestId( 'agree-button' );
+		await expect( button ).toBeVisible();
+		await button.click();
+
+		// Click "Success ••••" account
+		button = frame.getByRole( 'button', { name: 'Success ••••' } );
+		await expect( button ).toBeVisible();
+		await button.click();
+
+		// Click Connect account button
+		button = frame.getByTestId( 'select-button' );
+		await expect( button ).toBeVisible();
+		await button.click();
+
+		// Click Not now button
+		button = frame.getByTestId( 'link-not-now-button' );
+		await expect( button ).toBeVisible();
+		await button.click();
+
+		// Click the done button with retry logic
+		button = frame.getByTestId( 'done-button' );
+		await expect( button ).toBeVisible();
+		await button.click();
 
 		await page.locator( 'text=Place order' ).click();
 		await page.waitForURL( '**/checkout/order-received/**' );
@@ -71,15 +95,41 @@ test.describe( 'ACH payment tests @shortcode', () => {
 				config.get( 'users.customer.password' )
 			);
 			await setupACHCheckout( page, 'shortcode' );
-			await fillACHBankDetails( page );
+
+			const frame = page
+				.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
+				.first();
+
+			// Click Agree and Continue button
+			let button = frame.getByTestId( 'agree-button' );
+			await expect( button ).toBeVisible();
+			await button.click();
+
+			// Click Not now button
+			button = frame.getByTestId( 'link-not-now-button' );
+			await expect( button ).toBeVisible();
+			await button.click();
+
+			// Click "Success ••••" account
+			button = frame.getByRole( 'button', { name: 'Success ••••' } );
+			await expect( button ).toBeVisible();
+			await button.click();
+
+			// Click Connect account button
+			button = frame.getByTestId( 'select-button' );
+			await expect( button ).toBeVisible();
+			await button.click();
+
+			// Click the done button with retry logic
+			button = frame.getByTestId( 'done-button' );
+			await expect( button ).toBeVisible();
+			await button.click();
+
 			await page
 				.getByRole( 'checkbox', {
 					name: 'Save payment information to',
 				} )
 				.click();
-
-			// Wait for payment form to be stable before placing order
-			await waitForPaymentFormStable( page );
 
 			await clickPlaceOrder( page );
 			await page.waitForURL( '**/checkout/order-received/**' );
@@ -106,9 +156,6 @@ test.describe( 'ACH payment tests @shortcode', () => {
 				.locator( '.woocommerce-SavedPaymentMethods-token' )
 				.first()
 				.click();
-
-			// Wait for payment form to be stable before placing order
-			await waitForPaymentFormStable( page );
 
 			await clickPlaceOrder( page );
 			await page.waitForURL( '**/checkout/order-received/**' );

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -143,100 +143,6 @@ export async function waitForStripeReady(
 }
 
 /**
- * Wait for the payment form to be stable and ready for interaction.
- * This prevents issues with payment forms that are still initializing or re-rendering.
- *
- * @param {Page} page Playwright page fixture.
- * @param {number} stabilityDuration Time in milliseconds the form should remain stable (default: 500).
- * @param {number} timeout Maximum time to wait in milliseconds (default: 10000).
- */
-export async function waitForPaymentFormStable(
-	page,
-	stabilityDuration = 500,
-	timeout = 10000
-) {
-	const startTime = Date.now();
-	let lastChangeTime = startTime;
-
-	// Common selectors that indicate form changes
-	const formSelectors = [
-		'.wc-block-components-payment-methods',
-		'.payment_method_stripe',
-		'#wc-stripe-upe-form',
-		'.wc-stripe-upe-element',
-	];
-
-	// Wait for at least one form element to be present
-	let formFound = false;
-	for ( const selector of formSelectors ) {
-		if (
-			await page
-				.locator( selector )
-				.isVisible()
-				.catch( () => false )
-		) {
-			formFound = true;
-			break;
-		}
-	}
-
-	if ( ! formFound ) {
-		throw new Error( 'No payment form found on the page' );
-	}
-
-	// Monitor the DOM for changes using MutationObserver
-	await page.evaluate(
-		( { selectors, duration, maxTimeout } ) => {
-			return new Promise( ( resolve, reject ) => {
-				const startTime = Date.now();
-				let lastChangeTime = startTime;
-				let timeoutId;
-
-				const checkStability = () => {
-					const now = Date.now();
-					if ( now - lastChangeTime >= duration ) {
-						observer.disconnect();
-						clearTimeout( timeoutId );
-						resolve();
-					} else if ( now - startTime >= maxTimeout ) {
-						observer.disconnect();
-						clearTimeout( timeoutId );
-						reject(
-							new Error( 'Timeout waiting for form stability' )
-						);
-					} else {
-						timeoutId = setTimeout( checkStability, 100 );
-					}
-				};
-
-				const observer = new MutationObserver( () => {
-					lastChangeTime = Date.now();
-				} );
-
-				// Observe all form elements
-				for ( const selector of selectors ) {
-					const element = document.querySelector( selector );
-					if ( element ) {
-						observer.observe( element, {
-							childList: true,
-							subtree: true,
-							attributes: true,
-						} );
-					}
-				}
-
-				checkStability();
-			} );
-		},
-		{
-			selectors: formSelectors,
-			duration: stabilityDuration,
-			maxTimeout: timeout,
-		}
-	);
-}
-
-/**
  * Retry an async function with exponential backoff.
  * Useful for flaky operations like iframe interactions or API calls.
  *
@@ -618,8 +524,12 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 			.filter( { hasText: 'ACH Direct Debit' } )
 			.click();
 
-		// Wait for payment form to be stable after selecting ACH
-		await waitForPaymentFormStable( page );
+		// Wait for the iframe to be ready
+		const frameHandle = await page.waitForSelector(
+			'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[name^="__privateStripeFrame"]'
+		);
+		const stripeFrame = await frameHandle.contentFrame();
+		await stripeFrame.waitForLoadState( 'networkidle' );
 
 		// Wait for the iframe to be ready using the new helper
 		const iframeSelector =
@@ -650,8 +560,12 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 		await achLabel.waitFor( { state: 'visible' } );
 		await achLabel.click();
 
-		// Wait for payment form to be stable after selecting ACH
-		await waitForPaymentFormStable( page );
+		// Wait for the iframe to be ready
+		const frameHandle = await page.waitForSelector(
+			'.payment_method_stripe_us_bank_account iframe[name^="__privateStripeFrame"]'
+		);
+		const stripeFrame = await frameHandle.contentFrame();
+		await stripeFrame.waitForLoadState( 'networkidle' );
 
 		// Wait for the iframe to be ready using the new helper
 		const iframeSelector =
@@ -683,61 +597,30 @@ export const fillACHBankDetails = async ( page ) => {
 		.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
 		.first();
 
-	// Agree and Continue with retry logic
-	await retryWithBackoff( async () => {
-		const agreeButton = frame.getByTestId( 'agree-button' );
-		await expect( agreeButton ).toBeVisible( { timeout: 10000 } );
-		await agreeButton.click();
-	} );
+	// Click Agree and Continue button
+	let button = frame.getByTestId( 'agree-button' );
+	await expect( button ).toBeVisible();
+	await button.click();
 
-	// Wait for next screen to load
-	await page.waitForTimeout( 500 );
+	// Click Not now button
+	button = frame.getByTestId( 'link-not-now-button' );
+	await expect( button ).toBeVisible();
+	await button.click();
 
-	// Click "Success ••••" button with retry logic
-	await retryWithBackoff( async () => {
-		const successButton = frame.getByRole( 'button', {
-			name: 'Success ••••',
-		} );
-		await expect( successButton ).toBeVisible( { timeout: 10000 } );
-		await successButton.click();
-	} );
+	// Click "Success ••••" account
+	button = frame.getByRole( 'button', { name: 'Success ••••' } );
+	await expect( button ).toBeVisible();
+	await button.click();
 
-	// Wait for next screen to load
-	await page.waitForTimeout( 500 );
-
-	// Click "Connect Account" button with retry logic
-	await retryWithBackoff( async () => {
-		const selectButton = frame.getByTestId( 'select-button' );
-		await expect( selectButton ).toBeVisible( { timeout: 10000 } );
-		await selectButton.click();
-	} );
-
-	// Wait for Link dialog or Done button
-	// Link registration button may or may not appear
-	// Check for both buttons with proper timeout handling
-	const linkNotNowButton = frame.getByTestId( 'link-not-now-button' );
-	const doneButton = frame.getByTestId( 'done-button' );
-
-	try {
-		// Try to find the Link registration "Not now" button first
-		await linkNotNowButton.waitFor( { state: 'visible', timeout: 5000 } );
-		await linkNotNowButton.click();
-
-		// After clicking "Not now", wait for the done button
-		await expect( doneButton ).toBeVisible( { timeout: 10000 } );
-	} catch ( error ) {
-		// Link dialog didn't appear, done button should already be visible
-		await expect( doneButton ).toBeVisible( { timeout: 10000 } );
-	}
+	// Click Connect account button
+	button = frame.getByTestId( 'select-button' );
+	await expect( button ).toBeVisible();
+	await button.click();
 
 	// Click the done button with retry logic
-	await retryWithBackoff( async () => {
-		await expect( doneButton ).toBeVisible( { timeout: 10000 } );
-		await doneButton.click();
-	} );
-
-	// Wait for the ACH setup to complete
-	await page.waitForTimeout( 500 );
+	button = frame.getByTestId( 'done-button' );
+	await expect( button ).toBeVisible();
+	await button.click();
 };
 
 /**

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -125,19 +125,21 @@ export async function waitForStripeReady(
 	// Wait for the frame to be fully loaded
 	await stripeFrame.waitForLoadState( 'networkidle', { timeout } );
 
-	// Additional wait for any loading indicators to disappear
+	// Additional wait for any loading indicators to disappear in parallel
 	const loadingIndicators = [
 		'.__PrivateStripeElementLoader',
 		'.LightboxModalLoadingIndicator',
 		'[data-testid="loading"]',
 	];
 
-	for ( const indicator of loadingIndicators ) {
-		const loader = stripeFrame.locator( indicator );
-		if ( await loader.isVisible().catch( () => false ) ) {
-			await expect( loader ).toBeHidden( { timeout: 10000 } );
-		}
-	}
+	await Promise.all(
+		loadingIndicators.map( ( indicator ) =>
+			stripeFrame
+				.locator( indicator )
+				.waitFor( { state: 'hidden', timeout } )
+				.catch( () => {} )
+		)
+	);
 
 	return stripeFrame;
 }
@@ -513,10 +515,11 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 	await emptyCart( page );
 	await setupCart( page );
 
-	let iframeSelector = 'iframe[src*="elements-inner-payment"]';
+	const rawIframeSelector = 'iframe[src*="elements-inner-payment"]';
+	let iframeSelector;
 
 	if ( checkoutType === 'blocks' ) {
-		iframeSelector = `#radio-control-wc-payment-method-options-stripe_us_bank_account__content ${ iframeSelector }`;
+		iframeSelector = `#radio-control-wc-payment-method-options-stripe_us_bank_account__content ${ rawIframeSelector }`;
 
 		await setupBlocksCheckout(
 			page,
@@ -529,7 +532,7 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 			.filter( { hasText: 'ACH Direct Debit' } )
 			.click();
 	} else {
-		iframeSelector = `.wc_payment_method.payment_method_stripe_us_bank_account ${ iframeSelector }`;
+		iframeSelector = `.wc_payment_method.payment_method_stripe_us_bank_account ${ rawIframeSelector }`;
 
 		await setupShortcodeCheckout(
 			page,
@@ -574,13 +577,13 @@ export const fillACHBankDetails = async ( page ) => {
 	await Promise.race( [
 		frame
 			.getByTestId( 'link-not-now-button' )
-			.waitFor( { state: 'visible', timeout: 5000 } )
+			.waitFor( { state: 'visible' } )
 			.then( async () => {
 				await frame.getByTestId( 'link-not-now-button' ).click();
 			} ),
 		frame
 			.getByRole( 'button', { name: 'Success ••••' } )
-			.waitFor( { state: 'visible', timeout: 5000 } ),
+			.waitFor( { state: 'visible' } ),
 	] );
 
 	// Click "Success ••••" account
@@ -597,13 +600,11 @@ export const fillACHBankDetails = async ( page ) => {
 	await Promise.race( [
 		frame
 			.getByTestId( 'link-not-now-button' )
-			.waitFor( { state: 'visible', timeout: 5000 } )
+			.waitFor( { state: 'visible' } )
 			.then( async () => {
 				await frame.getByTestId( 'link-not-now-button' ).click();
 			} ),
-		frame
-			.getByTestId( 'done-button' )
-			.waitFor( { state: 'visible', timeout: 5000 } ),
+		frame.getByTestId( 'done-button' ).waitFor( { state: 'visible' } ),
 	] );
 
 	// Click the done button with retry logic

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -513,43 +513,24 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 	await emptyCart( page );
 	await setupCart( page );
 
+	let iframeSelector = 'iframe[src*="elements-inner-payment"]';
+
 	if ( checkoutType === 'blocks' ) {
+		iframeSelector = `#radio-control-wc-payment-method-options-stripe_us_bank_account__content ${ iframeSelector }`;
+
 		await setupBlocksCheckout(
 			page,
 			config.get( 'addresses.customer.billing' )
 		);
+
 		// Select ACH in blocks checkout
 		await page
 			.locator( 'label' )
 			.filter( { hasText: 'ACH Direct Debit' } )
 			.click();
-
-		// Wait for the iframe to be ready
-		const frameHandle = await page.waitForSelector(
-			'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[name^="__privateStripeFrame"]'
-		);
-		const stripeFrame = await frameHandle.contentFrame();
-		await stripeFrame.waitForLoadState( 'networkidle' );
-
-		// Wait for the iframe to be ready using the new helper
-		const iframeSelector =
-			'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[name^="__privateStripeFrame"]';
-		await waitForStripeReady( page, iframeSelector );
-
-		// Click "Test Institution" with retry logic
-		await retryWithBackoff( async () => {
-			const testInstitutionButton = page
-				.frameLocator(
-					'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[src*="elements-inner-payment"]'
-				)
-				.getByText( 'Test Institution' );
-
-			await expect( testInstitutionButton ).toBeVisible( {
-				timeout: 10000,
-			} );
-			await testInstitutionButton.click();
-		} );
 	} else {
+		iframeSelector = `.wc_payment_method.payment_method_stripe_us_bank_account ${ iframeSelector }`;
+
 		await setupShortcodeCheckout(
 			page,
 			config.get( 'addresses.customer.billing' )
@@ -559,33 +540,20 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 		const achLabel = page.getByText( 'ACH Direct Debit' );
 		await achLabel.waitFor( { state: 'visible' } );
 		await achLabel.click();
-
-		// Wait for the iframe to be ready
-		const frameHandle = await page.waitForSelector(
-			'.payment_method_stripe_us_bank_account iframe[name^="__privateStripeFrame"]'
-		);
-		const stripeFrame = await frameHandle.contentFrame();
-		await stripeFrame.waitForLoadState( 'networkidle' );
-
-		// Wait for the iframe to be ready using the new helper
-		const iframeSelector =
-			'.payment_method_stripe_us_bank_account iframe[name^="__privateStripeFrame"]';
-		await waitForStripeReady( page, iframeSelector );
-
-		// Click "Test Institution" with retry logic
-		await retryWithBackoff( async () => {
-			const testInstitutionButton = page
-				.frameLocator(
-					'.wc_payment_method.payment_method_stripe_us_bank_account iframe[src*="elements-inner-payment"]'
-				)
-				.getByTestId( 'featured-institution-default' );
-
-			await expect( testInstitutionButton ).toBeVisible( {
-				timeout: 10000,
-			} );
-			await testInstitutionButton.click();
-		} );
 	}
+
+	await waitForStripeReady( page, iframeSelector );
+
+	// Click "Test Institution" with retry logic
+	await retryWithBackoff( async () => {
+		const testInstitutionButton = page
+			.frameLocator( iframeSelector )
+			.getByText( 'Test Institution' )
+			.first();
+
+		await expect( testInstitutionButton ).toBeVisible();
+		await testInstitutionButton.click();
+	} );
 };
 
 /**

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -91,6 +91,197 @@ export async function setupCart(
 }
 
 /**
+ * Wait for Stripe iframe to be fully loaded and ready for interaction.
+ * This helper addresses common race conditions with Stripe Elements.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {string} iframeSelector The selector for the Stripe iframe.
+ * @param {number} timeout Maximum time to wait in milliseconds (default: 15000).
+ * @returns {Promise<Frame>} The loaded Stripe frame.
+ */
+export async function waitForStripeReady(
+	page,
+	iframeSelector,
+	timeout = 15000
+) {
+	// Wait for iframe to be present and visible
+	await page.waitForSelector( iframeSelector, {
+		state: 'visible',
+		timeout,
+	} );
+
+	// Get the frame handle and content frame
+	const frameHandle = await page.waitForSelector( iframeSelector, {
+		timeout,
+	} );
+	const stripeFrame = await frameHandle.contentFrame();
+
+	if ( ! stripeFrame ) {
+		throw new Error(
+			`Could not get content frame for: ${ iframeSelector }`
+		);
+	}
+
+	// Wait for the frame to be fully loaded
+	await stripeFrame.waitForLoadState( 'networkidle', { timeout } );
+
+	// Additional wait for any loading indicators to disappear
+	const loadingIndicators = [
+		'.__PrivateStripeElementLoader',
+		'.LightboxModalLoadingIndicator',
+		'[data-testid="loading"]',
+	];
+
+	for ( const indicator of loadingIndicators ) {
+		const loader = stripeFrame.locator( indicator );
+		if ( await loader.isVisible().catch( () => false ) ) {
+			await expect( loader ).toBeHidden( { timeout: 10000 } );
+		}
+	}
+
+	return stripeFrame;
+}
+
+/**
+ * Wait for the payment form to be stable and ready for interaction.
+ * This prevents issues with payment forms that are still initializing or re-rendering.
+ *
+ * @param {Page} page Playwright page fixture.
+ * @param {number} stabilityDuration Time in milliseconds the form should remain stable (default: 500).
+ * @param {number} timeout Maximum time to wait in milliseconds (default: 10000).
+ */
+export async function waitForPaymentFormStable(
+	page,
+	stabilityDuration = 500,
+	timeout = 10000
+) {
+	const startTime = Date.now();
+	let lastChangeTime = startTime;
+
+	// Common selectors that indicate form changes
+	const formSelectors = [
+		'.wc-block-components-payment-methods',
+		'.payment_method_stripe',
+		'#wc-stripe-upe-form',
+		'.wc-stripe-upe-element',
+	];
+
+	// Wait for at least one form element to be present
+	let formFound = false;
+	for ( const selector of formSelectors ) {
+		if (
+			await page
+				.locator( selector )
+				.isVisible()
+				.catch( () => false )
+		) {
+			formFound = true;
+			break;
+		}
+	}
+
+	if ( ! formFound ) {
+		throw new Error( 'No payment form found on the page' );
+	}
+
+	// Monitor the DOM for changes using MutationObserver
+	await page.evaluate(
+		( { selectors, duration, maxTimeout } ) => {
+			return new Promise( ( resolve, reject ) => {
+				const startTime = Date.now();
+				let lastChangeTime = startTime;
+				let timeoutId;
+
+				const checkStability = () => {
+					const now = Date.now();
+					if ( now - lastChangeTime >= duration ) {
+						observer.disconnect();
+						clearTimeout( timeoutId );
+						resolve();
+					} else if ( now - startTime >= maxTimeout ) {
+						observer.disconnect();
+						clearTimeout( timeoutId );
+						reject(
+							new Error( 'Timeout waiting for form stability' )
+						);
+					} else {
+						timeoutId = setTimeout( checkStability, 100 );
+					}
+				};
+
+				const observer = new MutationObserver( () => {
+					lastChangeTime = Date.now();
+				} );
+
+				// Observe all form elements
+				for ( const selector of selectors ) {
+					const element = document.querySelector( selector );
+					if ( element ) {
+						observer.observe( element, {
+							childList: true,
+							subtree: true,
+							attributes: true,
+						} );
+					}
+				}
+
+				checkStability();
+			} );
+		},
+		{
+			selectors: formSelectors,
+			duration: stabilityDuration,
+			maxTimeout: timeout,
+		}
+	);
+}
+
+/**
+ * Retry an async function with exponential backoff.
+ * Useful for flaky operations like iframe interactions or API calls.
+ *
+ * @param {Function} fn The async function to retry.
+ * @param {Object} options Retry configuration.
+ * @param {number} options.maxRetries Maximum number of retries (default: 3).
+ * @param {number} options.initialDelay Initial delay in milliseconds (default: 500).
+ * @param {number} options.maxDelay Maximum delay in milliseconds (default: 5000).
+ * @param {Function} options.shouldRetry Optional function to determine if error should trigger retry.
+ * @returns {Promise<any>} The result of the function call.
+ */
+export async function retryWithBackoff( fn, options = {} ) {
+	const {
+		maxRetries = 3,
+		initialDelay = 500,
+		maxDelay = 5000,
+		shouldRetry = () => true,
+	} = options;
+
+	let lastError;
+	let delay = initialDelay;
+
+	for ( let attempt = 0; attempt <= maxRetries; attempt++ ) {
+		try {
+			return await fn();
+		} catch ( error ) {
+			lastError = error;
+
+			// Don't retry if we've exhausted attempts or if shouldRetry returns false
+			if ( attempt === maxRetries || ! shouldRetry( error ) ) {
+				break;
+			}
+
+			// Wait before retrying
+			await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+
+			// Exponential backoff with max delay cap
+			delay = Math.min( delay * 2, maxDelay );
+		}
+	}
+
+	throw lastError;
+}
+
+/**
  * Fills in the credit card details on the default (blocks) checkout page.
  * @param {Page} page Playwright page fixture.
  * @param {Object} card The CC info in the format provided on the test-data.

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -602,10 +602,18 @@ export const fillACHBankDetails = async ( page ) => {
 	await expect( button ).toBeVisible();
 	await button.click();
 
-	// Click Not now button
-	button = frame.getByTestId( 'link-not-now-button' );
-	await expect( button ).toBeVisible();
-	await button.click();
+	// Link registration button may or may not appear.
+	await Promise.race( [
+		frame
+			.getByTestId( 'link-not-now-button' )
+			.waitFor( { state: 'visible', timeout: 5000 } )
+			.then( async () => {
+				await frame.getByTestId( 'link-not-now-button' ).click();
+			} ),
+		frame
+			.getByRole( 'button', { name: 'Success ••••' } )
+			.waitFor( { state: 'visible', timeout: 5000 } ),
+	] );
 
 	// Click "Success ••••" account
 	button = frame.getByRole( 'button', { name: 'Success ••••' } );
@@ -616,6 +624,19 @@ export const fillACHBankDetails = async ( page ) => {
 	button = frame.getByTestId( 'select-button' );
 	await expect( button ).toBeVisible();
 	await button.click();
+
+	// If link registration did not load when starting the flow, it will appear here.
+	await Promise.race( [
+		frame
+			.getByTestId( 'link-not-now-button' )
+			.waitFor( { state: 'visible', timeout: 5000 } )
+			.then( async () => {
+				await frame.getByTestId( 'link-not-now-button' ).click();
+			} ),
+		frame
+			.getByTestId( 'done-button' )
+			.waitFor( { state: 'visible', timeout: 5000 } ),
+	] );
 
 	// Click the done button with retry logic
 	button = frame.getByTestId( 'done-button' );

--- a/tests/e2e/utils/payments.js
+++ b/tests/e2e/utils/payments.js
@@ -616,22 +616,29 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 		await page
 			.locator( 'label' )
 			.filter( { hasText: 'ACH Direct Debit' } )
-			.dispatchEvent( 'click' );
+			.click();
 
-		// Wait for the iframe to be ready
-		const frameHandle = await page.waitForSelector(
-			'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[name^="__privateStripeFrame"]'
-		);
-		const stripeFrame = await frameHandle.contentFrame();
-		await stripeFrame.waitForLoadState( 'networkidle' );
+		// Wait for payment form to be stable after selecting ACH
+		await waitForPaymentFormStable( page );
 
-		// Click "Test Institution"
-		await page
-			.frameLocator(
-				'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[src*="elements-inner-payment"]'
-			)
-			.getByText( 'Test Institution' )
-			.dispatchEvent( 'click' );
+		// Wait for the iframe to be ready using the new helper
+		const iframeSelector =
+			'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[name^="__privateStripeFrame"]';
+		await waitForStripeReady( page, iframeSelector );
+
+		// Click "Test Institution" with retry logic
+		await retryWithBackoff( async () => {
+			const testInstitutionButton = page
+				.frameLocator(
+					'#radio-control-wc-payment-method-options-stripe_us_bank_account__content iframe[src*="elements-inner-payment"]'
+				)
+				.getByText( 'Test Institution' );
+
+			await expect( testInstitutionButton ).toBeVisible( {
+				timeout: 10000,
+			} );
+			await testInstitutionButton.click();
+		} );
 	} else {
 		await setupShortcodeCheckout(
 			page,
@@ -641,22 +648,29 @@ export const setupACHCheckout = async ( page, checkoutType = 'blocks' ) => {
 		// Select ACH in shortcode checkout
 		const achLabel = page.getByText( 'ACH Direct Debit' );
 		await achLabel.waitFor( { state: 'visible' } );
-		await achLabel.dispatchEvent( 'click' );
+		await achLabel.click();
 
-		// Wait for the iframe to be ready
-		const frameHandle = await page.waitForSelector(
-			'.payment_method_stripe_us_bank_account iframe[name^="__privateStripeFrame"]'
-		);
-		const stripeFrame = await frameHandle.contentFrame();
-		await stripeFrame.waitForLoadState( 'networkidle' );
+		// Wait for payment form to be stable after selecting ACH
+		await waitForPaymentFormStable( page );
 
-		// Click "Test Institution"
-		await page
-			.frameLocator(
-				'.wc_payment_method.payment_method_stripe_us_bank_account iframe[src*="elements-inner-payment"]'
-			)
-			.getByTestId( 'featured-institution-default' )
-			.dispatchEvent( 'click' );
+		// Wait for the iframe to be ready using the new helper
+		const iframeSelector =
+			'.payment_method_stripe_us_bank_account iframe[name^="__privateStripeFrame"]';
+		await waitForStripeReady( page, iframeSelector );
+
+		// Click "Test Institution" with retry logic
+		await retryWithBackoff( async () => {
+			const testInstitutionButton = page
+				.frameLocator(
+					'.wc_payment_method.payment_method_stripe_us_bank_account iframe[src*="elements-inner-payment"]'
+				)
+				.getByTestId( 'featured-institution-default' );
+
+			await expect( testInstitutionButton ).toBeVisible( {
+				timeout: 10000,
+			} );
+			await testInstitutionButton.click();
+		} );
 	}
 };
 
@@ -669,34 +683,61 @@ export const fillACHBankDetails = async ( page ) => {
 		.frameLocator( 'iframe[name^="__privateStripeFrame"]' )
 		.first();
 
-	// Agree and Continue
-	await frame.getByTestId( 'agree-button' ).click();
+	// Agree and Continue with retry logic
+	await retryWithBackoff( async () => {
+		const agreeButton = frame.getByTestId( 'agree-button' );
+		await expect( agreeButton ).toBeVisible( { timeout: 10000 } );
+		await agreeButton.click();
+	} );
 
-	// Click "Success ••••" button
-	await frame.getByRole( 'button', { name: 'Success ••••' } ).click();
+	// Wait for next screen to load
+	await page.waitForTimeout( 500 );
 
-	// Click "Connect Account" button.
-	await frame.getByTestId( 'select-button' ).click();
+	// Click "Success ••••" button with retry logic
+	await retryWithBackoff( async () => {
+		const successButton = frame.getByRole( 'button', {
+			name: 'Success ••••',
+		} );
+		await expect( successButton ).toBeVisible( { timeout: 10000 } );
+		await successButton.click();
+	} );
 
-	// Link registration button may or may not appear.
-	await Promise.race( [
-		frame
-			.getByTestId( 'link-not-now-button' )
-			.waitFor( {
-				state: 'visible',
-				timeout: 5000,
-			} )
-			.then( async () => {
-				await frame.getByTestId( 'link-not-now-button' ).click();
-			} ),
+	// Wait for next screen to load
+	await page.waitForTimeout( 500 );
 
-		frame.getByTestId( 'done-button' ).waitFor( {
-			state: 'visible',
-			timeout: 5000,
-		} ),
-	] );
+	// Click "Connect Account" button with retry logic
+	await retryWithBackoff( async () => {
+		const selectButton = frame.getByTestId( 'select-button' );
+		await expect( selectButton ).toBeVisible( { timeout: 10000 } );
+		await selectButton.click();
+	} );
 
-	await frame.getByTestId( 'done-button' ).click();
+	// Wait for Link dialog or Done button
+	// Link registration button may or may not appear
+	// Check for both buttons with proper timeout handling
+	const linkNotNowButton = frame.getByTestId( 'link-not-now-button' );
+	const doneButton = frame.getByTestId( 'done-button' );
+
+	try {
+		// Try to find the Link registration "Not now" button first
+		await linkNotNowButton.waitFor( { state: 'visible', timeout: 5000 } );
+		await linkNotNowButton.click();
+
+		// After clicking "Not now", wait for the done button
+		await expect( doneButton ).toBeVisible( { timeout: 10000 } );
+	} catch ( error ) {
+		// Link dialog didn't appear, done button should already be visible
+		await expect( doneButton ).toBeVisible( { timeout: 10000 } );
+	}
+
+	// Click the done button with retry logic
+	await retryWithBackoff( async () => {
+		await expect( doneButton ).toBeVisible( { timeout: 10000 } );
+		await doneButton.click();
+	} );
+
+	// Wait for the ACH setup to complete
+	await page.waitForTimeout( 500 );
 };
 
 /**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

This PR fixes the flakiness of the ACH E2E tests.

It updates the selectors for the ACH Stripe iframe modal and it adds two new helpers:
- _waitForStripeReady_
    Wait for Stripe iframe to be fully loaded and ready for interaction (to address race conditions with Stripe Elements rendering).
- _retryWithBackoff_
    Retry an async function with exponential backoff (for iframe interactions).

## Testing instructions

Verify that all PR checks pass, particularly the two E2E suites:
<img width="840" height="88" alt="Screenshot 2025-10-30 at 16 54 43" src="https://github.com/user-attachments/assets/30309784-6e32-454a-a646-516e53509223" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

This PR only fixes E2E tests, it has no customer facing changes.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
