### PR TITLE
Enable Amazon Pay for eligible new installs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.3.0 - xxxx-xx-xx =
+* Add - Enable Amazon Pay for eligible new installs
 
 
 = 10.2.0 - 2025-12-08 =

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -562,12 +562,21 @@ class WC_Stripe_Payment_Method_Configurations {
 			);
 		}
 
-		// Add Google Pay and Apple Pay to the list if payment_request is enabled
+		// Add default express checkout methods to the list if express checkout is enabled
 		if ( ! empty( $stripe_settings['express_checkout'] ) && 'yes' === $stripe_settings['express_checkout'] ) {
 			$enabled_payment_methods = array_merge(
 				$enabled_payment_methods,
 				[ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY ]
 			);
+
+			// If Amazon Pay is available and should be defaulted on, and the account country and currency are supported, enable Amazon Pay.
+			if ( WC_Stripe_Feature_Flags::is_amazon_pay_available() && 'yes' === get_option( 'wc_stripe_amazon_pay_default_on' ) ) {
+				$amazon_pay = new WC_Stripe_UPE_Payment_Method_Amazon_Pay();
+
+				if ( $amazon_pay->is_available_for_account_country() && in_array( get_woocommerce_currency(), $amazon_pay->get_supported_currencies(), true ) ) {
+					$enabled_payment_methods[] = WC_Stripe_Payment_Methods::AMAZON_PAY;
+				}
+			}
 		}
 
 		// Update the PMC if there are locally enabled payment methods

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -343,58 +343,60 @@ class WC_Stripe {
 
 		$previous_version = get_option( 'wc_stripe_version' );
 
-		if ( WC_STRIPE_VERSION !== $previous_version ) {
-			do_action( 'woocommerce_stripe_updated' );
+		if ( WC_STRIPE_VERSION === $previous_version ) {
+			return;
+		}
 
-			if ( ! defined( 'WC_STRIPE_INSTALLING' ) ) {
-				define( 'WC_STRIPE_INSTALLING', true );
-			}
+		do_action( 'woocommerce_stripe_updated' );
 
-			$is_new_install = false === $previous_version;
+		if ( ! defined( 'WC_STRIPE_INSTALLING' ) ) {
+			define( 'WC_STRIPE_INSTALLING', true );
+		}
 
-			// Mark optimized checkout as default on for new installs.
-			if ( $is_new_install && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
-				update_option( 'wc_stripe_optimized_checkout_default_on', true );
-			}
+		$is_new_install = false === $previous_version;
 
-			if ( $is_new_install ) {
-				update_option( 'wc_stripe_amazon_pay_default_on', 'yes' );
-			}
+		// Mark optimized checkout as default on for new installs.
+		if ( $is_new_install && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
+			update_option( 'wc_stripe_optimized_checkout_default_on', true );
+		}
 
-			add_woocommerce_inbox_variant();
-			$this->update_plugin_version();
+		if ( $is_new_install ) {
+			update_option( 'wc_stripe_amazon_pay_default_on', 'yes' );
+		}
 
-			// Add webhook reconfiguration
-			$account = self::get_instance()->account;
-			$account->maybe_reconfigure_webhooks_on_update();
+		add_woocommerce_inbox_variant();
+		$this->update_plugin_version();
 
-			// TODO: Remove this when we're reasonably sure most merchants have had their
-			// settings updated like this. ~80% of merchants is a good threshold.
-			// - @reykjalin
-			$this->update_prb_location_settings();
+		// Add webhook reconfiguration
+		$account = self::get_instance()->account;
+		$account->maybe_reconfigure_webhooks_on_update();
 
-			// Migrate to the new checkout experience.
-			$this->migrate_to_new_checkout_experience();
+		// TODO: Remove this when we're reasonably sure most merchants have had their
+		// settings updated like this. ~80% of merchants is a good threshold.
+		// - @reykjalin
+		$this->update_prb_location_settings();
 
-			// Check for subscriptions using legacy SEPA tokens on upgrade.
-			// Handled by WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update.
-			delete_option( 'woocommerce_stripe_subscriptions_legacy_sepa_tokens_updated' );
+		// Migrate to the new checkout experience.
+		$this->migrate_to_new_checkout_experience();
 
-			// TODO: Remove this call when all the merchants have moved to the new checkout experience.
-			// We are calling this function here to make sure that the Stripe methods are added to the `woocommerce_gateway_order` option.
-			WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order();
+		// Check for subscriptions using legacy SEPA tokens on upgrade.
+		// Handled by WC_Stripe_Subscriptions_Legacy_SEPA_Token_Update.
+		delete_option( 'woocommerce_stripe_subscriptions_legacy_sepa_tokens_updated' );
 
-			// Try to schedule the daily async cleanup of the Stripe database cache.
-			WC_Stripe_Database_Cache::maybe_schedule_daily_async_cleanup();
+		// TODO: Remove this call when all the merchants have moved to the new checkout experience.
+		// We are calling this function here to make sure that the Stripe methods are added to the `woocommerce_gateway_order` option.
+		WC_Stripe_Helper::add_stripe_methods_in_woocommerce_gateway_order();
 
-			// If we have previously disabled settings synchronization, remove the flag after the upgrade,
-			// just to make sure we are still ineligible for settings synchronization.
-			$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
-			if ( isset( $stripe_settings['pmc_enabled'] ) && 'no' === $stripe_settings['pmc_enabled'] ) {
-				unset( $stripe_settings['pmc_enabled'] );
-				WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
-				WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
-			}
+		// Try to schedule the daily async cleanup of the Stripe database cache.
+		WC_Stripe_Database_Cache::maybe_schedule_daily_async_cleanup();
+
+		// If we have previously disabled settings synchronization, remove the flag after the upgrade,
+		// just to make sure we are still ineligible for settings synchronization.
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		if ( isset( $stripe_settings['pmc_enabled'] ) && 'no' === $stripe_settings['pmc_enabled'] ) {
+			unset( $stripe_settings['pmc_enabled'] );
+			WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+			WC_Stripe_Logger::warning( 'Settings synchronization eligibility will be re-checked after upgrade' );
 		}
 	}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -337,16 +337,28 @@ class WC_Stripe {
 			return;
 		}
 
-		if ( ! defined( 'IFRAME_REQUEST' ) && ( WC_STRIPE_VERSION !== get_option( 'wc_stripe_version' ) ) ) {
+		if ( defined( 'IFRAME_REQUEST' ) ) {
+			return;
+		}
+
+		$previous_version = get_option( 'wc_stripe_version' );
+
+		if ( WC_STRIPE_VERSION !== $previous_version ) {
 			do_action( 'woocommerce_stripe_updated' );
 
 			if ( ! defined( 'WC_STRIPE_INSTALLING' ) ) {
 				define( 'WC_STRIPE_INSTALLING', true );
 			}
 
+			$is_new_install = false === $previous_version;
+
 			// Mark optimized checkout as default on for new installs.
-			if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
+			if ( $is_new_install && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
 				update_option( 'wc_stripe_optimized_checkout_default_on', true );
+			}
+
+			if ( $is_new_install ) {
+				update_option( 'wc_stripe_amazon_pay_default_on', 'yes' );
 			}
 
 			add_woocommerce_inbox_variant();

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.3.0 - xxxx-xx-xx =
+* Add - Enable Amazon Pay for eligible new installs
 
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
+++ b/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
@@ -53,10 +53,11 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		// Set up environment with pmc_enabled = 'yes'
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
 		$stripe_settings['pmc_enabled'] = 'yes';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'card' ];
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		$this->mock_payment_method_configurations( [ 'card' ], [] );
-		$this->expect_payment_method_configurations_update( [] );
+		$this->mock_payment_method_configurations( [], [ 'card', 'link' ] );
+		$this->expect_payment_method_configurations_update( [ 'card' ], [ 'link' ] );
 
 		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc( true );
 

--- a/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
+++ b/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
@@ -75,18 +75,11 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		$stripe_settings['pmc_enabled']                               = '';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		$set_currency_usd = function () {
-			return 'USD';
-		};
-		add_filter( 'woocommerce_currency', $set_currency_usd );
-
 		$this->mock_payment_method_configurations( [], [ 'link', 'sepa_debit', 'google_pay', 'apple_pay' ] );
 		$this->expect_payment_method_configurations_update( [ 'link', 'sepa_debit', 'google_pay', 'apple_pay' ], [] );
 
 		// Execute migration
 		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
-
-		remove_filter( 'woocommerce_currency', $set_currency_usd );
 
 		// Verify pmc_enabled is set to 'yes'
 		$updated_settings = WC_Stripe_Helper::get_stripe_settings();

--- a/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
+++ b/tests/phpunit/Admin/Migrations/Migrate_Payment_Methods_From_DB_To_PMC_Test.php
@@ -49,6 +49,23 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 			->method( 'update_payment_method_configurations' );
 	}
 
+	public function test_migration_executed_when_pmc_enabled_is_yes_and_force_migration_is_true() {
+		// Set up environment with pmc_enabled = 'yes'
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['pmc_enabled'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->mock_payment_method_configurations( [ 'card' ], [] );
+		$this->expect_payment_method_configurations_update( [] );
+
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc( true );
+
+		// Verify pmc_enabled is set to 'yes'
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
+		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
+	}
+
 	public function test_migration_executed_when_pmc_enabled_is_not_set() {
 		// Set pmc_enabled to '' to trigger migration
 		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
@@ -58,11 +75,18 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		$stripe_settings['pmc_enabled']                               = '';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
+		$set_currency_usd = function () {
+			return 'USD';
+		};
+		add_filter( 'woocommerce_currency', $set_currency_usd );
+
 		$this->mock_payment_method_configurations( [], [ 'link', 'sepa_debit', 'google_pay', 'apple_pay' ] );
 		$this->expect_payment_method_configurations_update( [ 'link', 'sepa_debit', 'google_pay', 'apple_pay' ], [] );
 
 		// Execute migration
 		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		remove_filter( 'woocommerce_currency', $set_currency_usd );
 
 		// Verify pmc_enabled is set to 'yes'
 		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
@@ -126,5 +150,77 @@ class Migrate_Payment_Methods_From_DB_To_PMC_Test extends WC_Mock_Stripe_API_Uni
 		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
 		$this->assertArrayHasKey( 'stripe_upe_payment_method_order', $updated_settings );
 		$this->assertEquals( $existing_order, $updated_settings['stripe_upe_payment_method_order'] );
+	}
+
+	/**
+	 * Provide test cases for {@see test_migration_executed_and_amazon_pay_enabled_correctly()}.
+	 */
+	public function provide_test_migration_executed_and_amazon_pay_enabled_correctly_tests(): array {
+		return [
+			'Auto-enable undefined, US + USD, expect no Amazon Pay' => [ null, 'US', 'USD', false ],
+			'Auto-enable on, US + USD, expect Amazon Pay'           => [ true, 'US', 'USD', true ],
+			'Auto-enable off, US + USD, expect no Amazon Pay'       => [ false, 'US', 'USD', false ],
+			'Auto-enable on, CA + USD, expect no Amazon Pay'        => [ true, 'CA', 'USD', false ],
+			'Auto-enable on, GB + GBP, expect Amazon Pay'           => [ true, 'GB', 'GBP', true ],
+			'Auto-enable on, DE + EUR, expect Amazon Pay'           => [ true, 'DE', 'EUR', true ],
+			'Auto-enable on, GR + EUR, expect no Amazon Pay'        => [ true, 'GR', 'EUR', false ],
+			'Auto-enable on, GB + ZAR, expect Amazon Pay'           => [ true, 'GB', 'ZAR', true ],
+		];
+	}
+
+	/**
+	 * Test the migration executed and Amazon Pay was enabled as expected.
+	 *
+	 * @param ?bool  $should_auto_enable_amazon_pay Whether Amazon Pay should be auto-enabled.
+	 * @param string $account_country               The country code for the Stripe account.
+	 * @param string $store_currency                The currency of the store.
+	 * @param bool   $expect_amazon_pay             Whether Amazon Pay should be expected.
+	 * @dataProvider provide_test_migration_executed_and_amazon_pay_enabled_correctly_tests
+	 */
+	public function test_migration_executed_and_amazon_pay_enabled_correctly( ?bool $should_auto_enable_amazon_pay, string $account_country, string $store_currency, bool $expect_amazon_pay ) {
+		// Set pmc_enabled to '' to trigger migration
+		$stripe_settings = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['test_connection_type']                      = 'connect';
+		$stripe_settings['express_checkout']                          = 'yes';
+		$stripe_settings['upe_checkout_experience_accepted_payments'] = [ 'link', 'sepa_debit' ];
+		$stripe_settings['pmc_enabled']                               = '';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->set_stripe_account_data( [ 'country' => $account_country ] );
+
+		// Initialize the Amazon Pay auto-on option
+		if ( null === $should_auto_enable_amazon_pay ) {
+			delete_option( 'wc_stripe_amazon_pay_default_on' );
+		} else {
+			update_option( 'wc_stripe_amazon_pay_default_on', $should_auto_enable_amazon_pay ? 'yes' : 'no' );
+		}
+
+		$mock_currency = function () use ( $store_currency ) {
+			return $store_currency;
+		};
+		add_filter( 'woocommerce_currency', $mock_currency );
+
+		$disabled_method_ids = [ 'link', 'sepa_debit', 'google_pay', 'apple_pay', 'amazon_pay' ];
+		$this->mock_payment_method_configurations( [], $disabled_method_ids );
+
+		$expected_payment_methods     = [ 'link', 'sepa_debit', 'google_pay', 'apple_pay' ];
+		$expected_disabled_method_ids = [];
+		if ( $expect_amazon_pay ) {
+			$expected_payment_methods[] = 'amazon_pay';
+		} else {
+			$expected_disabled_method_ids[] = 'amazon_pay';
+		}
+
+		$this->expect_payment_method_configurations_update( $expected_payment_methods, $expected_disabled_method_ids );
+
+		// Execute migration
+		$this->pmc->maybe_migrate_payment_methods_from_db_to_pmc();
+
+		remove_filter( 'woocommerce_currency', $mock_currency );
+
+		// Verify pmc_enabled is set to 'yes'
+		$updated_settings = WC_Stripe_Helper::get_stripe_settings();
+		$this->assertArrayHasKey( 'pmc_enabled', $updated_settings );
+		$this->assertEquals( 'yes', $updated_settings['pmc_enabled'] );
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-817

Blocked by https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4858

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that new installs will set the `wc_stripe_amazon_pay_default_on` option, and our logic to initialise PMCs will now check that flag to see if Amazon Pay should be enabled by default alongside Apple Pay and Google Pay. Those checks take into account the store currency and the Stripe account country so we only enable Amazon Pay where it is available through Stripe.

Note that this PR doesn't work without the changes from https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4858, as I uncovered those subtle issues while testing this PR. We will need to merge that PR into `develop` and then merge `develop` into `feature/amazon-pay-beta` for this to be fully testable.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
As noted above, you'll need the changes from https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4858 and the changes from this branch.

* Build the code out of this branch along with the necessary fixes form https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4858 patched or cherry-picked onto this code.
* Create a brand new site with WooCommerce installed - we don't want the Stripe plugin ever to have been installed before
* Install and activate the newly built plugin on the site
* Verify that the `wc_stripe_amazon_pay_default_on` option is now set to `yes`: `wp option get wc_stripe_amazon_pay_default_on`
* Ensure your store is configured to use a currency supported by Amazon Pay
* Connect to Stripe via OAuth using an account that supports Amazon Pay in your store currency
* Confirm that Amazon Pay is enabled
* Now change your store currency and disconnect from Stripe
* Connect to Stripe using an account country and currency combination not supported by Amazon Pay -- the easiest is EUR for a US account, as Amazon Pay only supports USD for US accounts.
* Confirm that Amazon Pay is not enabled.

* Use the built plugin to upgrade a site that already had the Stripe plugin installed and activated - ensure the plugin is also activated after the installation
* Confirm that the `wc_stripe_amazon_pay_default_on` option is _not_ set: `wp option get wc_stripe_amazon_pay_default_on`
* (Re)connect to Stripe, and confirm that Amazon Pay is not defaulted on

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
