### PR TITLE
Ensure Link is not translated

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - Update Ukraine state mapping list
 * Fix - Use same default locations for Amazon Pay express checkout
 * Dev - Add configuration and workflow for PHPStan
+* Fix - Ensure that 'Link' and 'Stripe Link' are not translated
 
 = 10.2.0 - 2025-12-08 =
 * Dev - Refactor display logic for payment method issue pills

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-link.php
@@ -16,13 +16,17 @@ class WC_Stripe_UPE_Payment_Method_Link extends WC_Stripe_UPE_Payment_Method {
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id   = self::STRIPE_ID;
-		$this->title       = __( 'Link', 'woocommerce-gateway-stripe' );
+		// Note that the title and label are not translated, as "Link" should not be translated.
+		$this->title       = 'Link';
 		$this->is_reusable = true;
-		$this->label       = __( 'Stripe Link', 'woocommerce-gateway-stripe' );
-		$this->description = __(
-			'Link is a payment method that allows customers to save payment information  and use the payment details
-			for further payments.',
-			'woocommerce-gateway-stripe'
+		$this->label       = 'Stripe Link';
+		$this->description = sprintf(
+			/* translators: %s: "Link" - a product name that should not be translated. */
+			__(
+				'%s is a payment method that allows customers to save payment information and use the payment details for further payments.',
+				'woocommerce-gateway-stripe'
+			),
+			'Link'
 		);
 
 		add_filter( 'woocommerce_gateway_title', [ $this, 'filter_gateway_title' ], 10, 2 );

--- a/includes/payment-tokens/class-wc-stripe-link-payment-token.php
+++ b/includes/payment-tokens/class-wc-stripe-link-payment-token.php
@@ -37,13 +37,8 @@ class WC_Payment_Token_Link extends WC_Payment_Token implements WC_Stripe_Paymen
 	 * @return string
 	 */
 	public function get_display_name( $deprecated = '' ) {
-		$display = sprintf(
-			/* translators: customer email */
-			__( 'Stripe Link (%s)', 'woocommerce-gateway-stripe' ),
-			$this->get_email()
-		);
-
-		return $display;
+		// Note that 'Stripe Link' is a branded product, and should not be translated.
+		return sprintf( 'Stripe Link (%s)', $this->get_email() );
 	}
 
 	/**

--- a/includes/payment-tokens/class-wc-stripe-payment-tokens.php
+++ b/includes/payment-tokens/class-wc-stripe-payment-tokens.php
@@ -437,10 +437,12 @@ class WC_Stripe_Payment_Tokens {
 				$item['method']['last4'] = $payment_token->get_last4();
 				break;
 			case WC_Stripe_Payment_Methods::LINK:
-				$item['method']['brand'] = sprintf(
-					/* translators: customer email */
-					esc_html__( 'Stripe Link (%s)', 'woocommerce-gateway-stripe' ),
-					esc_html( $payment_token->get_email() )
+				// Note that 'Stripe Link' is a branded product, and should not be translated.
+				$item['method']['brand'] = esc_html(
+					sprintf(
+						'Stripe Link (%s)',
+						$payment_token->get_email()
+					)
 				);
 				break;
 			case WC_Stripe_Payment_Methods::AMAZON_PAY:

--- a/readme.txt
+++ b/readme.txt
@@ -156,5 +156,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Update Ukraine state mapping list
 * Fix - Use same default locations for Amazon Pay express checkout
 * Dev - Add configuration and workflow for PHPStan
+* Fix - Ensure that 'Link' and 'Stripe Link' are not translated
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-864

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that we do not translate the "Link" and "Stripe Link" titles for payments made using Link. It is a product name that should not be translated, and was incorrectly getting translated so order and payment details showed translated text instead of the product name.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->
<img width="1415" height="562" alt="Screenshot 2025-12-24 at 11 04 44" src="https://github.com/user-attachments/assets/aac28d3f-1a0e-4417-ae87-2fdbaa248435" />
Fixed case with untranslated `Link` text. (This was in German.)

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Set up a store to use a non-English locale -- the original report was using Spanish
* Connect to Stripe and ensure that card and Link payment methods are enabled
* Ensure that you have a valid Link login -- you can do that by making a card purchase and checking the option to save your details in Link
* Make a purchase using Link
* Verify that the payment method details are not translated

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
