### PR TITLE
Replacing the SEPA legacy constant identifier

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
+* Dev - Replacing the constant reference for the SEPA payment method in the legacy checkout
 * Update - Changes labels related to saved payment methods from "cards" to "payment methods"
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
-* Dev - Replacing the constant reference for the SEPA payment method in the legacy checkout
+* Dev - Replace the constant reference for the legacy SEPA payment method
 * Update - Changes the list of payment methods shown in the Stripe account connection modal
 * Update - Changes labels related to saved payment methods from "cards" to "payment methods"
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -158,13 +158,13 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	 */
 	private function set_subscription_updated_payment_gateway_id( WC_Subscription $subscription ) {
 		// The subscription is not using the legacy SEPA gateway ID.
-		if ( WC_Gateway_Stripe_Sepa::ID !== $subscription->get_payment_method() ) {
+		if ( WC_Stripe_Payment_Methods::LEGACY_SEPA !== $subscription->get_payment_method() ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( '---- Skipping migration of subscription #%d. Subscription is not using the legacy SEPA payment method.', $subscription->get_id() ) );
 		}
 
 		// Add a meta to the subscription to flag that its token got updated.
-		$subscription->update_meta_data( self::LEGACY_TOKEN_PAYMENT_METHOD_META_KEY, WC_Gateway_Stripe_Sepa::ID );
+		$subscription->update_meta_data( self::LEGACY_TOKEN_PAYMENT_METHOD_META_KEY, WC_Stripe_Payment_Methods::LEGACY_SEPA );
 		$subscription->set_payment_method( $this->updated_sepa_gateway_id );
 
 		$subscription->save();

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -35,6 +35,8 @@ class WC_Stripe_Payment_Methods {
 	const WECHAT_PAY        = 'wechat_pay';
 	const OC                = 'card'; // This is a special case for the Optimized Checkout
 
+	const LEGACY_SEPA       = 'stripe_sepa'; // Sepa method identifier for the legacy checkout (now removed)
+
 	// Express method constants
 	const AMAZON_PAY = 'amazon_pay';
 	const GOOGLE_PAY = 'google_pay';

--- a/includes/constants/class-wc-stripe-payment-methods.php
+++ b/includes/constants/class-wc-stripe-payment-methods.php
@@ -35,7 +35,7 @@ class WC_Stripe_Payment_Methods {
 	const WECHAT_PAY        = 'wechat_pay';
 	const OC                = 'card'; // This is a special case for the Optimized Checkout
 
-	const LEGACY_SEPA       = 'stripe_sepa'; // Sepa method identifier for the legacy checkout (now removed)
+	public const LEGACY_SEPA       = 'stripe_sepa'; // Sepa method identifier for the legacy checkout (now removed)
 
 	// Express method constants
 	const AMAZON_PAY = 'amazon_pay';

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -145,7 +145,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 				'posts_per_page' => 20,
 				'status'         => 'any',
 				'paged'          => $page,
-				'payment_method' => WC_Gateway_Stripe_Sepa::ID,
+				'payment_method' => WC_Stripe_Payment_Methods::LEGACY_SEPA,
 				'order'          => 'ASC',
 				'orderby'        => 'ID',
 			]
@@ -177,7 +177,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 		}
 
 		// Run the full repair if the subscription is using the Legacy SEPA gateway ID.
-		if ( $subscription->get_payment_method() === WC_Gateway_Stripe_Sepa::ID ) {
+		if ( $subscription->get_payment_method() === WC_Stripe_Payment_Methods::LEGACY_SEPA ) {
 			$this->repair_item( $subscription_id );
 
 			// Unschedule the repair action as it's no longer needed.
@@ -369,7 +369,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 				'type'           => 'shop_subscription',
 				'status'         => 'any',
 				'posts_per_page' => 1,
-				'payment_method' => WC_Gateway_Stripe_Sepa::ID,
+				'payment_method' => WC_Stripe_Payment_Methods::LEGACY_SEPA,
 			]
 		);
 		$subscriptions_count = count( $subscriptions );

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -122,7 +122,7 @@ class WC_Stripe_Payment_Tokens {
 	 * @return bool
 	 */
 	public static function customer_has_saved_methods( $customer_id ) {
-		$gateways = [ WC_Stripe_UPE_Payment_Gateway::ID, WC_Gateway_Stripe_Sepa::ID ];
+		$gateways = [ WC_Stripe_UPE_Payment_Gateway::ID, WC_Stripe_Payment_Methods::LEGACY_SEPA ];
 
 		if ( empty( $customer_id ) ) {
 			return false;
@@ -220,7 +220,7 @@ class WC_Stripe_Payment_Tokens {
 					}
 				}
 
-				if ( WC_Gateway_Stripe_Sepa::ID === $gateway_id ) {
+				if ( WC_Stripe_Payment_Methods::LEGACY_SEPA === $gateway_id ) {
 					$stripe_customer = new WC_Stripe_Customer( $customer_id );
 					$stripe_sources  = $stripe_customer->get_sources();
 
@@ -229,7 +229,7 @@ class WC_Stripe_Payment_Tokens {
 							if ( ! isset( $stored_tokens[ $source->id ] ) ) {
 								$token = new WC_Payment_Token_SEPA();
 								$token->set_token( $source->id );
-								$token->set_gateway_id( WC_Gateway_Stripe_Sepa::ID );
+								$token->set_gateway_id( WC_Stripe_Payment_Methods::LEGACY_SEPA );
 								$token->set_last4( $source->sepa_debit->last4 );
 								$token->set_user_id( $customer_id );
 								if ( isset( $source->sepa_debit->fingerprint ) ) {
@@ -496,7 +496,7 @@ class WC_Stripe_Payment_Tokens {
 				}
 
 				$stripe_customer->detach_payment_method( $token->get_token() );
-			} elseif ( WC_Stripe_UPE_Payment_Gateway::ID === $token->get_gateway_id() || WC_Gateway_Stripe_Sepa::ID === $token->get_gateway_id() ) {
+			} elseif ( WC_Stripe_UPE_Payment_Gateway::ID === $token->get_gateway_id() || WC_Stripe_Payment_Methods::LEGACY_SEPA === $token->get_gateway_id() ) {
 				$stripe_customer->delete_source( $token->get_token() );
 			}
 		} catch ( WC_Stripe_Exception $e ) {

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
-* Dev - Replacing the constant reference for the SEPA payment method in the legacy checkout
+* Dev - Replace the constant reference for the legacy SEPA payment method
 * Update - Changes the list of payment methods shown in the Stripe account connection modal
 * Update - Changes labels related to saved payment methods from "cards" to "payment methods"
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
+* Dev - Replacing the constant reference for the SEPA payment method in the legacy checkout
 * Update - Changes labels related to saved payment methods from "cards" to "payment methods"
 * Fix - Ensure Amazon Pay, Apple Pay, and Google Pay display settings are managed correctly
 * Dev - Add logging with DNS resolution diagnostics for URL validation issues when calling Stripe API

--- a/tests/phpunit/Admin/Migrations/WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test.php
+++ b/tests/phpunit/Admin/Migrations/WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test.php
@@ -4,6 +4,7 @@ namespace WooCommerce\Stripe\Tests\Admin\Migrations;
 
 use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
+use WC_Stripe_Payment_Methods;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 use WC_Gateway_Stripe_Sepa;
 use WC_Logger;
@@ -68,7 +69,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test extends WP_UnitTe
 	 *
 	 * @var string
 	 */
-	private $legacy_sepa_gateway_id = WC_Gateway_Stripe_Sepa::ID;
+	private $legacy_sepa_gateway_id = WC_Stripe_Payment_Methods::LEGACY_SEPA;
 
 	public function set_up() {
 		parent::set_up();

--- a/tests/phpunit/Admin/Migrations/WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test.php
+++ b/tests/phpunit/Admin/Migrations/WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens_Test.php
@@ -6,7 +6,6 @@ use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use WC_Stripe_Payment_Methods;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
-use WC_Gateway_Stripe_Sepa;
 use WC_Logger;
 use WC_Stripe_API;
 use WC_Stripe_Database_Cache;

--- a/tests/phpunit/Helpers/WC_Helper_Token.php
+++ b/tests/phpunit/Helpers/WC_Helper_Token.php
@@ -3,7 +3,6 @@
 namespace WooCommerce\Stripe\Tests\Helpers;
 
 use WC_Stripe_UPE_Payment_Gateway;
-use WC_Gateway_Stripe_Sepa;
 use WC_Payment_Token_CC;
 use WC_Payment_Token_SEPA;
 use WC_Payment_Tokens;

--- a/tests/phpunit/Helpers/WC_Helper_Token.php
+++ b/tests/phpunit/Helpers/WC_Helper_Token.php
@@ -42,9 +42,9 @@ class WC_Helper_Token {
 	 *
 	 * @param string $payment_method Token payment method.
 	 * @param int    $user_id        ID of the token's user, defaults to get_current_user_id().
-	 * @param string $gateway        Token's Gateway ID, default to WC_Gateway_Stripe_Sepa::ID
+	 * @param string $gateway        Token's Gateway ID, default to WC_Stripe_Payment_Methods::LEGACY_SEPA
 	 */
-	public static function create_sepa_token( $payment_method, $user_id = null, $gateway = WC_Gateway_Stripe_Sepa::ID ) {
+	public static function create_sepa_token( $payment_method, $user_id = null, $gateway = WC_Stripe_Payment_Methods::LEGACY_SEPA ) {
 		$token = new WC_Payment_Token_SEPA();
 		$token->set_payment_method_type( WC_Stripe_Payment_Methods::SEPA_DEBIT );
 		$token->set_token( $payment_method );


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4787#issuecomment-3532386449

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, I am replacing all references to the legacy Sepa payment method ID with a new constant, allowing us to remove the legacy Sepa class in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4787 safely.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review. Check if the tests are still passing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
