### PR TITLE
Allow invalid payment methods to be disabled

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
+* Fix - Allow payment methods to be disabled when they are not available
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/client/settings/general-settings-section/__tests__/payment-method.test.js
+++ b/client/settings/general-settings-section/__tests__/payment-method.test.js
@@ -1,0 +1,176 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import icons from '../../../payment-method-icons';
+import UpeToggleContext from '../../upe-toggle/context';
+import PaymentMethod from '../payment-method';
+import PaymentMethodDescription from '../payment-method-description';
+import { useEnabledPaymentMethodIds, useManualCapture } from 'wcstripe/data';
+import {
+	PAYMENT_METHOD_CARD,
+	PAYMENT_METHOD_SEPA,
+	PAYMENT_METHOD_UNAVAILABLE_REASONS,
+} from 'wcstripe/stripe-utils/constants';
+import usePaymentMethodUnavailableReason from 'utils/use-payment-method-unavailable-reason';
+import { getFormattedPaymentMethodDescription } from 'wcstripe/settings/general-settings-section/get-formatted-payment-method-description';
+
+jest.mock( '../payment-method-description' );
+jest.mock( 'wcstripe/data', () => ( {
+	...jest.requireActual( 'wcstripe/data' ),
+	useManualCapture: jest.fn(),
+	useEnabledPaymentMethodIds: jest.fn(),
+} ) );
+jest.mock( 'utils/use-payment-method-unavailable-reason' );
+jest.mock(
+	'wcstripe/settings/general-settings-section/get-formatted-payment-method-description',
+	() => ( {
+		getFormattedPaymentMethodDescription: jest.fn(),
+	} )
+);
+
+describe( 'PaymentMethod', () => {
+	const globalSettingsParams = global.wc_stripe_settings_params;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		global.wc_stripe_settings_params = {
+			...globalSettingsParams,
+			are_apms_deprecated: false,
+		};
+
+		useManualCapture.mockReturnValue( [ false ] );
+		useEnabledPaymentMethodIds.mockReturnValue( [
+			[ PAYMENT_METHOD_CARD ],
+			jest.fn(),
+		] );
+		usePaymentMethodUnavailableReason.mockReturnValue( null );
+
+		PaymentMethodDescription.mockReturnValue(
+			<div data-testid="payment-method-description" />
+		);
+	} );
+
+	const renderPaymentMethod = ( method, data ) => {
+		render(
+			<UpeToggleContext.Provider value={ { isUpeEnabled: true } }>
+				<PaymentMethod method={ method } data={ data } />
+			</UpeToggleContext.Provider>
+		);
+	};
+
+	it( 'card payment method should be enabled with expected details', () => {
+		const data = {
+			account: {
+				default_currency: 'USD',
+			},
+		};
+
+		const mockDescription = 'TEST credit card description';
+		getFormattedPaymentMethodDescription.mockReturnValue( mockDescription );
+
+		renderPaymentMethod( PAYMENT_METHOD_CARD, data );
+
+		const cardCheckbox = screen.getByRole( 'checkbox', {
+			name: 'Credit card / debit card',
+		} );
+		expect( cardCheckbox ).toBeInTheDocument();
+		expect( cardCheckbox ).toBeEnabled();
+		expect( cardCheckbox ).toBeChecked();
+
+		expect(
+			screen.getByTestId( 'payment-method-description' )
+		).toBeInTheDocument();
+		expect( PaymentMethodDescription ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				id: PAYMENT_METHOD_CARD,
+				Icon: icons.card,
+				description: mockDescription,
+				label: 'Credit card / debit card',
+				deprecated: false,
+				supportsRecurring: true,
+			} ),
+			expect.any( Object )
+		);
+	} );
+
+	it( 'SEPA payment method should be disabled when payment method is not enabled and not available', () => {
+		const data = {
+			account: {
+				default_currency: 'USD',
+			},
+		};
+
+		const mockDescription = 'TEST SEPA description';
+		getFormattedPaymentMethodDescription.mockReturnValue( mockDescription );
+		usePaymentMethodUnavailableReason.mockReturnValue(
+			PAYMENT_METHOD_UNAVAILABLE_REASONS.UNSUPPORTED_CURRENCY
+		);
+
+		renderPaymentMethod( PAYMENT_METHOD_SEPA, data );
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: 'Direct debit payment',
+		} );
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).toBeDisabled();
+		expect( checkbox ).not.toBeChecked();
+
+		expect(
+			screen.getByTestId( 'payment-method-description' )
+		).toBeInTheDocument();
+		expect( PaymentMethodDescription ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				id: PAYMENT_METHOD_SEPA,
+				Icon: icons.sepa_debit,
+				description: mockDescription,
+				label: 'Direct debit payment',
+				deprecated: false,
+				supportsRecurring: true,
+			} ),
+			expect.any( Object )
+		);
+	} );
+
+	it( 'SEPA payment method should be enabled when payment method is enabled and not available', () => {
+		const data = {
+			account: {
+				default_currency: 'EUR',
+			},
+		};
+
+		const mockDescription = 'TEST SEPA description';
+		getFormattedPaymentMethodDescription.mockReturnValue( mockDescription );
+
+		usePaymentMethodUnavailableReason.mockReturnValue(
+			PAYMENT_METHOD_UNAVAILABLE_REASONS.UNSUPPORTED_CURRENCY
+		);
+		useEnabledPaymentMethodIds.mockReturnValue( [
+			[ PAYMENT_METHOD_SEPA ],
+			jest.fn(),
+		] );
+
+		renderPaymentMethod( PAYMENT_METHOD_SEPA, data );
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: 'Direct debit payment',
+		} );
+		expect( checkbox ).toBeInTheDocument();
+		expect( checkbox ).toBeEnabled();
+		expect( checkbox ).toBeChecked();
+
+		expect(
+			screen.getByTestId( 'payment-method-description' )
+		).toBeInTheDocument();
+		expect( PaymentMethodDescription ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				id: PAYMENT_METHOD_SEPA,
+				Icon: icons.sepa_debit,
+				description: mockDescription,
+				label: 'Direct debit payment',
+				deprecated: false,
+				supportsRecurring: true,
+			} ),
+			expect.any( Object )
+		);
+	} );
+} );

--- a/client/settings/general-settings-section/__tests__/payment-method.test.js
+++ b/client/settings/general-settings-section/__tests__/payment-method.test.js
@@ -134,7 +134,7 @@ describe( 'PaymentMethod', () => {
 	it( 'SEPA payment method should be enabled when payment method is enabled and not available', () => {
 		const data = {
 			account: {
-				default_currency: 'EUR',
+				default_currency: 'USD',
 			},
 		};
 

--- a/client/settings/general-settings-section/payment-method.js
+++ b/client/settings/general-settings-section/payment-method.js
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import PaymentMethodsMap from '../../payment-methods-map';
 import PaymentMethodDescription from './payment-method-description';
 import PaymentMethodCheckbox from './payment-method-checkbox';
-import { useManualCapture } from 'wcstripe/data';
+import { useEnabledPaymentMethodIds, useManualCapture } from 'wcstripe/data';
 import { PAYMENT_METHOD_CARD } from 'wcstripe/stripe-utils/constants';
 import PaymentMethodFeesPill from 'wcstripe/components/payment-method-fees-pill';
 import usePaymentMethodUnavailableReason from 'utils/use-payment-method-unavailable-reason';
@@ -65,6 +65,7 @@ const PaymentMethod = ( { method, data } ) => {
 	const [ isManualCaptureEnabled ] = useManualCapture();
 	const paymentMethodUnavailableReason =
 		usePaymentMethodUnavailableReason( method );
+	const [ enabledPaymentMethods ] = useEnabledPaymentMethodIds();
 
 	const {
 		Icon,
@@ -84,7 +85,10 @@ const PaymentMethod = ( { method, data } ) => {
 		wc_stripe_settings_params.are_apms_deprecated &&
 		method !== PAYMENT_METHOD_CARD;
 
-	const isDisabled = paymentMethodUnavailableReason !== null;
+	// If the payment method is unavailable and enabled, we should not disable so it can be unchecked.
+	const isDisabled =
+		paymentMethodUnavailableReason !== null &&
+		! enabledPaymentMethods.includes( method );
 
 	return (
 		<div key={ method }>

--- a/readme.txt
+++ b/readme.txt
@@ -111,5 +111,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
+* Fix - Allow payment methods to be disabled when they are not available
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-734
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4711

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates our logic in the payment method list to make it possible for enabled payment methods to be disabled when they should not be available, as we currently don't allow merchants to fix that problem in the UI. We will not allow the payment method to be (re)enabled, but we do make it possible for the user to disable the payment method.

While this is a slightly weird UX, it allows merchants to fix their payment method configuration to align with their store and avoid any notices we might show them when they have a payment method enabled that we don't allow under the current store configuration.

I also added some initial unit tests for the `PaymentMethod` component.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Check the unit tests to check they're testing the two existing cases, and the new case where we want the checkbox to be enabled when the payment method is enabled despite not being permitted.
* Run this branch in a test site.
* Connect to Stripe.
* Enable one or more payment methods that are only permitted in your current store currency.
   - If your store is using USD, you can enable payment methods like Affirm and ACH, which support USD but not EUR.
   - If your store is using EUR, you can enable payment methods like SEPA, Bancontact, and iDEAL, which only support EUR.
* Navigate to _WooCommerce_ > _Settings_ and change your store currency in such a way that at least some of the payment methods above are incompatible with the new currency.
* Open the Stripe payment method list.
* Verify that the previously enabled payment methods show the expected pill about the currency _and_ are enabled.
* Verify that you can disable one or more of the payment methods, and can save the result.
* After disabling each payment method, verify that the checkbox is disabled and does not permit re-enabling the payment method.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)