### PR TITLE
Ignore missingType.iterableValue errors from PHPStan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,48 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:check_permission\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-connect-rest-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:delete_internal\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-connect-rest-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:delete_internal\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-connect-rest-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:get_internal\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-connect-rest-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:get_internal\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-connect-rest-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:post_internal\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-connect-rest-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:post_internal\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-connect-rest-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Connect_REST_Controller\:\:prevent_route_caching\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -139,38 +97,14 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:can_refund_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:create_or_update_payment_intent\(\) should return object but returns array\|stdClass\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:get_confirm_payment_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
@@ -183,12 +117,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:process_payment\(\) has parameter \$force_save_save with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway_Voucher\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
@@ -241,12 +169,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
 		-
-			message: '#^Property WC_Stripe_Payment_Gateway_Voucher\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
 			message: '#^Property WC_Stripe_Payment_Gateway_Voucher\:\:\$stripe_id has no type specified\.$#'
 			identifier: missingType.property
 			count: 1
@@ -255,12 +177,6 @@ parameters:
 		-
 			message: '#^Property WC_Stripe_Payment_Gateway_Voucher\:\:\$supported_countries has no type specified\.$#'
 			identifier: missingType.property
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
-
-		-
-			message: '#^Property WC_Stripe_Payment_Gateway_Voucher\:\:\$supported_currencies type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway-voucher.php
 
@@ -1045,12 +961,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:add_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:add_subscription_information_to_intent\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1063,24 +973,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:admin_options\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1089,12 +981,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:change_idempotency_key\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:change_idempotency_key\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1119,12 +1005,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:create_intent\(\) should return object but returns array\|stdClass\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1183,20 +1063,8 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:generate_create_intent_request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:generate_payment_request\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_charge_object\(\) has parameter \$params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1222,12 +1090,6 @@ parameters:
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_intent_from_order\(\) should return bool\|obect but returns bool\|object\.$#'
 			identifier: return.type
 			count: 2
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_level3_data_from_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
@@ -1269,18 +1131,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_stripe_return_url\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_unique_settings\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:get_unique_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1339,12 +1189,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:is_original_request\(\) has parameter \$headers with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:is_retryable_error\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1365,12 +1209,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:is_type_payment_method\(\) should return bool but returns int\|false\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1423,12 +1261,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:payment_icons\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1441,26 +1273,8 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:process_pre_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1555,12 +1369,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:send_failed_order_email\(\) has parameter \$status_update with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:setup_intent\(\) should return string\|null but empty return statement found\.$#'
 			identifier: return.empty
 			count: 1
@@ -1623,12 +1431,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Gateway\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Gateway\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
@@ -1891,12 +1693,6 @@ parameters:
 			path: includes/abstracts/abstract-wc-stripe-payment-gateway.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Account_Controller\:\:get_account_oauth_connection_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Account_Controller\:\:register_routes\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -1929,24 +1725,6 @@ parameters:
 		-
 			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:configure_webhooks\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:decommission_configured_webhook_after_key_update\(\) has parameter \$current_account_keys with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:decommission_configured_webhook_after_key_update\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:decommission_configured_webhook_after_key_update\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
 
@@ -2055,12 +1833,6 @@ parameters:
 		-
 			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:validate_stripe_param\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Account_Keys_Controller\:\:validate_stripe_param\(\) has parameter \$validate_options with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-account-keys-controller.php
 
@@ -2257,18 +2029,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-locations-controller.php
 
 		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:transform_pr_address\(\) has parameter \$location with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:transform_pr_address\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-locations-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Locations_Controller\:\:update_location\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2395,12 +2155,6 @@ parameters:
 			path: includes/admin/class-wc-rest-stripe-orders-controller.php
 
 		-
-			message: '#^Property WC_REST_Stripe_Orders_Controller\:\:\$minimum_amounts type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-orders-controller.php
-
-		-
 			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:dismiss_customization_notice\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
 			count: 1
@@ -2415,18 +2169,6 @@ parameters:
 		-
 			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:get_payment_method_ids_to_enable\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types\: T$#'
 			identifier: missingType.generics
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:record_payment_method_settings_event\(\) has parameter \$disabled_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:record_payment_method_settings_event\(\) has parameter \$enabled_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-settings-controller.php
 
@@ -2457,12 +2199,6 @@ parameters:
 		-
 			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_enabled_payment_methods\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/admin/class-wc-rest-stripe-settings-controller.php
-
-		-
-			message: '#^Method WC_REST_Stripe_Settings_Controller\:\:update_enabled_payment_methods\(\) has parameter \$payment_method_ids_to_enable with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/admin/class-wc-rest-stripe-settings-controller.php
 
@@ -2725,12 +2461,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-admin-notices.php
 
 		-
-			message: '#^Method WC_Stripe_Admin_Notices\:\:get_payment_methods\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-admin-notices.php
-
-		-
 			message: '#^Method WC_Stripe_Admin_Notices\:\:hide_notices\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -2773,12 +2503,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-admin-notices.php
 
 		-
-			message: '#^Property WC_Stripe_Admin_Notices\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-admin-notices.php
-
-		-
 			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
 			identifier: constant.notFound
 			count: 1
@@ -2795,6 +2519,12 @@ parameters:
 			identifier: missingType.return
 			count: 1
 			path: includes/admin/class-wc-stripe-amazon-pay-controller.php
+
+		-
+			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: includes/admin/class-wc-stripe-express-checkout-controller.php
 
 		-
 			message: '#^Call to WC_Stripe_UPE_Availability_Note\:\:init\(\) on a separate line has no effect\.$#'
@@ -3019,36 +2749,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-privacy.php
 
 		-
-			message: '#^Method WC_Stripe_Privacy\:\:account_settings\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:account_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:customer_data_eraser\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:customer_data_exporter\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:get_stripe_orders\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
 			message: '#^Method WC_Stripe_Privacy\:\:get_stripe_orders\(\) should return array but returns array\<WC_Order\>\|stdClass\.$#'
 			identifier: return.type
 			count: 1
@@ -3067,38 +2767,8 @@ parameters:
 			path: includes/admin/class-wc-stripe-privacy.php
 
 		-
-			message: '#^Method WC_Stripe_Privacy\:\:maybe_handle_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:maybe_handle_subscription\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:order_data_eraser\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:order_data_exporter\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
 			message: '#^Method WC_Stripe_Privacy\:\:register_erasers_exporters\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/admin/class-wc-stripe-privacy.php
-
-		-
-			message: '#^Method WC_Stripe_Privacy\:\:subscriptions_data_exporter\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/admin/class-wc-stripe-privacy.php
 
@@ -3235,12 +2905,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-settings-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Settings_Controller\:\:set_stripe_gateways_in_list\(\) has parameter \$ordering with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-settings-controller.php
-
-		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 2
@@ -3261,24 +2925,6 @@ parameters:
 		-
 			message: '#^Function wcs_get_subscription not found\.$#'
 			identifier: function.notFound
-			count: 1
-			path: includes/admin/class-wc-stripe-subscription-detached-bulk-action.php
-
-		-
-			message: '#^Method WC_Stripe_Subscription_Detached_Bulk_Action\:\:handle_subscription_detachment_check\(\) has parameter \$post_ids with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-subscription-detached-bulk-action.php
-
-		-
-			message: '#^Method WC_Stripe_Subscription_Detached_Bulk_Action\:\:subscriptions_bulk_actions\(\) has parameter \$bulk_actions with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/admin/class-wc-stripe-subscription-detached-bulk-action.php
-
-		-
-			message: '#^Method WC_Stripe_Subscription_Detached_Bulk_Action\:\:subscriptions_bulk_actions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/admin/class-wc-stripe-subscription-detached-bulk-action.php
 
@@ -3321,12 +2967,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Compatibility_Controller\:\:show_current_compatibility_notice\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/admin/class-wc-stripe-upe-compatibility-controller.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Compatibility_Controller\:\:show_current_compatibility_notice\(\) has parameter \$unsatisfied_requirements with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/admin/class-wc-stripe-upe-compatibility-controller.php
 
@@ -3601,12 +3241,6 @@ parameters:
 			path: includes/class-wc-gateway-stripe.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe\:\:complete_free_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-gateway-stripe.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe\:\:disable\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -3643,12 +3277,6 @@ parameters:
 			path: includes/class-wc-gateway-stripe.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe\:\:get_required_settings_keys\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-gateway-stripe.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe\:\:get_saved_payment_method_option_html\(\) should return string but returns string\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -3669,18 +3297,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-gateway-stripe.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe\:\:modify_successful_payment_result\(\) has parameter \$result with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-gateway-stripe.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe\:\:modify_successful_payment_result\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-gateway-stripe.php
 
@@ -3709,20 +3325,8 @@ parameters:
 			path: includes/class-wc-gateway-stripe.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-gateway-stripe.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe\:\:render_payment_intent_inputs\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-gateway-stripe.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe\:\:retry_after_error\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-gateway-stripe.php
 
@@ -3747,12 +3351,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe\:\:update_onboarding_settings\(\) has parameter \$settings with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-gateway-stripe.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe\:\:update_onboarding_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-gateway-stripe.php
 
@@ -4105,18 +3703,6 @@ parameters:
 			path: includes/class-wc-stripe-account.php
 
 		-
-			message: '#^Method WC_Stripe_Account\:\:get_cached_account_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-account.php
-
-		-
-			message: '#^Method WC_Stripe_Account\:\:read_account_from_cache\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-account.php
-
-		-
 			message: '#^Parameter \#1 \$json of function json_decode expects string, string\|false given\.$#'
 			identifier: argument.type
 			count: 1
@@ -4141,12 +3727,6 @@ parameters:
 			path: includes/class-wc-stripe-action-scheduler-service.php
 
 		-
-			message: '#^Method WC_Stripe_Action_Scheduler_Service\:\:schedule_job\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-action-scheduler-service.php
-
-		-
 			message: '#^Call to function method_exists\(\) with ''WCS_Staging'' and ''is_duplicate_site'' will always evaluate to false\.$#'
 			identifier: function.impossibleType
 			count: 1
@@ -4165,86 +3745,14 @@ parameters:
 			path: includes/class-wc-stripe-api.php
 
 		-
-			message: '#^Method WC_Stripe_API\:\:attach_payment_method_to_customer\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:detach_payment_method_from_customer\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
 			message: '#^Method WC_Stripe_API\:\:get_headers\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/class-wc-stripe-api.php
 
 		-
-			message: '#^Method WC_Stripe_API\:\:get_idempotency_key\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:get_payment_method_configurations\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:get_stripe_request_id\(\) has parameter \$response with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
 			message: '#^Method WC_Stripe_API\:\:get_user_agent\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:log_error_response\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:log_error_response\(\) has parameter \$response with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:request\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:request_with_level3_data\(\) has parameter \$level3_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:request_with_level3_data\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:request_with_level3_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-api.php
 
@@ -4279,18 +3787,6 @@ parameters:
 			path: includes/class-wc-stripe-api.php
 
 		-
-			message: '#^Method WC_Stripe_API\:\:update_payment_method\(\) has parameter \$payment_method_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:update_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
 			message: '#^Method WC_Stripe_API\:\:update_payment_method\(\) should return array but returns array\|stdClass\.$#'
 			identifier: return.type
 			count: 1
@@ -4305,12 +3801,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_API\:\:update_payment_method_configurations\(\) has parameter \$id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-api.php
-
-		-
-			message: '#^Method WC_Stripe_API\:\:update_payment_method_configurations\(\) has parameter \$payment_method_configurations with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-api.php
 
@@ -4345,12 +3835,6 @@ parameters:
 			path: includes/class-wc-stripe-apple-pay-registration.php
 
 		-
-			message: '#^Method WC_Stripe_Apple_Pay_Registration\:\:get_secret_key\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-apple-pay-registration.php
-
-		-
 			message: '#^Method WC_Stripe_Apple_Pay_Registration\:\:is_enabled\(\) should return string but returns bool\.$#'
 			identifier: return.type
 			count: 1
@@ -4371,18 +3855,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Apple_Pay_Registration\:\:register_domain_on_domain_name_change\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-apple-pay-registration.php
-
-		-
-			message: '#^Method WC_Stripe_Apple_Pay_Registration\:\:register_domain_on_updated_settings\(\) has parameter \$prev_settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-apple-pay-registration.php
-
-		-
-			message: '#^Method WC_Stripe_Apple_Pay_Registration\:\:register_domain_on_updated_settings\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-apple-pay-registration.php
 
@@ -4495,50 +3967,8 @@ parameters:
 			path: includes/class-wc-stripe-blocks-support.php
 
 		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:get_express_checkout_javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:get_gateway_javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:get_icons\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:get_payment_method_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:get_payment_method_script_handles\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
 			message: '#^Method WC_Stripe_Blocks_Support\:\:get_payment_request_javascript_params\(\) is unused\.$#'
 			identifier: method.unused
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:get_payment_request_javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:get_style\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-blocks-support.php
 
@@ -4551,12 +3981,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Blocks_Support\:\:initialize\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-blocks-support.php
-
-		-
-			message: '#^Method WC_Stripe_Blocks_Support\:\:is_upe_method_available\(\) has parameter \$available_gateways with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-blocks-support.php
 
@@ -4678,12 +4102,6 @@ parameters:
 			path: includes/class-wc-stripe-customer.php
 
 		-
-			message: '#^Method WC_Stripe_Customer\:\:create_customer\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
 			message: '#^Method WC_Stripe_Customer\:\:delete_id_from_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -4702,54 +4120,6 @@ parameters:
 			path: includes/class-wc-stripe-customer.php
 
 		-
-			message: '#^Method WC_Stripe_Customer\:\:generate_customer_request\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:generate_customer_request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:get_all_payment_methods\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:get_create_customer_required_fields\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:get_customer_preferred_locale\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:get_existing_customer\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:get_payment_methods\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:get_sources\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
 			message: '#^Method WC_Stripe_Customer\:\:get_user\(\) should return WP_User but returns WP_User\|false\.$#'
 			identifier: return.type
 			count: 1
@@ -4758,30 +4128,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Customer\:\:is_no_such_customer_error\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:is_no_such_customer_error\(\) has parameter \$error with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:is_source_already_attached_error\(\) has parameter \$error with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:map_customer_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:recreate_customer\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-customer.php
 
@@ -4834,32 +4180,14 @@ parameters:
 			path: includes/class-wc-stripe-customer.php
 
 		-
-			message: '#^Method WC_Stripe_Customer\:\:update_customer\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
 			message: '#^Method WC_Stripe_Customer\:\:update_id_in_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/class-wc-stripe-customer.php
 
 		-
-			message: '#^Method WC_Stripe_Customer\:\:update_or_create_customer\(\) has parameter \$args with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
 			message: '#^Method WC_Stripe_Customer\:\:validate_create_customer_request\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
-			message: '#^Method WC_Stripe_Customer\:\:validate_create_customer_request\(\) has parameter \$create_customer_request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-customer.php
 
@@ -4882,12 +4210,6 @@ parameters:
 			path: includes/class-wc-stripe-customer.php
 
 		-
-			message: '#^Property WC_Stripe_Customer\:\:\$customer_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-customer.php
-
-		-
 			message: '#^Property WC_Stripe_Customer\:\:\$id \(string\) does not accept array\|string\.$#'
 			identifier: assign.propertyType
 			count: 1
@@ -4900,80 +4222,14 @@ parameters:
 			path: includes/class-wc-stripe-database-cache-prefetch.php
 
 		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:delete_all_stale_entries\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:delete_all_stale_entries_async\(\) has parameter \$job_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:delete_stale_entries\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:get_expiry_time\(\) has parameter \$cache_contents with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:get_from_cache\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:is_expired\(\) has parameter \$cache_contents with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:maybe_trigger_prefetch\(\) has parameter \$cache_contents with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Method WC_Stripe_Database_Cache\:\:validate_stale_entries_async_job_data\(\) has parameter \$job_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
-			message: '#^Property WC_Stripe_Database_Cache\:\:\$in_memory_cache type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-database-cache.php
-
-		-
 			message: '#^Expected 3 @param tags, found 2\.$#'
 			identifier: paramTag.count
 			count: 1
 			path: includes/class-wc-stripe-feature-flags.php
 
 		-
-			message: '#^Method WC_Stripe_Feature_Flags\:\:get_all_feature_flags_with_defaults\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-feature-flags.php
-
-		-
 			message: '#^Method WC_Stripe_Feature_Flags\:\:is_oc_available\(\) should return bool but returns string\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/class-wc-stripe-feature-flags.php
-
-		-
-			message: '#^Property WC_Stripe_Feature_Flags\:\:\$feature_flags type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-feature-flags.php
 
@@ -5080,18 +4336,6 @@ parameters:
 			path: includes/class-wc-stripe-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Helper\:\:add_mandate_data\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:add_mandate_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Helper\:\:add_payment_intent_to_order\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -5110,26 +4354,8 @@ parameters:
 			path: includes/class-wc-stripe-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Helper\:\:add_payment_method_to_request_array\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:add_payment_method_to_request_array\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Helper\:\:add_stripe_methods_in_woocommerce_gateway_order\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:add_stripe_methods_in_woocommerce_gateway_order\(\) has parameter \$ordered_payment_method_ids with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-helper.php
 
@@ -5152,44 +4378,8 @@ parameters:
 			path: includes/class-wc-stripe-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Helper\:\:get_legacy_available_payment_method_ids\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:get_legacy_enabled_payment_method_ids\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:get_legacy_enabled_payment_methods\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Helper\:\:get_legacy_payment_method\(\) has parameter \$id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:get_legacy_payment_method_classes\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:get_legacy_payment_methods\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:get_localized_messages\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-helper.php
 
@@ -5248,20 +4438,8 @@ parameters:
 			path: includes/class-wc-stripe-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Helper\:\:get_stripe_gateway_ids\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Helper\:\:get_stripe_net\(\) should return string but returns false\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:get_stripe_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-helper.php
 
@@ -5278,26 +4456,8 @@ parameters:
 			path: includes/class-wc-stripe-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Helper\:\:has_gateway_plugin_active\(\) has parameter \$available_payment_gateways with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Helper\:\:is_stripe_gateway_order\(\) has parameter \$order with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:no_decimal_currencies\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Helper\:\:three_decimal_currencies\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-helper.php
 
@@ -5358,12 +4518,6 @@ parameters:
 		-
 			message: '#^Parameter \#3 \$subject of function str_replace expects array\<string\>\|string, string\|null given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/class-wc-stripe-helper.php
-
-		-
-			message: '#^Property WC_Stripe_Helper\:\:\$stripe_legacy_gateways type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-helper.php
 
@@ -5494,38 +4648,14 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:build_base_payment_intent_request_params\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:build_base_payment_intent_request_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:confirm_change_payment_from_setup_intent_ajax\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:create_and_confirm_payment_intent\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:create_and_confirm_payment_intent\(\) should return stdClass but returns array\|stdClass\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:create_and_confirm_setup_intent\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
@@ -5538,12 +4668,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:create_and_confirm_setup_intent_ajax\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:create_payment_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
@@ -5578,20 +4702,8 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:init_setup_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:init_setup_intent_ajax\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:is_delayed_confirmation_required\(\) has parameter \$payment_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
@@ -5602,38 +4714,8 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:maybe_add_mandate_options\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:maybe_add_mandate_options\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:maybe_process_upe_redirect\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:request_needs_redirection\(\) has parameter \$payment_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:update_and_confirm_payment_intent\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:update_and_confirm_payment_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
@@ -5650,12 +4732,6 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:update_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:update_order_status_ajax\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -5664,30 +4740,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Intent_Controller\:\:update_payment_intent_ajax\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:validate_payment_intent_required_params\(\) has parameter \$instance_params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:validate_payment_intent_required_params\(\) has parameter \$non_empty_params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:validate_payment_intent_required_params\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-intent-controller.php
-
-		-
-			message: '#^Method WC_Stripe_Intent_Controller\:\:validate_payment_intent_required_params\(\) has parameter \$required_params with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-intent-controller.php
 
@@ -5836,42 +4888,6 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Logger\:\:alert\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:critical\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:debug\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:emergency\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:error\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:info\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
 			message: '#^Method WC_Stripe_Logger\:\:log\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -5892,18 +4908,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Logger\:\:log\(\) has parameter \$start_time with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:notice\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:warning\(\) has parameter \$context with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-logger.php
 
@@ -6334,12 +5338,6 @@ parameters:
 			path: includes/class-wc-stripe-order-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Order_Helper\:\:update_stripe_multibanco_data\(\) has parameter \$multibanco_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-order-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Order_Helper\:\:update_stripe_net\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -6394,44 +5392,8 @@ parameters:
 			path: includes/class-wc-stripe-payment-method-configurations.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:get_fallback_payment_method_configuration\(\) has parameter \$payment_method_configurations with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:get_fallback_payment_method_configuration\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:get_upe_available_payment_method_ids\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:get_upe_enabled_payment_method_ids\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:maybe_migrate_payment_methods_from_db_to_pmc\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:record_payment_method_settings_event\(\) has parameter \$disabled_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:record_payment_method_settings_event\(\) has parameter \$enabled_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-payment-method-configurations.php
 
@@ -6442,26 +5404,8 @@ parameters:
 			path: includes/class-wc-stripe-payment-method-configurations.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:set_payment_method_configuration_cache\(\) has parameter \$configuration with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:update_payment_method_configuration\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:update_payment_method_configuration\(\) has parameter \$available_payment_method_ids with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Method_Configurations\:\:update_payment_method_configuration\(\) has parameter \$enabled_payment_method_ids with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-payment-method-configurations.php
 
@@ -6474,12 +5418,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Status\:\:debug_tools\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-status.php
-
-		-
-			message: '#^Method WC_Stripe_Status\:\:debug_tools\(\) has parameter \$tools with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-status.php
 
@@ -6784,12 +5722,6 @@ parameters:
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
-			message: '#^Method WC_Stripe_Webhook_Handler\:\:defer_webhook_processing\(\) has parameter \$additional_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
 			message: '#^Method WC_Stripe_Webhook_Handler\:\:get_order_from_intent\(\) should return WC_Order\|false but returns WC_Order\|WC_Order_Refund\|true\.$#'
 			identifier: return.type
 			count: 2
@@ -6852,12 +5784,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Webhook_Handler\:\:process_deferred_webhook\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_Handler\:\:process_deferred_webhook\(\) has parameter \$additional_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe-webhook-handler.php
 
@@ -6952,18 +5878,6 @@ parameters:
 			path: includes/class-wc-stripe-webhook-handler.php
 
 		-
-			message: '#^Method WC_Stripe_Webhook_Handler\:\:validate_request\(\) has parameter \$request_body with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Webhook_Handler\:\:validate_request\(\) has parameter \$request_headers with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-webhook-handler.php
-
-		-
 			message: '#^Parameter \#1 \$intent of method WC_Stripe_Payment_Gateway\:\:get_latest_charge_from_intent\(\) expects object, obect\|true given\.$#'
 			identifier: argument.type
 			count: 1
@@ -7054,12 +5968,6 @@ parameters:
 			path: includes/class-wc-stripe-webhook-state.php
 
 		-
-			message: '#^Method WC_Stripe_Webhook_State\:\:get_configured_webhook_urls\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe-webhook-state.php
-
-		-
 			message: '#^Method WC_Stripe_Webhook_State\:\:set_last_error_reason\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7144,18 +6052,6 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
-			message: '#^Method WC_Stripe\:\:checkout_update_email_field_priority\(\) has parameter \$fields with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:checkout_update_email_field_priority\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
 			message: '#^Method WC_Stripe\:\:disable_upe\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7188,24 +6084,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe\:\:filter_gateway_order_admin\(\) has parameter \$sections with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:gateway_settings_update\(\) has parameter \$old_settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:gateway_settings_update\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:gateway_settings_update\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe.php
 
@@ -7246,48 +6124,6 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
-			message: '#^Method WC_Stripe\:\:maybe_deactivate_amazon_pay\(\) has parameter \$enabled_payment_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:maybe_deactivate_amazon_pay\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:maybe_deactivate_bnpls\(\) has parameter \$available_payment_gateways with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:maybe_deactivate_bnpls\(\) has parameter \$enabled_payment_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:maybe_deactivate_bnpls\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:maybe_reset_stripe_in_memory_key\(\) has parameter \$old_settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:maybe_reset_stripe_in_memory_key\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
 			message: '#^Method WC_Stripe\:\:migrate_to_new_checkout_experience\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7306,38 +6142,8 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
-			message: '#^Method WC_Stripe\:\:plugin_row_meta\(\) has parameter \$links with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:plugin_row_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
 			message: '#^Method WC_Stripe\:\:register_routes\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:toggle_upe\(\) has parameter \$old_settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:toggle_upe\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/class-wc-stripe.php
-
-		-
-			message: '#^Method WC_Stripe\:\:toggle_upe\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/class-wc-stripe.php
 
@@ -7408,12 +6214,6 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
-			message: '#^Method WC_Stripe_Email_Admin_Failed_Refund\:\:get_template_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-email-admin-failed-refund.php
-
-		-
 			message: '#^Method WC_Stripe_Email_Admin_Failed_Refund\:\:trigger\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -7428,12 +6228,6 @@ parameters:
 		-
 			message: '#^Cannot access property \$billing_email on WC_Order\|false\.$#'
 			identifier: property.nonObject
-			count: 1
-			path: includes/compat/class-wc-stripe-email-customer-failed-refund.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Customer_Failed_Refund\:\:get_template_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/compat/class-wc-stripe-email-customer-failed-refund.php
 
@@ -7606,40 +6400,10 @@ parameters:
 			path: includes/compat/class-wc-stripe-email-failed-refund.php
 
 		-
-			message: '#^Method WC_Stripe_Email_Failed_Refund\:\:get_template_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-refund.php
-
-		-
 			message: '#^Method WC_Stripe_Email_Failed_Refund\:\:trigger\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/compat/class-wc-stripe-email-failed-refund.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Renewal_Authentication\:\:prevent_retry_notification_email\(\) has parameter \$rule_array with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Renewal_Authentication\:\:prevent_retry_notification_email\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Renewal_Authentication\:\:set_store_owner_custom_email\(\) has parameter \$rule_array with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Renewal_Authentication\:\:set_store_owner_custom_email\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
 
 		-
 			message: '#^Method WC_Stripe_Email_Failed_Renewal_Authentication\:\:trigger\(\) has no return type specified\.$#'
@@ -7716,24 +6480,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Subscriptions_Helper\:\:build_subscriptions_detached_messages\(\) has parameter \$subscriptions with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/compat/class-wc-stripe-subscriptions-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Helper\:\:get_detached_payment_data_from_subscription\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-subscriptions-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Helper\:\:get_detached_subscriptions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/compat/class-wc-stripe-subscriptions-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Helper\:\:get_some_detached_subscriptions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/compat/class-wc-stripe-subscriptions-helper.php
 
@@ -7852,62 +6598,14 @@ parameters:
 			path: includes/compat/class-wc-stripe-subscriptions-legacy-sepa-token-update.php
 
 		-
-			message: '#^Method WC_Stripe_Connect_API\:\:get_stripe_oauth_init\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_API\:\:get_stripe_oauth_keys\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
 			message: '#^Method WC_Stripe_Connect_API\:\:get_stripe_oauth_keys\(\) should return array but returns array\|WP_Error\.$#'
 			identifier: return.type
 			count: 2
 			path: includes/connect/class-wc-stripe-connect-api.php
 
 		-
-			message: '#^Method WC_Stripe_Connect_API\:\:refresh_stripe_app_oauth_keys\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
 			message: '#^Method WC_Stripe_Connect_API\:\:refresh_stripe_app_oauth_keys\(\) should return array but returns array\|WP_Error\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_API\:\:request\(\) has parameter \$body with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_API\:\:request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_API\:\:request_body\(\) has parameter \$initial_body with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_API\:\:request_body\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect-api.php
-
-		-
-			message: '#^Method WC_Stripe_Connect_API\:\:request_headers\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/connect/class-wc-stripe-connect-api.php
 
@@ -8008,18 +6706,6 @@ parameters:
 			path: includes/connect/class-wc-stripe-connect.php
 
 		-
-			message: '#^Method WC_Stripe_Connect\:\:redact_sensitive_data\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect.php
-
-		-
-			message: '#^Method WC_Stripe_Connect\:\:redact_sensitive_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/connect/class-wc-stripe-connect.php
-
-		-
 			message: '#^Method WC_Stripe_Connect\:\:redact_sensitive_data\(\) should return array\|string but returns string\|null\.$#'
 			identifier: return.type
 			count: 1
@@ -8098,34 +6784,10 @@ parameters:
 			path: includes/connect/class-wc-stripe-connect.php
 
 		-
-			message: '#^Constant WC_Stripe_Intent_Status\:\:SUCCESSFUL_STATUSES type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
+			message: '#^Constant WC_STRIPE_PLUGIN_PATH not found\.$#'
+			identifier: constant.notFound
 			count: 1
-			path: includes/constants/class-wc-stripe-intent-status.php
-
-		-
-			message: '#^Constant WC_Stripe_Payment_Methods\:\:BNPL_PAYMENT_METHODS type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/constants/class-wc-stripe-payment-methods.php
-
-		-
-			message: '#^Constant WC_Stripe_Payment_Methods\:\:EXPRESS_PAYMENT_METHODS type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/constants/class-wc-stripe-payment-methods.php
-
-		-
-			message: '#^Constant WC_Stripe_Payment_Methods\:\:VOUCHER_PAYMENT_METHODS type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/constants/class-wc-stripe-payment-methods.php
-
-		-
-			message: '#^Constant WC_Stripe_Payment_Methods\:\:WALLET_PAYMENT_METHODS type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/constants/class-wc-stripe-payment-methods.php
+			path: includes/constants/class-wc-stripe-payment-request-button-states.php
 
 		-
 			message: '#^Method WC_Stripe_Apple_Pay\:\:__call\(\) has no return type specified\.$#'
@@ -8278,18 +6940,6 @@ parameters:
 			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
 
 		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:add_debug_tool\(\) has parameter \$tools with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:add_debug_tool\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
 			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:display_admin_notice\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8298,12 +6948,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:get_items_to_repair\(\) should return array\<int\> but returns array\<WC_Order\>\|stdClass\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:get_scheduled_action_counts\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
 
@@ -8614,12 +7258,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Alipay\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Alipay\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8640,12 +7278,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Alipay\:\:process_payment\(\) has parameter \$force_save_save with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Alipay\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
 
@@ -8676,12 +7308,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, float\|int given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
-
-		-
-			message: '#^Property WC_Gateway_Stripe_Alipay\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-alipay.php
 
@@ -8752,12 +7378,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Bancontact\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Bancontact\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8772,12 +7392,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Bancontact\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Bancontact\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
 
@@ -8806,12 +7420,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
 
 		-
-			message: '#^Property WC_Gateway_Stripe_Bancontact\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-bancontact.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Boleto\:\:add_allowed_payment_processing_statuses\(\) has parameter \$allowed_statuses with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -8824,24 +7432,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Boleto\:\:get_confirm_payment_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Boleto\:\:get_unique_settings\(\) has parameter \$settings with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Boleto\:\:get_unique_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Boleto\:\:payment_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -8850,18 +7440,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Boleto\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Boleto\:\:update_request_body_on_create_or_update_payment_intent\(\) has parameter \$body with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Boleto\:\:update_request_body_on_create_or_update_payment_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
 
@@ -8902,12 +7480,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
 
 		-
-			message: '#^Property WC_Gateway_Stripe_Boleto\:\:\$supported_currencies type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-boleto.php
-
-		-
 			message: '#^Access to an undefined property WC_Cart\:\:\$total\.$#'
 			identifier: property.notFound
 			count: 1
@@ -8986,12 +7558,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Eps\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Eps\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -9006,12 +7572,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Eps\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Eps\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
 
@@ -9040,12 +7600,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
 
 		-
-			message: '#^Property WC_Gateway_Stripe_Eps\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-eps.php
-
-		-
 			message: '#^Access to an undefined property WC_Cart\:\:\$total\.$#'
 			identifier: property.notFound
 			count: 1
@@ -9124,12 +7678,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Giropay\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Giropay\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -9144,12 +7692,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Giropay\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Giropay\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
 
@@ -9178,12 +7720,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
 
 		-
-			message: '#^Property WC_Gateway_Stripe_Giropay\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-giropay.php
-
-		-
 			message: '#^Access to an undefined property WC_Cart\:\:\$total\.$#'
 			identifier: property.notFound
 			count: 1
@@ -9262,12 +7798,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Ideal\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Ideal\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -9282,12 +7812,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Ideal\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Ideal\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
 
@@ -9312,12 +7836,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, float\|int given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
-
-		-
-			message: '#^Property WC_Gateway_Stripe_Ideal\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-ideal.php
 
@@ -9454,12 +7972,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Multibanco\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Multibanco\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -9474,12 +7986,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Multibanco\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Multibanco\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
 
@@ -9526,12 +8032,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
 
 		-
-			message: '#^Property WC_Gateway_Stripe_Multibanco\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-multibanco.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Oxxo\:\:add_allowed_payment_processing_statuses\(\) has parameter \$allowed_statuses with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -9540,12 +8040,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Oxxo\:\:add_allowed_payment_processing_statuses\(\) has parameter \$order with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-oxxo.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Oxxo\:\:get_confirm_payment_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-oxxo.php
 
@@ -9582,12 +8076,6 @@ parameters:
 		-
 			message: '#^Property WC_Gateway_Stripe_Oxxo\:\:\$supported_countries has no type specified\.$#'
 			identifier: missingType.property
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-oxxo.php
-
-		-
-			message: '#^Property WC_Gateway_Stripe_Oxxo\:\:\$supported_currencies type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-oxxo.php
 
@@ -9670,12 +8158,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_P24\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_P24\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -9694,12 +8176,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_P24\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
-
-		-
 			message: '#^PHPDoc tag @extends has invalid value \(WC_Gateway_Stripe\)\: Unexpected token "\\n \*", expected ''\<'' at offset 78 on line 4$#'
 			identifier: phpDoc.parseError
 			count: 1
@@ -9714,12 +8190,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, float\|int given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
-
-		-
-			message: '#^Property WC_Gateway_Stripe_P24\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-p24.php
 
@@ -9808,12 +8278,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Sepa\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Sepa\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -9834,12 +8298,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Sepa\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Sepa\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
 
@@ -9900,12 +8358,6 @@ parameters:
 		-
 			message: '#^Parameter \#2 \$source of method WC_Stripe_Payment_Gateway\:\:save_source_to_order\(\) expects stdClass, object given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
-
-		-
-			message: '#^Property WC_Gateway_Stripe_Sepa\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-sepa.php
 
@@ -9994,12 +8446,6 @@ parameters:
 			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
 
 		-
-			message: '#^Method WC_Gateway_Stripe_Sofort\:\:get_supported_currency\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
-
-		-
 			message: '#^Method WC_Gateway_Stripe_Sofort\:\:init_form_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -10014,12 +8460,6 @@ parameters:
 		-
 			message: '#^Method WC_Gateway_Stripe_Sofort\:\:payment_scripts\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
-
-		-
-			message: '#^Method WC_Gateway_Stripe_Sofort\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
 
@@ -10044,12 +8484,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$text of function esc_attr expects string, float\|int given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
-
-		-
-			message: '#^Property WC_Gateway_Stripe_Sofort\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-gateway-stripe-sofort.php
 
@@ -10126,12 +8560,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Ajax_Handler\:\:ajax_add_to_cart\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Ajax_Handler\:\:ajax_clear_cart\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -10140,12 +8568,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Express_Checkout_Ajax_Handler\:\:ajax_get_cart_details\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Ajax_Handler\:\:ajax_get_selected_product_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
 
@@ -10176,18 +8598,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Express_Checkout_Ajax_Handler\:\:ajax_update_shipping_method\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Ajax_Handler\:\:modify_country_locale_for_express_checkout\(\) has parameter \$locale with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Ajax_Handler\:\:modify_country_locale_for_express_checkout\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
 
@@ -10264,32 +8674,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Custom_Fields\:\:get_custom_checkout_data_from_request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Custom_Fields\:\:get_custom_checkout_data_schema\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Custom_Fields\:\:get_custom_checkout_fields\(\) has parameter \$context with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Custom_Fields\:\:get_custom_checkout_fields\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Custom_Fields\:\:get_standard_checkout_fields\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-custom-fields.php
 
@@ -10372,12 +8758,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Element\:\:add_order_meta\(\) has parameter \$posted_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Element\:\:display_express_checkout_button_html\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -10402,12 +8782,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Element\:\:get_asset_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Element\:\:handle_express_checkout_redirect\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -10416,12 +8790,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Express_Checkout_Element\:\:instance\(\) has invalid return type class\.$#'
 			identifier: class.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Element\:\:javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-element.php
 
@@ -10678,42 +9046,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:calculate_shipping\(\) has parameter \$address with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:fix_address_fields_mapping\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:fix_address_fields_mapping\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_booking_ids_from_cart\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_button_locations\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_button_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_checkout_data\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -10722,18 +9054,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_default_shipping_option\(\) never returns void so it can be removed from the return type\.$#'
 			identifier: return.unusedType
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_default_shipping_option\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_login_confirmation_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
@@ -10774,24 +9094,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_shipping_options\(\) has parameter \$shipping_address with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_shipping_options\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:get_taxes_like_cart\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:has_pre_order_charged_upon_release\(\) has parameter \$order with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -10822,50 +9124,14 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:maybe_restore_recurring_chosen_shipping_methods\(\) has parameter \$previous_chosen_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:normalize_state\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:normalize_state\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:process_pre_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:remove_order_source_before_retry\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:supported_product_types\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
 			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:update_shipping_method\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Method WC_Stripe_Express_Checkout_Helper\:\:update_shipping_method\(\) has parameter \$shipping_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
@@ -11242,18 +9508,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:add_order_meta\(\) has parameter \$posted_data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:ajax_add_to_cart\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:ajax_clear_cart\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -11268,12 +9522,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:ajax_get_cart_details\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:ajax_get_selected_product_data\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
@@ -11326,12 +9574,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:calculate_shipping\(\) has parameter \$address with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:display_payment_request_button_html\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -11374,18 +9616,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:get_button_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:get_login_confirmation_settings\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:get_login_confirmation_settings\(\) should return array but returns false\.$#'
 			identifier: return.type
 			count: 1
@@ -11422,18 +9652,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:get_shipping_options\(\) has parameter \$shipping_address with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:get_shipping_options\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:handle_payment_request_redirect\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -11458,12 +9676,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:mark_order_as_pre_ordered\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -11482,12 +9694,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:maybe_restore_recurring_chosen_shipping_methods\(\) has parameter \$previous_chosen_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:migrate_button_size\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -11496,12 +9702,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:normalize_state\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:process_pre_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
@@ -11518,20 +9718,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:supported_product_types\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Request\:\:update_shipping_method\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-payment-request.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Request\:\:update_shipping_method\(\) has parameter \$shipping_methods with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-payment-request.php
 
@@ -12082,24 +10270,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:add_bnpl_debug_metadata\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:add_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:can_refund_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:clear_appearance_transients\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -12142,36 +10312,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:filter_my_account_my_orders_actions\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:filter_saved_payment_methods_list\(\) has parameter \$list with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:filter_saved_payment_methods_list\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:generate_upe_checkout_experience_accepted_payments_html\(\) has parameter \$data with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_address_data_for_payment_request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_appearance_transient_key\(\) never returns array so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
@@ -12184,38 +10324,14 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_appearance_transient_key\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_appearance_transient_key\(\) should return array\|null but returns string\.$#'
 			identifier: return.type
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_enabled_payment_method_config\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_existing_compatible_payment_intent\(\) has parameter \$payment_method_types with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_existing_compatible_payment_intent\(\) should return object\|null but returns obect\|true\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_metadata_from_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
@@ -12234,12 +10350,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_payment_method_options\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_payment_method_types_for_intent_creation\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
@@ -12280,12 +10390,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:handle_process_payment_error\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:handle_saving_payment_method\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -12300,12 +10404,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:is_setup_intent_success_creation_redirection\(\) should return bool but returns int\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:javascript_params\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
@@ -12334,50 +10432,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:prepare_payment_information_for_confirmation_token\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:prepare_payment_information_for_confirmation_token\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:prepare_payment_information_for_payment_method\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:prepare_payment_information_for_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:prepare_payment_information_from_request\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_order_for_confirmed_intent\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_payment_intent_for_order\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
@@ -12394,44 +10450,14 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_payment_with_confirmation_token\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_payment_with_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_payment_with_saved_payment_method\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_setup_intent_for_order\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:process_upe_redirect_payment\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:retry_after_error\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
@@ -12510,12 +10536,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:validate_selected_payment_method_type\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:validate_selected_payment_method_type\(\) has parameter \$payment_information with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
@@ -12994,12 +11014,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Property WC_Stripe_UPE_Payment_Gateway\:\:\$notices type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Property WooCommerce\:\:\$cart \(WC_Cart\) in isset\(\) is not nullable\.$#'
 			identifier: isset.property
 			count: 1
@@ -13426,30 +11440,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -13540,20 +11530,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -13602,12 +11580,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACH\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ach.php
 
@@ -14104,30 +12076,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -14218,20 +12166,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -14280,12 +12216,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_ACSS\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-acss.php
 
@@ -14366,18 +12296,6 @@ parameters:
 			identifier: constant.notFound
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay\:\:get_title\(\) has parameter \$payment_details with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Alipay\:\:get_supported_currencies\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-alipay.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$acss_debit\.$#'
@@ -14800,30 +12718,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -14878,12 +12772,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:get_supported_currencies\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:handle_add_payment_method_success\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -14920,20 +12808,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -14982,12 +12858,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Amazon_Pay\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
 
@@ -15490,30 +13360,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -15604,20 +13450,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
@@ -15666,12 +13500,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bacs_Debit\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bacs-debit.php
 
@@ -16156,30 +13984,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -16270,20 +14074,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -16332,12 +14124,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Bancontact\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-bancontact.php
 
@@ -16822,30 +14608,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -16936,20 +14698,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -16998,12 +14748,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Becs_Debit\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
 
@@ -17084,12 +14828,6 @@ parameters:
 			identifier: method.childReturnType
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-becs-debit.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_BLIK\:\:get_available_billing_countries\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-blik.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_BLIK\:\:get_retrievable_type\(\) has no return type specified\.$#'
@@ -17560,30 +15298,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -17668,20 +15382,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -17730,12 +15432,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Cash_App_Pay\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cash-app-pay.php
 
@@ -18226,30 +15922,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -18310,12 +15982,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:get_title\(\) has parameter \$payment_details with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:handle_add_payment_method_success\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -18352,20 +16018,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -18414,12 +16068,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_CC\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-cc.php
 
@@ -18922,30 +16570,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -19036,20 +16660,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -19098,12 +16710,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Ideal\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-ideal.php
 
@@ -19588,30 +17194,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -19654,20 +17236,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:get_available_billing_countries\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:get_mandate_for_subscription\(\) has parameter \$payment_method with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:get_supported_currencies\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -19708,20 +17278,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -19770,12 +17328,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Klarna\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-klarna.php
 
@@ -20392,30 +17944,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -20476,12 +18004,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:get_title\(\) has parameter \$payment_details with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:handle_add_payment_method_success\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -20518,20 +18040,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
@@ -20580,12 +18090,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_OC\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-oc.php
 
@@ -21100,30 +18604,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -21220,20 +18700,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -21282,12 +18750,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sepa\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sepa.php
 
@@ -21778,30 +19240,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:add_subscription_information_to_intent\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:add_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:add_subscription_payment_meta\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:create_mandate_options_for_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:delete_renewal_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -21886,20 +19324,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:process_change_subscription_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:process_change_subscription_payment_method\(\) should return array\|null but return statement is missing\.$#'
 			identifier: return.missing
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:process_change_subscription_payment_with_deferred_intent\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
@@ -21948,12 +19374,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:validate_subscription_payment_meta\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Sofort\:\:validate_subscription_payment_meta\(\) has parameter \$payment_meta with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
 
@@ -22022,12 +19442,6 @@ parameters:
 			identifier: isset.property
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-sofort.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Wechat_Pay\:\:get_supported_currencies\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-wechat-pay.php
 
 		-
 			message: '#^Access to an undefined property object\:\:\$id\.$#'
@@ -22102,26 +19516,8 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:__call\(\) has parameter \$arguments with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:add_payment_method\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:can_refund_via_stripe\(\) should return bool but returns array\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:get_available_billing_countries\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
@@ -22156,18 +19552,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:get_supported_currencies\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:get_title\(\) has parameter \$payment_details with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:get_woocommerce_currency\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -22194,18 +19578,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:payment_fields\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:process_payment\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method\:\:process_pre_order\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
@@ -22252,18 +19624,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
 
 		-
-			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$can_refund type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
-			message: '#^Property WC_Stripe_UPE_Payment_Method\:\:\$supported_currencies type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method.php
-
-		-
 			message: '#^Variable \$order might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -22300,12 +19660,6 @@ parameters:
 			path: includes/payment-tokens/class-wc-stripe-ach-payment-token.php
 
 		-
-			message: '#^Property WC_Payment_Token_ACH\:\:\$extra_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-ach-payment-token.php
-
-		-
 			message: '#^Access to an undefined property object\:\:\$type\.$#'
 			identifier: property.notFound
 			count: 1
@@ -22336,12 +19690,6 @@ parameters:
 			path: includes/payment-tokens/class-wc-stripe-acss-payment-token.php
 
 		-
-			message: '#^Property WC_Payment_Token_ACSS\:\:\$extra_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-acss-payment-token.php
-
-		-
 			message: '#^Access to an undefined property object\:\:\$type\.$#'
 			identifier: property.notFound
 			count: 1
@@ -22350,12 +19698,6 @@ parameters:
 		-
 			message: '#^Method WC_Payment_Token_Amazon_Pay\:\:set_email\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-amazon-pay-payment-token.php
-
-		-
-			message: '#^Property WC_Payment_Token_Amazon_Pay\:\:\$extra_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-tokens/class-wc-stripe-amazon-pay-payment-token.php
 
@@ -22384,12 +19726,6 @@ parameters:
 			path: includes/payment-tokens/class-wc-stripe-bacs-payment-token.php
 
 		-
-			message: '#^Property WC_Payment_Token_Bacs_Debit\:\:\$extra_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-bacs-payment-token.php
-
-		-
 			message: '#^Access to an undefined property object\:\:\$type\.$#'
 			identifier: property.notFound
 			count: 1
@@ -22404,12 +19740,6 @@ parameters:
 		-
 			message: '#^Method WC_Payment_Token_Becs_Debit\:\:set_last4\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-becs-debit-payment-token.php
-
-		-
-			message: '#^Property WC_Payment_Token_Becs_Debit\:\:\$extra_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-tokens/class-wc-stripe-becs-debit-payment-token.php
 
@@ -22482,12 +19812,6 @@ parameters:
 		-
 			message: '#^Method WC_Payment_Token_Link\:\:set_payment_method_type\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-link-payment-token.php
-
-		-
-			message: '#^Property WC_Payment_Token_Link\:\:\$extra_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-tokens/class-wc-stripe-link-payment-token.php
 
@@ -22600,36 +19924,6 @@ parameters:
 			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:add_token_to_user\(\) has parameter \$payment_method_ids with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:get_account_saved_payment_methods_list_item\(\) has parameter \$item with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:get_account_saved_payment_methods_list_item\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:get_account_saved_payment_methods_list_item_sepa\(\) has parameter \$item with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:get_account_saved_payment_methods_list_item_sepa\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Tokens\:\:get_duplicate_token\(\) has parameter \$gateway_id with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1
@@ -22654,26 +19948,8 @@ parameters:
 			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
 
 		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:get_token_from_request\(\) has parameter \$request with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
 			message: '#^Method WC_Stripe_Payment_Tokens\:\:update_token_from_method_details\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:woocommerce_get_customer_payment_tokens\(\) has parameter \$tokens with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:woocommerce_get_customer_payment_tokens\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
 
@@ -22686,30 +19962,6 @@ parameters:
 		-
 			message: '#^Method WC_Stripe_Payment_Tokens\:\:woocommerce_get_customer_payment_tokens_legacy\(\) has parameter \$gateway_id with no type specified\.$#'
 			identifier: missingType.parameter
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:woocommerce_get_customer_payment_tokens_legacy\(\) has parameter \$tokens with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:woocommerce_get_customer_payment_tokens_legacy\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:woocommerce_get_customer_upe_payment_tokens\(\) has parameter \$tokens with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Payment_Tokens\:\:woocommerce_get_customer_upe_payment_tokens\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-tokens/class-wc-stripe-payment-tokens.php
 
@@ -22776,12 +20028,6 @@ parameters:
 		-
 			message: '#^Method WC_Payment_Token_SEPA\:\:set_payment_method_type\(\) has no return type specified\.$#'
 			identifier: missingType.return
-			count: 1
-			path: includes/payment-tokens/class-wc-stripe-sepa-payment-token.php
-
-		-
-			message: '#^Property WC_Payment_Token_SEPA\:\:\$extra_data type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
 			count: 1
 			path: includes/payment-tokens/class-wc-stripe-sepa-payment-token.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,6 @@ parameters:
 	treatPhpDocTypesAsCertain: false
 	parallel:
 		maximumNumberOfProcesses: 4
+	ignoreErrors:
+		-
+			identifier: missingType.iterableValue


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR adds `missingType.iterableValue` errors to the list of errors that we want PHPStan to ignore completely. Loosely typed arrays are _everywhere_in WordPress and WooCommerce, so it feels like requiring typed arrays is overkill (at least for now). The PR also updates our PHPStan baseline file with the new configuration.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Code review. Confirm that PHPStan analysis passes.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a pretty limited change to our PHPStan configuration, which is not really relevant to anyone outside the development team.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
