### PR TITLE
Add the masked stored state (transient value) when OAuth Connect validation fails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
+* Dev - Add additional context data to the OAuth connect flow verbose debug logging mode
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -95,7 +95,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// The state parameter is used to protect against CSRF.
 			// It's a unique, randomly generated, opaque, and non-guessable string that is sent when starting the
 			// authentication request and validated when processing the response.
-			if ( get_transient( 'wcs_stripe_connect_state_' . $mode ) !== $state ) {
+			$stored_state = get_transient( 'wcs_stripe_connect_state_' . $mode );
+			if ( $stored_state !== $state ) {
 				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
 						'OAuth: Invalid state received from the WCC server',
@@ -105,6 +106,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 							'connect_type'           => $type,
 							'state'                  => self::redact_string( $state ),
 							'code'                   => self::redact_string( $code ),
+							'stored_state'           => false === $stored_state ? 'false' : self::redact_string( $stored_state ),
 						]
 					);
 				}
@@ -196,16 +198,22 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				}
 
 				if ( $is_verbose_debug_mode_enabled ) {
-					WC_Stripe_Logger::debug(
-						'OAuth: Account connected successfully, reloading the page to clear URL parameters',
-						[
-							'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
-							'connect_mode'           => $mode,
-							'connect_type'           => $type,
-							'connect_response'       => self::redact_sensitive_data( $response ),
-							'redirect_url'           => self::redact_sensitive_data( $redirect_url ),
-						]
-					);
+					$log_data = [
+						'current_stripe_api_key' => WC_Stripe_API::get_masked_secret_key(),
+						'connect_mode'           => $mode,
+						'connect_type'           => $type,
+						'state'                  => self::redact_string( $state ),
+						'code'                   => self::redact_string( $code ),
+						'nonce'                  => self::redact_string( $nonce ),
+						'connect_response'       => self::redact_sensitive_data( $response ),
+						'redirect_url'           => self::redact_sensitive_data( $redirect_url ),
+					];
+
+					if ( ! is_wp_error( $response ) ) {
+						WC_Stripe_Logger::debug( 'OAuth: Account connected successfully', $log_data );
+					} else {
+						WC_Stripe_Logger::error( 'OAuth: Account connection failed', $log_data );
+					}
 				}
 
 				wp_safe_redirect( esc_url_raw( $redirect_url ) );

--- a/readme.txt
+++ b/readme.txt
@@ -121,5 +121,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
+* Dev - Add additional context data to the OAuth connect flow verbose debug logging mode
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-745
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

This PR improves the OAuth optional verbose logs to include additional data:
- adds the expected state masked value (or false if not set)
- logs the final state, code, nonce, and connect_response (all masked) as an error in case of failure

## Testing instructions

0. Enable the Oauth connect verbose logging by adding the following filter:
    `add_filter( 'wc_stripe_is_verbose_debug_mode_enabled', '__return_true' );`
1. Disconnect your Stripe account
2. Go to the Onboard page (`WooCommerce > Payments > Stripe`)
3. Click `Create or connect a test account instead` (_do not complete the onboarding yet_)
4. Remove the state transient:
    `wp transient delete wcs_stripe_connect_state_test`
5. Select your account and complete the process
6. Check that there are 2 error logged:
    <img width="830" height="540" alt="Screenshot 2025-11-17 at 20 10 07" src="https://github.com/user-attachments/assets/e903d74f-707d-44a6-a70e-825d44c4461f" />
7. Verify that the attribute `stored_state` is present, and that it is `false`:
    <img width="892" height="407" alt="Screenshot 2025-11-17 at 20 10 40" src="https://github.com/user-attachments/assets/ae030523-f463-420c-8bb7-5344243026f3" />

---



-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
