### PR TITLE
Add logging for HTTP validation failures

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 * Fix - Prevent retrying requests that errored out due to declined payment methods
+* Tweak - Add logging for URL validation issues when calling Stripe API
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,8 +25,7 @@
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
-* Dev - Add logging for URL validation issues when calling Stripe API
-* Dev - Add logging when we detect a URL validation issue
+* Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
 * Dev - Add logging for URL validation issues when calling Stripe API
+* Dev - Add logging when we detect a URL validation issue
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -251,16 +251,11 @@ class WC_Stripe_API {
 		$response_headers = wp_remote_retrieve_headers( $response );
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
-			// Stripe redacts API keys in the response.
-			WC_Stripe_Logger::error(
-				"Stripe API error: {$method} {$api}",
-				[
-					'request'           => $request,
-					'stripe_request_id' => self::get_stripe_request_id( $response ),
-					'idempotency_key'   => $idempotency_key,
-					'response'          => $response,
-				]
-			);
+			$error_data = [
+				'request'           => $request,
+				'idempotency_key'   => $idempotency_key,
+			];
+			self::log_error_response( $response, $api, $method, $error_data );
 
 			throw new WC_Stripe_Exception( print_r( $response, true ), __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ) );
 		}
@@ -355,13 +350,8 @@ class WC_Stripe_API {
 		}
 
 		if ( is_wp_error( $response ) || empty( $response['body'] ) ) {
-			WC_Stripe_Logger::error(
-				"Stripe API error: GET {$api}",
-				[
-					'stripe_request_id' => self::get_stripe_request_id( $response ),
-					'response'          => $response,
-				]
-			);
+			self::log_error_response( $response, $api, 'GET' );
+
 			return new WP_Error( 'stripe_error', __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ) );
 		}
 
@@ -613,6 +603,48 @@ class WC_Stripe_API {
 			'payment_method_configurations/' . $id
 		);
 		return $response;
+	}
+
+	/**
+	 * Log an error response from the Stripe API.
+	 *
+	 * @param array|WP_Error $response HTTP response or error.
+	 * @param string         $api      The API endpoint.
+	 * @param string         $method   The HTTP method used for the request.
+	 * @param array          $data     Additional data to add to the log.
+	 * @return void
+	 */
+	private static function log_error_response( $response, string $api, string $method, array $data = [] ): void {
+		$error_message = "Stripe API error: {$method} {$api}";
+		$error_data = array_merge(
+			$data,
+			[
+				'stripe_request_id' => self::get_stripe_request_id( $response ),
+				'response'          => $response,
+			]
+		);
+
+		// Add logging for URL validation errors.
+		if (
+			is_wp_error( $response ) &&
+			'http_request_failed' === $response->get_error_code() &&
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			__( 'A valid URL was not provided.' ) === $response->get_error_message()
+		) {
+			$stripe_api_host     = 'api.stripe.com';
+			$resolved_ip_address = gethostbyname( $stripe_api_host );
+
+			$error_data['resolved_ip_address'] = $resolved_ip_address;
+
+			if ( $resolved_ip_address === $stripe_api_host ) {
+				$error_data['validation_details'] = "$stripe_api_host could not be resolved to an IP address";
+			} else {
+				$error_message .= "; Possible DNS resolution problem for $stripe_api_host";
+				$error_data['validation_details'] = "$stripe_api_host resolved to $resolved_ip_address";
+			}
+		}
+
+		WC_Stripe_Logger::error( $error_message, $error_data );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -135,5 +135,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
 * Dev - Add logging for URL validation issues when calling Stripe API
+* Dev - Add logging when we detect a URL validation issue
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -127,5 +127,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 * Fix - Prevent retrying requests that errored out due to declined payment methods
+* Tweak - Add logging for URL validation issues when calling Stripe API
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -135,7 +135,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
-* Dev - Add logging for URL validation issues when calling Stripe API
-* Dev - Add logging when we detect a URL validation issue
+* Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -250,7 +250,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			is_wp_error( $response ) &&
 			'http_request_failed' === $response->get_error_code() &&
 			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
-			'A valid URL was not provided.' === $response->get_error_message()
+			__( 'A valid URL was not provided.' ) === $response->get_error_message()
 		) {
 			$expected_data_keys[] = 'resolved_ip_address';
 			$expected_data_keys[] = 'validation_details';
@@ -329,12 +329,14 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 				'request_data' => [ 'test' => 'test' ],
 			],
 			'URL validation http_request_failed error for GET account' => [
-				'response' => new \WP_Error( 'http_request_failed', __( 'A valid URL was not provided.', 'woocommerce-gateway-stripe' ) ),
+				// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+				'response' => new \WP_Error( 'http_request_failed', __( 'A valid URL was not provided.' ) ),
 				'api' => 'account',
 				'method' => 'GET',
 			],
 			'URL validation http_request_failed error for POST account' => [
-				'response' => new \WP_Error( 'http_request_failed', __( 'A valid URL was not provided.', 'woocommerce-gateway-stripe' ) ),
+				// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+				'response' => new \WP_Error( 'http_request_failed', __( 'A valid URL was not provided.' ) ),
 				'api' => 'account',
 				'method' => 'POST',
 				'request_data' => [ 'test' => 'test' ],

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -246,6 +246,16 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			$expected_data_keys[] = 'request';
 		}
 
+		if (
+			is_wp_error( $response ) &&
+			'http_request_failed' === $response->get_error_code() &&
+			// phpcs:ignore WordPress.WP.I18n.MissingArgDomain
+			'A valid URL was not provided.' === $response->get_error_message()
+		) {
+			$expected_data_keys[] = 'resolved_ip_address';
+			$expected_data_keys[] = 'validation_details';
+		}
+
 		$expected_data_keys_callback = function ( $context ) use ( $expected_data_keys ) {
 			$this->assertLessThanOrEqual( count( $context ), count( $expected_data_keys ) );
 			foreach ( $expected_data_keys as $key ) {

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -209,4 +209,149 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			'body'     => json_encode( [ 'error' => 'invalid_api_key' ] ),
 		];
 	}
+
+	/**
+	 * Test WC_Stripe_API::log_error_response() as called from WC_Stripe_API::request() and WC_Stripe_API::retrieve().
+	 *
+	 * @param array|WP_Error $response     The mock response.
+	 * @param string         $api          The API endpoint.
+	 * @param string         $method       The HTTP method used for the request.
+	 * @param array|null     $request_data The mock request data. Only used for POST requests.
+	 * @dataProvider provide_test_log_error_response_tests
+	 */
+	public function test_log_error_response( $response, string $api, string $method, ?array $request_data = null ) {
+		$expected_url = WC_Stripe_API::ENDPOINT . $api;
+
+		$pre_http_filter = function ( $return_value, $parsed_args, $url ) use ( $response, $method, $expected_url ) {
+			if ( $url !== $expected_url ) {
+				return $return_value;
+			}
+			if ( ( $parsed_args['method'] ?? null ) !== $method ) {
+				return $return_value;
+			}
+
+			return $response;
+		};
+
+		$mock_logger = $this->createMock( \WC_Logger::class );
+		\WC_Stripe_Logger::$logger = $mock_logger;
+
+		$expected_data_keys = [
+			'stripe_request_id',
+			'response',
+		];
+
+		if ( 'POST' === $method ) {
+			$expected_data_keys[] = 'idempotency_key';
+			$expected_data_keys[] = 'request';
+		}
+
+		$expected_data_keys_callback = function ( $context ) use ( $expected_data_keys ) {
+			$this->assertLessThanOrEqual( count( $context ), count( $expected_data_keys ) );
+			foreach ( $expected_data_keys as $key ) {
+				$this->assertArrayHasKey( $key, $context );
+			}
+			return true;
+		};
+
+		$mock_logger->expects( $this->once() )
+			->method( 'error' )
+			->with(
+				$this->stringStartsWith( "Stripe API error: $method $api" ),
+				$this->callback( $expected_data_keys_callback )
+			);
+
+		add_filter( 'pre_http_request', $pre_http_filter, 10, 3 );
+
+		if ( 'GET' === $method ) {
+			$result = WC_Stripe_API::retrieve( $api );
+		} else {
+			$caught_exception = null;
+			try {
+				$result = WC_Stripe_API::request( $request_data, $api, $method, false );
+			} catch ( \WC_Stripe_Exception $stripe_exception ) {
+				$caught_exception = $stripe_exception;
+			}
+		}
+
+		// Clean up before we perform any assertions.
+		remove_filter( 'pre_http_request', $pre_http_filter );
+		\WC_Stripe_Logger::$logger = null;
+
+		if ( 'GET' === $method ) {
+			$this->assertInstanceof( \WP_Error::class, $result );
+			$this->assertEquals( 'stripe_error', $result->get_error_code() );
+			$this->assertEquals( __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ), $result->get_error_message() );
+		} else {
+			$this->assertInstanceof( \WC_Stripe_Exception::class, $caught_exception );
+			$this->assertEquals( print_r( $response, true ), $caught_exception->getMessage() );
+			$this->assertEquals( __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ), $caught_exception->getLocalizedMessage() );
+		}
+	}
+
+	/**
+	 * Data provider for {@see test_log_error_response()}.
+	 *
+	 * @return array
+	 */
+	public function provide_test_log_error_response_tests(): array {
+		return [
+			'generic error for GET account' => [
+				'response' => new \WP_Error( 'mock_error', 'Mock Error' ),
+				'api' => 'account',
+				'method' => 'GET',
+			],
+			'generic error for POST account' => [
+				'response' => new \WP_Error( 'mock_error', 'Mock Error' ),
+				'api' => 'account',
+				'method' => 'POST',
+				'request_data' => [ 'test' => 'test' ],
+			],
+			'general http_request_failed error for GET account' => [
+				'response' => new \WP_Error( 'http_request_failed', 'Mock Error' ),
+				'api' => 'account',
+				'method' => 'GET',
+			],
+			'general http_request_failed error for POST account' => [
+				'response' => new \WP_Error( 'http_request_failed', 'Mock Error' ),
+				'api' => 'account',
+				'method' => 'POST',
+				'request_data' => [ 'test' => 'test' ],
+			],
+			'URL validation http_request_failed error for GET account' => [
+				'response' => new \WP_Error( 'http_request_failed', __( 'A valid URL was not provided.', 'woocommerce-gateway-stripe' ) ),
+				'api' => 'account',
+				'method' => 'GET',
+			],
+			'URL validation http_request_failed error for POST account' => [
+				'response' => new \WP_Error( 'http_request_failed', __( 'A valid URL was not provided.', 'woocommerce-gateway-stripe' ) ),
+				'api' => 'account',
+				'method' => 'POST',
+				'request_data' => [ 'test' => 'test' ],
+			],
+			'empty response body for GET account' => [
+				'response' => [
+					'response' => [
+						'code' => 200,
+						'message' => 'OK',
+					],
+					'body' => '',
+				],
+				'api' => 'account',
+				'method' => 'GET',
+			],
+			'empty response body for POST account' => [
+				'response' => [
+					'response' => [
+						'code' => 200,
+						'message' => 'OK',
+					],
+					'body' => '',
+				],
+				'api' => 'account',
+				'method' => 'POST',
+				'request_data' => [ 'test' => 'test' ],
+			],
+		];
+	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-795

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR refactors some of our error logging in `WC_Stripe_API` into a single `log_error_response()` function and adds more logging when we encounter a specific situation where the URL we are trying to call fails validation. This specific case was seen while digging into error logs for STRIPE-745, but we need additional logging to be able to get more details when that occurs.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

The simplest way to test this is as follows:
 * Run this branch on an environment where you can modify `/etc/hosts` (or its equivalent)
    - In our default Docker environment, you can simply modify `/etc/hosts` for your host machine
 * Modify your `/etc/hosts` file to add a line like the following to redirect `api.stripe.com` to your local machine:
```
127.0.0.1      api.stripe.com
```
* You may need to flush your DNS cache. You can do on MacOS by running the following commands:
```
sudo dscacheutil -flushcache;
sudo killall -HUP mDNSResponder;
```
* Load your store so the Stripe code will try to load and call Stripe -- a surefire way is to navigate to the settings with payment methods
* Remove the DNS redirect quickly to prevent your logs from being flooded - you can do that by removing the line you added or prefixing it with `#`.
* Ensure you flush the DNS cache again to get back to the normal/real DNS records.
* Inspect your logs and verify that the response logs include errors with the following message:
```
ERROR: Stripe API error: GET account; Possible DNS resolution problem for api.stripe.com
```
* Inspect the detailed items for the log, and verify that it includes the `resolved_ip_address` and `validation_details` keys.

We don't think we're seeing anything as problematic as this in the wild, but we have seen some merchants report issues with HTTP requests to Stripe failing with this type of error, and this logging should help us to debug that should it occur again.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)