### PR TITLE
ECE: Make postal code verification optional for certain countries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Fix - Allow express checkout to complete successfully for addresses without postal codes in countries where it's not required (eg: Israel)
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -402,6 +402,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 	/**
 	 * Modify country locale for express checkout.
 	 * Countries that don't have state fields, make the state field optional.
+	 * Make postcode optional for specific countries during express checkout.
 	 *
 	 * @param array $locale The country locale.
 	 * @return array Modified country locale.
@@ -419,6 +420,20 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 			if ( empty( $states ) ) {
 				$locale[ $country_code ]['state']['required'] = false;
 			}
+		}
+
+		// List of countries where postcode is optional in payment providers (Google Pay, Apple Pay).
+		// These countries allow addresses without postal codes, but WooCommerce requires them by default.
+		$countries_with_optional_postcode = apply_filters(
+			'wc_stripe_express_checkout_countries_with_optional_postcode',
+			[
+				'IL', // Israel
+			]
+		);
+
+		// Make postcode optional for countries where payment providers don't require it.
+		foreach ( $countries_with_optional_postcode as $country_code ) {
+			$locale[ $country_code ]['postcode']['required'] = false;
 		}
 
 		return $locale;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -422,7 +422,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 			}
 		}
 
-		// List of countries where postcode is optional in payment providers (Google Pay, Apple Pay).
+		// List of countries where postcode is optional in express checkouts (Google Pay, Apple Pay).
 		// These countries allow addresses without postal codes, but WooCommerce requires them by default.
 		$countries_with_optional_postcode = apply_filters(
 			'wc_stripe_express_checkout_countries_with_optional_postcode',

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -433,7 +433,9 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 
 		// Make postcode optional for countries where payment providers don't require it.
 		foreach ( $countries_with_optional_postcode as $country_code ) {
-			$locale[ $country_code ]['postcode']['required'] = false;
+			if ( isset( $locale[ $country_code ] ) ) {
+				$locale[ $country_code ]['postcode']['required'] = false;
+			}
 		}
 
 		return $locale;

--- a/readme.txt
+++ b/readme.txt
@@ -126,5 +126,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Fix - Allow express checkout to complete successfully for addresses without postal codes in countries where it's not required (eg: Israel)
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-699

## Changes proposed in this Pull Request:

This PR fixes a checkout validation issue where express checkout fails for countries that don't require postal codes (eg: Israel). Although postal codes are optional on the express checkout form, WooCommerce's default validation requires them, causing order failures.

This PR extends `modify_country_locale_for_express_checkout` method to mark the postcode field as optional for specific countries. A similar approach was first introduced in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4451 for State validation. For postal codes, I couldn't find a definitive list of countries where they are optional on Google Pay/Apple Pay. So in this PR, I've only listed Israel (which was reported in the Linear issue attached) and introduced a filter that merchants can use to add more countries. 

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

**Setup**
Google Test Card suite doesn't have any Israel addresses and it didn't allow me to add one. So I ended up hard-coding an address in the `ajax_normalize_address` function.

```
	/**
	 * Normalizes address fields in WooCommerce supported format.
	 */
	public function ajax_normalize_address() {
		check_ajax_referer( 'wc-stripe-express-checkout-normalize-address', 'security' );

		$data = filter_input( INPUT_POST, 'data', FILTER_DEFAULT, FILTER_REQUIRE_ARRAY );

		// TEMPORARY TEST CODE - Simulate Israel address without postcode from Google Pay.
		if ( ! empty( $data['billing_address'] ) ) {
			$data['billing_address']['country']  = 'IL';
			$data['billing_address']['city']     = 'Tel Aviv';
			$data['billing_address']['address_1'] = 'Rothschild Blvd 1';
			$data['billing_address']['state']    = '';
			$data['billing_address']['postcode'] = ''; // Empty postcode - this is what causes the issue.
		}
		if ( ! empty( $data['shipping_address'] ) ) {
			$data['shipping_address']['country']  = 'IL';
			$data['shipping_address']['city']     = 'Tel Aviv';
			$data['shipping_address']['address_1'] = 'Rothschild Blvd 1';
			$data['shipping_address']['state']    = '';
			$data['shipping_address']['postcode'] = ''; // Empty postcode - this is what causes the issue.
		}

		// Normalizes billing and shipping state values.
		$normalized_data = $this->express_checkout_helper->normalize_state( $data );
		$normalized_data = $this->express_checkout_helper->fix_address_fields_mapping( $normalized_data );

		wp_send_json( $normalized_data );
	}

```

**Test Google Pay**
1. As a shopper, add a product to your cart and go to the checkout page.
2. Pay with Google Pay.
3. In `develop`, order will fail. On this branch, you should be able to place the order.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
