### PR TITLE
Use current payment method configuration for Optimized Checkout

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Fix - Ensure express payment methods are processed correctly when Optimized Checkout is enabled
 * Update - Include customer data in wc_stripe_create_customer_required_fields filter
 * Fix - Fix error handling when processing subscription renewals
+* Fix - Always use the current payment method configuration in Optimized Checkout
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -145,8 +145,7 @@ const PaymentElements = ( {
 				...options,
 				...{
 					paymentMethodConfiguration:
-						stripeServerData?.paymentMethodConfigurationId ??
-						stripeServerData?.paymentMethodConfigurationParentId,
+						stripeServerData?.paymentMethodConfigurationId,
 				},
 			};
 		} else {

--- a/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
+++ b/client/blocks/upe/upe-deferred-intent-creation/payment-elements.js
@@ -120,7 +120,8 @@ const PaymentElements = ( {
 	}
 
 	const stripe = api.getStripe();
-	const amount = Number( getBlocksConfiguration()?.cartTotal );
+	const stripeServerData = getBlocksConfiguration();
+	const amount = Number( stripeServerData?.cartTotal );
 
 	// Build options object.
 	let options = {
@@ -135,17 +136,17 @@ const PaymentElements = ( {
 			...{
 				mode: amount < 1 ? 'setup' : 'payment',
 				amount,
-				currency: getBlocksConfiguration()?.currency.toLowerCase(),
+				currency: stripeServerData?.currency.toLowerCase(),
 			},
 		};
 
-		if ( getBlocksConfiguration()?.isOCEnabled ) {
+		if ( stripeServerData?.isOCEnabled ) {
 			options = {
 				...options,
 				...{
 					paymentMethodConfiguration:
-						getBlocksConfiguration()
-							?.paymentMethodConfigurationParentId,
+						stripeServerData?.paymentMethodConfigurationId ??
+						stripeServerData?.paymentMethodConfigurationParentId,
 				},
 			};
 		} else {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -113,13 +113,15 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 		fonts: getFontRulesFromPage(),
 	};
 
+	const stripeServerData = getStripeServerData();
+
 	// If the payment method doesn't support deferred intent, the intent must be created here.
 	if ( ! supportsDeferredIntent ) {
 		try {
 			const isSetupIntent =
 				document.getElementById( 'add_payment_method' ) ||
-				! getStripeServerData()?.isPaymentNeeded ||
-				getStripeServerData()?.isChangingPayment;
+				! stripeServerData?.isPaymentNeeded ||
+				stripeServerData?.isChangingPayment;
 
 			if ( isSetupIntent ) {
 				intent = await api.initSetupIntent( paymentMethodType );
@@ -151,27 +153,27 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 			clientSecret: intent.client_secret,
 		};
 	} else {
-		const amount = Number( getStripeServerData()?.cartTotal );
+		const amount = Number( stripeServerData?.cartTotal );
 		const paymentMethodTypes = getPaymentMethodTypes( paymentMethodType );
 
 		options = {
 			...options,
 			mode: amount < 1 ? 'setup' : 'payment',
-			currency: getStripeServerData()?.currency.toLowerCase(),
+			currency: stripeServerData?.currency.toLowerCase(),
 			amount,
 		};
 
-		if ( getStripeServerData()?.isOCEnabled ) {
+		if ( stripeServerData?.isOCEnabled ) {
 			options = {
 				...options,
 				paymentMethodConfiguration:
-					getStripeServerData()?.paymentMethodConfigurationParentId,
+					stripeServerData?.paymentMethodConfigurationId ??
+					stripeServerData?.paymentMethodConfigurationParentId,
 			};
 
 			const setupFutureUsage =
 				document.getElementById( 'wc-stripe-new-payment-method' )
-					?.checked ||
-				getStripeServerData()?.cartContainsSubscription;
+					?.checked || stripeServerData?.cartContainsSubscription;
 			if ( setupFutureUsage ) {
 				options = {
 					...options,
@@ -206,11 +208,10 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	};
 
 	// Set the layout to accordion if OC is enabled.
-	if ( getStripeServerData()?.isOCEnabled ) {
+	if ( stripeServerData?.isOCEnabled ) {
 		const layout = {
 			type:
-				getStripeServerData()?.OCLayout ||
-				OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT,
+				stripeServerData?.OCLayout || OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT,
 		};
 		if ( layout.type === OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT ) {
 			layout.radios = false;
@@ -233,7 +234,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 	// When email or phone is updated and Link is enabled, we need to
 	// update the payment element to update its default values.
 	if (
-		getStripeServerData()?.isCheckout &&
+		stripeServerData?.isCheckout &&
 		isLinkEnabled() &&
 		paymentMethodType === PAYMENT_METHOD_CARD
 	) {

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -167,8 +167,7 @@ async function createStripePaymentElement( api, paymentMethodType ) {
 			options = {
 				...options,
 				paymentMethodConfiguration:
-					stripeServerData?.paymentMethodConfigurationId ??
-					stripeServerData?.paymentMethodConfigurationParentId,
+					stripeServerData?.paymentMethodConfigurationId,
 			};
 
 			const setupFutureUsage =

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -334,6 +334,24 @@ class WC_Stripe_Payment_Method_Configurations {
 	}
 
 	/**
+	 * Get the current payment method configuration ID.
+	 *
+	 * @return string|null The payment method configuration ID when settings sync is enabled and we have a PMC. Null otherwise.
+	 */
+	public static function get_configuration_id(): ?string {
+		if ( ! self::is_enabled() ) {
+			return null;
+		}
+
+		$primary_configuration = self::get_primary_configuration();
+		if ( ! $primary_configuration || empty( $primary_configuration->id ) ) {
+			return null;
+		}
+
+		return (string) $primary_configuration->id;
+	}
+
+	/**
 	 * Get the UPE available payment method IDs.
 	 *
 	 * @return array

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -534,8 +534,6 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['isOCEnabled'] = $this->oc_enabled;
 		$stripe_params['OCLayout']    = $this->get_option( 'optimized_checkout_layout', self::OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT );
 
-		// Single Payment Element payment method parent configuration ID
-		$stripe_params['paymentMethodConfigurationParentId'] = WC_Stripe_Payment_Method_Configurations::get_parent_configuration_id();
 		if ( $this->oc_enabled ) {
 			$stripe_params['paymentMethodConfigurationId'] = WC_Stripe_Payment_Method_Configurations::get_configuration_id();
 		}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -536,6 +536,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Single Payment Element payment method parent configuration ID
 		$stripe_params['paymentMethodConfigurationParentId'] = WC_Stripe_Payment_Method_Configurations::get_parent_configuration_id();
+		if ( $this->oc_enabled ) {
+			$stripe_params['paymentMethodConfigurationId'] = WC_Stripe_Payment_Method_Configurations::get_configuration_id();
+		}
 
 		// Checking for other BNPL extensions.
 		$stripe_params['hasAffirmGatewayPlugin'] = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM );

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -532,9 +532,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Optimized Checkout feature flag + setting.
 		$stripe_params['isOCEnabled'] = $this->oc_enabled;
-		$stripe_params['OCLayout']    = $this->get_option( 'optimized_checkout_layout', self::OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT );
 
 		if ( $this->oc_enabled ) {
+			$stripe_params['OCLayout']                     = $this->get_option( 'optimized_checkout_layout', self::OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT );
 			$stripe_params['paymentMethodConfigurationId'] = WC_Stripe_Payment_Method_Configurations::get_configuration_id();
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,5 +133,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Ensure express payment methods are processed correctly when Optimized Checkout is enabled
 * Update - Include customer data in wc_stripe_create_customer_required_fields filter
 * Fix - Fix error handling when processing subscription renewals
+* Fix - Always use the current payment method configuration in Optimized Checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Payment_Method_Configurations_Test.php
+++ b/tests/phpunit/WC_Stripe_Payment_Method_Configurations_Test.php
@@ -305,14 +305,14 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 	 */
 	public function provide_get_payment_method_configuration_from_stripe_tests(): array {
 		return [
-			'no_pmcs_returned' => [
+			'no_pmcs_returned'                             => [
 				'mock_pmc_response'        => [],
 				'expected_pmc_id'          => null,
 				'expected_fallback_pmc_id' => null,
 				'initial_fallback_pmc_id'  => null,
 				'is_test_mode'             => false,
 			],
-			'only_live_child_pmc_returned' => [
+			'only_live_child_pmc_returned'                 => [
 				'mock_pmc_response'        => [ (object) self::MOCK_CHILD_LIVE_PMC ],
 				'expected_pmc_id'          => self::MOCK_CHILD_LIVE_PMC['id'],
 				'expected_fallback_pmc_id' => null,
@@ -340,7 +340,7 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 				'initial_fallback_pmc_id'  => 'pmc_id_test',
 				'is_test_mode'             => false,
 			],
-			'only_test_child_pmc_returned' => [
+			'only_test_child_pmc_returned'                 => [
 				'mock_pmc_response'        => [ (object) self::MOCK_CHILD_TEST_PMC ],
 				'expected_pmc_id'          => self::MOCK_CHILD_TEST_PMC['id'],
 				'expected_fallback_pmc_id' => null,
@@ -368,7 +368,7 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 				'initial_fallback_pmc_id'  => 'pmc_id_test',
 				'is_test_mode'             => true,
 			],
-			'only_live_non_child_default_pmc_returned' => [
+			'only_live_non_child_default_pmc_returned'     => [
 				'mock_pmc_response'        => [ (object) self::MOCK_LIVE_NON_CHILD_DEFAULT_PMC ],
 				'expected_pmc_id'          => self::MOCK_LIVE_NON_CHILD_DEFAULT_PMC['id'],
 				'expected_fallback_pmc_id' => self::MOCK_LIVE_NON_CHILD_DEFAULT_PMC['id'],
@@ -410,7 +410,7 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 				'initial_fallback_pmc_id'  => self::MOCK_LIVE_NON_CHILD_NON_DEFAULT_PMC['id'],
 				'is_test_mode'             => false,
 			],
-			'only_test_non_child_default_pmc_returned' => [
+			'only_test_non_child_default_pmc_returned'     => [
 				'mock_pmc_response'        => [ (object) self::MOCK_TEST_NON_CHILD_DEFAULT_PMC ],
 				'expected_pmc_id'          => self::MOCK_TEST_NON_CHILD_DEFAULT_PMC['id'],
 				'expected_fallback_pmc_id' => self::MOCK_TEST_NON_CHILD_DEFAULT_PMC['id'],
@@ -586,7 +586,7 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 	 * @dataProvider provide_get_payment_method_configuration_from_stripe_tests()
 	 */
 	public function test_get_payment_method_configuration_from_stripe( array $mock_pmc_response, ?string $expected_pmc_id, ?string $expected_fallback_pmc_id, ?string $initial_fallback_pmc_id = null, bool $is_test_mode = false ) {
-		$settings = WC_Stripe_Helper::get_stripe_settings();
+		$settings             = WC_Stripe_Helper::get_stripe_settings();
 		$settings['testmode'] = $is_test_mode ? 'yes' : 'no';
 		WC_Stripe_Helper::update_main_stripe_settings( $settings );
 
@@ -639,6 +639,235 @@ class WC_Stripe_Payment_Method_Configurations_Test extends WC_Mock_Stripe_API_Un
 
 		if ( null !== $expected_pmc_id && null !== $expected_fallback_pmc_id ) {
 			$this->assertEquals( $expected_fallback_pmc_id, $primary_pmc->id );
+		}
+	}
+
+	/**
+	 * Provide test cases for {@see test_get_configuration_id()}.
+	 *
+	 * @return array
+	 */
+	public function provide_get_configuration_id_tests(): array {
+		return [
+			'PMC is disabled - live'                       => [
+				'is_test_mode'              => false,
+				'pmc_enabled'               => false,
+				'account_connected'         => true,
+				'has_primary_configuration' => false,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'PMC is disabled - test'                       => [
+				'is_test_mode'              => true,
+				'pmc_enabled'               => false,
+				'account_connected'         => true,
+				'has_primary_configuration' => false,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'Account is not connected - live'              => [
+				'is_test_mode'              => false,
+				'pmc_enabled'               => true,
+				'account_connected'         => false,
+				'has_primary_configuration' => false,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'Account is not connected - test'              => [
+				'is_test_mode'              => true,
+				'pmc_enabled'               => true,
+				'account_connected'         => false,
+				'has_primary_configuration' => false,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'Does not have a primary configuration - live' => [
+				'is_test_mode'              => false,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => false,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'Does not have a primary configuration - test' => [
+				'is_test_mode'              => true,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => false,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'Has a primary configuration with no id - live' => [
+				'is_test_mode'              => false,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'Has a primary configuration with no id - test' => [
+				'is_test_mode'              => true,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => null,
+				'from_cache'                => false,
+				'expected_configuration_id' => null,
+			],
+			'Has a cached primary configuration with no id - live' => [
+				'is_test_mode'              => false,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => null,
+				'from_cache'                => true,
+				'expected_configuration_id' => null,
+			],
+			'Has a cached primary configuration with no id - test' => [
+				'is_test_mode'              => true,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => null,
+				'from_cache'                => true,
+				'expected_configuration_id' => null,
+			],
+			'Has a primary configuration with an id - live' => [
+				'is_test_mode'              => false,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => 'pmc_12345',
+				'from_cache'                => false,
+				'expected_configuration_id' => 'pmc_12345',
+			],
+			'Has a primary configuration with an id - test' => [
+				'is_test_mode'              => true,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => 'pmc_12345',
+				'from_cache'                => false,
+				'expected_configuration_id' => 'pmc_12345',
+			],
+			'Has a cached primary configuration with an id - live' => [
+				'is_test_mode'              => false,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => 'pmc_12345',
+				'from_cache'                => true,
+				'expected_configuration_id' => 'pmc_12345',
+			],
+			'Has a cached primary configuration with an id - test' => [
+				'is_test_mode'              => true,
+				'pmc_enabled'               => true,
+				'account_connected'         => true,
+				'has_primary_configuration' => true,
+				'primary_configuration_id'  => 'pmc_12345',
+				'from_cache'                => true,
+				'expected_configuration_id' => 'pmc_12345',
+			],
+		];
+	}
+	/**
+	 * Tests for `get_configuration_id`.
+	 *
+	 * @dataProvider provide_get_configuration_id_tests()
+	 * @param bool        $is_test_mode              Whether test mode should be enabled.
+	 * @param bool        $pmc_enabled               Whether the PMC is enabled.
+	 * @param bool        $account_connected         Whether the account is connected.
+	 * @param bool        $has_primary_configuration Whether a primary configuration should be returned.
+	 * @param string|null $primary_configuration_id  The ID of the returned primary configuration.
+	 * @param bool        $from_cache                Should the mock configuration be set in the cache.
+	 * @param string|null $expected_configuration_id The expected configuration ID.
+	 * @return void
+	 */
+	public function test_get_configuration_id(
+		bool $is_test_mode,
+		bool $pmc_enabled,
+		bool $account_connected,
+		bool $has_primary_configuration,
+		?string $primary_configuration_id,
+		bool $from_cache,
+		?string $expected_configuration_id
+	): void {
+		$initial_settings = WC_Stripe_Helper::get_stripe_settings();
+		$settings         = $initial_settings;
+
+		$settings['testmode']    = $is_test_mode ? 'yes' : 'no';
+		$settings['pmc_enabled'] = $pmc_enabled ? 'yes' : 'no';
+		if ( $account_connected ) {
+			if ( $is_test_mode ) {
+				$settings['test_publishable_key'] = 'pk_test_1234567890';
+				$settings['test_secret_key']      = 'sk_test_1234567890';
+				$settings['test_connection_type'] = 'connect';
+			} else {
+				$settings['publishable_key'] = 'pk_live_1234567890';
+				$settings['secret_key']      = 'sk_live_1234567890';
+				$settings['connection_type'] = 'connect';
+			}
+		} elseif ( $is_test_mode ) {
+				unset( $settings['test_publishable_key'] );
+				unset( $settings['test_secret_key'] );
+				unset( $settings['test_connection_type'] );
+		} else {
+			unset( $settings['publishable_key'] );
+			unset( $settings['secret_key'] );
+			unset( $settings['connection_type'] );
+		}
+		WC_Stripe_Helper::update_main_stripe_settings( $settings );
+
+		delete_option( \WC_Stripe_Payment_Method_Configurations::FETCH_COOLDOWN_OPTION_KEY );
+		\WC_Stripe_Payment_Method_Configurations::clear_payment_method_configuration_cache();
+
+		$mock_configurations = [];
+		if ( $has_primary_configuration ) {
+			$mock_configurations[] = (object) [
+				'id'     => $primary_configuration_id,
+				'parent' => null,
+				'active' => true,
+			];
+		}
+
+		// Mock API to return the mock configurations from above.
+		$mock_api = $this->getMockBuilder( \WC_Stripe_API::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Don't test for a specific count of calls, as the method may or may not be called, and that
+		// is not what we are trying to test here.
+		$mock_api->method( 'get_payment_method_configurations' )
+			->willReturn( (object) [ 'data' => $mock_configurations ] );
+
+		$reflection = new ReflectionClass( \WC_Stripe_API::class );
+		$property   = $reflection->getProperty( 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( null, $mock_api );
+
+		if ( $from_cache && $has_primary_configuration ) {
+			\WC_Stripe_Database_Cache::set( \WC_Stripe_Payment_Method_Configurations::CONFIGURATION_CACHE_KEY, $mock_configurations[0] );
+		}
+
+		$configuration_id = \WC_Stripe_Payment_Method_Configurations::get_configuration_id();
+
+		// Reset settings and API instance before running assertions.
+		WC_Stripe_Helper::update_main_stripe_settings( $initial_settings );
+		$property->setValue( null, null );
+		delete_option( \WC_Stripe_Payment_Method_Configurations::FETCH_COOLDOWN_OPTION_KEY );
+		\WC_Stripe_Payment_Method_Configurations::clear_payment_method_configuration_cache();
+
+		if ( null === $expected_configuration_id ) {
+			$this->assertNull( $configuration_id );
+		} else {
+			$this->assertEquals( $expected_configuration_id, $configuration_id );
 		}
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-830
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4831

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that we use the current payment method configuration (PMC) for Optimized Checkout. This fixes two sets of problems stemming from our current logic that uses the WooCommerce parent PMC ID:
 * Optimized Checkout doesn't work for merchants who are not connected to the WooCommerce platform account, as they don't have a child PMC that can be used
 * If merchants are connected and specifying an alternative, non-child PMC, as can be done using the `wc_stripe_preselect_payment_method_configuration` filter, Optimized Checkout will use the child PMC instead of the specified PMC

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

It's a bit hard to test the case where an account is not connected, but we can verify that Optimized Checkout continues to work and the second case where an alternative PMC is specified.

* Set up a test store and connect to Stripe
* Find the PMCs for your test account, and identify a PMC that doesn't have a parent -- make a note of which payment methods are enabled
  - You can do this via the Stripe dashboard or via the debugging logs when we request all PMCs
* Enable Optimized Checkout
* Implement the following snippet to pick the alternative PMC:
```php
function test_pick_non_child_test_pmc( $pmc_id, $test_mode ) {
	if ( ! $test_mode ) {
		return $pmc_id;
	}
	
	return 'pmc_YourPMC';
}
add_filter( 'wc_stripe_preselect_payment_method_configuration', 'test_pick_non_child_test_pmc', 10, 2 );
```
* You may need to clear the database cache to pull down the new PMC (assuming you're in test mode): `wp option delete wcstripe_cache_test_payment_method_configuration`
* If needed, pick different payment methods in the Stripe settings so the list diverges from the child PMC list
* As a shopper, add a product to your cart
* Navigate to the block checkout
* Note that the list of payment methods shown in Optimized Checkout is from the child PMC, and not your custom PMC
* Now navigate to the classic checkout, and verify the same mismatch
* Check out this branch and build the updated UI code: `git checkout fix/use-of-parent-pmc-for-optimized-checkout && npm run build`
* As a shopper, navigate to block checkout
* Confirm that the list of payment methods in Optimized Checkout matches those from your custom PMC
* Now navigate to classic checkout
* Confirm that you see the same list of payment methods in Optimized Checkout

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
