### PR TITLE
Update AfterPay limits

### DIFF
--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-afterpay-clearpay.php
@@ -37,8 +37,8 @@ class WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay extends WC_Stripe_UPE_Payme
 			WC_Stripe_Currency_Code::AUSTRALIAN_DOLLAR    => [
 				'AU' => [
 					'min' => 100,
-					'max' => 200000,
-				], // Represents AUD 1 - 2,000 AUD.
+					'max' => 400000,
+				], // Represents AUD 1 - 4,000 AUD.
 			],
 			WC_Stripe_Currency_Code::CANADIAN_DOLLAR      => [
 				'CA' => [
@@ -49,8 +49,8 @@ class WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay extends WC_Stripe_UPE_Payme
 			WC_Stripe_Currency_Code::NEW_ZEALAND_DOLLAR   => [
 				'NZ' => [
 					'min' => 100,
-					'max' => 200000,
-				], // Represents NZD 1 - 2,000 NZD.
+					'max' => 400000,
+				], // Represents NZD 1 - 4,000 NZD.
 			],
 			WC_Stripe_Currency_Code::POUND_STERLING       => [
 				'GB' => [


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Australia and New Zealand AfterPay now supports up to $4,000 ([source](https://docs.stripe.com/payments/afterpay-clearpay#collection-schedule)).

I couldn't find existing tests for these limits, so no updates to test.

## Testing instructions

Unsure if testing is needed.

If it is:
1. Enable AfterPay within Stripe
2. Within WooCommerce for Stripe settings, enable AfterPay
3. Create a cart with more than AUD$2,000 or NZD$2,000 but not exceeding AUD$4,000 or NZD$4,000
4. Go to checkout
5. Ensure AfterPay shows as an option

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
