### PR TITLE
Don't show Amazon Pay when taxes are based on billing address

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 * Fix - Prevent retrying requests that errored out due to declined payment methods
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
+* Fix - Disable Amazon Pay when taxes are based on billing address and add notices with details
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
+++ b/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
@@ -49,9 +49,26 @@ describe( 'AmazonPayTaxesBillingAddressNotice', () => {
 			/>
 		);
 
+		// Check for the consolidated content for text to speech.
 		expect(
 			screen.getByText(
 				'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.',
+				{ exact: true }
+			)
+		).toBeInTheDocument();
+
+		// Check for the content within the <strong> element.
+		expect(
+			screen.getByText(
+				'Amazon Pay does not support taxes based on the billing address.',
+				{ exact: true }
+			)
+		).toBeInTheDocument();
+
+		// Check for the content from the trailing sentence.
+		expect(
+			screen.getByText(
+				'The checkout button will not be visible to shoppers with this setting in effect.',
 				{ exact: true }
 			)
 		).toBeInTheDocument();

--- a/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
+++ b/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
@@ -17,13 +17,7 @@ describe( 'AmazonPayTaxesBillingAddressNotice', () => {
 	} );
 
 	const verifyNoticeText = ( text ) => {
-		// Expect the notice text to appear twice:
-		//  - Once in the div for spoken content, and
-		//  - Once in the actual notice.
-		const noticeTextElements = screen.getAllByText( text, { exact: true } );
-		expect( noticeTextElements?.length ).toBe( 2 );
-		expect( noticeTextElements[ 0 ] ).toBeInTheDocument();
-		expect( noticeTextElements[ 1 ] ).toBeInTheDocument();
+		expect( screen.getByText( text, { exact: true } ) ).toBeInTheDocument();
 	};
 
 	it( 'should not render when Amazon Pay is disabled', () => {

--- a/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
+++ b/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
@@ -64,19 +64,10 @@ describe( 'AmazonPayTaxesBillingAddressNotice', () => {
 		);
 
 		expect(
-			container.querySelector( '.components-notice.is-error' )
+			container.querySelector(
+				'.wc-stripe-amazon-pay-taxes-billing-address-notice'
+			)
 		).toBeTruthy();
-	} );
-
-	it( 'should show the action link when showUpdateSettingsLink is true', () => {
-		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
-
-		render(
-			<AmazonPayTaxesBillingAddressNotice
-				areTaxesBasedOnBillingAddress={ true }
-				showUpdateSettingsLink={ true }
-			/>
-		);
 
 		const actionLink = screen.getByRole( 'link', {
 			name: 'Update tax settings',
@@ -86,60 +77,5 @@ describe( 'AmazonPayTaxesBillingAddressNotice', () => {
 			'href',
 			'/wp-admin/admin.php?page=wc-settings&tab=tax'
 		);
-	} );
-
-	it( 'should not show the action link when showUpdateSettingsLink is false', () => {
-		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
-
-		render(
-			<AmazonPayTaxesBillingAddressNotice
-				areTaxesBasedOnBillingAddress={ true }
-				showUpdateSettingsLink={ false }
-			/>
-		);
-
-		expect(
-			screen.queryByRole( 'link', {
-				name: 'Update tax settings',
-			} )
-		).not.toBeInTheDocument();
-	} );
-
-	it( 'should show the action link when showUpdateSettingsLink is not specified', () => {
-		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
-
-		render(
-			<AmazonPayTaxesBillingAddressNotice
-				areTaxesBasedOnBillingAddress={ true }
-			/>
-		);
-
-		const actionLink = screen.getByRole( 'link', {
-			name: 'Update tax settings',
-		} );
-		expect( actionLink ).toBeInTheDocument();
-		expect( actionLink ).toHaveAttribute(
-			'href',
-			'/wp-admin/admin.php?page=wc-settings&tab=tax'
-		);
-	} );
-
-	it( 'should respect the noticeStatus prop', () => {
-		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
-
-		const { container } = render(
-			<AmazonPayTaxesBillingAddressNotice
-				areTaxesBasedOnBillingAddress={ true }
-				noticeStatus="warning"
-			/>
-		);
-
-		verifyNoticeText(
-			'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.'
-		);
-
-		expect(
-			container.querySelector( '.components-notice.is-warning' )
-		).toBeTruthy();
 	} );
 } );

--- a/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
+++ b/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import AmazonPayTaxesBillingAddressNotice from '..';
+import { useAmazonPayEnabledSettings } from 'wcstripe/data';
+
+jest.mock( 'wcstripe/data', () => ( {
+	useAmazonPayEnabledSettings: jest.fn(),
+} ) );
+
+jest.mock( '@woocommerce/settings', () => ( {
+	getAdminLink: ( path ) => `/wp-admin/${ path }`,
+} ) );
+
+describe( 'AmazonPayTaxesBillingAddressNotice', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	const verifyNoticeText = ( text ) => {
+		// Expect the notice text to appear twice:
+		//  - Once in the div for spoken content, and
+		//  - Once in the actual notice.
+		const noticeTextElements = screen.getAllByText( text, { exact: true } );
+		expect( noticeTextElements?.length ).toBe( 2 );
+		expect( noticeTextElements[ 0 ] ).toBeInTheDocument();
+		expect( noticeTextElements[ 1 ] ).toBeInTheDocument();
+	};
+
+	it( 'should not render when Amazon Pay is disabled', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ false, jest.fn() ] );
+
+		const { container } = render(
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ true }
+			/>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should not render when taxes are not based on billing address', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
+
+		const { container } = render(
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ false }
+			/>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+
+	it( 'should render when Amazon Pay is enabled and taxes are based on billing address', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
+
+		const { container } = render(
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ true }
+			/>
+		);
+
+		verifyNoticeText(
+			'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.'
+		);
+
+		expect(
+			container.querySelector( '.components-notice.is-error' )
+		).toBeTruthy();
+	} );
+
+	it( 'should show the action link when showUpdateSettingsLink is true', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
+
+		render(
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ true }
+				showUpdateSettingsLink={ true }
+			/>
+		);
+
+		const actionLink = screen.getByRole( 'link', {
+			name: 'Update tax settings',
+		} );
+		expect( actionLink ).toBeInTheDocument();
+		expect( actionLink ).toHaveAttribute(
+			'href',
+			'/wp-admin/admin.php?page=wc-settings&tab=tax'
+		);
+	} );
+
+	it( 'should not show the action link when showUpdateSettingsLink is false', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
+
+		render(
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ true }
+				showUpdateSettingsLink={ false }
+			/>
+		);
+
+		expect(
+			screen.queryByRole( 'link', {
+				name: 'Update tax settings',
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should show the action link when showUpdateSettingsLink is not specified', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
+
+		render(
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ true }
+			/>
+		);
+
+		const actionLink = screen.getByRole( 'link', {
+			name: 'Update tax settings',
+		} );
+		expect( actionLink ).toBeInTheDocument();
+		expect( actionLink ).toHaveAttribute(
+			'href',
+			'/wp-admin/admin.php?page=wc-settings&tab=tax'
+		);
+	} );
+
+	it( 'should respect the noticeStatus prop', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [ true, jest.fn() ] );
+
+		const { container } = render(
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ true }
+				noticeStatus="warning"
+			/>
+		);
+
+		verifyNoticeText(
+			'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.'
+		);
+
+		expect(
+			container.querySelector( '.components-notice.is-warning' )
+		).toBeTruthy();
+	} );
+} );

--- a/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
+++ b/client/components/amazon-pay-taxes-billing-address-notice/__tests__/amazon-pay-taxes-billing-address-notice.test.js
@@ -16,10 +16,6 @@ describe( 'AmazonPayTaxesBillingAddressNotice', () => {
 		jest.clearAllMocks();
 	} );
 
-	const verifyNoticeText = ( text ) => {
-		expect( screen.getByText( text, { exact: true } ) ).toBeInTheDocument();
-	};
-
 	it( 'should not render when Amazon Pay is disabled', () => {
 		useAmazonPayEnabledSettings.mockReturnValue( [ false, jest.fn() ] );
 
@@ -53,9 +49,12 @@ describe( 'AmazonPayTaxesBillingAddressNotice', () => {
 			/>
 		);
 
-		verifyNoticeText(
-			'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.'
-		);
+		expect(
+			screen.getByText(
+				'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.',
+				{ exact: true }
+			)
+		).toBeInTheDocument();
 
 		expect(
 			container.querySelector(

--- a/client/components/amazon-pay-taxes-billing-address-notice/index.js
+++ b/client/components/amazon-pay-taxes-billing-address-notice/index.js
@@ -1,0 +1,52 @@
+import { getAdminLink } from '@woocommerce/settings';
+import React from 'react';
+import { Notice } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useAmazonPayEnabledSettings } from 'wcstripe/data';
+
+const AmazonPayTaxesBillingAddressNotice = ( {
+	areTaxesBasedOnBillingAddress = false,
+	noticeStatus = 'error',
+	showUpdateSettingsLink = true,
+} ) => {
+	const [ isAmazonPayEnabled ] = useAmazonPayEnabledSettings();
+
+	if ( ! isAmazonPayEnabled ) {
+		return null;
+	}
+	if ( ! areTaxesBasedOnBillingAddress ) {
+		return null;
+	}
+
+	const actions = showUpdateSettingsLink
+		? [
+				{
+					label: __(
+						'Update tax settings',
+						'woocommerce-gateway-stripe'
+					),
+					url: getAdminLink( 'admin.php?page=wc-settings&tab=tax' ),
+					variant: 'secondary',
+				},
+		  ]
+		: [];
+
+	return (
+		<Notice
+			status={ noticeStatus }
+			isDismissible={ false }
+			actions={ actions }
+		>
+			<p>
+				<strong>
+					{ __(
+						'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.',
+						'woocommerce-gateway-stripe'
+					) }
+				</strong>
+			</p>
+		</Notice>
+	);
+};
+
+export default AmazonPayTaxesBillingAddressNotice;

--- a/client/components/amazon-pay-taxes-billing-address-notice/index.js
+++ b/client/components/amazon-pay-taxes-billing-address-notice/index.js
@@ -1,13 +1,14 @@
 import { getAdminLink } from '@woocommerce/settings';
 import React from 'react';
+import interpolateComponents from '@automattic/interpolate-components';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useAmazonPayEnabledSettings } from 'wcstripe/data';
 
+import './style.scss';
+
 const AmazonPayTaxesBillingAddressNotice = ( {
 	areTaxesBasedOnBillingAddress = false,
-	noticeStatus = 'error',
-	showUpdateSettingsLink = true,
 } ) => {
 	const [ isAmazonPayEnabled ] = useAmazonPayEnabledSettings();
 
@@ -18,33 +19,30 @@ const AmazonPayTaxesBillingAddressNotice = ( {
 		return null;
 	}
 
-	const actions = showUpdateSettingsLink
-		? [
-				{
-					label: __(
-						'Update tax settings',
-						'woocommerce-gateway-stripe'
-					),
-					url: getAdminLink( 'admin.php?page=wc-settings&tab=tax' ),
-					variant: 'secondary',
-				},
-		  ]
-		: [];
+	const actions = [
+		{
+			label: __( 'Update tax settings', 'woocommerce-gateway-stripe' ),
+			url: getAdminLink( 'admin.php?page=wc-settings&tab=tax' ),
+			variant: 'secondary',
+		},
+	];
 
 	return (
 		<Notice
-			status={ noticeStatus }
+			className="wc-stripe-amazon-pay-taxes-billing-address-notice"
+			status="error"
 			isDismissible={ false }
 			actions={ actions }
 		>
-			<p>
-				<strong>
-					{ __(
-						'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.',
-						'woocommerce-gateway-stripe'
-					) }
-				</strong>
-			</p>
+			{ interpolateComponents( {
+				mixedString: __(
+					'{{strong}}Amazon Pay does not support taxes based on the billing address.{{/strong}} The checkout button will not be visible to shoppers with this setting in effect.',
+					'woocommerce-gateway-stripe'
+				),
+				components: {
+					strong: <strong />,
+				},
+			} ) }
 		</Notice>
 	);
 };

--- a/client/components/amazon-pay-taxes-billing-address-notice/style.scss
+++ b/client/components/amazon-pay-taxes-billing-address-notice/style.scss
@@ -1,0 +1,7 @@
+.wc-stripe-amazon-pay-taxes-billing-address-notice {
+	.components-notice__actions {
+		.components-notice__action {
+			margin-top: 0.5rem;
+		}
+	}
+}

--- a/client/entrypoints/amazon-pay-settings/__tests__/amazon-pay-enable-section.test.js
+++ b/client/entrypoints/amazon-pay-settings/__tests__/amazon-pay-enable-section.test.js
@@ -1,0 +1,179 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AmazonPayEnableSection from '../amazon-pay-enable-section';
+import { useAmazonPayEnabledSettings } from 'wcstripe/data';
+
+jest.mock( 'wcstripe/data', () => ( {
+	useAmazonPayEnabledSettings: jest.fn(),
+} ) );
+
+jest.mock(
+	'wcstripe/components/amazon-pay-taxes-billing-address-notice',
+	() => {
+		return jest.fn( ( { areTaxesBasedOnBillingAddress } ) => {
+			if ( ! areTaxesBasedOnBillingAddress ) {
+				return null;
+			}
+			return (
+				<div data-testid="amazon-pay-taxes-notice">
+					Taxes based on billing address notice
+				</div>
+			);
+		} );
+	}
+);
+
+describe( 'AmazonPayEnableSection', () => {
+	const globalValues = global.wc_stripe_amazon_pay_settings_params;
+	let updateIsAmazonPayEnabledMock;
+
+	beforeEach( () => {
+		updateIsAmazonPayEnabledMock = jest.fn();
+		useAmazonPayEnabledSettings.mockReturnValue( [
+			false,
+			updateIsAmazonPayEnabledMock,
+		] );
+
+		global.wc_stripe_amazon_pay_settings_params = {
+			...globalValues,
+			taxes_based_on_billing: false,
+		};
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+		global.wc_stripe_amazon_pay_settings_params = globalValues;
+	} );
+
+	it( 'renders the checkbox control with correct label and help text', () => {
+		render( <AmazonPayEnableSection /> );
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /Enable Amazon Pay/i,
+		} );
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).not.toBeChecked();
+
+		// Check help text is present
+		expect(
+			screen.getByText(
+				'When enabled, customers who have configured Amazon Pay enabled devices will be able to pay with their respective choice of Wallet.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'renders checkbox as checked when Amazon Pay is enabled', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [
+			true,
+			updateIsAmazonPayEnabledMock,
+		] );
+
+		render( <AmazonPayEnableSection /> );
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /Enable Amazon Pay/i,
+		} );
+		expect( checkbox ).toBeChecked();
+	} );
+
+	it( 'renders checkbox as unchecked when Amazon Pay is disabled', () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [
+			false,
+			updateIsAmazonPayEnabledMock,
+		] );
+
+		render( <AmazonPayEnableSection /> );
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /Enable Amazon Pay/i,
+		} );
+		expect( checkbox ).not.toBeChecked();
+	} );
+
+	it( 'calls updateIsAmazonPayEnabled when checkbox is clicked', async () => {
+		render( <AmazonPayEnableSection /> );
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /Enable Amazon Pay/i,
+		} );
+
+		expect( updateIsAmazonPayEnabledMock ).not.toHaveBeenCalled();
+
+		await userEvent.click( checkbox );
+
+		expect( updateIsAmazonPayEnabledMock ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'calls updateIsAmazonPayEnabled with false when unchecking enabled checkbox', async () => {
+		useAmazonPayEnabledSettings.mockReturnValue( [
+			true,
+			updateIsAmazonPayEnabledMock,
+		] );
+
+		render( <AmazonPayEnableSection /> );
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: /Enable Amazon Pay/i,
+		} );
+
+		await userEvent.click( checkbox );
+
+		expect( updateIsAmazonPayEnabledMock ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'renders AmazonPayTaxesBillingAddressNotice with areTaxesBasedOnBillingAddress=true when taxes are based on billing address', () => {
+		global.wc_stripe_amazon_pay_settings_params = {
+			...global.wc_stripe_amazon_pay_settings_params,
+			taxes_based_on_billing: true,
+		};
+
+		render( <AmazonPayEnableSection /> );
+
+		expect(
+			screen.getByTestId( 'amazon-pay-taxes-notice' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not render AmazonPayTaxesBillingAddressNotice when taxes are not based on billing address', () => {
+		global.wc_stripe_amazon_pay_settings_params = {
+			...global.wc_stripe_amazon_pay_settings_params,
+			taxes_based_on_billing: false,
+		};
+
+		render( <AmazonPayEnableSection /> );
+
+		expect(
+			screen.queryByTestId( 'amazon-pay-taxes-notice' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render AmazonPayTaxesBillingAddressNotice when taxes_based_on_billing is undefined', () => {
+		global.wc_stripe_amazon_pay_settings_params = {
+			...global.wc_stripe_amazon_pay_settings_params,
+			taxes_based_on_billing: undefined,
+		};
+
+		render( <AmazonPayEnableSection /> );
+
+		expect(
+			screen.queryByTestId( 'amazon-pay-taxes-notice' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'does not render AmazonPayTaxesBillingAddressNotice when wc_stripe_amazon_pay_settings_params is undefined', () => {
+		global.wc_stripe_amazon_pay_settings_params = undefined;
+
+		render( <AmazonPayEnableSection /> );
+
+		expect(
+			screen.queryByTestId( 'amazon-pay-taxes-notice' )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the component with express-checkout-settings class', () => {
+		const { container } = render( <AmazonPayEnableSection /> );
+
+		const card = container.querySelector( '.express-checkout-settings' );
+		expect( card ).toBeInTheDocument();
+	} );
+} );

--- a/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
+++ b/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
@@ -1,9 +1,9 @@
 /* global wc_stripe_amazon_pay_settings_params */
 
 import React from 'react';
+import AmazonPayTaxesBillingAddressNotice from '../../components/amazon-pay-taxes-billing-address-notice';
 import { __ } from '@wordpress/i18n';
 import { Card, CheckboxControl } from '@wordpress/components';
-import AmazonPayTaxesBillingAddressNotice from 'wcstripe/components/amazon-pay-taxes-billing-address-notice';
 import { useAmazonPayEnabledSettings } from 'wcstripe/data';
 import CardBody from 'wcstripe/settings/card-body';
 

--- a/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
+++ b/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
@@ -1,8 +1,40 @@
+/* global wc_stripe_amazon_pay_settings_params */
+
+import { getAdminLink } from '@woocommerce/settings';
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CheckboxControl } from '@wordpress/components';
+import { Card, CheckboxControl, Notice } from '@wordpress/components';
 import { useAmazonPayEnabledSettings } from 'wcstripe/data';
 import CardBody from 'wcstripe/settings/card-body';
+
+const AmazonPayTaxesBasedOnBillingAddressNotice = () => {
+	// eslint-disable-next-line camelcase
+	if ( ! wc_stripe_amazon_pay_settings_params?.taxes_based_on_billing ) {
+		return null;
+	}
+
+	const actions = [
+		{
+			label: __( 'Update tax settings', 'woocommerce-gateway-stripe' ),
+			url: getAdminLink( 'admin.php?page=wc-settings&tab=tax' ),
+			variant: 'secondary',
+		},
+	];
+
+	return (
+		<Notice status="error" isDismissible={ false } actions={ actions }>
+			<p>
+				<strong>
+					{ __(
+						'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.',
+						'woocommerce-gateway-stripe'
+					) }
+				</strong>
+			</p>
+		</Notice>
+	);
+};
+
 const AmazonPayEnableSection = () => {
 	const [ isAmazonPayEnabled, updateIsAmazonPayEnabled ] =
 		useAmazonPayEnabledSettings();
@@ -23,6 +55,8 @@ const AmazonPayEnableSection = () => {
 						'woocommerce-gateway-stripe'
 					) }
 				/>
+
+				<AmazonPayTaxesBasedOnBillingAddressNotice />
 			</CardBody>
 		</Card>
 	);

--- a/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
+++ b/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
@@ -7,7 +7,12 @@ import { Card, CheckboxControl, Notice } from '@wordpress/components';
 import { useAmazonPayEnabledSettings } from 'wcstripe/data';
 import CardBody from 'wcstripe/settings/card-body';
 
-const AmazonPayTaxesBasedOnBillingAddressNotice = () => {
+const AmazonPayTaxesBasedOnBillingAddressNotice = ( {
+	isAmazonPayEnabled,
+} ) => {
+	if ( ! isAmazonPayEnabled ) {
+		return null;
+	}
 	// eslint-disable-next-line camelcase
 	if ( ! wc_stripe_amazon_pay_settings_params?.taxes_based_on_billing ) {
 		return null;
@@ -56,7 +61,9 @@ const AmazonPayEnableSection = () => {
 					) }
 				/>
 
-				<AmazonPayTaxesBasedOnBillingAddressNotice />
+				<AmazonPayTaxesBasedOnBillingAddressNotice
+					isAmazonPayEnabled={ isAmazonPayEnabled }
+				/>
 			</CardBody>
 		</Card>
 	);

--- a/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
+++ b/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
@@ -1,48 +1,18 @@
 /* global wc_stripe_amazon_pay_settings_params */
 
-import { getAdminLink } from '@woocommerce/settings';
 import React from 'react';
 import { __ } from '@wordpress/i18n';
-import { Card, CheckboxControl, Notice } from '@wordpress/components';
+import { Card, CheckboxControl } from '@wordpress/components';
+import AmazonPayTaxesBillingAddressNotice from 'wcstripe/components/amazon-pay-taxes-billing-address-notice';
 import { useAmazonPayEnabledSettings } from 'wcstripe/data';
 import CardBody from 'wcstripe/settings/card-body';
-
-const AmazonPayTaxesBasedOnBillingAddressNotice = ( {
-	isAmazonPayEnabled,
-} ) => {
-	if ( ! isAmazonPayEnabled ) {
-		return null;
-	}
-	// eslint-disable-next-line camelcase
-	if ( ! wc_stripe_amazon_pay_settings_params?.taxes_based_on_billing ) {
-		return null;
-	}
-
-	const actions = [
-		{
-			label: __( 'Update tax settings', 'woocommerce-gateway-stripe' ),
-			url: getAdminLink( 'admin.php?page=wc-settings&tab=tax' ),
-			variant: 'secondary',
-		},
-	];
-
-	return (
-		<Notice status="error" isDismissible={ false } actions={ actions }>
-			<p>
-				<strong>
-					{ __(
-						'Amazon Pay does not support taxes based on the billing address. The checkout button will not be visible to shoppers with this setting in effect.',
-						'woocommerce-gateway-stripe'
-					) }
-				</strong>
-			</p>
-		</Notice>
-	);
-};
 
 const AmazonPayEnableSection = () => {
 	const [ isAmazonPayEnabled, updateIsAmazonPayEnabled ] =
 		useAmazonPayEnabledSettings();
+
+	const areTaxesBasedOnBillingAddress =
+		!! wc_stripe_amazon_pay_settings_params?.taxes_based_on_billing; // eslint-disable-line camelcase
 
 	return (
 		<Card className="express-checkout-settings">
@@ -61,8 +31,10 @@ const AmazonPayEnableSection = () => {
 					) }
 				/>
 
-				<AmazonPayTaxesBasedOnBillingAddressNotice
-					isAmazonPayEnabled={ isAmazonPayEnabled }
+				<AmazonPayTaxesBillingAddressNotice
+					areTaxesBasedOnBillingAddress={
+						areTaxesBasedOnBillingAddress
+					}
 				/>
 			</CardBody>
 		</Card>

--- a/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
+++ b/client/entrypoints/amazon-pay-settings/amazon-pay-enable-section.js
@@ -1,7 +1,7 @@
 /* global wc_stripe_amazon_pay_settings_params */
 
 import React from 'react';
-import AmazonPayTaxesBillingAddressNotice from '../../components/amazon-pay-taxes-billing-address-notice';
+import AmazonPayTaxesBillingAddressNotice from 'wcstripe/components/amazon-pay-taxes-billing-address-notice';
 import { __ } from '@wordpress/i18n';
 import { Card, CheckboxControl } from '@wordpress/components';
 import { useAmazonPayEnabledSettings } from 'wcstripe/data';

--- a/client/entrypoints/express-checkout/index.js
+++ b/client/entrypoints/express-checkout/index.js
@@ -219,6 +219,9 @@ jQuery( function ( $ ) {
 					?.is_amazon_pay_enabled;
 			const isLinkEnabled =
 				wc_stripe_express_checkout_params?.stripe?.is_link_enabled; // eslint-disable-line camelcase
+			const areTaxesBasedOnBillingAddress = getExpressCheckoutData(
+				'taxes_based_on_billing'
+			);
 
 			// For each supported express payment type, create their own
 			// express checkout element. This is necessary as some express payment types
@@ -229,7 +232,9 @@ jQuery( function ( $ ) {
 					EXPRESS_PAYMENT_METHOD_SETTING_APPLE_PAY,
 				isPaymentRequestEnabled &&
 					EXPRESS_PAYMENT_METHOD_SETTING_GOOGLE_PAY,
-				isAmazonPayEnabled && EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
+				isAmazonPayEnabled &&
+					! areTaxesBasedOnBillingAddress &&
+					EXPRESS_PAYMENT_METHOD_SETTING_AMAZON_PAY,
 				isLinkEnabled && EXPRESS_PAYMENT_METHOD_SETTING_LINK,
 			].filter( Boolean );
 

--- a/client/settings/payment-methods/__tests__/payment-methods.test.js
+++ b/client/settings/payment-methods/__tests__/payment-methods.test.js
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import PaymentMethods from '..';
+
+jest.mock(
+	'wcstripe/components/amazon-pay-taxes-billing-address-notice',
+	() => {
+		return jest.fn( ( { areTaxesBasedOnBillingAddress } ) => {
+			if ( ! areTaxesBasedOnBillingAddress ) {
+				return null;
+			}
+			return (
+				<div data-testid="amazon-pay-taxes-notice">
+					Taxes based on billing address notice
+				</div>
+			);
+		} );
+	}
+);
+
+describe( 'PaymentMethods', () => {
+	const globalValues = global.wc_stripe_settings_params;
+
+	beforeEach( () => {
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			taxes_based_on_billing: false,
+		};
+	} );
+
+	it( 'shows the Amazon Pay Taxes Billing Address Notice when taxes are based on billing address', () => {
+		global.wc_stripe_settings_params = {
+			...global.wc_stripe_settings_params,
+			taxes_based_on_billing: true,
+		};
+
+		render( <PaymentMethods /> );
+
+		expect(
+			screen.getByTestId( 'amazon-pay-taxes-notice' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'does not show the Amazon Pay Taxes Billing Address Notice when taxes are not based on billing address', () => {
+		global.wc_stripe_settings_params = {
+			...global.wc_stripe_settings_params,
+			taxes_based_on_billing: false,
+		};
+
+		render( <PaymentMethods /> );
+
+		expect(
+			screen.queryByTestId( 'amazon-pay-taxes-notice' )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -57,7 +57,6 @@ const AmazonPayTaxesBasedOnBillingAddressSection = () => {
 		<SettingsSection>
 			<AmazonPayTaxesBillingAddressNotice
 				areTaxesBasedOnBillingAddress={ areTaxesBasedOnBillingAddress }
-				showUpdateSettingsLink={ false }
 			/>
 		</SettingsSection>
 	);

--- a/client/settings/payment-methods/index.js
+++ b/client/settings/payment-methods/index.js
@@ -7,6 +7,7 @@ import LoadableSettingsSection from '../loadable-settings-section';
 import DisplayOrderCustomizationNotice from '../display-order-customization-notice';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import AmazonPayTaxesBillingAddressNotice from 'wcstripe/components/amazon-pay-taxes-billing-address-notice';
 import { NEW_CHECKOUT_EXPERIENCE_BANNER } from 'wcstripe/settings/payment-settings/constants';
 import PromotionalBanner from 'wcstripe/settings/payment-settings/promotional-banner';
 import OptimizedCheckoutNotice from 'wcstripe/settings/optimized-checkout-notice';
@@ -48,6 +49,20 @@ const PaymentRequestDescription = () => (
 	</>
 );
 
+const AmazonPayTaxesBasedOnBillingAddressSection = () => {
+	const areTaxesBasedOnBillingAddress =
+		!! wc_stripe_settings_params?.taxes_based_on_billing; // eslint-disable-line camelcase
+
+	return (
+		<SettingsSection>
+			<AmazonPayTaxesBillingAddressNotice
+				areTaxesBasedOnBillingAddress={ areTaxesBasedOnBillingAddress }
+				showUpdateSettingsLink={ false }
+			/>
+		</SettingsSection>
+	);
+};
+
 const PaymentMethodsPanel = ( {
 	onSaveChanges,
 	setShowPromotionalBanner,
@@ -59,6 +74,7 @@ const PaymentMethodsPanel = ( {
 } ) => {
 	return (
 		<>
+			<AmazonPayTaxesBasedOnBillingAddressSection />
 			{ showPromotionalBanner && (
 				<SettingsSection>
 					<PromotionalBanner

--- a/includes/admin/class-wc-stripe-amazon-pay-controller.php
+++ b/includes/admin/class-wc-stripe-amazon-pay-controller.php
@@ -39,9 +39,10 @@ class WC_Stripe_Amazon_Pay_Controller {
 
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$params          = [
-			'key'            => WC_Stripe_Mode::is_test() ? $stripe_settings['test_publishable_key'] : $stripe_settings['publishable_key'],
-			'locale'         => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
-			'is_ece_enabled' => WC_Stripe_Feature_Flags::is_stripe_ece_enabled(),
+			'key'                    => WC_Stripe_Mode::is_test() ? $stripe_settings['test_publishable_key'] : $stripe_settings['publishable_key'],
+			'locale'                 => WC_Stripe_Helper::convert_wc_locale_to_stripe_locale( get_locale() ),
+			'is_ece_enabled'         => WC_Stripe_Feature_Flags::is_stripe_ece_enabled(),
+			'taxes_based_on_billing' => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
 		];
 		wp_localize_script(
 			'wc-stripe-amazon-pay-settings',

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -288,6 +288,7 @@ class WC_Stripe_Settings_Controller {
 			'has_klarna_gateway_plugin'             => WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_KLARNA ),
 			'has_other_bnpl_plugins'                => WC_Stripe_Helper::has_other_bnpl_plugins_active(),
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
+			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/readme.txt
+++ b/readme.txt
@@ -128,5 +128,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Fix Express Checkout error with free trial subscription on blocks cart/checkout
 * Fix - Prevent retrying requests that errored out due to declined payment methods
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
+* Fix - Disable Amazon Pay when taxes are based on billing address and add notices with details
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to STRIPE-757
Related to https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4750

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that Amazon Pay will not be shown to shoppers when WooCommerce is configured to use shoppers' billing address to compute taxes on orders. The reasons for this are because we only get shoppers' billing address after they have approved a specific amount in Amazon, which may lead to a change in tax computations on our side, and thus a different purchase amount that will be declined.

While we are trying to work around that situation, we still want to offer Amazon Pay to other merchants. So this PR does the following:
 * We add data to the client configuration fields to represent when taxes are enabled and tax calculations are based on the shopper's billing address
 * The express checkout display logic in the client now requires that flag to be falsey for Amazon Pay to be shown (in addition to Amazon Pay being enabled)
 * When taxes are enabled and based on billing address _and_ Amazon Pay is enabled, we now show notices in the main payment method settings page and the Amazon Pay customisation page to tell merchants that Amazon Pay will not be shown to shoppers, and why.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
### Screenshots

#### Notice in payment method listing screen

<img width="1550" height="683" alt="Screenshot 2025-11-11 at 18 27 51" src="https://github.com/user-attachments/assets/3a0241b4-a9eb-4574-9bdf-893e2ff6276b" />

#### Notice in Amazon Pay customisation screen

<img width="1550" height="683" alt="Screenshot 2025-11-11 at 18 28 12" src="https://github.com/user-attachments/assets/05745171-002e-41f0-b60e-7996ff64ba5d" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

* Set up a test store using the code from this branch and connect to Stripe
* For now, ensure that the store is either configured not to compute taxes, or is set to calculate taxes based on the customer shipping address.
  - The overall flag to enable tax handling is on _WooCommerce_ > _Settings_ > _General_ via the "Enable taxes" checkbox
  - The control for which location to us is available from _WooCommerce_ > _Settings_ > _Tax_ via the "Calculate tax based on" dropdown.
* Enable the Amazon Pay feature flag: `wp option update _wcstripe_feature_amazon_pay yes`
* Navigate to the Stripe settings screen
* Enable Amazon Pay as an express checkout method
* Confirm that you don't see a notice regarding Amazon Pay and the billing address.
* Click on the "Customize" link for Amazon Pay
* Confirm that you don't see a notice regarding Amazon Pay and the billing address.
* Navigate to a screen/context where Amazon Pay (and other express checkout methods) should be shown to shoppers.
* Verify that Amazon Pay is displayed. (Keep this tab/window open.)
* Open a new tab/window, and enable tax (via _WooCommerce_ > _Settings_ > _General_ and then "Enable taxes") and change the logic to use the billing address (via _WooCommerce_ > _Settings_ > _Tax_ and then "Calculate tax based on").
* Reload the shopper-facing view.
* Verify that Amazon Pay is not shown to the shopper.
* Reload the tab looking at the customisation screen for Amazon Pay.
* Verify that you see the Amazon Pay notice, and it includes a link to the tax settings page.
* Click on the link so it opens in a new tab, and verify that it takes you to the tax settings page. Close the tab (or keep it open if it will be handy!)
* Disable Amazon Pay.
* Verify that you no longer see the Amazon Pay notice.
* Re-enable Amazon Pay.
* Verify that you see the notice again.
* Reload the shopper-facing view.
* Verify that Amazon Pay is not shown to the shopper.
* Now go back to the main payment method listing.
* Verify that you see the Amazon Pay notice, without a link to update the tax settings.
* Disable Amazon Pay.
* Verify that the notice is no longer shown.
* Re-enable Amazon Pay and verify that the notice is shown again.
* Disable taxes for the store.
* Verify that the notice now longer shows after reloading the page.
* Reload the shopper-facing view.
* Verify that Amazon Pay is shown to the shopper.
* Re-enable taxes.
* Verify that the notice appears.
* Now modify the tax calculation approach for the store, and verify that the notice is no longer shown.
* Reload the shopper-facing view.
* Verify that Amazon Pay is shown to the shopper.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
