### PR TITLE
Making OCS enabled by default for new installs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Makes the Optimized Checkout Suite feature enabled by default for all new installations
 * Dev - Expands the Stripe Order Helper class to handle mandate ID, Multibanco data, refund status, card brand, charge captured flag, status final flag, and the refund failure reason 
 * Dev - Remove the merchant email address from the System Status Report
 * Dev - Replace the constant reference for the legacy SEPA payment method

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
-* Update - Makes the Optimized Checkout Suite feature enabled by default for all new installations
+* Update - Enable the Optimized Checkout Suite feature for all new installations
 * Dev - Deprecates all the legacy checkout payment method classes
 * Dev - Deprecates all the LPM class constants
 * Dev - Remove all references to the UPE-enabled feature flag

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -370,13 +370,22 @@ class WC_Stripe {
 			// Try to schedule the daily async cleanup of the Stripe database cache.
 			WC_Stripe_Database_Cache::maybe_schedule_daily_async_cleanup();
 
-			// If we have previously disabled settings synchronization, remove the flag after the upgrade,
-			// just to make sure we are still ineligible for settings synchronization.
 			$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-			if ( isset( $stripe_settings['pmc_enabled'] ) && 'no' === $stripe_settings['pmc_enabled'] ) {
-				unset( $stripe_settings['pmc_enabled'] );
-				WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-				WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
+			if ( isset( $stripe_settings['pmc_enabled'] ) ) {
+				// If we have previously disabled settings synchronization, remove the flag after the upgrade,
+				// just to make sure we are still ineligible for settings synchronization.
+				if ( 'no' === $stripe_settings['pmc_enabled'] ) {
+					unset( $stripe_settings['pmc_enabled'] );
+					WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+					WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
+				} else if ( 'yes' === $stripe_settings['pmc_enabled'] ) {
+					// Enable the Optimized Checkout feature by default if not set.
+					// It requires PMC to be enabled.
+					if ( ! isset( $stripe_settings['optimized_checkout_element'] ) ) {
+						$stripe_settings['optimized_checkout_element'] = 'yes';
+						WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+					}
+				}
 			}
 		}
 	}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -344,7 +344,7 @@ class WC_Stripe {
 				define( 'WC_STRIPE_INSTALLING', true );
 			}
 
-			// Mark as fresh install if no version is set.
+			// Mark optimized checkout as default on for new installs.
 			if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
 				update_option( 'wc_stripe_optimized_checkout_default_on', true );
 			}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -375,15 +375,13 @@ class WC_Stripe {
 			// Try to schedule the daily async cleanup of the Stripe database cache.
 			WC_Stripe_Database_Cache::maybe_schedule_daily_async_cleanup();
 
+			// If we have previously disabled settings synchronization, remove the flag after the upgrade,
+			// just to make sure we are still ineligible for settings synchronization.
 			$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-			if ( isset( $stripe_settings['pmc_enabled'] ) ) {
-				// If we have previously disabled settings synchronization, remove the flag after the upgrade,
-				// just to make sure we are still ineligible for settings synchronization.
-				if ( 'no' === $stripe_settings['pmc_enabled'] ) {
-					unset( $stripe_settings['pmc_enabled'] );
-					WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-					WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
-				}
+			if ( isset( $stripe_settings['pmc_enabled'] ) && 'no' === $stripe_settings['pmc_enabled'] ) {
+				unset( $stripe_settings['pmc_enabled'] );
+				WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+				WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
 			}
 		}
 	}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -345,8 +345,8 @@ class WC_Stripe {
 			}
 
 			// Mark as fresh install if no version is set.
-			if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_fresh_install' ) ) {
-				update_option( 'wc_stripe_fresh_install', true );
+			if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
+				update_option( 'wc_stripe_optimized_checkout_default_on', true );
 			}
 
 			add_woocommerce_inbox_variant();

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -344,6 +344,11 @@ class WC_Stripe {
 				define( 'WC_STRIPE_INSTALLING', true );
 			}
 
+			// Mark as fresh install if no version is set.
+			if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_fresh_install' ) ) {
+				update_option( 'wc_stripe_fresh_install', true );
+			}
+
 			add_woocommerce_inbox_variant();
 			$this->update_plugin_version();
 
@@ -378,13 +383,6 @@ class WC_Stripe {
 					unset( $stripe_settings['pmc_enabled'] );
 					WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 					WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
-				} else if ( 'yes' === $stripe_settings['pmc_enabled'] ) {
-					// Enable the Optimized Checkout feature by default if not set.
-					// It requires PMC to be enabled.
-					if ( ! isset( $stripe_settings['optimized_checkout_element'] ) ) {
-						$stripe_settings['optimized_checkout_element'] = 'yes';
-						WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-					}
 				}
 			}
 		}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -263,7 +263,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$options['enabled']                         = 'yes';
 			$options['testmode']                        = $is_test ? 'yes' : 'no';
 			$options['upe_checkout_experience_enabled'] = $this->get_upe_checkout_experience_enabled();
-			$options['optimized_checkout_element']      = $this->get_optimized_checkout_element_default_value();
 			$options[ $prefix . 'publishable_key' ]     = $publishable_key;
 			$options[ $prefix . 'secret_key' ]          = $secret_key;
 			$options[ $prefix . 'connection_type' ]     = $type;
@@ -340,17 +339,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			}
 
 			return 'yes';
-		}
-
-		/**
-		 * If user is reconnecting and there are existing settings data, return the value from the settings.
-		 * Otherwise for new connections return 'yes' for `optimized_checkout_element` field.
-		 *
-		 * @return string 'yes' or 'no'
-		 */
-		private function get_optimized_checkout_element_default_value(): string {
-			$existing_stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-			return $existing_stripe_settings['optimized_checkout_element'] ?? 'yes';
 		}
 
 		/**

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -255,6 +255,7 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$options['enabled']                         = 'yes';
 			$options['testmode']                        = $is_test ? 'yes' : 'no';
 			$options['upe_checkout_experience_enabled'] = $this->get_upe_checkout_experience_enabled();
+			$options['optimized_checkout_element']      = $this->get_optimized_checkout_element_default_value();
 			$options[ $prefix . 'publishable_key' ]     = $publishable_key;
 			$options[ $prefix . 'secret_key' ]          = $secret_key;
 			$options[ $prefix . 'connection_type' ]     = $type;
@@ -331,6 +332,17 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			}
 
 			return 'yes';
+		}
+
+		/**
+		 * If user is reconnecting and there are existing settings data, return the value from the settings.
+		 * Otherwise for new connections return 'yes' for `optimized_checkout_element` field.
+		 *
+		 * @return string 'yes' or 'no'
+		 */
+		private function get_optimized_checkout_element_default_value(): string {
+			$existing_stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+			return $existing_stripe_settings['optimized_checkout_element'] ?? 'yes';
 		}
 
 		/**

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -267,9 +267,9 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$options[ $prefix . 'secret_key' ]          = $secret_key;
 			$options[ $prefix . 'connection_type' ]     = $type;
 			$options['pmc_enabled']                     = 'connect' === $type ? 'yes' : 'no'; // When not connected via Connect OAuth, the PMC is disabled.
-			if ( 'connect' === $type && get_option( 'wc_stripe_fresh_install' ) ) {
+			if ( 'connect' === $type && get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
 				$options['optimized_checkout_element'] = 'yes';
-				delete_option( 'wc_stripe_fresh_install' );
+				delete_option( 'wc_stripe_optimized_checkout_default_on' );
 			}
 			if ( 'app' === $type ) {
 				$options[ $prefix . 'refresh_token' ] = $result->refreshToken; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -267,6 +267,10 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$options[ $prefix . 'secret_key' ]          = $secret_key;
 			$options[ $prefix . 'connection_type' ]     = $type;
 			$options['pmc_enabled']                     = 'connect' === $type ? 'yes' : 'no'; // When not connected via Connect OAuth, the PMC is disabled.
+			if ( 'connect' === $type && get_option( 'wc_stripe_fresh_install' ) ) {
+				$options['optimized_checkout_element'] = 'yes';
+				delete_option( 'wc_stripe_fresh_install' );
+			}
 			if ( 'app' === $type ) {
 				$options[ $prefix . 'refresh_token' ] = $result->refreshToken; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			}

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -267,9 +267,11 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 			$options[ $prefix . 'secret_key' ]          = $secret_key;
 			$options[ $prefix . 'connection_type' ]     = $type;
 			$options['pmc_enabled']                     = 'connect' === $type ? 'yes' : 'no'; // When not connected via Connect OAuth, the PMC is disabled.
-			if ( 'connect' === $type && get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
+			$should_default_optimized_checkout_on = get_option( 'wc_stripe_optimized_checkout_default_on' );
+			// Clean up the option.
+			delete_option( 'wc_stripe_optimized_checkout_default_on' );
+			if ( 'connect' === $type && $should_default_optimized_checkout_on ) {
 				$options['optimized_checkout_element'] = 'yes';
-				delete_option( 'wc_stripe_optimized_checkout_default_on' );
 			}
 			if ( 'app' === $type ) {
 				$options[ $prefix . 'refresh_token' ] = $result->refreshToken; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/readme.txt
+++ b/readme.txt
@@ -111,7 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
-* Update - Makes the Optimized Checkout Suite feature enabled by default for all new installations
+* Update - Enable the Optimized Checkout Suite feature for all new installations
 * Dev - Deprecates all the legacy checkout payment method classes
 * Dev - Deprecates all the LPM class constants
 * Dev - Remove all references to the UPE-enabled feature flag

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Makes the Optimized Checkout Suite feature enabled by default for all new installations
 * Dev - Expands the Stripe Order Helper class to handle mandate ID, Multibanco data, refund status, card brand, charge captured flag, status final flag, and the refund failure reason 
 * Dev - Remove the merchant email address from the System Status Report
 * Dev - Replace the constant reference for the legacy SEPA payment method

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -154,4 +154,82 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 		];
 	}
+
+	/**
+	 * Tests for the 'install' method when it updates the main Stripe settings.
+	 *
+	 * @param array $stripe_settings   The initial Stripe settings.
+	 * @param array $expected_settings The expected Stripe settings after installation.
+	 * @return void
+	 *
+	 * @dataProvider provide_test_install_settings
+	 */
+	public function test_install_settings_update( array $stripe_settings = [], array $expected_settings = [] ): void {
+		// Activate the Stripe plugin.
+		update_option( 'active_plugins', [ plugin_basename( WC_STRIPE_MAIN_FILE ) ] );
+
+		// Set initial settings.
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$wc_stripe = $this->getMockBuilder( WC_Stripe::class )
+			->disableOriginalConstructor()
+			->onlyMethods(
+				[
+					'update_plugin_version',
+					'update_prb_location_settings',
+					'migrate_to_new_checkout_experience',
+				]
+			)
+			->getMock();
+
+		$wc_stripe->install();
+
+		$actual_settings = WC_Stripe_Helper::get_stripe_settings();
+		foreach ( $expected_settings as $key => $value ) {
+			if ( null == $value ) {
+				$this->assertArrayNotHasKey( $key, $actual_settings );
+			} else {
+				$this->assertArrayHasKey( $key, $actual_settings );
+				$this->assertSame( $value, $actual_settings[ $key ] );
+			}
+		}
+	}
+
+	/**
+	 * Data provider for `test_install_settings`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_install_settings(): array {
+		return [
+			'will not enable OCS by default due to PMC being disabled' => [
+				'stripe settings' => [
+					'pmc_enabled' => 'no',
+				],
+				'expected settings' => [
+					'pmc_enabled'                => null,
+					'optimized_checkout_element' => null,
+				],
+			],
+			'will not enable OCS by default due to OCS being set'  => [
+				'stripe settings' => [
+					'pmc_enabled'                => 'yes',
+					'optimized_checkout_element' => 'no',
+				],
+				'expected settings' => [
+					'pmc_enabled'                => 'yes',
+					'optimized_checkout_element' => 'no',
+				],
+			],
+			'will enable OCS by default'     => [
+				'stripe settings' => [
+					'pmc_enabled' => 'yes',
+				],
+				'expected settings' => [
+					'pmc_enabled'                => 'yes',
+					'optimized_checkout_element' => 'yes',
+				],
+			],
+		];
+	}
 }

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -223,4 +223,31 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			],
 		];
 	}
+
+	/**
+	 * Tests that the 'install' method sets the fresh install flag.
+	 *
+	 * @return void
+	 */
+	public function test_install_sets_fresh_install_flag(): void {
+		update_option( 'active_plugins', [ plugin_basename( WC_STRIPE_MAIN_FILE ) ] );
+
+		// Ensure the flag is not set.
+		delete_option( 'wc_stripe_fresh_install' );
+
+		$wc_stripe = $this->getMockBuilder( WC_Stripe::class )
+			->disableOriginalConstructor()
+			->onlyMethods(
+				[
+					'update_plugin_version',
+					'update_prb_location_settings',
+					'migrate_to_new_checkout_experience',
+				]
+			)
+			->getMock();
+
+		$wc_stripe->install();
+
+		$this->assertEquals( 'yes', get_option( 'wc_stripe_fresh_install' ) );
+	}
 }

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -233,7 +233,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		update_option( 'active_plugins', [ plugin_basename( WC_STRIPE_MAIN_FILE ) ] );
 
 		// Ensure the flag is not set.
-		delete_option( 'wc_stripe_fresh_install' );
+		delete_option( 'wc_stripe_optimized_checkout_default_on' );
 
 		$wc_stripe = $this->getMockBuilder( WC_Stripe::class )
 			->disableOriginalConstructor()
@@ -248,6 +248,6 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$wc_stripe->install();
 
-		$this->assertEquals( 'yes', get_option( 'wc_stripe_fresh_install' ) );
+		$this->assertEquals( 'yes', get_option( 'wc_stripe_optimized_checkout_default_on' ) );
 	}
 }

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -221,15 +221,6 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'optimized_checkout_element' => 'no',
 				],
 			],
-			'will enable OCS by default'     => [
-				'stripe settings' => [
-					'pmc_enabled' => 'yes',
-				],
-				'expected settings' => [
-					'pmc_enabled'                => 'yes',
-					'optimized_checkout_element' => 'yes',
-				],
-			],
 		];
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-818

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

As originally envisioned, with this PR, we are making the Optimized Checkout Suite feature enabled by default for all new installations. This is to make sure merchants are using the latest integration recommended by Stripe.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on a new test environment (`update/making-ocs-enabled-by-default-for-new-installs`)
- Connect your Stripe account
- Confirm the Optimized Checkout feature is enabled in settings:
<img width="774" height="112" alt="Screenshot 2025-11-18 at 16 52 41" src="https://github.com/user-attachments/assets/4bde31b8-e2da-45b6-a7c6-8976529287da" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
