### PR TITLE
Use the built-in Database Cache for Connect flow data instead of transients

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -11,6 +11,7 @@
 * Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
+* Fix - Use the builtin Database Cache for the Connect flow data
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/class-wc-stripe-database-cache.php
+++ b/includes/class-wc-stripe-database-cache.php
@@ -329,7 +329,13 @@ class WC_Stripe_Database_Cache {
 	 * @return string The key with the prefix.
 	 */
 	private static function add_key_prefix( string $key, ?string $mode = null ): string {
-		$mode = $mode ?? ( WC_Stripe_Mode::is_test() ? 'test' : 'live' );
+		if ( null === $mode ) {
+			$mode = WC_Stripe_Mode::is_test() ? 'test' : 'live';
+		} elseif ( 'live' !== $mode && 'test' !== $mode ) {
+			// Don't allow other values for $mode
+			$mode = 'test';
+		}
+		// Otherwise $mode is either 'live' or 'test'
 		return self::CACHE_KEY_PREFIX . $mode . '_' . $key;
 	}
 

--- a/includes/class-wc-stripe-database-cache.php
+++ b/includes/class-wc-stripe-database-cache.php
@@ -80,7 +80,21 @@ class WC_Stripe_Database_Cache {
 	 * @return void
 	 */
 	public static function set( $key, $data, $ttl = HOUR_IN_SECONDS ) {
-		$prefixed_key = self::add_key_prefix( $key );
+		self::set_with_mode( $key, $data, $ttl, null );
+	}
+
+	/**
+	 * Stores a value in the cache for the specified mode.
+	 *
+	 * @param string $key The key to store the value under.
+	 * @param mixed  $data The value to store.
+	 * @param int    $ttl  The TTL of the cache. Dafault 1 hour.
+	 * @param string|null $mode The mode to use as prefix for the key. Default is null, which means the current plugin mode.
+	 *
+	 * @return void
+	 */
+	public static function set_with_mode( $key, $data, $ttl = HOUR_IN_SECONDS, ?string $mode = null ) {
+		$prefixed_key = self::add_key_prefix( $key, $mode );
 		self::write_to_cache( $prefixed_key, $data, $ttl );
 	}
 
@@ -94,7 +108,21 @@ class WC_Stripe_Database_Cache {
 	 * @return mixed|null The cache contents. NULL if the cache value is expired or missing.
 	 */
 	public static function get( $key ) {
-		$prefixed_key = self::add_key_prefix( $key );
+		return self::get_with_mode( $key, null );
+	}
+
+	/**
+	 * Gets a value from the cache for the specified mode.
+	 *
+	 * The key is automatically prefixed with "wcstripe_cache_[mode]_".
+	 *
+	 * @param string $key       The key to look for.
+	 * @param string|null $mode The mode to use as prefix for the key. Default is null, which means the current plugin mode.
+	 *
+	 * @return mixed|null The cache contents. NULL if the cache value is expired or missing.
+	 */
+	public static function get_with_mode( $key, ?string $mode = null ) {
+		$prefixed_key = self::add_key_prefix( $key, $mode );
 		$cache_contents = self::get_from_cache( $prefixed_key );
 		if ( is_array( $cache_contents ) && array_key_exists( 'data', $cache_contents ) ) {
 			if ( self::is_expired( $prefixed_key, $cache_contents ) ) {
@@ -119,8 +147,19 @@ class WC_Stripe_Database_Cache {
 	 * @return void
 	 */
 	public static function delete( $key ) {
-		$prefixed_key = self::add_key_prefix( $key );
+		self::delete_with_mode( $key, null );
+	}
 
+	/**
+	 * Deletes a value from the cache for the specified mode.
+	 *
+	 * @param string $key  The key to delete.
+	 * @param string $mode The mode to use as prefix for the key. Default is null, which means the current plugin mode.
+	 *
+	 * @return void
+	 */
+	public static function delete_with_mode( $key, ?string $mode = null ): void {
+		$prefixed_key = self::add_key_prefix( $key, $mode );
 		self::delete_from_cache( $prefixed_key );
 	}
 
@@ -284,13 +323,14 @@ class WC_Stripe_Database_Cache {
 	 * Adds the CACHE_KEY_PREFIX + plugin mode prefix to the key.
 	 * Ex: "wcstripe_cache_[mode]_[key].
 	 *
-	 * @param string $key The key to add the prefix to.
+	 * @param string $key       The key to add the prefix to.
+	 * @param string|null $mode The mode to use as prefix for the key. Default is null, which means the current plugin mode.
 	 *
 	 * @return string The key with the prefix.
 	 */
-	private static function add_key_prefix( $key ) {
-		$mode = WC_Stripe_Mode::is_test() ? 'test_' : 'live_';
-		return self::CACHE_KEY_PREFIX . $mode . $key;
+	private static function add_key_prefix( string $key, ?string $mode = null ): string {
+		$mode = $mode ?? ( WC_Stripe_Mode::is_test() ? 'test' : 'live' );
+		return self::CACHE_KEY_PREFIX . $mode . '_' . $key;
 	}
 
 	/**

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return $result;
 			}
 
-			WC_Stripe_Database_Cache::set( 'wcs_stripe_connect_state_' . $mode, $result->state, 6 * HOUR_IN_SECONDS );
+			WC_Stripe_Database_Cache::set_with_mode( 'oauth_connect_state', $result->state, 6 * HOUR_IN_SECONDS, $mode );
 
 			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 				WC_Stripe_Logger::debug(
@@ -95,7 +95,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// The state parameter is used to protect against CSRF.
 			// It's a unique, randomly generated, opaque, and non-guessable string that is sent when starting the
 			// authentication request and validated when processing the response.
-			$stored_state = WC_Stripe_Database_Cache::get( 'wcs_stripe_connect_state_' . $mode );
+			$stored_state = WC_Stripe_Database_Cache::get_with_mode( 'oauth_connect_state', $mode );
 			if ( $stored_state !== $state ) {
 				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
@@ -133,7 +133,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return $response;
 			}
 
-			WC_Stripe_Database_Cache::delete( 'wcs_stripe_connect_state_' . $mode );
+			WC_Stripe_Database_Cache::delete_with_mode( 'oauth_connect_state', $mode );
 
 			return $this->save_stripe_keys( $response, $type, $mode );
 		}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -64,7 +64,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return $result;
 			}
 
-			set_transient( 'wcs_stripe_connect_state_' . $mode, $result->state, 6 * HOUR_IN_SECONDS );
+			WC_Stripe_Database_Cache::set( 'wcs_stripe_connect_state_' . $mode, $result->state, 6 * HOUR_IN_SECONDS );
 
 			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 				WC_Stripe_Logger::debug(
@@ -95,7 +95,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			// The state parameter is used to protect against CSRF.
 			// It's a unique, randomly generated, opaque, and non-guessable string that is sent when starting the
 			// authentication request and validated when processing the response.
-			if ( get_transient( 'wcs_stripe_connect_state_' . $mode ) !== $state ) {
+			if ( WC_Stripe_Database_Cache::get( 'wcs_stripe_connect_state_' . $mode ) !== $state ) {
 				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
 					WC_Stripe_Logger::error(
 						'OAuth: Invalid state received from the WCC server',
@@ -131,7 +131,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				return $response;
 			}
 
-			delete_transient( 'wcs_stripe_connect_state_' . $mode );
+			WC_Stripe_Database_Cache::delete( 'wcs_stripe_connect_state_' . $mode );
 
 			return $this->save_stripe_keys( $response, $type, $mode );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -121,5 +121,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure state and postal code are optional in express checkout for Gulf countries (UAE, Bahrain, Kuwait, Oman, Qatar)
 * Dev - Removes the `_wcstripe_feature_upe` feature flag and the related method from the `WC_Stripe_Feature_Flags` class
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
+* Fix - Use the builtin Database Cache for the Connect flow data
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Database_Cache_Test.php
+++ b/tests/phpunit/WC_Stripe_Database_Cache_Test.php
@@ -167,6 +167,143 @@ class WC_Stripe_Database_Cache_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for {@see test_set_with_mode()}, {@see test_get_with_mode()}, and {@see test_delete_with_mode()}.
+	 *
+	 * @return array Array of test cases.
+	 */
+	public function provide_mode_test_cases() {
+		return [
+			'test_mode' => [
+				'mode' => 'test',
+				'key'  => 'mode_test_key',
+				'data' => 'mode_test_data',
+			],
+			'live_mode' => [
+				'mode' => 'live',
+				'key'  => 'mode_live_key',
+				'data' => 'mode_live_data',
+			],
+			'null_mode' => [
+				'mode' => null,
+				'key'  => 'mode_null_key',
+				'data' => 'mode_null_data',
+			],
+		];
+	}
+
+	/**
+	 * Test set_with_mode with different modes.
+	 *
+	 * @dataProvider provide_mode_test_cases
+	 * @param string|null $mode The mode to test.
+	 * @param string      $key  The cache key.
+	 * @param mixed       $data The data to cache.
+	 */
+	public function test_set_with_mode( ?string $mode, string $key, $data ) {
+		WC_Stripe_Database_Cache::set_with_mode( $key, $data, HOUR_IN_SECONDS, $mode );
+		$result = WC_Stripe_Database_Cache::get_with_mode( $key, $mode );
+
+		$this->assertEquals( $data, $result );
+
+		// For null mode, verify it's stored with the current mode prefix.
+		if ( null === $mode ) {
+			$current_mode = WC_Stripe_Mode::is_test() ? 'test' : 'live';
+			$prefixed_key = 'wcstripe_cache_' . $current_mode . '_' . $key;
+			$cache_contents = get_option( $prefixed_key );
+			$this->assertNotFalse( $cache_contents );
+			$this->assertEquals( $data, $cache_contents['data'] );
+		}
+	}
+
+	/**
+	 * Test get_with_mode with different modes.
+	 *
+	 * @dataProvider provide_mode_test_cases
+	 * @param string|null $mode The mode to test.
+	 * @param string      $key  The cache key.
+	 * @param mixed       $data The data to cache.
+	 */
+	public function test_get_with_mode( ?string $mode, string $key, $data ) {
+		WC_Stripe_Database_Cache::set_with_mode( $key, $data, HOUR_IN_SECONDS, $mode );
+		$result = WC_Stripe_Database_Cache::get_with_mode( $key, $mode );
+
+		$this->assertEquals( $data, $result );
+	}
+
+	/**
+	 * Data provider for {@see test_get_with_mode_non_existent_key()}.
+	 *
+	 * @return array Array of test cases.
+	 */
+	public function provide_get_with_mode_non_existent_key_test_cases() {
+		return [
+			'test_mode' => [ 'test' ],
+			'live_mode' => [ 'live' ],
+			'null_mode' => [ null ],
+		];
+	}
+
+	/**
+	 * Test get_with_mode returns null for non-existent key in specific mode.
+	 *
+	 * @dataProvider provide_get_with_mode_non_existent_key_test_cases
+	 * @param string|null $mode The mode to test.
+	 */
+	public function test_get_with_mode_non_existent_key( ?string $mode ) {
+		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( 'non_existent_key', $mode ) );
+	}
+
+	/**
+	 * Test delete_with_mode with different modes.
+	 *
+	 * @dataProvider provide_mode_test_cases
+	 * @param string|null $mode The mode to test.
+	 * @param string      $key  The cache key.
+	 * @param mixed       $data The data to cache.
+	 */
+	public function test_delete_with_mode( ?string $mode, string $key, $data ) {
+		// Set data in the specified mode.
+		WC_Stripe_Database_Cache::set_with_mode( $key, $data, HOUR_IN_SECONDS, $mode );
+		$this->assertEquals( $data, WC_Stripe_Database_Cache::get_with_mode( $key, $mode ) );
+
+		// Delete from the specified mode.
+		WC_Stripe_Database_Cache::delete_with_mode( $key, $mode );
+		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( $key, $mode ) );
+	}
+
+	/**
+	 * Test cross-mode isolation - data stored in different modes are isolated.
+	 */
+	public function test_cross_mode_isolation() {
+		$key        = 'cross_mode_key';
+		$test_data  = 'test_mode_data';
+		$live_data  = 'live_mode_data';
+
+		// Set data in test mode.
+		WC_Stripe_Database_Cache::set_with_mode( $key, $test_data, HOUR_IN_SECONDS, 'test' );
+
+		// Set different data in live mode.
+		WC_Stripe_Database_Cache::set_with_mode( $key, $live_data, HOUR_IN_SECONDS, 'live' );
+
+		// Verify test mode returns test data.
+		$test_result = WC_Stripe_Database_Cache::get_with_mode( $key, 'test' );
+		$this->assertEquals( $test_data, $test_result );
+
+		// Verify live mode returns live data.
+		$live_result = WC_Stripe_Database_Cache::get_with_mode( $key, 'live' );
+		$this->assertEquals( $live_data, $live_result );
+
+		// Delete only from test mode.
+		WC_Stripe_Database_Cache::delete_with_mode( $key, 'test' );
+
+		// Verify test mode data is deleted.
+		$this->assertNull( WC_Stripe_Database_Cache::get_with_mode( $key, 'test' ) );
+
+		// Verify live mode data still exists.
+		$this->assertEquals( $live_data, WC_Stripe_Database_Cache::get_with_mode( $key, 'live' ) );
+	}
+
+	/**
 	 * Data provider for {@see test_delete_stale_entries()}.
 	 *
 	 * @return array Array of test cases.


### PR DESCRIPTION
Fixes STRIPE-745
Fixes #4729

## Changes proposed in this Pull Request:

This PR replaces the transient used during the OAuth Connect with an entry in the built-in Database cache.

## Testing instructions

1. Disconnect your Stripe account
2. Go to the Onboard page (WooCommerce > Payments > Stripe)
3. Click `Create or connect a test account instead`
4. Verify that the connection succeeds. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
