### PR TITLE
Don't allow payment methods to be detached from WP-Cron jobs on staging sites

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
+* Fix - Don't allow WP-Cron jobs to detach payment methods on staging sites
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -590,7 +590,14 @@ class WC_Stripe_API {
 		}
 
 		// Requests coming from the customer account page i.e delete payment method, should always be allowed, and should return true.
-		$is_admin_request = is_admin() || ( defined( 'WP_CLI' ) && WP_CLI );
+		// We thus treat the following requests as admin requests:
+		// - Requests where is_admin() is true
+		// - Actions via WP CLI
+		// - WP Cron requests
+		$is_admin_request = is_admin() ||
+			( defined( 'WP_CLI' ) && WP_CLI ) ||
+			wp_doing_cron();
+
 		if ( ! $is_admin_request ) {
 			return true;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -114,5 +114,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API
 * Fix - Allow payment methods to be disabled when they are not available
+* Fix - Don't allow WP-Cron jobs to detach payment methods on staging sites
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -373,30 +373,56 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 				'expected_return'        => true,
 				'is_test_mode'           => true,
 				'is_admin_request'       => false,
+				'is_cron_request'        => false,
 				'is_wc_sub_staging_site' => false,
 			],
 			'live mode from non-admin context should detach' => [
 				'expected_return'        => true,
 				'is_test_mode'           => false,
 				'is_admin_request'       => false,
+				'is_cron_request'        => false,
 				'is_wc_sub_staging_site' => false,
 			],
 			'test mode from admin context should detach' => [
 				'expected_return'        => true,
 				'is_test_mode'           => true,
 				'is_admin_request'       => true,
+				'is_cron_request'        => false,
+				'is_wc_sub_staging_site' => false,
+			],
+			'test mode from wp cron context should detach' => [
+				'expected_return'        => true,
+				'is_test_mode'           => true,
+				'is_admin_request'       => false,
+				'is_cron_request'        => true,
 				'is_wc_sub_staging_site' => false,
 			],
 			'live mode from admin context with no subscription staging site should detach' => [
 				'expected_return'        => true,
 				'is_test_mode'           => false,
 				'is_admin_request'       => true,
+				'is_cron_request'        => false,
+				'is_wc_sub_staging_site' => false,
+			],
+			'live mode from wp cron context with no subscription staging site should detach' => [
+				'expected_return'        => true,
+				'is_test_mode'           => false,
+				'is_admin_request'       => false,
+				'is_cron_request'        => true,
 				'is_wc_sub_staging_site' => false,
 			],
 			'live mode from admin context with subscription staging site should not detach' => [
 				'expected_return'        => false,
 				'is_test_mode'           => false,
 				'is_admin_request'       => true,
+				'is_cron_request'        => false,
+				'is_wc_sub_staging_site' => true,
+			],
+			'live mode from wp cron context with subscription staging site should not detach' => [
+				'expected_return'        => false,
+				'is_test_mode'           => false,
+				'is_admin_request'       => false,
+				'is_cron_request'        => true,
 				'is_wc_sub_staging_site' => true,
 			],
 			// Ideally, we would test multiple environment types, but wp_get_environment_type() uses a
@@ -407,7 +433,7 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 	/**
 	 * @dataProvider provide_test_should_detach_payment_method_from_customer
 	 */
-	public function test_should_detach_payment_method_from_customer( bool $expected_return, bool $is_test_mode, bool $is_admin_request, bool $is_wc_sub_staging_site = false ) {
+	public function test_should_detach_payment_method_from_customer( bool $expected_return, bool $is_test_mode, bool $is_admin_request, bool $is_cron_request, bool $is_wc_sub_staging_site = false ) {
 		$initial_test_mode = \WC_Stripe_Mode::is_test();
 
 		$stripe_settings = \WC_Stripe_Helper::get_stripe_settings();
@@ -425,6 +451,9 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			$GLOBALS['current_screen'] = \WP_Screen::get( 'post.php' );
 		}
 
+		$cron_filter_return = $is_cron_request ? '__return_true' : '__return_false';
+		add_filter( 'wp_doing_cron', $cron_filter_return, 10, 1 );
+
 		require_once __DIR__ . '/Helpers/WCS_Staging.php';
 		\WCS_Staging::set_is_duplicate_site( $is_wc_sub_staging_site );
 
@@ -441,6 +470,8 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 			$stripe_settings['testmode'] = $initial_test_mode ? 'yes' : 'no';
 			\WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 		}
+
+		remove_filter( 'wp_doing_cron', $cron_filter_return, 10 );
 
 		\WCS_Staging::set_is_duplicate_site( false );
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-814

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates our logic for payment method detachment to treat WP-Cron requests as admin requests rather than user-initiated requests. The result of that is that when we get user modification requests via WP-Cron on staging sites, we won't detach the payment method.

The driver for this change is that there are some plugins that perform bulk actions via WP-Cron code, and our current implementation treats those requests as user-initiated requests, which then means we don't check the current environment type.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

We pretty much want to follow the original report in STRIPE-814:

* Run the code in `develop` for your site
* Create a user with customer role and some known email
* Set your site's Env type to staging or development
* Ensure you are connected to a live Stripe account -- these checks are bypassed for test connections
* In a private window login with this user, and add a payment card
* Come back to admin, adjust your function `should_detach_payment_method_from_customer()` so that it starts with the following:
```php
	public static function should_detach_payment_method_from_customer() {	
		// TEMP DEBUG
		$debug_is_admin_request = is_admin() || ( defined( 'WP_CLI' ) && WP_CLI );

		$current_url = '';
		if ( isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
			$scheme       = ! empty( $_SERVER['HTTPS'] ) && $_SERVER['HTTPS'] !== 'off' ? 'https' : 'http';
			$current_url  = $scheme . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
		}

		$logger = wc_get_logger();
		$logger->info( wc_print_r( var_export($current_url,true), true ), array( 'source' => 'stripe-env-debug' ) );
		$logger->info( wc_print_r( var_export($debug_is_admin_request,true), true ), array( 'source' => 'stripe-env-debug' ) );
		// TEMP DEBUG ENDS
		// Usual logic continues below
```
* Add the following plugin on your site, update `TARGET_EMAIL` to your email from above and activate it:
```php
<?php
/**
 * Plugin Name: KS Delete Stripe Test User
 * Description: Deletes user with email stripetest@woo.com every minute via WP-Cron.
 * Version: 1.1
 * Author: Stripe Debug
 */

if ( ! defined( 'ABSPATH' ) ) {
	exit;
}

class Debug_Delete_Stripe_Test_User {

	const CRON_HOOK = 'debug_delete_stripe_test_user_cron';
	const TARGET_EMAIL = 'stripetest@woo.com';

	public static function init() {
		// Add custom schedule
		add_filter( 'cron_schedules', [ __CLASS__, 'add_minute_schedule' ] );

		// Hook cron event
		add_action( self::CRON_HOOK, [ __CLASS__, 'delete_user' ] );
	}

	/**
	 * Custom cron interval: every 1 minute
	 */
	public static function add_minute_schedule( $schedules ) {
		$schedules['every_minute'] = [
			'interval' => 60,
			'display'  => __( 'Every Minute' ),
		];
		return $schedules;
	}

	/**
	 * Activate plugin → schedule cron
	 */
	public static function activate() {
		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
			wp_schedule_event( time(), 'every_minute', self::CRON_HOOK );
		}
	}

	/**
	 * Deactivate plugin → clear cron
	 */
	public static function deactivate() {
		wp_clear_scheduled_hook( self::CRON_HOOK );
	}

	/**
	 * Delete the user if exists.
	 */
	public static function delete_user() {

		$user = get_user_by( 'email', self::TARGET_EMAIL );

		if ( $user ) {
			require_once ABSPATH . 'wp-admin/includes/user.php';
			wp_delete_user( $user->ID );

			error_log( '[Debug Delete User] Deleted user ID ' . $user->ID );
		}
	}
}

Debug_Delete_Stripe_Test_User::init();

register_activation_hook( __FILE__, [ 'Debug_Delete_Stripe_Test_User', 'activate' ] );
register_deactivation_hook( __FILE__, [ 'Debug_Delete_Stripe_Test_User', 'deactivate' ] );
```
* Wait for a minute for deletion to occur
* Check your Woo > Status Logs > stripe-env-debug 
* Confirm that you see `false` for the request, which indicates that we will return `true` for the function we checked.
* Now check out this branch and repeat the steps above, but add ` || wp_doing_cron()` to the `$debug_is_admin_request` assignment
* Confirm that after the deletion occurs, the log file includes `true` for the Cron request

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
