### PR TITLE
Log the masked secret key when making API calls

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Dev - Add Stripe's masked API key to API request/response logs
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -235,8 +235,16 @@ class WC_Stripe_API {
 		 */
 		$request = apply_filters( 'wc_stripe_request_body', $request, $api );
 
+		$masked_secret_key = self::get_masked_secret_key();
+
 		// Log the request after the filters have been applied.
-		WC_Stripe_Logger::debug( "Stripe API request: {$method} {$api}", [ 'request' => $request ] );
+		WC_Stripe_Logger::debug(
+			"Stripe API request: {$method} {$api}",
+			[
+				'stripe_api_key' => $masked_secret_key,
+				'request'        => $request,
+			]
+		);
 
 		$response = wp_safe_remote_post(
 			self::ENDPOINT . $api,
@@ -255,9 +263,10 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: {$method} {$api}",
 				[
-					'request'           => $request,
+					'stripe_api_key'    => $masked_secret_key,
 					'stripe_request_id' => self::get_stripe_request_id( $response ),
 					'idempotency_key'   => $idempotency_key,
+					'request'           => $request,
 					'response'          => $response,
 				]
 			);
@@ -270,6 +279,7 @@ class WC_Stripe_API {
 		WC_Stripe_Logger::debug(
 			"Stripe API response: {$method} {$api}",
 			[
+				'stripe_api_key'    => $masked_secret_key,
 				'stripe_request_id' => self::get_stripe_request_id( $response ),
 				'response'          => $response_body,
 			]
@@ -307,7 +317,14 @@ class WC_Stripe_API {
 			return null;
 		}
 
-		WC_Stripe_Logger::debug( "Stripe API request: GET {$api}" );
+		$masked_secret_key = self::get_masked_secret_key();
+
+		WC_Stripe_Logger::debug(
+			"Stripe API request: GET {$api}",
+			[
+				'stripe_api_key' => $masked_secret_key,
+			]
+		);
 
 		$response = wp_safe_remote_get(
 			self::ENDPOINT . $api,
@@ -324,6 +341,7 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: GET {$api} returned a 401",
 				[
+					'stripe_api_key'    => $masked_secret_key,
 					'stripe_request_id' => self::get_stripe_request_id( $response ),
 					'response'          => json_decode( $response['body'] ),
 				]
@@ -336,8 +354,9 @@ class WC_Stripe_API {
 				WC_Stripe_Logger::error(
 					'Invalid API keys request rate limit exceeded',
 					[
-						'count'      => $invalid_api_key_error_count,
-						'next_retry' => date_i18n( 'Y-m-d H:i:sP', time() + self::INVALID_API_KEY_ERROR_COUNT_CACHE_TIMEOUT ),
+						'stripe_api_key' => $masked_secret_key,
+						'count'          => $invalid_api_key_error_count,
+						'next_retry'     => date_i18n( 'Y-m-d H:i:sP', time() + self::INVALID_API_KEY_ERROR_COUNT_CACHE_TIMEOUT ),
 					]
 				);
 
@@ -358,6 +377,7 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: GET {$api}",
 				[
+					'stripe_api_key'    => $masked_secret_key,
 					'stripe_request_id' => self::get_stripe_request_id( $response ),
 					'response'          => $response,
 				]
@@ -370,6 +390,7 @@ class WC_Stripe_API {
 		WC_Stripe_Logger::debug(
 			"Stripe API response: GET {$api}",
 			[
+				'stripe_api_key'    => $masked_secret_key,
 				'stripe_request_id' => self::get_stripe_request_id( $response ),
 				'response'          => $response_body,
 			]
@@ -631,5 +652,19 @@ class WC_Stripe_API {
 			return $headers->getAll()['request-id'] ?? '';
 		}
 		return '';
+	}
+
+	/**
+	 * Get the masked secret key.
+	 * It uses the same pattern as the Stripe dashboard: sk_live_...JLWaeq.
+	 *
+	 * @return string The masked secret key.
+	 */
+	private static function get_masked_secret_key(): string {
+		$key = self::get_secret_key();
+		if ( empty( $key ) ) {
+			return 'secret_key_not_configured';
+		}
+		return substr( $key, 0, 8 ) . '...' . substr( $key, -6 );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -126,5 +126,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Dev - Add Stripe's masked API key to API request/response logs
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

This PR logs the masked secret key when making API calls (to the`request` and `retrieve` methods).
It uses the same masking as the Stripe dashboard (the first 8 characters, 3 dots, and the last 6 characters).

<img width="774" height="512" alt="Screenshot 2025-11-05 at 11 38 43" src="https://github.com/user-attachments/assets/24695b93-0bc1-4ca4-92ec-6a334bdb3ee1" />

## Testing instructions

Code review.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
