### PR TITLE
Checkout Sessions: Add Stripe checkout sessions feature flag

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Dev - Introduce a feature flag for the Stripe checkout sessions feature
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -30,7 +30,7 @@ class WC_Stripe_Feature_Flags {
 	 * Feature flag for Stripe Checkout Sessions.
 	 *
 	 * @var string
-	 * @since 10.5.0
+	 * @since 10.4.0
 	 */
 	const CHECKOUT_SESSIONS_FEATURE_FLAG_NAME = '_wcstripe_feature_stripe_checkout_sessions';
 
@@ -90,7 +90,7 @@ class WC_Stripe_Feature_Flags {
 	 * Feature flag to control the availability of Stripe Checkout Sessions.
 	 *
 	 * @return bool
-	 * @since 10.5.0
+	 * @since 10.4.0
 	 */
 	public static function is_checkout_sessions_available() {
 		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
@@ -112,7 +112,7 @@ class WC_Stripe_Feature_Flags {
 		/**
 		 * Filter to control the availability of the Stripe Checkout Sessions feature.
 		 *
-		 * @since 10.5.0
+		 * @since 10.4.0
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
 		 * @deprecated This filter will be removed when the feature rolls out.
 		 */

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -100,6 +100,7 @@ class WC_Stripe_Feature_Flags {
 		 *
 		 * @since 10.5.0
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
+		 * @deprecated This filter will be removed when the feature rolls out.
 		 */
 		return (bool) apply_filters( 'wc_stripe_is_checkout_session_available', $is_checkout_sessions_available );
 	}

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -116,7 +116,7 @@ class WC_Stripe_Feature_Flags {
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
 		 * @deprecated This filter will be removed when the feature rolls out.
 		 */
-		return (bool) apply_filters( 'wc_stripe_is_checkout_session_available', $is_checkout_sessions_available );
+		return (bool) apply_filters( 'wc_stripe_is_checkout_sessions_available', $is_checkout_sessions_available );
 	}
 
 	/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -113,8 +113,8 @@ class WC_Stripe_Feature_Flags {
 		 * Filter to control the availability of the Stripe Checkout Sessions feature.
 		 *
 		 * @since 10.4.0
+		 * Note: This filter will be removed when the feature rolls out.
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
-		 * @deprecated This filter will be removed when the feature rolls out.
 		 */
 		return (bool) apply_filters( 'wc_stripe_is_checkout_sessions_available', $is_checkout_sessions_available );
 	}

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -103,7 +103,7 @@ class WC_Stripe_Feature_Flags {
 		// - OC Suite is enabled
 		// - Automatic capture is enabled (i.e. manual capture or later capture is disabled)
 		// If any of the above conditions are not met, the feature is not available.
-		if ( 'no' === $is_pmc_enabled || 'no' === $is_oc_enabled || 'no' === $is_automatic_capture_enabled ) {
+		if ( 'yes' !== $is_pmc_enabled || 'yes' !== $is_oc_enabled || 'yes' !== $is_automatic_capture_enabled ) {
 			return false;
 		}
 

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -93,6 +93,20 @@ class WC_Stripe_Feature_Flags {
 	 * @since 10.5.0
 	 */
 	public static function is_checkout_sessions_available() {
+		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
+		$is_pmc_enabled               = $stripe_settings['pmc_enabled'] ?? 'no';
+		$is_oc_enabled                = $stripe_settings['optimized_checkout_element'] ?? 'no';
+		$is_automatic_capture_enabled = $stripe_settings['capture'] ?? 'yes';
+
+		// Stripe checkout sessions feature can only be available if:
+		// - PMC is enabled
+		// - OC Suite is enabled
+		// - Automatic capture is enabled (i.e. manual capture or later capture is disabled)
+		// If any of the above conditions are not met, the feature is not available.
+		if ( 'no' === $is_pmc_enabled || 'no' === $is_oc_enabled || 'no' === $is_automatic_capture_enabled ) {
+			return false;
+		}
+
 		$is_checkout_sessions_available = 'yes' === self::get_option_with_default( self::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME );
 
 		/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -27,15 +27,25 @@ class WC_Stripe_Feature_Flags {
 	const OC_FEATURE_FLAG_NAME = '_wcstripe_feature_oc';
 
 	/**
+	 * Feature flag for Stripe Checkout Sessions.
+	 *
+	 * @var string
+	 * @since 10.5.0
+	 */
+	const CHECKOUT_SESSIONS_FEATURE_FLAG_NAME = '_wcstripe_feature_stripe_checkout_sessions';
+
+
+	/**
 	 * Map of feature flag option names => their default "yes"/"no" value.
 	 * This single source of truth makes it easier to maintain our dev tools.
 	 *
 	 * @var array
 	 */
 	protected static $feature_flags = [
-		'_wcstripe_feature_upe'                => 'yes',
-		self::AMAZON_PAY_FEATURE_FLAG_NAME     => 'no',
-		self::OC_FEATURE_FLAG_NAME             => 'no',
+		'_wcstripe_feature_upe'                   => 'yes',
+		self::AMAZON_PAY_FEATURE_FLAG_NAME        => 'no',
+		self::OC_FEATURE_FLAG_NAME                => 'no',
+		self::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME => 'no',
 	];
 
 	/**
@@ -74,6 +84,24 @@ class WC_Stripe_Feature_Flags {
 		 * @param bool $enable_amazon_pay Whether Amazon Pay should be enabled.
 		 */
 		return (bool) apply_filters( 'wc_stripe_is_amazon_pay_available', $enable_amazon_pay );
+	}
+
+	/**
+	 * Feature flag to control the availability of Stripe Checkout Sessions.
+	 *
+	 * @return bool
+	 * @since 10.5.0
+	 */
+	public static function is_checkout_sessions_available() {
+		$is_checkout_sessions_available = 'yes' === self::get_option_with_default( self::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME );
+
+		/**
+		 * Filter to control the availability of the Stripe Checkout Sessions feature.
+		 *
+		 * @since 10.5.0
+		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
+		 */
+		return (bool) apply_filters( 'wc_stripe_is_checkout_session_available', $is_checkout_sessions_available );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -155,5 +155,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Dev - Introduce a feature flag for the Stripe checkout sessions feature
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -5,6 +5,7 @@ namespace WooCommerce\Stripe\Tests;
 use WC_Stripe_Feature_Flags;
 use WC_Stripe_Helper;
 use WC_Stripe_UPE_Payment_Gateway;
+use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\PMC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 use WP_UnitTestCase;
@@ -95,6 +96,151 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'PMC enabled'     => true,
 				'filter function' => '__return_false',
 				'expected'        => false,
+			],
+		];
+	}
+
+	/**
+	 * Test for `is_checkout_sessions_available`.
+	 *
+	 * @param bool   $pmc_enabled           Whether the Payment Method Configuration API is enabled.
+	 * @param bool   $oc_enabled             Whether the Optimized Checkout is enabled.
+	 * @param bool   $automatic_capture      Whether automatic capture is enabled.
+	 * @param bool   $feature_flag_enabled   Whether the checkout sessions feature flag is enabled.
+	 * @param string $filter_function        The filter function to apply.
+	 * @param bool   $expected               The expected result.
+	 * @return void
+	 * @dataProvider provide_test_is_checkout_sessions_available
+	 */
+	public function test_is_checkout_sessions_available( $pmc_enabled, $oc_enabled, $automatic_capture, $feature_flag_enabled, $filter_function, $expected ) {
+		// Mock the payment method configuration for the test, to avoid it being disabled by default.
+		PMC_Test_Helper::cache_mocked_configuration();
+
+		if ( $pmc_enabled ) {
+			PMC_Test_Helper::enable_pmc();
+		} else {
+			PMC_Test_Helper::disable_pmc();
+		}
+
+		if ( $oc_enabled ) {
+			OC_Test_Helper::enable_oc();
+		} else {
+			OC_Test_Helper::disable_oc();
+		}
+
+		$stripe_settings            = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['capture'] = $automatic_capture ? 'yes' : 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		update_option( WC_Stripe_Feature_Flags::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME, $feature_flag_enabled ? 'yes' : 'no' );
+
+		if ( ! empty( $filter_function ) ) {
+			add_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+		}
+
+		$actual = WC_Stripe_Feature_Flags::is_checkout_sessions_available();
+
+		// Clean up
+		PMC_Test_Helper::disable_pmc();
+		PMC_Test_Helper::delete_cached_configuration();
+		OC_Test_Helper::disable_oc();
+		update_option( WC_Stripe_Feature_Flags::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME, 'no' );
+		$stripe_settings['capture'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->assertSame( $expected, $actual );
+
+		if ( ! empty( $filter_function ) ) {
+			remove_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+		}
+	}
+
+	/**
+	 * Provider for `test_is_checkout_sessions_available`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_is_checkout_sessions_available() {
+		return [
+			'All prerequisites met, feature flag enabled'  => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => true,
+			],
+			'All prerequisites met, feature flag disabled' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => false,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'PMC disabled'                                 => [
+				'PMC enabled'       => false,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'OC disabled'                                  => [
+				'PMC enabled'       => true,
+				'OC enabled'        => false,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'Manual capture enabled'                       => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => false,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'PMC disabled, filter set to true (filter ignored)' => [
+				'PMC enabled'       => false,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => false,
+			],
+			'OC disabled, filter set to true (filter ignored)' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => false,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => false,
+			],
+			'Manual capture, filter set to true (filter ignored)' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => false,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => false,
+			],
+			'All prerequisites met, feature flag enabled, filter set to true' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => true,
+			],
+			'All prerequisites met, feature flag enabled, filter set to false' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_false',
+				'expected'          => false,
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -147,11 +147,11 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$stripe_settings['capture'] = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		$this->assertSame( $expected, $actual );
-
 		if ( ! empty( $filter_function ) ) {
 			remove_filter( 'wc_stripe_is_checkout_sessions_available', $filter_function );
 		}
+
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -135,7 +135,7 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		update_option( WC_Stripe_Feature_Flags::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME, $feature_flag_enabled ? 'yes' : 'no' );
 
 		if ( ! empty( $filter_function ) ) {
-			add_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+			add_filter( 'wc_stripe_is_checkout_sessions_available', $filter_function );
 		}
 
 		$actual = WC_Stripe_Feature_Flags::is_checkout_sessions_available();
@@ -151,7 +151,7 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$this->assertSame( $expected, $actual );
 
 		if ( ! empty( $filter_function ) ) {
-			remove_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+			remove_filter( 'wc_stripe_is_checkout_sessions_available', $filter_function );
 		}
 	}
 

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -8,7 +8,6 @@ use WC_Stripe_UPE_Payment_Gateway;
 use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\PMC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
-use WP_UnitTestCase;
 
 /**
  * These tests make assertions against the class WC_Stripe_Feature_Flags


### PR DESCRIPTION
Fixes STRIPE-931
Fixes #4967 

## Changes proposed in this Pull Request:
Added a feature flag to control checkout sessions feature availability.

## Testing instructions
- Code review.
- All tests should pass.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
