### PR TITLE
Renaming the saved cards setting

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Changes labels related to saved payment methods from "cards" to "payment methods"
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available

--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -90,11 +90,11 @@ const PaymentsAndTransactionsSection = () => {
 					checked={ isSavedCardsEnabled }
 					onChange={ setIsSavedCardsEnabled }
 					label={ __(
-						'Enable payments via saved cards',
+						'Enable saved payment methods',
 						'woocommerce-gateway-stripe'
 					) }
 					help={ __(
-						'If enabled, users will be able to pay with a saved card during checkout. Card details are saved on Stripe servers, not on your store.',
+						'If enabled, returning customers can check out using payment details securely stored by Stripe. No payment information is stored on your store.',
 						'woocommerce-gateway-stripe'
 					) }
 				/>

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -218,10 +218,10 @@ $stripe_settings = apply_filters(
 			],
 		],
 		'saved_cards'                         => [
-			'title'       => __( 'Saved Cards', 'woocommerce-gateway-stripe' ),
-			'label'       => __( 'Enable Payment via Saved Cards', 'woocommerce-gateway-stripe' ),
+			'title'       => __( 'Saved payment methods', 'woocommerce-gateway-stripe' ),
+			'label'       => __( 'Enable saved payment methods', 'woocommerce-gateway-stripe' ),
 			'type'        => 'checkbox',
-			'description' => __( 'If enabled, users will be able to pay with a saved card during checkout. Card details are saved on Stripe servers, not on your store.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'If enabled, returning customers can check out using payment details securely stored by Stripe. No payment information is stored on your store.', 'woocommerce-gateway-stripe' ),
 			'default'     => 'yes',
 			'desc_tip'    => true,
 		],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "woocommerce-gateway-stripe",
-      "version": "10.0.1",
+      "version": "10.1.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Changes labels related to saved payment methods from "cards" to "payment methods"
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-797

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

Now that we can save many other payment methods, not just cards, we should update the setting wording accordingly. In this PR, I am doing just that, following the suggestion by the design team:

> Enable saved payment methods
> If enabled, returning customers can check out using payment details securely stored by Stripe. No payment information is stored on your store.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review. Or:

- Checkout and build this branch on your test environment (`update/renaming-saved-cards-setting`)
- Connect your Stripe account
- Go to the settings screen
- Confirm the setting reflects the new version:
<img width="775" height="129" alt="Screenshot 2025-11-13 at 16 29 39" src="https://github.com/user-attachments/assets/1729a441-e8a9-4c83-b095-c1ae922ea4b5" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
