### PR TITLE
Improve ECE compatibility with One Page Checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,7 @@
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
-* Fix - Improve ECE compatibility with One Page Checkout
+* Fix - Improve Express Checkout compatibility with One Page Checkout
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Fix - Improve ECE compatibility with One Page Checkout
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -233,7 +233,7 @@ class WC_Stripe_Express_Checkout_Element {
 			'is_pay_for_order'           => $this->express_checkout_helper->is_pay_for_order_page(),
 			'has_block'                  => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
 			'login_confirmation'         => $this->express_checkout_helper->get_login_confirmation_settings(),
-			'is_product_page'            => $this->express_checkout_helper->is_product(),
+			'is_product_page'            => $this->get_is_product_page_for_ece(),
 			'is_checkout_page'           => $this->express_checkout_helper->is_checkout(),
 			'product'                    => $this->express_checkout_helper->get_product_data(),
 			'is_cart_page'               => is_cart(),
@@ -243,6 +243,33 @@ class WC_Stripe_Express_Checkout_Element {
 			'has_free_trial'             => $this->express_checkout_helper->has_free_trial(),
 		];
 	}
+
+	/**
+	 * Should ECE use product pricing (vs. cart pricing) in the current context.
+	 *
+	 * For One Page Checkout (OPC), when checkout buttons are enabled, always use cart
+	 * context so discounts/coupons are reflected.
+	 *
+	 * @return bool True to use product pricing; false to use cart totals.
+	 */
+	private function get_is_product_page_for_ece() {
+		if ( ! $this->express_checkout_helper->is_product() ) {
+			return false;
+		}
+
+		// OPC renders checkout on product pages; if ECE is shown on checkout, use cart pricing.
+		if (
+			function_exists( 'is_wcopc_checkout' )
+			&& is_wcopc_checkout()
+			&& $this->express_checkout_helper->should_show_ece_on_checkout_page()
+		) {
+			return false;
+		}
+
+		// Otherwise, product context is valid for ECE.
+		return true;
+	}
+
 
 	/**
 	 * Localizes additional parameters necessary for the Pay for Order page.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -252,7 +252,7 @@ class WC_Stripe_Express_Checkout_Element {
 	 *
 	 * @return bool True to use product pricing; false to use cart totals.
 	 */
-	private function is_product_page_for_ece() {
+	public function is_product_page_for_ece() {
 		if ( ! $this->express_checkout_helper->is_product() ) {
 			return false;
 		}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -259,8 +259,7 @@ class WC_Stripe_Express_Checkout_Element {
 
 		// OPC renders checkout on product pages; if ECE is shown on checkout, use cart pricing.
 		if (
-			function_exists( 'is_wcopc_checkout' )
-			&& is_wcopc_checkout()
+			$this->express_checkout_helper->is_one_page_checkout()
 			&& $this->express_checkout_helper->should_show_ece_on_checkout_page()
 		) {
 			return false;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -233,7 +233,7 @@ class WC_Stripe_Express_Checkout_Element {
 			'is_pay_for_order'           => $this->express_checkout_helper->is_pay_for_order_page(),
 			'has_block'                  => has_block( 'woocommerce/cart' ) || has_block( 'woocommerce/checkout' ),
 			'login_confirmation'         => $this->express_checkout_helper->get_login_confirmation_settings(),
-			'is_product_page'            => $this->get_is_product_page_for_ece(),
+			'is_product_page'            => $this->is_product_page_for_ece(),
 			'is_checkout_page'           => $this->express_checkout_helper->is_checkout(),
 			'product'                    => $this->express_checkout_helper->get_product_data(),
 			'is_cart_page'               => is_cart(),
@@ -252,7 +252,7 @@ class WC_Stripe_Express_Checkout_Element {
 	 *
 	 * @return bool True to use product pricing; false to use cart totals.
 	 */
-	private function get_is_product_page_for_ece() {
+	private function is_product_page_for_ece() {
 		if ( ! $this->express_checkout_helper->is_product() ) {
 			return false;
 		}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -888,7 +888,7 @@ class WC_Stripe_Express_Checkout_Helper {
 	 *
 	 * @return boolean True if on a One Page Checkout page, false otherwise.
 	 */
-	public function is_one_page_checkout() {
+	public function is_one_page_checkout(): bool {
 		return function_exists( 'is_wcopc_checkout' ) && is_wcopc_checkout();
 	}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -682,8 +682,12 @@ class WC_Stripe_Express_Checkout_Helper {
 			return false;
 		}
 
+		// Detect One Page Checkout pages for special handling.
+		$is_one_page_checkout = function_exists( 'is_wcopc_checkout' ) && is_wcopc_checkout();
+
 		// Don't show on checkout if disabled.
-		if ( is_checkout() && ! $this->should_show_ece_on_checkout_page() ) {
+		// One Page Checkout plugin creates checkout functionality on product pages, so we need to check for it.
+		if ( ( is_checkout() || $is_one_page_checkout ) && ! $this->should_show_ece_on_checkout_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
 			return false;
 		}
@@ -691,8 +695,16 @@ class WC_Stripe_Express_Checkout_Helper {
 		$is_product = $this->is_product();
 
 		// Don't show if product page ECE is disabled.
-		if ( $is_product && ! $this->should_show_ece_on_product_pages() ) {
+		// Skip this check for One Page Checkout pages since they should be treated as checkout pages, not product pages.
+		if ( $is_product && ! $is_one_page_checkout && ! $this->should_show_ece_on_product_pages() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
+			return false;
+		}
+
+		// On One Page Checkout pages, if we're in the product section and checkout buttons are enabled,
+		// skip rendering here because the button will render in the checkout section instead.
+		if ( $is_one_page_checkout && $is_product && doing_action( 'woocommerce_after_add_to_cart_form' ) && $this->should_show_ece_on_checkout_page() ) {
+			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons on One Page Checkout will be displayed in checkout section, not product section.' );
 			return false;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -682,12 +682,9 @@ class WC_Stripe_Express_Checkout_Helper {
 			return false;
 		}
 
-		// Detect One Page Checkout pages for special handling.
-		$is_one_page_checkout = function_exists( 'is_wcopc_checkout' ) && is_wcopc_checkout();
-
 		// Don't show on checkout if disabled.
 		// One Page Checkout plugin creates checkout functionality on product pages, so we need to check for it.
-		if ( ( is_checkout() || $is_one_page_checkout ) && ! $this->should_show_ece_on_checkout_page() ) {
+		if ( ( is_checkout() || $this->is_one_page_checkout() ) && ! $this->should_show_ece_on_checkout_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
 			return false;
 		}
@@ -696,14 +693,14 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Don't show if product page ECE is disabled.
 		// Skip this check for One Page Checkout pages since they should be treated as checkout pages, not product pages.
-		if ( $is_product && ! $is_one_page_checkout && ! $this->should_show_ece_on_product_pages() ) {
+		if ( $is_product && ! $this->is_one_page_checkout() && ! $this->should_show_ece_on_product_pages() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
 			return false;
 		}
 
 		// On One Page Checkout pages, if we're in the product section and checkout buttons are enabled,
 		// skip rendering here because the button will render in the checkout section instead.
-		if ( $is_one_page_checkout && $is_product && doing_action( 'woocommerce_after_add_to_cart_form' ) && $this->should_show_ece_on_checkout_page() ) {
+		if ( $this->is_one_page_checkout() && $is_product && doing_action( 'woocommerce_after_add_to_cart_form' ) && $this->should_show_ece_on_checkout_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons on One Page Checkout will be displayed in checkout section, not product section.' );
 			return false;
 		}
@@ -884,6 +881,15 @@ class WC_Stripe_Express_Checkout_Helper {
 			$should_show_on_checkout_page,
 			$post
 		);
+	}
+
+	/**
+	 * Detects if the current page is a One Page Checkout page.
+	 *
+	 * @return boolean True if on a One Page Checkout page, false otherwise.
+	 */
+	public function is_one_page_checkout() {
+		return function_exists( 'is_wcopc_checkout' ) && is_wcopc_checkout();
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -684,7 +684,9 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Don't show on checkout if disabled.
 		// One Page Checkout plugin creates checkout functionality on product pages, so we need to check for it.
-		if ( ( is_checkout() || $this->is_one_page_checkout() ) && ! $this->should_show_ece_on_checkout_page() ) {
+		$is_one_page_checkout = $this->is_one_page_checkout();
+
+		if ( ( is_checkout() || $is_one_page_checkout ) && ! $this->should_show_ece_on_checkout_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
 			return false;
 		}
@@ -693,14 +695,14 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		// Don't show if product page ECE is disabled.
 		// Skip this check for One Page Checkout pages since they should be treated as checkout pages, not product pages.
-		if ( $is_product && ! $this->is_one_page_checkout() && ! $this->should_show_ece_on_product_pages() ) {
+		if ( $is_product && ! $is_one_page_checkout && ! $this->should_show_ece_on_product_pages() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
 			return false;
 		}
 
 		// On One Page Checkout pages, if we're in the product section and checkout buttons are enabled,
 		// skip rendering here because the button will render in the checkout section instead.
-		if ( $this->is_one_page_checkout() && $is_product && doing_action( 'woocommerce_after_add_to_cart_form' ) && $this->should_show_ece_on_checkout_page() ) {
+		if ( $is_one_page_checkout && $is_product && doing_action( 'woocommerce_after_add_to_cart_form' ) && $this->should_show_ece_on_checkout_page() ) {
 			WC_Stripe_Logger::log( 'Stripe Express Checkout buttons on One Page Checkout will be displayed in checkout section, not product section.' );
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -125,5 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Fix - Improve ECE compatibility with One Page Checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
-* Fix - Improve ECE compatibility with One Page Checkout
+* Fix - Improve Express Checkout compatibility with One Page Checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
@@ -114,12 +114,10 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->setMethods( [ 'is_page_supported', 'should_show_express_checkout_button' ] )
 			->getMock();
 
-		$helper->expects( $this->any() )
-			->method( 'is_page_supported' )
+		$helper->method( 'is_page_supported' )
 			->willReturn( $page_supported );
 
-		$helper->expects( $this->any() )
-			->method( 'should_show_express_checkout_button' )
+		$helper->method( 'should_show_express_checkout_button' )
 			->willReturn( $should_show );
 
 		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
@@ -262,12 +260,10 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->setMethods( [ 'is_page_supported', 'should_show_express_checkout_button' ] )
 			->getMock();
 
-		$helper->expects( $this->any() )
-			->method( 'is_page_supported' )
+		$helper->method( 'is_page_supported' )
 			->willReturn( $page_supported );
 
-		$helper->expects( $this->any() )
-			->method( 'should_show_express_checkout_button' )
+		$helper->method( 'should_show_express_checkout_button' )
 			->willReturn( $should_show );
 
 		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
@@ -360,8 +356,7 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->setMethods( [ 'get_button_locations' ] )
 			->getMock();
 
-		$helper->expects( $this->any() )
-			->method( 'get_button_locations' )
+		$helper->method( 'get_button_locations' )
 			->willReturn( [ $button_location ] );
 
 		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
@@ -457,16 +452,13 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 			->setMethods( [ 'is_product', 'is_one_page_checkout', 'should_show_ece_on_checkout_page' ] )
 			->getMock();
 
-		$helper->expects( $this->any() )
-			->method( 'is_product' )
+		$helper->method( 'is_product' )
 			->willReturn( $is_product );
 
-		$helper->expects( $this->any() )
-			->method( 'is_one_page_checkout' )
+		$helper->method( 'is_one_page_checkout' )
 			->willReturn( $is_opc );
 
-		$helper->expects( $this->any() )
-			->method( 'should_show_ece_on_checkout_page' )
+		$helper->method( 'should_show_ece_on_checkout_page' )
 			->willReturn( $show_ece_on_checkout );
 
 		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
@@ -431,4 +431,87 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertStringMatchesFormat( '%aid="wc-stripe-express-checkout__order-attribution-inputs"%a', $output );
 	}
+
+	/**
+	 * Test for `is_product_page_for_ece`.
+	 *
+	 * The is_product_page_for_ece method determines whether ECE should use product
+	 * pricing vs cart pricing. It returns false when:
+	 * - Not on a product page
+	 * - On a One Page Checkout page with ECE enabled on checkout (should use cart pricing)
+	 *
+	 * @param bool $is_product               Whether we're on a product page.
+	 * @param bool $is_opc                   Whether One Page Checkout is active.
+	 * @param bool $show_ece_on_checkout     Whether ECE is enabled on checkout pages.
+	 * @param bool $expected_result          Expected return value from is_product_page_for_ece.
+	 * @return void
+	 * @dataProvider provide_test_is_product_page_for_ece
+	 */
+	public function test_is_product_page_for_ece( $is_product, $is_opc, $show_ece_on_checkout, $expected_result ) {
+		$ajax_handler = $this->getMockBuilder( WC_Stripe_Express_Checkout_Ajax_Handler::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'is_product', 'is_one_page_checkout', 'should_show_ece_on_checkout_page' ] )
+			->getMock();
+
+		$helper->expects( $this->any() )
+			->method( 'is_product' )
+			->willReturn( $is_product );
+
+		$helper->expects( $this->any() )
+			->method( 'is_one_page_checkout' )
+			->willReturn( $is_opc );
+
+		$helper->expects( $this->any() )
+			->method( 'should_show_ece_on_checkout_page' )
+			->willReturn( $show_ece_on_checkout );
+
+		$element = new WC_Stripe_Express_Checkout_Element( $ajax_handler, $helper );
+		$result  = $element->is_product_page_for_ece();
+
+		$this->assertSame( $expected_result, $result );
+	}
+
+	/**
+	 * Data provider for test_is_product_page_for_ece.
+	 *
+	 * @return array
+	 */
+	public function provide_test_is_product_page_for_ece() {
+		return [
+			'not on product page'                                => [
+				'is_product'            => false,
+				'is_opc'                => false,
+				'show_ece_on_checkout'  => false,
+				'expected_result'       => false,
+			],
+			'product page, not OPC'                              => [
+				'is_product'            => true,
+				'is_opc'                => false,
+				'show_ece_on_checkout'  => false,
+				'expected_result'       => true,
+			],
+			'product page, not OPC, ECE on checkout enabled'     => [
+				'is_product'            => true,
+				'is_opc'                => false,
+				'show_ece_on_checkout'  => true,
+				'expected_result'       => true,
+			],
+			'product page, OPC active, ECE on checkout disabled' => [
+				'is_product'            => true,
+				'is_opc'                => true,
+				'show_ece_on_checkout'  => false,
+				'expected_result'       => true,
+			],
+			'product page, OPC active, ECE on checkout enabled'  => [
+				'is_product'            => true,
+				'is_opc'                => true,
+				'show_ece_on_checkout'  => true,
+				'expected_result'       => false,
+			],
+		];
+	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Element_Test.php
@@ -449,7 +449,7 @@ class WC_Stripe_Express_Checkout_Element_Test extends WP_UnitTestCase {
 
 		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'is_product', 'is_one_page_checkout', 'should_show_ece_on_checkout_page' ] )
+			->onlyMethods( [ 'is_product', 'is_one_page_checkout', 'should_show_ece_on_checkout_page' ] )
 			->getMock();
 
 		$helper->method( 'is_product' )

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1057,8 +1057,6 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	public function provide_opc_detection_scenarios() {
 		return [
 			'OPC with checkout enabled'     => [ true, [ 'checkout' ], true ],
-			'OPC with checkout disabled'    => [ true, [ 'product' ], false ],
-			'OPC with both enabled'         => [ true, [ 'checkout', 'product' ], true ],
 			'Non-OPC with checkout enabled' => [ false, [ 'checkout' ], true ],
 		];
 	}

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -112,10 +112,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			[ $gateway ]
 		);
 
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( false );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_cart_page' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'is_product' )->willReturn( false );
+		$wc_stripe_ece_helper_mock->method( 'allowed_items_in_cart' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'should_show_ece_on_cart_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->testmode = true;
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
@@ -282,10 +282,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 			[ $gateway ]
 		);
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( false );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_cart_page' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'is_product' )->willReturn( false );
+		$wc_stripe_ece_helper_mock->method( 'allowed_items_in_cart' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'should_show_ece_on_cart_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->testmode = true;
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
 			define( 'WOOCOMMERCE_CHECKOUT', true );
@@ -337,10 +337,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 		);
 
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_cart_page' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'is_product' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'allowed_items_in_cart' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'should_show_ece_on_cart_page' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'should_show_ece_on_checkout_page' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->testmode = true;
 
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
@@ -367,7 +367,6 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		WC()->cart->add_to_cart( $virtual_product->get_id(), 1 );
 		$wc_stripe_ece_helper_mock
-			->expects( $this->any() )
 			->method( 'get_product' )
 			->willReturn( $virtual_product );
 
@@ -384,7 +383,6 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		WC()->cart->add_to_cart( $shippable_product->get_id(), 1 );
 		$wc_stripe_ece_helper_mock
-			->expects( $this->any() )
 			->method( 'get_product' )
 			->willReturn( $shippable_product );
 
@@ -454,8 +452,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 			[ $gateway ]
 		);
-		$wc_stripe_ece_helper_mock->expects( $this->any() )
-			->method( 'is_account_creation_possible' )
+		$wc_stripe_ece_helper_mock->method( 'is_account_creation_possible' )
 			->willReturnOnConsecutiveCalls( true, false );
 
 		// Guest checkout is enabled.
@@ -486,8 +483,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 			[ $gateway ]
 		);
-		$wc_stripe_ece_helper_mock->expects( $this->any() )
-			->method( 'has_subscription_product' )
+		$wc_stripe_ece_helper_mock->method( 'has_subscription_product' )
 			->willReturn( false );
 
 		// Account creation on checkout is enabled.
@@ -510,8 +506,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			],
 			[ $gateway ]
 		);
-		$wc_stripe_ece_helper_mock2->expects( $this->any() )
-			->method( 'has_subscription_product' )
+		$wc_stripe_ece_helper_mock2->method( 'has_subscription_product' )
 			->willReturn( true );
 
 		// Account creation on checkout is disabled.
@@ -591,8 +586,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			[ 'is_request_to_store_api' ]
 		);
 
-		$helper->expects( $this->any() )
-			->method( 'is_request_to_store_api' )
+		$helper->method( 'is_request_to_store_api' )
 			->willReturn( $is_store_api );
 
 		// Set up $_SERVER superglobal for headers
@@ -1024,11 +1018,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		$is_product_page = $is_opc || in_array( 'product', $button_locations, true );
 
 		// Mock the methods.
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_one_page_checkout' )->willReturn( $is_opc );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( $is_product_page );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_checkout' )->willReturn( false );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
-		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'get_product' )->willReturn( $is_product_page ? $product : false );
+		$wc_stripe_ece_helper_mock->method( 'is_one_page_checkout' )->willReturn( $is_opc );
+		$wc_stripe_ece_helper_mock->method( 'is_product' )->willReturn( $is_product_page );
+		$wc_stripe_ece_helper_mock->method( 'is_checkout' )->willReturn( false );
+		$wc_stripe_ece_helper_mock->method( 'allowed_items_in_cart' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->method( 'get_product' )->willReturn( $is_product_page ? $product : false );
 
 		// Manually set the properties that would be set in the constructor.
 		$wc_stripe_ece_helper_mock->stripe_settings = $stripe_settings;

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1006,6 +1006,14 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// Ensure we're not on a checkout page for these tests.
+		add_filter(
+			'woocommerce_is_checkout',
+			function () {
+				return false;
+			}
+		);
+
 		$wc_stripe_ece_helper_mock = $this->createPartialMock(
 			WC_Stripe_Express_Checkout_Helper::class,
 			[
@@ -1042,8 +1050,9 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 
-		// Restore original gateways.
+		// Restore original gateways and remove filter.
 		WC()->payment_gateways()->payment_gateways = $original_gateways;
+		remove_all_filters( 'woocommerce_is_checkout' );
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1052,6 +1052,8 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		return [
 			'OPC with checkout enabled'     => [ true, [ 'checkout' ], true ],
 			'Non-OPC with checkout enabled' => [ false, [ 'checkout' ], true ],
+			'OPC with checkout disabled'    => [ true, [ 'product' ], false ],
+			'OPC with both enabled'         => [ true, [ 'checkout', 'product' ], true ],
 		];
 	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -991,8 +991,8 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_opc_detection_logic( $is_opc, $button_locations, $expected ) {
-		$stripe_settings                                     = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['payment_request_button_locations'] = $button_locations;
+		$stripe_settings                                      = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['express_checkout_button_locations'] = $button_locations;
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -21,7 +21,6 @@ use WP_UnitTestCase;
  * @package WooCommerce/Stripe/WC_Stripe_Express_Checkout_Helper
  *
  * WC_Stripe_Express_Checkout_Helper_Test class.
- * @group helper
  */
 class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	private $shipping_zone;
@@ -988,7 +987,6 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @param bool  $is_opc Whether the page is detected as One Page Checkout.
 	 * @param array $button_locations Button location settings.
 	 * @param bool  $expected Expected result for should_show_express_checkout_button.
-	 * @group opc
 	 *
 	 * @return void
 	 */

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -21,6 +21,7 @@ use WP_UnitTestCase;
  * @package WooCommerce/Stripe/WC_Stripe_Express_Checkout_Helper
  *
  * WC_Stripe_Express_Checkout_Helper_Test class.
+ * @group helper
  */
 class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	private $shipping_zone;
@@ -982,6 +983,48 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 				'cart contains free trial' => true,
 				'expected'                 => true,
 			],
+		];
+	}
+
+	/**
+	 * Test that OPC detection logic works correctly.
+	 *
+	 * @dataProvider provide_opc_detection_scenarios
+	 *
+	 * @param bool  $is_opc Whether OPC function returns true.
+	 * @param array $button_locations Button location settings.
+	 * @param bool  $should_allow_checkout Expected result for checkout location check.
+	 *
+	 * @return void
+	 */
+	public function test_opc_detection_logic( $is_opc, $button_locations, $should_allow_checkout ) {
+		$stripe_settings                                           = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['payment_request_button_locations']       = $button_locations;
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
+
+		// The actual test: Check if should_show_ece_on_checkout_page returns the expected value.
+		$result = $helper->should_show_ece_on_checkout_page();
+
+		$this->assertEquals( in_array( 'checkout', $button_locations, true ), $result );
+	}
+
+	/**
+	 * Data provider for OPC detection scenarios.
+	 *
+	 * @return array
+	 */
+	public function provide_opc_detection_scenarios() {
+		return [
+			'OPC with checkout enabled'     => [ true, [ 'checkout' ], true ],
+			'OPC with checkout disabled'    => [ true, [ 'product' ], false ],
+			'OPC with both enabled'         => [ true, [ 'checkout', 'product' ], true ],
+			'Non-OPC with checkout enabled' => [ false, [ 'checkout' ], true ],
 		];
 	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -21,7 +21,6 @@ use WP_UnitTestCase;
  * @package WooCommerce/Stripe/WC_Stripe_Express_Checkout_Helper
  *
  * WC_Stripe_Express_Checkout_Helper_Test class.
- * @group helper
  */
 class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	private $shipping_zone;

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -991,27 +991,60 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider provide_opc_detection_scenarios
 	 *
-	 * @param bool  $is_opc Whether OPC function returns true.
+	 * @param bool  $is_opc Whether the page is detected as One Page Checkout.
 	 * @param array $button_locations Button location settings.
-	 * @param bool  $should_allow_checkout Expected result for checkout location check.
+	 * @param bool  $expected Expected result for should_show_express_checkout_button.
+	 * @group opc
 	 *
 	 * @return void
 	 */
-	public function test_opc_detection_logic( $is_opc, $button_locations, $should_allow_checkout ) {
-		$stripe_settings                                           = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_settings['payment_request_button_locations']       = $button_locations;
+	public function test_opc_detection_logic( $is_opc, $button_locations, $expected ) {
+		$stripe_settings                                     = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['payment_request_button_locations'] = $button_locations;
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$helper = new WC_Stripe_Express_Checkout_Helper( $gateway );
+		$wc_stripe_ece_helper_mock = $this->createPartialMock(
+			WC_Stripe_Express_Checkout_Helper::class,
+			[
+				'is_one_page_checkout',
+				'is_product',
+				'allowed_items_in_cart',
+				'get_product',
+			],
+			[ $gateway ]
+		);
 
-		// The actual test: Check if should_show_ece_on_checkout_page returns the expected value.
-		$result = $helper->should_show_ece_on_checkout_page();
+		// Create a mock product.
+		$product = WC_Helper_Product::create_simple_product();
+		$is_product_page = $is_opc || in_array( 'product', $button_locations, true );
 
-		$this->assertEquals( in_array( 'checkout', $button_locations, true ), $result );
+		// Mock the methods.
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_one_page_checkout' )->willReturn( $is_opc );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( $is_product_page );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'get_product' )->willReturn( $is_product_page ? $product : false );
+
+		// Manually set the properties that would be set in the constructor.
+		$wc_stripe_ece_helper_mock->stripe_settings = $stripe_settings;
+		$wc_stripe_ece_helper_mock->testmode        = true;
+
+		// Ensure that the 'stripe' gateway is available.
+		$original_gateways                         = WC()->payment_gateways()->payment_gateways;
+		WC()->payment_gateways()->payment_gateways = [
+			'stripe' => new WC_Stripe_UPE_Payment_Gateway(),
+		];
+
+		// Test the actual OPC logic in should_show_express_checkout_button.
+		$result = $wc_stripe_ece_helper_mock->should_show_express_checkout_button();
+
+		$this->assertEquals( $expected, $result );
+
+		// Restore original gateways.
+		WC()->payment_gateways()->payment_gateways = $original_gateways;
 	}
 
 	/**

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -21,6 +21,7 @@ use WP_UnitTestCase;
  * @package WooCommerce/Stripe/WC_Stripe_Express_Checkout_Helper
  *
  * WC_Stripe_Express_Checkout_Helper_Test class.
+ * @group helper
  */
 class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	private $shipping_zone;
@@ -1006,19 +1007,12 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		// Ensure we're not on a checkout page for these tests.
-		add_filter(
-			'woocommerce_is_checkout',
-			function () {
-				return false;
-			}
-		);
-
 		$wc_stripe_ece_helper_mock = $this->createPartialMock(
 			WC_Stripe_Express_Checkout_Helper::class,
 			[
 				'is_one_page_checkout',
 				'is_product',
+				'is_checkout',
 				'allowed_items_in_cart',
 				'get_product',
 			],
@@ -1032,6 +1026,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		// Mock the methods.
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_one_page_checkout' )->willReturn( $is_opc );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_product' )->willReturn( $is_product_page );
+		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'is_checkout' )->willReturn( false );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'allowed_items_in_cart' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->expects( $this->any() )->method( 'get_product' )->willReturn( $is_product_page ? $product : false );
 
@@ -1050,9 +1045,8 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $result );
 
-		// Restore original gateways and remove filter.
+		// Restore original gateways.
 		WC()->payment_gateways()->payment_gateways = $original_gateways;
-		remove_all_filters( 'woocommerce_is_checkout' );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-743

## Changes proposed in this Pull Request:


This PR improves the compatibility between Stripe Express Checkout (ECE) buttons and the WooCommerce One Page Checkout (OPC) plugin. 

Problem:
When using the OPC plugin with ECE configured to show only on "checkout pages":
  1. ECE buttons don't appear on OPC pages because `is_checkout()` returns `false` (they're technically product pages)
  2. When buttons did appear with both locations enabled, they showed in the product section instead of the checkout section.
  3. ECE buttons displayed original product prices instead of discounted prices after applying coupon codes

Changes proposed:
  - Detect OPC pages using `is_wcopc_checkout()` and treat them as checkout context rather than product context
  - Skip product page restrictions for OPC pages when checkout buttons are enabled
  - Force frontend to use cart totals (which include discounts) instead of product pricing on OPC pages when checkout buttons are enabled

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Prerequisites

- [WooCommerce One Page Checkout](https://woocommerce.com/products/woocommerce-one-page-checkout/) plugin installed and active

Test Case 1: ECE shows on OPC with checkout location enabled

1. Go to WooCommerce > Settings > Payments > Stripe
2. Under "Express Checkout", set button locations to "Checkout" only (uncheck Product and Cart)
3. Create a product and mark it as One Page Checkout enabled (OPC meta field _wcopc = 'yes')
4. View the product page
5. Expected: Express Checkout buttons (Apple Pay, Google Pay, etc.) appear in the checkout section of the OPC
6. Expected: No ECE buttons appear in the add-to-cart section

Test Case 2: Correct pricing with discount codes on OPC

1. With the same setup as Test Case 1
2. On the OPC product page, apply a coupon code in the checkout section
3. Observe the ECE buttons
4. Open an ECE (eg: Google Pay), the total in the payment modal should have the discount applied

Optional:
Test for regressions with OPC disabled.
 

https://github.com/user-attachments/assets/c0b4c26d-806a-4ec7-bc10-97f1e8e7f342



<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
