### PR TITLE
Disable express checkout when Amazon Pay is disabled and the only method

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,6 +9,7 @@
 * Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
+* Fix - Disable express checkout when Amazon Pay is disabled and the only method
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -735,6 +735,15 @@ class WC_Stripe_Express_Checkout_Helper {
 			}
 		}
 
+		// Check if Amazon Pay is the only enabled method, but not available due to the tax configuration.
+		if ( $this->is_amazon_pay_enabled() &&
+			! ( $this->is_payment_request_enabled() || $this->is_link_enabled() ) &&
+			( wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ) )
+		) {
+			WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to Amazon Pay being the only enabled method, but not available due to taxes being based on billing address.' );
+			return false;
+		}
+
 		// Hide if cart/product doesn't require shipping and tax is based on billing or shipping address.
 		$hide_based_on_tax          = $this->should_hide_ece_based_on_tax_setup();
 		$hide_based_on_tax_filtered = apply_filters( 'wc_stripe_should_hide_express_checkout_button_based_on_tax_setup', $hide_based_on_tax );

--- a/readme.txt
+++ b/readme.txt
@@ -119,5 +119,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
+* Fix - Disable express checkout when Amazon Pay is disabled and the only method
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -44,6 +44,9 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			$this->shipping_zone->delete();
 		}
 
+		delete_option( 'woocommerce_calc_taxes' );
+		delete_option( 'woocommerce_tax_based_on' );
+
 		parent::tear_down();
 	}
 
@@ -1158,6 +1161,55 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			'Non-OPC with checkout enabled' => [ false, [ 'checkout' ], true ],
 			'OPC with checkout disabled'    => [ true, [ 'product' ], false ],
 			'OPC with both enabled'         => [ true, [ 'checkout', 'product' ], true ],
+		];
+	}
+
+	/**
+	 * Test that the express checkout button is shown or hidden when Amazon Pay is the only enabled method.
+	 *
+	 * @param bool   $taxes_enabled Whether taxes are enabled.
+	 * @param string $tax_based_on  The tax based on option.
+	 * @param bool   $expected      Expected result.
+	 * @return void
+	 * @dataProvider provide_test_should_show_express_checkout_button_with_amazon_pay_only
+	 */
+	public function test_should_show_express_checkout_button_with_amazon_pay_only( bool $taxes_enabled, string $tax_based_on, bool $expected ): void {
+		update_option( 'woocommerce_calc_taxes', $taxes_enabled ? 'yes' : 'no' );
+		update_option( 'woocommerce_tax_based_on', $tax_based_on );
+
+		$helper = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->onlyMethods( [ 'is_amazon_pay_enabled', 'is_payment_request_enabled', 'is_link_enabled' ] )
+			->getMock();
+
+		$helper->method( 'is_amazon_pay_enabled' )->willReturn( true );
+		$helper->method( 'is_payment_request_enabled' )->willReturn( false );
+		$helper->method( 'is_link_enabled' )->willReturn( false );
+		$helper->testmode = true;
+
+		$original_gateways = WC()->payment_gateways()->payment_gateways;
+		WC()->payment_gateways()->payment_gateways = [
+			'stripe' => new WC_Stripe_UPE_Payment_Gateway(),
+		];
+
+		$result = $helper->should_show_express_checkout_button();
+
+		// Restore original gateways.
+		WC()->payment_gateways()->payment_gateways = $original_gateways;
+
+		$this->assertEquals( $expected, $result );
+	}
+
+	/**
+	 * Data provider for {@see test_should_show_express_checkout_button_with_amazon_pay_only()}.
+	 *
+	 * @return array
+	 */
+	public function provide_test_should_show_express_checkout_button_with_amazon_pay_only(): array {
+		return [
+			'taxes enabled, billing address' => [ true, 'billing', false ],
+			'taxes disabled, billing address' => [ false, 'billing', true ],
+			'taxes enabled, shipping address' => [ true, 'shipping', true ],
+			'taxes disabled, shipping address' => [ false, 'shipping', true ],
 		];
 	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -103,16 +103,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			remove_filter( 'wc_stripe_should_hide_express_checkout_button_based_on_tax_setup', '__return_true' );
 		}
 
-		$wc_stripe_ece_helper_mock = $this->createPartialMock(
-			WC_Stripe_Express_Checkout_Helper::class,
-			[
-				'is_product',
-				'allowed_items_in_cart',
-				'should_show_ece_on_cart_page',
-				'should_show_ece_on_checkout_page',
-			],
-			[ $gateway ]
-		);
+		$wc_stripe_ece_helper_mock = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->onlyMethods( [ 'is_product', 'allowed_items_in_cart', 'should_show_ece_on_cart_page', 'should_show_ece_on_checkout_page' ] )
+			->setConstructorArgs( [ $gateway ] )
+			->getMock();
 
 		$wc_stripe_ece_helper_mock->method( 'is_product' )->willReturn( false );
 		$wc_stripe_ece_helper_mock->method( 'allowed_items_in_cart' )->willReturn( true );
@@ -274,16 +268,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$wc_stripe_ece_helper_mock = $this->createPartialMock(
-			WC_Stripe_Express_Checkout_Helper::class,
-			[
-				'is_product',
-				'allowed_items_in_cart',
-				'should_show_ece_on_cart_page',
-				'should_show_ece_on_checkout_page',
-			],
-			[ $gateway ]
-		);
+		$wc_stripe_ece_helper_mock = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->setConstructorArgs( [ $gateway ] )
+			->onlyMethods( [ 'is_product', 'allowed_items_in_cart', 'should_show_ece_on_cart_page', 'should_show_ece_on_checkout_page' ] )
+			->getMock();
+
 		$wc_stripe_ece_helper_mock->method( 'is_product' )->willReturn( false );
 		$wc_stripe_ece_helper_mock->method( 'allowed_items_in_cart' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->method( 'should_show_ece_on_cart_page' )->willReturn( true );
@@ -328,16 +317,14 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	public function test_hides_ece_if_free_trial_requires_shipping() {
 		$this->set_up_shipping_methods();
 
-		$wc_stripe_ece_helper_mock = $this->createPartialMock(
-			WC_Stripe_Express_Checkout_Helper::class,
-			[
-				'is_product',
-				'get_product',
-				'allowed_items_in_cart',
-				'should_show_ece_on_cart_page',
-				'should_show_ece_on_checkout_page',
-			],
-		);
+		$mock_gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$wc_stripe_ece_helper_mock = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->setConstructorArgs( [ $mock_gateway ] )
+			->onlyMethods( [ 'is_product', 'get_product', 'allowed_items_in_cart', 'should_show_ece_on_cart_page', 'should_show_ece_on_checkout_page' ] )
+			->getMock();
 
 		$wc_stripe_ece_helper_mock->method( 'is_product' )->willReturn( true );
 		$wc_stripe_ece_helper_mock->method( 'allowed_items_in_cart' )->willReturn( true );
@@ -1108,17 +1095,10 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$wc_stripe_ece_helper_mock = $this->createPartialMock(
-			WC_Stripe_Express_Checkout_Helper::class,
-			[
-				'is_one_page_checkout',
-				'is_product',
-				'is_checkout',
-				'allowed_items_in_cart',
-				'get_product',
-			],
-			[ $gateway ]
-		);
+		$wc_stripe_ece_helper_mock = $this->getMockBuilder( WC_Stripe_Express_Checkout_Helper::class )
+			->setConstructorArgs( [ $gateway ] )
+			->onlyMethods( [ 'is_one_page_checkout', 'is_product', 'is_checkout', 'allowed_items_in_cart', 'get_product' ] )
+			->getMock();
 
 		// Create a mock product.
 		$product = WC_Helper_Product::create_simple_product();


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-807
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4783

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4773

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that when Amazon Pay is the only available express checkout method AND Amazon Pay will be disabled because taxes are enabled on billing address, we won't enqueue any express checkout scripts or resources.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Set up a store using USD, enable taxes, and configure taxes to be based on billing address
* Run the Stripe plugin out of `develop`, and ensure it is connected to Stripe
* Enable Amazon Pay as a feature by setting the feature flag (`wp update option _wcstripe_feature_amazon_pay yes`) or by hooking into the feature filter (`add_filter( 'wc_stripe_is_amazon_pay_available', '__return_true' );`)
* Navigate to the Stripe payment methods screen
* Ensure that Apple Pay/Google Pay and Link are disabled, and Amazon Pay is enabled.
* Click on the "Customize" link for Amazon Pay, and confirm that Amazon Pay is configured to display in the cart, checkout, and product pages.
* For each of the following pages, navigate to the page and verify that the `express-checkout.js` script is loaded, or that the `wc_stripe_express_checkout_params` global variable is defined in the Javascript console:
   - a product page -- add a standard product to your cart so the pages below work
   - block cart
   - classic cart
   - block checkout
   - classic checkout
* Now switch to this branch: `git checkout fix/unnecessary-express-checkout-resources-when-amazon-pay-billing-address-disabled`
* Reload the product page, cart pages, and checkout pages, and verify that the scripts are no longer enqueued/visible

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)