### PR TITLE
tweak: subscriptions support to ECE methods in settings

### DIFF
--- a/client/components/recurring-payment-icon/index.js
+++ b/client/components/recurring-payment-icon/index.js
@@ -22,7 +22,13 @@ const RecurringPaymentIcon = () => {
 				'woocommerce-gateway-stripe'
 			) }
 		>
-			<Icon src={ icon } alt="" />
+			<Icon
+				src={ icon }
+				alt={ __(
+					'Supports recurring payments',
+					'woocommerce-gateway-stripe'
+				) }
+			/>
 		</StyledTooltip>
 	);
 };

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -23,6 +23,7 @@ import {
 	PAYMENT_METHOD_LINK,
 	PAYMENT_METHOD_AMAZON_PAY,
 } from 'wcstripe/stripe-utils/constants';
+import RecurringPaymentIcon from 'wcstripe/components/recurring-payment-icon';
 
 const PaymentRequestSection = () => {
 	const [ isPaymentRequestEnabled, updateIsPaymentRequestEnabled ] =
@@ -115,10 +116,13 @@ const PaymentRequestSection = () => {
 							</div>
 							<div className="express-checkout__label-container">
 								<div className="express-checkout__label">
-									{ __(
-										'Apple Pay / Google Pay',
-										'woocommerce-gateway-stripe'
-									) }
+									<span>
+										{ __(
+											'Apple Pay / Google Pay',
+											'woocommerce-gateway-stripe'
+										) }
+									</span>
+									<RecurringPaymentIcon />
 								</div>
 								<div className="express-checkout__description">
 									{
@@ -185,10 +189,13 @@ const PaymentRequestSection = () => {
 							</div>
 							<div className="express-checkout__label-container">
 								<div className="express-checkout__label">
-									{ __(
-										'Link by Stripe',
-										'woocommerce-gateway-stripe'
-									) }
+									<span>
+										{ __(
+											'Link by Stripe',
+											'woocommerce-gateway-stripe'
+										) }
+									</span>
+									<RecurringPaymentIcon />
 								</div>
 								<div className="express-checkout__description">
 									{
@@ -263,10 +270,13 @@ const PaymentRequestSection = () => {
 							</div>
 							<div className="express-checkout__label-container">
 								<div className="express-checkout__label">
-									{ __(
-										'Amazon Pay',
-										'woocommerce-gateway-stripe'
-									) }
+									<span>
+										{ __(
+											'Amazon Pay',
+											'woocommerce-gateway-stripe'
+										) }
+									</span>
+									<RecurringPaymentIcon />
 									<PaymentMethodMissingCurrencyPill
 										id="amazon_pay"
 										label={ __(

--- a/client/settings/payment-request-section/styles.scss
+++ b/client/settings/payment-request-section/styles.scss
@@ -43,7 +43,10 @@
 			}
 
 			&__label {
-				display: inline-block;
+				display: inline-flex;
+				align-items: center;
+				gap: 8px;
+				flex-wrap: wrap;
 				font-size: 14px;
 				font-weight: 600;
 				line-height: 20px;


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-<linear_issue_id>
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Adding the "Supports subscriptions" icon next to Google Pay/Apple Pay, Link, Amazon Pay ECE buttons - similar to the other payment methods.
<img width="1080" height="428" alt="Screenshot 2025-11-11 at 5 37 30 PM" src="https://github.com/user-attachments/assets/f219b816-7b06-42b9-862b-4cfbebae6edb" />

Before this change, the "Requires currency" tooltip was appearing too close to the payment method's name
<img width="786" height="148" alt="Screenshot 2025-11-11 at 5 35 04 PM" src="https://github.com/user-attachments/assets/d96fa311-0cc0-49b1-ac3c-7e355c895f9f" />


## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
