### PR TITLE
Transform WooCommerce prices correctly for express checkout with blocks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,7 +4,7 @@
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
-* Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration"
+* Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
+* Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration"
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/client/blocks/express-checkout/express-checkout-container.js
+++ b/client/blocks/express-checkout/express-checkout-container.js
@@ -7,6 +7,7 @@ import {
 	getPaymentMethodTypesForExpressMethod,
 	isManualPaymentMethodCreation,
 } from 'wcstripe/express-checkout/utils';
+import { transformPriceWithMinorUnits } from 'wcstripe/express-checkout/transformers/wc-to-stripe';
 
 export const ExpressCheckoutContainer = ( props ) => {
 	const { stripe, billing, expressPaymentMethod } = props;
@@ -19,7 +20,10 @@ export const ExpressCheckoutContainer = ( props ) => {
 		) && {
 			paymentMethodCreation: 'manual',
 		} ),
-		amount: billing.cartTotal.value,
+		amount: transformPriceWithMinorUnits(
+			billing.cartTotal.value,
+			billing.currency.minorUnit
+		),
 		currency: billing.currency.code.toLowerCase(),
 		paymentMethodTypes:
 			getPaymentMethodTypesForExpressMethod( expressPaymentMethod ),

--- a/client/express-checkout/transformers/__tests__/wc-to-stripe.test.js
+++ b/client/express-checkout/transformers/__tests__/wc-to-stripe.test.js
@@ -1,5 +1,6 @@
 import {
 	transformPrice,
+	transformPriceWithMinorUnits,
 	transformCartDataForDisplayItems,
 } from '../wc-to-stripe';
 
@@ -356,6 +357,124 @@ describe( 'wc-to-stripe transformers', () => {
 			expect( transformPrice( 180, { currency_minor_unit: 1 } ) ).toBe(
 				18
 			);
+		} );
+	} );
+
+	describe( 'transformPriceWithMinorUnits', () => {
+		afterEach( () => {
+			delete global.wc_stripe_express_checkout_params.checkout
+				.currency_decimals;
+		} );
+
+		const testCases = {
+			'minor units of 3 with Woo default (2)': {
+				price: 18000,
+				minorUnits: 3,
+				expected: 1800,
+			},
+			'minor units of 2 with Woo default (2)': {
+				price: 180,
+				minorUnits: 2,
+				expected: 180,
+			},
+			'minor units of 1 with Woo default (2)': {
+				price: 180,
+				minorUnits: 1,
+				expected: 1800,
+			},
+			'minor units of 0 with Woo default (2)': {
+				price: 180,
+				minorUnits: 0,
+				expected: 18000,
+			},
+			'minor units of 3 with explicit currency decimals 2': {
+				price: 1800,
+				minorUnits: 3,
+				expected: 180,
+				currencyDecimals: 2,
+			},
+			'minor units of 2 with explicit currency decimals 2': {
+				price: 1800,
+				minorUnits: 2,
+				expected: 1800,
+				currencyDecimals: 2,
+			},
+			'minor units of 1 with explicit currency decimals 2': {
+				price: 1800,
+				minorUnits: 1,
+				expected: 18000,
+				currencyDecimals: 2,
+			},
+			'minor units of 0 with explicit currency decimals 2': {
+				price: 180,
+				minorUnits: 0,
+				expected: 18000,
+				currencyDecimals: 2,
+			},
+			'minor units of 3 with explicit currency decimals 1': {
+				price: 18000,
+				minorUnits: 3,
+				expected: 180,
+				currencyDecimals: 1,
+			},
+			'minor units of 2 with explicit currency decimals 1': {
+				price: 1800,
+				minorUnits: 2,
+				expected: 180,
+				currencyDecimals: 1,
+			},
+			'minor units of 1 with explicit currency decimals 1': {
+				price: 1800,
+				minorUnits: 1,
+				expected: 1800,
+				currencyDecimals: 1,
+			},
+			'minor units of 0 with explicit currency decimals 1': {
+				price: 180,
+				minorUnits: 0,
+				expected: 1800,
+				currencyDecimals: 1,
+			},
+			'minor units of 3 with explicit currency decimals 0': {
+				price: 18000,
+				minorUnits: 3,
+				expected: 18,
+				currencyDecimals: 0,
+			},
+			'minor units of 2 with explicit currency decimals 0': {
+				price: 1800,
+				minorUnits: 2,
+				expected: 18,
+				currencyDecimals: 0,
+			},
+			'minor units of 1 with explicit currency decimals 0': {
+				price: 1800,
+				minorUnits: 1,
+				expected: 180,
+				currencyDecimals: 0,
+			},
+			'minor units of 0 with explicit currency decimals 0': {
+				price: 180,
+				minorUnits: 0,
+				expected: 180,
+				currencyDecimals: 0,
+			},
+		};
+
+		Object.entries( testCases ).forEach( ( [ description, testCase ] ) => {
+			// eslint-disable-next-line jest/valid-title
+			it( description, () => {
+				if ( undefined !== testCase.currencyDecimals ) {
+					global.wc_stripe_express_checkout_params.checkout.currency_decimals =
+						testCase.currencyDecimals;
+				}
+				expect(
+					transformPriceWithMinorUnits(
+						testCase.price,
+						testCase.minorUnits
+					)
+				).toBe( testCase.expected );
+			} );
 		} );
 	} );
 } );

--- a/client/express-checkout/transformers/wc-to-stripe.js
+++ b/client/express-checkout/transformers/wc-to-stripe.js
@@ -22,7 +22,7 @@ export const transformPrice = ( price, priceObject ) => {
 
 /**
  * Stripe expects prices to be in the whole numbers, while WooCommerce allows prices to be specified with
- * a configurable number of decimal places. This functions converts an internal WooCommerce price to a Stripe amount
+ * a configurable number of decimal places. This function converts an internal WooCommerce price to a Stripe amount
  * based on the Stripe and WooCommerce currency configuration.
  *
  * @param {number} price         The price to transform.

--- a/client/express-checkout/transformers/wc-to-stripe.js
+++ b/client/express-checkout/transformers/wc-to-stripe.js
@@ -4,22 +4,41 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { getExpressCheckoutData } from 'wcstripe/express-checkout/utils';
 
 /**
- * GooglePay/ApplePay expect the prices to be formatted in cents.
- * But WooCommerce has a setting to define the number of decimals for amounts.
- * Using this function to ensure the prices provided to GooglePay/ApplePay
- * are always provided accurately, regardless of the number of decimals.
+ * Stripe expects the prices to be formatted in whole numbers.
+ * But WooCommerce has a setting to define the number of decimals for amounts, so we
+ * need to transform the WooCommerce price to the correct format.
  *
  * @param {number}                          price       the price to format.
  * @param {{currency_minor_unit: {number}}} priceObject the price object returned by the Store API
  *
- * @return {number} the price amount for GooglePay/ApplePay, always expressed in cents.
+ * @return {number} The price amount for Stripe.
  */
 export const transformPrice = ( price, priceObject ) => {
+	return transformPriceWithMinorUnits(
+		price,
+		priceObject.currency_minor_unit
+	);
+};
+
+/**
+ * Stripe expects prices to be in the whole numbers, while WooCommerce allows prices to be specified with
+ * a configurable number of decimal places. This functions converts an internal WooCommerce price to a Stripe amount
+ * based on the Stripe and WooCommerce currency configuration.
+ *
+ * @param {number} price         The price to transform.
+ * @param {number} wooMinorUnits The number of minor units for the currency as configured in WooCommerce.
+ * @return {number} The transformed price.
+ */
+export const transformPriceWithMinorUnits = ( price, wooMinorUnits ) => {
 	const currencyDecimals =
 		getExpressCheckoutData( 'checkout' )?.currency_decimals ?? 2;
 
-	// making sure the decimals are always correctly represented for GooglePay/ApplePay, since they don't allow us to specify the decimals.
-	return price * 10 ** ( currencyDecimals - priceObject.currency_minor_unit );
+	// No need to convert if the number of decimals is the same.
+	if ( currencyDecimals === wooMinorUnits ) {
+		return price;
+	}
+
+	return price * 10 ** ( currencyDecimals - wooMinorUnits );
 };
 
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -114,6 +114,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
-* Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration"
+* Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -114,5 +114,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
+* Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration"
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-808

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4480

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that we correctly compute cart totals for express checkout when we're in a block context and there is a mismatch between the number of decimals expected by Stripe and the number of decimals specified in WooCommerce. We addressed the same issue for classic/shortcode contexts in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4480, but that didn't address the issue for block cart and checkout, where the billing data is injected differently.

From an implementation perspective, this patch refactors the main `transformPrice()` function added in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4480 to create a new `transformPriceWithMinorUnits()` function, and ensures that this function is used to compute the correct Stripe-facing price based on the Stripe and WooCommerce decimal configurations.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Set up a store to use USD with `0` decimal places
* Connect the store to Stripe, and enable one or more express checkout options, and ensure they will show up in the cart and checkout
* Set up a product with a price over $1,000 so you exceed the minimum price when the computed price is 1/100 of that value.
* Add your expensive product to your cart
* Run the code from `develop`
* Navigate to the block cart
* Launch the express payment method
   - Depending on which express payment methods are enabled, you may see an API request to `https://api.stripe.com/v1/elements/sessions` which includes a `deferred_intent[amount]` URL parameter that can be used to verify the amount we're sending to Stripe
* Notice that the price is sent as the original value from the server, which is 100 times too small, as it should use cents for the amount, e.g. if the price was `$1,800`, it would be shown as `1800` (i.e. $18), when it should be `180000`.
* Close the express checkout without completing payment
* Navigate to block checkout 
* Launch an express checkout (or check the API call) and confirm the amount is still incorrect
* Close the express checkout without completing payment
* Now run the code from this branch - `fix/incorrect-price-computations-for-block-express-checkout`
  - Note that you need to change branch and rebuild the JS files - `npm run build`
* Navigate to the block cart
  - As above, you may see an API request to `https://api.stripe.com/v1/elements/sessions` which includes a `deferred_intent[amount]` URL parameter that can be used to verify the amount we're sending to Stripe
* Launch an express checkout method, and verify that the price is now correct
* Close the express checkout without completing payment
* Navigate to block checkout
* Launch an express checkout method, and verify that the price is now correct

You can also check that things work if you have WooCommerce set to return 3 digits for USD -- we need to divide by 10 in this case, so $18 should be represented as $18.000 in the UI, and `1800` in the call to Stripe. (You don't need to use the expensive product for this case.)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)