### PR TITLE
Make changelog entrries consistent

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,17 +4,17 @@
 * Update - Increase Afterpay/Clearpay maximum transaction amount to 4,000 AUD and 4,000 NZD
 * Dev - Require milestones to be set on pull requests
 * Update - Remove legacy checkout payment method classes
-* Dev - Renames the express checkout frontend main setting key
-* Update - Deprecates and replaces Payment Request Button classes with Express Checkout equivalents
-* Dev - Renames the express checkout customization route
-* Dev - Renames all express checkout related frontend hooks
-* Dev - Removes deprecated legacy checkout settings retrieval methods
-* Dev - Removes all references to the UPE-enabled feature flag
-* Dev - Removes deprecated promotional banners (related to legacy checkout)
+* Dev - Rename the express checkout frontend main setting key
+* Update - Deprecate and replace Payment Request Button classes with Express Checkout equivalents
+* Dev - Rename the express checkout customization route
+* Dev - Rename all express checkout related frontend hooks
+* Dev - Remove deprecated legacy checkout settings retrieval methods
+* Dev - Remove all references to the UPE-enabled feature flag
+* Dev - Remove deprecated promotional banners (related to legacy checkout)
 * Fix - Error when using Puerto Rico addresses with express checkouts
 * Tweak - Improve error messages when Stripe API requests fail to better distinguish between request and retrieval errors
 * Fix - Resolve Level3 data validation error caused by rounding precision when shipping rates have 3+ decimal places
-* Tweak - Changes BLIK confirmation webhook processing from deferred to immediate
+* Tweak - Change BLIK confirmation webhook processing from deferred to immediate
 * Fix - Preserve express checkout button location settings when upgrading from older plugin versions
 * Fix - Fix some initialization bugs for reconnections
 * Fix - Update Ukraine state mapping list

--- a/readme.txt
+++ b/readme.txt
@@ -144,7 +144,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Require milestones to be set on pull requests
 * Update - Remove legacy checkout payment method classes
 * Dev - Rename the express checkout frontend main setting key
-* Update - Deprecate and replaces Payment Request Button classes with Express Checkout equivalents
+* Update - Deprecate and replace Payment Request Button classes with Express Checkout equivalents
 * Dev - Rename the express checkout customization route
 * Dev - Rename all express checkout related frontend hooks
 * Dev - Remove deprecated legacy checkout settings retrieval methods

--- a/readme.txt
+++ b/readme.txt
@@ -143,17 +143,17 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Increase Afterpay/Clearpay maximum transaction amount to 4,000 AUD and 4,000 NZD
 * Dev - Require milestones to be set on pull requests
 * Update - Remove legacy checkout payment method classes
-* Dev - Renames the express checkout frontend main setting key
-* Update - Deprecates and replaces Payment Request Button classes with Express Checkout equivalents
-* Dev - Renames the express checkout customization route
-* Dev - Renames all express checkout related frontend hooks
-* Dev - Removes deprecated legacy checkout settings retrieval methods
+* Dev - Rename the express checkout frontend main setting key
+* Update - Deprecate and replaces Payment Request Button classes with Express Checkout equivalents
+* Dev - Rename the express checkout customization route
+* Dev - Rename all express checkout related frontend hooks
+* Dev - Remove deprecated legacy checkout settings retrieval methods
 * Fix - Error when using Puerto Rico addresses with express checkouts
-* Dev - Removes all references to the UPE-enabled feature flag
-* Dev - Removes deprecated promotional banners (related to legacy checkout)
+* Dev - Remove all references to the UPE-enabled feature flag
+* Dev - Remove deprecated promotional banners (related to legacy checkout)
 * Tweak - Improve error messages when Stripe API requests fail to better distinguish between request and retrieval errors
 * Fix - Resolve Level3 data validation error caused by rounding precision when shipping rates have 3+ decimal places
-* Tweak - Changes BLIK confirmation webhook processing from deferred to immediate
+* Tweak - Change BLIK confirmation webhook processing from deferred to immediate
 * Fix - Preserve express checkout button location settings when upgrading from older plugin versions
 * Fix - Fix some initialization bugs for reconnections
 * Fix - Update Ukraine state mapping list


### PR DESCRIPTION
Discussed in p1767600757242299-slack-C055WHLA98D

## Changes proposed in this Pull Request:
Made the verbs of the changelog statements consistent.

## Testing instructions
- Code review.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Made the language of the changelog entry consistent. No need for a changelog entry for this.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)