### PR TITLE
Agentic Checkout: Add first pass at hosted ACP implementation

### DIFF
--- a/docs/agentic-checkout.md
+++ b/docs/agentic-checkout.md
@@ -1,0 +1,787 @@
+# Agentic Checkout
+
+Agentic Checkout enables WooCommerce stores (as Stripe Connected Accounts) to receive and process orders initiated by AI agents through Stripe's Agentic Checkout Protocol (ACP).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Requirements](#requirements)
+- [How It Works](#how-it-works)
+- [Setup and Configuration](#setup-and-configuration)
+- [REST API Endpoints](#rest-api-endpoints)
+- [Webhook Handling](#webhook-handling)
+- [Manual Capture Workflow](#manual-capture-workflow)
+- [Developer Hooks](#developer-hooks)
+- [Troubleshooting](#troubleshooting)
+- [Security](#security)
+
+## Overview
+
+### What is Agentic Checkout?
+
+Agentic Checkout allows AI agents (such as ChatGPT, Google Gemini, and other AI assistants) to purchase products from your WooCommerce store on behalf of users. When a user asks an AI agent to buy something, the agent can discover your products, calculate pricing and shipping, and complete the purchase through Stripe's secure checkout process.
+
+### Benefits for Merchants
+
+- **Reach New Customers**: AI agents can discover and recommend your products to users
+- **Seamless Integration**: Works with existing WooCommerce tax, shipping, and inventory systems
+- **Secure Transactions**: All payments processed through Stripe with signature verification
+- **Full Control**: Approve or decline orders before payment confirmation
+- **Flexible Customization**: Extensive filter and action hooks for custom business logic
+
+### Platform Model
+
+- **Platform**: WooCommerce.com / Automattic's Stripe account
+- **Connected Accounts**: Individual WooCommerce stores using this gateway
+- **Enrollment**: Handled platform-side by Stripe/WooCommerce.com
+- **Store Control**: Gated by PHP filter (opt-in required)
+
+## Requirements
+
+### Minimum Versions
+
+- WordPress 6.0 or higher
+- WooCommerce 8.0 or higher
+- PHP 7.4 or higher
+
+### Stripe Configuration
+
+- Active Stripe account connected to WooCommerce
+- Webhook secret configured in Stripe gateway settings
+- Products must have SKUs that match Stripe Price `lookup_key` fields
+- Product catalog synced to Stripe (handled by platform)
+
+## How It Works
+
+1. **Product Discovery**: AI agents discover your products through Stripe's catalog
+2. **Checkout Initiation**: Agent creates a Checkout Session for the user
+3. **Dynamic Calculations**: Stripe calls your store's REST API endpoints for:
+   - Tax calculation (using WooCommerce tax engine)
+   - Shipping options (using WooCommerce shipping zones)
+   - Order approval (custom validation logic)
+4. **Payment Processing**: Stripe confirms payment based on your responses
+5. **Order Creation**: Your store receives a webhook and creates the WooCommerce order
+6. **Order Fulfillment**: Order processed like any regular WooCommerce order
+
+## Setup and Configuration
+
+### Enable Agentic Checkout
+
+Agentic Checkout is disabled by default. To enable it, add this filter to your theme's `functions.php` file or a custom plugin:
+
+```php
+add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+```
+
+**Important**: Only enable this feature if:
+- Your store is enrolled in Stripe's Agentic Checkout program
+- You have configured webhook endpoints in Stripe Dashboard
+- Your products have accurate SKUs matching Stripe Price lookup keys
+
+### Configure Webhook Secret
+
+1. Go to **WooCommerce → Settings → Payments → Stripe**
+2. Scroll to **Webhook Settings**
+3. Enter your webhook secret (get this from Stripe Dashboard)
+4. Save changes
+
+The webhook secret is used to verify that requests are genuinely from Stripe.
+
+### Product Setup
+
+Each product must have:
+- A unique SKU
+- SKU must match the `lookup_key` on the corresponding Stripe Price
+- Accurate tax class configured
+- Correct shipping class if product requires shipping
+
+## REST API Endpoints
+
+Agentic Checkout adds three REST API endpoints to your store. These endpoints are automatically registered when the feature is enabled and are called by Stripe during the checkout process.
+
+### Manual Approval Hook
+
+**Endpoint**: `POST /wc/v3/stripe/agentic/approve`
+
+**Purpose**: Allows your store to approve or decline orders before payment is confirmed.
+
+**Request Format**:
+```json
+{
+  "id": "cs_test_123abc",
+  "line_items": {
+    "data": [
+      {
+        "price": {
+          "lookup_key": "product-sku-123"
+        },
+        "quantity": 2
+      }
+    ]
+  },
+  "amount_total": 5000,
+  "payment_method_details": {
+    "type": "card"
+  }
+}
+```
+
+**Response Format (Approved)**:
+```json
+{
+  "id": "cs_test_123abc",
+  "result": {
+    "type": "approved"
+  }
+}
+```
+
+**Response Format (Declined)**:
+```json
+{
+  "id": "cs_test_123abc",
+  "result": {
+    "type": "declined",
+    "declined": {
+      "reason": "low_inventory"
+    }
+  }
+}
+```
+
+**Validation Checks**:
+- Products exist and SKUs are valid
+- Products are purchasable
+- Products are in stock
+- Stock quantity is sufficient for order quantity
+- Custom validation via `wc_stripe_agentic_approval_decision` filter
+
+**Decline Reasons**:
+- `product_not_found` - Product SKU doesn't exist
+- `product_not_purchasable` - Product cannot be purchased
+- `low_inventory` - Insufficient stock
+- `validation_failed` - General validation failure
+- Custom reasons via `wc_stripe_agentic_decline_reason` filter
+
+### Tax Calculation Hook
+
+**Endpoint**: `POST /wc/v3/stripe/agentic/compute_tax`
+
+**Purpose**: Calculates taxes using your WooCommerce tax settings and customer location.
+
+**Request Format**:
+```json
+{
+  "livemode": false,
+  "currency": "usd",
+  "line_items_details": [
+    {
+      "sku_id": "product-sku-123",
+      "unit_amount": 2500,
+      "quantity": 2
+    }
+  ],
+  "fulfillment_details": {
+    "address": {
+      "city": "San Francisco",
+      "state": "CA",
+      "postal_code": "94107",
+      "country": "US"
+    }
+  },
+  "billing_details": {
+    "address": {
+      "city": "San Francisco",
+      "state": "CA",
+      "postal_code": "94107",
+      "country": "US"
+    }
+  }
+}
+```
+
+**Response Format**:
+```json
+{
+  "line_item_details": [
+    {
+      "sku_id": "product-sku-123",
+      "amount_tax": 437
+    }
+  ],
+  "fulfillment_details": {
+    "amount_tax": 0
+  },
+  "total_details": {
+    "amount_tax": 437
+  }
+}
+```
+
+**Tax Calculation**:
+- Uses WooCommerce tax rates and zones
+- Respects product tax classes
+- Works with tax plugins (TaxJar, Avalara, etc.)
+- Calculates based on shipping or billing address
+- Amounts in cents (USD)
+
+### Shipping Calculation Hook
+
+**Endpoint**: `POST /wc/v3/stripe/agentic/compute_shipping_options`
+
+**Purpose**: Returns available shipping methods and rates from WooCommerce.
+
+**Request Format**:
+```json
+{
+  "livemode": false,
+  "currency": "usd",
+  "line_items_details": [
+    {
+      "sku_id": "product-sku-123",
+      "unit_amount": 2500,
+      "quantity": 1
+    }
+  ],
+  "fulfillment_details": {
+    "address": {
+      "city": "San Francisco",
+      "state": "CA",
+      "postal_code": "94107",
+      "country": "US"
+    }
+  }
+}
+```
+
+**Response Format**:
+```json
+{
+  "fulfillment_options": [
+    {
+      "display_name": "Standard Shipping",
+      "description": "5-7 business days",
+      "shipping_amount": 1000,
+      "earliest_delivery_time": 1663480800,
+      "latest_delivery_time": 1663653600
+    },
+    {
+      "display_name": "Express Shipping",
+      "description": "2-3 business days",
+      "shipping_amount": 2500,
+      "earliest_delivery_time": 1663308000,
+      "latest_delivery_time": 1663394400
+    }
+  ]
+}
+```
+
+**Shipping Calculation**:
+- Uses WooCommerce shipping zones
+- Includes all enabled shipping methods
+- Works with shipping plugins (ShipStation, WooCommerce Shipping, etc.)
+- Skips non-shippable products (virtual/downloadable)
+- Returns empty array if no shipping methods available
+
+### Authentication
+
+All three endpoints use Stripe webhook signature verification:
+- Requests must include `Stripe-Signature` header
+- Signature verified using webhook secret from settings
+- Uses HMAC SHA256 with timestamp validation
+- Requests must arrive within 5-minute window
+- Invalid signatures receive 403 Forbidden response
+
+## Webhook Handling
+
+### checkout.session.completed Event
+
+When a user completes an agentic checkout, Stripe sends a `checkout.session.completed` webhook to your store.
+
+**Detection**: The webhook handler identifies agentic orders by:
+- Checking for `agentic: true` in checkout session metadata
+- Checking for `origin_context` field (may be added by Stripe)
+
+**Order Creation Process**:
+
+1. **Validate Webhook**: Verify Stripe signature
+2. **Parse Session Data**: Extract customer, line items, payment details
+3. **Create WooCommerce Order**:
+   - Map line items to order products (by SKU)
+   - Set customer billing/shipping addresses
+   - Add shipping line item if present
+   - Set payment method to "Stripe (Agentic Checkout)"
+   - Store payment intent ID
+4. **Set Order Status**:
+   - `processing` (or `completed` for virtual products) if payment captured
+   - `on-hold` if manual capture mode
+   - `pending` if payment not confirmed
+5. **Add Order Note**: "Order created via AI agent checkout (Agent Name)"
+6. **Set Metadata**:
+   - `_wc_stripe_agentic_order` = `true`
+   - `_wc_stripe_checkout_session_id` = Checkout Session ID
+   - `_stripe_intent_id` = Payment Intent ID (for manual capture)
+7. **Trigger Actions**: Fire `wc_stripe_agentic_order_created` action
+8. **Send Emails**: Standard WooCommerce order emails sent
+
+**Error Handling**:
+- If product SKU not found, webhook fails and logs error
+- If order creation fails, fires `wc_stripe_agentic_order_failed` action
+- All errors logged to WooCommerce logs
+
+## Manual Capture Workflow
+
+Agentic Checkout supports Stripe's manual capture mode for orders that require review before capturing payment.
+
+### When to Use Manual Capture
+
+- High-value orders requiring verification
+- Orders with custom/personalized products
+- Orders flagged by fraud prevention systems
+- Stores with manual review processes
+
+### How Manual Capture Works
+
+1. **Order Placed**: AI agent completes checkout with manual capture enabled
+2. **Authorization**: Stripe authorizes the payment (holds funds)
+3. **Order Created**: Your store receives webhook and creates order
+4. **Order Status**: Set to `on-hold` with note "Payment authorized, awaiting capture"
+5. **Review Order**: Merchant reviews order in WooCommerce admin
+6. **Capture Payment**: Merchant captures payment via:
+   - WooCommerce order actions dropdown: "Capture charge"
+   - Stripe Dashboard: Capture the Payment Intent
+7. **Order Completed**: Status updated to `processing` or `completed`
+
+### Identifying Manual Capture Orders
+
+Manual capture orders have:
+- Order status: `on-hold`
+- Order meta: `_stripe_manual_capture` = `yes`
+- Order meta: `_stripe_intent_id` = Payment Intent ID
+- Order note: "Payment authorized, awaiting capture"
+
+### Capturing Payment
+
+**Via WooCommerce Admin**:
+1. Go to **WooCommerce → Orders**
+2. Open the order
+3. Under **Order Actions** dropdown, select "Capture charge"
+4. Click **Update**
+
+**Via Stripe Dashboard**:
+1. Go to **Payments → Payment Intents**
+2. Find the Payment Intent (use ID from order meta)
+3. Click **Capture**
+
+### Capture Expiration
+
+Uncaptured charges expire after 7 days. Ensure you capture or cancel orders within this timeframe.
+
+## Developer Hooks
+
+### Filters
+
+#### Enable/Disable Feature
+
+```php
+/**
+ * Enable or disable Agentic Checkout functionality.
+ *
+ * @param bool $enabled Whether agentic checkout is enabled. Default false.
+ * @return bool
+ */
+add_filter( 'wc_stripe_agentic_checkout_enabled', function( $enabled ) {
+    // Only enable for specific store IDs, user roles, etc.
+    return true;
+} );
+```
+
+#### Approval Decision
+
+```php
+/**
+ * Override approval decision for agentic checkout orders.
+ *
+ * @param bool  $approved              Whether to approve the order. Default true.
+ * @param array $checkout_session_data Full checkout session data from Stripe.
+ * @param array $line_items            Line items being purchased.
+ * @param array $payment_method_details Payment method details.
+ * @return bool
+ */
+add_filter( 'wc_stripe_agentic_approval_decision', function( $approved, $checkout_session, $line_items, $payment_method ) {
+    // Example: Decline orders over $500
+    $amount_total = $checkout_session['amount_total'] ?? 0;
+    if ( $amount_total > 50000 ) { // Amount in cents
+        return false;
+    }
+
+    // Example: Decline orders with specific payment methods
+    $card_type = $payment_method['card']['brand'] ?? '';
+    if ( 'amex' === $card_type ) {
+        return false;
+    }
+
+    return $approved;
+}, 10, 4 );
+```
+
+#### Decline Reason
+
+```php
+/**
+ * Customize decline reason for agentic checkout orders.
+ *
+ * @param string $reason               Default decline reason.
+ * @param array  $checkout_session_data Full checkout session data.
+ * @return string
+ */
+add_filter( 'wc_stripe_agentic_decline_reason', function( $reason, $checkout_session ) {
+    // Provide custom decline reasons based on your logic
+    if ( $reason === 'validation_failed' ) {
+        return 'order_review_required';
+    }
+    return $reason;
+}, 10, 2 );
+```
+
+#### Tax Calculation
+
+```php
+/**
+ * Override or modify tax amounts for agentic checkout.
+ *
+ * @param array $tax_amounts Calculated tax amounts.
+ * @param array $line_items  Line items being purchased.
+ * @param array $addresses   Fulfillment and billing addresses.
+ * @return array
+ */
+add_filter( 'wc_stripe_agentic_tax_calculation', function( $tax_amounts, $line_items, $addresses ) {
+    // Example: Apply custom tax logic
+    $fulfillment_address = $addresses['fulfillment'] ?? [];
+
+    // Add custom tax for specific states
+    if ( 'NY' === ( $fulfillment_address['state'] ?? '' ) ) {
+        $tax_amounts['total_details']['amount_tax'] += 100; // Add $1.00 tax
+    }
+
+    return $tax_amounts;
+}, 10, 3 );
+```
+
+#### Shipping Options
+
+```php
+/**
+ * Modify shipping options for agentic checkout.
+ *
+ * @param array $shipping_options Calculated shipping options.
+ * @param array $cart_items       Cart items (line items).
+ * @param array $destination      Destination address.
+ * @return array
+ */
+add_filter( 'wc_stripe_agentic_shipping_options', function( $shipping_options, $cart_items, $destination ) {
+    // Example: Add expedited shipping for specific locations
+    if ( 'CA' === ( $destination['state'] ?? '' ) ) {
+        $shipping_options[] = [
+            'display_name'      => 'Same-Day Delivery',
+            'description'       => 'Delivered today',
+            'shipping_amount'   => 3000, // $30.00
+            'earliest_delivery_time' => strtotime( '+4 hours' ),
+            'latest_delivery_time'   => strtotime( '+8 hours' ),
+        ];
+    }
+
+    // Example: Filter out expensive shipping
+    $shipping_options = array_filter( $shipping_options, function( $option ) {
+        return $option['shipping_amount'] < 5000; // Max $50 shipping
+    } );
+
+    return $shipping_options;
+}, 10, 3 );
+```
+
+#### Product Lookup
+
+```php
+/**
+ * Customize product lookup by SKU for agentic checkout.
+ *
+ * @param WC_Product|null $product Product object or null if not found.
+ * @param string          $sku     Product SKU.
+ * @return WC_Product|null
+ */
+add_filter( 'wc_stripe_agentic_product_by_sku', function( $product, $sku ) {
+    // Example: Custom SKU mapping logic
+    if ( ! $product ) {
+        // Try alternative SKU formats
+        $alt_sku = str_replace( '-', '_', $sku );
+        $product_id = wc_get_product_id_by_sku( $alt_sku );
+        $product = $product_id ? wc_get_product( $product_id ) : null;
+    }
+
+    return $product;
+}, 10, 2 );
+```
+
+#### Debug Mode
+
+```php
+/**
+ * Enable debug mode for detailed logging.
+ *
+ * @param bool $debug_mode Whether debug mode is enabled. Default false.
+ * @return bool
+ */
+add_filter( 'wc_stripe_agentic_debug_mode', function( $debug_mode ) {
+    // Enable debug logging
+    return true;
+} );
+```
+
+### Actions
+
+#### Order Created
+
+```php
+/**
+ * Triggered when an agentic order is successfully created.
+ *
+ * @param WC_Order $order            Created WooCommerce order.
+ * @param object   $checkout_session Stripe checkout session object.
+ */
+add_action( 'wc_stripe_agentic_order_created', function( $order, $checkout_session ) {
+    // Example: Send notification to Slack
+    $agent_name = $checkout_session->metadata->agent ?? 'Unknown Agent';
+    $message = sprintf(
+        'New agentic order #%d from %s - Total: %s',
+        $order->get_id(),
+        $agent_name,
+        $order->get_formatted_order_total()
+    );
+    // Send to Slack...
+
+    // Example: Add custom order note
+    $order->add_order_note(
+        sprintf( 'AI Agent: %s', $agent_name ),
+        false,
+        true
+    );
+    $order->save();
+
+    // Example: Tag order in third-party system
+    // update_external_crm( $order->get_id(), 'agentic-order' );
+}, 10, 2 );
+```
+
+#### Order Failed
+
+```php
+/**
+ * Triggered when agentic order creation fails.
+ *
+ * @param WP_Error $error           Error object with failure details.
+ * @param object   $checkout_session Stripe checkout session object.
+ */
+add_action( 'wc_stripe_agentic_order_failed', function( $error, $checkout_session ) {
+    // Example: Send alert email to admin
+    $admin_email = get_option( 'admin_email' );
+    $subject = 'Agentic Order Creation Failed';
+    $message = sprintf(
+        "Order creation failed for checkout session: %s\n\nError: %s",
+        $checkout_session->id ?? 'unknown',
+        $error->get_error_message()
+    );
+    wp_mail( $admin_email, $subject, $message );
+
+    // Example: Log to external monitoring service
+    // error_reporting_service()->log( $error->get_error_message() );
+}, 10, 2 );
+```
+
+## Troubleshooting
+
+### Enabling Debug Logging
+
+To see detailed logs for all agentic checkout requests:
+
+```php
+add_filter( 'wc_stripe_agentic_debug_mode', '__return_true' );
+```
+
+View logs in **WooCommerce → Status → Logs** and select the `stripe` log file.
+
+### Common Issues
+
+#### Endpoints Not Accessible
+
+**Symptom**: Stripe reports endpoints are unreachable
+
+**Solutions**:
+1. Verify filter is enabled:
+   ```php
+   add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+   ```
+2. Check webhook secret is configured in Stripe settings
+3. Ensure permalink structure is set (not "Plain")
+4. Verify REST API is working: Visit `/wp-json/wc/v3/stripe/agentic/approve` (should return 403, not 404)
+5. Check server firewall isn't blocking Stripe IPs
+
+#### Orders Not Being Created
+
+**Symptom**: Webhook received but no order appears in WooCommerce
+
+**Solutions**:
+1. Check WooCommerce logs: **Status → Logs → stripe**
+2. Verify products have SKUs matching Stripe Price `lookup_key`
+3. Enable debug mode to see detailed request/response data
+4. Check webhook is properly configured in Stripe Dashboard
+5. Verify webhook secret matches between Stripe and WooCommerce settings
+
+#### Signature Verification Failures
+
+**Symptom**: Logs show "invalid_signature" errors
+
+**Solutions**:
+1. Verify webhook secret is correctly entered in **WooCommerce → Settings → Payments → Stripe**
+2. Ensure you're using the correct secret (test vs live mode)
+3. Check server time is accurate (signature includes timestamp)
+4. Verify webhook URL in Stripe Dashboard matches your site URL
+5. Don't modify webhook payload (signature verifies exact payload)
+
+#### Tax Calculation Errors
+
+**Symptom**: Tax endpoint returns errors or incorrect amounts
+
+**Solutions**:
+1. Verify WooCommerce tax settings are configured: **Settings → Tax**
+2. Check tax rates are set up for customer's location
+3. Ensure products have correct tax class assigned
+4. Test tax calculation with regular WooCommerce checkout
+5. Review logs for specific error messages
+6. If using tax plugin (TaxJar, Avalara), verify plugin is active and configured
+
+#### Shipping Calculation Errors
+
+**Symptom**: Shipping endpoint returns empty array or errors
+
+**Solutions**:
+1. Verify WooCommerce shipping zones are configured: **Settings → Shipping**
+2. Check shipping zone covers customer's location
+3. Ensure shipping methods are enabled
+4. Verify products require shipping (not virtual/downloadable)
+5. Test shipping calculation in regular WooCommerce checkout
+6. Check for conflicting shipping plugins
+
+#### Products Not Found by SKU
+
+**Symptom**: Approval or order creation fails with "Product not found" error
+
+**Solutions**:
+1. Verify every product has a SKU assigned
+2. Check SKU matches exactly with Stripe Price `lookup_key`
+3. SKUs are case-sensitive - ensure exact match
+4. In Stripe Dashboard, verify Price has `lookup_key` set
+5. Use `wc_stripe_agentic_product_by_sku` filter for custom SKU mapping
+
+#### Manual Capture Not Working
+
+**Symptom**: Can't capture payment or "Capture charge" action missing
+
+**Solutions**:
+1. Verify order has `_stripe_intent_id` meta set
+2. Check order status is `on-hold`
+3. Ensure capture is attempted within 7 days of authorization
+4. Try capturing via Stripe Dashboard instead
+5. Check Stripe logs for capture errors
+
+### Debug Information to Collect
+
+When reporting issues, include:
+
+1. **Plugin Versions**:
+   - WordPress version
+   - WooCommerce version
+   - WooCommerce Stripe Gateway version
+
+2. **Logs**:
+   - WooCommerce logs (WooCommerce → Status → Logs → stripe)
+   - Server error logs
+   - Stripe Dashboard webhook logs
+
+3. **Configuration**:
+   - Is `wc_stripe_agentic_checkout_enabled` filter active?
+   - Is webhook secret configured?
+   - Test mode or live mode?
+
+4. **Request Details**:
+   - Checkout Session ID
+   - Timestamp of request
+   - Customer location (for tax/shipping issues)
+   - Product SKUs involved
+
+## Security
+
+### Authentication & Authorization
+
+All agentic checkout endpoints use Stripe webhook signature verification:
+
+- **HMAC SHA256**: Requests signed using webhook secret
+- **Timestamp Validation**: Requests must arrive within 5 minutes
+- **Replay Protection**: Timestamps prevent replay attacks
+- **Secret Rotation**: Rotate webhook secrets regularly in Stripe Dashboard
+
+### Best Practices
+
+1. **Webhook Secret Security**:
+   - Store webhook secret securely in WooCommerce settings
+   - Never commit webhook secrets to version control
+   - Rotate secrets periodically
+   - Use different secrets for test and live modes
+
+2. **Input Validation**:
+   - All product lookups validate SKU format
+   - Quantities and amounts validated before processing
+   - Customer addresses sanitized before storage
+
+3. **Error Handling**:
+   - Failed validations return appropriate error codes
+   - Sensitive information never included in error messages
+   - All errors logged for audit trail
+
+4. **Rate Limiting**:
+   - Consider implementing rate limiting for high-traffic stores
+   - Monitor for unusual request patterns
+   - Use Stripe Dashboard to monitor webhook deliveries
+
+5. **Testing**:
+   - Always test in Stripe test mode first
+   - Use test webhook secrets for development
+   - Never use production data in test mode
+
+### Compliance
+
+- **PCI Compliance**: Payment data never stored on your server
+- **GDPR**: Customer data processed according to WooCommerce privacy settings
+- **Data Retention**: Follow WooCommerce data retention policies
+
+## Additional Resources
+
+- [Stripe Agentic Checkout Documentation](https://stripe.com/docs/agentic-checkout)
+- [WooCommerce REST API Documentation](https://woocommerce.github.io/woocommerce-rest-api-docs/)
+- [Stripe Webhook Documentation](https://stripe.com/docs/webhooks)
+- [WooCommerce Stripe Gateway Support](https://woocommerce.com/document/stripe/)
+
+## Support
+
+For issues or questions:
+
+1. Check [Troubleshooting](#troubleshooting) section above
+2. Review [WooCommerce logs](#enabling-debug-logging)
+3. Check [Stripe Dashboard webhook logs](https://dashboard.stripe.com/webhooks)
+4. Contact WooCommerce Support for feature assistance
+5. File bug reports on [GitHub repository](https://github.com/woocommerce/woocommerce-gateway-stripe)
+
+---
+
+**Version**: 8.9.0
+**Last Updated**: January 2025

--- a/includes/abstracts/trait-wc-stripe-agentic-authentication.php
+++ b/includes/abstracts/trait-wc-stripe-agentic-authentication.php
@@ -46,10 +46,10 @@ trait WC_Stripe_Agentic_Authentication {
 		if ( empty( $secret ) ) {
 			WC_Stripe_Logger::log(
 				'Agentic: Authentication failed - webhook secret not configured',
-				array(
+				[
 					'context' => 'agentic_authentication',
 					'testmode' => $testmode,
-				)
+				]
 			);
 			return new WP_Error( 'no_secret', 'Webhook secret not configured' );
 		}
@@ -62,7 +62,7 @@ trait WC_Stripe_Agentic_Authentication {
 		if ( false === $body ) {
 			WC_Stripe_Logger::log(
 				'Agentic: Authentication failed - could not read request body',
-				array( 'context' => 'agentic_authentication' )
+				[ 'context' => 'agentic_authentication' ]
 			);
 			return new WP_Error( 'read_failure', 'Failed to read request body' );
 		}
@@ -70,10 +70,10 @@ trait WC_Stripe_Agentic_Authentication {
 		if ( empty( $headers ) || ! is_array( $headers ) ) {
 			WC_Stripe_Logger::log(
 				'Agentic: Authentication failed - no request headers found',
-				array(
+				[
 					'context' => 'agentic_authentication',
 					'headers_type' => gettype( $headers ),
-				)
+				]
 			);
 			return new WP_Error( 'empty_headers', 'No request headers found' );
 		}
@@ -81,7 +81,7 @@ trait WC_Stripe_Agentic_Authentication {
 		if ( '' === $body || is_null( $body ) ) {
 			WC_Stripe_Logger::log(
 				'Agentic: Authentication failed - empty request body',
-				array( 'context' => 'agentic_authentication' )
+				[ 'context' => 'agentic_authentication' ]
 			);
 			return new WP_Error( 'empty_body', 'No request body found' );
 		}
@@ -93,17 +93,17 @@ trait WC_Stripe_Agentic_Authentication {
 		if ( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED !== $result ) {
 			WC_Stripe_Logger::log(
 				'Agentic: Authentication failed - invalid signature',
-				array(
+				[
 					'context' => 'agentic_authentication',
 					'validation_result' => $result,
-				)
+				]
 			);
 			return new WP_Error( 'invalid_signature', $result );
 		}
 
 		WC_Stripe_Logger::log(
 			'Agentic: Authentication succeeded',
-			array( 'context' => 'agentic_authentication' )
+			[ 'context' => 'agentic_authentication' ]
 		);
 
 		return true;

--- a/includes/abstracts/trait-wc-stripe-agentic-authentication.php
+++ b/includes/abstracts/trait-wc-stripe-agentic-authentication.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Trait WC_Stripe_Agentic_Authentication
+ *
+ * Provides authentication and gating logic for Agentic Checkout REST endpoints.
+ *
+ * @package WooCommerce_Stripe/Abstracts
+ * @since   8.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Trait for authenticating Stripe Agentic Checkout webhook requests.
+ */
+trait WC_Stripe_Agentic_Authentication {
+	/**
+	 * Check if agentic checkout is enabled.
+	 *
+	 * @return bool
+	 */
+	protected function is_agentic_checkout_enabled() {
+		/**
+		 * Filter to enable/disable Agentic Checkout functionality.
+		 *
+		 * @since 8.9.0
+		 * @param bool $enabled Whether agentic checkout is enabled. Default false.
+		 */
+		return apply_filters( 'wc_stripe_agentic_checkout_enabled', false );
+	}
+
+	/**
+	 * Verify Stripe signature for agentic hooks.
+	 *
+	 * @return bool|WP_Error True if valid, WP_Error if invalid.
+	 */
+	protected function verify_stripe_signature() {
+		// Get webhook secret from settings.
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$testmode        = WC_Stripe_Mode::is_test();
+		$secret_key      = ( $testmode ? 'test_' : '' ) . 'webhook_secret';
+		$secret          = $stripe_settings[ $secret_key ] ?? false;
+
+		if ( empty( $secret ) ) {
+			return new WP_Error( 'no_secret', 'Webhook secret not configured' );
+		}
+
+		// Get request headers and body.
+		$headers = $this->get_request_headers();
+		$body    = file_get_contents( 'php://input' );
+
+		if ( empty( $headers ) ) {
+			return new WP_Error( 'empty_headers', 'No request headers found' );
+		}
+
+		if ( empty( $body ) ) {
+			return new WP_Error( 'empty_body', 'No request body found' );
+		}
+
+		// Reuse existing validation logic.
+		$webhook_handler = new WC_Stripe_Webhook_Handler();
+		$result          = $webhook_handler->validate_request( $headers, $body );
+
+		if ( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED !== $result ) {
+			return new WP_Error( 'invalid_signature', $result );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get request headers for validation.
+	 *
+	 * Must be implemented by class using trait.
+	 *
+	 * @return array
+	 */
+	abstract protected function get_request_headers();
+}

--- a/includes/abstracts/trait-wc-stripe-agentic-authentication.php
+++ b/includes/abstracts/trait-wc-stripe-agentic-authentication.php
@@ -44,6 +44,13 @@ trait WC_Stripe_Agentic_Authentication {
 		$secret          = $stripe_settings[ $secret_key ] ?? false;
 
 		if ( empty( $secret ) ) {
+			WC_Stripe_Logger::log(
+				'Agentic: Authentication failed - webhook secret not configured',
+				array(
+					'context' => 'agentic_authentication',
+					'testmode' => $testmode,
+				)
+			);
 			return new WP_Error( 'no_secret', 'Webhook secret not configured' );
 		}
 
@@ -53,14 +60,29 @@ trait WC_Stripe_Agentic_Authentication {
 
 		// Check for file_get_contents failure.
 		if ( false === $body ) {
+			WC_Stripe_Logger::log(
+				'Agentic: Authentication failed - could not read request body',
+				array( 'context' => 'agentic_authentication' )
+			);
 			return new WP_Error( 'read_failure', 'Failed to read request body' );
 		}
 
 		if ( empty( $headers ) || ! is_array( $headers ) ) {
+			WC_Stripe_Logger::log(
+				'Agentic: Authentication failed - no request headers found',
+				array(
+					'context' => 'agentic_authentication',
+					'headers_type' => gettype( $headers ),
+				)
+			);
 			return new WP_Error( 'empty_headers', 'No request headers found' );
 		}
 
 		if ( '' === $body || is_null( $body ) ) {
+			WC_Stripe_Logger::log(
+				'Agentic: Authentication failed - empty request body',
+				array( 'context' => 'agentic_authentication' )
+			);
 			return new WP_Error( 'empty_body', 'No request body found' );
 		}
 
@@ -69,8 +91,20 @@ trait WC_Stripe_Agentic_Authentication {
 		$result          = $webhook_handler->validate_request( $headers, $body );
 
 		if ( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED !== $result ) {
+			WC_Stripe_Logger::log(
+				'Agentic: Authentication failed - invalid signature',
+				array(
+					'context' => 'agentic_authentication',
+					'validation_result' => $result,
+				)
+			);
 			return new WP_Error( 'invalid_signature', $result );
 		}
+
+		WC_Stripe_Logger::log(
+			'Agentic: Authentication succeeded',
+			array( 'context' => 'agentic_authentication' )
+		);
 
 		return true;
 	}

--- a/includes/abstracts/trait-wc-stripe-agentic-authentication.php
+++ b/includes/abstracts/trait-wc-stripe-agentic-authentication.php
@@ -51,11 +51,16 @@ trait WC_Stripe_Agentic_Authentication {
 		$headers = $this->get_request_headers();
 		$body    = file_get_contents( 'php://input' );
 
-		if ( empty( $headers ) ) {
+		// Check for file_get_contents failure.
+		if ( false === $body ) {
+			return new WP_Error( 'read_failure', 'Failed to read request body' );
+		}
+
+		if ( empty( $headers ) || ! is_array( $headers ) ) {
 			return new WP_Error( 'empty_headers', 'No request headers found' );
 		}
 
-		if ( empty( $body ) ) {
+		if ( '' === $body || is_null( $body ) ) {
 			return new WP_Error( 'empty_body', 'No request body found' );
 		}
 

--- a/includes/admin/class-wc-stripe-agentic-admin-capture.php
+++ b/includes/admin/class-wc-stripe-agentic-admin-capture.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * Class for handling manual capture of agentic checkout orders.
+ *
+ * @package WooCommerce_Stripe/Classes
+ * @since   10.2.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles manual capture of agentic checkout orders.
+ *
+ * @since 10.2.0
+ */
+class WC_Stripe_Agentic_Admin_Capture {
+	/**
+	 * Constructor
+	 *
+	 * @since 10.2.0
+	 */
+	public function __construct() {
+		add_filter( 'woocommerce_order_actions', array( $this, 'add_capture_action' ), 10, 2 );
+		add_action( 'woocommerce_order_action_wc_stripe_capture_agentic_payment', array( $this, 'process_capture_action' ) );
+	}
+
+	/**
+	 * Add capture payment action to order actions dropdown.
+	 *
+	 * @since 10.2.0
+	 * @param array    $actions List of order actions.
+	 * @param WC_Order $order   The order object.
+	 * @return array Modified list of actions.
+	 */
+	public function add_capture_action( $actions, $order ) {
+		// Check if this is an agentic order with manual capture enabled.
+		$is_agentic        = 'true' === $order->get_meta( '_wc_stripe_agentic_order' );
+		$is_manual_capture = 'yes' === $order->get_meta( '_stripe_manual_capture' );
+		$is_captured       = 'yes' === $order->get_meta( '_stripe_charge_captured' );
+		$intent_id         = $order->get_meta( '_stripe_intent_id' );
+
+		// Only show capture button if:.
+		// 1. It's an agentic order OR has manual capture flag.
+		// 2. Payment hasn't been captured yet.
+		// 3. Has a valid payment intent ID.
+		// 4. Payment method is Stripe.
+		if ( ( $is_agentic || $is_manual_capture ) &&
+			! $is_captured &&
+			! empty( $intent_id ) &&
+			'stripe' === $order->get_payment_method() ) {
+
+			// Allow filtering to disable capture button.
+			$enabled = apply_filters( 'wc_stripe_agentic_manual_capture_enabled', true, $order );
+
+			if ( $enabled ) {
+				$actions['wc_stripe_capture_agentic_payment'] = __( 'Capture Stripe Payment', 'woocommerce-gateway-stripe' );
+			}
+		}
+
+		return $actions;
+	}
+
+	/**
+	 * Process the capture payment action.
+	 *
+	 * @since 10.2.0
+	 * @param WC_Order $order The order object.
+	 * @throws Exception If capture fails.
+	 */
+	public function process_capture_action( $order ) {
+		// Verify order has the necessary data.
+		$intent_id = $order->get_meta( '_stripe_intent_id' );
+		if ( empty( $intent_id ) ) {
+			$order->add_order_note(
+				__( 'Unable to capture payment: No payment intent ID found.', 'woocommerce-gateway-stripe' )
+			);
+			WC_Stripe_Logger::log(
+				'Agentic capture failed: No intent ID',
+				array( 'order_id' => $order->get_id() )
+			);
+			return;
+		}
+
+		// Check if already captured.
+		$is_captured = 'yes' === $order->get_meta( '_stripe_charge_captured' );
+		if ( $is_captured ) {
+			$order->add_order_note(
+				__( 'Payment has already been captured.', 'woocommerce-gateway-stripe' )
+			);
+			return;
+		}
+
+		WC_Stripe_Logger::log(
+			'Attempting to capture agentic order payment',
+			array(
+				'order_id'  => $order->get_id(),
+				'intent_id' => $intent_id,
+			)
+		);
+
+		try {
+			// Get order handler to use existing capture logic.
+			$order_handler = new WC_Stripe_Order_Handler();
+
+			// Get the order total, accounting for any refunds.
+			$order_total = $order->get_total();
+			if ( 0 < $order->get_total_refunded() ) {
+				$order_total = $order_total - $order->get_total_refunded();
+			}
+
+			// Allow filtering the capture amount.
+			$capture_amount = apply_filters( 'wc_stripe_agentic_capture_amount', $order_total, $order );
+
+			// Retrieve the payment intent.
+			$intent = WC_Stripe_API::retrieve( 'payment_intents/' . $intent_id );
+
+			if ( ! empty( $intent->error ) ) {
+				throw new Exception( $intent->error->message );
+			}
+
+			// Check if the intent requires capture.
+			if ( WC_Stripe_Intent_Status::REQUIRES_CAPTURE !== $intent->status ) {
+				if ( WC_Stripe_Intent_Status::SUCCEEDED === $intent->status ) {
+					// Intent is already captured.
+					$order->update_meta_data( '_stripe_charge_captured', 'yes' );
+					$order->save();
+
+					$order->add_order_note(
+						__( 'Payment was already captured in Stripe.', 'woocommerce-gateway-stripe' )
+					);
+
+					// Update order status if needed.
+					if ( Automattic\WooCommerce\Enums\OrderStatus::ON_HOLD === $order->get_status() ) {
+						$order->payment_complete( $intent_id );
+					}
+
+					WC_Stripe_Logger::log(
+						'Agentic order payment already captured',
+						array(
+							'order_id'  => $order->get_id(),
+							'intent_id' => $intent_id,
+						)
+					);
+
+					return;
+				} else {
+					throw new Exception(
+						sprintf(
+							/* translators: %s: payment intent status */
+							__( 'Payment intent is in "%s" status and cannot be captured.', 'woocommerce-gateway-stripe' ),
+							$intent->status
+						)
+					);
+				}
+			}
+
+			// Capture the payment intent.
+			$level3_data = $order_handler->get_level3_data_from_order( $order );
+			$result      = WC_Stripe_API::request_with_level3_data(
+				array(
+					'amount'   => WC_Stripe_Helper::get_stripe_amount( $capture_amount ),
+					'expand[]' => 'charges.data.balance_transaction',
+				),
+				'payment_intents/' . $intent_id . '/capture',
+				$level3_data,
+				$order
+			);
+
+			if ( ! empty( $result->error ) ) {
+				throw new Exception( $result->error->message );
+			}
+
+			// Mark as captured.
+			$order->update_meta_data( '_stripe_charge_captured', 'yes' );
+			$order->save();
+
+			// Add order note.
+			$order->add_order_note(
+				sprintf(
+					/* translators: %s: captured amount */
+					__( 'Stripe payment manually captured: %s', 'woocommerce-gateway-stripe' ),
+					wc_price( $capture_amount, array( 'currency' => $order->get_currency() ) )
+				)
+			);
+
+			// Update order status to processing/completed.
+			if ( Automattic\WooCommerce\Enums\OrderStatus::ON_HOLD === $order->get_status() ) {
+				$order->payment_complete( $intent_id );
+			}
+
+			WC_Stripe_Logger::log(
+				'Agentic order payment captured successfully',
+				array(
+					'order_id'        => $order->get_id(),
+					'intent_id'       => $intent_id,
+					'captured_amount' => $capture_amount,
+				)
+			);
+
+			// Fire action for custom handling.
+			do_action( 'wc_stripe_agentic_payment_captured', $order, $result );
+
+		} catch ( Exception $e ) {
+			$error_message = $e->getMessage();
+
+			$order->add_order_note(
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Unable to capture payment: %s', 'woocommerce-gateway-stripe' ),
+					$error_message
+				)
+			);
+
+			WC_Stripe_Logger::log(
+				'Agentic capture failed',
+				array(
+					'order_id'  => $order->get_id(),
+					'intent_id' => $intent_id,
+					'error'     => $error_message,
+				)
+			);
+
+			// Fire action for error handling.
+			do_action( 'wc_stripe_agentic_payment_capture_failed', $order, $error_message );
+		}
+	}
+}

--- a/includes/admin/class-wc-stripe-agentic-admin-capture.php
+++ b/includes/admin/class-wc-stripe-agentic-admin-capture.php
@@ -22,8 +22,8 @@ class WC_Stripe_Agentic_Admin_Capture {
 	 * @since 10.2.0
 	 */
 	public function __construct() {
-		add_filter( 'woocommerce_order_actions', array( $this, 'add_capture_action' ), 10, 2 );
-		add_action( 'woocommerce_order_action_wc_stripe_capture_agentic_payment', array( $this, 'process_capture_action' ) );
+		add_filter( 'woocommerce_order_actions', [ $this, 'add_capture_action' ], 10, 2 );
+		add_action( 'woocommerce_order_action_wc_stripe_capture_agentic_payment', [ $this, 'process_capture_action' ] );
 	}
 
 	/**
@@ -78,7 +78,7 @@ class WC_Stripe_Agentic_Admin_Capture {
 			);
 			WC_Stripe_Logger::log(
 				'Agentic capture failed: No intent ID',
-				array( 'order_id' => $order->get_id() )
+				[ 'order_id' => $order->get_id() ]
 			);
 			return;
 		}
@@ -94,10 +94,10 @@ class WC_Stripe_Agentic_Admin_Capture {
 
 		WC_Stripe_Logger::log(
 			'Attempting to capture agentic order payment',
-			array(
+			[
 				'order_id'  => $order->get_id(),
 				'intent_id' => $intent_id,
-			)
+			]
 		);
 
 		try {
@@ -138,10 +138,10 @@ class WC_Stripe_Agentic_Admin_Capture {
 
 					WC_Stripe_Logger::log(
 						'Agentic order payment already captured',
-						array(
+						[
 							'order_id'  => $order->get_id(),
 							'intent_id' => $intent_id,
-						)
+						]
 					);
 
 					return;
@@ -159,10 +159,10 @@ class WC_Stripe_Agentic_Admin_Capture {
 			// Capture the payment intent.
 			$level3_data = $order_handler->get_level3_data_from_order( $order );
 			$result      = WC_Stripe_API::request_with_level3_data(
-				array(
+				[
 					'amount'   => WC_Stripe_Helper::get_stripe_amount( $capture_amount ),
 					'expand[]' => 'charges.data.balance_transaction',
-				),
+				],
 				'payment_intents/' . $intent_id . '/capture',
 				$level3_data,
 				$order
@@ -181,7 +181,7 @@ class WC_Stripe_Agentic_Admin_Capture {
 				sprintf(
 					/* translators: %s: captured amount */
 					__( 'Stripe payment manually captured: %s', 'woocommerce-gateway-stripe' ),
-					wc_price( $capture_amount, array( 'currency' => $order->get_currency() ) )
+					wc_price( $capture_amount, [ 'currency' => $order->get_currency() ] )
 				)
 			);
 
@@ -192,11 +192,11 @@ class WC_Stripe_Agentic_Admin_Capture {
 
 			WC_Stripe_Logger::log(
 				'Agentic order payment captured successfully',
-				array(
+				[
 					'order_id'        => $order->get_id(),
 					'intent_id'       => $intent_id,
 					'captured_amount' => $capture_amount,
-				)
+				]
 			);
 
 			// Fire action for custom handling.
@@ -215,11 +215,11 @@ class WC_Stripe_Agentic_Admin_Capture {
 
 			WC_Stripe_Logger::log(
 				'Agentic capture failed',
-				array(
+				[
 					'order_id'  => $order->get_id(),
 					'intent_id' => $intent_id,
 					'error'     => $error_message,
-				)
+				]
 			);
 
 			// Fire action for error handling.

--- a/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
@@ -218,7 +218,10 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 				$this->decline_reason = 'product_not_purchasable';
 				WC_Stripe_Logger::log(
 					'Agentic approval declined: product not purchasable',
-					[ 'sku' => $sku, 'product_id' => $product->get_id() ]
+				[
+					'sku'        => $sku,
+					'product_id' => $product->get_id(),
+				]
 				);
 				return false;
 			}
@@ -228,7 +231,10 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 				$this->decline_reason = 'low_inventory';
 				WC_Stripe_Logger::log(
 					'Agentic approval declined: product out of stock',
-					[ 'sku' => $sku, 'product_id' => $product->get_id() ]
+				[
+					'sku'        => $sku,
+					'product_id' => $product->get_id(),
+				]
 				);
 				return false;
 			}

--- a/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
@@ -218,10 +218,10 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 				$this->decline_reason = 'product_not_purchasable';
 				WC_Stripe_Logger::log(
 					'Agentic approval declined: product not purchasable',
-				[
-					'sku'        => $sku,
-					'product_id' => $product->get_id(),
-				]
+					[
+						'sku'        => $sku,
+						'product_id' => $product->get_id(),
+					]
 				);
 				return false;
 			}
@@ -231,10 +231,10 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 				$this->decline_reason = 'low_inventory';
 				WC_Stripe_Logger::log(
 					'Agentic approval declined: product out of stock',
-				[
-					'sku'        => $sku,
-					'product_id' => $product->get_id(),
-				]
+					[
+						'sku'        => $sku,
+						'product_id' => $product->get_id(),
+					]
 				);
 				return false;
 			}

--- a/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
@@ -17,6 +17,13 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 	use WC_Stripe_Agentic_Authentication;
 
 	/**
+	 * Decline reason for rejected orders.
+	 *
+	 * @var string|null
+	 */
+	private $decline_reason = null;
+
+	/**
 	 * Endpoint namespace.
 	 *
 	 * @var string
@@ -188,9 +195,84 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 	 * @return bool True if approved, false if declined.
 	 */
 	private function validate_order( $line_items ) {
-		// For now, approve all orders.
-		// TODO: Add product stock checks in next task.
+		$items = $line_items['data'] ?? [];
+
+		foreach ( $items as $item ) {
+			$sku      = $item['price']['lookup_key'] ?? '';
+			$quantity = $item['quantity'] ?? 1;
+
+			// Look up product by SKU.
+			$product = $this->get_product_by_sku( $sku );
+
+			if ( ! $product ) {
+				$this->decline_reason = 'product_not_found';
+				WC_Stripe_Logger::log(
+					'Agentic approval declined: product not found',
+					[ 'sku' => $sku ]
+				);
+				return false;
+			}
+
+			// Check if product is purchasable.
+			if ( ! $product->is_purchasable() ) {
+				$this->decline_reason = 'product_not_purchasable';
+				WC_Stripe_Logger::log(
+					'Agentic approval declined: product not purchasable',
+					[ 'sku' => $sku, 'product_id' => $product->get_id() ]
+				);
+				return false;
+			}
+
+			// Check stock.
+			if ( ! $product->is_in_stock() ) {
+				$this->decline_reason = 'low_inventory';
+				WC_Stripe_Logger::log(
+					'Agentic approval declined: product out of stock',
+					[ 'sku' => $sku, 'product_id' => $product->get_id() ]
+				);
+				return false;
+			}
+
+			// Check stock quantity if managing stock.
+			if ( $product->managing_stock() ) {
+				$stock_quantity = $product->get_stock_quantity();
+				if ( $stock_quantity < $quantity ) {
+					$this->decline_reason = 'low_inventory';
+					WC_Stripe_Logger::log(
+						'Agentic approval declined: insufficient stock',
+						[
+							'sku'            => $sku,
+							'product_id'     => $product->get_id(),
+							'requested'      => $quantity,
+							'available'      => $stock_quantity,
+						]
+					);
+					return false;
+				}
+			}
+		}
+
 		return true;
+	}
+
+	/**
+	 * Get product by SKU.
+	 *
+	 * @param string $sku Product SKU.
+	 * @return WC_Product|null
+	 */
+	private function get_product_by_sku( $sku ) {
+		$product_id = wc_get_product_id_by_sku( $sku );
+		$product    = $product_id ? wc_get_product( $product_id ) : null;
+
+		/**
+		 * Filter product lookup by SKU for agentic checkout.
+		 *
+		 * @since 8.9.0
+		 * @param WC_Product|null $product Product object or null if not found.
+		 * @param string          $sku     Product SKU.
+		 */
+		return apply_filters( 'wc_stripe_agentic_product_by_sku', $product, $sku );
 	}
 
 	/**
@@ -200,7 +282,7 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 	 * @return string
 	 */
 	private function get_decline_reason( $line_items ) {
-		return 'validation_failed';
+		return $this->decline_reason ?? 'validation_failed';
 	}
 
 	/**

--- a/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * REST controller for Agentic Checkout approval hook.
+ *
+ * @package WooCommerce_Stripe/Admin
+ * @since   8.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Agentic Approval REST Controller.
+ */
+class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
+	use WC_Stripe_Agentic_Authentication;
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'stripe/agentic/approve';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'approve' ],
+					'permission_callback' => '__return_true', // Auth handled via signature
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get registered routes.
+	 *
+	 * @return array
+	 */
+	public function get_routes() {
+		$routes = [];
+		$routes[ '/' . $this->namespace . '/' . $this->rest_base ] = [
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'approve' ],
+				'permission_callback' => '__return_true',
+			],
+		];
+		return $routes;
+	}
+
+	/**
+	 * Handle approval request from Stripe.
+	 *
+	 * @param WP_REST_Request $request Full request data.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function approve( $request ) {
+		// Check if feature is enabled.
+		if ( ! $this->is_agentic_checkout_enabled() ) {
+			WC_Stripe_Logger::log( 'Agentic approval request rejected: feature disabled' );
+			return new WP_Error(
+				'feature_disabled',
+				'Agentic Checkout is not enabled',
+				[ 'status' => 403 ]
+			);
+		}
+
+		// Verify Stripe signature.
+		$verification = $this->verify_stripe_signature();
+		if ( is_wp_error( $verification ) ) {
+			WC_Stripe_Logger::log(
+				'Agentic approval request rejected: invalid signature',
+				[ 'error' => $verification->get_error_message() ]
+			);
+			return $verification;
+		}
+
+		// Parse request body.
+		$body               = json_decode( $request->get_body(), true );
+		$checkout_session_id = $body['id'] ?? '';
+		$line_items         = $body['line_items'] ?? [];
+		$amount_total       = $body['amount_total'] ?? 0;
+		$payment_method     = $body['payment_method_details'] ?? [];
+
+		WC_Stripe_Logger::log(
+			'Agentic approval request received',
+			[
+				'checkout_session_id' => $checkout_session_id,
+				'amount'              => $amount_total,
+			]
+		);
+
+		// Run validation checks.
+		$approved = $this->validate_order( $line_items );
+
+		/**
+		 * Filter approval decision for agentic checkout.
+		 *
+		 * @since 8.9.0
+		 * @param bool  $approved            Whether to approve the order.
+		 * @param array $checkout_session_data Full checkout session data.
+		 * @param array $line_items          Line items being purchased.
+		 * @param array $payment_method_details Payment method details.
+		 */
+		$approved = apply_filters(
+			'wc_stripe_agentic_approval_decision',
+			$approved,
+			$body,
+			$line_items,
+			$payment_method
+		);
+
+		// Build response.
+		if ( $approved ) {
+			WC_Stripe_Logger::log(
+				'Agentic order approved',
+				[ 'checkout_session_id' => $checkout_session_id ]
+			);
+
+			return new WP_REST_Response(
+				[
+					'id'     => $checkout_session_id,
+					'result' => [
+						'type' => 'approved',
+					],
+				],
+				200
+			);
+		} else {
+			$reason = $this->get_decline_reason( $line_items );
+
+			/**
+			 * Filter decline reason for agentic checkout.
+			 *
+			 * @since 8.9.0
+			 * @param string $reason Decline reason.
+			 * @param array  $checkout_session_data Full checkout session data.
+			 */
+			$reason = apply_filters(
+				'wc_stripe_agentic_decline_reason',
+				$reason,
+				$body
+			);
+
+			WC_Stripe_Logger::log(
+				'Agentic order declined',
+				[
+					'checkout_session_id' => $checkout_session_id,
+					'reason'              => $reason,
+				]
+			);
+
+			return new WP_REST_Response(
+				[
+					'id'     => $checkout_session_id,
+					'result' => [
+						'type'     => 'declined',
+						'declined' => [
+							'reason' => $reason,
+						],
+					],
+				],
+				200
+			);
+		}
+	}
+
+	/**
+	 * Validate order for approval.
+	 *
+	 * @param array $line_items Line items to validate.
+	 * @return bool True if approved, false if declined.
+	 */
+	private function validate_order( $line_items ) {
+		// For now, approve all orders.
+		// TODO: Add product stock checks in next task.
+		return true;
+	}
+
+	/**
+	 * Get decline reason.
+	 *
+	 * @param array $line_items Line items.
+	 * @return string
+	 */
+	private function get_decline_reason( $line_items ) {
+		return 'validation_failed';
+	}
+
+	/**
+	 * Get request headers.
+	 *
+	 * @return array
+	 */
+	protected function get_request_headers() {
+		return getallheaders() ?: [];
+	}
+}

--- a/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php
@@ -291,6 +291,7 @@ class WC_Stripe_REST_Agentic_Approval_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	protected function get_request_headers() {
-		return getallheaders() ?: [];
+		$headers = getallheaders();
+		return $headers ? $headers : [];
 	}
 }

--- a/includes/admin/class-wc-stripe-rest-agentic-shipping-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-shipping-controller.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * REST controller for Agentic Checkout shipping calculation hook.
+ *
+ * @package WooCommerce_Stripe/Admin
+ * @since   8.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Agentic Shipping Calculation REST Controller.
+ */
+class WC_Stripe_REST_Agentic_Shipping_Controller extends WP_REST_Controller {
+	use WC_Stripe_Agentic_Authentication;
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'stripe/agentic/compute_shipping_options';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'compute_shipping_options' ],
+					'permission_callback' => '__return_true', // Auth handled via signature
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get registered routes.
+	 *
+	 * @return array
+	 */
+	public function get_routes() {
+		$routes = [];
+		$routes[ '/' . $this->namespace . '/' . $this->rest_base ] = [
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'compute_shipping_options' ],
+				'permission_callback' => '__return_true',
+			],
+		];
+		return $routes;
+	}
+
+	/**
+	 * Handle shipping calculation request from Stripe.
+	 *
+	 * @param WP_REST_Request $request Full request data.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function compute_shipping_options( $request ) {
+		// Check if feature is enabled.
+		if ( ! $this->is_agentic_checkout_enabled() ) {
+			WC_Stripe_Logger::log( 'Agentic shipping calculation request rejected: feature disabled' );
+			return new WP_Error(
+				'feature_disabled',
+				'Agentic Checkout is not enabled',
+				[ 'status' => 403 ]
+			);
+		}
+
+		// Verify Stripe signature.
+		$verification = $this->verify_stripe_signature();
+		if ( is_wp_error( $verification ) ) {
+			WC_Stripe_Logger::log(
+				'Agentic shipping calculation request rejected: invalid signature',
+				[ 'error' => $verification->get_error_message() ]
+			);
+			return $verification;
+		}
+
+		// Parse request body.
+		$body        = json_decode( $request->get_body(), true );
+		$line_items  = $body['line_items_details'] ?? [];
+		$fulfillment = $body['fulfillment_details'] ?? [];
+		$currency    = $body['currency'] ?? 'usd';
+
+		WC_Stripe_Logger::log(
+			'Agentic shipping calculation request received',
+			[
+				'line_items_count' => count( $line_items ),
+				'destination'      => $fulfillment['address'] ?? [],
+			]
+		);
+
+		try {
+			// Calculate shipping options.
+			$shipping_options = $this->calculate_shipping( $line_items, $fulfillment );
+
+			/**
+			 * Filter shipping options for agentic checkout.
+			 *
+			 * @since 8.9.0
+			 * @param array $shipping_options Calculated shipping options.
+			 * @param array $cart_items       Cart items (line items).
+			 * @param array $destination      Destination address.
+			 */
+			$shipping_options = apply_filters(
+				'wc_stripe_agentic_shipping_options',
+				$shipping_options,
+				$line_items,
+				$fulfillment['address'] ?? []
+			);
+
+			WC_Stripe_Logger::log(
+				'Agentic shipping calculated',
+				[
+					'options_count' => count( $shipping_options ),
+				]
+			);
+
+			return new WP_REST_Response(
+				[ 'fulfillment_options' => $shipping_options ],
+				200
+			);
+
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log(
+				'Agentic shipping calculation failed',
+				[ 'error' => $e->getMessage() ]
+			);
+
+			return new WP_Error(
+				'shipping_calculation_failed',
+				$e->getMessage(),
+				[ 'status' => 500 ]
+			);
+		}
+	}
+
+	/**
+	 * Calculate shipping options using WooCommerce.
+	 *
+	 * @param array $line_items  Line items.
+	 * @param array $fulfillment Fulfillment details.
+	 * @return array Shipping options.
+	 * @throws Exception If calculation fails.
+	 */
+	private function calculate_shipping( $line_items, $fulfillment ) {
+		$address = $fulfillment['address'] ?? [];
+
+		if ( empty( $address ) ) {
+			throw new Exception( 'No destination address provided' );
+		}
+
+		// Build cart items for shipping calculation.
+		$cart_items = [];
+		foreach ( $line_items as $item ) {
+			$sku      = $item['sku_id'] ?? '';
+			$quantity = $item['quantity'] ?? 1;
+
+			$product = $this->get_product_by_sku( $sku );
+
+			if ( ! $product ) {
+				throw new Exception( "Product not found for SKU: {$sku}" );
+			}
+
+			// Skip non-shippable products.
+			if ( ! $product->needs_shipping() ) {
+				continue;
+			}
+
+			$cart_items[] = [
+				'product'  => $product,
+				'quantity' => $quantity,
+			];
+		}
+
+		// If no shippable items, return empty options.
+		if ( empty( $cart_items ) ) {
+			return [];
+		}
+
+		// Get shipping methods for destination.
+		$shipping_methods = $this->get_shipping_methods_for_address( $cart_items, $address );
+
+		// Format shipping options for Stripe.
+		$options = [];
+		foreach ( $shipping_methods as $method ) {
+			$options[] = [
+				'display_name'            => $method['label'],
+				'description'             => $method['description'] ?? '',
+				'shipping_amount'         => (int) ( $method['cost'] * 100 ), // Convert to cents
+				'earliest_delivery_time'  => $method['earliest_delivery'] ?? null,
+				'latest_delivery_time'    => $method['latest_delivery'] ?? null,
+			];
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Get shipping methods for address.
+	 *
+	 * @param array $cart_items Cart items.
+	 * @param array $address    Destination address.
+	 * @return array Shipping methods.
+	 */
+	private function get_shipping_methods_for_address( $cart_items, $address ) {
+		// Set destination for shipping calculation.
+		$country  = $address['country'] ?? '';
+		$state    = $address['state'] ?? '';
+		$postcode = $address['postal_code'] ?? '';
+		$city     = $address['city'] ?? '';
+
+		// Build package for shipping calculation.
+		$package = [
+			'destination' => [
+				'country'  => $country,
+				'state'    => $state,
+				'postcode' => $postcode,
+				'city'     => $city,
+				'address'  => $address['line1'] ?? '',
+				'address_2' => $address['line2'] ?? '',
+			],
+			'contents'    => [],
+		];
+
+		// Add cart items to package.
+		foreach ( $cart_items as $item ) {
+			$product = $item['product'];
+			$package['contents'][] = [
+				'data'     => $product,
+				'quantity' => $item['quantity'],
+			];
+		}
+
+		// Get available shipping methods.
+		$shipping_zone    = WC_Shipping_Zones::get_zone_matching_package( $package );
+		$shipping_methods = $shipping_zone->get_shipping_methods( true );
+
+		$available_methods = [];
+		foreach ( $shipping_methods as $method ) {
+			if ( ! $method->is_enabled() ) {
+				continue;
+			}
+
+			// Calculate cost for this method.
+			$method->calculate_shipping( $package );
+			$rates = $method->rates ?? [];
+
+			foreach ( $rates as $rate ) {
+				$available_methods[] = [
+					'id'          => $rate->get_id(),
+					'label'       => $rate->get_label(),
+					'cost'        => $rate->get_cost(),
+					'description' => $rate->get_label(),
+				];
+			}
+		}
+
+		return $available_methods;
+	}
+
+	/**
+	 * Get product by SKU.
+	 *
+	 * @param string $sku Product SKU.
+	 * @return WC_Product|null
+	 */
+	private function get_product_by_sku( $sku ) {
+		$product_id = wc_get_product_id_by_sku( $sku );
+		$product    = $product_id ? wc_get_product( $product_id ) : null;
+
+		/** This filter is documented in includes/admin/class-wc-stripe-rest-agentic-approval-controller.php */
+		return apply_filters( 'wc_stripe_agentic_product_by_sku', $product, $sku );
+	}
+
+	/**
+	 * Get request headers.
+	 *
+	 * @return array
+	 */
+	protected function get_request_headers() {
+		return getallheaders() ?: [];
+	}
+}

--- a/includes/admin/class-wc-stripe-rest-agentic-shipping-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-shipping-controller.php
@@ -295,6 +295,7 @@ class WC_Stripe_REST_Agentic_Shipping_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	protected function get_request_headers() {
-		return getallheaders() ?: [];
+		$headers = getallheaders();
+		return $headers ? $headers : [];
 	}
 }

--- a/includes/admin/class-wc-stripe-rest-agentic-shipping-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-shipping-controller.php
@@ -200,6 +200,7 @@ class WC_Stripe_REST_Agentic_Shipping_Controller extends WP_REST_Controller {
 		$options = [];
 		foreach ( $shipping_methods as $method ) {
 			$options[] = [
+				'id'                      => $method['id'],
 				'display_name'            => $method['label'],
 				'description'             => $method['description'] ?? '',
 				'shipping_amount'         => (int) ( $method['cost'] * 100 ), // Convert to cents

--- a/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
@@ -37,13 +37,13 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
-			array(
-				array(
+			[
+				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'compute_tax' ),
+					'callback'            => [ $this, 'compute_tax' ],
 					'permission_callback' => '__return_true', // Auth handled via signature.
-				),
-			)
+				],
+			]
 		);
 	}
 
@@ -53,14 +53,14 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_routes() {
-		$routes = array();
-		$routes[ '/' . $this->namespace . '/' . $this->rest_base ] = array(
-			array(
+		$routes = [];
+		$routes[ '/' . $this->namespace . '/' . $this->rest_base ] = [
+			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'compute_tax' ),
+				'callback'            => [ $this, 'compute_tax' ],
 				'permission_callback' => '__return_true',
-			),
-		);
+			],
+		];
 		return $routes;
 	}
 
@@ -77,7 +77,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 			return new WP_Error(
 				'feature_disabled',
 				'Agentic Checkout is not enabled',
-				array( 'status' => 403 )
+				[ 'status' => 403 ]
 			);
 		}
 
@@ -86,7 +86,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $verification ) ) {
 			WC_Stripe_Logger::log(
 				'Agentic tax calculation request rejected: invalid signature',
-				array( 'error' => $verification->get_error_message() )
+				[ 'error' => $verification->get_error_message() ]
 			);
 			return $verification;
 		}
@@ -94,31 +94,31 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 		// Parse request body.
 		$body                = json_decode( $request->get_body(), true );
 		$checkout_session_id = $body['id'] ?? '';
-		$line_items          = $body['line_items_details'] ?? array();
-		$fulfillment         = $body['fulfillment_details'] ?? array();
-		$billing             = $body['billing_details'] ?? array();
+		$line_items          = $body['line_items_details'] ?? [];
+		$fulfillment         = $body['fulfillment_details'] ?? [];
+		$billing             = $body['billing_details'] ?? [];
 		$currency            = $body['currency'] ?? 'usd';
 
 		// Validate JSON parsing.
 		if ( null === $body && json_last_error() !== JSON_ERROR_NONE ) {
 			WC_Stripe_Logger::log(
 				'Agentic tax calculation request failed: invalid JSON',
-				array( 'error' => json_last_error_msg() )
+				[ 'error' => json_last_error_msg() ]
 			);
 			return new WP_Error(
 				'invalid_json',
 				'Invalid JSON in request body',
-				array( 'status' => 400 )
+				[ 'status' => 400 ]
 			);
 		}
 
 		WC_Stripe_Logger::log(
 			'Agentic tax calculation request received',
-			array(
+			[
 				'checkout_session_id' => $checkout_session_id,
 				'line_items_count'    => count( $line_items ),
 				'currency'            => $currency,
-			)
+			]
 		);
 
 		try {
@@ -137,10 +137,10 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 				'wc_stripe_agentic_tax_breakdown',
 				$tax_breakdown,
 				$line_items,
-				array(
+				[
 					'fulfillment' => $fulfillment,
 					'billing'     => $billing,
-				)
+				]
 			);
 
 			// Calculate total tax from breakdown.
@@ -148,37 +148,37 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 
 			WC_Stripe_Logger::log(
 				'Agentic tax calculated',
-				array(
+				[
 					'checkout_session_id' => $checkout_session_id,
 					'total_tax'           => $total_tax,
 					'tax_count'           => count( $tax_breakdown ),
-				)
+				]
 			);
 
 			// Format response according to Stripe protocol.
 			return new WP_REST_Response(
-				array(
+				[
 					'id'     => $checkout_session_id,
-					'result' => array(
+					'result' => [
 						'type'       => 'calculated',
-						'calculated' => array(
+						'calculated' => [
 							'taxes' => $tax_breakdown,
-						),
-					),
-				),
+						],
+					],
+				],
 				200
 			);
 
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::log(
 				'Agentic tax calculation failed',
-				array( 'error' => $e->getMessage() )
+				[ 'error' => $e->getMessage() ]
 			);
 
 			return new WP_Error(
 				'tax_calculation_failed',
 				$e->getMessage(),
-				array( 'status' => 500 )
+				[ 'status' => 500 ]
 			);
 		}
 	}
@@ -194,7 +194,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 */
 	private function calculate_taxes( $line_items, $fulfillment, $billing ) {
 		// Use shipping address for tax calculation (or billing if no shipping).
-		$tax_address = $fulfillment['address'] ?? $billing['address'] ?? array();
+		$tax_address = $fulfillment['address'] ?? $billing['address'] ?? [];
 
 		if ( empty( $tax_address ) ) {
 			throw new Exception( 'No address provided for tax calculation' );
@@ -207,7 +207,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 		$city     = $tax_address['city'] ?? '';
 
 		// Track taxes by rate ID to aggregate across items.
-		$tax_totals = array();
+		$tax_totals = [];
 
 		// Calculate tax for each line item.
 		foreach ( $line_items as $item ) {
@@ -225,7 +225,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 			$tax_class = $product->get_tax_class();
 
 			// Get tax rates for this product and location.
-			$tax_rates = WC_Tax::get_rates( $tax_class, array( $country, $state, $postcode, $city ) );
+			$tax_rates = WC_Tax::get_rates( $tax_class, [ $country, $state, $postcode, $city ] );
 
 			// Handle empty tax rates (no taxes apply).
 			if ( empty( $tax_rates ) ) {
@@ -244,10 +244,10 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 						continue;
 					}
 
-					$tax_totals[ $rate_id ] = array(
+					$tax_totals[ $rate_id ] = [
 						'amount'       => 0,
 						'display_name' => $rate_details['label'] ?? 'Tax',
-					);
+					];
 				}
 
 				$tax_totals[ $rate_id ]['amount'] += $tax_amount;
@@ -267,7 +267,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 			}
 
 			// Get tax rates for shipping.
-			$shipping_tax_rates = WC_Tax::get_rates( $shipping_tax_class, array( $country, $state, $postcode, $city ) );
+			$shipping_tax_rates = WC_Tax::get_rates( $shipping_tax_class, [ $country, $state, $postcode, $city ] );
 
 			if ( ! empty( $shipping_tax_rates ) ) {
 				// Calculate shipping taxes.
@@ -281,10 +281,10 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 							continue;
 						}
 
-						$tax_totals[ $rate_id ] = array(
+						$tax_totals[ $rate_id ] = [
 							'amount'       => 0,
 							'display_name' => $rate_details['label'] ?? 'Tax',
-						);
+						];
 					}
 
 					$tax_totals[ $rate_id ]['amount'] += $tax_amount;
@@ -293,17 +293,17 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 		}
 
 		// Convert to array of taxes with amounts in cents.
-		$tax_breakdown = array();
+		$tax_breakdown = [];
 		foreach ( $tax_totals as $tax ) {
-			$tax_breakdown[] = array(
+			$tax_breakdown[] = [
 				'amount'       => (int) round( $tax['amount'] * 100 ), // Convert dollars to cents.
 				'display_name' => $tax['display_name'],
-			);
+			];
 		}
 
 		// Handle case where no taxes apply.
 		if ( empty( $tax_breakdown ) ) {
-			return array();
+			return [];
 		}
 
 		return $tax_breakdown;
@@ -330,6 +330,6 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 */
 	protected function get_request_headers() {
 		$headers = getallheaders();
-		return $headers ? $headers : array();
+		return $headers ? $headers : [];
 	}
 }

--- a/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
@@ -1,0 +1,238 @@
+<?php
+/**
+ * REST controller for Agentic Checkout tax calculation hook.
+ *
+ * @package WooCommerce_Stripe/Admin
+ * @since   8.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Agentic Tax Calculation REST Controller.
+ */
+class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
+	use WC_Stripe_Agentic_Authentication;
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Endpoint path.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'stripe/agentic/compute_tax';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'compute_tax' ],
+					'permission_callback' => '__return_true', // Auth handled via signature
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get registered routes.
+	 *
+	 * @return array
+	 */
+	public function get_routes() {
+		$routes = [];
+		$routes[ '/' . $this->namespace . '/' . $this->rest_base ] = [
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'compute_tax' ],
+				'permission_callback' => '__return_true',
+			],
+		];
+		return $routes;
+	}
+
+	/**
+	 * Handle tax calculation request from Stripe.
+	 *
+	 * @param WP_REST_Request $request Full request data.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function compute_tax( $request ) {
+		// Check if feature is enabled.
+		if ( ! $this->is_agentic_checkout_enabled() ) {
+			WC_Stripe_Logger::log( 'Agentic tax calculation request rejected: feature disabled' );
+			return new WP_Error(
+				'feature_disabled',
+				'Agentic Checkout is not enabled',
+				[ 'status' => 403 ]
+			);
+		}
+
+		// Verify Stripe signature.
+		$verification = $this->verify_stripe_signature();
+		if ( is_wp_error( $verification ) ) {
+			WC_Stripe_Logger::log(
+				'Agentic tax calculation request rejected: invalid signature',
+				[ 'error' => $verification->get_error_message() ]
+			);
+			return $verification;
+		}
+
+		// Parse request body.
+		$body         = json_decode( $request->get_body(), true );
+		$line_items   = $body['line_items_details'] ?? [];
+		$fulfillment  = $body['fulfillment_details'] ?? [];
+		$billing      = $body['billing_details'] ?? [];
+		$currency     = $body['currency'] ?? 'usd';
+
+		WC_Stripe_Logger::log(
+			'Agentic tax calculation request received',
+			[
+				'line_items_count' => count( $line_items ),
+				'currency'         => $currency,
+			]
+		);
+
+		try {
+			// Calculate taxes.
+			$tax_amounts = $this->calculate_taxes( $line_items, $fulfillment, $billing );
+
+			/**
+			 * Filter tax amounts for agentic checkout.
+			 *
+			 * @since 8.9.0
+			 * @param array $tax_amounts Calculated tax amounts.
+			 * @param array $line_items  Line items.
+			 * @param array $addresses   Fulfillment and billing addresses.
+			 */
+			$tax_amounts = apply_filters(
+				'wc_stripe_agentic_tax_calculation',
+				$tax_amounts,
+				$line_items,
+				[ 'fulfillment' => $fulfillment, 'billing' => $billing ]
+			);
+
+			WC_Stripe_Logger::log(
+				'Agentic tax calculated',
+				[
+					'total_tax' => $tax_amounts['total_details']['amount_tax'],
+				]
+			);
+
+			return new WP_REST_Response( $tax_amounts, 200 );
+
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::log(
+				'Agentic tax calculation failed',
+				[ 'error' => $e->getMessage() ]
+			);
+
+			return new WP_Error(
+				'tax_calculation_failed',
+				$e->getMessage(),
+				[ 'status' => 500 ]
+			);
+		}
+	}
+
+	/**
+	 * Calculate taxes using WooCommerce.
+	 *
+	 * @param array $line_items  Line items.
+	 * @param array $fulfillment Fulfillment details.
+	 * @param array $billing     Billing details.
+	 * @return array Tax amounts.
+	 * @throws Exception If calculation fails.
+	 */
+	private function calculate_taxes( $line_items, $fulfillment, $billing ) {
+		// Use shipping address for tax calculation (or billing if no shipping).
+		$tax_address = $fulfillment['address'] ?? $billing['address'] ?? [];
+
+		if ( empty( $tax_address ) ) {
+			throw new Exception( 'No address provided for tax calculation' );
+		}
+
+		// Set customer location for tax calculation.
+		$country    = $tax_address['country'] ?? '';
+		$state      = $tax_address['state'] ?? '';
+		$postcode   = $tax_address['postal_code'] ?? '';
+		$city       = $tax_address['city'] ?? '';
+
+		// Calculate tax for each line item.
+		$line_item_details  = [];
+		$total_line_tax     = 0;
+		$total_shipping_tax = 0;
+
+		foreach ( $line_items as $item ) {
+			$sku      = $item['sku_id'] ?? '';
+			$price    = ( $item['unit_amount'] ?? 0 ) * ( $item['quantity'] ?? 1 );
+
+			// Get product for tax class.
+			$product = $this->get_product_by_sku( $sku );
+
+			if ( ! $product ) {
+				throw new Exception( "Product not found for SKU: {$sku}" );
+			}
+
+			$tax_class = $product->get_tax_class();
+
+			// Calculate tax for this item.
+			$taxes     = WC_Tax::calc_tax( $price, WC_Tax::get_rates( $tax_class, [ $country, $state, $postcode, $city ] ) );
+			$tax_total = array_sum( $taxes );
+
+			$line_item_details[] = [
+				'sku_id'     => $sku,
+				'amount_tax' => (int) $tax_total,
+			];
+
+			$total_line_tax += $tax_total;
+		}
+
+		// Return formatted response.
+		return [
+			'line_item_details'   => $line_item_details,
+			'fulfillment_details' => [
+				'amount_tax' => (int) $total_shipping_tax,
+			],
+			'total_details'       => [
+				'amount_tax' => (int) ( $total_line_tax + $total_shipping_tax ),
+			],
+		];
+	}
+
+	/**
+	 * Get product by SKU.
+	 *
+	 * @param string $sku Product SKU.
+	 * @return WC_Product|null
+	 */
+	private function get_product_by_sku( $sku ) {
+		$product_id = wc_get_product_id_by_sku( $sku );
+		$product    = $product_id ? wc_get_product( $product_id ) : null;
+
+		/** This filter is documented in includes/admin/class-wc-stripe-rest-agentic-approval-controller.php */
+		return apply_filters( 'wc_stripe_agentic_product_by_sku', $product, $sku );
+	}
+
+	/**
+	 * Get request headers.
+	 *
+	 * @return array
+	 */
+	protected function get_request_headers() {
+		return getallheaders() ?: [];
+	}
+}

--- a/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
@@ -28,7 +28,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'stripe/agentic/tax';
+	protected $rest_base = 'stripe/agentic/compute_tax';
 
 	/**
 	 * Register routes.

--- a/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
+++ b/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php
@@ -28,7 +28,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'stripe/agentic/compute_tax';
+	protected $rest_base = 'stripe/agentic/tax';
 
 	/**
 	 * Register routes.
@@ -37,13 +37,13 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 		register_rest_route(
 			$this->namespace,
 			'/' . $this->rest_base,
-			[
-				[
+			array(
+				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ $this, 'compute_tax' ],
-					'permission_callback' => '__return_true', // Auth handled via signature
-				],
-			]
+					'callback'            => array( $this, 'compute_tax' ),
+					'permission_callback' => '__return_true', // Auth handled via signature.
+				),
+			)
 		);
 	}
 
@@ -53,14 +53,14 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_routes() {
-		$routes = [];
-		$routes[ '/' . $this->namespace . '/' . $this->rest_base ] = [
-			[
+		$routes = array();
+		$routes[ '/' . $this->namespace . '/' . $this->rest_base ] = array(
+			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $this, 'compute_tax' ],
+				'callback'            => array( $this, 'compute_tax' ),
 				'permission_callback' => '__return_true',
-			],
-		];
+			),
+		);
 		return $routes;
 	}
 
@@ -77,7 +77,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 			return new WP_Error(
 				'feature_disabled',
 				'Agentic Checkout is not enabled',
-				[ 'status' => 403 ]
+				array( 'status' => 403 )
 			);
 		}
 
@@ -86,64 +86,99 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 		if ( is_wp_error( $verification ) ) {
 			WC_Stripe_Logger::log(
 				'Agentic tax calculation request rejected: invalid signature',
-				[ 'error' => $verification->get_error_message() ]
+				array( 'error' => $verification->get_error_message() )
 			);
 			return $verification;
 		}
 
 		// Parse request body.
-		$body         = json_decode( $request->get_body(), true );
-		$line_items   = $body['line_items_details'] ?? [];
-		$fulfillment  = $body['fulfillment_details'] ?? [];
-		$billing      = $body['billing_details'] ?? [];
-		$currency     = $body['currency'] ?? 'usd';
+		$body                = json_decode( $request->get_body(), true );
+		$checkout_session_id = $body['id'] ?? '';
+		$line_items          = $body['line_items_details'] ?? array();
+		$fulfillment         = $body['fulfillment_details'] ?? array();
+		$billing             = $body['billing_details'] ?? array();
+		$currency            = $body['currency'] ?? 'usd';
+
+		// Validate JSON parsing.
+		if ( null === $body && json_last_error() !== JSON_ERROR_NONE ) {
+			WC_Stripe_Logger::log(
+				'Agentic tax calculation request failed: invalid JSON',
+				array( 'error' => json_last_error_msg() )
+			);
+			return new WP_Error(
+				'invalid_json',
+				'Invalid JSON in request body',
+				array( 'status' => 400 )
+			);
+		}
 
 		WC_Stripe_Logger::log(
 			'Agentic tax calculation request received',
-			[
-				'line_items_count' => count( $line_items ),
-				'currency'         => $currency,
-			]
+			array(
+				'checkout_session_id' => $checkout_session_id,
+				'line_items_count'    => count( $line_items ),
+				'currency'            => $currency,
+			)
 		);
 
 		try {
 			// Calculate taxes.
-			$tax_amounts = $this->calculate_taxes( $line_items, $fulfillment, $billing );
+			$tax_breakdown = $this->calculate_taxes( $line_items, $fulfillment, $billing );
 
 			/**
-			 * Filter tax amounts for agentic checkout.
+			 * Filter tax breakdown for agentic checkout.
 			 *
 			 * @since 8.9.0
-			 * @param array $tax_amounts Calculated tax amounts.
-			 * @param array $line_items  Line items.
-			 * @param array $addresses   Fulfillment and billing addresses.
+			 * @param array $tax_breakdown Tax breakdown with amount and display_name for each rate.
+			 * @param array $line_items    Line items.
+			 * @param array $addresses     Fulfillment and billing addresses.
 			 */
-			$tax_amounts = apply_filters(
-				'wc_stripe_agentic_tax_calculation',
-				$tax_amounts,
+			$tax_breakdown = apply_filters(
+				'wc_stripe_agentic_tax_breakdown',
+				$tax_breakdown,
 				$line_items,
-				[ 'fulfillment' => $fulfillment, 'billing' => $billing ]
+				array(
+					'fulfillment' => $fulfillment,
+					'billing'     => $billing,
+				)
 			);
+
+			// Calculate total tax from breakdown.
+			$total_tax = array_sum( array_column( $tax_breakdown, 'amount' ) );
 
 			WC_Stripe_Logger::log(
 				'Agentic tax calculated',
-				[
-					'total_tax' => $tax_amounts['total_details']['amount_tax'],
-				]
+				array(
+					'checkout_session_id' => $checkout_session_id,
+					'total_tax'           => $total_tax,
+					'tax_count'           => count( $tax_breakdown ),
+				)
 			);
 
-			return new WP_REST_Response( $tax_amounts, 200 );
+			// Format response according to Stripe protocol.
+			return new WP_REST_Response(
+				array(
+					'id'     => $checkout_session_id,
+					'result' => array(
+						'type'       => 'calculated',
+						'calculated' => array(
+							'taxes' => $tax_breakdown,
+						),
+					),
+				),
+				200
+			);
 
 		} catch ( Exception $e ) {
 			WC_Stripe_Logger::log(
 				'Agentic tax calculation failed',
-				[ 'error' => $e->getMessage() ]
+				array( 'error' => $e->getMessage() )
 			);
 
 			return new WP_Error(
 				'tax_calculation_failed',
 				$e->getMessage(),
-				[ 'status' => 500 ]
+				array( 'status' => 500 )
 			);
 		}
 	}
@@ -154,63 +189,124 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 * @param array $line_items  Line items.
 	 * @param array $fulfillment Fulfillment details.
 	 * @param array $billing     Billing details.
-	 * @return array Tax amounts.
+	 * @return array Tax breakdown with amount and display_name for each rate.
 	 * @throws Exception If calculation fails.
 	 */
 	private function calculate_taxes( $line_items, $fulfillment, $billing ) {
 		// Use shipping address for tax calculation (or billing if no shipping).
-		$tax_address = $fulfillment['address'] ?? $billing['address'] ?? [];
+		$tax_address = $fulfillment['address'] ?? $billing['address'] ?? array();
 
 		if ( empty( $tax_address ) ) {
 			throw new Exception( 'No address provided for tax calculation' );
 		}
 
 		// Set customer location for tax calculation.
-		$country    = $tax_address['country'] ?? '';
-		$state      = $tax_address['state'] ?? '';
-		$postcode   = $tax_address['postal_code'] ?? '';
-		$city       = $tax_address['city'] ?? '';
+		$country  = $tax_address['country'] ?? '';
+		$state    = $tax_address['state'] ?? '';
+		$postcode = $tax_address['postal_code'] ?? '';
+		$city     = $tax_address['city'] ?? '';
+
+		// Track taxes by rate ID to aggregate across items.
+		$tax_totals = array();
 
 		// Calculate tax for each line item.
-		$line_item_details  = [];
-		$total_line_tax     = 0;
-		$total_shipping_tax = 0;
-
 		foreach ( $line_items as $item ) {
-			$sku      = $item['sku_id'] ?? '';
-			$price    = ( $item['unit_amount'] ?? 0 ) * ( $item['quantity'] ?? 1 );
+			$sku = $item['sku_id'] ?? '';
+			// Convert cents to dollars for WC tax calculation.
+			$price = ( ( $item['unit_amount'] ?? 0 ) / 100 ) * ( $item['quantity'] ?? 1 );
 
 			// Get product for tax class.
 			$product = $this->get_product_by_sku( $sku );
 
 			if ( ! $product ) {
-				throw new Exception( "Product not found for SKU: {$sku}" );
+				throw new Exception( sprintf( 'Product not found for SKU: %s', esc_html( $sku ) ) );
 			}
 
 			$tax_class = $product->get_tax_class();
 
+			// Get tax rates for this product and location.
+			$tax_rates = WC_Tax::get_rates( $tax_class, array( $country, $state, $postcode, $city ) );
+
+			// Handle empty tax rates (no taxes apply).
+			if ( empty( $tax_rates ) ) {
+				continue;
+			}
+
 			// Calculate tax for this item.
-			$taxes     = WC_Tax::calc_tax( $price, WC_Tax::get_rates( $tax_class, [ $country, $state, $postcode, $city ] ) );
-			$tax_total = array_sum( $taxes );
+			$taxes = WC_Tax::calc_tax( $price, $tax_rates );
 
-			$line_item_details[] = [
-				'sku_id'     => $sku,
-				'amount_tax' => (int) $tax_total,
-			];
+			// Aggregate taxes by rate ID.
+			foreach ( $taxes as $rate_id => $tax_amount ) {
+				if ( ! isset( $tax_totals[ $rate_id ] ) ) {
+					// Get the tax rate details for display name.
+					$rate_details = $tax_rates[ $rate_id ] ?? null;
+					if ( ! $rate_details ) {
+						continue;
+					}
 
-			$total_line_tax += $tax_total;
+					$tax_totals[ $rate_id ] = array(
+						'amount'       => 0,
+						'display_name' => $rate_details['label'] ?? 'Tax',
+					);
+				}
+
+				$tax_totals[ $rate_id ]['amount'] += $tax_amount;
+			}
 		}
 
-		// Return formatted response.
-		return [
-			'line_item_details'   => $line_item_details,
-			'fulfillment_details' => [
-				'amount_tax' => (int) $total_shipping_tax,
-			],
-			'total_details'       => [
-				'amount_tax' => (int) ( $total_line_tax + $total_shipping_tax ),
-			],
-		];
+		// Calculate shipping tax if shipping amount is provided.
+		$shipping_amount = $fulfillment['shipping_amount'] ?? 0;
+		if ( $shipping_amount > 0 ) {
+			// Convert cents to dollars for WC tax calculation.
+			$shipping_amount_dollars = $shipping_amount / 100;
+
+			// Get shipping tax class (usually empty string for standard rate).
+			$shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );
+			if ( 'inherit' === $shipping_tax_class ) {
+				$shipping_tax_class = '';
+			}
+
+			// Get tax rates for shipping.
+			$shipping_tax_rates = WC_Tax::get_rates( $shipping_tax_class, array( $country, $state, $postcode, $city ) );
+
+			if ( ! empty( $shipping_tax_rates ) ) {
+				// Calculate shipping taxes.
+				$shipping_taxes = WC_Tax::calc_shipping_tax( $shipping_amount_dollars, $shipping_tax_rates );
+
+				// Aggregate shipping taxes.
+				foreach ( $shipping_taxes as $rate_id => $tax_amount ) {
+					if ( ! isset( $tax_totals[ $rate_id ] ) ) {
+						$rate_details = $shipping_tax_rates[ $rate_id ] ?? null;
+						if ( ! $rate_details ) {
+							continue;
+						}
+
+						$tax_totals[ $rate_id ] = array(
+							'amount'       => 0,
+							'display_name' => $rate_details['label'] ?? 'Tax',
+						);
+					}
+
+					$tax_totals[ $rate_id ]['amount'] += $tax_amount;
+				}
+			}
+		}
+
+		// Convert to array of taxes with amounts in cents.
+		$tax_breakdown = array();
+		foreach ( $tax_totals as $tax ) {
+			$tax_breakdown[] = array(
+				'amount'       => (int) round( $tax['amount'] * 100 ), // Convert dollars to cents.
+				'display_name' => $tax['display_name'],
+			);
+		}
+
+		// Handle case where no taxes apply.
+		if ( empty( $tax_breakdown ) ) {
+			return array();
+		}
+
+		return $tax_breakdown;
 	}
 
 	/**
@@ -233,6 +329,7 @@ class WC_Stripe_REST_Agentic_Tax_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	protected function get_request_headers() {
-		return getallheaders() ?: [];
+		$headers = getallheaders();
+		return $headers ? $headers : array();
 	}
 }

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1462,6 +1462,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			case 'setup_intent.succeeded':
 			case 'setup_intent.setup_failed':
 				$this->process_setup_intent( $notification );
+				break;
+
+			case 'checkout.session.completed':
+				// Check if this is an agentic checkout session.
+				if ( $this->is_agentic_checkout( $notification->data->object ) ) {
+					$order = $this->create_order_from_checkout_session( $notification->data->object );
+					if ( $order instanceof WC_Order ) {
+						$this->resolved_order = $order;
+					}
+				}
+				break;
 
 		}
 
@@ -1569,6 +1580,230 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Check if checkout session is from agentic checkout.
+	 *
+	 * @since 8.9.0
+	 * @param object $checkout_session Checkout session object.
+	 * @return bool
+	 */
+	public function is_agentic_checkout( $checkout_session ) {
+		// Check metadata for agentic flag.
+		if ( isset( $checkout_session->metadata->agentic ) && 'true' === $checkout_session->metadata->agentic ) {
+			return true;
+		}
+
+		// Check origin_context if available (Stripe may add this).
+		if ( isset( $checkout_session->origin_context ) && ! empty( $checkout_session->origin_context ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Create WooCommerce order from agentic checkout session.
+	 *
+	 * @since 8.9.0
+	 * @param object $checkout_session Checkout session object.
+	 * @return WC_Order|WP_Error Order object or error.
+	 */
+	public function create_order_from_checkout_session( $checkout_session ) {
+		try {
+			// Check for duplicate processing.
+			$existing_orders = wc_get_orders(
+				[
+					'limit'      => 1,
+					'meta_key'   => '_wc_stripe_checkout_session_id',
+					'meta_value' => $checkout_session->id,
+				]
+			);
+
+			if ( ! empty( $existing_orders ) ) {
+				WC_Stripe_Logger::log(
+					'Agentic order already exists for session',
+					[
+						'checkout_session_id' => $checkout_session->id,
+						'order_id'            => $existing_orders[0]->get_id(),
+					]
+				);
+				return $existing_orders[0];
+			}
+
+			// Create order.
+			$order = wc_create_order();
+
+			// Add metadata.
+			$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+			$order->update_meta_data( '_wc_stripe_checkout_session_id', $checkout_session->id );
+
+			// Set customer details.
+			$customer = $checkout_session->customer_details ?? null;
+			if ( $customer ) {
+				$order->set_billing_first_name( $customer->name ?? '' );
+				$order->set_billing_email( $customer->email ?? '' );
+				$order->set_billing_phone( $customer->phone ?? '' );
+
+				if ( isset( $customer->address ) ) {
+					$address = $customer->address;
+					$order->set_billing_address_1( $address->line1 ?? '' );
+					$order->set_billing_address_2( $address->line2 ?? '' );
+					$order->set_billing_city( $address->city ?? '' );
+					$order->set_billing_state( $address->state ?? '' );
+					$order->set_billing_postcode( $address->postal_code ?? '' );
+					$order->set_billing_country( $address->country ?? '' );
+				}
+			}
+
+			// Set shipping details if present.
+			$shipping_details = $checkout_session->shipping_details ?? null;
+			if ( $shipping_details && isset( $shipping_details->address ) ) {
+				$shipping_address = $shipping_details->address;
+				$order->set_shipping_first_name( $shipping_details->name ?? '' );
+				$order->set_shipping_address_1( $shipping_address->line1 ?? '' );
+				$order->set_shipping_address_2( $shipping_address->line2 ?? '' );
+				$order->set_shipping_city( $shipping_address->city ?? '' );
+				$order->set_shipping_state( $shipping_address->state ?? '' );
+				$order->set_shipping_postcode( $shipping_address->postal_code ?? '' );
+				$order->set_shipping_country( $shipping_address->country ?? '' );
+			}
+
+			// Add line items.
+			$line_items = $checkout_session->line_items->data ?? [];
+			foreach ( $line_items as $item ) {
+				$sku      = $item->price->lookup_key ?? '';
+				$quantity = $item->quantity ?? 1;
+				$total    = ( $item->amount_total ?? 0 ) / 100; // Convert from cents.
+
+				// Get product by SKU.
+				$product_id = wc_get_product_id_by_sku( $sku );
+				$product    = $product_id ? wc_get_product( $product_id ) : null;
+
+				/**
+				 * Filter to allow custom product lookup by SKU.
+				 *
+				 * @since 8.9.0
+				 * @param WC_Product|null $product The product object or null if not found.
+				 * @param string          $sku     The SKU to lookup.
+				 */
+				$product = apply_filters( 'wc_stripe_agentic_product_by_sku', $product, $sku );
+
+				if ( ! $product ) {
+					throw new Exception( sprintf( 'Product not found for SKU: %s', $sku ) );
+				}
+
+				$order->add_product( $product, $quantity, [ 'subtotal' => $total, 'total' => $total ] );
+			}
+
+			// Add shipping if present.
+			$shipping_cost = $checkout_session->shipping_cost ?? null;
+			if ( $shipping_cost && isset( $shipping_cost->amount_total ) ) {
+				$shipping = new WC_Order_Item_Shipping();
+				$shipping->set_method_title( $shipping_cost->shipping_rate->display_name ?? 'Shipping' );
+				$shipping->set_total( ( $shipping_cost->amount_total ?? 0 ) / 100 );
+				$order->add_item( $shipping );
+			}
+
+			// Set payment method.
+			$order->set_payment_method( 'stripe' );
+			$order->set_payment_method_title( 'Stripe (Agentic Checkout)' );
+
+			// Set transaction ID from payment intent.
+			$payment_intent    = $checkout_session->payment_intent ?? null;
+			$payment_intent_id = is_object( $payment_intent ) ? $payment_intent->id : $payment_intent;
+
+			if ( $payment_intent_id ) {
+				$order->set_transaction_id( $payment_intent_id );
+			}
+
+			// Check if manual capture is required.
+			$capture_method    = is_object( $payment_intent ) && isset( $payment_intent->capture_method ) ? $payment_intent->capture_method : null;
+			$is_manual_capture = 'manual' === $capture_method;
+
+			if ( $is_manual_capture ) {
+				// Store payment intent ID for later capture.
+				$order->update_meta_data( '_stripe_intent_id', $payment_intent_id );
+				$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+				$order->update_meta_data( '_stripe_charge_captured', 'no' );
+
+				// Set order to on-hold status.
+				$order->update_status( OrderStatus::ON_HOLD, __( 'Payment authorized, awaiting capture.', 'woocommerce-gateway-stripe' ) );
+
+				WC_Stripe_Logger::log(
+					'Agentic order created with manual capture',
+					[
+						'order_id'  => $order->get_id(),
+						'intent_id' => $payment_intent_id,
+					]
+				);
+			} else {
+				// Set order status based on payment status.
+				$payment_status = $checkout_session->payment_status ?? 'unpaid';
+				if ( 'paid' === $payment_status ) {
+					$order->payment_complete( $payment_intent_id );
+				} else {
+					$order->update_status( OrderStatus::PENDING );
+				}
+			}
+
+			// Add order note.
+			$agent_name = $checkout_session->metadata->agent ?? 'Unknown';
+			$order->add_order_note(
+				sprintf(
+					/* translators: %s: Agent name */
+					__( 'Order created via AI agent checkout (%s)', 'woocommerce-gateway-stripe' ),
+					$agent_name
+				)
+			);
+
+			$order->save();
+
+			/**
+			 * Action fired when agentic order is created.
+			 *
+			 * @since 8.9.0
+			 * @param WC_Order $order            Created order.
+			 * @param object   $checkout_session Checkout session object.
+			 */
+			do_action( 'wc_stripe_agentic_order_created', $order, $checkout_session );
+
+			WC_Stripe_Logger::log(
+				'Agentic order created',
+				[
+					'order_id'            => $order->get_id(),
+					'checkout_session_id' => $checkout_session->id,
+					'agent'               => $agent_name,
+				]
+			);
+
+			return $order;
+
+		} catch ( Exception $e ) {
+			/**
+			 * Action fired when agentic order creation fails.
+			 *
+			 * @since 8.9.0
+			 * @param WP_Error $error            Error object.
+			 * @param object   $checkout_session Checkout session object.
+			 */
+			do_action(
+				'wc_stripe_agentic_order_failed',
+				new WP_Error( 'order_creation_failed', $e->getMessage() ),
+				$checkout_session
+			);
+
+			WC_Stripe_Logger::log(
+				'Agentic order creation failed',
+				[
+					'error'               => $e->getMessage(),
+					'checkout_session_id' => $checkout_session->id ?? 'unknown',
+				]
+			);
+
+			return new WP_Error( 'order_creation_failed', $e->getMessage() );
+		}
 	}
 }
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1670,12 +1670,19 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 				$order->set_shipping_country( $shipping_address->country ?? '' );
 			}
 
+			// Get currency and determine divisor for zero-decimal currencies.
+			$currency = strtolower( $checkout_session->currency ?? 'usd' );
+			$divisor  = in_array( $currency, WC_Stripe_Helper::no_decimal_currencies(), true ) ? 1 : 100;
+
+			// Set order currency.
+			$order->set_currency( strtoupper( $currency ) );
+
 			// Add line items.
 			$line_items = $checkout_session->line_items->data ?? [];
 			foreach ( $line_items as $item ) {
 				$sku      = $item->price->lookup_key ?? '';
 				$quantity = $item->quantity ?? 1;
-				$total    = ( $item->amount_total ?? 0 ) / 100; // Convert from cents.
+				$total    = ( $item->amount_total ?? 0 ) / $divisor;
 
 				// Get product by SKU.
 				$product_id = wc_get_product_id_by_sku( $sku );
@@ -1702,7 +1709,7 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			if ( $shipping_cost && isset( $shipping_cost->amount_total ) ) {
 				$shipping = new WC_Order_Item_Shipping();
 				$shipping->set_method_title( $shipping_cost->shipping_rate->display_name ?? 'Shipping' );
-				$shipping->set_total( ( $shipping_cost->amount_total ?? 0 ) / 100 );
+				$shipping->set_total( ( $shipping_cost->amount_total ?? 0 ) / $divisor );
 				$order->add_item( $shipping );
 			}
 
@@ -1757,6 +1764,17 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					$agent_name
 				)
 			);
+
+			/**
+			 * Filter order data before saving agentic order.
+			 *
+			 * Allows modification of the order object before it's saved to the database.
+			 *
+			 * @since 8.9.0
+			 * @param WC_Order $order            Order object.
+			 * @param object   $checkout_session Checkout session data.
+			 */
+			$order = apply_filters( 'wc_stripe_agentic_order_data', $order, $checkout_session );
 
 			$order->save();
 

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1701,7 +1701,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					throw new Exception( sprintf( 'Product not found for SKU: %s', $sku ) );
 				}
 
-				$order->add_product( $product, $quantity, [ 'subtotal' => $total, 'total' => $total ] );
+				$order->add_product(
+					$product,
+					$quantity,
+					[
+						'subtotal' => $total,
+						'total'    => $total,
+					]
+				);
 			}
 
 			// Add shipping if present.

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -103,6 +103,7 @@ class WC_Stripe {
 		$this->init();
 
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		add_action( 'rest_api_init', [ $this, 'register_agentic_rest_controllers' ] );
 	}
 
 	/**
@@ -795,6 +796,32 @@ class WC_Stripe {
 
 		$oc_setting_toggle_controller = new WC_Stripe_REST_OC_Setting_Toggle_Controller( $this->get_main_stripe_gateway() );
 		$oc_setting_toggle_controller->register_routes();
+	}
+
+	/**
+	 * Register Agentic Checkout REST API controllers.
+	 *
+	 * @since 8.9.0
+	 */
+	public function register_agentic_rest_controllers() {
+		// Only register if feature is enabled.
+		if ( ! apply_filters( 'wc_stripe_agentic_checkout_enabled', false ) ) {
+			return;
+		}
+
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/abstracts/trait-wc-stripe-agentic-authentication.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-agentic-approval-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-agentic-tax-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-rest-agentic-shipping-controller.php';
+
+		$approval_controller = new WC_Stripe_REST_Agentic_Approval_Controller();
+		$approval_controller->register_routes();
+
+		$tax_controller = new WC_Stripe_REST_Agentic_Tax_Controller();
+		$tax_controller->register_routes();
+
+		$shipping_controller = new WC_Stripe_REST_Agentic_Shipping_Controller();
+		$shipping_controller->register_routes();
 	}
 
 	/**

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -235,6 +235,10 @@ class WC_Stripe {
 		if ( is_admin() ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-settings-controller.php';
+			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-agentic-admin-capture.php';
+
+			// Initialize agentic admin capture handler.
+			new WC_Stripe_Agentic_Admin_Capture();
 
 			if ( isset( $_GET['area'] ) && 'payment_requests' === $_GET['area'] ) {
 				require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-payment-requests-controller.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: credit card, stripe, payments, woocommerce, woo
 Requires at least: 6.7
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 10.1.0
+Stable tag: 10.2.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 Attributions: thorsten-stripe

--- a/tests/phpunit/WC_Stripe_Agentic_Controllers_Registration_Test.php
+++ b/tests/phpunit/WC_Stripe_Agentic_Controllers_Registration_Test.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests;
+
+use WC_Stripe;
+
+/**
+ * Tests for Agentic Checkout REST controller registration.
+ *
+ * @package WooCommerce/Stripe/WC_Stripe
+ */
+class WC_Stripe_Agentic_Controllers_Registration_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
+
+	/**
+	 * Test that agentic controllers are not registered when feature is disabled.
+	 */
+	public function test_agentic_controllers_not_registered_when_disabled() {
+		// Remove the filter to disable agentic checkout.
+		remove_all_filters( 'wc_stripe_agentic_checkout_enabled' );
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_false' );
+
+		$wc_stripe = WC_Stripe::get_instance();
+
+		// Trigger REST API init.
+		do_action( 'rest_api_init' );
+
+		// Check that agentic routes are not registered.
+		$server = rest_get_server();
+		$routes = $server->get_routes();
+
+		$this->assertArrayNotHasKey( '/wc/v3/stripe/agentic/approve', $routes );
+		$this->assertArrayNotHasKey( '/wc/v3/stripe/agentic/compute_tax', $routes );
+		$this->assertArrayNotHasKey( '/wc/v3/stripe/agentic/compute_shipping_options', $routes );
+
+		// Clean up.
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_false' );
+	}
+
+	/**
+	 * Test that agentic controllers are registered when feature is enabled.
+	 */
+	public function test_agentic_controllers_registered_when_enabled() {
+		// Enable agentic checkout.
+		remove_all_filters( 'wc_stripe_agentic_checkout_enabled' );
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		$wc_stripe = WC_Stripe::get_instance();
+
+		// Trigger REST API init.
+		do_action( 'rest_api_init' );
+
+		// Check that agentic routes are registered.
+		$server = rest_get_server();
+		$routes = $server->get_routes();
+
+		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/approve', $routes );
+		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/compute_tax', $routes );
+		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/compute_shipping_options', $routes );
+
+		// Clean up.
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+
+	/**
+	 * Test that register_agentic_rest_controllers method exists.
+	 */
+	public function test_register_agentic_rest_controllers_method_exists() {
+		$wc_stripe = WC_Stripe::get_instance();
+		$this->assertTrue( method_exists( $wc_stripe, 'register_agentic_rest_controllers' ) );
+	}
+
+	/**
+	 * Test that register_agentic_rest_controllers is hooked to rest_api_init.
+	 */
+	public function test_register_agentic_rest_controllers_hooked_to_rest_api_init() {
+		$wc_stripe = WC_Stripe::get_instance();
+		$this->assertNotFalse( has_action( 'rest_api_init', [ $wc_stripe, 'register_agentic_rest_controllers' ] ) );
+	}
+}

--- a/tests/phpunit/unit/test-wc-stripe-agentic-admin-capture.php
+++ b/tests/phpunit/unit/test-wc-stripe-agentic-admin-capture.php
@@ -1,0 +1,269 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests;
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use Mockery;
+use WC_Order;
+use WC_Product_Simple;
+use WC_Stripe_Agentic_Admin_Capture;
+use WC_Stripe_API;
+use WC_Stripe_Intent_Status;
+use WP_UnitTestCase;
+
+/**
+ * Test agentic checkout manual capture admin functionality.
+ */
+class WC_Stripe_Agentic_Admin_Capture_Test extends WP_UnitTestCase {
+	/**
+	 * The admin capture handler instance for testing.
+	 *
+	 * @var WC_Stripe_Agentic_Admin_Capture
+	 */
+	private $capture_handler;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->capture_handler = new WC_Stripe_Agentic_Admin_Capture();
+	}
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tear_down() {
+		Mockery::close();
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that capture action appears for manual capture agentic orders.
+	 */
+	public function test_capture_action_appears_for_manual_capture_orders() {
+		// Create a test order with manual capture flag.
+		$order = wc_create_order();
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+		$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+		$order->update_meta_data( '_stripe_intent_id', 'pi_test_123' );
+		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$order->set_payment_method( 'stripe' );
+		$order->save();
+
+		$actions = [];
+		$actions = $this->capture_handler->add_capture_action( $actions, $order );
+
+		$this->assertArrayHasKey( 'wc_stripe_capture_agentic_payment', $actions );
+		$this->assertEquals( 'Capture Stripe Payment', $actions['wc_stripe_capture_agentic_payment'] );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that capture action does not appear for regular orders.
+	 */
+	public function test_capture_action_does_not_appear_for_regular_orders() {
+		// Create a regular order without manual capture flag.
+		$order = wc_create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order->set_payment_method( 'stripe' );
+		$order->save();
+
+		$actions = [];
+		$actions = $this->capture_handler->add_capture_action( $actions, $order );
+
+		$this->assertArrayNotHasKey( 'wc_stripe_capture_agentic_payment', $actions );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that capture action does not appear for already captured orders.
+	 */
+	public function test_capture_action_does_not_appear_for_captured_orders() {
+		// Create an order that was already captured.
+		$order = wc_create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+		$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+		$order->update_meta_data( '_stripe_intent_id', 'pi_test_456' );
+		$order->update_meta_data( '_stripe_charge_captured', 'yes' );
+		$order->set_payment_method( 'stripe' );
+		$order->save();
+
+		$actions = [];
+		$actions = $this->capture_handler->add_capture_action( $actions, $order );
+
+		$this->assertArrayNotHasKey( 'wc_stripe_capture_agentic_payment', $actions );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that capture action does not appear without intent ID.
+	 */
+	public function test_capture_action_does_not_appear_without_intent_id() {
+		// Create an order without intent ID.
+		$order = wc_create_order();
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+		$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$order->set_payment_method( 'stripe' );
+		$order->save();
+
+		$actions = [];
+		$actions = $this->capture_handler->add_capture_action( $actions, $order );
+
+		$this->assertArrayNotHasKey( 'wc_stripe_capture_agentic_payment', $actions );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that filter hook can disable capture action.
+	 */
+	public function test_filter_can_disable_capture_action() {
+		// Create a manual capture order.
+		$order = wc_create_order();
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+		$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+		$order->update_meta_data( '_stripe_intent_id', 'pi_test_789' );
+		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$order->set_payment_method( 'stripe' );
+		$order->save();
+
+		// Add filter to disable capture.
+		add_filter( 'wc_stripe_agentic_manual_capture_enabled', '__return_false' );
+
+		$actions = [];
+		$actions = $this->capture_handler->add_capture_action( $actions, $order );
+
+		$this->assertArrayNotHasKey( 'wc_stripe_capture_agentic_payment', $actions );
+
+		// Remove filter.
+		remove_filter( 'wc_stripe_agentic_manual_capture_enabled', '__return_false' );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test successful payment capture.
+	 */
+	public function test_successful_payment_capture() {
+		// Create a manual capture order.
+		$order = wc_create_order();
+		$order->set_total( 10.00 );
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+		$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+		$order->update_meta_data( '_stripe_intent_id', 'pi_test_capture' );
+		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$order->set_payment_method( 'stripe' );
+		$order->set_transaction_id( 'pi_test_capture' );
+		$order->save();
+
+		// Mock the Stripe API response for successful capture.
+		$mock_intent = (object) [
+			'id'     => 'pi_test_capture',
+			'status' => WC_Stripe_Intent_Status::SUCCEEDED,
+			'amount' => 1000,
+			'charges' => (object) [
+				'data' => [
+					(object) [
+						'id'      => 'ch_test_123',
+						'captured' => true,
+					],
+				],
+			],
+		];
+
+		// Process the capture action.
+		$this->capture_handler->process_capture_action( $order );
+
+		// Verify order status changed.
+		$order = wc_get_order( $order->get_id() );
+		// Note: In actual implementation, this will be set to processing/completed
+		// For now, we're just testing the structure exists.
+		$this->assertInstanceOf( WC_Order::class, $order );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test capture with invalid intent ID.
+	 */
+	public function test_capture_with_invalid_intent() {
+		// Create a manual capture order.
+		$order = wc_create_order();
+		$order->set_total( 10.00 );
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+		$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+		$order->update_meta_data( '_stripe_intent_id', 'pi_invalid' );
+		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$order->set_payment_method( 'stripe' );
+		$order->set_transaction_id( 'pi_invalid' );
+		$order->save();
+
+		// Process the capture action (will fail due to invalid intent).
+		$this->capture_handler->process_capture_action( $order );
+
+		// Verify order still exists and wasn't corrupted.
+		$order = wc_get_order( $order->get_id() );
+		$this->assertInstanceOf( WC_Order::class, $order );
+
+		// Clean up.
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that filter hook can modify capture amount.
+	 */
+	public function test_filter_can_modify_capture_amount() {
+		// Create a manual capture order.
+		$order = wc_create_order();
+		$order->set_total( 10.00 );
+		$order->set_status( OrderStatus::ON_HOLD );
+		$order->update_meta_data( '_wc_stripe_agentic_order', 'true' );
+		$order->update_meta_data( '_stripe_manual_capture', 'yes' );
+		$order->update_meta_data( '_stripe_intent_id', 'pi_test_amount' );
+		$order->update_meta_data( '_stripe_charge_captured', 'no' );
+		$order->set_payment_method( 'stripe' );
+		$order->set_transaction_id( 'pi_test_amount' );
+		$order->save();
+
+		$filter_called = false;
+
+		// Add filter to modify amount.
+		add_filter(
+			'wc_stripe_agentic_capture_amount',
+			function ( $amount, $order_obj ) use ( &$filter_called ) {
+				$filter_called = true;
+				$this->assertEquals( 10.00, $amount );
+				return 5.00; // Capture only half.
+			},
+			10,
+			2
+		);
+
+		// Process the capture action.
+		$this->capture_handler->process_capture_action( $order );
+
+		// Verify filter was called.
+		$this->assertTrue( $filter_called, 'wc_stripe_agentic_capture_amount filter should be called' );
+
+		// Clean up.
+		remove_all_filters( 'wc_stripe_agentic_capture_amount' );
+		$order->delete( true );
+	}
+}

--- a/tests/phpunit/unit/test-wc-stripe-agentic-authentication.php
+++ b/tests/phpunit/unit/test-wc-stripe-agentic-authentication.php
@@ -4,6 +4,8 @@ namespace WooCommerce\Stripe\Tests;
 
 use WP_UnitTestCase;
 use WP_Error;
+use WC_Stripe_Webhook_Handler;
+use WC_Stripe_Webhook_State;
 
 /**
  * Test authentication trait for Agentic Checkout.
@@ -11,8 +13,59 @@ use WP_Error;
 class WC_Stripe_Agentic_Authentication_Test extends WP_UnitTestCase {
 	use \WC_Stripe_Agentic_Authentication;
 
+	/**
+	 * Mock webhook handler for testing.
+	 *
+	 * @var WC_Stripe_Webhook_Handler|null
+	 */
+	private $mock_webhook_handler = null;
+
+	/**
+	 * Override verify_stripe_signature to allow injection of mock webhook handler.
+	 *
+	 * @return bool|WP_Error
+	 */
+	protected function verify_stripe_signature_with_handler( $webhook_handler = null ) {
+		// Get webhook secret from settings.
+		$stripe_settings = \WC_Stripe_Helper::get_stripe_settings();
+		$testmode        = \WC_Stripe_Mode::is_test();
+		$secret_key      = ( $testmode ? 'test_' : '' ) . 'webhook_secret';
+		$secret          = $stripe_settings[ $secret_key ] ?? false;
+
+		if ( empty( $secret ) ) {
+			return new WP_Error( 'no_secret', 'Webhook secret not configured' );
+		}
+
+		// Get request headers and body.
+		$headers = $this->get_request_headers();
+		$body    = file_get_contents( 'php://input' );
+
+		// Check for file_get_contents failure.
+		if ( false === $body ) {
+			return new WP_Error( 'read_failure', 'Failed to read request body' );
+		}
+
+		if ( empty( $headers ) || ! is_array( $headers ) ) {
+			return new WP_Error( 'empty_headers', 'No request headers found' );
+		}
+
+		if ( '' === $body || is_null( $body ) ) {
+			return new WP_Error( 'empty_body', 'No request body found' );
+		}
+
+		// Use injected handler or create new one.
+		$handler = $webhook_handler ?? new WC_Stripe_Webhook_Handler();
+		$result  = $handler->validate_request( $headers, $body );
+
+		if ( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED !== $result ) {
+			return new WP_Error( 'invalid_signature', $result );
+		}
+
+		return true;
+	}
+
 	protected function get_request_headers() {
-		return [];
+		return $this->headers ?? [];
 	}
 
 	public function test_is_agentic_checkout_enabled_returns_false_by_default() {
@@ -29,5 +82,117 @@ class WC_Stripe_Agentic_Authentication_Test extends WP_UnitTestCase {
 		$result = $this->verify_stripe_signature();
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertEquals( 'no_secret', $result->get_error_code() );
+	}
+
+	public function test_verify_stripe_signature_returns_true_for_valid_signature() {
+		// Mock Stripe settings with webhook secret.
+		add_filter(
+			'wc_stripe_settings',
+			function () {
+				return [
+					'testmode'            => 'yes',
+					'test_webhook_secret' => 'whsec_test_secret',
+				];
+			}
+		);
+
+		// Set headers.
+		$this->headers = [ 'Stripe-Signature' => 't=123,v1=valid_signature' ];
+
+		// Mock the webhook handler to return successful validation.
+		$mock_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'validate_request' ] )
+			->getMock();
+
+		$mock_handler->expects( $this->once() )
+			->method( 'validate_request' )
+			->with( $this->headers, $this->anything() )
+			->willReturn( WC_Stripe_Webhook_State::VALIDATION_SUCCEEDED );
+
+		$result = $this->verify_stripe_signature_with_handler( $mock_handler );
+		$this->assertTrue( $result );
+
+		// Clean up.
+		remove_all_filters( 'wc_stripe_settings' );
+	}
+
+	public function test_verify_stripe_signature_returns_error_for_invalid_signature() {
+		// Mock Stripe settings with webhook secret.
+		add_filter(
+			'wc_stripe_settings',
+			function () {
+				return [
+					'testmode'            => 'yes',
+					'test_webhook_secret' => 'whsec_test_secret',
+				];
+			}
+		);
+
+		// Set headers.
+		$this->headers = [ 'Stripe-Signature' => 't=123,v1=invalid_signature' ];
+
+		// Mock the webhook handler to return failed validation.
+		$mock_handler = $this->getMockBuilder( WC_Stripe_Webhook_Handler::class )
+			->setMethods( [ 'validate_request' ] )
+			->getMock();
+
+		$mock_handler->expects( $this->once() )
+			->method( 'validate_request' )
+			->with( $this->headers, $this->anything() )
+			->willReturn( WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH );
+
+		$result = $this->verify_stripe_signature_with_handler( $mock_handler );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'invalid_signature', $result->get_error_code() );
+		$this->assertEquals( WC_Stripe_Webhook_State::VALIDATION_FAILED_SIGNATURE_MISMATCH, $result->get_error_message() );
+
+		// Clean up.
+		remove_all_filters( 'wc_stripe_settings' );
+	}
+
+	public function test_verify_stripe_signature_returns_error_for_empty_headers() {
+		// Mock Stripe settings with webhook secret.
+		add_filter(
+			'wc_stripe_settings',
+			function () {
+				return [
+					'testmode'            => 'yes',
+					'test_webhook_secret' => 'whsec_test_secret',
+				];
+			}
+		);
+
+		// Set empty headers.
+		$this->headers = [];
+
+		$result = $this->verify_stripe_signature();
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'empty_headers', $result->get_error_code() );
+
+		// Clean up.
+		remove_all_filters( 'wc_stripe_settings' );
+	}
+
+	public function test_verify_stripe_signature_returns_error_for_non_array_headers() {
+		// Mock Stripe settings with webhook secret.
+		add_filter(
+			'wc_stripe_settings',
+			function () {
+				return [
+					'testmode'            => 'yes',
+					'test_webhook_secret' => 'whsec_test_secret',
+				];
+			}
+		);
+
+		// Set non-array headers.
+		$this->headers = 'not an array';
+
+		$result = $this->verify_stripe_signature();
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'empty_headers', $result->get_error_code() );
+
+		// Clean up.
+		remove_all_filters( 'wc_stripe_settings' );
 	}
 }

--- a/tests/phpunit/unit/test-wc-stripe-agentic-authentication.php
+++ b/tests/phpunit/unit/test-wc-stripe-agentic-authentication.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests;
+
+use WP_UnitTestCase;
+use WP_Error;
+
+/**
+ * Test authentication trait for Agentic Checkout.
+ */
+class WC_Stripe_Agentic_Authentication_Test extends WP_UnitTestCase {
+	use \WC_Stripe_Agentic_Authentication;
+
+	protected function get_request_headers() {
+		return [];
+	}
+
+	public function test_is_agentic_checkout_enabled_returns_false_by_default() {
+		$this->assertFalse( $this->is_agentic_checkout_enabled() );
+	}
+
+	public function test_is_agentic_checkout_enabled_respects_filter() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+		$this->assertTrue( $this->is_agentic_checkout_enabled() );
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+
+	public function test_verify_stripe_signature_returns_error_when_no_secret() {
+		$result = $this->verify_stripe_signature();
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'no_secret', $result->get_error_code() );
+	}
+}

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-approval-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-approval-controller.php
@@ -35,11 +35,15 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
-		$request->set_body( json_encode( [
-			'id'          => 'cs_test_123',
-			'line_items'  => [],
-			'amount_total' => 1000,
-		] ) );
+		$request->set_body(
+			json_encode(
+				[
+					'id'          => 'cs_test_123',
+					'line_items'  => [],
+					'amount_total' => 1000,
+				]
+			)
+		);
 
 		$response = $this->controller->approve( $request );
 		$data     = $response->get_data();
@@ -54,18 +58,22 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
-		$request->set_body( json_encode( [
-			'id'         => 'cs_test_123',
-			'line_items' => [
-				'data' => [
-					[
-						'price'    => [ 'lookup_key' => 'invalid_sku' ],
-						'quantity' => 1,
+		$request->set_body(
+			json_encode(
+				[
+					'id'         => 'cs_test_123',
+					'line_items' => [
+						'data' => [
+							[
+								'price'    => [ 'lookup_key' => 'invalid_sku' ],
+								'quantity' => 1,
+							],
+						],
 					],
-				],
-			],
-			'amount_total' => 1000,
-		] ) );
+					'amount_total' => 1000,
+				]
+			)
+		);
 
 		$response = $this->controller->approve( $request );
 		$data     = $response->get_data();
@@ -85,23 +93,30 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 		$product->method( 'is_in_stock' )->willReturn( true );
 		$product->method( 'get_sku' )->willReturn( 'test_sku' );
 
-		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
-			return $product;
-		} );
+		add_filter(
+			'wc_stripe_agentic_product_by_sku',
+			function () use ( $product ) {
+				return $product;
+			}
+		);
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
-		$request->set_body( json_encode( [
-			'id'         => 'cs_test_123',
-			'line_items' => [
-				'data' => [
-					[
-						'price'    => [ 'lookup_key' => 'test_sku' ],
-						'quantity' => 1,
+		$request->set_body(
+			json_encode(
+				[
+					'id'         => 'cs_test_123',
+					'line_items' => [
+						'data' => [
+							[
+								'price'    => [ 'lookup_key' => 'test_sku' ],
+								'quantity' => 1,
+							],
+						],
 					],
-				],
-			],
-			'amount_total' => 1000,
-		] ) );
+					'amount_total' => 1000,
+				]
+			)
+		);
 
 		$response = $this->controller->approve( $request );
 		$data     = $response->get_data();
@@ -122,23 +137,30 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 		$product->method( 'is_in_stock' )->willReturn( false );
 		$product->method( 'get_sku' )->willReturn( 'test_sku' );
 
-		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
-			return $product;
-		} );
+		add_filter(
+			'wc_stripe_agentic_product_by_sku',
+			function () use ( $product ) {
+				return $product;
+			}
+		);
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
-		$request->set_body( json_encode( [
-			'id'         => 'cs_test_123',
-			'line_items' => [
-				'data' => [
-					[
-						'price'    => [ 'lookup_key' => 'test_sku' ],
-						'quantity' => 1,
+		$request->set_body(
+			json_encode(
+				[
+					'id'         => 'cs_test_123',
+					'line_items' => [
+						'data' => [
+							[
+								'price'    => [ 'lookup_key' => 'test_sku' ],
+								'quantity' => 1,
+							],
+						],
 					],
-				],
-			],
-			'amount_total' => 1000,
-		] ) );
+					'amount_total' => 1000,
+				]
+			)
+		);
 
 		$response = $this->controller->approve( $request );
 		$data     = $response->get_data();
@@ -161,23 +183,30 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 		$product->method( 'get_stock_quantity' )->willReturn( 2 );
 		$product->method( 'get_sku' )->willReturn( 'test_sku' );
 
-		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
-			return $product;
-		} );
+		add_filter(
+			'wc_stripe_agentic_product_by_sku',
+			function () use ( $product ) {
+				return $product;
+			}
+		);
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
-		$request->set_body( json_encode( [
-			'id'         => 'cs_test_123',
-			'line_items' => [
-				'data' => [
-					[
-						'price'    => [ 'lookup_key' => 'test_sku' ],
-						'quantity' => 5, // Request 5, but only 2 available
+		$request->set_body(
+			json_encode(
+				[
+					'id'         => 'cs_test_123',
+					'line_items' => [
+						'data' => [
+							[
+								'price'    => [ 'lookup_key' => 'test_sku' ],
+								'quantity' => 5, // Request 5, but only 2 available
+							],
+						],
 					],
-				],
-			],
-			'amount_total' => 5000,
-		] ) );
+					'amount_total' => 5000,
+				]
+			)
+		);
 
 		$response = $this->controller->approve( $request );
 		$data     = $response->get_data();
@@ -200,23 +229,30 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 		$product->method( 'get_stock_quantity' )->willReturn( 10 );
 		$product->method( 'get_sku' )->willReturn( 'test_sku' );
 
-		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
-			return $product;
-		} );
+		add_filter(
+			'wc_stripe_agentic_product_by_sku',
+			function () use ( $product ) {
+				return $product;
+			}
+		);
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
-		$request->set_body( json_encode( [
-			'id'         => 'cs_test_123',
-			'line_items' => [
-				'data' => [
-					[
-						'price'    => [ 'lookup_key' => 'test_sku' ],
-						'quantity' => 5,
+		$request->set_body(
+			json_encode(
+				[
+					'id'         => 'cs_test_123',
+					'line_items' => [
+						'data' => [
+							[
+								'price'    => [ 'lookup_key' => 'test_sku' ],
+								'quantity' => 5,
+							],
+						],
 					],
-				],
-			],
-			'amount_total' => 5000,
-		] ) );
+					'amount_total' => 5000,
+				]
+			)
+		);
 
 		$response = $this->controller->approve( $request );
 		$data     = $response->get_data();
@@ -237,31 +273,40 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 		$product1->method( 'managing_stock' )->willReturn( false );
 		$product1->method( 'get_sku' )->willReturn( 'valid_sku' );
 
-		add_filter( 'wc_stripe_agentic_product_by_sku', function( $product, $sku ) use ( $product1 ) {
-			if ( $sku === 'valid_sku' ) {
-				return $product1;
-			}
-			// Second product not found
-			return null;
-		}, 10, 2 );
+		add_filter(
+			'wc_stripe_agentic_product_by_sku',
+			function ( $product, $sku ) use ( $product1 ) {
+				if ( 'valid_sku' === $sku ) {
+					return $product1;
+				}
+				// Second product not found
+				return null;
+			},
+			10,
+			2
+		);
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
-		$request->set_body( json_encode( [
-			'id'         => 'cs_test_123',
-			'line_items' => [
-				'data' => [
-					[
-						'price'    => [ 'lookup_key' => 'valid_sku' ],
-						'quantity' => 1,
+		$request->set_body(
+			json_encode(
+				[
+					'id'         => 'cs_test_123',
+					'line_items' => [
+						'data' => [
+							[
+								'price'    => [ 'lookup_key' => 'valid_sku' ],
+								'quantity' => 1,
+							],
+							[
+								'price'    => [ 'lookup_key' => 'invalid_sku' ],
+								'quantity' => 1,
+							],
+						],
 					],
-					[
-						'price'    => [ 'lookup_key' => 'invalid_sku' ],
-						'quantity' => 1,
-					],
-				],
-			],
-			'amount_total' => 2000,
-		] ) );
+					'amount_total' => 2000,
+				]
+			)
+		);
 
 		$response = $this->controller->approve( $request );
 		$data     = $response->get_data();

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-approval-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-approval-controller.php
@@ -49,4 +49,227 @@ class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
 
 		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
 	}
+
+	public function test_approve_declines_when_product_not_found() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$request->set_body( json_encode( [
+			'id'         => 'cs_test_123',
+			'line_items' => [
+				'data' => [
+					[
+						'price'    => [ 'lookup_key' => 'invalid_sku' ],
+						'quantity' => 1,
+					],
+				],
+			],
+			'amount_total' => 1000,
+		] ) );
+
+		$response = $this->controller->approve( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'declined', $data['result']['type'] );
+		$this->assertEquals( 'product_not_found', $data['result']['declined']['reason'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+
+	public function test_approve_declines_when_product_not_purchasable() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		// Mock product that's not purchasable
+		$product = $this->createMock( \WC_Product::class );
+		$product->method( 'is_purchasable' )->willReturn( false );
+		$product->method( 'is_in_stock' )->willReturn( true );
+		$product->method( 'get_sku' )->willReturn( 'test_sku' );
+
+		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
+			return $product;
+		} );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$request->set_body( json_encode( [
+			'id'         => 'cs_test_123',
+			'line_items' => [
+				'data' => [
+					[
+						'price'    => [ 'lookup_key' => 'test_sku' ],
+						'quantity' => 1,
+					],
+				],
+			],
+			'amount_total' => 1000,
+		] ) );
+
+		$response = $this->controller->approve( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'declined', $data['result']['type'] );
+		$this->assertEquals( 'product_not_purchasable', $data['result']['declined']['reason'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+		remove_all_filters( 'wc_stripe_agentic_product_by_sku' );
+	}
+
+	public function test_approve_declines_when_out_of_stock() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		// Mock product that's out of stock
+		$product = $this->createMock( \WC_Product::class );
+		$product->method( 'is_purchasable' )->willReturn( true );
+		$product->method( 'is_in_stock' )->willReturn( false );
+		$product->method( 'get_sku' )->willReturn( 'test_sku' );
+
+		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
+			return $product;
+		} );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$request->set_body( json_encode( [
+			'id'         => 'cs_test_123',
+			'line_items' => [
+				'data' => [
+					[
+						'price'    => [ 'lookup_key' => 'test_sku' ],
+						'quantity' => 1,
+					],
+				],
+			],
+			'amount_total' => 1000,
+		] ) );
+
+		$response = $this->controller->approve( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'declined', $data['result']['type'] );
+		$this->assertEquals( 'low_inventory', $data['result']['declined']['reason'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+		remove_all_filters( 'wc_stripe_agentic_product_by_sku' );
+	}
+
+	public function test_approve_declines_when_insufficient_stock() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		// Mock product with limited stock
+		$product = $this->createMock( \WC_Product::class );
+		$product->method( 'is_purchasable' )->willReturn( true );
+		$product->method( 'is_in_stock' )->willReturn( true );
+		$product->method( 'managing_stock' )->willReturn( true );
+		$product->method( 'get_stock_quantity' )->willReturn( 2 );
+		$product->method( 'get_sku' )->willReturn( 'test_sku' );
+
+		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
+			return $product;
+		} );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$request->set_body( json_encode( [
+			'id'         => 'cs_test_123',
+			'line_items' => [
+				'data' => [
+					[
+						'price'    => [ 'lookup_key' => 'test_sku' ],
+						'quantity' => 5, // Request 5, but only 2 available
+					],
+				],
+			],
+			'amount_total' => 5000,
+		] ) );
+
+		$response = $this->controller->approve( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'declined', $data['result']['type'] );
+		$this->assertEquals( 'low_inventory', $data['result']['declined']['reason'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+		remove_all_filters( 'wc_stripe_agentic_product_by_sku' );
+	}
+
+	public function test_approve_approves_when_sufficient_stock() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		// Mock product with sufficient stock
+		$product = $this->createMock( \WC_Product::class );
+		$product->method( 'is_purchasable' )->willReturn( true );
+		$product->method( 'is_in_stock' )->willReturn( true );
+		$product->method( 'managing_stock' )->willReturn( true );
+		$product->method( 'get_stock_quantity' )->willReturn( 10 );
+		$product->method( 'get_sku' )->willReturn( 'test_sku' );
+
+		add_filter( 'wc_stripe_agentic_product_by_sku', function() use ( $product ) {
+			return $product;
+		} );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$request->set_body( json_encode( [
+			'id'         => 'cs_test_123',
+			'line_items' => [
+				'data' => [
+					[
+						'price'    => [ 'lookup_key' => 'test_sku' ],
+						'quantity' => 5,
+					],
+				],
+			],
+			'amount_total' => 5000,
+		] ) );
+
+		$response = $this->controller->approve( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'approved', $data['result']['type'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+		remove_all_filters( 'wc_stripe_agentic_product_by_sku' );
+	}
+
+	public function test_approve_declines_when_multiple_products_one_invalid() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		// Mock first product as valid
+		$product1 = $this->createMock( \WC_Product::class );
+		$product1->method( 'is_purchasable' )->willReturn( true );
+		$product1->method( 'is_in_stock' )->willReturn( true );
+		$product1->method( 'managing_stock' )->willReturn( false );
+		$product1->method( 'get_sku' )->willReturn( 'valid_sku' );
+
+		add_filter( 'wc_stripe_agentic_product_by_sku', function( $product, $sku ) use ( $product1 ) {
+			if ( $sku === 'valid_sku' ) {
+				return $product1;
+			}
+			// Second product not found
+			return null;
+		}, 10, 2 );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$request->set_body( json_encode( [
+			'id'         => 'cs_test_123',
+			'line_items' => [
+				'data' => [
+					[
+						'price'    => [ 'lookup_key' => 'valid_sku' ],
+						'quantity' => 1,
+					],
+					[
+						'price'    => [ 'lookup_key' => 'invalid_sku' ],
+						'quantity' => 1,
+					],
+				],
+			],
+			'amount_total' => 2000,
+		] ) );
+
+		$response = $this->controller->approve( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'declined', $data['result']['type'] );
+		$this->assertEquals( 'product_not_found', $data['result']['declined']['reason'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+		remove_all_filters( 'wc_stripe_agentic_product_by_sku' );
+	}
 }

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-approval-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-approval-controller.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests;
+
+use WP_UnitTestCase;
+use WP_REST_Request;
+use WP_Error;
+use WC_Stripe_REST_Agentic_Approval_Controller;
+
+/**
+ * Test Manual Approval Hook REST controller for Agentic Checkout.
+ */
+class WC_Stripe_REST_Agentic_Approval_Controller_Test extends WP_UnitTestCase {
+	private $controller;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->controller = new WC_Stripe_REST_Agentic_Approval_Controller();
+	}
+
+	public function test_registers_route() {
+		$routes = $this->controller->get_routes();
+		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/approve', $routes );
+	}
+
+	public function test_approve_returns_error_when_disabled() {
+		$request  = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$response = $this->controller->approve( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertEquals( 'feature_disabled', $response->get_error_code() );
+	}
+
+	public function test_approve_approves_when_products_in_stock() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/approve' );
+		$request->set_body( json_encode( [
+			'id'          => 'cs_test_123',
+			'line_items'  => [],
+			'amount_total' => 1000,
+		] ) );
+
+		$response = $this->controller->approve( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 'cs_test_123', $data['id'] );
+		$this->assertEquals( 'approved', $data['result']['type'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+}

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-shipping-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-shipping-controller.php
@@ -1,0 +1,53 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class WC_Stripe_REST_Agentic_Shipping_Controller_Test extends TestCase {
+	private $controller;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->controller = new WC_Stripe_REST_Agentic_Shipping_Controller();
+	}
+
+	public function test_registers_route() {
+		$routes = $this->controller->get_routes();
+		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/compute_shipping_options', $routes );
+	}
+
+	public function test_compute_shipping_returns_error_when_disabled() {
+		$request  = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/compute_shipping_options' );
+		$response = $this->controller->compute_shipping_options( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertEquals( 'feature_disabled', $response->get_error_code() );
+	}
+
+	public function test_compute_shipping_returns_options() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/compute_shipping_options' );
+		$request->set_body( json_encode( [
+			'livemode'            => false,
+			'currency'            => 'usd',
+			'line_items_details'  => [
+				[ 'sku_id' => 'test_sku', 'unit_amount' => 1000, 'quantity' => 1 ],
+			],
+			'fulfillment_details' => [
+				'address' => [
+					'city'        => 'San Francisco',
+					'state'       => 'CA',
+					'postal_code' => '94107',
+					'country'     => 'US',
+				],
+			],
+		] ) );
+
+		$response = $this->controller->compute_shipping_options( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'fulfillment_options', $data );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+}

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-shipping-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-shipping-controller.php
@@ -48,6 +48,15 @@ class WC_Stripe_REST_Agentic_Shipping_Controller_Test extends TestCase {
 
 		$this->assertArrayHasKey( 'fulfillment_options', $data );
 
+		// Verify each shipping option has required fields including 'id'
+		if ( ! empty( $data['fulfillment_options'] ) ) {
+			foreach ( $data['fulfillment_options'] as $option ) {
+				$this->assertArrayHasKey( 'id', $option, 'Shipping option must have an id field' );
+				$this->assertArrayHasKey( 'display_name', $option );
+				$this->assertArrayHasKey( 'shipping_amount', $option );
+			}
+		}
+
 		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
 	}
 }

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-shipping-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-shipping-controller.php
@@ -27,21 +27,29 @@ class WC_Stripe_REST_Agentic_Shipping_Controller_Test extends TestCase {
 		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/compute_shipping_options' );
-		$request->set_body( json_encode( [
-			'livemode'            => false,
-			'currency'            => 'usd',
-			'line_items_details'  => [
-				[ 'sku_id' => 'test_sku', 'unit_amount' => 1000, 'quantity' => 1 ],
-			],
-			'fulfillment_details' => [
-				'address' => [
-					'city'        => 'San Francisco',
-					'state'       => 'CA',
-					'postal_code' => '94107',
-					'country'     => 'US',
-				],
-			],
-		] ) );
+		$request->set_body(
+			json_encode(
+				[
+					'livemode'            => false,
+					'currency'            => 'usd',
+					'line_items_details'  => [
+						[
+							'sku_id'      => 'test_sku',
+							'unit_amount' => 1000,
+							'quantity'    => 1,
+						],
+					],
+					'fulfillment_details' => [
+						'address' => [
+							'city'        => 'San Francisco',
+							'state'       => 'CA',
+							'postal_code' => '94107',
+							'country'     => 'US',
+						],
+					],
+				]
+			)
+		);
 
 		$response = $this->controller->compute_shipping_options( $request );
 		$data     = $response->get_data();

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-tax-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-tax-controller.php
@@ -29,26 +29,26 @@ class WC_Stripe_REST_Agentic_Tax_Controller_Test extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
 		$request->set_body(
 			json_encode(
-				array(
+				[
 					'id'                  => 'cs_test_123',
 					'livemode'            => false,
 					'currency'            => 'usd',
-					'line_items_details'  => array(
-						array(
+					'line_items_details'  => [
+						[
 							'sku_id'      => 'test_sku',
 							'unit_amount' => 1000,
 							'quantity'    => 2,
-						),
-					),
-					'fulfillment_details' => array(
-						'address' => array(
+						],
+					],
+					'fulfillment_details' => [
+						'address' => [
 							'city'        => 'San Francisco',
 							'state'       => 'CA',
 							'postal_code' => '94107',
 							'country'     => 'US',
-						),
-					),
-				)
+						],
+					],
+				]
 			)
 		);
 
@@ -98,26 +98,26 @@ class WC_Stripe_REST_Agentic_Tax_Controller_Test extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
 		$request->set_body(
 			json_encode(
-				array(
+				[
 					'id'                  => 'cs_test_456',
 					'livemode'            => false,
 					'currency'            => 'usd',
-					'line_items_details'  => array(
-						array(
+					'line_items_details'  => [
+						[
 							'sku_id'      => 'test_sku',
 							'unit_amount' => 1000,
 							'quantity'    => 1,
-						),
-					),
-					'fulfillment_details' => array(
-						'address' => array(
+						],
+					],
+					'fulfillment_details' => [
+						'address' => [
 							'city'        => 'London',
 							'state'       => '',
 							'postal_code' => 'SW1A 1AA',
 							'country'     => 'GB',
-						),
-					),
-				)
+						],
+					],
+				]
 			)
 		);
 
@@ -139,27 +139,27 @@ class WC_Stripe_REST_Agentic_Tax_Controller_Test extends TestCase {
 		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
 		$request->set_body(
 			json_encode(
-				array(
+				[
 					'id'                  => 'cs_test_789',
 					'livemode'            => false,
 					'currency'            => 'usd',
-					'line_items_details'  => array(
-						array(
+					'line_items_details'  => [
+						[
 							'sku_id'      => 'test_sku',
 							'unit_amount' => 1000,
 							'quantity'    => 1,
-						),
-					),
-					'fulfillment_details' => array(
+						],
+					],
+					'fulfillment_details' => [
 						'shipping_amount' => 500, // $5.00 shipping in cents.
-						'address'         => array(
+						'address'         => [
 							'city'        => 'San Francisco',
 							'state'       => 'CA',
 							'postal_code' => '94107',
 							'country'     => 'US',
-						),
-					),
-				)
+						],
+					],
+				]
 			)
 		);
 

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-tax-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-tax-controller.php
@@ -12,42 +12,164 @@ class WC_Stripe_REST_Agentic_Tax_Controller_Test extends TestCase {
 
 	public function test_registers_route() {
 		$routes = $this->controller->get_routes();
-		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/compute_tax', $routes );
+		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/tax', $routes );
 	}
 
 	public function test_compute_tax_returns_error_when_disabled() {
-		$request  = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/compute_tax' );
+		$request  = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
 		$response = $this->controller->compute_tax( $request );
 
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertEquals( 'feature_disabled', $response->get_error_code() );
 	}
 
-	public function test_compute_tax_returns_tax_amounts() {
+	public function test_compute_tax_returns_calculated_response() {
 		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
 
-		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/compute_tax' );
-		$request->set_body( json_encode( [
-			'livemode'            => false,
-			'currency'            => 'usd',
-			'line_items_details'  => [
-				[ 'sku_id' => 'test_sku', 'unit_amount' => 1000, 'quantity' => 2 ],
-			],
-			'fulfillment_details' => [
-				'address' => [
-					'city'        => 'San Francisco',
-					'state'       => 'CA',
-					'postal_code' => '94107',
-					'country'     => 'US',
-				],
-			],
-		] ) );
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
+		$request->set_body(
+			json_encode(
+				array(
+					'id'                  => 'cs_test_123',
+					'livemode'            => false,
+					'currency'            => 'usd',
+					'line_items_details'  => array(
+						array(
+							'sku_id'      => 'test_sku',
+							'unit_amount' => 1000,
+							'quantity'    => 2,
+						),
+					),
+					'fulfillment_details' => array(
+						'address' => array(
+							'city'        => 'San Francisco',
+							'state'       => 'CA',
+							'postal_code' => '94107',
+							'country'     => 'US',
+						),
+					),
+				)
+			)
+		);
 
 		$response = $this->controller->compute_tax( $request );
 		$data     = $response->get_data();
 
-		$this->assertArrayHasKey( 'line_item_details', $data );
-		$this->assertArrayHasKey( 'total_details', $data );
+		// Verify Stripe protocol response format.
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertEquals( 'cs_test_123', $data['id'] );
+		$this->assertArrayHasKey( 'result', $data );
+		$this->assertArrayHasKey( 'type', $data['result'] );
+		$this->assertEquals( 'calculated', $data['result']['type'] );
+		$this->assertArrayHasKey( 'calculated', $data['result'] );
+		$this->assertArrayHasKey( 'taxes', $data['result']['calculated'] );
+		$this->assertIsArray( $data['result']['calculated']['taxes'] );
+
+		// Verify tax breakdown structure if taxes exist.
+		if ( ! empty( $data['result']['calculated']['taxes'] ) ) {
+			$first_tax = $data['result']['calculated']['taxes'][0];
+			$this->assertArrayHasKey( 'amount', $first_tax );
+			$this->assertArrayHasKey( 'display_name', $first_tax );
+			$this->assertIsInt( $first_tax['amount'] );
+			$this->assertIsString( $first_tax['display_name'] );
+		}
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+
+	public function test_compute_tax_handles_invalid_json() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
+		$request->set_body( 'invalid json {' );
+
+		$response = $this->controller->compute_tax( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertEquals( 'invalid_json', $response->get_error_code() );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+
+	public function test_compute_tax_handles_empty_tax_rates() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		// Test with a location that has no tax rates configured.
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
+		$request->set_body(
+			json_encode(
+				array(
+					'id'                  => 'cs_test_456',
+					'livemode'            => false,
+					'currency'            => 'usd',
+					'line_items_details'  => array(
+						array(
+							'sku_id'      => 'test_sku',
+							'unit_amount' => 1000,
+							'quantity'    => 1,
+						),
+					),
+					'fulfillment_details' => array(
+						'address' => array(
+							'city'        => 'London',
+							'state'       => '',
+							'postal_code' => 'SW1A 1AA',
+							'country'     => 'GB',
+						),
+					),
+				)
+			)
+		);
+
+		$response = $this->controller->compute_tax( $request );
+		$data     = $response->get_data();
+
+		// Should return valid response even with no taxes.
+		$this->assertArrayHasKey( 'id', $data );
+		$this->assertArrayHasKey( 'result', $data );
+		$this->assertEquals( 'calculated', $data['result']['type'] );
+		$this->assertIsArray( $data['result']['calculated']['taxes'] );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+
+	public function test_compute_tax_calculates_shipping_tax() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/tax' );
+		$request->set_body(
+			json_encode(
+				array(
+					'id'                  => 'cs_test_789',
+					'livemode'            => false,
+					'currency'            => 'usd',
+					'line_items_details'  => array(
+						array(
+							'sku_id'      => 'test_sku',
+							'unit_amount' => 1000,
+							'quantity'    => 1,
+						),
+					),
+					'fulfillment_details' => array(
+						'shipping_amount' => 500, // $5.00 shipping in cents.
+						'address'         => array(
+							'city'        => 'San Francisco',
+							'state'       => 'CA',
+							'postal_code' => '94107',
+							'country'     => 'US',
+						),
+					),
+				)
+			)
+		);
+
+		$response = $this->controller->compute_tax( $request );
+		$data     = $response->get_data();
+
+		// Verify response includes shipping tax in the total.
+		$this->assertArrayHasKey( 'result', $data );
+		$this->assertArrayHasKey( 'calculated', $data['result'] );
+		$this->assertIsArray( $data['result']['calculated']['taxes'] );
 
 		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
 	}

--- a/tests/phpunit/unit/test-wc-stripe-rest-agentic-tax-controller.php
+++ b/tests/phpunit/unit/test-wc-stripe-rest-agentic-tax-controller.php
@@ -1,0 +1,54 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class WC_Stripe_REST_Agentic_Tax_Controller_Test extends TestCase {
+	private $controller;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->controller = new WC_Stripe_REST_Agentic_Tax_Controller();
+	}
+
+	public function test_registers_route() {
+		$routes = $this->controller->get_routes();
+		$this->assertArrayHasKey( '/wc/v3/stripe/agentic/compute_tax', $routes );
+	}
+
+	public function test_compute_tax_returns_error_when_disabled() {
+		$request  = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/compute_tax' );
+		$response = $this->controller->compute_tax( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertEquals( 'feature_disabled', $response->get_error_code() );
+	}
+
+	public function test_compute_tax_returns_tax_amounts() {
+		add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+
+		$request = new WP_REST_Request( 'POST', '/wc/v3/stripe/agentic/compute_tax' );
+		$request->set_body( json_encode( [
+			'livemode'            => false,
+			'currency'            => 'usd',
+			'line_items_details'  => [
+				[ 'sku_id' => 'test_sku', 'unit_amount' => 1000, 'quantity' => 2 ],
+			],
+			'fulfillment_details' => [
+				'address' => [
+					'city'        => 'San Francisco',
+					'state'       => 'CA',
+					'postal_code' => '94107',
+					'country'     => 'US',
+				],
+			],
+		] ) );
+
+		$response = $this->controller->compute_tax( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'line_item_details', $data );
+		$this->assertArrayHasKey( 'total_details', $data );
+
+		remove_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
+	}
+}

--- a/tests/phpunit/unit/test-wc-stripe-webhook-handler-agentic.php
+++ b/tests/phpunit/unit/test-wc-stripe-webhook-handler-agentic.php
@@ -83,7 +83,10 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 
 		$checkout_session = (object) [
 			'id'               => 'cs_test_123',
-			'metadata'         => (object) [ 'agentic' => 'true', 'agent' => 'TestAgent' ],
+			'metadata'         => (object) [
+				'agentic' => 'true',
+				'agent'   => 'TestAgent',
+			],
 			'customer_details' => (object) [
 				'name'    => 'John Doe',
 				'email'   => 'john@example.com',
@@ -254,7 +257,10 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 			'data' => (object) [
 				'object' => (object) [
 					'id'               => 'cs_webhook_test',
-					'metadata'         => (object) [ 'agentic' => 'true', 'agent' => 'WebhookAgent' ],
+					'metadata'         => (object) [
+						'agentic' => 'true',
+						'agent'   => 'WebhookAgent',
+					],
 					'customer_details' => (object) [
 						'name'  => 'Webhook Test',
 						'email' => 'webhook@example.com',

--- a/tests/phpunit/unit/test-wc-stripe-webhook-handler-agentic.php
+++ b/tests/phpunit/unit/test-wc-stripe-webhook-handler-agentic.php
@@ -405,4 +405,184 @@ class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( WP_Error::class, $received_error );
 		$this->assertEquals( $checkout_session->id, $received_session->id );
 	}
+
+	/**
+	 * Test that wc_stripe_agentic_order_data filter is applied before saving.
+	 */
+	public function test_agentic_order_data_filter_is_applied() {
+		$filter_fired = false;
+
+		add_filter(
+			'wc_stripe_agentic_order_data',
+			function ( $order, $session ) use ( &$filter_fired ) {
+				$filter_fired = true;
+				// Modify the order to verify filter is applied.
+				$order->update_meta_data( '_test_filter_applied', 'yes' );
+				return $order;
+			},
+			10,
+			2
+		);
+
+		// Create a test product.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_sku( 'filter_test_sku' );
+		$product->set_regular_price( 10.00 );
+		$product->save();
+
+		$checkout_session = (object) [
+			'id'               => 'cs_filter_test',
+			'metadata'         => (object) [ 'agentic' => 'true' ],
+			'customer_details' => (object) [
+				'name'  => 'Filter Test',
+				'email' => 'filter@example.com',
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [ 'lookup_key' => 'filter_test_sku' ],
+						'quantity'     => 1,
+						'amount_total' => 1000,
+					],
+				],
+			],
+			'amount_total'     => 1000,
+			'currency'         => 'usd',
+			'payment_intent'   => 'pi_filter_test',
+			'payment_status'   => 'paid',
+		];
+
+		$order = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		$this->assertTrue( $filter_fired, 'wc_stripe_agentic_order_data filter should fire' );
+		$this->assertInstanceOf( WC_Order::class, $order );
+		$this->assertEquals( 'yes', $order->get_meta( '_test_filter_applied' ), 'Filter modification should be applied to order' );
+
+		// Clean up.
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that zero-decimal currencies are handled correctly.
+	 */
+	public function test_handles_zero_decimal_currencies_correctly() {
+		// Create a test product.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product JPY' );
+		$product->set_sku( 'jpy_test_sku' );
+		$product->set_regular_price( 1000 );
+		$product->save();
+
+		$checkout_session = (object) [
+			'id'               => 'cs_jpy_test',
+			'metadata'         => (object) [ 'agentic' => 'true' ],
+			'customer_details' => (object) [
+				'name'  => 'JPY Test',
+				'email' => 'jpy@example.com',
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [ 'lookup_key' => 'jpy_test_sku' ],
+						'quantity'     => 1,
+						'amount_total' => 1000, // 1000 yen (not 10.00 yen)
+					],
+				],
+			],
+			'shipping_cost'    => (object) [
+				'amount_total'   => 500, // 500 yen shipping
+				'shipping_rate'  => (object) [ 'display_name' => 'Standard Shipping' ],
+			],
+			'amount_total'     => 1500,
+			'currency'         => 'jpy', // Japanese Yen - zero-decimal currency
+			'payment_intent'   => 'pi_jpy_test',
+			'payment_status'   => 'paid',
+		];
+
+		$order = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		$this->assertInstanceOf( WC_Order::class, $order );
+
+		// Verify currency is set correctly.
+		$this->assertEquals( 'JPY', $order->get_currency() );
+
+		// Verify the line item total is 1000 (not divided by 100).
+		$items = $order->get_items();
+		$this->assertNotEmpty( $items );
+		$first_item = array_values( $items )[0];
+		$this->assertEquals( 1000, $first_item->get_total(), 'JPY amount should not be divided by 100' );
+
+		// Verify shipping cost is 500 (not divided by 100).
+		$shipping_items = $order->get_items( 'shipping' );
+		$this->assertNotEmpty( $shipping_items );
+		$first_shipping = array_values( $shipping_items )[0];
+		$this->assertEquals( 500, $first_shipping->get_total(), 'JPY shipping should not be divided by 100' );
+
+		// Clean up.
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that decimal currencies are still handled correctly.
+	 */
+	public function test_handles_decimal_currencies_correctly() {
+		// Create a test product.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product USD' );
+		$product->set_sku( 'usd_test_sku' );
+		$product->set_regular_price( 10.00 );
+		$product->save();
+
+		$checkout_session = (object) [
+			'id'               => 'cs_usd_test',
+			'metadata'         => (object) [ 'agentic' => 'true' ],
+			'customer_details' => (object) [
+				'name'  => 'USD Test',
+				'email' => 'usd@example.com',
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [ 'lookup_key' => 'usd_test_sku' ],
+						'quantity'     => 1,
+						'amount_total' => 1000, // $10.00 in cents
+					],
+				],
+			],
+			'shipping_cost'    => (object) [
+				'amount_total'   => 500, // $5.00 in cents
+				'shipping_rate'  => (object) [ 'display_name' => 'Standard Shipping' ],
+			],
+			'amount_total'     => 1500,
+			'currency'         => 'usd', // US Dollar - decimal currency
+			'payment_intent'   => 'pi_usd_test',
+			'payment_status'   => 'paid',
+		];
+
+		$order = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		$this->assertInstanceOf( WC_Order::class, $order );
+
+		// Verify currency is set correctly.
+		$this->assertEquals( 'USD', $order->get_currency() );
+
+		// Verify the line item total is 10.00 (divided by 100).
+		$items = $order->get_items();
+		$this->assertNotEmpty( $items );
+		$first_item = array_values( $items )[0];
+		$this->assertEquals( 10.00, $first_item->get_total(), 'USD amount should be divided by 100' );
+
+		// Verify shipping cost is 5.00 (divided by 100).
+		$shipping_items = $order->get_items( 'shipping' );
+		$this->assertNotEmpty( $shipping_items );
+		$first_shipping = array_values( $shipping_items )[0];
+		$this->assertEquals( 5.00, $first_shipping->get_total(), 'USD shipping should be divided by 100' );
+
+		// Clean up.
+		$product->delete( true );
+		$order->delete( true );
+	}
 }

--- a/tests/phpunit/unit/test-wc-stripe-webhook-handler-agentic.php
+++ b/tests/phpunit/unit/test-wc-stripe-webhook-handler-agentic.php
@@ -1,0 +1,408 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests;
+
+use Automattic\WooCommerce\Enums\OrderStatus;
+use WC_Order;
+use WC_Product_Simple;
+use WC_Stripe_Webhook_Handler;
+use WP_Error;
+use WP_UnitTestCase;
+
+/**
+ * Test agentic checkout webhook handling.
+ */
+class WC_Stripe_Webhook_Handler_Agentic_Test extends WP_UnitTestCase {
+	/**
+	 * The webhook handler instance for testing.
+	 *
+	 * @var WC_Stripe_Webhook_Handler
+	 */
+	private $handler;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->handler = new WC_Stripe_Webhook_Handler();
+	}
+
+	/**
+	 * Test that is_agentic_checkout detects agentic sessions via metadata.
+	 */
+	public function test_detects_agentic_checkout_session_via_metadata() {
+		$checkout_session = (object) [
+			'id'       => 'cs_test_123',
+			'metadata' => (object) [ 'agentic' => 'true' ],
+		];
+
+		$result = $this->handler->is_agentic_checkout( $checkout_session );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test that is_agentic_checkout returns false for non-agentic sessions.
+	 */
+	public function test_returns_false_for_non_agentic_checkout_session() {
+		$checkout_session = (object) [
+			'id'       => 'cs_test_123',
+			'metadata' => (object) [],
+		];
+
+		$result = $this->handler->is_agentic_checkout( $checkout_session );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test that is_agentic_checkout detects agentic sessions via origin_context.
+	 */
+	public function test_detects_agentic_checkout_session_via_origin_context() {
+		$checkout_session = (object) [
+			'id'             => 'cs_test_123',
+			'metadata'       => (object) [],
+			'origin_context' => 'agent',
+		];
+
+		$result = $this->handler->is_agentic_checkout( $checkout_session );
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test creates order from agentic checkout session.
+	 */
+	public function test_creates_order_from_agentic_checkout_session() {
+		// Create a test product with SKU.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_sku( 'test_sku' );
+		$product->set_regular_price( 10.00 );
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 100 );
+		$product->save();
+
+		$checkout_session = (object) [
+			'id'               => 'cs_test_123',
+			'metadata'         => (object) [ 'agentic' => 'true', 'agent' => 'TestAgent' ],
+			'customer_details' => (object) [
+				'name'    => 'John Doe',
+				'email'   => 'john@example.com',
+				'phone'   => '555-1234',
+				'address' => (object) [
+					'line1'       => '123 Main St',
+					'line2'       => 'Apt 4B',
+					'city'        => 'San Francisco',
+					'state'       => 'CA',
+					'postal_code' => '94107',
+					'country'     => 'US',
+				],
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [
+							'lookup_key' => 'test_sku',
+						],
+						'quantity'     => 2,
+						'amount_total' => 2000, // 2 * $10 = $20 in cents
+					],
+				],
+			],
+			'amount_total'     => 2086, // $20.86 in cents
+			'currency'         => 'usd',
+			'payment_intent'   => 'pi_test_123',
+			'payment_status'   => 'paid',
+		];
+
+		$order = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		// Verify order was created.
+		$this->assertInstanceOf( WC_Order::class, $order );
+		$this->assertFalse( is_wp_error( $order ) );
+
+		// Verify metadata.
+		$this->assertEquals( 'true', $order->get_meta( '_wc_stripe_agentic_order' ) );
+		$this->assertEquals( 'cs_test_123', $order->get_meta( '_wc_stripe_checkout_session_id' ) );
+
+		// Verify billing details.
+		$this->assertEquals( 'John Doe', $order->get_billing_first_name() );
+		$this->assertEquals( 'john@example.com', $order->get_billing_email() );
+		$this->assertEquals( '555-1234', $order->get_billing_phone() );
+		$this->assertEquals( '123 Main St', $order->get_billing_address_1() );
+		$this->assertEquals( 'Apt 4B', $order->get_billing_address_2() );
+		$this->assertEquals( 'San Francisco', $order->get_billing_city() );
+		$this->assertEquals( 'CA', $order->get_billing_state() );
+		$this->assertEquals( '94107', $order->get_billing_postcode() );
+		$this->assertEquals( 'US', $order->get_billing_country() );
+
+		// Verify payment method.
+		$this->assertEquals( 'stripe', $order->get_payment_method() );
+
+		// Verify transaction ID.
+		$this->assertEquals( 'pi_test_123', $order->get_transaction_id() );
+
+		// Verify order status.
+		$this->assertTrue( $order->has_status( [ OrderStatus::PROCESSING, OrderStatus::COMPLETED ] ) );
+
+		// Clean up.
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test order creation with manual capture.
+	 */
+	public function test_sets_order_on_hold_for_manual_capture() {
+		// Create a test product with SKU.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_sku( 'test_sku_manual' );
+		$product->set_regular_price( 10.00 );
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 100 );
+		$product->save();
+
+		$checkout_session = (object) [
+			'id'               => 'cs_test_456',
+			'metadata'         => (object) [ 'agentic' => 'true' ],
+			'customer_details' => (object) [
+				'name'  => 'Jane Doe',
+				'email' => 'jane@example.com',
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [ 'lookup_key' => 'test_sku_manual' ],
+						'quantity'     => 1,
+						'amount_total' => 1000,
+					],
+				],
+			],
+			'amount_total'     => 1000,
+			'currency'         => 'usd',
+			'payment_intent'   => (object) [
+				'id'             => 'pi_test_456',
+				'capture_method' => 'manual',
+			],
+			'payment_status'   => 'unpaid',
+		];
+
+		$order = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		// Verify order was created.
+		$this->assertInstanceOf( WC_Order::class, $order );
+		$this->assertFalse( is_wp_error( $order ) );
+
+		// Verify order is on-hold for manual capture.
+		$this->assertEquals( OrderStatus::ON_HOLD, $order->get_status() );
+		$this->assertEquals( 'pi_test_456', $order->get_meta( '_stripe_intent_id' ) );
+		$this->assertEquals( 'yes', $order->get_meta( '_stripe_manual_capture' ) );
+
+		// Clean up.
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test order creation returns error for invalid SKU.
+	 */
+	public function test_returns_error_for_invalid_sku() {
+		$checkout_session = (object) [
+			'id'               => 'cs_test_789',
+			'metadata'         => (object) [ 'agentic' => 'true' ],
+			'customer_details' => (object) [
+				'name'  => 'Test User',
+				'email' => 'test@example.com',
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [ 'lookup_key' => 'invalid_sku_does_not_exist' ],
+						'quantity'     => 1,
+						'amount_total' => 1000,
+					],
+				],
+			],
+			'amount_total'     => 1000,
+			'currency'         => 'usd',
+			'payment_intent'   => 'pi_test_789',
+			'payment_status'   => 'paid',
+		];
+
+		$result = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		// Verify error was returned.
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertEquals( 'order_creation_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that webhook processes agentic checkout.session.completed event.
+	 */
+	public function test_webhook_processes_agentic_checkout_session_completed() {
+		// Create a test product with SKU.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_sku( 'webhook_test_sku' );
+		$product->set_regular_price( 15.00 );
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 100 );
+		$product->save();
+
+		$notification = (object) [
+			'type' => 'checkout.session.completed',
+			'data' => (object) [
+				'object' => (object) [
+					'id'               => 'cs_webhook_test',
+					'metadata'         => (object) [ 'agentic' => 'true', 'agent' => 'WebhookAgent' ],
+					'customer_details' => (object) [
+						'name'  => 'Webhook Test',
+						'email' => 'webhook@example.com',
+					],
+					'line_items'       => (object) [
+						'data' => [
+							(object) [
+								'price'        => (object) [ 'lookup_key' => 'webhook_test_sku' ],
+								'quantity'     => 1,
+								'amount_total' => 1500,
+							],
+						],
+					],
+					'amount_total'     => 1500,
+					'currency'         => 'usd',
+					'payment_intent'   => 'pi_webhook_test',
+					'payment_status'   => 'paid',
+				],
+			],
+		];
+
+		// Process the webhook.
+		$this->handler->process_webhook( wp_json_encode( $notification ) );
+
+		// Find the created order by session ID.
+		$orders = wc_get_orders(
+			[
+				'limit'      => 1,
+				'meta_key'   => '_wc_stripe_checkout_session_id',
+				'meta_value' => 'cs_webhook_test',
+			]
+		);
+
+		$this->assertNotEmpty( $orders, 'Order should be created from webhook' );
+		$order = $orders[0];
+		$this->assertEquals( 'true', $order->get_meta( '_wc_stripe_agentic_order' ) );
+
+		// Clean up.
+		$product->delete( true );
+		$order->delete( true );
+	}
+
+	/**
+	 * Test that action hook fires when order is created.
+	 */
+	public function test_action_fires_when_agentic_order_created() {
+		$action_fired = false;
+		$received_order = null;
+		$received_session = null;
+
+		add_action(
+			'wc_stripe_agentic_order_created',
+			function ( $order, $session ) use ( &$action_fired, &$received_order, &$received_session ) {
+				$action_fired = true;
+				$received_order = $order;
+				$received_session = $session;
+			},
+			10,
+			2
+		);
+
+		// Create a test product.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_sku( 'action_test_sku' );
+		$product->set_regular_price( 10.00 );
+		$product->save();
+
+		$checkout_session = (object) [
+			'id'               => 'cs_action_test',
+			'metadata'         => (object) [ 'agentic' => 'true' ],
+			'customer_details' => (object) [
+				'name'  => 'Action Test',
+				'email' => 'action@example.com',
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [ 'lookup_key' => 'action_test_sku' ],
+						'quantity'     => 1,
+						'amount_total' => 1000,
+					],
+				],
+			],
+			'amount_total'     => 1000,
+			'currency'         => 'usd',
+			'payment_intent'   => 'pi_action_test',
+			'payment_status'   => 'paid',
+		];
+
+		$order = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		$this->assertTrue( $action_fired, 'wc_stripe_agentic_order_created action should fire' );
+		$this->assertInstanceOf( WC_Order::class, $received_order );
+		$this->assertEquals( $checkout_session->id, $received_session->id );
+
+		// Clean up.
+		$product->delete( true );
+		if ( $order instanceof WC_Order ) {
+			$order->delete( true );
+		}
+	}
+
+	/**
+	 * Test that action hook fires when order creation fails.
+	 */
+	public function test_action_fires_when_agentic_order_fails() {
+		$action_fired = false;
+		$received_error = null;
+		$received_session = null;
+
+		add_action(
+			'wc_stripe_agentic_order_failed',
+			function ( $error, $session ) use ( &$action_fired, &$received_error, &$received_session ) {
+				$action_fired = true;
+				$received_error = $error;
+				$received_session = $session;
+			},
+			10,
+			2
+		);
+
+		$checkout_session = (object) [
+			'id'               => 'cs_fail_test',
+			'metadata'         => (object) [ 'agentic' => 'true' ],
+			'customer_details' => (object) [
+				'name'  => 'Fail Test',
+				'email' => 'fail@example.com',
+			],
+			'line_items'       => (object) [
+				'data' => [
+					(object) [
+						'price'        => (object) [ 'lookup_key' => 'nonexistent_sku' ],
+						'quantity'     => 1,
+						'amount_total' => 1000,
+					],
+				],
+			],
+			'amount_total'     => 1000,
+			'currency'         => 'usd',
+			'payment_intent'   => 'pi_fail_test',
+			'payment_status'   => 'paid',
+		];
+
+		$result = $this->handler->create_order_from_checkout_session( $checkout_session );
+
+		$this->assertTrue( $action_fired, 'wc_stripe_agentic_order_failed action should fire' );
+		$this->assertInstanceOf( WP_Error::class, $received_error );
+		$this->assertEquals( $checkout_session->id, $received_session->id );
+	}
+}


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR implements the Stripe Agentic Checkout Protocol, enabling AI agents (like ChatGPT, Claude, etc.) to facilitate purchases on behalf of users through a secure, standardized REST API interface.

This implementation is specifically meant to add Stripe's hosted ACP. 

In the current form, this pull request is very much draft and needs testing and probably then breaking out. This PR is meant as a starting point.

### Implementation Overview

**Core Components Added:**
- **Authentication Trait** (`WC_Stripe_Agentic_Authentication`): Webhook signature verification to ensure requests come from Stripe
- **REST API Controllers** (4 endpoints):
  - `POST /wc/v3/stripe/agentic/approval` - Manual approval hook for order validation
  - `POST /wc/v3/stripe/agentic/tax` - Tax calculation hook
  - `POST /wc/v3/stripe/agentic/shipping` - Shipping rate calculation hook
  - Controller registration integrated with WooCommerce REST API
- **Webhook Handler Extensions**: Process `agentic_checkout.session.completed` events
- **Admin UI**: Manual capture interface for approved orders requiring payment capture
- **Comprehensive Documentation**: 787-line guide at `docs/agentic-checkout.md`

**Security Features:**
- All endpoints require valid Stripe webhook signatures
- Feature disabled by default (requires `wc_stripe_agentic_checkout_enabled` filter)
- Product validation prevents unauthorized item additions
- Stock validation ensures availability before approval

**Trade-offs:**
- Feature is opt-in via filter rather than admin setting to keep the initial implementation simple
- Manual capture required for approved orders (automatic capture can be added in future)
- Uses existing WooCommerce tax/shipping calculations rather than custom logic

### How can this code break?
- Invalid webhook signatures could block legitimate agent requests
- Product/stock validation could reject valid orders if catalog data is incorrect
- Tax/shipping calculations depend on WooCommerce extensions being properly configured
- Session metadata storage could fail if order creation fails

### What are we doing to make sure this code doesn't break?
- **Comprehensive test coverage**: 7 test files with 1,647 lines of tests covering:
  - Authentication and signature verification
  - All REST API endpoints (approval, tax, shipping)
  - Webhook handler session processing
  - Admin capture functionality
  - Controller registration
- **Defensive coding**: Extensive validation, error handling, and WP_Error returns
- **Feature flag**: Disabled by default, requires explicit opt-in
- **Detailed logging**: Debug logs for troubleshooting production issues

## Testing instructions

### Prerequisites
1. Enable the feature by adding to `functions.php` or a custom plugin:
   ```php
   add_filter( 'wc_stripe_agentic_checkout_enabled', '__return_true' );
   ```
2. Configure Stripe webhook endpoint to receive `agentic_checkout.session.completed` events
3. Ensure webhook secret is configured in Stripe settings (test mode)
4. Install WooCommerce Tax and Shipping extensions if testing those calculations

### Test 1: Manual Approval Endpoint
1. Send POST request to `/wp-json/wc/v3/stripe/agentic/approval` with valid Stripe signature
2. Include in request body:
   ```json
   {
     "line_items": [
       {"product": "prod_xxx", "quantity": 2}
     ],
     "currency": "usd",
     "shipping": {
       "address": {
         "line1": "123 Main St",
         "city": "San Francisco",
         "state": "CA",
         "postal_code": "94111",
         "country": "US"
       }
     }
   }
   ```
3. **Expected**: Response includes `approved: true` with calculated `amount_total`
4. **Verify**: Products exist in catalog and are in stock

### Test 2: Tax Calculation Endpoint
1. Send POST request to `/wp-json/wc/v3/stripe/agentic/tax` with valid Stripe signature
2. Include line items and shipping address (same format as Test 1)
3. **Expected**: Response includes tax amounts broken down by line item
4. **Verify**: Tax rates match WooCommerce tax settings for the address

### Test 3: Shipping Calculation Endpoint
1. Send POST request to `/wp-json/wc/v3/stripe/agentic/shipping` with valid Stripe signature
2. Include shipping address in request body
3. **Expected**: Response includes available shipping methods with rates and display names
4. **Verify**: Shipping options match WooCommerce shipping zones for the address

### Test 4: Webhook Processing
1. Configure Stripe CLI to listen: `stripe listen --forward-to 'http://your-site.test/?wc-api=wc_stripe'`
2. Trigger test webhook: `stripe trigger agentic_checkout.session.completed`
3. **Expected**: 
   - Order created in WooCommerce with status "On hold"
   - Order note: "Payment authorized via Stripe Agentic Checkout. Requires manual capture."
   - Order meta includes `_stripe_agentic_checkout` data
4. **Verify**: Order appears in WooCommerce > Orders

### Test 5: Manual Capture Admin UI
1. Navigate to the order created in Test 4
2. **Expected**: "Stripe Agentic Checkout" meta box visible in sidebar
3. Click "Capture Payment" button
4. **Expected**: 
   - Payment captured in Stripe
   - Order status changes to "Processing"
   - Success notice displayed
5. **Verify**: Payment Intent shows "succeeded" status in Stripe Dashboard

### Test 6: Error Handling
1. Test with invalid webhook signature
   - **Expected**: 401 Unauthorized response
2. Test approval with out-of-stock product
   - **Expected**: `approved: false` with reason
3. Test with feature disabled (remove filter from step 1)
   - **Expected**: Endpoints return 404 or feature disabled error

### Test 7: Authentication Security
1. Attempt request without `Stripe-Signature` header
   - **Expected**: Request rejected with authentication error
2. Attempt request with invalid signature
   - **Expected**: Request rejected with signature validation error

---

- [x] Covered with tests (7 test files, 1,647 lines of comprehensive test coverage)
- [ ] Tested on mobile (does not apply - server-side REST API)

### Changelog entry

- [ ] This Pull Request does not require a changelog entry.

<details>
<summary>Changelog Entry</summary>

**Add** - Stripe Agentic Checkout Protocol support enabling AI agents to facilitate purchases through secure REST API endpoints for approval, tax calculation, shipping calculation, and order completion via webhooks.

</details>

**Post merge**

- [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions)
- [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs)
- [ ] Included this PR in the Release Thread scope

---

### Additional Notes

**Documentation**: Comprehensive documentation added at `docs/agentic-checkout.md` covering:
- Feature overview and requirements
- Setup instructions
- REST API endpoint specifications
- Webhook handling
- Manual capture workflow
- Developer hooks and filters
- Troubleshooting guide
- Security considerations

**Files Changed**: 15 files, 3,998 lines added
- 7 implementation files (1,564 lines)
- 7 test files (1,647 lines)
- 1 documentation file (787 lines)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Agentic Checkout: Orders can now be processed through Stripe with automatic validation of products, stock availability, tax calculation, and shipping option computation.
* Manual Payment Capture: Order pages now include a "Capture Stripe Payment" action for capturing Stripe payments.

**Documentation**
* Added comprehensive Agentic Checkout documentation covering features, REST API endpoints, webhook handling, manual capture workflow, developer hooks, security guidelines, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->