### PR TITLE
Add unit tests to cover address normalization

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@
 * Dev - Ensure PHPStan runs when pushing changes
 * Dev - Add PHPStan stub for WC_Subscription class
 * Dev - Remove the deprecated WC_Stripe_Apple_Pay class
+* Dev - Unit tests to cover address normalization
 
 
 = 10.3.0 - 2026-01-13 =

--- a/readme.txt
+++ b/readme.txt
@@ -149,5 +149,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Ensure PHPStan runs when pushing changes
 * Dev - Add PHPStan stub for WC_Subscription class
 * Dev - Remove the deprecated WC_Stripe_Apple_Pay class
+* Dev - Unit tests to cover address normalization
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -19,7 +19,6 @@ use WP_UnitTestCase;
  * These tests make assertions against class WC_Stripe_Express_Checkout_Helper.
  *
  * @package WooCommerce/Stripe/WC_Stripe_Express_Checkout_Helper
- * @group helper
  *
  * WC_Stripe_Express_Checkout_Helper_Test class.
  */

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -19,6 +19,7 @@ use WP_UnitTestCase;
  * These tests make assertions against class WC_Stripe_Express_Checkout_Helper.
  *
  * @package WooCommerce/Stripe/WC_Stripe_Express_Checkout_Helper
+ * @group helper
  *
  * WC_Stripe_Express_Checkout_Helper_Test class.
  */
@@ -1297,5 +1298,264 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 		} else {
 			$this->assertFalse( $result, 'Amazon Pay should be disabled' );
 		}
+	}
+
+	/**
+	 * Test is_normalized_state method.
+	 *
+	 * @param string $state State value.
+	 * @param string $country Country code.
+	 * @param bool   $expected Expected result.
+	 * @return void
+	 * @dataProvider provide_test_is_normalized_state
+	 */
+	public function test_is_normalized_state( $state, $country, $expected ) {
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$this->assertEquals( $expected, $wc_stripe_ece_helper->is_normalized_state( $state, $country ) );
+	}
+
+	/**
+	 * Provider for `test_is_normalized_state`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_is_normalized_state() {
+		return [
+			'US state code CA is normalized'            => [
+				'state'    => 'CA',
+				'country'  => 'US',
+				'expected' => true,
+			],
+			'US state full name California is not normalized' => [
+				'state'    => 'California',
+				'country'  => 'US',
+				'expected' => false,
+			],
+			'AU state code NSW is normalized'           => [
+				'state'    => 'NSW',
+				'country'  => 'AU',
+				'expected' => true,
+			],
+			'AU state full name New South Wales is not normalized' => [
+				'state'    => 'New South Wales',
+				'country'  => 'AU',
+				'expected' => false,
+			],
+			'CA province code BC is normalized'         => [
+				'state'    => 'BC',
+				'country'  => 'CA',
+				'expected' => true,
+			],
+			'CA province full name British Columbia is not normalized' => [
+				'state'    => 'British Columbia',
+				'country'  => 'CA',
+				'expected' => false,
+			],
+			'Empty state returns false'                 => [
+				'state'    => '',
+				'country'  => 'US',
+				'expected' => false,
+			],
+			'Country without states returns false'      => [
+				'state'    => 'SomeState',
+				'country'  => 'DE',
+				'expected' => false,
+			],
+		];
+	}
+
+	/**
+	 * Test get_normalized_state_from_pr_states method.
+	 *
+	 * This test ensures that the Payment Request API state mapping file is loaded correctly
+	 * and state normalization works as expected.
+	 *
+	 * @param string $state State value from Payment Request API.
+	 * @param string $country Country code.
+	 * @param string $expected Expected normalized state code.
+	 * @return void
+	 * @dataProvider provide_test_get_normalized_state_from_pr_states
+	 */
+	public function test_get_normalized_state_from_pr_states( $state, $country, $expected ) {
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$this->assertEquals( $expected, $wc_stripe_ece_helper->get_normalized_state_from_pr_states( $state, $country ) );
+	}
+
+	/**
+	 * Provider for `test_get_normalized_state_from_pr_states`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_normalized_state_from_pr_states() {
+		return [
+			'US state California normalizes to CA'      => [
+				'state'    => 'California',
+				'country'  => 'US',
+				'expected' => 'CA',
+			],
+			'US state New York normalizes to NY'        => [
+				'state'    => 'New York',
+				'country'  => 'US',
+				'expected' => 'NY',
+			],
+			'US state code CA stays CA'                 => [
+				'state'    => 'CA',
+				'country'  => 'US',
+				'expected' => 'CA',
+			],
+			'AU state New South Wales normalizes to NSW' => [
+				'state'    => 'New South Wales',
+				'country'  => 'AU',
+				'expected' => 'NSW',
+			],
+			'AU state Queensland normalizes to QLD'     => [
+				'state'    => 'Queensland',
+				'country'  => 'AU',
+				'expected' => 'QLD',
+			],
+			'CA province British Columbia normalizes to BC' => [
+				'state'    => 'British Columbia',
+				'country'  => 'CA',
+				'expected' => 'BC',
+			],
+			'CA province French name Colombie-Britannique normalizes to BC' => [
+				'state'    => 'Colombie-Britannique',
+				'country'  => 'CA',
+				'expected' => 'BC',
+			],
+			'BR state São Paulo normalizes to SP'       => [
+				'state'    => 'São Paulo',
+				'country'  => 'BR',
+				'expected' => 'SP',
+			],
+			'Unknown state returns original value'      => [
+				'state'    => 'UnknownState',
+				'country'  => 'US',
+				'expected' => 'UnknownState',
+			],
+			'Country without PR states returns original value' => [
+				'state'    => 'SomeState',
+				'country'  => 'DE',
+				'expected' => 'SomeState',
+			],
+			'Case insensitive matching for US state'    => [
+				'state'    => 'california',
+				'country'  => 'US',
+				'expected' => 'CA',
+			],
+			'Case insensitive matching for AU state'    => [
+				'state'    => 'new south wales',
+				'country'  => 'AU',
+				'expected' => 'NSW',
+			],
+		];
+	}
+
+	/**
+	 * Test get_normalized_state method.
+	 *
+	 * This is the main state normalization method that combines PR states and WC states lookup.
+	 *
+	 * @param string $state State value.
+	 * @param string $country Country code.
+	 * @param string $expected Expected normalized state code.
+	 * @return void
+	 * @dataProvider provide_test_get_normalized_state
+	 */
+	public function test_get_normalized_state( $state, $country, $expected ) {
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+		$this->assertEquals( $expected, $wc_stripe_ece_helper->get_normalized_state( $state, $country ) );
+	}
+
+	/**
+	 * Provider for `test_get_normalized_state`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_get_normalized_state() {
+		return [
+			'Already normalized US state code stays unchanged' => [
+				'state'    => 'CA',
+				'country'  => 'US',
+				'expected' => 'CA',
+			],
+			'US state full name normalizes to code'     => [
+				'state'    => 'California',
+				'country'  => 'US',
+				'expected' => 'CA',
+			],
+			'Empty state returns empty'                 => [
+				'state'    => '',
+				'country'  => 'US',
+				'expected' => '',
+			],
+			'AU state full name normalizes to code'     => [
+				'state'    => 'New South Wales',
+				'country'  => 'AU',
+				'expected' => 'NSW',
+			],
+			'CA province full name normalizes to code'  => [
+				'state'    => 'British Columbia',
+				'country'  => 'CA',
+				'expected' => 'BC',
+			],
+			'Unknown state returns original value'      => [
+				'state'    => 'UnknownState',
+				'country'  => 'US',
+				'expected' => 'UnknownState',
+			],
+		];
+	}
+
+	/**
+	 * Test normalize_state method with address data.
+	 *
+	 * This tests the full normalization flow with billing and shipping addresses.
+	 *
+	 * @return void
+	 */
+	public function test_normalize_state_with_address_data() {
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+
+		$data = [
+			'billing_address'  => [
+				'country' => 'US',
+				'state'   => 'California',
+			],
+			'shipping_address' => [
+				'country' => 'AU',
+				'state'   => 'New South Wales',
+			],
+		];
+
+		$result = $wc_stripe_ece_helper->normalize_state( $data );
+
+		$this->assertEquals( 'CA', $result['billing_address']['state'] );
+		$this->assertEquals( 'NSW', $result['shipping_address']['state'] );
+	}
+
+	/**
+	 * Test normalize_state method when states are already normalized.
+	 *
+	 * @return void
+	 */
+	public function test_normalize_state_with_already_normalized_states() {
+		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
+
+		$data = [
+			'billing_address'  => [
+				'country' => 'US',
+				'state'   => 'CA',
+			],
+			'shipping_address' => [
+				'country' => 'AU',
+				'state'   => 'NSW',
+			],
+		];
+
+		$result = $wc_stripe_ece_helper->normalize_state( $data );
+
+		$this->assertEquals( 'CA', $result['billing_address']['state'] );
+		$this->assertEquals( 'NSW', $result['shipping_address']['state'] );
 	}
 }

--- a/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_Express_Checkout_Helper_Test.php
@@ -1308,7 +1308,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @return void
 	 * @dataProvider provide_test_is_normalized_state
 	 */
-	public function test_is_normalized_state( $state, $country, $expected ) {
+	public function test_is_normalized_state( string $state, string $country, bool $expected ): void {
 		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 		$this->assertEquals( $expected, $wc_stripe_ece_helper->is_normalized_state( $state, $country ) );
 	}
@@ -1318,7 +1318,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_test_is_normalized_state() {
+	public function provide_test_is_normalized_state(): array {
 		return [
 			'US state code CA is normalized'            => [
 				'state'    => 'CA',
@@ -1375,7 +1375,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @return void
 	 * @dataProvider provide_test_get_normalized_state_from_pr_states
 	 */
-	public function test_get_normalized_state_from_pr_states( $state, $country, $expected ) {
+	public function test_get_normalized_state_from_pr_states( string $state, string $country, string $expected ): void {
 		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 		$this->assertEquals( $expected, $wc_stripe_ece_helper->get_normalized_state_from_pr_states( $state, $country ) );
 	}
@@ -1385,7 +1385,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_test_get_normalized_state_from_pr_states() {
+	public function provide_test_get_normalized_state_from_pr_states(): array {
 		return [
 			'US state California normalizes to CA'      => [
 				'state'    => 'California',
@@ -1461,7 +1461,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 * @return void
 	 * @dataProvider provide_test_get_normalized_state
 	 */
-	public function test_get_normalized_state( $state, $country, $expected ) {
+	public function test_get_normalized_state( string $state, string $country, string $expected ): void {
 		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 		$this->assertEquals( $expected, $wc_stripe_ece_helper->get_normalized_state( $state, $country ) );
 	}
@@ -1471,7 +1471,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function provide_test_get_normalized_state() {
+	public function provide_test_get_normalized_state(): array {
 		return [
 			'Already normalized US state code stays unchanged' => [
 				'state'    => 'CA',
@@ -1513,7 +1513,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_normalize_state_with_address_data() {
+	public function test_normalize_state_with_address_data(): void {
 		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 
 		$data = [
@@ -1538,7 +1538,7 @@ class WC_Stripe_Express_Checkout_Helper_Test extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_normalize_state_with_already_normalized_states() {
+	public function test_normalize_state_with_already_normalized_states(): void {
 		$wc_stripe_ece_helper = new WC_Stripe_Express_Checkout_Helper();
 
 		$data = [


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR adds unit tests to cover address normalization that happens on express checkout payment flows.


<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Code review. Make sure tests pass.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
