### PR TITLE
Run all e2e tests on PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           STRIPE_PUB_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_AU || secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
           STRIPE_SECRET_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_SECRET_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_SECRET_KEY_AU || secrets.E2E_STRIPE_SECRET_KEY }}
-        run: ./tests/e2e/bin/run-tests.sh --project=${{ matrix.project }}
+        run: npm run test:e2e-run -- --project=${{ matrix.project }}
 
       - name: Upload E2E-${{ matrix.project }}-WP_latest-WC_latest-results
         if: ${{ failure() }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        checkout: [ 'Default', 'OptimizedCheckout' ]
+        project: [ 'default', 'acss', 'optimized-checkout', 'blik', 'becs' ]
 
-    name: ${{ matrix.checkout }} WP=latest, WC=latest, PHP=7.4
+    name: E2E - ${{ matrix.project }} WP=latest, WC=latest, PHP=7.4
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -76,35 +76,30 @@ jobs:
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.E2E_GH_TOKEN }}
-          STRIPE_PUB_KEY: ${{ secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.E2E_STRIPE_SECRET_KEY }}
+          STRIPE_PUB_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_AU || secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_SECRET_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_SECRET_KEY_AU || secrets.E2E_STRIPE_SECRET_KEY }}
         run: npm run test:e2e-setup
 
       - name: Upload e2e setup logs
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.checkout }}-WP_latest-WC_latest-setup-logs
+          name: E2E-${{ matrix.project }}-WP_latest-WC_latest-setup-logs
           path: tests/e2e/e2e-setup.log
           if-no-files-found: ignore
           retention-days: 7
 
-      - name: Run ${{ matrix.checkout }} E2E tests
-        shell: bash
+      - name: Run E2E tests
         env:
-          STRIPE_PUB_KEY: ${{ secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
-          STRIPE_SECRET_KEY: ${{ secrets.E2E_STRIPE_SECRET_KEY }}
-        run: |
-          if [ "${{ matrix.checkout }}" = "OptimizedCheckout" ]; then
-            npm run test:e2e-oc
-          else
-            npm run test:e2e
-          fi
-      - name: Upload ${{ matrix.checkout }} E2E test results
+          STRIPE_PUB_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_AU || secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
+          STRIPE_SECRET_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_SECRET_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_SECRET_KEY_AU || secrets.E2E_STRIPE_SECRET_KEY }}
+        run: npm run test:e2e -- --project=${{ matrix.project }}
+
+      - name: Upload E2E-${{ matrix.project }}-WP_latest-WC_latest-results
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.checkout }}-WP_latest-WC_latest-results
+          name: E2E-${{ matrix.project }}-WP_latest-WC_latest-results
           path: tests/e2e/test-results
           if-no-files-found: ignore
           retention-days: 14

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
         env:
           STRIPE_PUB_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_PUBLISHABLE_KEY_AU || secrets.E2E_STRIPE_PUBLISHABLE_KEY }}
           STRIPE_SECRET_KEY: ${{ matrix.project == 'blik' && secrets.E2E_STRIPE_SECRET_KEY_PL || matrix.project == 'becs' && secrets.E2E_STRIPE_SECRET_KEY_AU || secrets.E2E_STRIPE_SECRET_KEY }}
-        run: npm run test:e2e -- --project=${{ matrix.project }}
+        run: ./tests/e2e/bin/run-tests.sh --project=${{ matrix.project }}
 
       - name: Upload E2E-${{ matrix.project }}-WP_latest-WC_latest-results
         if: ${{ failure() }}

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "test:e2e-down": "./tests/e2e/bin/down.sh",
     "test:e2e-cleanup": "npm run test:e2e-down && ./tests/e2e/bin/cleanup.sh",
     "test:e2e": "./tests/e2e/bin/run-tests.sh --project=default",
+    "test:e2e-run": "./tests/e2e/bin/run-tests.sh",
     "test:e2e-debug": "npm run test:e2e -- --debug",
     "test:e2e-legacy": "./tests/e2e/bin/run-tests.sh --project=legacy",
     "test:e2e-legacy-debug": "npm run test:e2e-legacy -- --debug",


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR ensures that our standard e2e tests that run on every PR run the separate tests for specific payment methods in addition to the standard and optimized checkout e2e tests that we have been running. In particular, that means that we're adding the e2e tests for ACSS, Becs, and BLIK to our standard e2e test runs so we can identify problems with those payment methods far sooner.

At an implementation level, the PR also adds a new `test:e2e-run` command, as the existing `test:e2e` command always specified the `--project=default` argument, which is incompatible with the Optimized Checkout e2e tests. The new command doesn't specify any arguments, and expects callers to provide their own.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Code review
* Verify that the e2e tests are passing, and that the additional `acss`, `becs`, and `blik` e2e tests are running.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a workflow automation change that doesn't impact merchants, so I don't think we need a changelog entry.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
