### PR TITLE
Improve error messages

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Dev - Removes all references to the UPE-enabled feature flag
 * Dev - Removes deprecated promotional banners (related to legacy checkout)
 * Fix - Error when using Puerto Rico addresses with express checkouts
+* Tweak - Improve error messages when Stripe API requests fail to better distinguish between request and retrieval errors
 
 = 10.2.0 - 2025-12-08 =
 * Dev - Refactor display logic for payment method issue pills

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -266,7 +266,7 @@ class WC_Stripe_API {
 			];
 			self::log_error_response( $response, $api, $method, $error_data );
 
-			throw new WC_Stripe_Exception( print_r( $response, true ), __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ) );
+			throw new WC_Stripe_Exception( print_r( $response, true ), __( 'There was a problem sending a request to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ) );
 		}
 
 		$response_body = json_decode( $response['body'] );
@@ -374,7 +374,7 @@ class WC_Stripe_API {
 			];
 			self::log_error_response( $response, $api, 'GET', $error_data );
 
-			return new WP_Error( 'stripe_error', __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ) );
+			return new WP_Error( 'stripe_error', __( 'There was a problem retrieving data from the Stripe API endpoint.', 'woocommerce-gateway-stripe' ) );
 		}
 
 		$response_body = json_decode( $response['body'] );

--- a/readme.txt
+++ b/readme.txt
@@ -143,5 +143,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Error when using Puerto Rico addresses with express checkouts
 * Dev - Removes all references to the UPE-enabled feature flag
 * Dev - Removes deprecated promotional banners (related to legacy checkout)
+* Tweak - Improve error messages when Stripe API requests fail to better distinguish between request and retrieval errors
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_API_Test.php
+++ b/tests/phpunit/WC_Stripe_API_Test.php
@@ -291,11 +291,11 @@ class WC_Stripe_API_Test extends WP_UnitTestCase {
 		if ( 'GET' === $method ) {
 			$this->assertInstanceof( \WP_Error::class, $result );
 			$this->assertEquals( 'stripe_error', $result->get_error_code() );
-			$this->assertEquals( __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ), $result->get_error_message() );
+			$this->assertEquals( __( 'There was a problem retrieving data from the Stripe API endpoint.', 'woocommerce-gateway-stripe' ), $result->get_error_message() );
 		} else {
 			$this->assertInstanceof( \WC_Stripe_Exception::class, $caught_exception );
 			$this->assertEquals( print_r( $response, true ), $caught_exception->getMessage() );
-			$this->assertEquals( __( 'There was a problem connecting to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ), $caught_exception->getLocalizedMessage() );
+			$this->assertEquals( __( 'There was a problem sending a request to the Stripe API endpoint.', 'woocommerce-gateway-stripe' ), $caught_exception->getLocalizedMessage() );
 		}
 	}
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-849
Fixes #4862

## Changes proposed in this Pull Request:

As suggested in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4862, this PR updates the error messages to better distinguish between Stripe API retrieval and request failures.

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
A code review is sufficient
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
