### PR TITLE
Exclude order parameter from the request args when creating/updating a Stripe customer

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@
 * Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
 * Fix - Always use the current payment method configuration in Optimized Checkout
 * Fix - Fix revoked secret_key error during the OAuth account connection flow
+* Fix - Exclude order parameter from customer creation request arguments
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/changelog.txt
+++ b/changelog.txt
@@ -38,7 +38,7 @@
 * Update - Expand Amazon Pay support for all permitted currencies and countries
 * Add - Allow cache prefetch window to be adjusted via the wc_stripe_database_cache_prefetch_window filter
 * Fix - Respect button.radius value of 0 in Express Checkout Element appearance settings
-* Fix - Exclude order parameter from customer creation request arguments
+* Fix - Exclude order parameter from customer request data
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -522,7 +522,7 @@ class WC_Stripe_Customer {
 			throw new WC_Stripe_Exception( 'id_required_to_update_user', __( 'Attempting to update a Stripe customer without a customer ID.', 'woocommerce-gateway-stripe' ) );
 		}
 
-		$args = $this->generate_customer_request( $args );
+		$args = $this->generate_customer_request( $args, $order );
 
 		/**
 		 * Filters the arguments used to update a customer.
@@ -571,7 +571,7 @@ class WC_Stripe_Customer {
 
 			return $this->recreate_customer( $args, $current_context, $order );
 		} else {
-			return $this->update_customer( $args, $order );
+			return $this->update_customer( $args, false, $order );
 		}
 	}
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -175,7 +175,7 @@ class WC_Stripe_Customer {
 
 			// If the user email is not set, use the billing email.
 			if ( empty( $email ) ) {
-				$email = $this->get_billing_data_field( 'billing_email', $args );
+				$email = $this->get_billing_data_field( 'billing_email', $order );
 			}
 
 			// translators: %1$s First name, %2$s Second name, %3$s Username.
@@ -191,9 +191,9 @@ class WC_Stripe_Customer {
 				$defaults['name'] = $billing_full_name;
 			}
 		} else {
-			$billing_email      = $this->get_billing_data_field( 'billing_email', $args );
-			$billing_first_name = $this->get_billing_data_field( 'billing_first_name', $args );
-			$billing_last_name  = $this->get_billing_data_field( 'billing_last_name', $args );
+			$billing_email      = $this->get_billing_data_field( 'billing_email', $order );
+			$billing_first_name = $this->get_billing_data_field( 'billing_first_name', $order );
+			$billing_last_name  = $this->get_billing_data_field( 'billing_last_name', $order );
 
 			// translators: %1$s First name, %2$s Second name.
 			$description = sprintf( __( 'Name: %1$s %2$s, Guest', 'woocommerce-gateway-stripe' ), $billing_first_name, $billing_last_name );
@@ -226,7 +226,7 @@ class WC_Stripe_Customer {
 			if ( $user ) {
 				$defaults['address'][ $key ] = get_user_meta( $user->ID, $field, true );
 			} else {
-				$defaults['address'][ $key ] = $this->get_billing_data_field( $field, $args );
+				$defaults['address'][ $key ] = $this->get_billing_data_field( $field, $order );
 			}
 		}
 

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -156,6 +156,12 @@ class WC_Stripe_Customer {
 	 * @return array
 	 */
 	protected function generate_customer_request( $args = [], $order = null ) {
+		// The $order parameter was added in 10.2.0, so check for `$args['order'] for backwards compatibility.
+		if ( null === $order && isset( $args['order'] ) && $args['order'] instanceof WC_Order ) {
+			$order = $args['order'];
+		}
+		// Always ensure the old 'order' key is unset
+		unset( $args['order'] );
 		$user = $this->get_user();
 		if ( $user ) {
 			$billing_first_name = get_user_meta( $user->ID, 'billing_first_name', true );

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -150,10 +150,12 @@ class WC_Stripe_Customer {
 	/**
 	 * Generates the customer request, used for both creating and updating customers.
 	 *
-	 * @param  array $args Additional arguments (optional).
+	 * @param  array        $args  Additional arguments for the request (optional).
+	 * @param WC_Order|null $order The order object (optional). If provided, billing details will be retrieved from the order.
+	 *
 	 * @return array
 	 */
-	protected function generate_customer_request( $args = [] ) {
+	protected function generate_customer_request( $args = [], $order = null ) {
 		$user = $this->get_user();
 		if ( $user ) {
 			$billing_first_name = get_user_meta( $user->ID, 'billing_first_name', true );
@@ -341,12 +343,12 @@ class WC_Stripe_Customer {
 	/**
 	 * Get value of billing data field, either from POST or order object.
 	 *
-	 * @param string $field Field name.
-	 * @param array  $args  Additional arguments (optional).
+	 * @param string        $field Field name.
+	 * @param WC_Order|null $order The order object (optional).
 	 *
 	 * @return string
 	 */
-	private function get_billing_data_field( $field, $args = [] ) {
+	private function get_billing_data_field( $field, $order = null ) {
 		$valid_fields = [
 			'billing_email',
 			'billing_first_name',
@@ -366,31 +368,30 @@ class WC_Stripe_Customer {
 
 		// Prioritize POST data, if available.
 		if ( isset( $_POST[ $field ] ) ) {
-			if ( 'billing_email' === $field ) {
-				return filter_var( wp_unslash( $_POST[ $field ] ), FILTER_SANITIZE_EMAIL ); // phpcs:ignore WordPress.Security.NonceVerification
-			}
+			$filter = 'billing_email' === $field ? FILTER_SANITIZE_EMAIL : FILTER_SANITIZE_SPECIAL_CHARS;
+			return filter_var( wp_unslash( $_POST[ $field ] ), $filter ); // phpcs:ignore WordPress.Security.NonceVerification
+		}
 
-			return filter_var( wp_unslash( $_POST[ $field ] ), FILTER_SANITIZE_SPECIAL_CHARS ); // phpcs:ignore WordPress.Security.NonceVerification
-		} elseif ( isset( $args['order'] ) && $args['order'] instanceof WC_Order ) {
+		if ( $order instanceof WC_Order ) {
 			switch ( $field ) {
 				case 'billing_email':
-					return $args['order']->get_billing_email();
+					return $order->get_billing_email();
 				case 'billing_first_name':
-					return $args['order']->get_billing_first_name();
+					return $order->get_billing_first_name();
 				case 'billing_last_name':
-					return $args['order']->get_billing_last_name();
+					return $order->get_billing_last_name();
 				case 'billing_address_1':
-					return $args['order']->get_billing_address_1();
+					return $order->get_billing_address_1();
 				case 'billing_address_2':
-					return $args['order']->get_billing_address_2();
+					return $order->get_billing_address_2();
 				case 'billing_postcode':
-					return $args['order']->get_billing_postcode();
+					return $order->get_billing_postcode();
 				case 'billing_city':
-					return $args['order']->get_billing_city();
+					return $order->get_billing_city();
 				case 'billing_state':
-					return $args['order']->get_billing_state();
+					return $order->get_billing_state();
 				case 'billing_country':
-					return $args['order']->get_billing_country();
+					return $order->get_billing_country();
 				default:
 					return '';
 			}
@@ -448,14 +449,16 @@ class WC_Stripe_Customer {
 	/**
 	 * Create a customer via API.
 	 *
-	 * @param array $args
-	 * @param string|null $current_context The context we are creating the customer in.
+	 * @param array         $args            Additional arguments for the request (optional).
+	 * @param string|null   $current_context The context we are creating the customer in (optional).
+	 * @param WC_Order|null $order           The order object (optional). If provided, billing details will be retrieved from the order.
+	 *
 	 * @return WP_Error|int
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function create_customer( $args = [], $current_context = null ) {
-		$args = $this->generate_customer_request( $args );
+	public function create_customer( $args = [], $current_context = null, $order = null ) {
+		$args = $this->generate_customer_request( $args, $order );
 
 		// For guest users, check if a customer already exists with the same email and name in Stripe account before creating a new one.
 		if ( ! $this->get_id() && 0 === $this->get_user_id() && ! empty( $args['email'] ) && ! empty( $args['name'] ) ) {
@@ -506,14 +509,15 @@ class WC_Stripe_Customer {
 	/**
 	 * Updates the Stripe customer through the API.
 	 *
-	 * @param array $args     Additional arguments for the request (optional).
-	 * @param bool  $is_retry Whether the current call is a retry (optional, defaults to false). If true, then an exception will be thrown instead of further retries on error.
+	 * @param array         $args     Additional arguments for the request (optional).
+	 * @param bool          $is_retry Whether the current call is a retry (optional, defaults to false). If true, then an exception will be thrown instead of further retries on error.
+	 * @param WC_Order|null $order    The order object (optional). If provided, billing details will be retrieved from the order.
 	 *
 	 * @return string Customer ID
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function update_customer( $args = [], $is_retry = false ) {
+	public function update_customer( $args = [], $is_retry = false, $order = null ) {
 		if ( empty( $this->get_id() ) ) {
 			throw new WC_Stripe_Exception( 'id_required_to_update_user', __( 'Attempting to update a Stripe customer without a customer ID.', 'woocommerce-gateway-stripe' ) );
 		}
@@ -552,21 +556,22 @@ class WC_Stripe_Customer {
 	/**
 	 * Updates existing Stripe customer or creates new customer for User through API.
 	 *
-	 * @param array $args     Additional arguments for the request (optional).
-	 * @param string|null $current_context The context we are creating the customer in.
+	 * @param array         $args            Additional arguments for the request (optional).
+	 * @param string|null   $current_context The context we are creating the customer in (optional).
+	 * @param WC_Order|null $order           The order object (optional). If provided, billing details will be retrieved from the order.
 	 *
 	 * @return string Customer ID
 	 *
 	 * @throws WC_Stripe_Exception
 	 */
-	public function update_or_create_customer( $args = [], $current_context = null ) {
+	public function update_or_create_customer( $args = [], $current_context = null, $order = null ) {
 		if ( empty( $this->get_id() ) ) {
 			// $current_context was initially introduced as a boolean flag, so check for old callers.
 			$current_context = $this->normalize_current_context( $current_context );
 
-			return $this->recreate_customer( $args, $current_context );
+			return $this->recreate_customer( $args, $current_context, $order );
 		} else {
-			return $this->update_customer( $args );
+			return $this->update_customer( $args, $order );
 		}
 	}
 
@@ -1033,14 +1038,15 @@ class WC_Stripe_Customer {
 	/**
 	 * Recreates the customer for this user.
 	 *
-	 * @param array $args Additional arguments for the request (optional).
-	 * @param string|null $current_context The context we are creating the customer in.
+	 * @param array         $args            Additional arguments for the request (optional).
+	 * @param string|null   $current_context The context we are creating the customer in (optional).
+	 * @param WC_Order|null $order           The order object (optional). If provided, billing details will be retrieved from the order.
 	 *
 	 * @return string ID of the new Customer object.
 	 */
-	private function recreate_customer( $args = [], ?string $current_context = null ) {
+	private function recreate_customer( $args = [], ?string $current_context = null, $order = null ) {
 		$this->delete_id_from_meta();
-		return $this->create_customer( $args, $current_context );
+		return $this->create_customer( $args, $current_context, $order );
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -2992,8 +2992,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 
 		// Pass the order object so we can retrieve billing details
 		// in payment flows where it is not present in the request.
-		$args = [ 'order' => $order ];
-		return $customer->update_or_create_customer( $args, $current_context );
+		return $customer->update_or_create_customer( [], $current_context, $order );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -140,5 +140,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
 * Fix - Always use the current payment method configuration in Optimized Checkout
 * Fix - Fix revoked secret_key error during the OAuth account connection flow
+* Fix - Exclude order parameter from customer creation request arguments
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3340,4 +3340,244 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$this->assertArrayHasKey( 'pmc_enabled', $result );
 		$this->assertEquals( 'yes', $result['pmc_enabled'] );
 	}
+
+	/**
+	 * Test that get_customer_id_for_order() correctly creates or updates customers with billing details.
+	 *
+	 * For guest users, billing details are retrieved from the order object.
+	 * For logged-in users, billing details come from user meta (user email and user meta fields),
+	 * with the order parameter available as a fallback when user data is missing.
+	 *
+	 * @dataProvider provide_get_customer_id_for_order_billing_details_test_cases
+	 *
+	 * @param string $scenario_name Description of the test scenario.
+	 * @param bool   $is_guest Whether the order is for a guest user.
+	 * @param string $existing_stripe_customer_id Existing Stripe customer ID for the user (empty for new customer).
+	 * @param string $expected_customer_id Expected Stripe customer ID to be returned.
+	 * @param string $api_url_pattern Pattern to match the API URL.
+	 * @param array  $billing_data Billing data to set on the order (and user meta for logged-in users).
+	 * @param array  $expected_customer_data Expected customer data in the API request.
+	 *
+	 * @return void
+	 */
+	public function test_get_customer_id_for_order_retrieves_billing_details_from_order( $scenario_name, $is_guest, $existing_stripe_customer_id, $expected_customer_id, $api_url_pattern, $billing_data, $expected_customer_data ) {
+		// Create user if needed.
+		$user_id = 0;
+		$customer_id = 0;
+		$user_email = '';
+		if ( ! $is_guest ) {
+			// For logged-in users, the code uses user email and user meta, not order data.
+			// Set user email to match expected data, and set user meta to match order billing data.
+			$user_email = $billing_data['email'];
+			$user_id = wp_create_user( 'testuser_' . uniqid(), 'password', $user_email );
+			$customer_id = $user_id;
+			if ( ! empty( $existing_stripe_customer_id ) ) {
+				update_user_option( $user_id, '_stripe_customer_id', $existing_stripe_customer_id );
+			}
+			// Set user meta to match the order billing data.
+			// For logged-in users, user meta takes precedence over order data.
+			update_user_meta( $user_id, 'billing_first_name', $billing_data['first_name'] );
+			update_user_meta( $user_id, 'billing_last_name', $billing_data['last_name'] );
+			update_user_meta( $user_id, 'billing_address_1', $billing_data['address_1'] );
+			update_user_meta( $user_id, 'billing_address_2', $billing_data['address_2'] ?? '' );
+			update_user_meta( $user_id, 'billing_city', $billing_data['city'] );
+			update_user_meta( $user_id, 'billing_state', $billing_data['state'] );
+			update_user_meta( $user_id, 'billing_postcode', $billing_data['postcode'] );
+			update_user_meta( $user_id, 'billing_country', $billing_data['country'] );
+		}
+
+		// Create an order with specific billing details.
+		$order = WC_Helper_Order::create_order( $customer_id );
+		$order->set_billing_email( $billing_data['email'] );
+		$order->set_billing_first_name( $billing_data['first_name'] );
+		$order->set_billing_last_name( $billing_data['last_name'] );
+		$order->set_billing_address_1( $billing_data['address_1'] );
+		$order->set_billing_address_2( $billing_data['address_2'] ?? '' );
+		$order->set_billing_city( $billing_data['city'] );
+		$order->set_billing_state( $billing_data['state'] );
+		$order->set_billing_postcode( $billing_data['postcode'] );
+		$order->set_billing_country( $billing_data['country'] );
+		$order->save();
+
+		// Ensure no customer ID is set on the order.
+		$order_helper = WC_Stripe_Order_Helper::get_instance();
+		$order_helper->delete_stripe_customer_id( $order );
+
+		// Create a real gateway instance to test the actual behavior.
+		$gateway = new WC_Stripe_UPE_Payment_Gateway();
+
+		// Mock the API request to verify billing details are used.
+		$api_called = false;
+		$captured_args = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $parsed_args, $url ) use ( &$api_called, &$captured_args, $expected_customer_data, $api_url_pattern, $expected_customer_id ) {
+				if ( preg_match( $api_url_pattern, $url ) ) {
+					$api_called = true;
+					$captured_args = $parsed_args;
+
+					// Return a mock successful response.
+					return [
+						'response' => [
+							'code'    => 200,
+							'message' => 'OK',
+						],
+						'headers'  => [ 'Content-Type' => 'application/json' ],
+						'body'     => wp_json_encode(
+							[
+								'id'    => $expected_customer_id,
+								'email' => $expected_customer_data['email'],
+								'name'  => $expected_customer_data['name'],
+							]
+						),
+					];
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		// Use reflection to access the private method.
+		$reflection = new \ReflectionClass( $gateway );
+		$method     = $reflection->getMethod( 'get_customer_id_for_order' );
+		$method->setAccessible( true );
+
+		// Mock get_stripe_customer_id to return empty (no existing customer).
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->onlyMethods( [ 'get_stripe_customer_id', 'get_user_from_order', 'is_valid_pay_for_order_endpoint' ] )
+			->getMock();
+
+		$gateway->expects( $this->once() )
+			->method( 'get_stripe_customer_id' )
+			->with( $order )
+			->willReturn( '' ); // No customer ID on order.
+
+		if ( ! $is_guest ) {
+			$user = get_user_by( 'id', $user_id );
+		} else {
+			$user = new \WP_User();
+			$user->ID = 0;
+		}
+
+		$gateway->expects( $this->once() )
+			->method( 'get_user_from_order' )
+			->with( $order )
+			->willReturn( $user );
+
+		$gateway->expects( $this->any() )
+			->method( 'is_valid_pay_for_order_endpoint' )
+			->willReturn( false );
+
+		// Call the method.
+		$result_customer_id = $method->invoke( $gateway, $order );
+
+		// Verify the API was called and billing details were used.
+		$this->assertTrue( $api_called, "Stripe API should have been called to {$scenario_name}." );
+		$this->assertEquals( $expected_customer_id, $result_customer_id );
+
+		// Verify the request body contains the expected billing details.
+		// The body is passed as an array to wp_safe_remote_post, so we check it directly.
+		if ( $captured_args && isset( $captured_args['body'] ) ) {
+			$request_body = $captured_args['body'];
+			// Ensure we have an array (wp_safe_remote_post receives body as array).
+			$this->assertIsArray( $request_body, 'Request body should be an array.' );
+
+			// Verify billing details from the order are used in the customer creation/update request.
+			$this->assertEquals( $expected_customer_data['email'], $request_body['email'] ?? '', 'Billing email should match order billing email.' );
+			$this->assertEquals( $expected_customer_data['name'], $request_body['name'] ?? '', 'Billing name should match order billing name.' );
+
+			// Verify address details are present and match the order.
+			$this->assertArrayHasKey( 'address', $request_body, 'Request should include address data.' );
+			$this->assertEquals( $expected_customer_data['address']['line1'], $request_body['address']['line1'] ?? '', 'Billing address line1 should match order.' );
+			if ( ! empty( $expected_customer_data['address']['line2'] ) ) {
+				$this->assertEquals( $expected_customer_data['address']['line2'], $request_body['address']['line2'] ?? '', 'Billing address line2 should match order.' );
+			}
+			$this->assertEquals( $expected_customer_data['address']['city'], $request_body['address']['city'] ?? '', 'Billing city should match order.' );
+			$this->assertEquals( $expected_customer_data['address']['state'], $request_body['address']['state'] ?? '', 'Billing state should match order.' );
+			$this->assertEquals( $expected_customer_data['address']['postal_code'], $request_body['address']['postal_code'] ?? '', 'Billing postal code should match order.' );
+			$this->assertEquals( $expected_customer_data['address']['country'], $request_body['address']['country'] ?? '', 'Billing country should match order.' );
+		}
+
+		// Cleanup.
+		if ( $user_id > 0 ) {
+			wp_delete_user( $user_id );
+		}
+		remove_all_filters( 'pre_http_request' );
+	}
+
+	/**
+	 * Data provider for test_get_customer_id_for_order_retrieves_billing_details_from_order.
+	 *
+	 * @return array Test cases.
+	 */
+	public function provide_get_customer_id_for_order_billing_details_test_cases() {
+		return [
+			'creating customer for guest user' => [
+				'scenario_name'            => 'create customer',
+				'is_guest'                 => true,
+				'existing_stripe_customer_id' => '',
+				'expected_customer_id'     => 'cus_test123',
+				'api_url_pattern'          => '#/v1/customers$#',
+				'billing_data'             => [
+					'email'      => 'test-billing@example.com',
+					'first_name' => 'TestFirstName',
+					'last_name'  => 'TestLastName',
+					'address_1'  => '123 Test Street',
+					'address_2'  => 'Apt 4B',
+					'city'       => 'TestCity',
+					'state'      => 'CA',
+					'postcode'   => '90210',
+					'country'    => 'US',
+				],
+				'expected_customer_data'   => [
+					'email'       => 'test-billing@example.com',
+					'name'        => 'TestFirstName TestLastName',
+					'description' => 'Name: TestFirstName TestLastName, Guest',
+					'address'     => [
+						'line1'       => '123 Test Street',
+						'line2'       => 'Apt 4B',
+						'city'        => 'TestCity',
+						'state'       => 'CA',
+						'postal_code' => '90210',
+						'country'     => 'US',
+					],
+				],
+			],
+			'updating customer for logged-in user' => [
+				'scenario_name'            => 'update customer',
+				'is_guest'                 => false,
+				'existing_stripe_customer_id' => 'cus_existing123',
+				'expected_customer_id'     => 'cus_existing123',
+				'api_url_pattern'          => '#/v1/customers/cus_existing123$#',
+				'billing_data'             => [
+					'email'      => 'updated-billing@example.com',
+					'first_name' => 'UpdatedFirstName',
+					'last_name'  => 'UpdatedLastName',
+					'address_1'  => '456 Updated Street',
+					'address_2'  => '',
+					'city'       => 'UpdatedCity',
+					'state'      => 'NY',
+					'postcode'   => '10001',
+					'country'    => 'US',
+				],
+				// For logged-in users, user email and user meta are used (not order data).
+				// The expected data should match what will be in user meta (set in the test).
+				'expected_customer_data'   => [
+					'email'       => 'updated-billing@example.com', // User email matches order email (set in test)
+					'name'        => 'UpdatedFirstName UpdatedLastName',
+					'address'     => [
+						'line1'       => '456 Updated Street',
+						'line2'       => '',
+						'city'        => 'UpdatedCity',
+						'state'       => 'NY',
+						'postal_code' => '10001',
+						'country'     => 'US',
+					],
+				],
+			],
+		];
+	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3499,7 +3499,14 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			$this->assertEquals( $expected_customer_data['address']['line1'], $request_body['address']['line1'] ?? '', 'Billing address line1 should match order.' );
 			if ( ! empty( $expected_customer_data['address']['line2'] ) ) {
 				$this->assertEquals( $expected_customer_data['address']['line2'], $request_body['address']['line2'] ?? '', 'Billing address line2 should match order.' );
+			} else {
+				// When line2 is empty, verify it's either not present or empty in the request body.
+				$this->assertTrue(
+					null === $request_body['address']['line2'] || '' === $request_body['address']['line2'],
+					'Billing address line2 should be empty or not present when order has no line2.'
+				);
 			}
+
 			$this->assertEquals( $expected_customer_data['address']['city'], $request_body['address']['city'] ?? '', 'Billing city should match order.' );
 			$this->assertEquals( $expected_customer_data['address']['state'], $request_body['address']['state'] ?? '', 'Billing state should match order.' );
 			$this->assertEquals( $expected_customer_data['address']['postal_code'], $request_body['address']['postal_code'] ?? '', 'Billing postal code should match order.' );

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3363,7 +3363,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 *
 	 * @return void
 	 */
-	public function test_get_customer_id_for_order_retrieves_billing_details_from_order( $scenario_name, $is_guest, $existing_stripe_customer_id, $expected_customer_id, $api_url_pattern, $billing_data, $expected_customer_data ) {
+	public function test_get_customer_id_for_order_retrieves_billing_details_from_order( string $scenario_name, bool $is_guest, string $existing_stripe_customer_id, string $expected_customer_id, string $api_url_pattern, array $billing_data, array $expected_customer_data ) {
 		// Create user if needed.
 		$user_id = 0;
 		$customer_id = 0;

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3403,9 +3403,6 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$order_helper = WC_Stripe_Order_Helper::get_instance();
 		$order_helper->delete_stripe_customer_id( $order );
 
-		// Create a real gateway instance to test the actual behavior.
-		$gateway = new WC_Stripe_UPE_Payment_Gateway();
-
 		// Mock the API request to verify billing details are used.
 		$api_called = false;
 		$captured_args = null;
@@ -3440,15 +3437,17 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			3
 		);
 
-		// Use reflection to access the private method.
-		$reflection = new \ReflectionClass( $gateway );
-		$method     = $reflection->getMethod( 'get_customer_id_for_order' );
-		$method->setAccessible( true );
-
-		// Mock get_stripe_customer_id to return empty (no existing customer).
+		// Create a mock gateway instance with specific methods mocked.
+		// The mock inherits all methods from WC_Stripe_UPE_Payment_Gateway, including the private method we'll test.
 		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
 			->onlyMethods( [ 'get_stripe_customer_id', 'get_user_from_order', 'is_valid_pay_for_order_endpoint' ] )
 			->getMock();
+
+		// Use reflection to access the private method on the mock instance.
+		// The mock inherits the method from the parent class, so reflection works correctly.
+		$reflection = new \ReflectionClass( $gateway );
+		$method     = $reflection->getMethod( 'get_customer_id_for_order' );
+		$method->setAccessible( true );
 
 		$gateway->expects( $this->once() )
 			->method( 'get_stripe_customer_id' )
@@ -3484,6 +3483,9 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 			$request_body = $captured_args['body'];
 			// Ensure we have an array (wp_safe_remote_post receives body as array).
 			$this->assertIsArray( $request_body, 'Request body should be an array.' );
+
+			// Verify that the order object is NOT included in the API request (main purpose of this PR).
+			$this->assertArrayNotHasKey( 'order', $request_body, 'Order object should not be included in the API request.' );
 
 			// Verify billing details from the order are used in the customer creation/update request.
 			$this->assertEquals( $expected_customer_data['email'], $request_body['email'] ?? '', 'Billing email should match order billing email.' );

--- a/tests/phpunit/WC_Stripe_Customer_Test.php
+++ b/tests/phpunit/WC_Stripe_Customer_Test.php
@@ -11,6 +11,57 @@ namespace WooCommerce\Stripe\Tests;
  */
 class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 
+	/**
+	 * Helper method to create a mock WC_Order with billing data.
+	 *
+	 * @param array $billing_data Billing data array with keys: email, first_name, last_name, address_1, address_2, city, state, postcode, country.
+	 * @return \PHPUnit\Framework\MockObject\MockObject Mock WC_Order instance.
+	 */
+	private function create_mock_order( array $billing_data = [] ) {
+		$default_billing_data = [
+			'email'      => 'test@example.com',
+			'first_name' => 'Test',
+			'last_name'  => 'User',
+			'address_1' => '123 Test St',
+			'address_2' => '',
+			'city'       => 'Test City',
+			'state'      => 'CA',
+			'postcode'   => '90210',
+			'country'    => 'US',
+		];
+
+		$billing_data = wp_parse_args( $billing_data, $default_billing_data );
+
+		$mock_order = $this->getMockBuilder( \WC_Order::class )
+			->disableOriginalConstructor()
+			->onlyMethods(
+				[
+					'get_billing_address_1',
+					'get_billing_address_2',
+					'get_billing_city',
+					'get_billing_country',
+					'get_billing_email',
+					'get_billing_first_name',
+					'get_billing_last_name',
+					'get_billing_postcode',
+					'get_billing_state',
+				]
+			)
+			->getMock();
+
+		$mock_order->method( 'get_billing_email' )->willReturn( $billing_data['email'] );
+		$mock_order->method( 'get_billing_first_name' )->willReturn( $billing_data['first_name'] );
+		$mock_order->method( 'get_billing_last_name' )->willReturn( $billing_data['last_name'] );
+		$mock_order->method( 'get_billing_address_1' )->willReturn( $billing_data['address_1'] );
+		$mock_order->method( 'get_billing_address_2' )->willReturn( $billing_data['address_2'] );
+		$mock_order->method( 'get_billing_city' )->willReturn( $billing_data['city'] );
+		$mock_order->method( 'get_billing_state' )->willReturn( $billing_data['state'] );
+		$mock_order->method( 'get_billing_postcode' )->willReturn( $billing_data['postcode'] );
+		$mock_order->method( 'get_billing_country' )->willReturn( $billing_data['country'] );
+
+		return $mock_order;
+	}
+
 	public function provide_test_validate_create_customer_request_cases(): array {
 		return [
 			'all fields present and required, no overrides' => [
@@ -244,30 +295,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 			add_filter( 'wc_stripe_create_customer_required_fields', $stripe_billing_fields_filter, 10, 1 );
 		}
 
-		$mock_order = $this->getMockBuilder( \WC_Order::class )
-			->disableOriginalConstructor()
-			->onlyMethods(
-				[
-					'get_billing_address_1',
-					'get_billing_city',
-					'get_billing_country',
-					'get_billing_email',
-					'get_billing_first_name',
-					'get_billing_last_name',
-					'get_billing_postcode',
-					'get_billing_state',
-				]
-			)
-			->getMock();
-
-		$mock_order->method( 'get_billing_address_1' )->willReturn( $billing_data['address_1'] );
-		$mock_order->method( 'get_billing_city' )->willReturn( $billing_data['city'] );
-		$mock_order->method( 'get_billing_country' )->willReturn( $billing_data['country'] );
-		$mock_order->method( 'get_billing_email' )->willReturn( $billing_data['email'] );
-		$mock_order->method( 'get_billing_first_name' )->willReturn( $billing_data['first_name'] );
-		$mock_order->method( 'get_billing_last_name' )->willReturn( $billing_data['last_name'] );
-		$mock_order->method( 'get_billing_postcode' )->willReturn( $billing_data['postcode'] );
-		$mock_order->method( 'get_billing_state' )->willReturn( $billing_data['state'] );
+		$mock_order = $this->create_mock_order( $billing_data );
 
 		$args = [];
 		$customer = new \WC_Stripe_Customer();
@@ -351,6 +379,92 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 
 		if ( null === $expected_exception_message ) {
 			$this->assertFalse( $was_exception_thrown, 'No exception was thrown when no exception was expected' );
+		}
+	}
+
+	/**
+	 * Test that order data is excluded from Stripe API requests when passed via $args['order'].
+	 *
+	 * This test verifies the fix for backwards compatibility: when order is passed via $args['order'],
+	 * it should be extracted and used for billing data, but the 'order' key itself should not be
+	 * sent to the Stripe API.
+	 */
+	public function test_order_excluded_from_stripe_api_when_passed_via_args() {
+		$customer = new \WC_Stripe_Customer();
+
+		$mock_order = $this->create_mock_order( [ 'address_2' => 'Apt 1' ] );
+
+		$captured_create_request = null;
+		$captured_update_request  = null;
+
+		// Mock for create_customer
+		$mock_create_call = function ( $return_value, $parsed_args, $url ) use ( &$captured_create_request ) {
+			if ( 'https://api.stripe.com/v1/customers' === $url ) {
+				if ( isset( $parsed_args['body'] ) ) {
+					$captured_create_request = is_array( $parsed_args['body'] ) ? $parsed_args['body'] : [];
+					if ( ! is_array( $captured_create_request ) ) {
+						parse_str( $captured_create_request, $captured_create_request );
+					}
+				}
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( [ 'id' => 'cus_123' ] ),
+				];
+			}
+			if ( str_starts_with( $url, 'https://api.stripe.com/v1/customers/search' ) ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( [ 'data' => [] ] ),
+				];
+			}
+			return $return_value;
+		};
+
+		// Mock for update_customer
+		$mock_update_call = function ( $return_value, $parsed_args, $url ) use ( &$captured_update_request ) {
+			if ( 'https://api.stripe.com/v1/customers/cus_existing' === $url ) {
+				if ( isset( $parsed_args['body'] ) ) {
+					$captured_update_request = is_array( $parsed_args['body'] ) ? $parsed_args['body'] : [];
+					if ( ! is_array( $captured_update_request ) ) {
+						parse_str( $captured_update_request, $captured_update_request );
+					}
+				}
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( [ 'id' => 'cus_existing' ] ),
+				];
+			}
+			return $return_value;
+		};
+
+		add_filter( 'pre_http_request', $mock_create_call, 10, 3 );
+
+		try {
+			// Test create_customer with $args['order']
+			$args = [ 'order' => $mock_order ];
+			$customer->create_customer( $args );
+
+			$this->assertNotNull( $captured_create_request, 'Create request should have been captured' );
+			$this->assertArrayNotHasKey( 'order', $captured_create_request, 'Order should not be sent to Stripe API in create_customer' );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_create_call, 10 );
+		}
+
+		// Test update_customer with $args['order']
+		$customer->set_id( 'cus_existing' );
+		add_filter( 'pre_http_request', $mock_update_call, 10, 3 );
+
+		try {
+			$args = [ 'order' => $mock_order ];
+			$customer->update_customer( $args );
+
+			$this->assertNotNull( $captured_update_request, 'Update request should have been captured' );
+			$this->assertArrayNotHasKey( 'order', $captured_update_request, 'Order should not be sent to Stripe API in update_customer' );
+		} finally {
+			remove_filter( 'pre_http_request', $mock_update_call, 10 );
 		}
 	}
 }

--- a/tests/phpunit/WC_Stripe_Customer_Test.php
+++ b/tests/phpunit/WC_Stripe_Customer_Test.php
@@ -269,9 +269,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 		$mock_order->method( 'get_billing_postcode' )->willReturn( $billing_data['postcode'] );
 		$mock_order->method( 'get_billing_state' )->willReturn( $billing_data['state'] );
 
-		$args     = [
-			'order' => $mock_order,
-		];
+		$args = [];
 		$customer = new \WC_Stripe_Customer();
 
 		$was_exception_thrown = false;
@@ -318,7 +316,7 @@ class WC_Stripe_Customer_Test extends \WP_UnitTestCase {
 		}
 
 		try {
-			$customer->create_customer( $args, $current_context );
+			$customer->create_customer( $args, $current_context, $mock_order );
 		} catch ( \WC_Stripe_Exception $stripe_exception ) {
 			$was_exception_thrown = true;
 


### PR DESCRIPTION
Fixes STRIPE-832

## Changes proposed in this Pull Request:

I was unable to to actually reproduce this problem

This PR refactors how the order object is passed when creating or updating Stripe customers. Previously, the order was included in the `$args` array (`$args['order']`), which caused it to be sent to the Stripe API. 

Now, the order is passed as a separate parameter, ensuring it's only used to extract billing details and never included in the API request payload.


--

An alternative solution would have been to remove the `order' entry from the `$args` parameter just before making the call to the `customers` endpoint, but that feels confusing as the `$order` arg is being added in the gateway class, not in this customer class:
```
unset( $args['order'] );
$response = WC_Stripe_API::request( $args, 'customers/' . $this->get_id() );
```
- https://github.com/woocommerce/woocommerce-gateway-stripe/blob/5e73f347de6c0d322041f61c76acc41b06523f43/includes/class-wc-stripe-customer.php#L480
- https://github.com/woocommerce/woocommerce-gateway-stripe/blob/5e73f347de6c0d322041f61c76acc41b06523f43/includes/class-wc-stripe-customer.php#L486
- https://github.com/woocommerce/woocommerce-gateway-stripe/blob/5e73f347de6c0d322041f61c76acc41b06523f43/includes/class-wc-stripe-customer.php#L531

## Testing instructions

**With a new user (wihtout a Stripe customer)**

1. Go to the Store and add a product to the Cart
2. Go to the checkout, fill in billing details, and select Stripe payment method
4. Complete the payment using a test card (e.g., `4242 4242 4242 4242`)
5. Verify that the order was completed successfully
6. Go to the Stripe Dashboard and verify that the customer was correctly created and that the billing information matches

|Stripe | Woo |
|-|-|
| <img width="1317" height="964" alt="Screenshot 2025-12-04 at 15 53 08" src="https://github.com/user-attachments/assets/4dadc4dc-a1cb-454c-bdfb-f53be5467d8c" /> | <img width="1398" height="994" alt="Screenshot 2025-12-04 at 15 53 19" src="https://github.com/user-attachments/assets/176ed618-261e-4034-bf70-e9c712145a27" />|

**As a registered user: **
1. Go to the `Store > My Account > Subscriptions` and select the Subcription from the list:
2. Remove the saved `customer_id` from the `order_meta` for the Subscriptions order created in the steps above, ex:
    `DELETE FROM `wp_wc_orders_meta` WHERE `meta_key` = '_stripe_customer_id' AND `order_id` = '163';`
3. Click change payment and use any test card (eg., 5555 5555 5555 4444)
4. In `develop` the change fails with the error from the issue:
    <img width="1406" height="478" alt="Screenshot 2025-12-04 at 16 15 39" src="https://github.com/user-attachments/assets/5cb5844f-6be5-42c0-8618-725118014f74" />
5. In this branch (`fix/832-exclude-order-parameter-when-creating-stripe-customers`), the change succeeds:
    <img width="1076" height="436" alt="Screenshot 2025-12-04 at 16 19 52" src="https://github.com/user-attachments/assets/bb5da4b3-bf23-4ae1-afbe-ee5f3180dc5a" />

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
