### PR TITLE
Prevent button radius value of 0 in Express Checkout Element using the default instead

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@
 * Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
 * Fix - Always use the current payment method configuration in Optimized Checkout
 * Fix - Fix revoked secret_key error during the OAuth account connection flow
+* Fix - Respect button.radius value of 0 in Express Checkout Element appearance settings
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -105,7 +105,7 @@ export const getExpressCheckoutButtonAppearance = () => {
 	return {
 		variables: {
 			borderRadius: `${
-				getExpressCheckoutData( 'button' )?.radius ||
+				getExpressCheckoutData( 'button' )?.radius ??
 				getDefaultBorderRadius()
 			}px`,
 			spacingUnit: '6px',

--- a/readme.txt
+++ b/readme.txt
@@ -140,5 +140,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Tweak - Hide Amazon Pay from the standard payments in Optimized Checkout
 * Fix - Always use the current payment method configuration in Optimized Checkout
 * Fix - Fix revoked secret_key error during the OAuth account connection flow
+* Fix - Respect button.radius value of 0 in Express Checkout Element appearance settings
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-835

## Changes proposed in this Pull Request:

This PR fixes a bug where setting `button.radius` to `0` via the `wc_stripe_express_checkout_params` filter was not being respected. The code was using the logical OR operator (`||`) which treats `0` as falsy, causing it to fall back to the default border radius value instead of using `0`.

| Before | After |
|-|-|
|<img width="820" height="350" alt="Screenshot 2025-12-03 at 17 20 58" src="https://github.com/user-attachments/assets/e334dd1b-d86b-4e27-94a0-33b3018588a8" />|<img width="817" height="354" alt="Screenshot 2025-12-03 at 17 21 13" src="https://github.com/user-attachments/assets/3e241c36-84a9-4e7c-91b1-cc41cf939fc3" />|


## Testing instructions

1. Add a filter to set `button.radius` to `0`:
   ```php
   add_filter( 'wc_stripe_express_checkout_params', function( $params ) {
       if ( isset( $params['button'] ) ) {
           $params['button']['radius'] = 0;
       }
       return $params;
   } );
   ```
2. Load a page with Express Checkout Element (product page, cart, or checkout)
3. Verify that the button does have a border radius of `0`

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
