### PR TITLE
Remove the saved oauth_connect_state immediately after validating it

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,7 +3,7 @@
 = 10.2.0 - xxxx-xx-xx =
 * Dev - Remove all references to the UPE-enabled feature flag
 * Dev - Removing all usages of the `is_stripe_ece_enabled` feature flag method
-* Dev - Expands the Stripe Order Helper class to handle mandate ID, Multibanco data, refund status, card brand, charge captured flag, status final flag, and the refund failure reason 
+* Dev - Expands the Stripe Order Helper class to handle mandate ID, Multibanco data, refund status, card brand, charge captured flag, status final flag, and the refund failure reason
 * Dev - Remove the merchant email address from the System Status Report
 * Dev - Replace the constant reference for the legacy SEPA payment method
 * Update - Changes the list of payment methods shown in the Stripe account connection modal
@@ -24,6 +24,7 @@
 * Update - Include customer data in wc_stripe_create_customer_required_fields filter
 * Fix - Fix error handling when processing subscription renewals
 * Fix - Use the built-in Database Cache for the Connect flow data
+* Fix - Fix revoked secret_key error during the OAuth account connection flow
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/connect/class-wc-stripe-connect.php
+++ b/includes/connect/class-wc-stripe-connect.php
@@ -112,6 +112,8 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 				}
 				return new WP_Error( 'Invalid state received from the WCC server' );
 			}
+			// Delete the state from the cache immediately after validating it to prevent duplicate requests.
+			WC_Stripe_Database_Cache::delete_with_mode( 'oauth_connect_state', $mode );
 
 			$response = $this->api->get_stripe_oauth_keys( $code, $type, $mode );
 
@@ -132,8 +134,6 @@ if ( ! class_exists( 'WC_Stripe_Connect' ) ) {
 
 				return $response;
 			}
-
-			WC_Stripe_Database_Cache::delete_with_mode( 'oauth_connect_state', $mode );
 
 			return $this->save_stripe_keys( $response, $type, $mode );
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -113,7 +113,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 10.2.0 - xxxx-xx-xx =
 * Dev - Remove all references to the UPE-enabled feature flag
 * Dev - Removing all usages of the `is_stripe_ece_enabled` feature flag method
-* Dev - Expands the Stripe Order Helper class to handle mandate ID, Multibanco data, refund status, card brand, charge captured flag, status final flag, and the refund failure reason 
+* Dev - Expands the Stripe Order Helper class to handle mandate ID, Multibanco data, refund status, card brand, charge captured flag, status final flag, and the refund failure reason
 * Dev - Remove the merchant email address from the System Status Report
 * Dev - Replace the constant reference for the legacy SEPA payment method
 * Update - Changes the list of payment methods shown in the Stripe account connection modal
@@ -134,5 +134,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Include customer data in wc_stripe_create_customer_required_fields filter
 * Fix - Fix error handling when processing subscription renewals
 * Fix - Use the built-in Database Cache for the Connect flow data
+* Fix - Fix revoked secret_key error during the OAuth account connection flow
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-831
Fix https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4836

## Changes proposed in this Pull Request:

Attempting to exchange an `authorization_code` for a `token` multiple times results in the previously exchanged token to be revoked.

> This authorization code has already been used. All tokens issued with this code have been revoked.

This PR removes the `saved_state` cache entry immediately after validating it, preventing multiple concurrent requests from causing the `access_token` (secret_key) to be revoked.

More info in this issue comment: https://linear.app/a8c/issue/STRIPE-745/persistent-reconnection-notice-with-v1000#comment-61a81388

## Testing instructions

Code review should be enough.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
