### PR TITLE
ECE: Empty state and optional postal code support for addresses in Saudi Arabia

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
+* Fix - Fix express checkout error for a Saudi Arabian address without state and postal code
 
 = 10.0.1 - 2025-10-15 =
 * Fix - Remove persistent reconnection notices

--- a/includes/constants/class-wc-stripe-payment-request-button-states.php
+++ b/includes/constants/class-wc-stripe-payment-request-button-states.php
@@ -906,6 +906,8 @@ class WC_Stripe_Payment_Request_Button_States {
 		'RO' => [],
 		// Serbia.
 		'RS' => [],
+		// Saudi Arabia.
+		'SA' => [],
 		// Sweden.
 		'SE' => [],
 		// Singapore.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -428,6 +428,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 			'wc_stripe_express_checkout_countries_with_optional_postcode',
 			[
 				'IL', // Israel
+				'SA', // Saudi Arabia
 			]
 		);
 

--- a/readme.txt
+++ b/readme.txt
@@ -135,5 +135,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Detect WooCommerce Subscriptions staging sites when checking if payments can be detached
 * Fix - Fix saved ACH payment methods sending unsupported capture_method parameter causing checkout failures
 * Dev - Add Stripe's masked API key to API request/response logs
+* Fix - Fix express checkout error for a Saudi Arabian address without state and postal code
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-802

## Changes proposed in this Pull Request:
- In Google Pay and Apple Pay, a Saudi Arabian address only has the city field. There is no state or any equivalent field. Here, I have added Saudi Arabia (`SA`) in the state mapping to allow an empty value for the state field.
- In Google Pay and Apple Pay, a Saudi Arabian address has postal code as an optional field. So shoppers may have their saved address without a postal code. Here, I have made the postal code optional for Saudi Arabia on the WooCommerce side to prevent checkout failures caused by an empty postal code.

## Testing instructions
- Enable express checkout (Google/Apple Pay) in your Stripe settings page.
- Checkout to `develop` branch.
- As a shopper, add a physical product to your cart.
- From cart or checkout page, click the Google Pay button.
- Add a new shipping address in the country Saudi Arabia, keep the post code empty.
- Select this Saudi Arabian address for shipping.
- Click the pay button.
- You should see a validation error on the checkout page.
- Now checkout to `fix/ece-payment-failure-for-sa` branch.
- As a shopper, try to pay with Google Pay again with the Saudi Arabian shipping address.
- This time the order should be successfully palced.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
