### PR TITLE
Check for supplied express checkout payment when processing payment in Optimized Checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -14,6 +14,7 @@
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
 * Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration
 * Fix - Disable express checkout when Amazon Pay is disabled and the only method
+* Fix - Ensure express payment methods are processed correctly when Optimized Checkout is enabled
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2528,6 +2528,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 	 */
 	protected function prepare_payment_information_from_request( WC_Order $order ) {
 		$selected_payment_type = $this->get_selected_payment_method_type_from_request();
+		$express_payment_type  = $this->get_express_payment_type_from_request();
 		$capture_method        = $this->is_automatic_capture_enabled() ? 'automatic' : 'manual'; // automatic | manual.
 		$currency              = strtolower( $order->get_currency() );
 		$amount                = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $currency );
@@ -2569,7 +2570,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Override the payment method type with the API value when OC is enabled
 		if ( $this->oc_enabled ) {
-			$selected_payment_type = $payment_method_details->type ?? null;
+			// Make sure we're not handling an express payment type like Amazon Pay, which wasn't directly triggered via Optimized Checkout.
+			if ( empty( $express_payment_type ) || $selected_payment_type !== $express_payment_type ) {
+				$selected_payment_type = $payment_method_details->type ?? null;
+			}
 			$payment_method_types  = [ $selected_payment_type ];
 		} else {
 			$payment_method_types = $this->get_payment_method_types_for_intent_creation(

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2565,11 +2565,18 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		$payment_method_details = ! empty( $payment_method_id ) ? WC_Stripe_API::get_payment_method( $payment_method_id ) : (object) [];
 
-		// Override the payment method type with the API value when OC is enabled
+		// When Optimized Checkout is enabled, check which payment method we need to use.
 		if ( $this->oc_enabled ) {
-			// Make sure we're not handling an express payment type like Amazon Pay, which wasn't directly triggered via Optimized Checkout.
-			if ( empty( $express_payment_type ) || $selected_payment_type !== $express_payment_type ) {
-				$selected_payment_type = $payment_method_details->type ?? null;
+			// Check if we are handling an express payment type, where we should not expect a payment method to have been created, and
+			// need to rely on either $selected_payment_type or $express_payment_type.
+			if ( empty( $payment_method_id ) || empty( $payment_method_details->type ) ) {
+				if ( '' === $selected_payment_type && null !== $express_payment_type ) {
+					$selected_payment_type = $express_payment_type;
+				}
+				// Otherwise keep using $selected_payment_type.
+			} else {
+				// Otherwise use the payment method type from the API.
+				$selected_payment_type = $payment_method_details->type;
 			}
 			$payment_method_types  = [ $selected_payment_type ];
 		} else {

--- a/readme.txt
+++ b/readme.txt
@@ -124,5 +124,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Fixes some incorrect subscriptions support implementations for payment methods
 * Fix - Ensure correct express checkout prices in block cart and checkout with non-default decimal configuration
 * Fix - Disable express checkout when Amazon Pay is disabled and the only method
+* Fix - Ensure express payment methods are processed correctly when Optimized Checkout is enabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -2991,7 +2991,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 				$this->callback(
 					function ( $payment_information ) use ( $payment_method_id, $express_payment_method, $confirmation_token_id, $order_id ) {
 						if ( '' === $confirmation_token_id ) {
-								$this->assertArrayNotHasKey( 'confirmation_token', $payment_information );
+							$this->assertArrayNotHasKey( 'confirmation_token', $payment_information );
 						} else {
 							$this->assertArrayHasKey( 'confirmation_token', $payment_information );
 							$this->assertEquals( $confirmation_token_id, $payment_information['confirmation_token'] );

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -109,12 +109,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 * Base template for Stripe payment intent.
 	 */
 	const MOCK_CARD_PAYMENT_INTENT_TEMPLATE = [
-		'id'                 => 'pi_mock',
-		'object'             => 'payment_intent',
-		'status'             => WC_Stripe_Intent_Status::SUCCEEDED,
-		'last_payment_error' => [],
-		'client_secret'      => 'cs_mock',
-		'charges'            => [
+		'id'                   => 'pi_mock',
+		'object'               => 'payment_intent',
+		'status'               => WC_Stripe_Intent_Status::SUCCEEDED,
+		'last_payment_error'   => [],
+		'client_secret'        => 'cs_mock',
+		'charges'              => [
 			'total_count' => 1,
 			'data'        => [
 				[
@@ -319,6 +319,50 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Helper method to create a mock express checkout payment method.
+	 *
+	 * @param string $payment_method_id      The payment method ID.
+	 * @param string $express_payment_method The express payment method type.
+	 * @return object The mock express checkout payment method.
+	 */
+	private function get_mock_express_checkout_payment_method( string $payment_method_id, string $express_payment_method ): object {
+		return (object) [
+			'id'              => $payment_method_id,
+			'object'          => 'payment_method',
+			'billing_details' => [
+				'address' => [
+					'city'        => 'San Francisco',
+					'country'     => 'US',
+					'line1'       => '60 29th Street 343',
+					'line2'       => '',
+					'postal_code' => '94110',
+					'state'       => 'CA',
+				],
+				'email'   => 'test.express.checkout@example.com',
+				'name'    => 'Test Express Checkout',
+				'phone'   => '+1234567890',
+				'tax_id'  => null,
+			],
+			'type'            => 'card',
+			'card'            => [
+				'brand'       => 'visa',
+				'last4'       => '4242',
+				'country'     => 'US',
+				'exp_month'   => '12',
+				'exp_year'    => '2025',
+				'funding'     => 'credit',
+				'fingerprint' => 'FingerMOCK',
+				'wallet'      => [
+					'type'                  => $express_payment_method,
+					$express_payment_method => [
+						'type' => $express_payment_method,
+					],
+				],
+			],
+		];
+	}
+
+	/**
 	 * @dataProvider get_upe_available_payment_methods_provider
 	 */
 	public function test_get_upe_available_payment_methods( $country, $available_payment_methods ) {
@@ -427,8 +471,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 					WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 				],
-				'OC enabled' => false,
-				'expected' => [
+				'OC enabled'        => false,
+				'expected'          => [
 					WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 				],
@@ -438,8 +482,8 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 					WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 				],
-				'OC enabled' => true,
-				'expected' => [
+				'OC enabled'                  => true,
+				'expected'                    => [
 					WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
 					WC_Stripe_UPE_Payment_Method_Link::STRIPE_ID,
 				],
@@ -1202,7 +1246,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway->process_upe_redirect_payment( $order_id, $setup_intent_id, true );
 
-		$final_order = wc_get_order( $order_id );
+		$final_order  = wc_get_order( $order_id );
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 
 		$this->assertEquals( OrderStatus::PROCESSING, $final_order->get_status() );
@@ -2827,6 +2871,171 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Data provider for {@see test_process_payment_with_express_checkout_payment_method()}.
+	 *
+	 * @return array
+	 */
+	public function provide_test_process_payment_with_express_checkout_payment_method(): array {
+		return [
+			'Amazon Pay with OC enabled'  => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::AMAZON_PAY,
+				'payment_method_id'          => '',
+				'confirmation_token_id'      => 'ctoken_mock789',
+				'optimized_checkout_enabled' => true,
+			],
+			'Amazon Pay with OC disabled' => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::AMAZON_PAY,
+				'payment_method_id'          => '',
+				'confirmation_token_id'      => 'ctoken_mock789',
+				'optimized_checkout_enabled' => false,
+			],
+			'Apple Pay with OC enabled'   => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::APPLE_PAY,
+				'payment_method_id'          => 'pm_mock321',
+				'confirmation_token_id'      => '',
+				'optimized_checkout_enabled' => true,
+			],
+			'Apple Pay with OC disabled'  => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::APPLE_PAY,
+				'payment_method_id'          => 'pm_mock321',
+				'confirmation_token_id'      => '',
+				'optimized_checkout_enabled' => false,
+			],
+			'Google Pay with OC enabled'  => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::GOOGLE_PAY,
+				'payment_method_id'          => 'pm_mock123',
+				'confirmation_token_id'      => '',
+				'optimized_checkout_enabled' => true,
+			],
+			'Google Pay with OC disabled' => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::GOOGLE_PAY,
+				'payment_method_id'          => 'pm_mock123',
+				'confirmation_token_id'      => '',
+				'optimized_checkout_enabled' => false,
+			],
+			'Link with OC enabled'        => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::LINK,
+				'payment_method_id'          => '',
+				'confirmation_token_id'      => 'ctoken_mock789',
+				'optimized_checkout_enabled' => true,
+			],
+			'Link with OC disabled'       => [
+				'express_payment_method'     => WC_Stripe_Payment_Methods::LINK,
+				'payment_method_id'          => '',
+				'confirmation_token_id'      => 'ctoken_mock789',
+				'optimized_checkout_enabled' => false,
+			],
+		];
+	}
+
+	/**
+	 * Test for `process_payment` with an express checkout payment method.
+	 *
+	 * @param string $express_payment_method     The express payment method.
+	 * @param string $payment_method_id          The payment method ID.
+	 * @param string $confirmation_token_id      The confirmation token ID.
+	 * @param bool   $optimized_checkout_enabled Whether optimized checkout is enabled.
+	 * @return void
+	 *
+	 * @dataProvider provide_test_process_payment_with_express_checkout_payment_method
+	 */
+	public function test_process_payment_with_express_checkout_payment_method( string $express_payment_method, string $payment_method_id, string $confirmation_token_id, bool $optimized_checkout_enabled ): void {
+		$order         = WC_Helper_Order::create_order();
+		$order_id      = $order->get_id();
+		$customer_id   = 'cus_mock1234567890';
+		$stripe_amount = WC_Stripe_Helper::get_stripe_amount( $order->get_total(), $order->get_currency() );
+
+		$_POST['payment_method']               = 'stripe';
+		$_POST['wc-stripe-confirmation-token'] = $confirmation_token_id;
+		$_POST['wc-stripe-payment-method']     = $payment_method_id;
+		$_POST['wc-stripe-is-deferred-intent'] = '1';
+		$_POST['express_payment_type']         = $express_payment_method;
+
+		$this->mock_gateway->oc_enabled = $optimized_checkout_enabled;
+
+		$payment_method_pre_http_filter = null;
+		if ( '' !== $payment_method_id ) {
+			$payment_method_pre_http_filter = function ( $result, $args, $url ) use ( $payment_method_id, $express_payment_method ) {
+				if ( 'payment_methods/' . $payment_method_id === $url ) {
+					return $this->get_mock_express_checkout_payment_method( $payment_method_id, $express_payment_method );
+				}
+				return $result;
+			};
+			add_filter( 'pre_http_request', $payment_method_pre_http_filter, 10, 3 );
+		}
+
+		$mock_intent = (object) [
+			'id'                   => 'pi_mock1234567890',
+			'object'               => 'payment_intent',
+			'amount'               => $stripe_amount,
+			'amount_received'      => $stripe_amount,
+			'currency'             => strtolower( $order->get_currency() ),
+			'customer'             => 'cus_mock1234567890',
+			'description'          => 'Test Store - Order ' . $order_id,
+			'latest_charge'        => 'ch_mock1234567890',
+			'payment_method'       => '' === $payment_method_id ? 'pm_mock1234' : $payment_method_id,
+			'payment_method_types' => [ WC_Stripe_Payment_Methods::AMAZON_PAY === $express_payment_method ? WC_Stripe_Payment_Methods::AMAZON_PAY : WC_Stripe_Payment_Methods::CARD ],
+			'status'               => 'succeeded',
+			'created'              => time(),
+		];
+
+		$this->mock_gateway
+			->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->willReturn( $customer_id );
+
+		$this->mock_gateway->intent_controller
+			->expects( $this->once() )
+			->method( 'create_and_confirm_payment_intent' )
+			->with(
+				$this->callback(
+					function ( $payment_information ) use ( $payment_method_id, $express_payment_method, $confirmation_token_id, $order_id ) {
+						if ( '' === $confirmation_token_id ) {
+								$this->assertArrayNotHasKey( 'confirmation_token', $payment_information );
+						} else {
+							$this->assertArrayHasKey( 'confirmation_token', $payment_information );
+							$this->assertEquals( $confirmation_token_id, $payment_information['confirmation_token'] );
+						}
+						if ( '' === $payment_method_id ) {
+							$this->assertArrayNotHasKey( 'payment_method', $payment_information );
+						} else {
+							$this->assertEquals( $payment_method_id, $payment_information['payment_method'] );
+						}
+						$this->assertInstanceOf( WC_Order::class, $payment_information['order'] );
+						$this->assertEquals( $order_id, $payment_information['order']->get_id() );
+						$expected_selected_payment_type = WC_Stripe_Payment_Methods::AMAZON_PAY === $express_payment_method ? WC_Stripe_Payment_Methods::AMAZON_PAY : WC_Stripe_Payment_Methods::CARD;
+						$this->assertEquals( $expected_selected_payment_type, $payment_information['selected_payment_type'] );
+						$this->assertIsArray( $payment_information['payment_method_types'] );
+						$this->assertContains( $expected_selected_payment_type, $payment_information['payment_method_types'] );
+
+						return true;
+					}
+				)
+			)
+			->willReturn( $mock_intent );
+
+		$mock_charge = (object) [
+			'id'       => 'ch_mock1234567890',
+			'captured' => true,
+			'status'   => 'succeeded',
+		];
+
+		$this->mock_gateway
+			->expects( $this->exactly( 2 ) )
+			->method( 'get_latest_charge_from_intent' )
+			->willReturn( $mock_charge );
+
+		$response = $this->mock_gateway->process_payment( $order_id );
+
+		if ( null !== $payment_method_pre_http_filter ) {
+			remove_filter( 'pre_http_request', $payment_method_pre_http_filter, 10 );
+		}
+
+		$this->assertIsArray( $response );
+		$this->assertEquals( 'success', $response['result'] );
+	}
+
+	/**
 	 * Test for `filter_saved_payment_methods_list`
 	 *
 	 * @param bool $saved_cards Whether saved cards are enabled.
@@ -3110,7 +3319,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$init_oc_enabled  = $this->mock_gateway->oc_enabled;
 		$init_pmc_enabled = $this->mock_gateway->settings['pmc_enabled'] ?? null;
 
-		$this->mock_gateway->oc_enabled = true;
+		$this->mock_gateway->oc_enabled              = true;
 		$this->mock_gateway->settings['pmc_enabled'] = true;
 
 		$order = WC_Helper_Order::create_order();

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -182,7 +182,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$this->mock_gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
 			->setConstructorArgs( [] )
-			->setMethods(
+			->onlyMethods(
 				[
 					'create_and_confirm_intent_for_off_session',
 					'generate_payment_request',
@@ -208,19 +208,19 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			)
 			->getMock();
 
-		$this->mock_gateway->expects( $this->any() )
+		$this->mock_gateway
 			->method( 'get_return_url' )
 			->will(
 				$this->returnValue( self::MOCK_RETURN_URL )
 			);
 
 		$this->mock_gateway->intent_controller = $this->getMockBuilder( WC_Stripe_Intent_Controller::class )
-			->setMethods( [ 'create_and_confirm_payment_intent', 'update_and_confirm_payment_intent', 'create_and_confirm_setup_intent' ] )
+			->onlyMethods( [ 'create_and_confirm_payment_intent', 'update_and_confirm_payment_intent', 'create_and_confirm_setup_intent' ] )
 			->getMock();
 
 		$this->mock_stripe_customer = $this->getMockBuilder( WC_Stripe_Customer::class )
 			->disableOriginalConstructor()
-			->setMethods(
+			->onlyMethods(
 				[
 					'create_customer',
 					'update_customer',
@@ -228,12 +228,12 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			)
 			->getMock();
 
-		$this->mock_stripe_customer->expects( $this->any() )
+		$this->mock_stripe_customer
 			->method( 'create_customer' )
 			->will(
 				$this->returnValue( 'cus_mock' )
 			);
-		$this->mock_stripe_customer->expects( $this->any() )
+		$this->mock_stripe_customer
 			->method( 'update_customer' )
 			->will(
 				$this->returnValue( 'cus_mock' )
@@ -244,14 +244,13 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			[ 'lock_order_payment', 'unlock_order_payment' ]
 		);
 
-		$order_helper->expects( $this->any() )
+		$order_helper
 			->method( 'lock_order_payment' )
 			->will(
 				$this->returnValue( false )
 			);
 
-		$order_helper->expects( $this->any() )
-			->method( 'unlock_order_payment' );
+		$order_helper->method( 'unlock_order_payment' );
 
 		WC_Stripe_Order_Helper::set_instance( $order_helper );
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Towards STRIPE-590

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR fixes a bug that prevents Amazon Pay express checkout purchases from working correctly when Optimized Checkout is enabled.
<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Set up a US-based store with USD as the currency
* Install the Stripe plugin using the code from `develop`
* Ensure that Amazon Pay is available by enabling the feature flag: `wp option update _wcstripe_feature_amazon_pay yes`
* Connect your store to Stripe, and ensure that Optimized Checkout is enabled
* Ensure that Amazon Pay is enabled as an express checkout method, and that it is available from the product, cart, and checkout pages
* Try to make a purchase using Amazon Pay from the product, cart, or checkout page
* Verify that you get an error from the checkout API after completing the express checkout process for Amazon Pay
* Now check out this branch -- `git checkout fix/optimized-checkout-amazon-pay-compatibility-issue`
* Confirm that you can make an Amazon Pay purchase from the product page, block-based cart, block-based checkout, classic cart, and classic checkout.
* Also smoke test that express checkout via Apple Pay and/or Google Pay continue to work
* Also smoke test that a normal purchase using another payment method from checkout continues to work
* 
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
