### PR TITLE
Removing the UPE checkout enabled feature flag usages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
+* Dev - Remove all references to the UPE-enabled feature flag
 * Dev - Remove the merchant email address from the System Status Report
 * Dev - Replace the constant reference for the legacy SEPA payment method
 * Update - Changes the list of payment methods shown in the Stripe account connection modal

--- a/includes/abstracts/abstract-wc-stripe-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-stripe-payment-gateway.php
@@ -1421,12 +1421,7 @@ abstract class WC_Stripe_Payment_Gateway extends WC_Payment_Gateway_CC {
 		// The request for a charge contains metadata for the intent.
 		$full_request = $this->generate_payment_request( $order, $prepared_source );
 
-		$payment_method_types = [ WC_Stripe_Payment_Methods::CARD ];
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			$payment_method_types = $this->get_upe_enabled_at_checkout_payment_method_ids(); // @phpstan-ignore-line (get_upe_enabled_at_checkout_payment_method_ids is defined in the classes that use this class)
-		} elseif ( isset( $prepared_source->source_object->type ) ) {
-			$payment_method_types = [ $prepared_source->source_object->type ];
-		}
+		$payment_method_types = $this->get_upe_enabled_at_checkout_payment_method_ids(); // @phpstan-ignore-line (get_upe_enabled_at_checkout_payment_method_ids is defined in the classes that use this class)
 
 		$currency = strtolower( $order->get_currency() );
 

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -209,14 +209,13 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return WP_REST_Response
 	 */
 	public function get_settings() {
-		$is_upe_enabled = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
 		// When UPE and the payment method configurations API are enabled, fetch the enabled payment methods from the payment method configurations API.
 		// We force a refresh of the enabled payment methods (by passing true) when on the settings page to ensure the latest data.
 		// The available payment methods are also fetched from the payment method configurations API under similar conditions,
 		// but we do not force a refresh for available methods, since calling get_upe_enabled_payment_method_ids first already ensures the list is up to date.
-		$enabled_payment_method_ids   = $is_upe_enabled ? $this->gateway->get_upe_enabled_payment_method_ids( true ) : WC_Stripe_Helper::get_legacy_enabled_payment_method_ids();
-		$available_payment_method_ids = $is_upe_enabled ? $this->gateway->get_upe_available_payment_methods() : WC_Stripe_Helper::get_legacy_available_payment_method_ids();
-		$ordered_payment_method_ids   = $is_upe_enabled ? WC_Stripe_Helper::get_upe_ordered_payment_method_ids( $this->gateway ) : $available_payment_method_ids;
+		$enabled_payment_method_ids   = $this->gateway->get_upe_enabled_payment_method_ids( true );
+		$available_payment_method_ids = $this->gateway->get_upe_available_payment_methods();
+		$ordered_payment_method_ids   = WC_Stripe_Helper::get_upe_ordered_payment_method_ids( $this->gateway );
 
 		return new WP_REST_Response(
 			[
@@ -252,7 +251,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 
 				/* Settings > Advanced settings */
 				'is_debug_log_enabled'                     => 'yes' === $this->gateway->get_option( 'logging' ),
-				'is_upe_enabled'                           => $is_upe_enabled,
+				'is_upe_enabled'                           => true,
 				'is_oc_enabled'                            => 'yes' === $this->gateway->get_option( 'optimized_checkout_element' ),
 				'oc_layout'                                => $this->gateway->get_validated_option( 'optimized_checkout_layout' ),
 				'is_pmc_enabled'                           => 'yes' === $this->gateway->get_option( 'pmc_enabled' ),
@@ -274,7 +273,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		$payment_method_ids_to_enable = $this->get_payment_method_ids_to_enable( $request );
 		$is_upe_enabled               = $request->get_param( 'is_upe_enabled' );
 		$this->update_enabled_payment_methods( $payment_method_ids_to_enable, $is_upe_enabled );
-		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() || ! WC_Stripe_Payment_Method_Configurations::is_enabled() ) {
+		if ( ! WC_Stripe_Payment_Method_Configurations::is_enabled() ) {
 			// We need to update a separate setting for legacy checkout.
 			$this->update_is_payment_request_enabled_for_legacy_checkout( $request );
 		}
@@ -330,28 +329,13 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	 * @return WP_REST_Response
 	 */
 	public function update_payment_methods_order( WP_REST_Request $request ) {
-		$is_upe_enabled             = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
 		$ordered_payment_method_ids = $request->get_param( 'ordered_payment_method_ids' );
 
 		if ( empty( $ordered_payment_method_ids ) ) {
 			return new WP_REST_Response( [], 403 );
 		}
 
-		if ( $is_upe_enabled ) {
-			$this->gateway->update_option( 'stripe_upe_payment_method_order', $ordered_payment_method_ids );
-		} else {
-			$ordered_payment_method_ids = array_map(
-				function ( $id ) {
-					if ( WC_Stripe_Payment_Methods::CARD === $id ) {
-						return 'stripe';
-					}
-					return 'stripe_' . $id;
-				},
-				$ordered_payment_method_ids
-			);
-
-			$this->gateway->update_option( 'stripe_legacy_method_order', $ordered_payment_method_ids );
-		}
+		$this->gateway->update_option( 'stripe_upe_payment_method_order', $ordered_payment_method_ids );
 
 		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order( $ordered_payment_method_ids );
 

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -32,7 +32,6 @@ class WC_Stripe_Admin_Notices {
 		add_action( 'admin_notices', [ $this, 'admin_notices' ] );
 		add_action( 'wp_loaded', [ $this, 'hide_notices' ] );
 		add_action( 'woocommerce_stripe_updated', [ $this, 'stripe_updated' ] );
-		add_action( 'after_plugin_row_woocommerce-gateway-stripe/woocommerce-gateway-stripe.php', [ $this, 'display_legacy_deprecation_notice' ], 10, 1 );
 	}
 
 	/**

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -128,57 +128,7 @@ class WC_Stripe_Admin_Notices {
 	 * @param string $plugin_file Plugin file.
 	 */
 	public static function display_legacy_deprecation_notice( $plugin_file ) {
-		global $wp_list_table;
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-
-		// If Stripe is not enabled, don't show the legacy deprecation notice.
-		if ( ! isset( $stripe_settings['enabled'] ) || 'no' === $stripe_settings['enabled'] ) {
-			return;
-		}
-
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return;
-		}
-
-		if ( is_null( $wp_list_table ) ) {
-			return;
-		}
-
-		$columns_count   = $wp_list_table->get_column_count();
-		$is_active       = is_plugin_active( $plugin_file );
-		$is_active_class = $is_active ? 'active' : 'inactive';
-
-		$setting_link = esc_url( admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings' ) );
-		$message      = sprintf(
-			/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-			__( 'WooCommerce Stripe Gateway legacy checkout experience has been deprecated since version 9.6.0. Please %1$smigrate to the new checkout experience%2$s to access more payment methods and avoid disruptions. %3$sLearn more%4$s', 'woocommerce-gateway-stripe' ),
-			'<a href="' . $setting_link . '">',
-			'</a>',
-			'<a href="https://woocommerce.com/document/stripe/admin-experience/legacy-checkout-experience/" target="_blank">',
-			'</a>'
-		);
-
-		?>
-		<tr class='plugin-update-tr <?php echo esc_html( $is_active_class ); ?>' data-id="woocommerce-gateway-stripe-update" data-slug="woocommerce-gateway-stripe" data-plugin='<?php echo esc_html( $plugin_file ); ?>'>
-			<td colspan='<?php echo esc_html( $columns_count ); ?>' class='plugin-update colspanchange'>
-				<div class='notice inline notice-warning notice-alt'>
-					<p>
-						<span style="display: inline-block; vertical-align: text-top;">
-							<svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-								<path d="M12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20Z" stroke="#dba617" stroke-width="1.5"/>
-								<path d="M13 7H11V13H13V7Z" fill="#dba617"/>
-								<path d="M13 15H11V17H13V15Z" fill="#dba617"/>
-							</svg>
-						</span>
-						<?php
-						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						echo $message;
-						?>
-					</p>
-				</div>
-			</td>
-		</tr>
-		<?php
+		return;
 	}
 
 	/**
@@ -402,23 +352,6 @@ class WC_Stripe_Admin_Notices {
 
 				$this->add_admin_notice( 'changed_keys', 'notice notice-warning', $message, true );
 			}
-
-			if ( empty( $legacy_deprecation_notice ) ) {
-				// Show legacy deprecation notice in version 9.3.0 if legacy checkout experience is enabled.
-				if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-					$setting_link = $this->get_setting_link();
-					$message      = sprintf(
-						/* translators: 1) HTML anchor open tag 2) HTML anchor closing tag */
-						__( 'WooCommerce Stripe Gateway legacy checkout experience has been deprecated since version 9.6.0. Please %1$smigrate to the new checkout experience%2$s to access more payment methods and avoid disruptions. %3$sLearn more%4$s', 'woocommerce-gateway-stripe' ),
-						'<a href="' . $setting_link . '">',
-						'</a>',
-						'<a href="https://woocommerce.com/document/stripe/admin-experience/legacy-checkout-experience/" target="_blank">',
-						'</a>'
-					);
-
-					$this->add_admin_notice( 'legacy_deprecation', 'notice notice-warning', $message, true );
-				}
-			}
 		}
 	}
 
@@ -428,51 +361,29 @@ class WC_Stripe_Admin_Notices {
 	 * @since 4.1.0
 	 */
 	public function payment_methods_check_environment() {
-		$payment_methods = $this->get_payment_methods();
-
 		// phpcs:ignore
 		$is_stripe_settings_page = isset( $_GET['page'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 0 === strpos( $_GET['section'], 'stripe' );
 		$currency_messages       = '';
 
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $method_class ) {
-				if ( WC_Stripe_UPE_Payment_Method_CC::class === $method_class || WC_Stripe_UPE_Payment_Method_Link::class === $method_class ) {
-					continue;
-				}
-				$method     = $method_class::STRIPE_ID;
-				$upe_method = new $method_class();
-				if ( ! $upe_method->is_enabled() ) {
-					continue;
-				}
-
-				if ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $upe_method->get_supported_currencies(), true ) ) {
-					/* translators: %1$s Payment method, %2$s List of supported currencies */
-					$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $upe_method->get_supported_currencies() ) );
-				}
+		foreach ( WC_Stripe_UPE_Payment_Gateway::UPE_AVAILABLE_METHODS as $method_class ) {
+			if ( WC_Stripe_UPE_Payment_Method_CC::class === $method_class || WC_Stripe_UPE_Payment_Method_Link::class === $method_class ) {
+				continue;
+			}
+			$method     = $method_class::STRIPE_ID;
+			$upe_method = new $method_class();
+			if ( ! $upe_method->is_enabled() ) {
+				continue;
 			}
 
-			$show_notice = get_option( 'wc_stripe_show_upe_payment_methods_notice' );
-			if ( ! empty( $currency_messages ) && 'no' !== $show_notice ) {
-				$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true );
+			if ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $upe_method->get_supported_currencies(), true ) ) {
+				/* translators: %1$s Payment method, %2$s List of supported currencies */
+				$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $upe_method->get_label(), implode( ', ', $upe_method->get_supported_currencies() ) );
 			}
-		} else {
-			foreach ( $payment_methods as $method => $class ) {
-				$gateway = new $class();
+		}
 
-				if ( 'yes' !== $gateway->enabled ) {
-					continue;
-				}
-
-				if ( ! $is_stripe_settings_page && ! in_array( get_woocommerce_currency(), $gateway->get_supported_currency(), true ) ) {
-					/* translators: 1) Payment method, 2) List of supported currencies */
-					$currency_messages .= sprintf( __( '%1$s is enabled - it requires store currency to be set to %2$s<br>', 'woocommerce-gateway-stripe' ), $gateway->get_method_title(), implode( ', ', $gateway->get_supported_currency() ) );
-				}
-			}
-
-			$show_notice = get_option( 'wc_stripe_show_payment_methods_notice' );
-			if ( ! empty( $currency_messages && 'no' !== $show_notice ) ) {
-				$this->add_admin_notice( 'payment_methods', 'notice notice-error', $currency_messages, true );
-			}
+		$show_notice = get_option( 'wc_stripe_show_upe_payment_methods_notice' );
+		if ( ! empty( $currency_messages ) && 'no' !== $show_notice ) {
+			$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true );
 		}
 	}
 

--- a/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
@@ -72,11 +72,6 @@ class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Base_Cont
 	 * @deprecated 10.2.0 UPE is generally available and this endpoint will be removed in a future release.
 	 */
 	public function set_flag( WP_REST_Request $request ) {
-		$settings = WC_Stripe_Helper::get_stripe_settings();
-		$settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = 'yes';
-
-		WC_Stripe_Helper::update_main_stripe_settings( $settings );
-
 		// including the class again because otherwise it's not present.
 		if ( WC_Stripe_Inbox_Notes::are_inbox_notes_supported() ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/notes/class-wc-stripe-upe-availability-note.php';

--- a/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
@@ -55,7 +55,7 @@ class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Base_Cont
 	public function get_flag() {
 		return new WP_REST_Response(
 			[
-				'is_upe_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+				'is_upe_enabled' => true,
 			]
 		);
 	}

--- a/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
+++ b/includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
@@ -7,6 +7,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * REST controller for UPE feature flag.
+ *
+ * @deprecated 10.2.0 UPE is generally available and this endpoint will be removed in a future release.
  */
 class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Base_Controller {
 	/**
@@ -51,6 +53,8 @@ class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Base_Cont
 	 * Retrieve flag status.
 	 *
 	 * @return WP_REST_Response
+	 *
+	 * @deprecated 10.2.0 UPE is generally available and this endpoint will be removed in a future release.
 	 */
 	public function get_flag() {
 		return new WP_REST_Response(
@@ -64,16 +68,12 @@ class WC_Stripe_REST_UPE_Flag_Toggle_Controller extends WC_Stripe_REST_Base_Cont
 	 * Update the data.
 	 *
 	 * @param WP_REST_Request $request Full data about the request.
+	 *
+	 * @deprecated 10.2.0 UPE is generally available and this endpoint will be removed in a future release.
 	 */
 	public function set_flag( WP_REST_Request $request ) {
-		$is_upe_enabled = $request->get_param( 'is_upe_enabled' );
-
-		if ( null === $is_upe_enabled ) {
-			return new WP_REST_Response( [ 'result' => 'bad_request' ], 400 );
-		}
-
 		$settings = WC_Stripe_Helper::get_stripe_settings();
-		$settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = $is_upe_enabled ? 'yes' : 'disabled';
+		$settings[ WC_Stripe_Feature_Flags::UPE_CHECKOUT_FEATURE_ATTRIBUTE_NAME ] = 'yes';
 
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -266,7 +266,7 @@ class WC_Stripe_Settings_Controller {
 		$params = [
 			'time'                                  => time(),
 			'i18n_out_of_sync'                      => $message,
-			'is_upe_checkout_enabled'               => WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+			'is_upe_checkout_enabled'               => true,
 			'stripe_oauth_url'                      => $oauth_url,
 			'stripe_test_oauth_url'                 => $test_oauth_url,
 			'show_customization_notice'             => get_option( 'wc_stripe_show_customization_notice', 'yes' ) === 'yes' ? true : false,
@@ -278,7 +278,7 @@ class WC_Stripe_Settings_Controller {
 			'account_country'                       => $this->account->get_account_country(),
 			'are_apms_deprecated'                   => WC_Stripe_Feature_Flags::are_apms_deprecated(),
 			'is_amazon_pay_available'               => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
-			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available() && WC_Stripe_Feature_Flags::is_upe_checkout_enabled(),
+			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
 			'is_oc_enabled'                         => $is_oc_enabled,
 			'oc_layout'                             => $this->get_gateway()->get_validated_option( 'optimized_checkout_layout' ),
 			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_urls' ),

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -138,26 +138,6 @@ class WC_Gateway_Stripe extends WC_Stripe_Payment_Gateway {
 	}
 
 	/**
-	 * Gets the payment gateway's Title.
-	 *
-	 * On payment settings page the default title includes the number of legacy payment methods enabled.
-	 *
-	 * @return string The payment gateway's title.
-	 */
-	public function get_title() {
-		// Change the title on the payment methods settings page to include the number of enabled payment methods.
-		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab'] ) {
-			$enabled_payment_methods_count = count( WC_Stripe_Helper::get_legacy_enabled_payment_method_ids() );
-			$this->title                   = $enabled_payment_methods_count ?
-				/* translators: $1. Count of enabled payment methods. */
-				sprintf( _n( '%d payment method', '%d payment methods', $enabled_payment_methods_count, 'woocommerce-gateway-stripe' ), $enabled_payment_methods_count )
-				: $this->method_title;
-		}
-
-		return parent::get_title();
-	}
-
-	/**
 	 * Checks if gateway should be available to use.
 	 *
 	 * @since 4.0.2

--- a/includes/class-wc-stripe-blocks-support.php
+++ b/includes/class-wc-stripe-blocks-support.php
@@ -103,11 +103,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 			true
 		);
 
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			$this->register_upe_payment_method_script_handles();
-		} else {
-			$this->register_legacy_payment_method_script_handles();
-		}
+		$this->register_upe_payment_method_script_handles();
 
 		return [ 'wc-stripe-blocks-integration' ];
 	}
@@ -184,7 +180,7 @@ final class WC_Stripe_Blocks_Support extends AbstractPaymentMethodType {
 	 * @return array
 	 */
 	public function get_payment_method_data() {
-		$js_params = WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_stripe_ece_enabled()
+		$js_params = WC_Stripe_Feature_Flags::is_stripe_ece_enabled()
 			? $this->get_express_checkout_javascript_params()
 			: $this->get_payment_request_javascript_params();
 		// We need to call array_merge_recursive so the blocks 'button' setting doesn't overwrite

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -118,7 +118,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool Whether the APMs are deprecated.
 	 */
 	public static function are_apms_deprecated() {
-		return ( new \DateTime() )->format( 'Y-m-d' ) > '2024-10-28' && ! self::is_upe_checkout_enabled();
+		return false;
 	}
 
 	/**

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -809,14 +809,9 @@ class WC_Stripe_Helper {
 	public static function add_stripe_methods_in_woocommerce_gateway_order( $ordered_payment_method_ids = [] ) {
 		// If the ordered payment method ids are not passed, get them from the relevant settings.
 		if ( empty( $ordered_payment_method_ids ) ) {
-			$is_upe_enabled  = WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
 			$stripe_settings = self::get_stripe_settings();
 
-			if ( $is_upe_enabled ) {
-				$ordered_payment_method_ids = $stripe_settings['stripe_upe_payment_method_order'] ?? [];
-			} else {
-				$ordered_payment_method_ids = $stripe_settings['stripe_legacy_method_order'] ?? [];
-			}
+			$ordered_payment_method_ids = $stripe_settings['stripe_upe_payment_method_order'] ?? [];
 
 			if ( empty( $ordered_payment_method_ids ) ) {
 				return;

--- a/includes/class-wc-stripe-status.php
+++ b/includes/class-wc-stripe-status.php
@@ -136,21 +136,6 @@ class WC_Stripe_Status {
 				</td>
 			</tr>
 			<tr>
-				<td data-export-label="Legacy Checkout Experience"><?php esc_html_e( 'Legacy Checkout Experience Enabled', 'woocommerce-gateway-stripe' ); ?>:</td>
-				<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the payment gateway has the legacy checkout experience enabled.', 'woocommerce-gateway-stripe' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
-				<td>
-					<?php
-					$legacy_checkout_enabled = ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled();
-					$class                   = $legacy_checkout_enabled ? 'no' : 'yes';
-					?>
-					<mark class="<?php echo esc_attr( $class ); ?>"><span class="dashicons dashicons-<?php echo esc_attr( $class ); ?>"></span>
-					<?php
-					WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ? esc_html_e( 'No', 'woocommerce-gateway-stripe' ) : esc_html_e( 'Yes', 'woocommerce-gateway-stripe' );
-					?>
-					</mark>
-				</td>
-			</tr>
-			<tr>
 				<td data-export-label="Optimized Checkout Enabled"><?php esc_html_e( 'Optimized Checkout Enabled', 'woocommerce-gateway-stripe' ); ?>:</td>
 				<td class="help"><?php echo wc_help_tip( esc_html__( 'Whether the Optimized Checkout Suite is enabled.', 'woocommerce-gateway-stripe' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped, WordPress.Security.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -246,10 +246,8 @@ class WC_Stripe {
 				new WC_Stripe_Settings_Controller( $this->account );
 			}
 
-			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
-				new WC_Stripe_Payment_Gateways_Controller();
-			}
+			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-payment-gateways-controller.php';
+			new WC_Stripe_Payment_Gateways_Controller();
 
 			if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-subscription-detached-bulk-action.php';

--- a/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
+++ b/includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
@@ -89,11 +89,6 @@ class WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update {
 	 * @throws \Exception When the subscription can't be updated.
 	 */
 	private function get_subscription_to_migrate( $subscription_id ) {
-		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-			throw new \Exception( sprintf( '---- Skipping migration of subscription #%d. The Legacy experience is enabled.', $subscription_id ) );
-		}
-
 		if ( ! class_exists( 'WC_Subscriptions' ) ) {
 			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
 			throw new \Exception( sprintf( '---- Skipping migration of subscription #%d. The WooCommerce Subscriptions extension is not active.', $subscription_id ) );

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -381,40 +381,6 @@ trait WC_Stripe_Subscriptions_Trait {
 		try {
 			$order_id = $renewal_order->get_id();
 
-			// Unlike regular off-session subscription payments, early renewals are treated as on-session payments, involving the customer.
-			// This makes the SCA authorization popup show up for the "Renew early" modal (Subscriptions settings > Accept Early Renewal Payments via a Modal).
-			// Note: Currently available for non-UPE credit card only.
-			if ( isset( $_REQUEST['process_early_renewal'] ) && 'stripe' === $this->id && ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) { // phpcs:ignore WordPress.Security.NonceVerification
-				$response = $this->process_payment( $order_id, true, false, $previous_error, true );
-
-				if ( 'success' === $response['result'] && isset( $response['payment_intent_secret'] ) ) {
-					$verification_url = add_query_arg(
-						[
-							'order'         => $order_id,
-							'nonce'         => wp_create_nonce( 'wc_stripe_confirm_pi' ),
-							'redirect_to'   => esc_url_raw( remove_query_arg( [ 'process_early_renewal', 'subscription_id', 'wcs_nonce' ] ) ),
-							'early_renewal' => true,
-						],
-						WC_AJAX::get_endpoint( 'wc_stripe_verify_intent' )
-					);
-
-					echo wp_json_encode(
-						[
-							'stripe_sca_required' => true,
-							'intent_secret'       => $response['payment_intent_secret'],
-							'redirect_url'        => wp_sanitize_redirect( esc_url_raw( $verification_url ) ),
-						]
-					);
-
-					exit;
-				}
-
-				// Hijack all other redirects in order to do the redirection in JavaScript.
-				add_action( 'wp_redirect', [ $this, 'redirect_after_early_renewal' ], 100 );
-
-				return;
-			}
-
 			// Check for an existing intent, which is associated with the order.
 			if ( $this->has_authentication_already_failed( $renewal_order ) ) {
 				return;

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -72,7 +72,6 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	public function maybe_update() {
 		if (
 			! class_exists( 'WC_Subscriptions' ) ||
-			! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ||
 			'yes' === get_option( 'woocommerce_stripe_subscriptions_legacy_sepa_tokens_updated' )
 		) {
 			return;
@@ -166,7 +165,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 * @param int $subscription_id The subscription ID which is about to renew.
 	 */
 	public function maybe_migrate_before_renewal( $subscription_id ) {
-		if ( ! class_exists( 'WC_Subscriptions' ) || ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+		if ( ! class_exists( 'WC_Subscriptions' ) ) {
 			return;
 		}
 
@@ -205,8 +204,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 * What % of the repair is complete, or when the next scheduled action is expected to run.
 	 */
 	public function display_admin_notice() {
-
-		if ( ! class_exists( 'WC_Subscriptions' ) || ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+		if ( ! class_exists( 'WC_Subscriptions' ) ) {
 			return;
 		}
 
@@ -332,7 +330,7 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 */
 	public function add_debug_tool( $tools ) {
 		// We don't need to show the tool if the WooCommerce Subscriptions extension isn't active or the UPE checkout isn't enabled
-		if ( ! class_exists( 'WC_Subscriptions' ) || ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
+		if ( ! class_exists( 'WC_Subscriptions' ) ) {
 			return $tools;
 		}
 

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -13,6 +13,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class WC_Stripe_UPE_Availability_Note
+ *
+ * @deprecated 10.2.0 This note is now deprecated since UPE is generally available.
  */
 class WC_Stripe_UPE_Availability_Note {
 	use NoteTraits;
@@ -71,26 +73,6 @@ class WC_Stripe_UPE_Availability_Note {
 	}
 
 	public static function init() {
-		/**
-		 * No need to display the admin inbox note when
-		 * - UPE is already enabled
-		 * - UPE has been manually disabled
-		 * - Stripe is not enabled
-		 */
-		if ( WC_Stripe_Feature_Flags::did_merchant_disable_upe() ) {
-			return;
-		}
-
-		if ( ! woocommerce_gateway_stripe()->connect->is_connected() ) {
-			return;
-		}
-
-		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-		$stripe_enabled  = isset( $stripe_settings['enabled'] ) && 'yes' === $stripe_settings['enabled'];
-		if ( ! $stripe_enabled ) {
-			return;
-		}
-
-		self::possibly_add_note();
+		return;
 	}
 }

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -82,10 +82,6 @@ class WC_Stripe_UPE_Availability_Note {
 			return;
 		}
 
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return;
-		}
-
 		if ( WC_Stripe_Feature_Flags::did_merchant_disable_upe() ) {
 			return;
 		}

--- a/includes/notes/class-wc-stripe-upe-stripelink-note.php
+++ b/includes/notes/class-wc-stripe-upe-stripelink-note.php
@@ -73,10 +73,6 @@ class WC_Stripe_UPE_StripeLink_Note {
 	 * @throws \Automattic\WooCommerce\Admin\Notes\NotesUnavailableException
 	 */
 	public static function init( WC_Stripe_Payment_Gateway $gateway ) {
-		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return;
-		}
-
 		// Check if Link payment is available.
 		$available_upe_payment_methods = $gateway->get_upe_available_payment_methods();
 

--- a/includes/notes/class-wc-stripe-upe-stripelink-note.php
+++ b/includes/notes/class-wc-stripe-upe-stripelink-note.php
@@ -80,10 +80,6 @@ class WC_Stripe_UPE_StripeLink_Note {
 			return;
 		}
 
-		if ( ! is_a( $gateway, 'WC_Stripe_UPE_Payment_Gateway' ) ) {
-			return;
-		}
-
 		// If store currency is not USD, skip
 		if ( WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR !== get_woocommerce_currency() ) {
 			return;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -68,11 +68,6 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
-		// ECE is only available when UPE checkout is enabled.
-		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return;
-		}
-
 		// Checks if Stripe Gateway is enabled.
 		if ( empty( $this->stripe_settings ) || ( isset( $this->stripe_settings['enabled'] ) && 'yes' !== $this->stripe_settings['enabled'] ) ) {
 			return;

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * WC_Stripe_Payment_Request class.
+ *
+ * @deprecated 10.2.0 This class is now deprecated in favor of ECE and will be removed in future versions.
  */
 class WC_Stripe_Payment_Request {
 
@@ -70,7 +72,6 @@ class WC_Stripe_Payment_Request {
 	 * @version 4.0.0
 	 */
 	public function __construct() {
-		return;
 
 		self::$_this           = $this;
 		$this->stripe_settings = WC_Stripe_Helper::get_stripe_settings();
@@ -87,6 +88,9 @@ class WC_Stripe_Payment_Request {
 		$this->total_label = str_replace( "'", '', $this->total_label ) . apply_filters( 'wc_stripe_payment_request_total_label_suffix', ' (via WooCommerce)' );
 
 		add_action( 'woocommerce_stripe_updated', [ $this, 'migrate_button_size' ] );
+
+		// Don't initiate this class as it is deprecated.
+		return;
 
 		// Checks if Stripe Gateway is enabled.
 		if ( empty( $this->stripe_settings ) || ( isset( $this->stripe_settings['enabled'] ) && 'yes' !== $this->stripe_settings['enabled'] ) ) {

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -85,7 +85,7 @@ class WC_Stripe_Payment_Request {
 		add_action( 'woocommerce_stripe_updated', [ $this, 'migrate_button_size' ] );
 
 		// Check if ECE feature flag is enabled.
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_stripe_ece_enabled() ) {
+		if ( WC_Stripe_Feature_Flags::is_stripe_ece_enabled() ) {
 			return;
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -247,7 +247,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->secret_key                    = ! empty( $main_settings['secret_key'] ) ? $main_settings['secret_key'] : '';
 		$this->statement_descriptor          = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
 
-		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
+		// Title shows the count of enabled payment methods in settings page only.
 		if ( isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab'] ) {
 			$enabled_payment_methods_count = count( $enabled_payment_methods );
 			$this->title                   = $enabled_payment_methods_count ?

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -248,7 +248,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$this->statement_descriptor          = ! empty( $main_settings['statement_descriptor'] ) ? $main_settings['statement_descriptor'] : '';
 
 		// When feature flags are enabled, title shows the count of enabled payment methods in settings page only.
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() && WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab'] ) {
+		if ( WC_Stripe_Feature_Flags::is_upe_preview_enabled() && isset( $_GET['page'] ) && 'wc-settings' === $_GET['page'] && isset( $_GET['tab'] ) && 'checkout' === $_GET['tab'] ) {
 			$enabled_payment_methods_count = count( $enabled_payment_methods );
 			$this->title                   = $enabled_payment_methods_count ?
 				/* translators: $1. Count of enabled payment methods. */
@@ -2238,7 +2238,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		return array_merge(
 			$metadata,
 			[
-				'is_legacy_checkout_enabled' => WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ? 'no' : 'yes',
+				'is_legacy_checkout_enabled' => 'no',
 				'is_oc_enabled'              => $this->is_oc_enabled() ? 'yes' : 'no',
 				'pmc_enabled'                => $pmc_enabled,
 			]

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
@@ -70,11 +70,6 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 			return false;
 		}
 
-		// Amazon Pay is disabled if UPE is disabled.
-		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return false;
-		}
-
 		$upe_enabled_method_ids = $gateway->get_upe_enabled_payment_method_ids();
 
 		return is_array( $upe_enabled_method_ids ) && in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -35,11 +35,6 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	 * @return bool
 	 */
 	public static function is_link_enabled( WC_Gateway_Stripe $gateway ) {
-		// Assume Link is disabled if UPE is disabled.
-		if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return false;
-		}
-
 		$upe_enabled_method_ids = $gateway->get_upe_enabled_payment_method_ids();
 
 		return is_array( $upe_enabled_method_ids ) && in_array( self::STRIPE_ID, $upe_enabled_method_ids, true );

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -152,11 +152,7 @@ class WC_Stripe_Payment_Tokens {
 	 * @return array
 	 */
 	public function woocommerce_get_customer_payment_tokens( $tokens, $user_id, $gateway_id ) {
-		if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-			return $this->woocommerce_get_customer_upe_payment_tokens( $tokens, $user_id, $gateway_id );
-		} else {
-			return $this->woocommerce_get_customer_payment_tokens_legacy( $tokens, $user_id, $gateway_id );
-		}
+		return $this->woocommerce_get_customer_upe_payment_tokens( $tokens, $user_id, $gateway_id );
 	}
 
 	/**
@@ -474,31 +470,27 @@ class WC_Stripe_Payment_Tokens {
 	public function woocommerce_payment_token_deleted( $token_id, $token ) {
 		$stripe_customer = new WC_Stripe_Customer( $token->get_user_id() );
 		try {
-			if ( WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-				// If it's not reusable payment method, we don't need to perform any additional checks.
-				if ( ! in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
-					return;
-				}
-
-				/**
-				 * 1. Check if it's live mode.
-				 * 2. Check if it's admin.
-				 * 3. Check if it's not production environment.
-				 * When all conditions are met, we don't want to delete the payment method from Stripe.
-				 * This is to avoid detaching the payment method from the live stripe account on non production environments.
-				 */
-				if (
-					WC_Stripe_Mode::is_live() &&
-					is_admin() &&
-					'production' !== wp_get_environment_type()
-				) {
-					return;
-				}
-
-				$stripe_customer->detach_payment_method( $token->get_token() );
-			} elseif ( WC_Stripe_UPE_Payment_Gateway::ID === $token->get_gateway_id() || WC_Gateway_Stripe_Sepa::ID === $token->get_gateway_id() ) {
-				$stripe_customer->delete_source( $token->get_token() );
+			// If it's not reusable payment method, we don't need to perform any additional checks.
+			if ( ! in_array( $token->get_gateway_id(), self::UPE_REUSABLE_GATEWAYS_BY_PAYMENT_METHOD, true ) ) {
+				return;
 			}
+
+			/**
+			 * 1. Check if it's live mode.
+			 * 2. Check if it's admin.
+			 * 3. Check if it's not production environment.
+			 * When all conditions are met, we don't want to delete the payment method from Stripe.
+			 * This is to avoid detaching the payment method from the live stripe account on non production environments.
+			 */
+			if (
+				WC_Stripe_Mode::is_live() &&
+				is_admin() &&
+				'production' !== wp_get_environment_type()
+			) {
+				return;
+			}
+
+			$stripe_customer->detach_payment_method( $token->get_token() );
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
+* Dev - Remove all references to the UPE-enabled feature flag
 * Dev - Remove the merchant email address from the System Status Report
 * Dev - Replace the constant reference for the legacy SEPA payment method
 * Update - Changes the list of payment methods shown in the Stripe account connection modal

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -180,10 +180,6 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				// This means a version support notice will be added.
 				$expected_notices[] = 'wcver';
 			}
-			if ( ! WC_Stripe_Feature_Flags::is_upe_checkout_enabled() ) {
-				// This means the legacy checkout support notice will be added.
-				$expected_notices[] = 'legacy_deprecation';
-			}
 		}
 
 		if ( $expected_output ) {

--- a/tests/phpunit/WC_Stripe_Inbox_Notes_Test.php
+++ b/tests/phpunit/WC_Stripe_Inbox_Notes_Test.php
@@ -78,16 +78,7 @@ class WC_Stripe_Inbox_Notes_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$this->assertSame( 1, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_StripeLink_Note::NOTE_NAME ) ) );
 	}
 
-	public function test_create_upe_notes_does_not_create_note_when_upe_preview_is_disabled() {
-		update_option( '_wcstripe_feature_upe', 'no' );
-
-		WC_Stripe_Inbox_Notes::create_upe_notes();
-
-		$admin_note_store = WC_Data_Store::load( 'admin-note' );
-		$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_Availability_Note::NOTE_NAME ) ) );
-	}
-
-	public function test_create_upe_notes_does_not_create_availability_note_when_upe_is_enbled() {
+	public function test_create_upe_notes_does_not_create_availability_note_when_upe_is_enabled() {
 		$upe_helper = new UPE_Test_Helper();
 		$upe_helper->enable_upe();
 		$upe_helper->reload_payment_gateways();
@@ -105,7 +96,6 @@ class WC_Stripe_Inbox_Notes_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		WC_Stripe_Inbox_Notes::create_upe_notes();
 
 		$admin_note_store = WC_Data_Store::load( 'admin-note' );
-		$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_Availability_Note::NOTE_NAME ) ) );
 		$this->assertSame( 1, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_StripeLink_Note::NOTE_NAME ) ) );
 	}
 
@@ -120,22 +110,6 @@ class WC_Stripe_Inbox_Notes_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		WC_Stripe_Inbox_Notes::create_upe_notes();
 
 		$admin_note_store = WC_Data_Store::load( 'admin-note' );
-		$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_Availability_Note::NOTE_NAME ) ) );
-		$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_StripeLink_Note::NOTE_NAME ) ) );
-	}
-
-	public function test_create_upe_notes_does_not_create_note_when_upe_has_been_manually_disabled() {
-		WC_Stripe_Helper::update_main_stripe_settings(
-			[
-				'enabled'                         => 'yes',
-				'upe_checkout_experience_enabled' => 'disabled',
-			]
-		);
-
-		WC_Stripe_Inbox_Notes::create_upe_notes();
-
-		$admin_note_store = WC_Data_Store::load( 'admin-note' );
-		$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_Availability_Note::NOTE_NAME ) ) );
 		$this->assertSame( 0, count( $admin_note_store->get_notes_with_name( WC_Stripe_UPE_StripeLink_Note::NOTE_NAME ) ) );
 	}
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this simple cleanup PR, I am removing all references to the UPE-enabled feature flag, as that is no longer necessary, since UPE is now the only version available.

I am also deprecating `WC_Stripe_UPE_Availability_Note` and `WC_Stripe_REST_UPE_Flag_Toggle_Controller` as they do not make sense anymore.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

Code review. Check if the tests are still passing. Perform some basic smoke testing and confirm no regression was introduced.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
