### PR TITLE
Don't show Amazon Pay as a standard payment method in Optimized Checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Fix - Ensure express payment methods are processed correctly when Optimized Checkout is enabled
 * Update - Include customer data in wc_stripe_create_customer_required_fields filter
 * Fix - Fix error handling when processing subscription renewals
+* Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -18,6 +18,7 @@ import {
 	getBlocksConfiguration,
 	shouldSetupOffSessionPayment,
 } from 'wcstripe/blocks/utils';
+import { PAYMENT_METHOD_AMAZON_PAY } from 'wcstripe/stripe-utils/constants';
 import { getFontRulesFromPage } from 'wcstripe/styles/upe';
 
 /**
@@ -146,6 +147,8 @@ const PaymentElements = ( {
 					paymentMethodConfiguration:
 						getBlocksConfiguration()
 							?.paymentMethodConfigurationParentId,
+					// Only show Amazon Pay via Express Checkout, and not within Optimized Checkout.
+					excludedPaymentMethodTypes: [ PAYMENT_METHOD_AMAZON_PAY ],
 				},
 			};
 		} else {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -20,6 +20,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import {
 	OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT,
 	PAYMENT_INTENT_STATUS_REQUIRES_ACTION,
+	PAYMENT_METHOD_AMAZON_PAY,
 	PAYMENT_METHOD_BLIK,
 	PAYMENT_METHOD_BOLETO,
 	PAYMENT_METHOD_CARD,
@@ -166,6 +167,8 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 				...options,
 				paymentMethodConfiguration:
 					getStripeServerData()?.paymentMethodConfigurationParentId,
+				// Only show Amazon Pay via Express Checkout, and not within Optimized Checkout.
+				excludedPaymentMethodTypes: [ PAYMENT_METHOD_AMAZON_PAY ],
 			};
 
 			const setupFutureUsage =

--- a/readme.txt
+++ b/readme.txt
@@ -133,5 +133,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure express payment methods are processed correctly when Optimized Checkout is enabled
 * Update - Include customer data in wc_stripe_create_customer_required_fields filter
 * Fix - Fix error handling when processing subscription renewals
+* Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-590

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that we don't allow Amazon Pay to be displayed as a normal payment method when Optimized Checkout Suite is enabled, as we only want Amazon Pay to be enabled via express checkout. The change here ensures that Amazon Pay is not shown in both sections when Optimized Checkout is enabled. At a technical level, all this change does is add Amazon Pay to the `excludedPaymentMethodTypes` option - [docs](https://docs.stripe.com/js/elements_object/create_without_intent#stripe_elements_no_intent-options-excludedPaymentMethodTypes).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Set up a test store in the US using USD as the currency
* Enable the Amazon Pay feature flag: `wp option update _wcstripe_feature_amazon_pay yes`
* Connect to Stripe in test mode, and ensure that settings sync is enabled
* Enable Optimized Checkout via the Settings UI
* Enable Amazon Pay via the Payment Methods UI, and ensure that it will display in the checkout page
* Disable all other payment methods except cards
* Add a product to your cart and navigate to the block checkout
* Verify that Amazon Pay is shown as an express checkout method _and_ in the Optimized Checkout payment methods.
* Now navigate to the classic checkout, and verify that you see the same.
* Check out this branch and build the updated UI: `git checkout try/hide-amazon-pay-within-optimized-checkout && npm run build`
* Now navigate to (or reload) the block checkout
* Verify that Amazon Pay is only shown as an express checkout method, and not in the main payment list
* Now navigate to (or reload) the classic checkout
* Verify that Amazon Pay is only shown as an express checkout method, and not in the main payment list

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
