### PR TITLE
Add wc_stripe_is_amazon_pay_available filter to override Amazon Pay feature flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
+* Add - Add wc_stripe_is_amazon_pay_available filter to override Amazon Pay feature flag
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -65,7 +65,15 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_amazon_pay_available() {
-		return 'yes' === self::get_option_with_default( self::AMAZON_PAY_FEATURE_FLAG_NAME );
+		$enable_amazon_pay = 'yes' === self::get_option_with_default( self::AMAZON_PAY_FEATURE_FLAG_NAME );
+
+		/**
+		 * Filter to control the availability of the Amazon Pay feature.
+		 *
+		 * @since 10.1.0
+		 * @param bool $enable_amazon_pay Whether Amazon Pay should be enabled.
+		 */
+		return (bool) apply_filters( 'wc_stripe_is_amazon_pay_available', $enable_amazon_pay );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -130,5 +130,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
+* Add - Add wc_stripe_is_amazon_pay_available filter to override Amazon Pay feature flag
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-803

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR implements a new `wc_stripe_is_amazon_pay_available` filter to make it easier to enable the Amazon Pay feature without modifying the feature flag option. This should make it easier for merchants wanting to test the feature before we release it more widely. The filter accepts only one argument, which is the value that we'd use if we were basing the value on the feature flag alone.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
 * Run a build using the code from this branch
 * Ensure that the `_wcstripe_feature_amazon_pay` option is empty - `wp option delete _wcstripe_feature_amazon_pay`
 * Ensure that your site is connected to Stripe
 * Navigate to the payment method listing in the Settings (_WooCommerce_ > _Settings_ > _Payments_ and then "Manage" next to the Stripe plugin)
 * Verify that Amazon Pay is not shown in the express checkout section
 * Add a snippet with the following:
```php
add_filter( 'wc_stripe_is_amazon_pay_available', '__return_false' );
```
* Reload the payment method list, and verify that Amazon Pay is still not shown in the express checkout section.
* Now update the filter to the following to enable Amazon Pay:
```php
add_filter( 'wc_stripe_is_amazon_pay_available', '__return_true' );
```
* Reload the payment method list, and verify that Amazon Pay is shown in the express checkout section.
* Now enable the feature flag via the option: `wp option update _wcstripe_feature_amazon_pay yes`
* Reload the payment method list, and verify that Amazon Pay is still shown in the express checkout section.
* Update the snippet to `__return_false`.
* Reload the payment method list, and verify that Amazon Pay is no longer shown in the express checkout section.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
