### PR TITLE
Ensure Amazon Pay feature flag is enabled by default

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,7 @@
 *** Changelog ***
 
 = 10.3.0 - xxxx-xx-xx =
-* Add - Enable Amazon Pay as an express checkout method
-
+* Add - Support Amazon Pay as an express checkout method
 
 = 10.2.0 - 2025-12-08 =
 * Dev - Refactor display logic for payment method issue pills

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.3.0 - xxxx-xx-xx =
+* Add - Enable Amazon Pay as an express checkout method
 
 
 = 10.2.0 - 2025-12-08 =

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -65,15 +65,7 @@ class WC_Stripe_Feature_Flags {
 	 * @return bool
 	 */
 	public static function is_amazon_pay_available() {
-		$enable_amazon_pay = 'yes' === self::get_option_with_default( self::AMAZON_PAY_FEATURE_FLAG_NAME );
-
-		/**
-		 * Filter to control the availability of the Amazon Pay feature.
-		 *
-		 * @since 10.1.0
-		 * @param bool $enable_amazon_pay Whether Amazon Pay should be enabled.
-		 */
-		return (bool) apply_filters( 'wc_stripe_is_amazon_pay_available', $enable_amazon_pay );
+		return true;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.3.0 - xxxx-xx-xx =
-* Add - Enable Amazon Pay as an express checkout method
+* Add - Support Amazon Pay as an express checkout method
 
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.3.0 - xxxx-xx-xx =
+* Add - Enable Amazon Pay as an express checkout method
 
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1200,32 +1200,29 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 */
 	public function provide_test_amazon_pay_is_available(): array {
 		return [
-			'feature flag disabled, payment method enabled, US account, USD currency' => [ false, true, 'US', 'USD', false ],
-			'feature flag enabled, payment method enabled, US account, USD currency'  => [ true, true, 'US', 'USD', true ],
-			'feature flag enabled, payment method disabled, US account, USD currency' => [ true, false, 'US', 'USD', false ],
-			'feature flag enabled, payment method enabled, US account, EUR currency'  => [ true, true, 'US', 'EUR', false ],
-			'feature flag disabled, payment method enabled, AT account, EUR currency' => [ false, true, 'AT', 'EUR', false ],
-			'feature flag enabled, payment method enabled, AT account, EUR currency'  => [ true, true, 'AT', 'EUR', true ],
-			'feature flag enabled, payment method disabled, AT account, EUR currency' => [ true, false, 'AT', 'EUR', false ],
-			'feature flag enabled, payment method enabled, AT account, USD currency'  => [ true, true, 'AT', 'USD', true ],
-			'feature flag enabled, payment method enabled, BE account, CAD currency'  => [ true, true, 'BE', 'CAD', false ],
-			'feature flag enabled, payment method enabled, CA account, USD currency'  => [ true, true, 'CA', 'USD', false ],
-			'feature flag enabled, payment method enabled, DE account, HKD currency'  => [ true, true, 'DE', 'HKD', true ],
-			'feature flag enabled, payment method enabled, HU account, HUF currency'  => [ true, true, 'HU', 'HUF', false ],
-			'feature flag enabled, payment method enabled, IE account, ZAR currency'  => [ true, true, 'IE', 'ZAR', true ],
-			'feature flag enabled, payment method enabled, IT account, JPY currency'  => [ true, true, 'IT', 'JPY', true ],
-			'feature flag enabled, payment method enabled, LU account, EUR currency'  => [ true, true, 'LU', 'EUR', true ],
-			'feature flag enabled, payment method enabled, NL account, EUR currency'  => [ true, true, 'NL', 'EUR', true ],
-			'feature flag enabled, payment method enabled, PT account, EUR currency'  => [ true, true, 'PT', 'EUR', true ],
-			'feature flag enabled, payment method enabled, ES account, EUR currency'  => [ true, true, 'ES', 'EUR', true ],
-			'feature flag enabled, payment method enabled, SE account, EUR currency'  => [ true, true, 'SE', 'EUR', true ],
+			'payment method enabled, US account, USD currency'  => [ true, 'US', 'USD', true ],
+			'payment method disabled, US account, USD currency' => [ false, 'US', 'USD', false ],
+			'payment method enabled, US account, EUR currency'  => [ true, 'US', 'EUR', false ],
+			'payment method enabled, AT account, EUR currency'  => [ true, 'AT', 'EUR', true ],
+			'payment method disabled, AT account, EUR currency' => [ false, 'AT', 'EUR', false ],
+			'payment method enabled, AT account, USD currency'  => [ true, 'AT', 'USD', true ],
+			'payment method enabled, BE account, CAD currency'  => [ true, 'BE', 'CAD', false ],
+			'payment method enabled, CA account, USD currency'  => [ true, 'CA', 'USD', false ],
+			'payment method enabled, DE account, HKD currency'  => [ true, 'DE', 'HKD', true ],
+			'payment method enabled, HU account, HUF currency'  => [ true, 'HU', 'HUF', false ],
+			'payment method enabled, IE account, ZAR currency'  => [ true, 'IE', 'ZAR', true ],
+			'payment method enabled, IT account, JPY currency'  => [ true, 'IT', 'JPY', true ],
+			'payment method enabled, LU account, EUR currency'  => [ true, 'LU', 'EUR', true ],
+			'payment method enabled, NL account, EUR currency'  => [ true, 'NL', 'EUR', true ],
+			'payment method enabled, PT account, EUR currency'  => [ true, 'PT', 'EUR', true ],
+			'payment method enabled, ES account, EUR currency'  => [ true, 'ES', 'EUR', true ],
+			'payment method enabled, SE account, EUR currency'  => [ true, 'SE', 'EUR', true ],
 		];
 	}
 
 	/**
 	 * Test the `is_amazon_pay_enabled()` method.
 	 *
-	 * @param bool   $feature_flag_enabled   Whether the feature flag is enabled.
 	 * @param bool   $payment_method_enabled Whether the payment method is enabled.
 	 * @param string $account_country        The country code for the Stripe account.
 	 * @param string $currency               The currency of the store.
@@ -1233,15 +1230,11 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @dataProvider provide_test_amazon_pay_is_available
 	 */
 	public function test_amazon_pay_is_available(
-		bool $feature_flag_enabled,
 		bool $payment_method_enabled,
 		string $account_country,
 		string $currency,
 		bool $expected_availability
 	): void {
-		$feature_flag_value = $feature_flag_enabled ? 'yes' : 'no';
-		update_option( \WC_Stripe_Feature_Flags::AMAZON_PAY_FEATURE_FLAG_NAME, $feature_flag_value );
-
 		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'get_upe_enabled_payment_method_ids' ] )

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -150,7 +150,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					WC_Stripe_Payment_Methods::CARD,
 					WC_Stripe_Payment_Methods::AMAZON_PAY,
 				],
-				'update enable payment methods calls' => 1,
+				'update enable payment methods calls' => 0,
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-837

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that the Amazon Pay feature flag is enabled by default. The target branch for this change is the `feature/amazon-pay-beta` branch for now so we can put together a beta release that allows for full end-to-end testing of Amazon Pay, including enabling it by default for new installs.

From an implementation perspective, I am ensuring that the flag defaulted on.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Code inspection
* Running this build, navigate to the Stripe plugin settings for a connected account
* Verify that if you're using a supported currency and country combination, Amazon Pay appears as an express checkout option
* You can also verify that `wc_stripe_settings_params?.is_amazon_pay_available` returns `'1'` in your Javascript console while viewing the Stripe admin UI
* Navigate to a product page, cart page, or checkout page
* Verify that `wc_stripe_upe_params?.isAmazonPayAvailable` returns `'1'` in your Javascript console

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
