### PR TITLE
Incompatible tax pill + Requires card method pill

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Block Amazon Pay from being enabled when taxes are based on the billing address. Adds new pills to indicate why it is disabled, and another pill to indicate when a express method is disabled due card being disabled
 * Dev - Deprecates all the legacy checkout payment method classes
 * Dev - Deprecates all the LPM class constants
 * Dev - Remove all references to the UPE-enabled feature flag

--- a/client/components/payment-method-requires-card-method-pill/__tests__/index.test.js
+++ b/client/components/payment-method-requires-card-method-pill/__tests__/index.test.js
@@ -4,13 +4,7 @@ import PaymentMethodRequiresCardMethodPill from '..';
 import { PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY } from 'wcstripe/stripe-utils/constants';
 
 describe( 'PaymentMethodRequiresCardMethodPill', () => {
-	beforeEach( () => {
-		global.wc_stripe_settings_params = { is_card_method_enabled: true };
-	} );
-
 	it( 'should render the "Enable credit card / debit card" text', () => {
-		global.wc_stripe_settings_params = { is_card_method_enabled: false };
-
 		render(
 			<PaymentMethodRequiresCardMethodPill
 				id={ PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY }
@@ -21,16 +15,5 @@ describe( 'PaymentMethodRequiresCardMethodPill', () => {
 		expect(
 			screen.queryByText( 'Enable credit card / debit card' )
 		).toBeInTheDocument();
-	} );
-
-	it( 'should not render when card is enabled', () => {
-		const { container } = render(
-			<PaymentMethodRequiresCardMethodPill
-				id={ PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY }
-				label="Apple Pay / Google Pay"
-			/>
-		);
-
-		expect( container.firstChild ).toBeNull();
 	} );
 } );

--- a/client/components/payment-method-requires-card-method-pill/__tests__/index.test.js
+++ b/client/components/payment-method-requires-card-method-pill/__tests__/index.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import PaymentMethodRequiresCardMethodPill from '..';
+
+describe( 'PaymentMethodRequiresCardMethodPill', () => {
+	beforeEach( () => {
+		global.wc_stripe_settings_params = { is_card_method_enabled: true };
+	} );
+
+	it( 'should render the "Enable credit card / debit card" text', () => {
+		global.wc_stripe_settings_params = { is_card_method_enabled: false };
+
+		render(
+			<PaymentMethodRequiresCardMethodPill
+				id="apple_pay_google_pay"
+				label="Apple Pay / Google Pay"
+			/>
+		);
+
+		expect(
+			screen.queryByText( 'Enable credit card / debit card' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render when card is enabled', () => {
+		const { container } = render(
+			<PaymentMethodRequiresCardMethodPill
+				id="apple_pay_google_pay"
+				label="Apple Pay / Google Pay"
+			/>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+} );

--- a/client/components/payment-method-requires-card-method-pill/__tests__/index.test.js
+++ b/client/components/payment-method-requires-card-method-pill/__tests__/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import PaymentMethodRequiresCardMethodPill from '..';
+import { PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY } from 'wcstripe/stripe-utils/constants';
 
 describe( 'PaymentMethodRequiresCardMethodPill', () => {
 	beforeEach( () => {
@@ -12,7 +13,7 @@ describe( 'PaymentMethodRequiresCardMethodPill', () => {
 
 		render(
 			<PaymentMethodRequiresCardMethodPill
-				id="apple_pay_google_pay"
+				id={ PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY }
 				label="Apple Pay / Google Pay"
 			/>
 		);
@@ -25,7 +26,7 @@ describe( 'PaymentMethodRequiresCardMethodPill', () => {
 	it( 'should not render when card is enabled', () => {
 		const { container } = render(
 			<PaymentMethodRequiresCardMethodPill
-				id="apple_pay_google_pay"
+				id={ PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY }
 				label="Apple Pay / Google Pay"
 			/>
 		);

--- a/client/components/payment-method-requires-card-method-pill/index.js
+++ b/client/components/payment-method-requires-card-method-pill/index.js
@@ -1,19 +1,8 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import PaymentMethodUnavailablePill from 'wcstripe/components/payment-method-unavailable-pill';
-import usePaymentMethodUnavailableReason from 'utils/use-payment-method-unavailable-reason';
-import { PAYMENT_METHOD_UNAVAILABLE_REASONS } from 'wcstripe/stripe-utils/constants';
 
-const PaymentMethodRequiresCardMethodPill = ( { id, label } ) => {
-	const unavailableReason = usePaymentMethodUnavailableReason( id );
-
-	if (
-		unavailableReason !==
-		PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD
-	) {
-		return null;
-	}
-
+const PaymentMethodRequiresCardMethodPill = ( { label } ) => {
 	return (
 		<PaymentMethodUnavailablePill
 			title={ __(

--- a/client/components/payment-method-requires-card-method-pill/index.js
+++ b/client/components/payment-method-requires-card-method-pill/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+import PaymentMethodUnavailablePill from 'wcstripe/components/payment-method-unavailable-pill';
+import usePaymentMethodUnavailableReason from 'utils/use-payment-method-unavailable-reason';
+import { PAYMENT_METHOD_UNAVAILABLE_REASONS } from 'wcstripe/stripe-utils/constants';
+
+const PaymentMethodRequiresCardMethodPill = ( { id, label } ) => {
+	const unavailableReason = usePaymentMethodUnavailableReason( id );
+
+	if (
+		unavailableReason !==
+		PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD
+	) {
+		return null;
+	}
+
+	return (
+		<PaymentMethodUnavailablePill
+			title={ __(
+				'Enable credit card / debit card',
+				'woocommerce-gateway-stripe'
+			) }
+		>
+			{ sprintf(
+				/* translators: $1: a payment method name */
+				__(
+					'Credit card / debit card payment method must be enabled in order to use %1$s.',
+					'woocommerce-gateway-stripe'
+				),
+				label
+			) }
+		</PaymentMethodUnavailablePill>
+	);
+};
+
+export default PaymentMethodRequiresCardMethodPill;

--- a/client/components/payment-method-unavailable-due-tax-setup-pill/__tests__/index.test.js
+++ b/client/components/payment-method-unavailable-due-tax-setup-pill/__tests__/index.test.js
@@ -4,13 +4,7 @@ import PaymentMethodUnavailableDueTaxSetupPill from '..';
 import { PAYMENT_METHOD_AMAZON_PAY } from 'wcstripe/stripe-utils/constants';
 
 describe( 'PaymentMethodUnavailableDueTaxSetupPill', () => {
-	beforeEach( () => {
-		global.wc_stripe_settings_params = { taxes_based_on_billing: false };
-	} );
-
 	it( 'should render the "Incompatible tax setup" text', () => {
-		global.wc_stripe_settings_params = { taxes_based_on_billing: true };
-
 		render(
 			<PaymentMethodUnavailableDueTaxSetupPill
 				id={ PAYMENT_METHOD_AMAZON_PAY }
@@ -21,16 +15,5 @@ describe( 'PaymentMethodUnavailableDueTaxSetupPill', () => {
 		expect(
 			screen.queryByText( 'Incompatible tax setup' )
 		).toBeInTheDocument();
-	} );
-
-	it( 'should not render when tax is not based on billing', () => {
-		const { container } = render(
-			<PaymentMethodUnavailableDueTaxSetupPill
-				id={ PAYMENT_METHOD_AMAZON_PAY }
-				label="Amazon Pay"
-			/>
-		);
-
-		expect( container.firstChild ).toBeNull();
 	} );
 } );

--- a/client/components/payment-method-unavailable-due-tax-setup-pill/__tests__/index.test.js
+++ b/client/components/payment-method-unavailable-due-tax-setup-pill/__tests__/index.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { screen, render } from '@testing-library/react';
+import PaymentMethodUnavailableDueTaxSetupPill from '..';
+import { PAYMENT_METHOD_AMAZON_PAY } from 'wcstripe/stripe-utils/constants';
+
+describe( 'PaymentMethodUnavailableDueTaxSetupPill', () => {
+	beforeEach( () => {
+		global.wc_stripe_settings_params = { taxes_based_on_billing: false };
+	} );
+
+	it( 'should render the "Incompatible tax setup" text', () => {
+		global.wc_stripe_settings_params = { taxes_based_on_billing: true };
+
+		render(
+			<PaymentMethodUnavailableDueTaxSetupPill
+				id={ PAYMENT_METHOD_AMAZON_PAY }
+				label="Amazon Pay"
+			/>
+		);
+
+		expect(
+			screen.queryByText( 'Incompatible tax setup' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not render when tax is not based on billing', () => {
+		const { container } = render(
+			<PaymentMethodUnavailableDueTaxSetupPill
+				id={ PAYMENT_METHOD_AMAZON_PAY }
+				label="Amazon Pay"
+			/>
+		);
+
+		expect( container.firstChild ).toBeNull();
+	} );
+} );

--- a/client/components/payment-method-unavailable-due-tax-setup-pill/index.js
+++ b/client/components/payment-method-unavailable-due-tax-setup-pill/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { __, sprintf } from '@wordpress/i18n';
+import PaymentMethodUnavailablePill from 'wcstripe/components/payment-method-unavailable-pill';
+import usePaymentMethodUnavailableReason from 'utils/use-payment-method-unavailable-reason';
+import { PAYMENT_METHOD_UNAVAILABLE_REASONS } from 'wcstripe/stripe-utils/constants';
+
+const PaymentMethodUnavailableDueTaxSetupPill = ( { id, label } ) => {
+	const unavailableReason = usePaymentMethodUnavailableReason( id );
+
+	if (
+		unavailableReason !==
+		PAYMENT_METHOD_UNAVAILABLE_REASONS.TAX_BASED_ON_BILLING_ADDRESS
+	) {
+		return null;
+	}
+
+	return (
+		<PaymentMethodUnavailablePill
+			title={ __(
+				'Incompatible tax setup',
+				'woocommerce-gateway-stripe'
+			) }
+		>
+			{ sprintf(
+				/* translators: $1: a payment method name */
+				__(
+					"%1$s is unavailable due to the store tax setup being based on the customer's billing address.",
+					'woocommerce-gateway-stripe'
+				),
+				label
+			) }
+		</PaymentMethodUnavailablePill>
+	);
+};
+
+export default PaymentMethodUnavailableDueTaxSetupPill;

--- a/client/components/payment-method-unavailable-due-tax-setup-pill/index.js
+++ b/client/components/payment-method-unavailable-due-tax-setup-pill/index.js
@@ -1,19 +1,8 @@
 import React from 'react';
 import { __, sprintf } from '@wordpress/i18n';
 import PaymentMethodUnavailablePill from 'wcstripe/components/payment-method-unavailable-pill';
-import usePaymentMethodUnavailableReason from 'utils/use-payment-method-unavailable-reason';
-import { PAYMENT_METHOD_UNAVAILABLE_REASONS } from 'wcstripe/stripe-utils/constants';
 
-const PaymentMethodUnavailableDueTaxSetupPill = ( { id, label } ) => {
-	const unavailableReason = usePaymentMethodUnavailableReason( id );
-
-	if (
-		unavailableReason !==
-		PAYMENT_METHOD_UNAVAILABLE_REASONS.TAX_BASED_ON_BILLING_ADDRESS
-	) {
-		return null;
-	}
-
+const PaymentMethodUnavailableDueTaxSetupPill = ( { label } ) => {
 	return (
 		<PaymentMethodUnavailablePill
 			title={ __(

--- a/client/settings/payment-request-section/__tests__/index.test.js
+++ b/client/settings/payment-request-section/__tests__/index.test.js
@@ -47,6 +47,8 @@ describe( 'PaymentRequestSection', () => {
 		global.wc_stripe_settings_params = {
 			...globalValues,
 			is_amazon_pay_available: true,
+			taxes_based_on_billing: false,
+			is_card_method_enabled: true,
 		};
 	} );
 
@@ -144,5 +146,52 @@ describe( 'PaymentRequestSection', () => {
 			name: /Amazon Pay Input/i,
 		} );
 		expect( amazonPayCheckbox ).toBeChecked();
+	} );
+
+	it( 'Amazon Pay checkbox disabled', () => {
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			is_amazon_pay_available: true,
+			taxes_based_on_billing: true,
+		};
+
+		const container = render( <PaymentRequestSection /> );
+		const amazonPayCheckbox = container.getByRole( 'checkbox', {
+			name: /Amazon Pay Input/i,
+		} );
+		expect( amazonPayCheckbox ).toBeDisabled();
+	} );
+
+	it( 'Apple Pay / Google Pay checkbox disabled', () => {
+		usePaymentRequestEnabledSettings.mockReturnValue(
+			getMockPaymentRequestEnabledSettings( false, jest.fn() )
+		);
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			is_card_method_enabled: false,
+		};
+
+		const container = render( <PaymentRequestSection /> );
+		const eceCheckbox = container.getByRole( 'checkbox', {
+			name: /Apple Pay \/ Google Pay Input/i,
+		} );
+		expect( eceCheckbox ).toBeDisabled();
+	} );
+
+	it( 'Link checkbox disabled', () => {
+		useEnabledPaymentMethodIds.mockReturnValue( [
+			[ PAYMENT_METHOD_CARD ],
+			jest.fn(),
+		] );
+		global.wc_stripe_settings_params = {
+			...globalValues,
+			is_card_method_enabled: false,
+		};
+
+		const container = render( <PaymentRequestSection /> );
+		const linkCheckbox = container.getByRole( 'checkbox', {
+			name: /Link by Stripe Input/i,
+		} );
+		expect( linkCheckbox ).toBeDisabled();
 	} );
 } );

--- a/client/settings/payment-request-section/__tests__/index.test.js
+++ b/client/settings/payment-request-section/__tests__/index.test.js
@@ -62,49 +62,6 @@ describe( 'PaymentRequestSection', () => {
 		expect( label ).toBeInTheDocument();
 	} );
 
-	it( 'hide link payment if card payment method is inactive (OC disabled)', () => {
-		useGetAvailablePaymentMethodIds.mockReturnValue( [
-			PAYMENT_METHOD_LINK,
-			PAYMENT_METHOD_CARD,
-		] );
-		useEnabledPaymentMethodIds.mockReturnValue( [
-			[ PAYMENT_METHOD_LINK ],
-		] );
-
-		render( <PaymentRequestSection /> );
-
-		expect( screen.queryByText( 'Link by Stripe' ) ).toBeNull();
-	} );
-
-	it( 'show link payment if card payment method is active (OC disabled)', () => {
-		useGetAvailablePaymentMethodIds.mockReturnValue( [
-			PAYMENT_METHOD_LINK,
-			PAYMENT_METHOD_CARD,
-		] );
-		useEnabledPaymentMethodIds.mockReturnValue( [
-			[ PAYMENT_METHOD_CARD, PAYMENT_METHOD_LINK ],
-		] );
-
-		render( <PaymentRequestSection /> );
-
-		expect( screen.queryByText( 'Link by Stripe' ) ).toBeInTheDocument();
-	} );
-
-	it( 'show link payment if card payment method is inactive (OC enabled)', () => {
-		useGetAvailablePaymentMethodIds.mockReturnValue( [
-			PAYMENT_METHOD_LINK,
-			PAYMENT_METHOD_CARD,
-		] );
-		useEnabledPaymentMethodIds.mockReturnValue( [
-			[ PAYMENT_METHOD_LINK ],
-		] );
-		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
-
-		render( <PaymentRequestSection /> );
-
-		expect( screen.queryByText( 'Link by Stripe' ) ).toBeInTheDocument();
-	} );
-
 	it( 'test stripe link checkbox checked', () => {
 		useGetAvailablePaymentMethodIds.mockReturnValue( [
 			PAYMENT_METHOD_LINK,

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -20,6 +20,7 @@ import { addQueryArgs } from '@wordpress/url';
 import {
 	PAYMENT_METHOD_LINK,
 	PAYMENT_METHOD_AMAZON_PAY,
+	PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY,
 } from 'wcstripe/stripe-utils/constants';
 import PaymentMethodUnavailableDueTaxSetupPill from 'wcstripe/components/payment-method-unavailable-due-tax-setup-pill';
 import usePaymentMethodUnavailableReason from 'wcstripe/utils/use-payment-method-unavailable-reason';
@@ -42,9 +43,12 @@ const PaymentRequestSection = () => {
 	);
 
 	const applePayGooglePayUnavailableReason =
-		usePaymentMethodUnavailableReason( 'apple_pay_google_pay' );
+		usePaymentMethodUnavailableReason(
+			PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY
+		);
 
-	const linkUnavailableReason = usePaymentMethodUnavailableReason( 'link' );
+	const linkUnavailableReason =
+		usePaymentMethodUnavailableReason( PAYMENT_METHOD_LINK );
 
 	const updateStripeLinkCheckout = ( isEnabled ) => {
 		// Add/remove Stripe Link from the list of enabled payment methods.
@@ -116,7 +120,7 @@ const PaymentRequestSection = () => {
 									'woocommerce-gateway-stripe'
 								) }
 								<PaymentMethodRequiresCardMethodPill
-									id="apple_pay_google_pay"
+									id={ PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY }
 									label={ __(
 										'Apple Pay / Google Pay',
 										'woocommerce-gateway-stripe'
@@ -192,7 +196,7 @@ const PaymentRequestSection = () => {
 									'woocommerce-gateway-stripe'
 								) }
 								<PaymentMethodRequiresCardMethodPill
-									id="link"
+									id={ PAYMENT_METHOD_LINK }
 									label={ __(
 										'Link by Stripe',
 										'woocommerce-gateway-stripe'
@@ -277,14 +281,14 @@ const PaymentRequestSection = () => {
 										'woocommerce-gateway-stripe'
 									) }
 									<PaymentMethodMissingCurrencyPill
-										id="amazon_pay"
+										id={ PAYMENT_METHOD_AMAZON_PAY }
 										label={ __(
 											'Amazon Pay',
 											'woocommerce-gateway-stripe'
 										) }
 									/>
 									<PaymentMethodUnavailableDueTaxSetupPill
-										id="amazon_pay"
+										id={ PAYMENT_METHOD_AMAZON_PAY }
 										label={ __(
 											'Amazon Pay',
 											'woocommerce-gateway-stripe'

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -23,6 +23,8 @@ import {
 	PAYMENT_METHOD_LINK,
 	PAYMENT_METHOD_AMAZON_PAY,
 } from 'wcstripe/stripe-utils/constants';
+import PaymentMethodUnavailableDueTaxSetupPill from 'wcstripe/components/payment-method-unavailable-due-tax-setup-pill';
+import usePaymentMethodUnavailableReason from 'wcstripe/utils/use-payment-method-unavailable-reason';
 
 const PaymentRequestSection = () => {
 	const [ isPaymentRequestEnabled, updateIsPaymentRequestEnabled ] =
@@ -35,6 +37,10 @@ const PaymentRequestSection = () => {
 
 	const [ enabledMethodIds, updateEnabledMethodIds ] =
 		useEnabledPaymentMethodIds();
+
+	const amazonPayUnavailableReason = usePaymentMethodUnavailableReason(
+		PAYMENT_METHOD_AMAZON_PAY
+	);
 
 	const [ isOCEnabled ] = useIsOCEnabled();
 
@@ -75,6 +81,10 @@ const PaymentRequestSection = () => {
 	const isAmazonPayAvailable =
 		wc_stripe_settings_params.is_amazon_pay_available && // eslint-disable-line camelcase
 		availablePaymentMethodIds.includes( PAYMENT_METHOD_AMAZON_PAY );
+
+	const isAmazonPayDisabled =
+		amazonPayUnavailableReason !== null &&
+		! enabledMethodIds.includes( PAYMENT_METHOD_AMAZON_PAY );
 
 	return (
 		<Card className="express-checkouts">
@@ -256,6 +266,7 @@ const PaymentRequestSection = () => {
 									) }
 									checked={ isAmazonPayEnabled }
 									onChange={ updateIsAmazonPayEnabled }
+									disabled={ isAmazonPayDisabled }
 								/>
 							</div>
 							<div className="express-checkout__icon">
@@ -268,6 +279,13 @@ const PaymentRequestSection = () => {
 										'woocommerce-gateway-stripe'
 									) }
 									<PaymentMethodMissingCurrencyPill
+										id="amazon_pay"
+										label={ __(
+											'Amazon Pay',
+											'woocommerce-gateway-stripe'
+										) }
+									/>
+									<PaymentMethodUnavailableDueTaxSetupPill
 										id="amazon_pay"
 										label={ __(
 											'Amazon Pay',

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -21,6 +21,7 @@ import {
 	PAYMENT_METHOD_LINK,
 	PAYMENT_METHOD_AMAZON_PAY,
 	PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY,
+	PAYMENT_METHOD_UNAVAILABLE_REASONS,
 } from 'wcstripe/stripe-utils/constants';
 import PaymentMethodUnavailableDueTaxSetupPill from 'wcstripe/components/payment-method-unavailable-due-tax-setup-pill';
 import usePaymentMethodUnavailableReason from 'wcstripe/utils/use-payment-method-unavailable-reason';
@@ -42,13 +43,25 @@ const PaymentRequestSection = () => {
 		PAYMENT_METHOD_AMAZON_PAY
 	);
 
+	const showUnavailableDueTaxSetupPillForAmazonPay =
+		amazonPayUnavailableReason ===
+		PAYMENT_METHOD_UNAVAILABLE_REASONS.TAX_BASED_ON_BILLING_ADDRESS;
+
 	const applePayGooglePayUnavailableReason =
 		usePaymentMethodUnavailableReason(
 			PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY
 		);
 
+	const showRequiresCardMethodPillForApplePayGooglePay =
+		applePayGooglePayUnavailableReason ===
+		PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD;
+
 	const linkUnavailableReason =
 		usePaymentMethodUnavailableReason( PAYMENT_METHOD_LINK );
+
+	const showRequiresCardMethodPillForLink =
+		linkUnavailableReason ===
+		PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD;
 
 	const updateStripeLinkCheckout = ( isEnabled ) => {
 		// Add/remove Stripe Link from the list of enabled payment methods.
@@ -119,13 +132,17 @@ const PaymentRequestSection = () => {
 									'Apple Pay / Google Pay',
 									'woocommerce-gateway-stripe'
 								) }
-								<PaymentMethodRequiresCardMethodPill
-									id={ PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY }
-									label={ __(
-										'Apple Pay / Google Pay',
-										'woocommerce-gateway-stripe'
-									) }
-								/>
+								{ showRequiresCardMethodPillForApplePayGooglePay && (
+									<PaymentMethodRequiresCardMethodPill
+										id={
+											PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY
+										}
+										label={ __(
+											'Apple Pay / Google Pay',
+											'woocommerce-gateway-stripe'
+										) }
+									/>
+								) }
 							</div>
 							<div className="express-checkout__description">
 								{
@@ -195,13 +212,15 @@ const PaymentRequestSection = () => {
 									'Link by Stripe',
 									'woocommerce-gateway-stripe'
 								) }
-								<PaymentMethodRequiresCardMethodPill
-									id={ PAYMENT_METHOD_LINK }
-									label={ __(
-										'Link by Stripe',
-										'woocommerce-gateway-stripe'
-									) }
-								/>
+								{ showRequiresCardMethodPillForLink && (
+									<PaymentMethodRequiresCardMethodPill
+										id={ PAYMENT_METHOD_LINK }
+										label={ __(
+											'Link by Stripe',
+											'woocommerce-gateway-stripe'
+										) }
+									/>
+								) }
 							</div>
 							<div className="express-checkout__description">
 								{
@@ -287,13 +306,15 @@ const PaymentRequestSection = () => {
 											'woocommerce-gateway-stripe'
 										) }
 									/>
-									<PaymentMethodUnavailableDueTaxSetupPill
-										id={ PAYMENT_METHOD_AMAZON_PAY }
-										label={ __(
-											'Amazon Pay',
-											'woocommerce-gateway-stripe'
-										) }
-									/>
+									{ showUnavailableDueTaxSetupPillForAmazonPay && (
+										<PaymentMethodUnavailableDueTaxSetupPill
+											id={ PAYMENT_METHOD_AMAZON_PAY }
+											label={ __(
+												'Amazon Pay',
+												'woocommerce-gateway-stripe'
+											) }
+										/>
+									) }
 								</div>
 								<div className="express-checkout__description">
 									{

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -25,6 +25,7 @@ import {
 } from 'wcstripe/stripe-utils/constants';
 import PaymentMethodUnavailableDueTaxSetupPill from 'wcstripe/components/payment-method-unavailable-due-tax-setup-pill';
 import usePaymentMethodUnavailableReason from 'wcstripe/utils/use-payment-method-unavailable-reason';
+import PaymentMethodRequiresCardMethodPill from 'wcstripe/components/payment-method-requires-card-method-pill';
 
 const PaymentRequestSection = () => {
 	const [ isPaymentRequestEnabled, updateIsPaymentRequestEnabled ] =
@@ -129,6 +130,13 @@ const PaymentRequestSection = () => {
 										'Apple Pay / Google Pay',
 										'woocommerce-gateway-stripe'
 									) }
+									<PaymentMethodRequiresCardMethodPill
+										id="apple_pay_google_pay"
+										label={ __(
+											'Apple Pay / Google Pay',
+											'woocommerce-gateway-stripe'
+										) }
+									/>
 								</div>
 								<div className="express-checkout__description">
 									{

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -97,6 +97,10 @@ const PaymentRequestSection = () => {
 					<li className="express-checkout has-icon-border">
 						<div className="express-checkout__checkbox">
 							<CheckboxControl
+								label={ __(
+									'Apple Pay / Google Pay Input',
+									'woocommerce-gateway-stripe'
+								) }
 								checked={ isPaymentRequestEnabled }
 								onChange={ updateIsPaymentRequestEnabled }
 								disabled={ isApplePayGooglePayDisabled }

--- a/client/settings/payment-request-section/index.js
+++ b/client/settings/payment-request-section/index.js
@@ -10,7 +10,6 @@ import {
 	useAmazonPayEnabledSettings,
 	useEnabledPaymentMethodIds,
 	useGetAvailablePaymentMethodIds,
-	useIsOCEnabled,
 } from '../../data';
 import './styles.scss';
 import AmazonPayIcon from '../../payment-method-icons/amazon-pay';
@@ -19,7 +18,6 @@ import { __ } from '@wordpress/i18n';
 import { Card, CheckboxControl } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import {
-	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_LINK,
 	PAYMENT_METHOD_AMAZON_PAY,
 } from 'wcstripe/stripe-utils/constants';
@@ -43,7 +41,10 @@ const PaymentRequestSection = () => {
 		PAYMENT_METHOD_AMAZON_PAY
 	);
 
-	const [ isOCEnabled ] = useIsOCEnabled();
+	const applePayGooglePayUnavailableReason =
+		usePaymentMethodUnavailableReason( 'apple_pay_google_pay' );
+
+	const linkUnavailableReason = usePaymentMethodUnavailableReason( 'link' );
 
 	const updateStripeLinkCheckout = ( isEnabled ) => {
 		// Add/remove Stripe Link from the list of enabled payment methods.
@@ -61,11 +62,6 @@ const PaymentRequestSection = () => {
 		}
 	};
 
-	const displayExpressPaymentMethods =
-		enabledMethodIds.includes( PAYMENT_METHOD_CARD );
-	const displayLinkPaymentMethod =
-		( enabledMethodIds.includes( PAYMENT_METHOD_CARD ) || isOCEnabled ) &&
-		availablePaymentMethodIds.includes( PAYMENT_METHOD_LINK );
 	const isStripeLinkEnabled =
 		enabledMethodIds.includes( PAYMENT_METHOD_LINK );
 
@@ -87,183 +83,173 @@ const PaymentRequestSection = () => {
 		amazonPayUnavailableReason !== null &&
 		! enabledMethodIds.includes( PAYMENT_METHOD_AMAZON_PAY );
 
+	const isApplePayGooglePayDisabled =
+		applePayGooglePayUnavailableReason !== null &&
+		! isPaymentRequestEnabled;
+
+	const isLinkDisabled =
+		linkUnavailableReason !== null && ! isStripeLinkEnabled;
+
 	return (
 		<Card className="express-checkouts">
 			<CardBody size={ 0 }>
 				<ul className="express-checkouts-list">
-					{ ! displayExpressPaymentMethods &&
-						! displayLinkPaymentMethod && (
-							<li className="express-checkout">
-								<div>
-									{ __(
-										'Credit card / debit card must be enabled as a payment method in order to use Express Checkout.',
-										'woocommerce-gateway-stripe'
-									) }
-								</div>
-							</li>
-						) }
-					{ ! displayExpressPaymentMethods &&
-						displayLinkPaymentMethod && (
-							<li className="express-checkout">
-								<div>
-									{ __(
-										'Credit card / debit card must be enabled as a payment method in order to use Google Pay and Apple Pay (and Link in the classic checkout).',
-										'woocommerce-gateway-stripe'
-									) }
-								</div>
-							</li>
-						) }
-					{ displayExpressPaymentMethods && (
-						<li className="express-checkout has-icon-border">
-							<div className="express-checkout__checkbox">
-								<CheckboxControl
-									checked={ isPaymentRequestEnabled }
-									onChange={ updateIsPaymentRequestEnabled }
-								/>
-							</div>
-							<div className="express-checkout__icon">
-								<PaymentRequestIcon size="medium" />
-							</div>
-							<div className="express-checkout__label-container">
-								<div className="express-checkout__label">
-									{ __(
+					<li className="express-checkout has-icon-border">
+						<div className="express-checkout__checkbox">
+							<CheckboxControl
+								checked={ isPaymentRequestEnabled }
+								onChange={ updateIsPaymentRequestEnabled }
+								disabled={ isApplePayGooglePayDisabled }
+							/>
+						</div>
+						<div className="express-checkout__icon">
+							<PaymentRequestIcon size="medium" />
+						</div>
+						<div className="express-checkout__label-container">
+							<div className="express-checkout__label">
+								{ __(
+									'Apple Pay / Google Pay',
+									'woocommerce-gateway-stripe'
+								) }
+								<PaymentMethodRequiresCardMethodPill
+									id="apple_pay_google_pay"
+									label={ __(
 										'Apple Pay / Google Pay',
 										'woocommerce-gateway-stripe'
 									) }
-									<PaymentMethodRequiresCardMethodPill
-										id="apple_pay_google_pay"
-										label={ __(
-											'Apple Pay / Google Pay',
-											'woocommerce-gateway-stripe'
-										) }
-									/>
-								</div>
-								<div className="express-checkout__description">
-									{
-										/* eslint-disable jsx-a11y/anchor-has-content */
-										interpolateComponents( {
-											mixedString: __(
-												'Boost sales by offering a fast, simple, and secure checkout experience.' +
-													'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}}, ' +
-													"{{appleLink}}Apple{{/appleLink}}, and {{googleLink}}Google{{/googleLink}}'s terms of use.",
-												'woocommerce-gateway-stripe'
-											),
-											components: {
-												stripeLink: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://stripe.com/apple-pay/legal"
-													/>
-												),
-												appleLink: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/"
-													/>
-												),
-												googleLink: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://androidpay.developers.google.com/terms/sellertos"
-													/>
-												),
-											},
-										} )
-										/* eslint-enable jsx-a11y/anchor-has-content */
-									}
-								</div>
-							</div>
-							<div className="express-checkout__link">
-								<a href={ customizeAppearanceURL }>
-									{ __(
-										'Customize',
-										'woocommerce-gateway-stripe'
-									) }
-								</a>
-							</div>
-						</li>
-					) }
-					{ displayLinkPaymentMethod && (
-						<li className="express-checkout has-icon-border">
-							<div className="express-checkout__checkbox loadable-checkbox label-hidden">
-								<CheckboxControl
-									label={ __(
-										'Link by Stripe Input',
-										'woocommerce-gateway-stripe'
-									) }
-									checked={ isStripeLinkEnabled }
-									onChange={ updateStripeLinkCheckout }
 								/>
 							</div>
-							<div className="express-checkout__icon">
-								<LinkIcon size="medium" />
-							</div>
-							<div className="express-checkout__label-container">
-								<div className="express-checkout__label">
-									{ __(
-										'Link by Stripe',
-										'woocommerce-gateway-stripe'
-									) }
-								</div>
-								<div className="express-checkout__description">
-									{
-										/* eslint-disable jsx-a11y/anchor-has-content */
-										interpolateComponents( {
-											mixedString: __(
-												'Link autofills your customers’ payment and shipping details to ' +
-													'deliver an easy and seamless checkout experience. ' +
-													'New checkout experience needs to be enabled for Link. ' +
-													'By enabling this feature, you agree to the ' +
-													'{{stripeLinkTerms}}Link by Stripe terms{{/stripeLinkTerms}}, ' +
-													'and {{privacyPolicy}}Privacy Policy{{/privacyPolicy}}.',
-												'woocommerce-gateway-stripe'
-											),
-											components: {
-												stripeLinkTerms: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://link.com/terms"
-													/>
-												),
-												privacyPolicy: (
-													<a
-														target="_blank"
-														rel="noreferrer"
-														href="https://link.com/privacy"
-													/>
-												),
-											},
-										} )
-										/* eslint-enable jsx-a11y/anchor-has-content */
-									}
-								</div>
-							</div>
-							<div className="express-checkout__link">
+							<div className="express-checkout__description">
 								{
 									/* eslint-disable jsx-a11y/anchor-has-content */
 									interpolateComponents( {
 										mixedString: __(
-											'{{linkDocs}}Read more{{/linkDocs}}',
+											'Boost sales by offering a fast, simple, and secure checkout experience.' +
+												'By enabling this feature, you agree to {{stripeLink}}Stripe{{/stripeLink}}, ' +
+												"{{appleLink}}Apple{{/appleLink}}, and {{googleLink}}Google{{/googleLink}}'s terms of use.",
 											'woocommerce-gateway-stripe'
 										),
 										components: {
-											linkDocs: (
+											stripeLink: (
 												<a
 													target="_blank"
 													rel="noreferrer"
-													href="https://woocommerce.com/document/stripe/customer-experience/express-checkouts/#link-by-stripe"
+													href="https://stripe.com/apple-pay/legal"
+												/>
+											),
+											appleLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://developer.apple.com/apple-pay/acceptable-use-guidelines-for-websites/"
+												/>
+											),
+											googleLink: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://androidpay.developers.google.com/terms/sellertos"
 												/>
 											),
 										},
 									} )
+									/* eslint-enable jsx-a11y/anchor-has-content */
 								}
 							</div>
-						</li>
-					) }
+						</div>
+						<div className="express-checkout__link">
+							<a href={ customizeAppearanceURL }>
+								{ __(
+									'Customize',
+									'woocommerce-gateway-stripe'
+								) }
+							</a>
+						</div>
+					</li>
+					<li className="express-checkout has-icon-border">
+						<div className="express-checkout__checkbox loadable-checkbox label-hidden">
+							<CheckboxControl
+								label={ __(
+									'Link by Stripe Input',
+									'woocommerce-gateway-stripe'
+								) }
+								checked={ isStripeLinkEnabled }
+								onChange={ updateStripeLinkCheckout }
+								disabled={ isLinkDisabled }
+							/>
+						</div>
+						<div className="express-checkout__icon">
+							<LinkIcon size="medium" />
+						</div>
+						<div className="express-checkout__label-container">
+							<div className="express-checkout__label">
+								{ __(
+									'Link by Stripe',
+									'woocommerce-gateway-stripe'
+								) }
+								<PaymentMethodRequiresCardMethodPill
+									id="link"
+									label={ __(
+										'Link by Stripe',
+										'woocommerce-gateway-stripe'
+									) }
+								/>
+							</div>
+							<div className="express-checkout__description">
+								{
+									/* eslint-disable jsx-a11y/anchor-has-content */
+									interpolateComponents( {
+										mixedString: __(
+											'Link autofills your customers’ payment and shipping details to ' +
+												'deliver an easy and seamless checkout experience. ' +
+												'New checkout experience needs to be enabled for Link. ' +
+												'By enabling this feature, you agree to the ' +
+												'{{stripeLinkTerms}}Link by Stripe terms{{/stripeLinkTerms}}, ' +
+												'and {{privacyPolicy}}Privacy Policy{{/privacyPolicy}}.',
+											'woocommerce-gateway-stripe'
+										),
+										components: {
+											stripeLinkTerms: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://link.com/terms"
+												/>
+											),
+											privacyPolicy: (
+												<a
+													target="_blank"
+													rel="noreferrer"
+													href="https://link.com/privacy"
+												/>
+											),
+										},
+									} )
+									/* eslint-enable jsx-a11y/anchor-has-content */
+								}
+							</div>
+						</div>
+						<div className="express-checkout__link">
+							{
+								/* eslint-disable jsx-a11y/anchor-has-content */
+								interpolateComponents( {
+									mixedString: __(
+										'{{linkDocs}}Read more{{/linkDocs}}',
+										'woocommerce-gateway-stripe'
+									),
+									components: {
+										linkDocs: (
+											<a
+												target="_blank"
+												rel="noreferrer"
+												href="https://woocommerce.com/document/stripe/customer-experience/express-checkouts/#link-by-stripe"
+											/>
+										),
+									},
+								} )
+							}
+						</div>
+					</li>
 					{ isAmazonPayAvailable && (
 						<li className="express-checkout has-icon-border">
 							<div className="express-checkout__checkbox">

--- a/client/settings/payment-request-section/styles.scss
+++ b/client/settings/payment-request-section/styles.scss
@@ -43,12 +43,15 @@
 			}
 
 			&__label {
-				display: inline-block;
+				display: inline-flex;
 				font-size: 14px;
 				font-weight: 600;
 				line-height: 20px;
 				color: styles.$gray-900;
 				margin-bottom: 4px;
+				align-items: center;
+				gap: 8px;
+				flex-wrap: wrap;
 			}
 
 			&__link {

--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -177,6 +177,8 @@ export const BNPL_METHODS = [
 export const PAYMENT_METHOD_UNAVAILABLE_REASONS = {
 	UNSUPPORTED_CURRENCY: 'unsupported_currency',
 	OFFICIAL_PLUGIN_CONFLICT: 'official_plugin_conflict',
+	TAX_BASED_ON_BILLING_ADDRESS: 'tax_based_on_billing_address',
+	REQUIRES_CARD_METHOD: 'requires_card_method',
 };
 
 /**

--- a/client/stripe-utils/constants.js
+++ b/client/stripe-utils/constants.js
@@ -27,6 +27,7 @@ export const PAYMENT_METHOD_ACH = 'us_bank_account';
 export const PAYMENT_METHOD_ACSS = 'acss_debit';
 export const PAYMENT_METHOD_BACS = 'bacs_debit';
 export const PAYMENT_METHOD_BECS = 'au_becs_debit';
+export const PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY = 'apple_pay_google_pay';
 
 /**
  * Payment method names constants with the `stripe` prefix

--- a/client/utils/__tests__/get-payment-method-unavailable-reason.test.js
+++ b/client/utils/__tests__/get-payment-method-unavailable-reason.test.js
@@ -1,5 +1,6 @@
 import {
 	PAYMENT_METHOD_AFFIRM,
+	PAYMENT_METHOD_AMAZON_PAY,
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_KLARNA,
 	PAYMENT_METHOD_SEPA,
@@ -17,6 +18,7 @@ describe( 'getPaymentMethodUnavailableReason', () => {
 		global.wc_stripe_settings_params = {
 			has_klarna_gateway_plugin: false,
 			has_affirm_gateway_plugin: false,
+			taxes_based_on_billing: false,
 		};
 		getPaymentMethodCurrencies.mockImplementation( ( paymentMethodId ) => {
 			if ( paymentMethodId === PAYMENT_METHOD_CARD ) {
@@ -111,5 +113,17 @@ describe( 'getPaymentMethodUnavailableReason', () => {
 				storeCurrencyCode: 'EUR',
 			} )
 		).toBe( PAYMENT_METHOD_UNAVAILABLE_REASONS.UNSUPPORTED_CURRENCY );
+	} );
+
+	it( 'should return TAX_BASED_ON_BILLING_ADDRESS when Amazon Pay is unavailable due to taxes being based on billing address', () => {
+		global.wc_stripe_settings_params.taxes_based_on_billing = true;
+		expect(
+			getPaymentMethodUnavailableReason( {
+				paymentMethodId: PAYMENT_METHOD_AMAZON_PAY,
+				storeCurrencyCode: 'USD',
+			} )
+		).toBe(
+			PAYMENT_METHOD_UNAVAILABLE_REASONS.TAX_BASED_ON_BILLING_ADDRESS
+		);
 	} );
 } );

--- a/client/utils/__tests__/get-payment-method-unavailable-reason.test.js
+++ b/client/utils/__tests__/get-payment-method-unavailable-reason.test.js
@@ -19,6 +19,7 @@ describe( 'getPaymentMethodUnavailableReason', () => {
 			has_klarna_gateway_plugin: false,
 			has_affirm_gateway_plugin: false,
 			taxes_based_on_billing: false,
+			is_card_method_enabled: true,
 		};
 		getPaymentMethodCurrencies.mockImplementation( ( paymentMethodId ) => {
 			if ( paymentMethodId === PAYMENT_METHOD_CARD ) {
@@ -125,5 +126,15 @@ describe( 'getPaymentMethodUnavailableReason', () => {
 		).toBe(
 			PAYMENT_METHOD_UNAVAILABLE_REASONS.TAX_BASED_ON_BILLING_ADDRESS
 		);
+	} );
+
+	it( 'should return REQUIRES_CARD_METHOD when ECE are unavailable due to the card method being disabled', () => {
+		global.wc_stripe_settings_params.is_card_method_enabled = false;
+		expect(
+			getPaymentMethodUnavailableReason( {
+				paymentMethodId: 'apple_pay_google_pay',
+				storeCurrencyCode: 'USD',
+			} )
+		).toBe( PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD );
 	} );
 } );

--- a/client/utils/__tests__/get-payment-method-unavailable-reason.test.js
+++ b/client/utils/__tests__/get-payment-method-unavailable-reason.test.js
@@ -1,6 +1,7 @@
 import {
 	PAYMENT_METHOD_AFFIRM,
 	PAYMENT_METHOD_AMAZON_PAY,
+	PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY,
 	PAYMENT_METHOD_CARD,
 	PAYMENT_METHOD_KLARNA,
 	PAYMENT_METHOD_SEPA,
@@ -132,7 +133,7 @@ describe( 'getPaymentMethodUnavailableReason', () => {
 		global.wc_stripe_settings_params.is_card_method_enabled = false;
 		expect(
 			getPaymentMethodUnavailableReason( {
-				paymentMethodId: 'apple_pay_google_pay',
+				paymentMethodId: PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY,
 				storeCurrencyCode: 'USD',
 			} )
 		).toBe( PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD );

--- a/client/utils/get-payment-method-unavailable-reason.js
+++ b/client/utils/get-payment-method-unavailable-reason.js
@@ -43,7 +43,8 @@ const getPaymentMethodUnavailableReason = ( {
 	}
 
 	if (
-		paymentMethodId === 'apple_pay_google_pay' &&
+		( paymentMethodId === 'apple_pay_google_pay' ||
+			paymentMethodId === 'link' ) &&
 		! window?.wc_stripe_settings_params?.is_card_method_enabled
 	) {
 		return PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD;

--- a/client/utils/get-payment-method-unavailable-reason.js
+++ b/client/utils/get-payment-method-unavailable-reason.js
@@ -1,5 +1,6 @@
 import {
 	PAYMENT_METHOD_AFFIRM,
+	PAYMENT_METHOD_AMAZON_PAY,
 	PAYMENT_METHOD_KLARNA,
 	PAYMENT_METHOD_UNAVAILABLE_REASONS,
 } from 'wcstripe/stripe-utils/constants';
@@ -32,6 +33,13 @@ const getPaymentMethodUnavailableReason = ( {
 		window?.wc_stripe_settings_params?.has_affirm_gateway_plugin
 	) {
 		return PAYMENT_METHOD_UNAVAILABLE_REASONS.OFFICIAL_PLUGIN_CONFLICT;
+	}
+
+	if (
+		paymentMethodId === PAYMENT_METHOD_AMAZON_PAY &&
+		window?.wc_stripe_settings_params?.taxes_based_on_billing
+	) {
+		return PAYMENT_METHOD_UNAVAILABLE_REASONS.TAX_BASED_ON_BILLING_ADDRESS;
 	}
 
 	if ( ! storeCurrencyCode || ! isUpeEnabled ) {

--- a/client/utils/get-payment-method-unavailable-reason.js
+++ b/client/utils/get-payment-method-unavailable-reason.js
@@ -42,6 +42,13 @@ const getPaymentMethodUnavailableReason = ( {
 		return PAYMENT_METHOD_UNAVAILABLE_REASONS.TAX_BASED_ON_BILLING_ADDRESS;
 	}
 
+	if (
+		paymentMethodId === 'apple_pay_google_pay' &&
+		! window?.wc_stripe_settings_params?.is_card_method_enabled
+	) {
+		return PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD;
+	}
+
 	if ( ! storeCurrencyCode || ! isUpeEnabled ) {
 		return null;
 	}

--- a/client/utils/get-payment-method-unavailable-reason.js
+++ b/client/utils/get-payment-method-unavailable-reason.js
@@ -1,7 +1,9 @@
 import {
 	PAYMENT_METHOD_AFFIRM,
 	PAYMENT_METHOD_AMAZON_PAY,
+	PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY,
 	PAYMENT_METHOD_KLARNA,
+	PAYMENT_METHOD_LINK,
 	PAYMENT_METHOD_UNAVAILABLE_REASONS,
 } from 'wcstripe/stripe-utils/constants';
 import { getPaymentMethodCurrencies } from 'utils/use-payment-method-currencies';
@@ -43,8 +45,8 @@ const getPaymentMethodUnavailableReason = ( {
 	}
 
 	if (
-		( paymentMethodId === 'apple_pay_google_pay' ||
-			paymentMethodId === 'link' ) &&
+		( paymentMethodId === PAYMENT_METHOD_APPLE_PAY_GOOGLE_PAY ||
+			paymentMethodId === PAYMENT_METHOD_LINK ) &&
 		! window?.wc_stripe_settings_params?.is_card_method_enabled
 	) {
 		return PAYMENT_METHOD_UNAVAILABLE_REASONS.REQUIRES_CARD_METHOD;

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -319,13 +319,13 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 		}
 
 		// Amazon Pay cannot be enabled when taxes are based on the customer billing address.
-		if ( in_array( WC_Stripe_Payment_Methods::AMAZON_PAY, $payment_method_ids_to_enable, true ) ) {
-			if ( 'billing' === get_option( 'woocommerce_tax_based_on' ) ) {
-				$payment_method_ids_to_enable = array_diff(
-					$payment_method_ids_to_enable,
-					[ WC_Stripe_Payment_Methods::AMAZON_PAY ]
-				);
-			}
+		if ( ! empty( $payment_method_ids_to_enable ) && in_array( WC_Stripe_Payment_Methods::AMAZON_PAY, $payment_method_ids_to_enable, true ) &&
+			'billing' === get_option( 'woocommerce_tax_based_on' )
+		) {
+			$payment_method_ids_to_enable = array_diff(
+				$payment_method_ids_to_enable,
+				[ WC_Stripe_Payment_Methods::AMAZON_PAY ]
+			);
 		}
 
 		return $payment_method_ids_to_enable;

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -318,6 +318,16 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			);
 		}
 
+		// Amazon Pay cannot be enabled when taxes are based on the customer billing address.
+		if ( in_array( WC_Stripe_Payment_Methods::AMAZON_PAY, $payment_method_ids_to_enable, true ) ) {
+			if ( 'billing' === get_option( 'woocommerce_tax_based_on' ) ) {
+				$payment_method_ids_to_enable = array_diff(
+					$payment_method_ids_to_enable,
+					[ WC_Stripe_Payment_Methods::AMAZON_PAY ]
+				);
+			}
+		}
+
 		return $payment_method_ids_to_enable;
 	}
 

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -289,6 +289,7 @@ class WC_Stripe_Settings_Controller {
 			'has_other_bnpl_plugins'                => WC_Stripe_Helper::has_other_bnpl_plugins_active(),
 			'is_payments_onboarding_task_completed' => $this->is_payments_onboarding_task_completed(),
 			'taxes_based_on_billing'                => wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ),
+			'is_card_method_enabled'                => in_array( WC_Stripe_Payment_Methods::CARD, $enabled_payment_methods, true ),
 		];
 		wp_localize_script(
 			'woocommerce_stripe_admin',

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -702,6 +702,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				if ( is_callable( [ $payment_method, 'is_available_for_account_country' ] ) && ! $payment_method->is_available_for_account_country() ) {
 					continue;
 				}
+				// Amazon Pay is not available when taxes are based on the customer billing address.
+				if ( wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' )
+					&& WC_Stripe_Payment_Methods::AMAZON_PAY === $payment_method->get_id() ) {
+					continue;
+				}
 				$available_payment_methods[] = $payment_method->get_id();
 			}
 			return $available_payment_methods;

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.2.0 - xxxx-xx-xx =
+* Update - Block Amazon Pay from being enabled when taxes are based on the billing address. Adds new pills to indicate why it is disabled, and another pill to indicate when a express method is disabled due card being disabled
 * Dev - Deprecates all the legacy checkout payment method classes
 * Dev - Deprecates all the LPM class constants
 * Dev - Remove all references to the UPE-enabled feature flag


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-806 / #4782
Fixes STRIPE-685 / #4618

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR I am introducing two new payment method pills to be shown above methods in the list screen:
- Incompatible tax: shown above the Amazon Pay method when the store taxes are based on the customer's billing address
- Requires card: shown above Apple Pay / Google Pay and Link when the card payment method is disabled

Preview for the incompatible tax pill:
<img width="761" height="260" alt="Screenshot 2025-12-02 at 14 34 35" src="https://github.com/user-attachments/assets/8fa895d1-b265-41b4-8dc3-1e78e95251a1" />

Preview for the "requires card method" pill:
<img width="782" height="200" alt="Screenshot 2025-12-02 at 17 11 42" src="https://github.com/user-attachments/assets/22cd50a9-0125-4152-a857-31e474e7a74a" />

I am also filtering out Amazon Pay when saving settings, and the store has an incompatible tax setup.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`update/remove-amazon-pay-from-list-when-taxes-are-based-on-billing`)

## Incompatible tax pill

- Enable the Amazon Pay feature flag (you can use the `wc_stripe_is_amazon_pay_available` filter)
- Enable taxes for the store
- In the Tax tab, set taxes based on the customer billing address
- Go to the Stripe payment methods list in wp-admin
- Make sure Amazon Pay is disabled
- Confirm the new pill is shown above Amazon Pay

## Requires card method pill

- Disable the credit card payment method
- Go to the Stripe payment methods list in wp-admin
- Make sure Link and Apple Pay / Google Pay are disabled
- Confirm the pill is shown above both

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
