### PR TITLE
Changing the payment method listed in connection modals

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Changes the list of payment methods shown in the Stripe account connection modal
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available

--- a/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
+++ b/client/settings/connect-stripe-account/__tests__/connect-stripe-account.test.js
@@ -21,7 +21,7 @@ describe( 'ConnectStripeAccount', () => {
 		).toBeInTheDocument();
 		expect(
 			screen.queryByText(
-				'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDEAL, SEPA, and more international payment methods.'
+				'Connect or create a Stripe account to accept all major debit and credit cards, digital wallets (including Apple Pay and Google Pay), buy now, pay later options (such as Klarna and Affirm), and a wide range of local and international payment methods.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/client/settings/connect-stripe-account/index.js
+++ b/client/settings/connect-stripe-account/index.js
@@ -70,7 +70,7 @@ const ConnectStripeAccount = ( { oauthUrl, testOauthUrl } ) => {
 				</h2>
 				<InformationText>
 					{ __(
-						'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDEAL, SEPA, and more international payment methods.',
+						'Connect or create a Stripe account to accept all major debit and credit cards, digital wallets (including Apple Pay and Google Pay), buy now, pay later options (such as Klarna and Affirm), and a wide range of local and international payment methods.',
 						'woocommerce-gateway-stripe'
 					) }
 				</InformationText>

--- a/client/settings/stripe-auth-account/index.js
+++ b/client/settings/stripe-auth-account/index.js
@@ -80,7 +80,7 @@ const StripeAuthAccount = ( { testMode } ) => {
 			<h2>{ getHeading( testMode ) }</h2>
 			<p>
 				{ __(
-					'Connect or create a Stripe account to accept payments directly onsite, including Payment Request buttons (such as Apple Pay and Google Pay), iDEAL, SEPA, and more international payment methods.',
+					'Connect or create a Stripe account to accept all major debit and credit cards, digital wallets (including Apple Pay and Google Pay), buy now, pay later options (such as Klarna and Affirm), and a wide range of local and international payment methods.',
 					'woocommerce-gateway-stripe'
 				) }
 			</p>

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Changes the list of payment methods shown in the Stripe account connection modal
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-812

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, I am updating the list of payment methods promoted on our account connection modal. It should reflect the current most popular methods. The suggested copy is:

> Connect or create a Stripe account to accept all major debit and credit cards, digital wallets (including Apple Pay and Google Pay), buy now, pay later options (such as Klarna and Affirm), and a wide range of local and international payment methods.

Preview for initial connection:
<img width="578" height="400" alt="Screenshot 2025-11-13 at 18 08 04" src="https://github.com/user-attachments/assets/38fb2171-29fe-4670-acf2-4dff50f52371" />

Preview for reconnection:
<img width="612" height="592" alt="Screenshot 2025-11-13 at 18 09 25" src="https://github.com/user-attachments/assets/3fee333d-3722-459d-8f95-a92454f8750e" />

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`update/changing-the-payment-method-listed-in-connection-modals`)
- When attempting to connect your Stripe account, confirm the copy reflects the new version above
- Connect your Stripe account
- Go to the settings page
- Click the "Configure connection" button
- Confirm the modal also shows the new copy

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
