### PR TITLE
chore: remove unused shouldShowPaymentRequestButton from backend

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
-* Dev - Remove `shouldShowPaymentRequestButton` parameter and calculations from backend
+* Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend
 * Fix - Remove `redirect_url` parameter from Express Checkout payment flow
 * Fix - Adjust UI spacing of help text on express checkout theme settings page
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.1.0 - xxxx-xx-xx =
+* Dev - Remove `shouldShowPaymentRequestButton` parameter and calculations from backend
 * Update - Remove `redirect_url` parameter from ECE payment flow
 * Fix - Adjust UI spacing of help text on express checkout theme settings page
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -200,7 +200,6 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				'showSavedCards'                  => $this->get_show_saved_cards(),
 				'showSaveOption'                  => $this->get_show_save_option(),
 				'isAdmin'                         => is_admin(),
-				'shouldShowPaymentRequestButton'  => $this->should_show_payment_request_button(),
 				'shouldShowExpressCheckoutButton' => $this->should_show_express_checkout_button(),
 				'button'                          => [
 					'customLabel' => $this->payment_request_configuration->get_button_label(),
@@ -209,54 +208,6 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 				'baseLocation'                    => wc_get_base_location(),
 			]
 		);
-	}
-
-	/**
-	 * Returns true if the PRB should be shown on the current page, false otherwise.
-	 *
-	 * Note: We use `has_block()` in this function, which isn't supported until WP 5.0. However,
-	 * WooCommerce Blocks hasn't supported a WP version lower than 5.0 since 2019. Since this
-	 * function is only called when the WooCommerce Blocks extension is available, it should be
-	 * safe to call `has_block()` here.
-	 * That said, we only run those checks if the `has_block()` function exists, just in case.
-	 *
-	 * @return boolean  True if PRBs should be displayed, false otherwise
-	 */
-	private function should_show_payment_request_button() {
-		// TODO: Remove the `function_exists()` check once the minimum WP version has been bumped
-		//       to version 5.0.
-		if ( function_exists( 'has_block' ) ) {
-			// Don't show if PRBs are turned off entirely.
-			if ( ! $this->payment_request_configuration->is_at_least_one_payment_request_button_enabled() ) {
-				return false;
-			}
-
-			// Don't show if PRBs are supposed to be hidden on the cart page.
-			if (
-				has_block( 'woocommerce/cart' )
-				&& ! $this->payment_request_configuration->should_show_prb_on_cart_page()
-			) {
-				return false;
-			}
-
-			// Don't show if PRBs are supposed to be hidden on the checkout page.
-			if (
-				has_block( 'woocommerce/checkout' )
-				&& ! $this->payment_request_configuration->should_show_prb_on_checkout_page()
-			) {
-				return false;
-			}
-
-			// Don't show PRB if there are unsupported products in the cart.
-			if (
-				( has_block( 'woocommerce/checkout' ) || has_block( 'woocommerce/cart' ) )
-				&& ! $this->payment_request_configuration->allowed_items_in_cart()
-			) {
-				return false;
-			}
-		}
-
-		return $this->payment_request_configuration->should_show_payment_request_button();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.1.0 - xxxx-xx-xx =
-* Dev - Remove `shouldShowPaymentRequestButton` parameter and calculations from backend
+* Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend
 * Fix - Remove `redirect_url` parameter from Express Checkout payment flow
 * Fix - Adjust UI spacing of help text on express checkout theme settings page
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.1.0 - xxxx-xx-xx =
+* Dev - Remove `shouldShowPaymentRequestButton` parameter and calculations from backend
 * Update - Remove `redirect_url` parameter from ECE payment flow
 * Fix - Adjust UI spacing of help text on express checkout theme settings page
 * Update - Renames and migrates all Payment Request Buttons settings to Express Checkout


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

I noticed that the backend is providing an unused `shouldShowPaymentRequestButton` flag.
The flag's front-end usage was removed in ee97d972845bc877dbac7bc4c71bcef627ed101d .

Just cleaning up the last bit.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Nothing to test. Look for `shouldShowPaymentRequestButton` in the codebase - there should be no usage.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
