### PR TITLE
Explore post-confirm price recalculation for Amazon Pay

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -537,6 +537,19 @@ export default class WCStripeAPI {
 	}
 
 	/**
+	 * Update cart customer data.
+	 *
+	 * @param {Object} customerData Customer data.
+	 * @return {Promise} Promise for the request to the server.
+	 */
+	expressCheckoutUpdateCartCustomer( customerData ) {
+		return this.postToBlocksAPI(
+			'/wc/store/v1/cart/update-customer',
+			customerData
+		);
+	}
+
+	/**
 	 * Add product to cart from product page.
 	 *
 	 * @param {Object} productData Product data.

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -8,10 +8,12 @@ import { __ } from '@wordpress/i18n';
 import {
 	displayExpressCheckoutNotice,
 	displayLoginConfirmation,
+	getBillingAddressData,
 	getExpressCheckoutButtonAppearance,
 	getExpressCheckoutButtonStyleSettings,
 	getExpressCheckoutData,
 	getPaymentMethodTypesForExpressMethod,
+	getTotalPriceFromCart,
 	isManualPaymentMethodCreation,
 	normalizeLineItems,
 } from 'wcstripe/express-checkout/utils';
@@ -35,11 +37,11 @@ import {
 	EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_LINK,
+	PAYMENT_METHOD_AMAZON_PAY,
 } from 'wcstripe/stripe-utils/constants';
 import {
 	transformCartDataForDisplayItems,
 	transformLabeledDisplayItems,
-	transformPrice,
 } from 'wcstripe/express-checkout/transformers/wc-to-stripe';
 
 jQuery( function ( $ ) {
@@ -456,6 +458,43 @@ jQuery( function ( $ ) {
 					}
 				}
 
+				// When taxes are based on the billing address and Amazon Pay is used, we need to update the cart customer data and recompute taxes
+				// before we can finalise the payment.
+				if (
+					getExpressCheckoutData( 'taxes_based_on_billing' ) &&
+					event?.expressPaymentType === PAYMENT_METHOD_AMAZON_PAY
+				) {
+					const initialBillingAddress =
+						getBillingAddressData( event );
+
+					// Pass the billing address through our standard express checkout address normalization process.
+					const normalizedBillingData =
+						await api.expressCheckoutNormalizeAddress(
+							initialBillingAddress,
+							{}
+						);
+
+					// Update the cart customer data with the normalized billing address, with the initial address as a fallback.
+					const customerData = {
+						billing_address:
+							normalizedBillingData.billing_address ||
+							initialBillingAddress,
+					};
+					const customerUpdateResult =
+						await api.expressCheckoutUpdateCartCustomer(
+							customerData
+						);
+
+					if ( customerUpdateResult?.totals ) {
+						const updatedPrice =
+							getTotalPriceFromCart( customerUpdateResult );
+
+						await elements.update( {
+							amount: updatedPrice,
+						} );
+					}
+				}
+
 				const order = options.order ? options.order : 0;
 				const orderDetails = options.orderDetails ?? {};
 				return await onConfirmHandler( {
@@ -560,11 +599,7 @@ jQuery( function ( $ ) {
 			} else {
 				// Cart and Checkout page specific initialization.
 				api.expressCheckoutGetCartDetails().then( ( cart ) => {
-					const total = transformPrice(
-						parseInt( cart.totals.total_price, 10 ) -
-							parseInt( cart.totals.total_refund || 0, 10 ),
-						cart.totals
-					);
+					const total = getTotalPriceFromCart( cart );
 
 					if (
 						total === 0 &&

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -2,6 +2,7 @@
 import jQuery from 'jquery';
 import { isAmazonPayEnabled, isLinkEnabled } from 'wcstripe/stripe-utils';
 import { EXPRESS_CHECKOUT_NOTICE_DELAY } from 'wcstripe/data/constants';
+import { transformPrice } from 'wcstripe/express-checkout/transformers/wc-to-stripe';
 import {
 	EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 	EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
@@ -402,5 +403,19 @@ export const isManualPaymentMethodCreation = (
 			EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 			PAYMENT_METHOD_AMAZON_PAY,
 		].includes( expressPaymentType ) || hasFreeTrial
+	);
+};
+
+/**
+ * Get the total price from a cart response.
+ *
+ * @param {Object} cart The cart response from the server.
+ * @return {number} The total price.
+ */
+export const getTotalPriceFromCart = ( cart ) => {
+	return transformPrice(
+		parseInt( cart.totals.total_price, 10 ) -
+			parseInt( cart.totals.total_refund || 0, 10 ),
+		cart.totals
 	);
 };

--- a/client/express-checkout/utils/normalize.js
+++ b/client/express-checkout/utils/normalize.js
@@ -346,7 +346,7 @@ export const normalizeShippingAddress = ( shippingAddress ) => {
  *
  * @return {Object} The billing address data.
  */
-const getBillingAddressData = ( event ) => {
+export const getBillingAddressData = ( event ) => {
 	const name = event?.billingDetails?.name;
 	const email = event?.billingDetails?.email ?? '';
 	const billing = event?.billingDetails?.address ?? {};


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-757
Towards https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4750

## Changes proposed in this Pull Request:

This PR explores adding some special logic for Amazon Pay when the store is configured to calculate taxes based on billing address. The core issue is that we are getting the shopper's address in the `confirm` event, and are then initiating checkout immediately. However, depending on the store's tax setup, this may cause the taxes in checkout to be different from the taxes we sent to Amazon which the user agreed to, as the user's tax rates may change. This results in the payment being declined.

To try and address that problem, this PR does the following:
 * When we receive the `confirm` event for an express checkout method, we check if taxes are based on billing address and we have an Amazon Pay payment.
    - If we are in that situation, we then extract the billing address from the event payload, pass that address through our standard express checkout address normalisation API, and then update the customer's billing address (which may write to the current session or the persistent customer data), the server returns an update cart, and we use the total amount from the returned cart to update the express checkout element.

This is not working at present, though it is updating the amount of the intent when we update the amount.
 
<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
