### PR TITLE
fix: spacing of help text on ECE settings

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
+* Fix - Adjust UI spacing of help text on express checkout theme settings page
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection

--- a/client/entrypoints/express-checkout-settings/express-checkout-settings-section.js
+++ b/client/entrypoints/express-checkout-settings/express-checkout-settings-section.js
@@ -87,41 +87,28 @@ const buttonActionOptions = [
 	},
 ];
 
-const makeButtonThemeText = ( string ) =>
-	interpolateComponents( {
-		mixedString: string,
-		components: {
-			br: <br />,
-			helpText: (
-				<span className="payment-method-settings__option-help-text" />
-			),
-		},
-	} );
 const buttonThemeOptions = [
 	{
-		label: makeButtonThemeText(
-			__(
-				'Dark {{br/}}{{helpText}}Recommended for white or light-colored backgrounds with high contrast.{{/helpText}}',
-				'woocommerce-gateway-stripe'
-			)
+		label: __( 'Dark', 'woocommerce-gateway-stripe' ),
+		description: __(
+			'Recommended for white or light-colored backgrounds with high contrast.',
+			'woocommerce-gateway-stripe'
 		),
 		value: 'dark',
 	},
 	{
-		label: makeButtonThemeText(
-			__(
-				'Light {{br/}}{{helpText}}Recommended for dark or colored backgrounds with high contrast.{{/helpText}}',
-				'woocommerce-gateway-stripe'
-			)
+		label: __( 'Light', 'woocommerce-gateway-stripe' ),
+		description: __(
+			'Recommended for dark or colored backgrounds with high contrast.',
+			'woocommerce-gateway-stripe'
 		),
 		value: 'light',
 	},
 	{
-		label: makeButtonThemeText(
-			__(
-				'Outline {{br/}}{{helpText}}Recommended for white or light-colored backgrounds with insufficient contrast.{{/helpText}}',
-				'woocommerce-gateway-stripe'
-			)
+		label: __( 'Outline', 'woocommerce-gateway-stripe' ),
+		description: __(
+			'Recommended for white or light-colored backgrounds with insufficient contrast.',
+			'woocommerce-gateway-stripe'
 		),
 		value: 'light-outline',
 	},

--- a/client/entrypoints/express-checkout-settings/style.scss
+++ b/client/entrypoints/express-checkout-settings/style.scss
@@ -9,15 +9,6 @@
 		color: styles.$gray-700;
 	}
 
-	&__option-help-text {
-		color: styles.$gray-700;
-		padding-left: 30px;
-
-		@media ( min-width: 600px ) {
-			padding-left: 26px;
-		}
-	}
-
 	&__cta-selection {
 		.components-base-control__label {
 			// hack until the `hideLabelFromVision` is fixed for radio controls in Gutenberg

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.1.0 - xxxx-xx-xx =
+* Fix - Adjust UI spacing of help text on express checkout theme settings page
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection


### PR DESCRIPTION
Fixes STRIPE-798

<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the help text on the express checkout buttons settings page has some weird spacing.
Fixing to use the `description` attribute on the option itself, instead, which achieves the same result.

Before:
<img width="651" height="208" alt="Screenshot 2025-11-07 at 3 33 52 PM" src="https://github.com/user-attachments/assets/61a83819-b15c-4ec7-8de2-daf9572f5e58" />

After:
<img width="761" height="314" alt="Screenshot 2025-11-07 at 3 34 11 PM" src="https://github.com/user-attachments/assets/1b8ce296-08a1-4be2-9e56-f2d01104555b" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- In `wp-admin`, navigate to WooCommerce > Settings > Payments > Stripe
- Scroll down the page, click "Customize" next to "Google Pay / Apple Pay"
- In the "Settings" section, notice how the help text of the "Theme" options is now better aligned

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
