### PR TITLE
Prevent retries on unrecoverable errors

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Fix - Prevent retrying requests that errored out due to declined payment methods
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -157,7 +157,9 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 			(
 				'payment_intent_mandate_invalid' === $error->code || // Don't retry payments when a 3DS mandate is invalid.
 				'charge_exceeds_transaction_limit' === $error->code || // Don't retry payments when the charge exceeds the transaction limit.
-				'amount_too_small' === $error->code
+				'amount_too_small' === $error->code ||
+				'card_declined' === $error->code ||
+				'payment_method_provider_decline' === $error->code
 			)
 		) {
 			return false;

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -152,26 +152,27 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 	public function is_retryable_error( $error ) {
 		// Note that this check is required since the error type is 'invalid_request_error' which
 		// would otherwise return true.
-		if (
-			isset( $error->code ) &&
-			(
-				'payment_intent_mandate_invalid' === $error->code || // Don't retry payments when a 3DS mandate is invalid.
-				'charge_exceeds_transaction_limit' === $error->code || // Don't retry payments when the charge exceeds the transaction limit.
-				'amount_too_small' === $error->code ||
-				'card_declined' === $error->code ||
-				'payment_method_provider_decline' === $error->code
-			)
-		) {
+		$non_retryable_codes = [
+			'payment_intent_mandate_invalid',     // Don't retry payments when a 3DS mandate is invalid.
+			'charge_exceeds_transaction_limit',   // Don't retry payments when the charge exceeds the transaction limit.
+			'amount_too_small',
+			'card_declined',
+			'payment_method_provider_decline',
+		];
+
+		if ( isset( $error->code ) && in_array( $error->code, $non_retryable_codes, true ) ) {
 			return false;
 		}
 
-		return (
-			'invalid_request_error' === $error->type ||
-			'idempotency_error' === $error->type ||
-			'rate_limit_error' === $error->type ||
-			'api_connection_error' === $error->type ||
-			'api_error' === $error->type
-		);
+		$retryable_types = [
+			'invalid_request_error',
+			'idempotency_error',
+			'rate_limit_error',
+			'api_connection_error',
+			'api_error',
+		];
+
+		return in_array( $error->type, $retryable_types, true );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -125,5 +125,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Fix - Prevent retrying requests that errored out due to declined payment methods
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
+++ b/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
@@ -871,4 +871,20 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			'api_error'             => [ 'api_error' ],
 		];
 	}
+
+	/**
+	 * Test that invalid_request_error with non-blocked error codes returns true
+	 *
+	 * This explicitly tests the case where we have an invalid_request_error type
+	 * with an error code that is NOT in the non-retryable codes list.
+	 */
+	public function test_invalid_request_error_with_non_blocked_code_is_retryable() {
+		$error       = new \stdClass();
+		$error->type = 'invalid_request_error';
+		$error->code = 'non_existent_code';
+
+		$result = $this->gateway->is_retryable_error( $error );
+
+		$this->assertTrue( $result, 'invalid_request_error with non-blocked code should be retryable' );
+	}
 }

--- a/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
+++ b/tests/phpunit/WC_Stripe_Payment_Gateway_Test.php
@@ -9,7 +9,6 @@ use WC_Stripe_Order_Helper;
 use WC_Stripe_UPE_Payment_Gateway;
 use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\WC_Helper_Order;
-use WP_UnitTestCase;
 use WC_Stripe_Payment_Methods;
 use WC_Stripe_UPE_Payment_Method_CC;
 
@@ -815,6 +814,61 @@ class WC_Stripe_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'filter'                     => $mocked_filter,
 				'expected'                   => [],
 			],
+		];
+	}
+
+	/**
+	 * Test that non-retryable error codes return false
+	 *
+	 * @dataProvider non_retryable_error_codes_provider
+	 */
+	public function test_non_retryable_error_codes_return_false( $error_code ) {
+		$error       = new \stdClass();
+		$error->code = $error_code;
+		$error->type = 'invalid_request_error';
+
+		$result = $this->gateway->is_retryable_error( $error );
+
+		$this->assertFalse( $result, "Error code '{$error_code}' should not be retryable" );
+	}
+
+	/**
+	 * Data provider for non-retryable error codes
+	 */
+	public function non_retryable_error_codes_provider() {
+		return [
+			'payment_intent_mandate_invalid'   => [ 'payment_intent_mandate_invalid' ],
+			'charge_exceeds_transaction_limit' => [ 'charge_exceeds_transaction_limit' ],
+			'amount_too_small'                 => [ 'amount_too_small' ],
+			'card_declined'                    => [ 'card_declined' ],
+			'payment_method_provider_decline'  => [ 'payment_method_provider_decline' ],
+		];
+	}
+
+	/**
+	 * Test that retryable error types return true
+	 *
+	 * @dataProvider retryable_error_types_provider
+	 */
+	public function test_retryable_error_types_return_true( $error_type ) {
+		$error       = new \stdClass();
+		$error->type = $error_type;
+
+		$result = $this->gateway->is_retryable_error( $error );
+
+		$this->assertTrue( $result, "Error type '{$error_type}' should be retryable" );
+	}
+
+	/**
+	 * Data provider for retryable error types
+	 */
+	public function retryable_error_types_provider() {
+		return [
+			'invalid_request_error' => [ 'invalid_request_error' ],
+			'idempotency_error'     => [ 'idempotency_error' ],
+			'rate_limit_error'      => [ 'rate_limit_error' ],
+			'api_connection_error'  => [ 'api_connection_error' ],
+			'api_error'             => [ 'api_error' ],
 		];
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Relates STRIPE-739

## Changes proposed in this Pull Request:

This PR updates the request retry logic so that we don't retry requests that failed due to payment method declines, as they will continue to fail.

Additional context: https://linear.app/a8c/issue/STRIPE-739/payment-failed-the-provided-paymentmethod-cannot-be-attached#comment-d139b0e7


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
Code review is enough. Linked Linear issue has links to Stripe Platform logs that contain the error codes added here.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
