### PR TITLE
Add verbose debug mode for OAuth connect flow

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Dev - Add Stripe's masked API key to API request/response logs
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
+* Dev - Add verbose debug logging mode to the OAuth connect flow
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -235,8 +235,16 @@ class WC_Stripe_API {
 		 */
 		$request = apply_filters( 'wc_stripe_request_body', $request, $api );
 
+		$masked_secret_key = self::get_masked_secret_key();
+
 		// Log the request after the filters have been applied.
-		WC_Stripe_Logger::debug( "Stripe API request: {$method} {$api}", [ 'request' => $request ] );
+		WC_Stripe_Logger::debug(
+			"Stripe API request: {$method} {$api}",
+			[
+				'stripe_api_key' => $masked_secret_key,
+				'request'        => $request,
+			]
+		);
 
 		$response = wp_safe_remote_post(
 			self::ENDPOINT . $api,
@@ -255,9 +263,10 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: {$method} {$api}",
 				[
-					'request'           => $request,
+					'stripe_api_key'    => $masked_secret_key,
 					'stripe_request_id' => self::get_stripe_request_id( $response ),
 					'idempotency_key'   => $idempotency_key,
+					'request'           => $request,
 					'response'          => $response,
 				]
 			);
@@ -270,6 +279,7 @@ class WC_Stripe_API {
 		WC_Stripe_Logger::debug(
 			"Stripe API response: {$method} {$api}",
 			[
+				'stripe_api_key'    => $masked_secret_key,
 				'stripe_request_id' => self::get_stripe_request_id( $response ),
 				'response'          => $response_body,
 			]
@@ -307,7 +317,14 @@ class WC_Stripe_API {
 			return null;
 		}
 
-		WC_Stripe_Logger::debug( "Stripe API request: GET {$api}" );
+		$masked_secret_key = self::get_masked_secret_key();
+
+		WC_Stripe_Logger::debug(
+			"Stripe API request: GET {$api}",
+			[
+				'stripe_api_key' => $masked_secret_key,
+			]
+		);
 
 		$response = wp_safe_remote_get(
 			self::ENDPOINT . $api,
@@ -324,6 +341,7 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: GET {$api} returned a 401",
 				[
+					'stripe_api_key'    => $masked_secret_key,
 					'stripe_request_id' => self::get_stripe_request_id( $response ),
 					'response'          => json_decode( $response['body'] ),
 				]
@@ -336,8 +354,9 @@ class WC_Stripe_API {
 				WC_Stripe_Logger::error(
 					'Invalid API keys request rate limit exceeded',
 					[
-						'count'      => $invalid_api_key_error_count,
-						'next_retry' => date_i18n( 'Y-m-d H:i:sP', time() + self::INVALID_API_KEY_ERROR_COUNT_CACHE_TIMEOUT ),
+						'stripe_api_key' => $masked_secret_key,
+						'count'          => $invalid_api_key_error_count,
+						'next_retry'     => date_i18n( 'Y-m-d H:i:sP', time() + self::INVALID_API_KEY_ERROR_COUNT_CACHE_TIMEOUT ),
 					]
 				);
 
@@ -358,6 +377,7 @@ class WC_Stripe_API {
 			WC_Stripe_Logger::error(
 				"Stripe API error: GET {$api}",
 				[
+					'stripe_api_key'    => $masked_secret_key,
 					'stripe_request_id' => self::get_stripe_request_id( $response ),
 					'response'          => $response,
 				]
@@ -370,6 +390,7 @@ class WC_Stripe_API {
 		WC_Stripe_Logger::debug(
 			"Stripe API response: GET {$api}",
 			[
+				'stripe_api_key'    => $masked_secret_key,
 				'stripe_request_id' => self::get_stripe_request_id( $response ),
 				'response'          => $response_body,
 			]
@@ -631,5 +652,19 @@ class WC_Stripe_API {
 			return $headers->getAll()['request-id'] ?? '';
 		}
 		return '';
+	}
+
+	/**
+	 * Get the masked secret key.
+	 * It uses the same pattern as the Stripe dashboard: sk_live_...JLWaeq.
+	 *
+	 * @return string The masked secret key.
+	 */
+	private static function get_masked_secret_key(): string {
+		$key = self::get_secret_key();
+		if ( empty( $key ) ) {
+			return 'secret_key_not_configured';
+		}
+		return substr( $key, 0, 8 ) . '...' . substr( $key, -6 );
 	}
 }

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -660,7 +660,7 @@ class WC_Stripe_API {
 	 *
 	 * @return string The masked secret key.
 	 */
-	private static function get_masked_secret_key(): string {
+	public static function get_masked_secret_key(): string {
 		$key = self::get_secret_key();
 		if ( empty( $key ) ) {
 			return 'secret_key_not_configured';

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -2046,13 +2046,13 @@ class WC_Stripe_Helper {
 	}
 
 	/**
-	 * Checks if the enhanced debug mode is enabled.
+	 * Checks if the verbose debug mode is enabled.
 	 *
 	 * @return bool True if enabled, false otherwise.
 	 */
-	public static function is_enhanced_debug_mode_enabled(): bool {
+	public static function is_verbose_debug_mode_enabled(): bool {
 		/**
-		 * Filters the flag that decides if the enhanced debug mode is enabled.
+		 * Filters the flag that decides if the verbose debug mode is enabled.
 		 *
 		 * @since 10.1.0
 		 *
@@ -2060,6 +2060,6 @@ class WC_Stripe_Helper {
 		 *
 		 * @return bool True if enabled, false otherwise.
 		*/
-		return apply_filters( 'wc_stripe_enhanced_debug_mode_enabled', false );
+		return apply_filters( 'wc_stripe_is_verbose_debug_mode_enabled', false );
 	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -2045,7 +2045,21 @@ class WC_Stripe_Helper {
 		return WC_Stripe_UPE_Payment_Gateway::ID === substr( (string) $order->get_payment_method(), 0, 6 );
 	}
 
-	public static function is_enhanced_debug_mode_enabled() {
+	/**
+	 * Checks if the enhanced debug mode is enabled.
+	 *
+	 * @return bool True if enabled, false otherwise.
+	 */
+	public static function is_enhanced_debug_mode_enabled(): bool {
+		/**
+		 * Filters the flag that decides if the enhanced debug mode is enabled.
+		 *
+		 * @since 10.1.0
+		 *
+		 * @param bool $enabled True if enabled, false otherwise.
+		 *
+		 * @return bool True if enabled, false otherwise.
+		*/
 		return apply_filters( 'wc_stripe_enhanced_debug_mode_enabled', false );
 	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -2044,4 +2044,8 @@ class WC_Stripe_Helper {
 	public static function is_stripe_gateway_order( $order ) {
 		return WC_Stripe_UPE_Payment_Gateway::ID === substr( (string) $order->get_payment_method(), 0, 6 );
 	}
+
+	public static function is_enhanced_debug_mode_enabled() {
+		return apply_filters( 'wc_stripe_enhanced_debug_mode_enabled', false );
+	}
 }

--- a/includes/class-wc-stripe-logger.php
+++ b/includes/class-wc-stripe-logger.php
@@ -244,6 +244,10 @@ class WC_Stripe_Logger {
 	 * @return boolean
 	 */
 	public static function can_log(): bool {
+		if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+			return true;
+		}
+
 		$settings = WC_Stripe_Helper::get_stripe_settings();
 
 		if ( empty( $settings ) || ( isset( $settings['logging'] ) && 'yes' !== $settings['logging'] ) ) {

--- a/includes/class-wc-stripe-logger.php
+++ b/includes/class-wc-stripe-logger.php
@@ -244,7 +244,7 @@ class WC_Stripe_Logger {
 	 * @return boolean
 	 */
 	public static function can_log(): bool {
-		if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+		if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 			return true;
 		}
 

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -182,7 +182,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
 				// Log the request after the filters have been applied.
 				WC_Stripe_Logger::debug(
-					"WCC API request: {$method} {$path}",
+					"OAuth: WCC API request: {$method} {$path}",
 					[
 						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 						'url'                    => $url,
@@ -199,7 +199,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			if ( false === strpos( $content_type, 'application/json' ) ) {
 				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
-						"WCC API unexpected response: {$method} {$path}",
+						"OAuth: WCC API unexpected response: {$method} {$path}",
 						[
 							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 							'response_code'          => $response_code,
@@ -238,7 +238,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			if ( 200 !== $response_code ) {
 				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
-						"WCC API invalid response: {$method} {$path}",
+						"OAuth: WCC API invalid response: {$method} {$path}",
 						[
 							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 							'response_code'          => $response_code,
@@ -278,7 +278,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 
 			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
 				WC_Stripe_Logger::debug(
-					"WCC API response: {$method} {$path}",
+					"OAuth: WCC API response: {$method} {$path}",
 					[
 						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 						'response'               => WC_Stripe_Connect::redact_sensitive_data( $response_body ),

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -204,7 +204,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 							'response_code'          => $response_code,
 							'response_content_type'  => $content_type,
-							'response'               => $response,
+							'response'               => WC_Stripe_Connect::redact_sensitive_data( $response ),
 						]
 					);
 				}
@@ -243,7 +243,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 							'response_code'          => $response_code,
 							'response_content_type'  => $content_type,
-							'response_body'          => $response_body,
+							'response_body'          => WC_Stripe_Connect::redact_sensitive_data( $response_body ),
 						]
 					);
 				}

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -179,7 +179,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 				'The wc_connect_request_args filter is deprecated since WooCommerce Stripe Gateway 9.6.0, and will be removed in a future version.'
 			);
 
-			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 				// Log the request after the filters have been applied.
 				WC_Stripe_Logger::debug(
 					"OAuth: WCC API request: {$method} {$path}",
@@ -198,7 +198,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			$content_type  = wp_remote_retrieve_header( $response, 'content-type' );
 
 			if ( false === strpos( $content_type, 'application/json' ) ) {
-				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
 						"OAuth: WCC API unexpected response: {$method} {$path}",
 						[
@@ -237,7 +237,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			}
 
 			if ( 200 !== $response_code ) {
-				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
 						"OAuth: WCC API invalid response: {$method} {$path}",
 						[
@@ -277,7 +277,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 				);
 			}
 
-			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 				WC_Stripe_Logger::debug(
 					"OAuth: WCC API response: {$method} {$path}",
 					[

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -171,13 +171,27 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 				'timeout'     => $http_timeout,
 			];
 
-			$args          = apply_filters_deprecated(
+			$args = apply_filters_deprecated(
 				'wc_connect_request_args',
 				[ $args ],
 				'9.6.0',
 				'',
 				'The wc_connect_request_args filter is deprecated since WooCommerce Stripe Gateway 9.6.0, and will be removed in a future version.'
 			);
+
+			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				// Log the request after the filters have been applied.
+				WC_Stripe_Logger::info(
+					"WCC API request: {$method} {$path}",
+					[
+						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+						'url'                    => $url,
+						'headers'                => $headers,
+						'body'                   => json_decode( $body ),
+					]
+				);
+			}
+
 			$response      = wp_remote_request( $url, $args );
 			$response_code = wp_remote_retrieve_response_code( $response );
 			$content_type  = wp_remote_retrieve_header( $response, 'content-type' );
@@ -235,6 +249,16 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 						$response_code
 					),
 					$data
+				);
+			}
+
+			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				WC_Stripe_Logger::info(
+					"WCC API response: {$method} {$path}",
+					[
+						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+						'response'               => $response_body,
+					]
 				);
 			}
 

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -181,13 +181,13 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 
 			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
 				// Log the request after the filters have been applied.
-				WC_Stripe_Logger::info(
+				WC_Stripe_Logger::debug(
 					"WCC API request: {$method} {$path}",
 					[
 						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 						'url'                    => $url,
 						'headers'                => $headers,
-						'body'                   => json_decode( $body ),
+						'body'                   => WC_Stripe_Connect::redact_sensitive_data( json_decode( $body ) ),
 					]
 				);
 			}
@@ -197,6 +197,18 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			$content_type  = wp_remote_retrieve_header( $response, 'content-type' );
 
 			if ( false === strpos( $content_type, 'application/json' ) ) {
+				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+					WC_Stripe_Logger::error(
+						"WCC API unexpected response: {$method} {$path}",
+						[
+							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+							'response_code'          => $response_code,
+							'response_content_type'  => $content_type,
+							'response'               => $response,
+						]
+					);
+				}
+
 				if ( 200 !== $response_code ) {
 					return new WP_Error(
 						'wcc_server_error',
@@ -224,6 +236,18 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			}
 
 			if ( 200 !== $response_code ) {
+				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+					WC_Stripe_Logger::error(
+						"WCC API invalid response: {$method} {$path}",
+						[
+							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+							'response_code'          => $response_code,
+							'response_content_type'  => $content_type,
+							'response_body'          => $response_body,
+						]
+					);
+				}
+
 				if ( empty( $response_body ) ) {
 					return new WP_Error(
 						'wcc_server_empty_response',
@@ -253,11 +277,11 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 			}
 
 			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
-				WC_Stripe_Logger::info(
+				WC_Stripe_Logger::debug(
 					"WCC API response: {$method} {$path}",
 					[
 						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
-						'response'               => $response_body,
+						'response'               => WC_Stripe_Connect::redact_sensitive_data( $response_body ),
 					]
 				);
 			}

--- a/includes/connect/class-wc-stripe-connect-api.php
+++ b/includes/connect/class-wc-stripe-connect-api.php
@@ -188,6 +188,7 @@ if ( ! class_exists( 'WC_Stripe_Connect_API' ) ) {
 						'url'                    => $url,
 						'headers'                => $headers,
 						'body'                   => WC_Stripe_Connect::redact_sensitive_data( json_decode( $body ) ),
+						'is_args_filtered'       => has_filter( 'wc_connect_request_args' ),
 					]
 				);
 			}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -199,7 +199,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 						'OAuth: Account connected successfully, reloading the page to clear URL parameters',
 						[
 							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
-							'redirect_url'           => $redirect_url,
+							'redirect_url'           => self::redact_sensitive_data( $redirect_url ),
 						]
 					);
 				}
@@ -269,6 +269,18 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( 'wc_stripe_' . $prefix . 'oauth_updated_at', time() );
 			update_option( 'wc_stripe_' . $prefix . 'oauth_failed_attempts', 0 );
 			update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', '' );
+
+			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug(
+					'OAuth: Plugin settings udpated',
+					[
+						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+						'connect_mode'           => $mode,
+						'connect_type'           => $type,
+						'options'                => self::redact_sensitive_data( $options ),
+					]
+				);
+			}
 
 			if ( 'app' === $type ) {
 				// Stripe App OAuth access_tokens expire after 1 hour:
@@ -493,6 +505,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				'_wpnonce',
 				'state',
 				'code',
+				'secretKey',
+				'refreshToken',
 			];
 
 			if ( is_object( $data ) ) {
@@ -540,11 +554,16 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		 */
 		public static function redact_string( $string ) {
 			$len = strlen( $string );
-			if ( $len > 4 ) {
-				return '[...' . substr( $string, -4 ) . ']';
-			} else {
-				return '[...]';
+			if ( $len > 15 ) {
+				return substr( $string, 0, 8 ) . '...' . substr( $string, -6 );
 			}
+			if ( $len > 9 ) {
+				// This applies only to wponces.
+				return substr( $string, 0, 3 ) . '...' . substr( $string, -3 );
+			}
+
+			// This should never be the case, as the shortest strings are 10 chars long (wponces).
+			return '[REDACTED]';
 		}
 	}
 }

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -566,11 +566,11 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return substr( $string, 0, 8 ) . '...' . substr( $string, -6 );
 			}
 			if ( $len > 9 ) {
-				// This applies only to wponces.
+				// This applies only to wp nonces.
 				return substr( $string, 0, 3 ) . '...' . substr( $string, -3 );
 			}
 
-			// This should never be the case, as the shortest strings are 10 chars long (wponces).
+			// This should never be the case, as the shortest strings are 10 chars long (wp nonces).
 			return '[REDACTED]';
 		}
 	}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -510,6 +510,10 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				'code',
 				'secretKey',
 				'refreshToken',
+				'secret_key',
+				'test_secret_key',
+				'webhook_secret',
+				'test_webhook_secret',
 			];
 
 			if ( is_object( $data ) ) {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 						'connect_mode'           => $mode,
 						'connect_type'           => $result->type,
-						'connect_url'            => self::redact_sensitive_data( $result->oauthUrl ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						'wcc_response'           => self::redact_sensitive_data( $result ),
 					]
 				);
 			}
@@ -150,9 +150,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			// redirect from oauth-init
 			if ( isset( $_GET['wcs_stripe_code'], $_GET['wcs_stripe_state'] ) ) {
+				$nonce = isset( $_GET['_wpnonce'] ) ? wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) : '';
 				$state = wc_clean( wp_unslash( $_GET['wcs_stripe_state'] ) );
 				$code  = wc_clean( wp_unslash( $_GET['wcs_stripe_code'] ) );
-				$nonce = isset( $_GET['_wpnonce'] ) ? wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) : '';
 				$type  = isset( $_GET['wcs_stripe_type'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_type'] ) ) : 'connect';
 				$mode  = isset( $_GET['wcs_stripe_mode'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_mode'] ) ) : 'live';
 
@@ -199,6 +199,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 						'OAuth: Account connected successfully, reloading the page to clear URL parameters',
 						[
 							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+							'connect_mode'           => $mode,
+							'connect_type'           => $type,
+							'connect_response'       => self::redact_sensitive_data( $response ),
 							'redirect_url'           => self::redact_sensitive_data( $redirect_url ),
 						]
 					);
@@ -528,6 +531,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			}
 
 			if ( is_string( $data ) ) {
+				// Handle a form-urlencoded string (like an URI or form payload).
 				foreach ( $sensitive_keys as $key ) {
 					$data = preg_replace_callback(
 						'/([?&]' . preg_quote( $key, '/' ) . '=)([^&#]*)/i',

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			set_transient( 'wcs_stripe_connect_state_' . $mode, $result->state, 6 * HOUR_IN_SECONDS );
 
-			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 				WC_Stripe_Logger::debug(
 					"OAuth: Generated {$mode} connect URL",
 					[
@@ -96,7 +96,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// It's a unique, randomly generated, opaque, and non-guessable string that is sent when starting the
 			// authentication request and validated when processing the response.
 			if ( get_transient( 'wcs_stripe_connect_state_' . $mode ) !== $state ) {
-				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
 						'OAuth: Invalid state received from the WCC server',
 						[
@@ -114,7 +114,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$response = $this->api->get_stripe_oauth_keys( $code, $type, $mode );
 
 			if ( is_wp_error( $response ) ) {
-				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
 						'OAuth: Unable to exchange OAuth code for account keys',
 						[
@@ -156,7 +156,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				$type  = isset( $_GET['wcs_stripe_type'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_type'] ) ) : 'connect';
 				$mode  = isset( $_GET['wcs_stripe_mode'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_mode'] ) ) : 'live';
 
-				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::debug(
 						'OAuth: Processing redirect back from Stripe/WCC',
 						[
@@ -171,7 +171,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				}
 
 				if ( ! wp_verify_nonce( $nonce, 'wcs_stripe_connected' ) ) {
-					if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+					if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 						WC_Stripe_Logger::error(
 							'OAuth: Invalid nonce received from the WCC server',
 							[
@@ -194,7 +194,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 					$redirect_url = add_query_arg( [ 'wc_stripe_connected' => 'true' ], $redirect_url );
 				}
 
-				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::debug(
 						'OAuth: Account connected successfully, reloading the page to clear URL parameters',
 						[
@@ -222,7 +222,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		 * @return stdObject|WP_Error OAuth's response result or WP_Error.
 		 */
 		private function save_stripe_keys( $result, $type = 'connect', $mode = 'live' ) {
-			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 				WC_Stripe_Logger::debug(
 					'OAuth: Saving account keys',
 					[
@@ -273,9 +273,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( 'wc_stripe_' . $prefix . 'oauth_failed_attempts', 0 );
 			update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', '' );
 
-			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 				WC_Stripe_Logger::debug(
-					'OAuth: Plugin settings udpated',
+					'OAuth: Plugin settings updated',
 					[
 						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
 						'connect_mode'           => $mode,

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -66,6 +66,18 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			set_transient( 'wcs_stripe_connect_state_' . $mode, $result->state, 6 * HOUR_IN_SECONDS );
 
+			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug(
+					"OAuth: Generated {$mode} connect URL",
+					[
+						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+						'connect_mode'           => $mode,
+						'connect_type'           => $result->type,
+						'connect_url'            => self::redact_sensitive_data( $result->oauthUrl ), // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					]
+				);
+			}
+
 			return $result->oauthUrl; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 
@@ -84,12 +96,38 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// It's a unique, randomly generated, opaque, and non-guessable string that is sent when starting the
 			// authentication request and validated when processing the response.
 			if ( get_transient( 'wcs_stripe_connect_state_' . $mode ) !== $state ) {
-				return new WP_Error( 'Invalid state received from Stripe server' );
+				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+					WC_Stripe_Logger::error(
+						'OAuth: Invalid state received from the WCC server',
+						[
+							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+							'connect_mode'           => $mode,
+							'connect_type'           => $type,
+							'state'                  => self::redact_string( $state ),
+							'code'                   => self::redact_string( $code ),
+						]
+					);
+				}
+				return new WP_Error( 'Invalid state received from the WCC server' );
 			}
 
 			$response = $this->api->get_stripe_oauth_keys( $code, $type, $mode );
 
 			if ( is_wp_error( $response ) ) {
+				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+					WC_Stripe_Logger::error(
+						'OAuth: Unable to exchange OAuth code for account keys',
+						[
+							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+							'connect_mode'           => $mode,
+							'connect_type'           => $type,
+							'state'                  => self::redact_string( $state ),
+							'code'                   => self::redact_string( $code ),
+							'response'               => self::redact_sensitive_data( $response ),
+						]
+					);
+				}
+
 				return $response;
 			}
 
@@ -112,16 +150,40 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			// redirect from oauth-init
 			if ( isset( $_GET['wcs_stripe_code'], $_GET['wcs_stripe_state'] ) ) {
-				$nonce = isset( $_GET['_wpnonce'] ) ? wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) : '';
-
-				if ( ! wp_verify_nonce( $nonce, 'wcs_stripe_connected' ) ) {
-					return new WP_Error( 'Invalid nonce received from Stripe server' );
-				}
-
 				$state = wc_clean( wp_unslash( $_GET['wcs_stripe_state'] ) );
 				$code  = wc_clean( wp_unslash( $_GET['wcs_stripe_code'] ) );
+				$nonce = isset( $_GET['_wpnonce'] ) ? wc_clean( wp_unslash( $_GET['_wpnonce'] ) ) : '';
 				$type  = isset( $_GET['wcs_stripe_type'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_type'] ) ) : 'connect';
 				$mode  = isset( $_GET['wcs_stripe_mode'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_mode'] ) ) : 'live';
+
+				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+					WC_Stripe_Logger::debug(
+						'OAuth: Processing redirect back from Stripe/WCC',
+						[
+							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+							'connect_mode'           => $mode,
+							'connect_type'           => $type,
+							'state'                  => self::redact_string( $state ),
+							'code'                   => self::redact_string( $code ),
+							'nonce'                  => self::redact_string( $nonce ),
+						]
+					);
+				}
+
+				if ( ! wp_verify_nonce( $nonce, 'wcs_stripe_connected' ) ) {
+					if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+						WC_Stripe_Logger::error(
+							'OAuth: Invalid nonce received from the WCC server',
+							[
+								'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+								'connect_mode'           => $mode,
+								'connect_type'           => $type,
+								'nonce'                  => self::redact_string( $nonce ),
+							]
+						);
+					}
+					return new WP_Error( 'Invalid nonce received from the WCC server' );
+				}
 
 				$response = $this->connect_oauth( $state, $code, $type, $mode );
 
@@ -131,6 +193,17 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				if ( ! is_wp_error( $response ) ) {
 					$redirect_url = add_query_arg( [ 'wc_stripe_connected' => 'true' ], $redirect_url );
 				}
+
+				if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+					WC_Stripe_Logger::debug(
+						'OAuth: Account connected successfully, reloading the page to clear URL parameters',
+						[
+							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+							'redirect_url'           => $redirect_url,
+						]
+					);
+				}
+
 				wp_safe_redirect( esc_url_raw( $redirect_url ) );
 				exit;
 			}
@@ -146,6 +219,18 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		 * @return stdObject|WP_Error OAuth's response result or WP_Error.
 		 */
 		private function save_stripe_keys( $result, $type = 'connect', $mode = 'live' ) {
+			if ( WC_Stripe_Helper::is_enhanced_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug(
+					'OAuth: Saving account keys',
+					[
+						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+						'connect_mode'           => $mode,
+						'connect_type'           => $type,
+						'result'                 => self::redact_sensitive_data( $result ),
+					]
+				);
+			}
+
 			if ( ! isset( $result->publishableKey, $result->secretKey ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				return new WP_Error( 'Invalid credentials received from WooCommerce Connect server' );
 			}
@@ -395,6 +480,71 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 			// save_stripe_keys() schedules a connection_refresh after saving the keys,
 			// we don't need to do it explicitly here.
+		}
+
+		/**
+		 * Redacts sensitive information from strings, arrays, or objects.
+		 *
+		 * @param string|array|object $data The string, array, or object to redact sensitive information from.
+		 * @return string|array
+		 */
+		public static function redact_sensitive_data( $data ) {
+			$sensitive_keys = [
+				'_wpnonce',
+				'state',
+				'code',
+			];
+
+			if ( is_object( $data ) ) {
+				// Handle objects (stdClass) by converting to array, processing, and returning as array
+				return self::redact_sensitive_data( (array) $data );
+			}
+
+			if ( is_array( $data ) ) {
+				// Handle arrays recursively
+				$redacted = [];
+				foreach ( $data as $key => $value ) {
+					if ( in_array( $key, $sensitive_keys, true ) && is_string( $value ) && ! empty( $value ) ) {
+						$redacted[ $key ] = self::redact_string( $value );
+					} else {
+						$redacted[ $key ] = self::redact_sensitive_data( $value );
+					}
+				}
+				return $redacted;
+			}
+
+			if ( is_string( $data ) ) {
+				foreach ( $sensitive_keys as $key ) {
+					$data = preg_replace_callback(
+						'/([?&]' . preg_quote( $key, '/' ) . '=)([^&#]*)/i',
+						function ( $matches ) {
+							$value = $matches[2];
+							if ( strlen( $value ) > 0 ) {
+								return $matches[1] . self::redact_string( $value );
+							}
+							return $matches[0];
+						},
+						$data
+					);
+				}
+			}
+
+			return $data;
+		}
+
+		/**
+		 * Redacts a string to: 3 periods and the last 4 characters in square brackets.
+		 *
+		 * @param string $string The string to redact.
+		 * @return string
+		 */
+		public static function redact_string( $string ) {
+			$len = strlen( $string );
+			if ( $len > 4 ) {
+				return '[...' . substr( $string, -4 ) . ']';
+			} else {
+				return '[...]';
+			}
 		}
 	}
 }

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -517,8 +517,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			];
 
 			if ( is_object( $data ) ) {
-				// Handle objects (stdClass) by converting to array, processing, and returning as array
-				return self::redact_sensitive_data( (array) $data );
+				// Handle objects (stdClass) by converting to array, processing, and returning as array.
+				$data = (array) $data;
 			}
 
 			if ( is_array( $data ) ) {

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -156,7 +156,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				$type  = isset( $_GET['wcs_stripe_type'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_type'] ) ) : 'connect';
 				$mode  = isset( $_GET['wcs_stripe_mode'] ) ? wc_clean( wp_unslash( $_GET['wcs_stripe_mode'] ) ) : 'live';
 
-				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				$is_verbose_debug_mode_enabled = WC_Stripe_Helper::is_verbose_debug_mode_enabled();
+				if ( $is_verbose_debug_mode_enabled ) {
 					WC_Stripe_Logger::debug(
 						'OAuth: Processing redirect back from Stripe/WCC',
 						[
@@ -171,7 +172,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				}
 
 				if ( ! wp_verify_nonce( $nonce, 'wcs_stripe_connected' ) ) {
-					if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+					if ( $is_verbose_debug_mode_enabled ) {
 						WC_Stripe_Logger::error(
 							'OAuth: Invalid nonce received from the WCC server',
 							[
@@ -194,7 +195,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 					$redirect_url = add_query_arg( [ 'wc_stripe_connected' => 'true' ], $redirect_url );
 				}
 
-				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				if ( $is_verbose_debug_mode_enabled ) {
 					WC_Stripe_Logger::debug(
 						'OAuth: Account connected successfully, reloading the page to clear URL parameters',
 						[
@@ -222,7 +223,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 		 * @return stdObject|WP_Error OAuth's response result or WP_Error.
 		 */
 		private function save_stripe_keys( $result, $type = 'connect', $mode = 'live' ) {
-			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+			$is_verbose_debug_mode_enabled = WC_Stripe_Helper::is_verbose_debug_mode_enabled();
+
+			if ( $is_verbose_debug_mode_enabled ) {
 				WC_Stripe_Logger::debug(
 					'OAuth: Saving account keys',
 					[
@@ -273,7 +276,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			update_option( 'wc_stripe_' . $prefix . 'oauth_failed_attempts', 0 );
 			update_option( 'wc_stripe_' . $prefix . 'oauth_last_failed_at', '' );
 
-			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+			if ( $is_verbose_debug_mode_enabled ) {
 				WC_Stripe_Logger::debug(
 					'OAuth: Plugin settings updated',
 					[

--- a/readme.txt
+++ b/readme.txt
@@ -126,5 +126,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Increase limit when listing available payment method configurations from the Stripe API
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
+* Dev - Add Stripe's masked API key to API request/response logs
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -137,5 +137,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
+* Dev - Add verbose debug logging mode to the OAuth connect flow
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

This PR adds detailed logging to the OAuth connection flow, especially to the save/update keys related functions.

All the new logging calls are wrapped in `if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {...}` checks, so it won't have any impact on the plugin's normal usage unless the filter `wc_stripe_is_verbose_debug_mode_enabled` is set.

## Testing instructions

1. Add the following snippet to your store:
    `add_filter( 'wc_stripe_is_verbose_debug_mode_enabled', '__return_true' );`
2. Disconnect the Stripe account (if connected)
3. Navigate to the plugin settings
4. Connect a Stripe account (any mode)
5. Open the plugin logs (`WooCommerce > Status > Logs` and then `woocommerce-gateway-stripe`)
6. Check that the new log entries (`OAuth: *`) are being logged:
    <img width="970" height="845" alt="Screenshot 2025-11-06 at 17 16 37" src="https://github.com/user-attachments/assets/d75ffcc0-a01c-4057-bd3e-87c42f643a6b" />
7. Check that no sensitive information is being logged:
    <img width="1161" height="361" alt="Screenshot 2025-11-06 at 17 18 26" src="https://github.com/user-attachments/assets/9009074e-ac71-4f08-95d6-df82e6d18f31" />

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
