### PR TITLE
Preload customer billing info in Stripe element fields

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -36,6 +36,7 @@
 * Add - Add wc_stripe_express_checkout_normalize_address filter for express checkout address normalization
 * Update - Expand Amazon Pay support for all permitted currencies and countries
 * Add - Allow cache prefetch window to be adjusted via the wc_stripe_database_cache_prefetch_window filter
+* Fix - Prefill customer billing information on the Pay for Order and Change Payment Method pages
 
 = 10.1.0 - 2025-11-11 =
 * Dev - Remove unused `shouldShowPaymentRequestButton` parameter and calculations from backend

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { getFontSizeBase } from '../utils';
+import { getFontSizeBase, getDefaultValues } from '../utils';
 
 describe( 'utils', () => {
 	describe( 'getFontSizeBase', () => {
@@ -37,6 +37,300 @@ describe( 'utils', () => {
 			const expectedFontSize = '16px';
 			const result = getFontSizeBase( fontSize );
 			expect( result ).toBe( expectedFontSize );
+		} );
+	} );
+
+	describe( 'getDefaultValues', () => {
+		const globalValues = global.wc_stripe_upe_params;
+		let mockGetElementById;
+
+		beforeEach( () => {
+			global.wc_stripe_upe_params = {
+				isOCEnabled: false,
+			};
+
+			// Mock document.getElementById for fallback behavior
+			mockGetElementById = jest.fn();
+			document.getElementById = mockGetElementById;
+		} );
+
+		afterEach( () => {
+			global.wc_stripe_upe_params = globalValues;
+			jest.restoreAllMocks();
+		} );
+
+		describe( 'when isOrderPay, isChangingPayment, or isAddPaymentMethod is true', () => {
+			it( 'should return correctly formatted billing data from customerBillingData', () => {
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						name: 'John Doe',
+						email: 'john@example.com',
+						phone: '+1234567890',
+						address: {
+							country: 'us', // lowercase, should be uppercased
+							line1: '123 Main St',
+							line2: 'Apt 4B',
+							city: 'New York',
+							state: 'NY',
+							postal_code: '10001',
+						},
+					},
+				};
+
+				const result = getDefaultValues();
+
+				expect( result ).toEqual( {
+					defaultValues: {
+						billingDetails: {
+							name: 'John Doe',
+							email: 'john@example.com',
+							phone: '+1234567890',
+							address: {
+								country: 'US', // Should be uppercase
+								line1: '123 Main St',
+								line2: 'Apt 4B',
+								city: 'New York',
+								state: 'NY',
+								postal_code: '10001',
+							},
+						},
+					},
+				} );
+			} );
+
+			it( 'should filter out empty address fields and trim whitespace', () => {
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						name: '  John Doe  ',
+						email: '  john@example.com  ',
+						phone: '  +1234567890  ',
+						address: {
+							country: '  us  ',
+							line1: '  123 Main St  ',
+							line2: '', // empty, should be filtered out
+							city: '  New York  ',
+							state: '', // empty, should be filtered out
+							postal_code: '  10001  ',
+						},
+					},
+				};
+
+				const result = getDefaultValues();
+
+				expect( result.defaultValues.billingDetails.name ).toBe(
+					'John Doe'
+				);
+				expect( result.defaultValues.billingDetails.email ).toBe(
+					'john@example.com'
+				);
+				expect( result.defaultValues.billingDetails.phone ).toBe(
+					'+1234567890'
+				);
+				expect( result.defaultValues.billingDetails.address ).toEqual( {
+					country: 'US',
+					line1: '123 Main St',
+					city: 'New York',
+					postal_code: '10001',
+				} );
+				expect(
+					result.defaultValues.billingDetails.address.line2
+				).toBeUndefined();
+				expect(
+					result.defaultValues.billingDetails.address.state
+				).toBeUndefined();
+			} );
+
+			it( 'should not include address object if all address fields are empty', () => {
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						email: 'test@example.com',
+						address: {
+							country: '',
+							line1: '',
+							line2: '',
+							city: '',
+							state: '',
+							postal_code: '',
+						},
+					},
+				};
+
+				const result = getDefaultValues();
+
+				expect(
+					result.defaultValues.billingDetails.address
+				).toBeUndefined();
+				expect( result.defaultValues.billingDetails.email ).toBe(
+					'test@example.com'
+				);
+			} );
+
+			it( 'should return undefined for empty name and phone', () => {
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						email: 'test@example.com',
+						name: '',
+						phone: '',
+						address: {
+							country: 'US',
+						},
+					},
+				};
+
+				const result = getDefaultValues();
+
+				expect(
+					result.defaultValues.billingDetails.name
+				).toBeUndefined();
+				expect(
+					result.defaultValues.billingDetails.phone
+				).toBeUndefined();
+			} );
+
+			it( 'should return empty object if customerBillingData is missing or email is missing', () => {
+				mockGetElementById.mockReturnValue( null );
+
+				// Missing customerBillingData
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+				};
+				expect( getDefaultValues() ).toEqual( {} );
+
+				// Missing email
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						name: 'John Doe',
+						// email missing
+					},
+				};
+				expect( getDefaultValues() ).toEqual( {} );
+			} );
+		} );
+
+		describe( 'fallback behavior when no customer billing data', () => {
+			it( 'should read from DOM elements for Link on checkout page', () => {
+				global.wc_stripe_upe_params = {
+					isCheckout: true,
+					// No isOrderPay, isChangingPayment, or isAddPaymentMethod
+				};
+
+				const mockBillingEmail = {
+					value: 'checkout@example.com',
+				};
+				const mockBillingPhone = {
+					value: '+1987654321',
+				};
+
+				mockGetElementById
+					.mockReturnValueOnce( mockBillingEmail ) // billing_email
+					.mockReturnValueOnce( mockBillingPhone ); // billing_phone
+
+				const result = getDefaultValues();
+
+				expect( result ).toEqual( {
+					defaultValues: {
+						billingDetails: {
+							email: 'checkout@example.com',
+							phone: '+1987654321',
+						},
+					},
+				} );
+			} );
+
+			it( 'should return empty object if billing_email is not found', () => {
+				global.wc_stripe_upe_params = {
+					isCheckout: true,
+				};
+
+				mockGetElementById.mockReturnValue( null );
+
+				const result = getDefaultValues();
+
+				expect( result ).toEqual( {} );
+			} );
+
+			it( 'should fallback to shipping_phone if billing_phone is not available', () => {
+				global.wc_stripe_upe_params = {
+					isCheckout: true,
+				};
+
+				const mockBillingEmail = {
+					value: 'checkout@example.com',
+				};
+				const mockShippingPhone = {
+					value: '+1555555555',
+				};
+
+				mockGetElementById
+					.mockReturnValueOnce( mockBillingEmail ) // billing_email
+					.mockReturnValueOnce( null ) // billing_phone
+					.mockReturnValueOnce( mockShippingPhone ); // shipping_phone
+
+				const result = getDefaultValues();
+
+				expect( result.defaultValues.billingDetails.phone ).toBe(
+					'+1555555555'
+				);
+			} );
+		} );
+
+		describe( 'edge cases', () => {
+			it( 'should handle missing or null address object gracefully', () => {
+				// Null address
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						email: 'test@example.com',
+						address: null,
+					},
+				};
+				let result = getDefaultValues();
+				expect( result.defaultValues.billingDetails.email ).toBe(
+					'test@example.com'
+				);
+				expect(
+					result.defaultValues.billingDetails.address
+				).toBeUndefined();
+
+				// Undefined address
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						email: 'test@example.com',
+						// address is undefined
+					},
+				};
+				result = getDefaultValues();
+				expect( result.defaultValues.billingDetails.email ).toBe(
+					'test@example.com'
+				);
+				expect(
+					result.defaultValues.billingDetails.address
+				).toBeUndefined();
+
+				// Partial address data
+				global.wc_stripe_upe_params = {
+					isOrderPay: true,
+					customerBillingData: {
+						email: 'test@example.com',
+						address: {
+							country: 'FR',
+							city: 'Paris',
+							// Other fields missing
+						},
+					},
+				};
+				result = getDefaultValues();
+				expect( result.defaultValues.billingDetails.address ).toEqual( {
+					country: 'FR',
+					city: 'Paris',
+				} );
+			} );
 		} );
 	} );
 } );

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -111,7 +111,7 @@ describe( 'utils', () => {
 							line1: '  123 Main St  ',
 							line2: '', // empty, should be filtered out
 							city: '  New York  ',
-							state: '', // empty, should be filtered out
+							state: '    ', // only whitespace, should be filtered out
 							postal_code: '  10001  ',
 						},
 					},

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -213,7 +213,7 @@ describe( 'utils', () => {
 		} );
 
 		describe( 'fallback behavior when no customer billing data', () => {
-			it( 'should read from DOM elements for Link on checkout page', () => {
+			it( 'should fallback to reading from DOM elements for Link on checkout page', () => {
 				global.wc_stripe_upe_params = {
 					isCheckout: true,
 					// No isOrderPay, isChangingPayment, or isAddPaymentMethod
@@ -239,96 +239,6 @@ describe( 'utils', () => {
 							phone: '+1987654321',
 						},
 					},
-				} );
-			} );
-
-			it( 'should return empty object if billing_email is not found', () => {
-				global.wc_stripe_upe_params = {
-					isCheckout: true,
-				};
-
-				mockGetElementById.mockReturnValue( null );
-
-				const result = getDefaultValues();
-
-				expect( result ).toEqual( {} );
-			} );
-
-			it( 'should fallback to shipping_phone if billing_phone is not available', () => {
-				global.wc_stripe_upe_params = {
-					isCheckout: true,
-				};
-
-				const mockBillingEmail = {
-					value: 'checkout@example.com',
-				};
-				const mockShippingPhone = {
-					value: '+1555555555',
-				};
-
-				mockGetElementById
-					.mockReturnValueOnce( mockBillingEmail ) // billing_email
-					.mockReturnValueOnce( null ) // billing_phone
-					.mockReturnValueOnce( mockShippingPhone ); // shipping_phone
-
-				const result = getDefaultValues();
-
-				expect( result.defaultValues.billingDetails.phone ).toBe(
-					'+1555555555'
-				);
-			} );
-		} );
-
-		describe( 'edge cases', () => {
-			it( 'should handle missing or null address object gracefully', () => {
-				// Null address
-				global.wc_stripe_upe_params = {
-					isOrderPay: true,
-					customerBillingData: {
-						email: 'test@example.com',
-						address: null,
-					},
-				};
-				let result = getDefaultValues();
-				expect( result.defaultValues.billingDetails.email ).toBe(
-					'test@example.com'
-				);
-				expect(
-					result.defaultValues.billingDetails.address
-				).toBeUndefined();
-
-				// Undefined address
-				global.wc_stripe_upe_params = {
-					isOrderPay: true,
-					customerBillingData: {
-						email: 'test@example.com',
-						// address is undefined
-					},
-				};
-				result = getDefaultValues();
-				expect( result.defaultValues.billingDetails.email ).toBe(
-					'test@example.com'
-				);
-				expect(
-					result.defaultValues.billingDetails.address
-				).toBeUndefined();
-
-				// Partial address data
-				global.wc_stripe_upe_params = {
-					isOrderPay: true,
-					customerBillingData: {
-						email: 'test@example.com',
-						address: {
-							country: 'FR',
-							city: 'Paris',
-							// Other fields missing
-						},
-					},
-				};
-				result = getDefaultValues();
-				expect( result.defaultValues.billingDetails.address ).toEqual( {
-					country: 'FR',
-					city: 'Paris',
 				} );
 			} );
 		} );

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -505,7 +505,9 @@ export const getDefaultValues = () => {
 						name: billingData.name?.trim() || undefined,
 						email: billingData.email.trim(),
 						phone: billingData.phone?.trim() || undefined,
-						...( Object.keys( address ).length > 0 ? { address } : {} ),
+						...( Object.keys( address ).length > 0
+							? { address }
+							: {} ),
 					},
 				},
 			};

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -466,7 +466,7 @@ export const getDefaultValues = () => {
 	const isChangingPayment = stripeServerData?.isChangingPayment;
 	const isAddPaymentMethod = stripeServerData?.isAddPaymentMethod;
 
-	// On order pay and change payment method pages, use billing data from order/subscription
+	// On order pay, change payment method, and add payment method pages, use billing data from customer.
 	if ( isOrderPay || isChangingPayment || isAddPaymentMethod ) {
 		const billingData = stripeServerData?.customerBillingData;
 

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -470,7 +470,7 @@ export const getDefaultValues = () => {
 	if ( isOrderPay || isChangingPayment || isAddPaymentMethod ) {
 		const billingData = stripeServerData?.customerBillingData;
 
-		if ( billingData && billingData.email ) {
+		if ( billingData && billingData.email?.trim() ) {
 			// Build address object, only including non-empty values
 			const address = {};
 			const country = billingData.address?.country?.trim();
@@ -505,7 +505,7 @@ export const getDefaultValues = () => {
 						name: billingData.name?.trim() || undefined,
 						email: billingData.email.trim(),
 						phone: billingData.phone?.trim() || undefined,
-						...( Object.keys( address ).length > 0 && { address } ),
+						...( Object.keys( address ).length > 0 ? { address } : {} ),
 					},
 				},
 			};

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -455,10 +455,64 @@ export const getUpeSettings = () => {
 /**
  * Craft the defaultValues parameter, used to pre-fill
  * user email and phone number for Link in the Payment Element.
+ * On order pay and change payment method pages, also preloads all billing details
+ * from the customer billing data passed from the server.
  *
  * @return {Object} The defaultValues object for the Payment Element.
  */
 export const getDefaultValues = () => {
+	const stripeServerData = getStripeServerData();
+	const isOrderPay = stripeServerData?.isOrderPay;
+	const isChangingPayment = stripeServerData?.isChangingPayment;
+	const isAddPaymentMethod = stripeServerData?.isAddPaymentMethod;
+
+	// On order pay and change payment method pages, use billing data from order/subscription
+	if ( isOrderPay || isChangingPayment || isAddPaymentMethod ) {
+		const billingData = stripeServerData?.customerBillingData;
+
+		if ( billingData && billingData.email ) {
+			// Build address object, only including non-empty values
+			const address = {};
+			const country = billingData.address?.country?.trim();
+			if ( country ) {
+				// Country must be uppercase ISO 3166-1 alpha-2 code for Stripe
+				address.country = country.toUpperCase();
+			}
+			const line1 = billingData.address?.line1?.trim();
+			if ( line1 ) {
+				address.line1 = line1;
+			}
+			const line2 = billingData.address?.line2?.trim();
+			if ( line2 ) {
+				address.line2 = line2;
+			}
+			const city = billingData.address?.city?.trim();
+			if ( city ) {
+				address.city = city;
+			}
+			const state = billingData.address?.state?.trim();
+			if ( state ) {
+				address.state = state;
+			}
+			const postalCode = billingData.address?.postal_code?.trim();
+			if ( postalCode ) {
+				address.postal_code = postalCode;
+			}
+
+			return {
+				defaultValues: {
+					billingDetails: {
+						name: billingData.name?.trim() || undefined,
+						email: billingData.email.trim(),
+						phone: billingData.phone?.trim() || undefined,
+						...( Object.keys( address ).length > 0 && { address } ),
+					},
+				},
+			};
+		}
+	}
+
+	// On checkout and other pages, read from form fields for Link
 	const userEmail = document.getElementById( 'billing_email' )?.value;
 	if ( ! userEmail ) {
 		return {};

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -548,7 +548,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['cartTotal'] = WC_Stripe_Helper::get_stripe_amount( $cart_total, strtolower( $currency ) );
 		$stripe_params['currency']  = $currency;
 
-		// Pass billing details from user's customer data for preloading Payment Element fields in Pay for Order and Change Payment Method pages.
+		// Pass billing details from user's customer data for preloading Payment Element fields in Pay for Order, Change Payment Method, and Add Payment Method pages.
 		if ( is_wc_endpoint_url( 'add-payment-method' ) || parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
 			// Get billing details from the current user's customer data instead of the order.
 			$customer = WC()->customer;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -548,8 +548,10 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['cartTotal'] = WC_Stripe_Helper::get_stripe_amount( $cart_total, strtolower( $currency ) );
 		$stripe_params['currency']  = $currency;
 
+		$is_pay_for_order = parent::is_valid_pay_for_order_endpoint();
+
 		// Pass billing details from user's customer data for preloading Payment Element fields in Pay for Order, Change Payment Method, and Add Payment Method pages.
-		if ( is_wc_endpoint_url( 'add-payment-method' ) || parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
+		if ( is_wc_endpoint_url( 'add-payment-method' ) || $is_pay_for_order || $is_change_payment_method ) {
 			// Get billing details from the current user's customer data instead of the order.
 			$customer = WC()->customer;
 			if ( $customer ) {
@@ -569,7 +571,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 			}
 		}
 
-		if ( parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
+		if ( $is_pay_for_order || $is_change_payment_method ) {
 			$order_id = absint( get_query_var( 'order-pay' ) );
 			$order    = wc_get_order( $order_id );
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -548,6 +548,27 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 		$stripe_params['cartTotal'] = WC_Stripe_Helper::get_stripe_amount( $cart_total, strtolower( $currency ) );
 		$stripe_params['currency']  = $currency;
 
+		// Pass billing details from user's customer data for preloading Payment Element fields in Pay for Order and Change Payment Method pages.
+		if ( is_wc_endpoint_url( 'add-payment-method' ) || parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
+			// Get billing details from the current user's customer data instead of the order.
+			$customer = WC()->customer;
+			if ( $customer ) {
+				$stripe_params['customerBillingData'] = [
+					'name'    => trim( $customer->get_billing_first_name() . ' ' . $customer->get_billing_last_name() ),
+					'email'   => $customer->get_billing_email(),
+					'phone'   => $customer->get_billing_phone(),
+					'address' => [
+						'country'     => $customer->get_billing_country(),
+						'line1'       => $customer->get_billing_address_1(),
+						'line2'       => $customer->get_billing_address_2(),
+						'city'        => $customer->get_billing_city(),
+						'state'       => $customer->get_billing_state(),
+						'postal_code' => $customer->get_billing_postcode(),
+					],
+				];
+			}
+		}
+
 		if ( parent::is_valid_pay_for_order_endpoint() || $is_change_payment_method ) {
 			$order_id = absint( get_query_var( 'order-pay' ) );
 			$order    = wc_get_order( $order_id );
@@ -590,6 +611,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Gateway_Stripe {
 				);
 			}
 		} elseif ( is_wc_endpoint_url( 'add-payment-method' ) ) {
+			$stripe_params['isAddPaymentMethod'] = true;
 			$stripe_params['cartTotal']    = 0;
 			$stripe_params['customerData'] = [ 'billing_country' => WC()->customer->get_billing_country() ];
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -146,5 +146,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add wc_stripe_express_checkout_normalize_address filter for express checkout address normalization
 * Update - Expand Amazon Pay support for all permitted currencies and countries
 * Add - Allow cache prefetch window to be adjusted via the wc_stripe_database_cache_prefetch_window filter
+* Fix - Prefill customer billing information on the Pay for Order and Change Payment Method pages
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-838
Fixes #<github_issue_id>

## Changes proposed in this Pull Request:

During checkout, billing fields in the Stripe payment elements are hidden, and the values from the WooCommerce form are used, causing a discrepancy with the Change Payment Method and Add Payment Method pages, which require those fields.

This PR adds prefilling of the billing field in the Stripe Payment Element on the Change Payment Method and Add Payment Method pages using the customer's billing information.

| Checkout | add / Change Payment Method |
|-|-|
|<img width="503" height="442" alt="Screenshot 2025-12-05 at 14 39 41" src="https://github.com/user-attachments/assets/eae2a038-fcda-4ea9-8b53-f9976f1b1a83" />|<img width="809" height="366" alt="Screenshot 2025-12-05 at 14 39 29" src="https://github.com/user-attachments/assets/e7e8b3b1-7b52-41ed-b498-3de1673ed74f" />|
|<img width="505" height="564" alt="Screenshot 2025-12-05 at 14 38 19" src="https://github.com/user-attachments/assets/d86fc9be-19e8-4493-9234-7e06fc6ec8ff" />|<img width="811" height="751" alt="Screenshot 2025-12-05 at 14 39 14" src="https://github.com/user-attachments/assets/8a6f5ec2-b9a7-465c-be33-302a2f7a1096" />|

## Testing instructions

0. Set the store currency to `EUR` and enable `SEPA`.

### Checkout Page (Regression Test)
1. Add a subscription product to the Cart
2. Go to the Checkout page
3. Fill in billing details
4. Select Stripe as the payment method
5. Select SEPA Direct Debit
6. Verify only the IBAN field is present
    <img width="505" height="564" alt="Screenshot 2025-12-05 at 14 38 19" src="https://github.com/user-attachments/assets/d86fc9be-19e8-4493-9234-7e06fc6ec8ff" />

### Change Payment Method Page (Subscription)
1. Navigate to: `My Account → Subscriptions → [subscription created in step above] → Change Payment Method`
2. Select Stripe as the payment method
3. Select SEPA Direct Debit payment method
4. Verify that the fields are correctly preloaded:
    <img width="811" height="751" alt="Screenshot 2025-12-05 at 14 39 14" src="https://github.com/user-attachments/assets/8a6f5ec2-b9a7-465c-be33-302a2f7a1096" />

### Test 3: Add Payment Method Page
1. Navigate to: `My Account → Payment Methods → Add Payment Method`
2. Select Stripe as the payment gateway
3. Select SEPA Direct Debit payment method
4. Verify that the fields are correctly preloaded

### Pay for Order Page
1. Navigate to `WP-Admin > WooCommerce > Orders` and create a pending order (or use an existing pending order)
2. Use the `Customer payment page →` link to go to the Pay for order page
3. Select Stripe as the payment method
4. Select SEPA Direct Debit payment method
5. Verify that the fields are correctly preloaded

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
