### PR TITLE
update: remove redirect_url from ECE payment

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
-* Fix - Remove `redirect_url` parameter from Express Checkout payment flow
+* Update - Remove `redirect_url` parameter from ECE payment flow
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
-* Update - Remove `redirect_url` parameter from ECE payment flow
+* Fix - Remove `redirect_url` parameter from Express Checkout payment flow
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
+* Update - Remove `redirect_url` parameter from ECE payment flow
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection

--- a/client/express-checkout/payment-flow.js
+++ b/client/express-checkout/payment-flow.js
@@ -155,11 +155,6 @@ export const handleConfirmationTokenFlow = async ( {
 	// Create a ConfirmationToken that we can use later to create and confirm the payment intent.
 	const { error, confirmationToken } = await stripe.createConfirmationToken( {
 		elements,
-		params: {
-			// Required by Amazon Pay, but is not used by express checkout
-			// as it uses a payment modal instead of redirection.
-			return_url: window.location.href,
-		},
 	} );
 
 	if ( error ) {

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.1.0 - xxxx-xx-xx =
+* Update - Remove `redirect_url` parameter from ECE payment flow
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout
 * Dev - Upgrades `@automattic/interpolate-components` to 1.2.1 to remove the `node-fetch` dependency
 * Add - Includes a notice to inform merchants about methods that are automatically enabled upon account connection


### PR DESCRIPTION
Fixes STRIPE-799

<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Discussed here: p1762519898532299-slack-C055WHLA98D
There are some concerns that the `redirect_url` parameter provided to the ECE payment flow might not be safely stripped.
After testing and consulting [the Stripe docs](https://docs.stripe.com/js/confirmation_tokens/create_confirmation_token#create_confirmation_token-options-params-return_url), it looks like it might not be needed.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Allow your site to use Amazon Pay with `wp option update _wcstripe_feature_amazon_pay yes`
- Navigate to WooCommerce > Settings > Payments > Stripe
- Scroll down to the "Express checkouts" section
- Enable Amazon Pay
- Save
- Click "Customize" on Amazon Pay
- Ensure it's enabled on Checkout, Cart, & Product Page locations
- As a customer, add a product to the cart (or attempt the checkout from the product page)
- Navigate to the Cart or Checkout pages
- Click on the Amazon Pay button
- If you don't have an account, create one (you can't login with your "real" Amazon account)
- Fill in the details, such as address & payment information
- Pay
- You should be redirected to the "Order received" page

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)