### PR TITLE
Add order validation in Multibanco email instructions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,7 +8,7 @@
 * Dev - Ensure PHPStan runs when pushing changes
 * Dev - Add PHPStan stub for WC_Subscription class
 * Dev - Remove the deprecated WC_Stripe_Apple_Pay class
-
+* Fix - Add order validation in Multibanco email instructions to prevent fatal error when order is invalid
 
 = 10.3.0 - 2026-01-13 =
 * Update - Increase Afterpay/Clearpay maximum transaction amount to 4,000 AUD and 4,000 NZD

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
@@ -56,8 +56,12 @@ class WC_Stripe_UPE_Payment_Method_Multibanco extends WC_Stripe_UPE_Payment_Meth
 	 * @param WC_Order $order
 	 * @param bool     $sent_to_admin
 	 * @param bool     $plain_text
+	 * @return void
 	 */
 	public function email_instructions( $order, $sent_to_admin, $plain_text = false ) {
+		if ( ! $order || ! is_a( $order, 'WC_Order' ) ) {
+			return;
+		}
 		$payment_method = $order->get_payment_method();
 		if ( ! $sent_to_admin && 'stripe_multibanco' === $payment_method && $order->has_status( OrderStatus::ON_HOLD ) ) {
 			$this->get_instructions( $order, $plain_text );

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12979,12 +12979,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Method_Multibanco\:\:email_instructions\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Method_Multibanco\:\:get_instructions\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/readme.txt
+++ b/readme.txt
@@ -147,5 +147,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Ensure PHPStan runs when pushing changes
 * Dev - Add PHPStan stub for WC_Subscription class
 * Dev - Remove the deprecated WC_Stripe_Apple_Pay class
+* Fix - Add order validation in Multibanco email instructions to prevent fatal error when order is invalid
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Fixes STRIPE-890

## Changes proposed in this Pull Request:
Added order validation in Multibanco email instructions to prevent the following fatal error-
```
PHP Fatal error: Uncaught Error: Call to a member function get_payment_method() on false in /wordpress/plugins/woocommerce-gateway-stripe/10.3.0/includes/payment-methods/class-wc-stripe-upe-payment-method-multibanco.php:61
```

## Testing instructions
- Code review.

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
