### PR TITLE
ECE: Empty state and optional postal code support for addresses in the Gulf countries

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
+* Fix - Add express checkout support for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar) with optional state and postal code
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,7 @@
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
-* Fix - Add express checkout support for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar) with optional state and postal code
+* Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
 

--- a/includes/constants/class-wc-stripe-payment-request-button-states.php
+++ b/includes/constants/class-wc-stripe-payment-request-button-states.php
@@ -46,6 +46,8 @@ class WC_Stripe_Payment_Request_Button_States {
 	const STATES = [
 		// Afghanistan.
 		'AF' => [],
+		// United Arab Emirates.
+		'AE' => [],
 		// Angola.
 		'AO' => [],
 		// Argentina.
@@ -776,6 +778,8 @@ class WC_Stripe_Payment_Request_Button_States {
 		'NP' => [],
 		// New Zealand.
 		'NZ' => [],
+		// Oman.
+		'OM' => [],
 		// Peru.
 		'PE' => [
 			'CAL' => [ 'Callao', 'Callao', NULL ],
@@ -900,6 +904,8 @@ class WC_Stripe_Payment_Request_Button_States {
 		'PT' => [],
 		// Paraguay.
 		'PY' => [],
+		// Qatar.
+		'QA' => [],
 		// Reunion.
 		'RE' => [],
 		// Romania.

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -427,7 +427,12 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		$countries_with_optional_postcode = apply_filters(
 			'wc_stripe_express_checkout_countries_with_optional_postcode',
 			[
+				'AE', // United Arab Emirates
+				'BH', // Bahrain
 				'IL', // Israel
+				'KW', // Kuwait
+				'OM', // Oman
+				'QA', // Qatar
 				'SA', // Saudi Arabia
 			]
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -114,5 +114,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
+* Fix - Add express checkout support for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar) with optional state and postal code
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -116,7 +116,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
-* Fix - Add express checkout support for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar) with optional state and postal code
+* Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
 


### PR DESCRIPTION
Fixes STRIPE-809

## Changes proposed in this Pull Request:
- Similar to the fix for Saudi Arabia https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4779
- Fixed express checkout for other Gulf countries, UAE, Qatar, Oman, Bahrain and Kuwait.
- In Google Pay and Apple Pay, a Gulf country's address only has the city field. There is no state or any equivalent field. I have added them in the state mapping to allow an empty value for the state field.
- In Google Pay and Apple Pay, these countries either do not have the postal code field or have the postal code as an optional field. So shoppers may have their saved address without a postal code. Here, I have made the postal code optional to prevent checkout failures caused by an empty postal code.

## Testing instructions
- Enable express checkout (Google/Apple Pay) in your Stripe settings page.
- Checkout to `develop` branch.
- As a shopper, add a physical product to your cart.
- From the cart or checkout page, click the Google Pay button.
- Add a new shipping address in any Gulf countries like Qatar/UAE/Bahrain, keep the post code empty.
- Select this address for shipping.
- Click the pay button.
- You should see a validation error on the checkout page.
- Now checkout to `fix/ece-gulf-countries` branch.
- As a shopper, try to pay with Google Pay again with the same shipping address.
- This time the order should be successfully placed.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
