### PR TITLE
Allow filtering the state when "normalize_state" is called for express payments

### DIFF
--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1127,6 +1127,10 @@ class WC_Stripe_Express_Checkout_Helper {
 			}
 		}
 
+		// Allow 3rd parties to hook into state normalization process.
+		$billing_state  = apply_filters( 'wc_stripe_normalize_billing_state', $billing_state, $billing_country, $data );
+		$shipping_state = apply_filters( 'wc_stripe_normalize_shipping_state', $shipping_state, $shipping_country, $data );
+
 		// Finally we normalize the state value we want to process.
 		if ( $billing_state && $billing_country ) {
 			$data['billing_address']['state'] = $this->get_normalized_state( $billing_state, $billing_country );

--- a/includes/payment-methods/class-wc-stripe-payment-request.php
+++ b/includes/payment-methods/class-wc-stripe-payment-request.php
@@ -1540,6 +1540,10 @@ class WC_Stripe_Payment_Request {
 			}
 		}
 
+		// Allow 3rd parties to hook into state normalization process.
+		$billing_state  = apply_filters( 'wc_stripe_normalize_billing_state', $billing_state, $billing_country, $data );
+		$shipping_state = apply_filters( 'wc_stripe_normalize_shipping_state', $shipping_state, $shipping_country, $data );
+
 		// Finally we normalize the state value we want to process.
 		if ( $billing_state && $billing_country ) {
 			$_POST['billing_state'] = $this->get_normalized_state( $billing_state, $billing_country );


### PR DESCRIPTION
Issue: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4819

Fixes #4819

## Changes proposed in this Pull Request:

See the linked issue.

## Testing instructions

As mentioned in the linked issue, we can filter the address at the choosing shipping method step, but not later in the process. If a similar filter is added here, we can override the state and allow the checkout process to finish.

### Changelog entry

Allow filtering the state when "normalize_state" is called for express payments