### PR TITLE
Fix default locations for Amazon Pay

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 * Fix - Preserve express checkout button location settings when upgrading from older plugin versions
 * Fix - Fix some initialization bugs for reconnections
 * Fix - Update Ukraine state mapping list
+* Fix - Use same default locations for Amazon Pay express checkout
 
 = 10.2.0 - 2025-12-08 =
 * Dev - Refactor display logic for payment method issue pills

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -291,8 +291,9 @@ $stripe_settings = apply_filters(
 	]
 );
 
-// in the new settings, "checkout" is going to be enabled by default (if it is a new WCStripe installation).
+// Ensure express checkout buttons are displayed on the checkout page by default.
 $stripe_settings['express_checkout_button_locations']['default'][] = 'checkout';
+$stripe_settings['amazon_pay_button_locations']['default'][]       = 'checkout';
 
 // no longer needed in the new settings.
 unset( $stripe_settings['express_checkout_button_branded_type'] );

--- a/readme.txt
+++ b/readme.txt
@@ -151,5 +151,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Preserve express checkout button location settings when upgrading from older plugin versions
 * Fix - Fix some initialization bugs for reconnections
 * Fix - Update Ukraine state mapping list
+* Fix - Use same default locations for Amazon Pay express checkout
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1089,6 +1089,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	public function test_opc_detection_logic( $is_opc, $button_locations, $expected ) {
 		$stripe_settings                                      = WC_Stripe_Helper::get_stripe_settings();
 		$stripe_settings['express_checkout_button_locations'] = $button_locations;
+		$stripe_settings['amazon_pay_button_locations']       = $button_locations;
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
 		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-859
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4881

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that Amazon Pay picks up the same default locations as the other express checkout methods by always defaulting on the checkout location outside of the `wc_stripe_settings` filter.

Note that this PR doesn't perform any checks when enabling Amazon Pay. We _might_ want to update the logic in `WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()` to make the value of `amazon_pay_button_locations` match the value of `express_checkout_button_locations`, but for new installs, we should always be migrating the PMC configuration before the user can modify any settings. After that stage, we should generally leave the settings as-is.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

* Install WooCommerce on a brand new site that has never had the Stripe plugin installed
* Install the Stripe plugin built from this branch
* Connect to Stripe
* After connecting to Stripe, confirm that Amazon Pay is enabled
* Also confirm that Amazon Pay is configured to display in the product page, cart, and checkout.
* Also check that Apple Pay and Google Pay are still configured to display in the product page, cart, and checkout.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
