### PR TITLE
Deprecating the UPE preview feature flag and removing its usages

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -12,7 +12,7 @@ runs:
 
     # PHP
     - name: Setup PHP
-      uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
+      uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2.35.5
       with:
         php-version: ${{ inputs.php-version }}
         tools: composer

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -12,7 +12,7 @@ runs:
 
     # PHP
     - name: Setup PHP
-      uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2.35.5
+      uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
       with:
         php-version: ${{ inputs.php-version }}
         tools: composer

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
+* Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -291,44 +291,38 @@ $stripe_settings = apply_filters(
 	]
 );
 
-if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-	// in the new settings, "checkout" is going to be enabled by default (if it is a new WCStripe installation).
-	$stripe_settings['payment_request_button_locations']['default'][] = 'checkout';
+// in the new settings, "checkout" is going to be enabled by default (if it is a new WCStripe installation).
+$stripe_settings['payment_request_button_locations']['default'][] = 'checkout';
 
-	// no longer needed in the new settings.
-	unset( $stripe_settings['payment_request_button_branded_type'] );
-	unset( $stripe_settings['payment_request_button_height'] );
-	unset( $stripe_settings['payment_request_button_label'] );
-	// injecting some of the new options.
-	$stripe_settings['payment_request_button_type']['options']['default'] = __( 'Only icon', 'woocommerce-gateway-stripe' );
-	$stripe_settings['payment_request_button_type']['options']['book']    = __( 'Book', 'woocommerce-gateway-stripe' );
-	// no longer valid options.
-	unset( $stripe_settings['payment_request_button_type']['options']['branded'] );
-	unset( $stripe_settings['payment_request_button_type']['options']['custom'] );
-} else {
-	unset( $stripe_settings['payment_request_button_size'] );
-}
+// no longer needed in the new settings.
+unset( $stripe_settings['payment_request_button_branded_type'] );
+unset( $stripe_settings['payment_request_button_height'] );
+unset( $stripe_settings['payment_request_button_label'] );
+// injecting some of the new options.
+$stripe_settings['payment_request_button_type']['options']['default'] = __( 'Only icon', 'woocommerce-gateway-stripe' );
+$stripe_settings['payment_request_button_type']['options']['book']    = __( 'Book', 'woocommerce-gateway-stripe' );
+// no longer valid options.
+unset( $stripe_settings['payment_request_button_type']['options']['branded'] );
+unset( $stripe_settings['payment_request_button_type']['options']['custom'] );
 
-if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-	$upe_settings = [
-		WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => [
-			'title'       => __( 'New checkout experience', 'woocommerce-gateway-stripe' ),
-			'label'       => sprintf(
-				/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe dashboard opening anchor tag 5) Stripe dashboard closing anchor tag */
-				__( 'Try the new payment experience (Early access) %1$sGet early access to a new, smarter payment experience on checkout and let us know what you think by %2$s. We recommend this feature for experienced merchants as the functionality is currently limited. %3$s', 'woocommerce-gateway-stripe' ),
-				'<br />',
-				'<a href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" target="_blank">submitting your feedback</a>',
-				'<a href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" target="_blank">Learn more</a>'
-			),
-			'type'        => 'checkbox',
-			'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),
-			'default'     => 'no',
-			'desc_tip'    => true,
-		],
-	];
-	// Insert UPE options below the 'logging' setting.
-	$stripe_settings = array_merge( $stripe_settings, $upe_settings );
-}
+$upe_settings = [
+	WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => [
+		'title'       => __( 'New checkout experience', 'woocommerce-gateway-stripe' ),
+		'label'       => sprintf(
+			/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe dashboard opening anchor tag 5) Stripe dashboard closing anchor tag */
+			__( 'Try the new payment experience (Early access) %1$sGet early access to a new, smarter payment experience on checkout and let us know what you think by %2$s. We recommend this feature for experienced merchants as the functionality is currently limited. %3$s', 'woocommerce-gateway-stripe' ),
+			'<br />',
+			'<a href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" target="_blank">submitting your feedback</a>',
+			'<a href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" target="_blank">Learn more</a>'
+		),
+		'type'        => 'checkbox',
+		'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),
+		'default'     => 'no',
+		'desc_tip'    => true,
+	],
+];
+// Insert UPE options below the 'logging' setting.
+$stripe_settings = array_merge( $stripe_settings, $upe_settings );
 
 return apply_filters(
 	'wc_stripe_settings',

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -305,25 +305,6 @@ $stripe_settings['express_checkout_button_type']['options']['book']    = __( 'Bo
 unset( $stripe_settings['express_checkout_button_type']['options']['branded'] );
 unset( $stripe_settings['express_checkout_button_type']['options']['custom'] );
 
-$upe_settings = [
-	WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME => [
-		'title'       => __( 'New checkout experience', 'woocommerce-gateway-stripe' ),
-		'label'       => sprintf(
-			/* translators: 1) br tag 2) Stripe anchor tag 3) Apple anchor tag 4) Stripe dashboard opening anchor tag 5) Stripe dashboard closing anchor tag */
-			__( 'Try the new payment experience (Early access) %1$sGet early access to a new, smarter payment experience on checkout and let us know what you think by %2$s. We recommend this feature for experienced merchants as the functionality is currently limited. %3$s', 'woocommerce-gateway-stripe' ),
-			'<br />',
-			'<a href="https://woocommerce.survey.fm/woocommerce-stripe-upe-opt-out-survey" target="_blank">submitting your feedback</a>',
-			'<a href="https://woocommerce.com/document/stripe/admin-experience/new-checkout-experience/" target="_blank">Learn more</a>'
-		),
-		'type'        => 'checkbox',
-		'description' => __( 'New checkout experience allows you to manage all payment methods on one screen and display them to customers based on their currency and location.', 'woocommerce-gateway-stripe' ),
-		'default'     => 'no',
-		'desc_tip'    => true,
-	],
-];
-// Insert UPE options below the 'logging' setting.
-$stripe_settings = array_merge( $stripe_settings, $upe_settings );
-
 return apply_filters(
 	'wc_stripe_settings',
 	$stripe_settings

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -85,9 +85,11 @@ class WC_Stripe_Feature_Flags {
 	 * This allows the merchant to enable/disable UPE checkout.
 	 *
 	 * @return bool
+	 *
+	 * @deprecated 10.0.0 UPE is always enabled. This method will be removed in a future release.
 	 */
 	public static function is_upe_preview_enabled() {
-		return 'yes' === self::get_option_with_default( '_wcstripe_feature_upe' );
+		return true;
 	}
 
 	/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -86,7 +86,7 @@ class WC_Stripe_Feature_Flags {
 	 *
 	 * @return bool
 	 *
-	 * @deprecated 10.0.0 UPE is always enabled. This method will be removed in a future release.
+	 * @deprecated 10.1.0 UPE is always enabled. This method will be removed in a future release.
 	 */
 	public static function is_upe_preview_enabled() {
 		return true;

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -541,9 +541,7 @@ class WC_Stripe {
 	 */
 	public function filter_gateway_order_admin( $sections ) {
 		unset( $sections['stripe'] );
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			unset( $sections['stripe_upe'] );
-		}
+		unset( $sections['stripe_upe'] );
 		unset( $sections['stripe_bancontact'] );
 		unset( $sections['stripe_sofort'] );
 		unset( $sections['stripe_giropay'] );
@@ -554,10 +552,9 @@ class WC_Stripe {
 		unset( $sections['stripe_sepa'] );
 		unset( $sections['stripe_multibanco'] );
 
-		$sections['stripe'] = 'Stripe';
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			$sections['stripe_upe'] = 'Stripe checkout experience';
-		}
+		$sections['stripe']     = 'Stripe';
+		$sections['stripe_upe'] = 'Stripe checkout experience';
+
 		$sections['stripe_bancontact'] = __( 'Stripe Bancontact', 'woocommerce-gateway-stripe' );
 		$sections['stripe_sofort']     = __( 'Stripe Sofort', 'woocommerce-gateway-stripe' );
 		$sections['stripe_giropay']    = __( 'Stripe giropay', 'woocommerce-gateway-stripe' );
@@ -591,10 +588,6 @@ class WC_Stripe {
 
 		// Note that we need to run these checks before we call toggle_upe() below.
 		$this->maybe_reset_stripe_in_memory_key( $settings, $old_settings );
-
-		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return $settings;
-		}
 
 		return $this->toggle_upe( $settings, $old_settings );
 	}
@@ -791,24 +784,22 @@ class WC_Stripe {
 		$oauth_connect->register_routes();
 		$stripe_account_controller->register_routes();
 
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-settings-controller.php';
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';
-			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-oc-setting-toggle-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-settings-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-rest-stripe-account-keys-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-oc-setting-toggle-controller.php';
 
-			$upe_flag_toggle_controller = new WC_Stripe_REST_UPE_Flag_Toggle_Controller();
-			$upe_flag_toggle_controller->register_routes();
+		$upe_flag_toggle_controller = new WC_Stripe_REST_UPE_Flag_Toggle_Controller();
+		$upe_flag_toggle_controller->register_routes();
 
-			$settings_controller = new WC_REST_Stripe_Settings_Controller( $this->get_main_stripe_gateway() );
-			$settings_controller->register_routes();
+		$settings_controller = new WC_REST_Stripe_Settings_Controller( $this->get_main_stripe_gateway() );
+		$settings_controller->register_routes();
 
-			$stripe_account_keys_controller = new WC_REST_Stripe_Account_Keys_Controller( $this->account );
-			$stripe_account_keys_controller->register_routes();
+		$stripe_account_keys_controller = new WC_REST_Stripe_Account_Keys_Controller( $this->account );
+		$stripe_account_keys_controller->register_routes();
 
-			$oc_setting_toggle_controller = new WC_Stripe_REST_OC_Setting_Toggle_Controller( $this->get_main_stripe_gateway() );
-			$oc_setting_toggle_controller->register_routes();
-		}
+		$oc_setting_toggle_controller = new WC_Stripe_REST_OC_Setting_Toggle_Controller( $this->get_main_stripe_gateway() );
+		$oc_setting_toggle_controller->register_routes();
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -540,7 +540,6 @@ class WC_Stripe {
 	 */
 	public function filter_gateway_order_admin( $sections ) {
 		unset( $sections['stripe'] );
-		unset( $sections['stripe_upe'] );
 		unset( $sections['stripe_bancontact'] );
 		unset( $sections['stripe_sofort'] );
 		unset( $sections['stripe_giropay'] );

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -78,10 +78,6 @@ class WC_Stripe_UPE_Availability_Note {
 		 * - UPE has been manually disabled
 		 * - Stripe is not enabled
 		 */
-		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return;
-		}
-
 		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
 			return;
 		}

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -73,7 +73,6 @@ class WC_Stripe_UPE_Availability_Note {
 	public static function init() {
 		/**
 		 * No need to display the admin inbox note when
-		 * - UPE preview is disabled
 		 * - UPE is already enabled
 		 * - UPE has been manually disabled
 		 * - Stripe is not enabled

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -283,10 +283,6 @@ class WC_Stripe_Payment_Request {
 	 * @return  string
 	 */
 	public function get_button_height() {
-		if ( ! WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return isset( $this->stripe_settings['payment_request_button_height'] ) ? str_replace( 'px', '', $this->stripe_settings['payment_request_button_height'] ) : '64';
-		}
-
 		$height = isset( $this->stripe_settings['payment_request_button_size'] ) ? $this->stripe_settings['payment_request_button_size'] : 'default';
 		if ( 'small' === $height ) {
 			return '40';
@@ -330,12 +326,7 @@ class WC_Stripe_Payment_Request {
 	 * @return  boolean
 	 */
 	public function is_custom_button() {
-		// no longer a valid option
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return false;
-		}
-
-		return 'custom' === $this->get_button_type();
+		return false;
 	}
 
 	/**
@@ -357,12 +348,7 @@ class WC_Stripe_Payment_Request {
 	 * @return  string
 	 */
 	public function get_button_label() {
-		// no longer a valid option
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return '';
-		}
-
-		return isset( $this->stripe_settings['payment_request_button_label'] ) ? $this->stripe_settings['payment_request_button_label'] : 'Buy now';
+		return '';
 	}
 
 	/**
@@ -1824,32 +1810,18 @@ class WC_Stripe_Payment_Request {
 		// it would be DRYer to use `array_merge`,
 		// but I thought that this approach might be more straightforward to clean up when we remove the feature flag code.
 		$button_type = $this->get_button_type();
-		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() ) {
-			return [
-				'type'         => $button_type,
-				'theme'        => $this->get_button_theme(),
-				'height'       => $this->get_button_height(),
-				// Default format is en_US.
-				'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
-				'branded_type' => 'default' === $button_type ? 'short' : 'long',
-				// these values are no longer applicable - all the JS relying on them can be removed.
-				'css_selector' => '',
-				'label'        => '',
-				'is_custom'    => false,
-				'is_branded'   => false,
-			];
-		}
-
 		return [
 			'type'         => $button_type,
 			'theme'        => $this->get_button_theme(),
 			'height'       => $this->get_button_height(),
-			'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
 			// Default format is en_US.
-			'is_custom'    => $this->is_custom_button(),
-			'is_branded'   => $this->is_branded_button(),
-			'css_selector' => $this->custom_button_selector(),
-			'branded_type' => $this->get_button_branded_type(),
+			'locale'       => apply_filters( 'wc_stripe_payment_request_button_locale', substr( get_locale(), 0, 2 ) ),
+			'branded_type' => 'default' === $button_type ? 'short' : 'long',
+			// these values are no longer applicable - all the JS relying on them can be removed.
+			'css_selector' => '',
+			'label'        => '',
+			'is_custom'    => false,
+			'is_branded'   => false,
 		];
 	}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -248,7 +248,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->statement_descriptor          = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
 
 		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab'] ) {
+		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab'] ) {
 			$enabled_payment_methods_count = count( $enabled_payment_methods );
 			$this->title                   = $enabled_payment_methods_count ?
 				/* translators: $1. Count of enabled payment methods. */

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.1.0 - xxxx-xx-xx =
+* Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection

--- a/tests/phpunit/WC_Stripe_Helper_Test.php
+++ b/tests/phpunit/WC_Stripe_Helper_Test.php
@@ -799,22 +799,6 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		];
 	}
 
-	public function test_turning_on_upe_with_no_stripe_legacy_payment_methods_enabled_will_not_turn_on_the_upe_gateway_and_default_to_card_and_link() {
-		$this->upe_helper->enable_upe_feature_flag();
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		$this->assertEquals( 'no', $stripe_settings['enabled'] );
-		$this->assertEquals( 'no', $stripe_settings['upe_checkout_experience_enabled'] );
-
-		$stripe_settings['upe_checkout_experience_enabled'] = 'yes';
-		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		// Because no Stripe LPM's were enabled when UPE was enabled, the Stripe gateway is not enabled yet.
-		$this->assertEquals( 'no', $stripe_settings['enabled'] );
-		$this->assertEquals( 'yes', $stripe_settings['upe_checkout_experience_enabled'] );
-	}
-
 	public function test_turning_on_upe_enables_the_correct_upe_methods_based_on_which_legacy_payment_methods_were_enabled() {
 		update_option( 'woocommerce_currency', 'EUR' );
 		$this->upe_helper->enable_upe_feature_flag();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, I am deprecating the `is_upe_preview_enabled` method and removing the actual feature flag (`_wcstripe_feature_upe`). This has not been used for a while, since we deprecated the legacy checkout. I am also updating all parts of the code referencing the `is_upe_preview_enabled` method.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review. Check if the tests are still passing. Perform some basic smoke-testing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
