### PR TITLE
Fix PHPStan handling of plugin constants defined via function calls

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - Update Ukraine state mapping list
 * Fix - Use same default locations for Amazon Pay express checkout
 * Dev - Add configuration and workflow for PHPStan
+* Dev - Improve PHPStan handling of plugin constants
 
 = 10.2.0 - 2025-12-08 =
 * Dev - Refactor display logic for payment method issue pills

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,12 +91,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:create_or_update_payment_intent\(\) should return object but returns array\|stdClass\.$#'
 			identifier: return.type
 			count: 1
@@ -2497,12 +2491,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-admin-notices.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/admin/class-wc-stripe-amazon-pay-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Amazon_Pay_Controller\:\:admin_options\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2513,12 +2501,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: includes/admin/class-wc-stripe-amazon-pay-controller.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/admin/class-wc-stripe-express-checkout-controller.php
 
 		-
 			message: '#^Call to WC_Stripe_UPE_Availability_Note\:\:init\(\) on a separate line has no effect\.$#'
@@ -6730,12 +6712,6 @@ parameters:
 			path: includes/connect/class-wc-stripe-connect.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/constants/class-wc-stripe-payment-request-button-states.php
-
-		-
 			message: '#^Method WC_Stripe_Apple_Pay\:\:__call\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7198,12 +7174,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Alipay\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7314,12 +7284,6 @@ parameters:
 		-
 			message: '#^Cannot call method validate_minimum_order_amount\(\) on WC_Stripe_Order_Helper\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
 
@@ -7498,12 +7462,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Eps\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7618,12 +7576,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Giropay\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7734,12 +7686,6 @@ parameters:
 		-
 			message: '#^Cannot call method validate_minimum_order_amount\(\) on WC_Stripe_Order_Helper\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
 
@@ -8092,12 +8038,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_P24\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8374,12 +8314,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Sofort\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8484,12 +8418,6 @@ parameters:
 		-
 			message: '#^Cannot call method needs_shipping\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
 
@@ -8677,18 +8605,6 @@ parameters:
 			message: '#^Cannot call method update_meta_data\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
 			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_URL not found\.$#'
-			identifier: constant.notFound
-			count: 2
 			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
 
 		-
@@ -12200,12 +12116,6 @@ parameters:
 			identifier: method.childReturnType
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_URL not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$acss_debit\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -133,12 +133,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:can_refund_order\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -1024,12 +1018,6 @@ parameters:
 			message: '#^Cannot call method update_stripe_source_id\(\) on WC_Stripe_Order_Helper\|null\.$#'
 			identifier: method.nonObject
 			count: 3
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_URL not found\.$#'
-			identifier: constant.notFound
-			count: 20
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
@@ -2779,12 +2767,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-admin-notices.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/admin/class-wc-stripe-amazon-pay-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Amazon_Pay_Controller\:\:admin_options\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2863,12 +2845,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-inbox-notes.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 4
-			path: includes/admin/class-wc-stripe-inbox-notes.php
-
-		-
 			message: '#^Method WC_Stripe_Inbox_Notes\:\:are_inbox_notes_supported\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2929,12 +2905,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-inbox-notes.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/admin/class-wc-stripe-payment-gateways-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateways_Controller\:\:enqueue_payments_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2951,12 +2921,6 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: includes/admin/class-wc-stripe-payment-gateways-controller.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/admin/class-wc-stripe-payment-requests-controller.php
 
 		-
 			message: '#^Method WC_Stripe_Payment_Requests_Controller\:\:admin_options\(\) has no return type specified\.$#'
@@ -3145,12 +3109,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-rest-oc-setting-toggle-controller.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: includes/admin/class-wc-stripe-rest-upe-flag-toggle-controller.php
-
-		-
 			message: '#^Method WC_Stripe_REST_UPE_Flag_Toggle_Controller\:\:register_routes\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3178,12 +3136,6 @@ parameters:
 			message: '#^Cannot call method get_option\(\) on WC_Stripe_Payment_Gateway\|null\.$#'
 			identifier: method.nonObject
 			count: 2
-			path: includes/admin/class-wc-stripe-settings-controller.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
@@ -4450,18 +4402,6 @@ parameters:
 			message: '#^Cannot assign offset ''verification…'' to string\.$#'
 			identifier: offsetAssign.dimType
 			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_URL not found\.$#'
-			identifier: constant.notFound
-			count: 10
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-
@@ -7126,12 +7066,6 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 125
-			path: includes/class-wc-stripe.php
-
-		-
 			message: '#^Method WC_Stripe\:\:add_gateways\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8098,6 +8032,12 @@ parameters:
 			path: includes/connect/class-wc-stripe-connect.php
 
 		-
+			message: '#^Constant WC_Stripe_Express_Checkout_Button_States\:\:STATES type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: includes/constants/class-wc-stripe-express-checkout-button-states.php
+
+		-
 			message: '#^Constant WC_Stripe_Intent_Status\:\:SUCCESSFUL_STATUSES type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -8608,12 +8548,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Alipay\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -8742,12 +8676,6 @@ parameters:
 		-
 			message: '#^Cannot call method validate_minimum_order_amount\(\) on WC_Stripe_Order_Helper\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
 
@@ -8980,12 +8908,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Eps\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -9118,12 +9040,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Giropay\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -9252,12 +9168,6 @@ parameters:
 		-
 			message: '#^Cannot call method validate_minimum_order_amount\(\) on WC_Stripe_Order_Helper\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
 
@@ -9426,12 +9336,6 @@ parameters:
 		-
 			message: '#^Cannot call method validate_minimum_order_amount\(\) on WC_Stripe_Order_Helper\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
 
@@ -9664,12 +9568,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_P24\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -9792,12 +9690,6 @@ parameters:
 		-
 			message: '#^Cannot call method validate_minimum_order_amount\(\) on WC_Stripe_Order_Helper\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
 
@@ -9988,12 +9880,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
 
 		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Sofort\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -10116,12 +10002,6 @@ parameters:
 		-
 			message: '#^Cannot call method needs_shipping\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
 
@@ -10357,18 +10237,6 @@ parameters:
 			message: '#^Cannot call method update_meta_data\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
 			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_URL not found\.$#'
-			identifier: constant.notFound
-			count: 2
 			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
 
 		-
@@ -10639,12 +10507,6 @@ parameters:
 			message: '#^Cannot call method needs_shipping\(\) on WC_Product\|false\|null\.$#'
 			identifier: method.nonObject
 			count: 2
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 3
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
@@ -11226,12 +11088,6 @@ parameters:
 		-
 			message: '#^Cannot call method set_payment_method_title\(\) on bool\|WC_Order\|WC_Order_Refund\.$#'
 			identifier: method.nonObject
-			count: 3
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
 			count: 3
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
@@ -12055,18 +11911,6 @@ parameters:
 			message: '#^Constant LOGGED_IN_COOKIE not found\.$#'
 			identifier: constant.notFound
 			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
-			identifier: constant.notFound
-			count: 2
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_URL not found\.$#'
-			identifier: constant.notFound
-			count: 2
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
@@ -14360,12 +14204,6 @@ parameters:
 			identifier: method.childReturnType
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Constant WC_STRIPE_PLUGIN_URL not found\.$#'
-			identifier: constant.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay\:\:get_title\(\) has parameter \$payment_details with no value type specified in iterable type array\.$#'

--- a/phpstan-stubs/wc_stripe_constants.php
+++ b/phpstan-stubs/wc_stripe_constants.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Stubs for constants defined via function calls in WooCommerce Stripe that
+ * PHPStan doesn't seem to pick up correctly. As of 2025-12-24, this is not resolved.
+ *
+ * @see https://github.com/phpstan/phpstan/issues/11210
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'WC_STRIPE_PLUGIN_URL' ) ) {
+	define( 'WC_STRIPE_PLUGIN_URL', 'https://example.com/wp-content/plugins/woocommerce-gateway-stripe' );
+}
+
+if ( ! defined( 'WC_STRIPE_PLUGIN_PATH' ) ) {
+	// This definition is not correct, but we can't use a function like dirname( __DIR__ ) as PHPStan can't resolve it.
+	define( 'WC_STRIPE_PLUGIN_PATH', __DIR__ );
+}

--- a/phpstan-stubs/wc_stripe_constants.php
+++ b/phpstan-stubs/wc_stripe_constants.php
@@ -7,10 +7,6 @@
  * @see https://github.com/phpstan/phpstan/issues/11210
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 if ( ! defined( 'WC_STRIPE_PLUGIN_URL' ) ) {
 	define( 'WC_STRIPE_PLUGIN_URL', 'https://example.com/wp-content/plugins/woocommerce-gateway-stripe' );
 }

--- a/readme.txt
+++ b/readme.txt
@@ -156,5 +156,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Update Ukraine state mapping list
 * Fix - Use same default locations for Amazon Pay express checkout
 * Dev - Add configuration and workflow for PHPStan
+* Dev - Improve PHPStan handling of plugin constants
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR works around [a bug or limitation in PHPStan](https://github.com/phpstan/phpstan/issues/11210) where it does not recognise constants defined using the return value from a function. The issue was resulting in the `WC_STRIPE_PLUGIN_URL` and `WC_STRIPE_PLUGIN_PATH` constants not being found/seen by PHPStan. To work around the issue, I've added conditional definitions for those two constants in `phpstan-stubs/wc_stripe_constants.php` so they get picked up during PHPStan analysis runs. Note that the values are not correct, as we need to use constant values for both.

I have also updated the PHPStan baseline to remove the previously tracked errors stemming from the "missing" constants.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
Code review should be good enough on this one, and the PHPStan analysis should be clean.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
