### PR TITLE
Fix error handling in subscription renewal processing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@
 * Update - Add minimum transaction amounts for BRL, INR, NZD, THB, CZK, HUF, AED, MYR, PLN, RON
 * Dev - Add additional context data to the OAuth connect flow verbose debug logging mode
 * Fix - Make token detachment checks use shared logic for detaching payment methods
+* Fix - Fix error handling when processing subscription renewals
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -378,6 +378,8 @@ trait WC_Stripe_Subscriptions_Trait {
 	 * @param object $previous_error
 	 */
 	public function process_subscription_payment( $amount, $renewal_order, $retry = true, $previous_error = false ) {
+		$order_locked = false;
+
 		try {
 			$order_id = $renewal_order->get_id();
 
@@ -431,7 +433,13 @@ trait WC_Stripe_Subscriptions_Trait {
 				);
 			}
 
-			WC_Stripe_Logger::log( "Info: Begin processing subscription payment for order {$order_id} for the amount of {$amount}" );
+			WC_Stripe_Logger::debug(
+				"Begin processing subscription payment for order {$order_id} for the amount of {$amount}",
+				[
+					'order_id' => $order_id,
+					'amount'   => $amount,
+				]
+			);
 
 			/*
 			 * If we're doing a retry and source is chargeable, we need to pass
@@ -459,6 +467,7 @@ trait WC_Stripe_Subscriptions_Trait {
 				$is_authentication_required = false;
 			} else {
 				$order_helper->lock_order_payment( $renewal_order );
+				$order_locked               = true;
 				$response                   = $this->create_and_confirm_intent_for_off_session( $renewal_order, $prepared_source, $amount );
 				$is_authentication_required = $this->is_authentication_required_for_payment( $response );
 			}
@@ -513,13 +522,24 @@ trait WC_Stripe_Subscriptions_Trait {
 				throw new WC_Stripe_Exception( print_r( $response, true ), $localized_message );
 			}
 		} catch ( WC_Stripe_Exception $e ) {
-			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+			WC_Stripe_Logger::error(
+				'Error processing subscription payment: ' . $e->getMessage(),
+				[
+					'order_id'          => $order_id,
+					'amount'            => $amount,
+					'error_message'     => $e->getMessage(),
+					'localized_message' => $e->getLocalizedMessage(),
+				]
+			);
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
 
-			/* translators: error message */
 			$renewal_order->update_status( OrderStatus::FAILED );
-			$order_helper->unlock_order_payment( $renewal_order );
+
+			if ( $order_locked && isset( $order_helper ) ) {
+				$order_helper->unlock_order_payment( $renewal_order );
+				$order_locked = false;
+			}
 
 			return;
 		}
@@ -586,12 +606,22 @@ trait WC_Stripe_Subscriptions_Trait {
 				$this->process_response( ( ! empty( $latest_charge ) ) ? $latest_charge : $response, $renewal_order );
 			}
 		} catch ( WC_Stripe_Exception $e ) {
-			WC_Stripe_Logger::log( 'Error: ' . $e->getMessage() );
+			WC_Stripe_Logger::error(
+				'Error processing subscription payment: ' . $e->getMessage(),
+				[
+					'order_id'          => $order_id,
+					'amount'            => $amount,
+					'error_message'     => $e->getMessage(),
+					'localized_message' => $e->getLocalizedMessage(),
+				]
+			);
 
 			do_action( 'wc_gateway_stripe_process_payment_error', $e, $renewal_order );
 		}
 
-		$order_helper->unlock_order_payment( $renewal_order );
+		if ( $order_locked && isset( $order_helper ) ) {
+			$order_helper->unlock_order_payment( $renewal_order );
+		}
 	}
 
 	/**

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -523,7 +523,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			}
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::error(
-				'Error processing subscription payment: ' . $e->getMessage(),
+				'Error processing subscription renewal payment: ' . $e->getMessage(),
 				[
 					'order_id'          => $renewal_order->get_id(),
 					'amount'            => $amount,
@@ -607,7 +607,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			}
 		} catch ( WC_Stripe_Exception $e ) {
 			WC_Stripe_Logger::error(
-				'Error processing subscription payment: ' . $e->getMessage(),
+				'Error processing subscription renewal payment: ' . $e->getMessage(),
 				[
 					'order_id'          => $renewal_order->get_id(),
 					'amount'            => $amount,

--- a/includes/compat/trait-wc-stripe-subscriptions.php
+++ b/includes/compat/trait-wc-stripe-subscriptions.php
@@ -525,7 +525,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			WC_Stripe_Logger::error(
 				'Error processing subscription payment: ' . $e->getMessage(),
 				[
-					'order_id'          => $order_id,
+					'order_id'          => $renewal_order->get_id(),
 					'amount'            => $amount,
 					'error_message'     => $e->getMessage(),
 					'localized_message' => $e->getLocalizedMessage(),
@@ -609,7 +609,7 @@ trait WC_Stripe_Subscriptions_Trait {
 			WC_Stripe_Logger::error(
 				'Error processing subscription payment: ' . $e->getMessage(),
 				[
-					'order_id'          => $order_id,
+					'order_id'          => $renewal_order->get_id(),
 					'amount'            => $amount,
 					'error_message'     => $e->getMessage(),
 					'localized_message' => $e->getLocalizedMessage(),

--- a/readme.txt
+++ b/readme.txt
@@ -129,5 +129,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Add minimum transaction amounts for BRL, INR, NZD, THB, CZK, HUF, AED, MYR, PLN, RON
 * Dev - Add additional context data to the OAuth connect flow verbose debug logging mode
 * Fix - Make token detachment checks use shared logic for detaching payment methods
+* Fix - Fix error handling when processing subscription renewals
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Subscription_Renewal_Test.php
+++ b/tests/phpunit/WC_Stripe_Subscription_Renewal_Test.php
@@ -437,7 +437,7 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 		$source        = 'src_123abc';
 		$customer      = 'cus_123abc';
 
-		// Mock prepare_order_source() to return a missing customer.
+		// Mock prepare_order_source() to return a valid customer.
 		$this->wc_gateway_stripe
 			->method( 'prepare_order_source' )
 			->willReturn(

--- a/tests/phpunit/WC_Stripe_Subscription_Renewal_Test.php
+++ b/tests/phpunit/WC_Stripe_Subscription_Renewal_Test.php
@@ -48,16 +48,13 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		$this->wc_gateway_stripe = $this->getMockBuilder( 'WC_Stripe_UPE_Payment_Gateway' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'prepare_order_source', 'has_subscription' ] )
+			->onlyMethods( [ 'prepare_order_source', 'has_subscription' ] )
 			->getMock();
 
 		// Mocked in order to get metadata[payment_type] = recurring in the HTTP request.
 		$this->wc_gateway_stripe
-			->expects( $this->any() )
 			->method( 'has_subscription' )
-			->will(
-				$this->returnValue( true )
-			);
+			->willReturn( true );
 
 		$this->statement_descriptor = 'This is a statement descriptor.';
 
@@ -390,5 +387,117 @@ class WC_Stripe_Subscription_Renewal_Test extends WP_UnitTestCase {
 
 		// Clean up.
 		remove_filter( 'pre_http_request', [ $this, 'pre_http_request_response_success' ] );
+	}
+
+	public function test_missing_customer() {
+		$renewal_order = WC_Helper_Order::create_order();
+		$source        = 'src_123abc';
+
+		// Mock prepare_order_source() to return a missing customer.
+		$this->wc_gateway_stripe
+			->method( 'prepare_order_source' )
+			->willReturn(
+				(object) [
+					'token_id'       => false,
+					'customer'       => null,
+					'source'         => $source,
+					'source_object'  => (object) [
+						'type' => WC_Stripe_Payment_Methods::CARD,
+					],
+					'payment_method' => null,
+				]
+			);
+
+		$thrown_exception = null;
+		$error_helper     = function ( $exception, $order ) use ( &$thrown_exception, $renewal_order ) {
+			if ( $order && $order->get_id() === $renewal_order->get_id() ) {
+				$thrown_exception = $exception;
+			}
+		};
+
+		\add_action( 'wc_gateway_stripe_process_payment_error', $error_helper, 10, 2 );
+
+		// Process via the mocked gateway.
+		$this->wc_gateway_stripe->process_subscription_payment( $renewal_order->get_total(), $renewal_order, false, false );
+
+		\remove_action( 'wc_gateway_stripe_process_payment_error', $error_helper, 10 );
+
+		$this->assertEquals( \Automattic\WooCommerce\Enums\OrderStatus::FAILED, $renewal_order->get_status() );
+		$this->assertInstanceOf( \WC_Stripe_Exception::class, $thrown_exception );
+
+		$expected_raw_error       = 'Failed to process renewal for order ' . $renewal_order->get_id() . '. Stripe customer id is missing in the order';
+		$expected_localized_error = __( 'Customer not found', 'woocommerce-gateway-stripe' );
+
+		$this->assertEquals( $expected_raw_error, $thrown_exception->getMessage() );
+		$this->assertEquals( $expected_localized_error, $thrown_exception->getLocalizedMessage() );
+	}
+
+	public function test_payment_intent_returns_non_retryable_error() {
+		$renewal_order = WC_Helper_Order::create_order();
+		$source        = 'src_123abc';
+		$customer      = 'cus_123abc';
+
+		// Mock prepare_order_source() to return a missing customer.
+		$this->wc_gateway_stripe
+			->method( 'prepare_order_source' )
+			->willReturn(
+				(object) [
+					'token_id'       => false,
+					'customer'       => $customer,
+					'source'         => $source,
+					'source_object'  => (object) [
+						'type' => WC_Stripe_Payment_Methods::CARD,
+					],
+					'payment_method' => null,
+				]
+			);
+
+		$mock_error = (object) [
+			'error' => (object) [
+				'type'    => 'card_error',
+				'code'    => 'card_declined',
+				'message' => 'Mock card declined error',
+			],
+		];
+
+		// Arrange: Add filter that will return a mocked HTTP response for the payment_intent call.
+		// Note: There are assertions in the callback function.
+		$pre_http_request_response_callback = function ( $preempt, $request_args, $url ) use ( $mock_error ) {
+			if ( 'https://api.stripe.com/v1/payment_intents' !== $url ) {
+				return $preempt;
+			}
+
+			return [
+				'headers'  => [],
+				'body'     => json_encode( $mock_error ),
+				'response' => [
+					'code'    => 400,
+					'message' => 'Bad Request',
+				],
+			];
+		};
+		\add_filter( 'pre_http_request', $pre_http_request_response_callback, 10, 3 );
+
+		$thrown_exception = null;
+		$error_helper     = function ( $exception, $order ) use ( &$thrown_exception, $renewal_order ) {
+			if ( $order && $order->get_id() === $renewal_order->get_id() ) {
+				$thrown_exception = $exception;
+			}
+		};
+		\add_action( 'wc_gateway_stripe_process_payment_error', $error_helper, 10, 2 );
+
+		$this->wc_gateway_stripe->process_subscription_payment( $renewal_order->get_total(), $renewal_order, false, false );
+
+		\remove_filter( 'pre_http_request', $pre_http_request_response_callback, 10 );
+		\remove_action( 'wc_gateway_stripe_process_payment_error', $error_helper, 10 );
+
+		$this->assertEquals( \Automattic\WooCommerce\Enums\OrderStatus::FAILED, $renewal_order->get_status() );
+		$this->assertInstanceOf( \WC_Stripe_Exception::class, $thrown_exception );
+
+		$expected_raw_error       = print_r( $mock_error, true );
+		$expected_localized_error = __( 'The card was declined.', 'woocommerce-gateway-stripe' );
+
+		$this->assertEquals( $expected_raw_error, $thrown_exception->getMessage() );
+		$this->assertEquals( $expected_localized_error, $thrown_exception->getLocalizedMessage() );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-823

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates the error handling and logic in `WC_Stripe_Subscriptions_Trait->process_subscription_payment()` to ensure we don't trigger errors from our error handling. The key changes are to track whether we've locked the current payment, and to unlock it only when we've already locked it _and_ we have a reference to our order helper object.

This PR also updates the logging for the method to use the newer `debug()` and `error()` log methods, and updates the unit tests to ensure we catch the two most likely error conditions.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Code inspection should be a good first step here, as I haven't made changes to the core functional aspects.
* Next, we want to verify that the unit tests _fail_ against develop
   - Check out and update this branch to make sure you have all the commits: `git checkout fix/fatal-error-in-subscription-processing && git pull`
   - Now check out `develop` - `git checkout develop`
   - Now apply the unit test changes from c22cda4f15f224fdfa39619b714a92054ee6848e to the local develop: `git show -p c22cda4f15f224fdfa39619b714a92054ee6848e | git apply` (you could also cherry-pick, or any other mechanism you prefer -- this approach doesn't commit or stage any files)
   - Now run the PHP unit tests: `npm run test:php -- --filter=WC_Stripe_Subscription_Renewal_Test`
   - You should see that the `test_missing_customer` test triggers an error due to `$order_helper` being undefined
* Functionally, test that a subscription renewal works correctly (though my changes are focused on the error handling)

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
