### PR TITLE
Add filter for express checkout address normalization

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@
 * Fix - Use the built-in Database Cache for the Connect flow data
 * Add - Implement cache prefetch for account data
 * Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
+* Add - Add wc_stripe_express_checkout_normalize_address filter for express checkout address normalization
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -163,12 +163,14 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		$normalized_data = $this->express_checkout_helper->fix_address_fields_mapping( $normalized_data );
 
 		/**
-		 * Filters the address data for express checkout after the standard
-		 * normalization logic has been applied.
+		 * Filters the address data for express checkout after the standard normalization logic has been applied.
+		 * NOTE: This data is immediately returned to the client, so be careful with the filter implementation,
+		 * as it can cause issues for express checkout flows.
+		 *
+		 * @since 10.2.0
 		 *
 		 * @param array $normalized_data The normalized address data.
 		 * @param array $data            The original address data sent from the client before normalization.
-		 * @since 10.2.0
 		 */
 		$normalized_data = apply_filters( 'wc_stripe_express_checkout_normalize_address', $normalized_data, $data );
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -162,6 +162,16 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		$normalized_data = $this->express_checkout_helper->normalize_state( $data );
 		$normalized_data = $this->express_checkout_helper->fix_address_fields_mapping( $normalized_data );
 
+		/**
+		 * Filters the address data for express checkout after the standard
+		 * normalization logic has been applied.
+		 *
+		 * @param array $normalized_data The normalized address data.
+		 * @param array $data            The original address data sent from the client before normalization.
+		 * @since 10.2.0
+		 */
+		$normalized_data = apply_filters( 'wc_stripe_express_checkout_normalize_address', $normalized_data, $data );
+
 		wp_send_json( $normalized_data );
 	}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -164,8 +164,10 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 
 		/**
 		 * Filters the address data for express checkout after the standard normalization logic has been applied.
+		 *
 		 * NOTE: This data is immediately returned to the client, so be careful with the filter implementation,
-		 * as it can cause issues for express checkout flows.
+		 * as it can cause issues for express checkout flows. Also ensure that data is correctly sanitized and checked
+		 * as it will be visible to shoppers.
 		 *
 		 * @since 10.2.0
 		 *

--- a/readme.txt
+++ b/readme.txt
@@ -136,5 +136,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Use the built-in Database Cache for the Connect flow data
 * Add - Implement cache prefetch for account data
 * Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
+* Add - Add wc_stripe_express_checkout_normalize_address filter for express checkout address normalization
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-824
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4819

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

This PR implements a new `wc_stripe_express_checkout_normalize_address` filter that runs as part of our existing `wc_stripe_normalize_address` AJAX action that normalizes addresses for express checkout. This will allow for additional normalization of address data for express checkouts.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Start with inspection. You can also verify that the hook is running and would be used by doing the following:

* Set up a Stripe test site using the code from this branch
* Ensure that you have an express checkout payment method enabled
* Ensure that logging for Stripe is enabled
* Add the following snippet to log the data from the filter:
```php
function test_express_checkout_address_filter( $normalized_data, $original_data ) {
	WC_Stripe_Logger::debug( 'debug address filter', [ 'normalized_data' => $normalized_data, 'original_data' => $original_data ] );
	return $normalized_data;
}
add_filter( 'wc_stripe_express_checkout_normalize_address', 'test_express_checkout_address_filter', 10, 2 );
```
* Add a product to your cart and use an express checkout method to make the purchase
* After completing the purchase, verify that you're getting the data in your debug log from the filter

**Note:** I tried to write unit tests, but the fact that `ajax_normalize_address()` uses `filter_input()` means we can't mock the data in `$_POST`.
<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
