### PR TITLE
Fix shipping method integration error when there are more than 9 shipping options

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 * Fix - Prevent retrying requests that errored out due to declined payment methods
+* Fix - GooglePay/ApplePay fail when there are more than 9 shipping options
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/client/express-checkout/__tests__/event-handler.test.js
+++ b/client/express-checkout/__tests__/event-handler.test.js
@@ -124,6 +124,37 @@ describe( 'Express checkout event handlers', () => {
 			expect( event.resolve ).not.toHaveBeenCalled();
 			expect( event.reject ).toHaveBeenCalled();
 		} );
+
+		test( 'should truncate shipping options to 9 items when more than 9 are returned', async () => {
+			const shippingOptions = Array.from( { length: 15 }, ( _, i ) => ( {
+				id: `option_${ i + 1 }`,
+				label: `Shipping Option ${ i + 1 }`,
+			} ) );
+
+			const response = {
+				result: 'success',
+				total: { amount: 1000 },
+				shipping_options: shippingOptions,
+				displayItems: [ { label: 'Sample Item', amount: 500 } ],
+			};
+
+			api.expressCheckoutECECalculateShippingOptions.mockResolvedValue(
+				response
+			);
+
+			await shippingAddressChangeHandler( api, event, elements );
+
+			expect( event.resolve ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					shippingRates: expect.arrayContaining( [
+						expect.objectContaining( { id: 'option_1' } ),
+					] ),
+				} )
+			);
+
+			const resolveCall = event.resolve.mock.calls[ 0 ][ 0 ];
+			expect( resolveCall.shippingRates ).toHaveLength( 9 );
+		} );
 	} );
 
 	describe( 'shippingRateChangeHandler', () => {

--- a/client/express-checkout/event-handler.js
+++ b/client/express-checkout/event-handler.js
@@ -1,3 +1,4 @@
+import { SHIPPING_RATES_UPPER_LIMIT_COUNT } from '../stripe-utils/constants';
 import {
 	normalizeShippingAddress,
 	normalizeLineItems,
@@ -19,7 +20,10 @@ export const shippingAddressChangeHandler = async ( api, event, elements ) => {
 				amount: response.total.amount,
 			} );
 			event.resolve( {
-				shippingRates: response.shipping_options,
+				shippingRates: response.shipping_options?.slice(
+					0,
+					SHIPPING_RATES_UPPER_LIMIT_COUNT
+				),
 				lineItems: normalizeLineItems( response.displayItems ),
 			} );
 		} else {

--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -143,6 +143,12 @@ export const EXPRESS_PAYMENT_METHODS = [
 ];
 
 /**
+ * This constant defines the max number of shipping options that can be handled by the Express Checkout Element (ECE).
+ * More than 9 options will prevent the UI from behaving correctly and cause an IntegrationError.
+ */
+export const SHIPPING_RATES_UPPER_LIMIT_COUNT = 9;
+
+/**
  * List of payment methods that are not recurring
  */
 export const NON_REUSABLE_METHODS = [

--- a/readme.txt
+++ b/readme.txt
@@ -127,5 +127,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Klarna not processing recurring payments
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 * Fix - Prevent retrying requests that errored out due to declined payment methods
+* Fix - GooglePay/ApplePay fail when there are more than 9 shipping options
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-749

## Changes proposed in this Pull Request:

When there are 10 or more shipping options in the shipping options array, Stripe SDK throws the following error and the express checkout element never opens

```
Uncaught (in promise) IntegrationError: Invalid value for shippingaddresschange event resolve callback: shippingRates should be an array of size less than 10. 
```

WooPayments gets around this by truncating the shipping options array (https://github.com/Automattic/woocommerce-payments/pull/10491). This PR proposes the same solution to Stripe. While this fix is not ideal, as merchants don't have control over which options are cut off, it prevents ECE from breaking completely.


<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
1. Add more than 10 shipping options. You can do this by installing USPS and UPS extensions or simply creating 10 or more local pickup options.
2. Go to a page where Google Pay / Apple Pay is rendered.
3. Click the Google Pay/ Apple Pay button.
4. In `develop`, the payment modal will not open. On this branch, the payment modal should open, and the shipping options list should have 9 options.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
