### PR TITLE
Add a check to verify remote_oid exists locally

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -45,10 +45,7 @@ do
 			echo "Update your local branch, then try pushing again."
 			exit 1
 		fi
-	fi
 
-	if [ -n "$range" ]
-	then
 		# Get the changed files.
 		changed_files=$(git diff --name-only "$range")
 		# Get the changed PHP files or directories in the push.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -36,6 +36,19 @@ do
 
 	if [ -n "$range" ]
 	then
+		# Verify that the remote_oid exists locally. If the remote has commits
+		# we don't have, the push will be rejected by the remote anyway.
+		# Fail fast with a clear message.
+		if ! git cat-file -e "$remote_oid" 2>/dev/null
+		then
+			echo "Error: Remote branch has commits that don't exist locally."
+			echo "Update your local branch, then try pushing again."
+			exit 1
+		fi
+	fi
+
+	if [ -n "$range" ]
+	then
 		# Get the changed files.
 		changed_files=$(git diff --name-only "$range")
 		# Get the changed PHP files or directories in the push.

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Dev - Improve the pre-push hook
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/readme.txt
+++ b/readme.txt
@@ -155,5 +155,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Dev - Improve the pre-push hook
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->


## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

The pre-push hook was showing a cryptic error when pushing to a branch where the remote has commits that
don't exist locally:

```
fatal: Invalid revision range ad6a3f605c7e4c55480b1ea43f7d9cc309a033b0..822606c33f46c16d3b7f21509264f7895189bd9b
husky - pre-push hook exited with code 128 (error)
error: failed to push some refs to 'github.com:woocommerce/woocommerce-gateway-stripe.git'
```

This happens because the hook tried to run `git diff --name-only "$remote_oid..$local_oid"` when the `remote_oid` isn't in the local repo.

This PR adds a check using `git cat-file -e` to detect when the remote has commits we don't have locally.
When this happens, the hook now fails fast with a more clear message:

```
Error: Remote branch has commits that don't exist locally.
Update your local branch, then try pushing again.
```


<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions
I think it's sufficient to verify `git cat-file -e` is working as expected.

```
# This should succeed 
git cat-file -e HEAD && echo "exists" || echo "missing"

# This should fail as the SHA doesn't exist
git cat-file -e 0000000000000000000000000000000000000001 2>/dev/null && echo "exists" || echo "missing"
```

For a more comprehensive test:

1. Create a test branch off of this branch and push it.
2. Add a commit directly on GitHub (edit any file via the UI)
3. Locally, create another commit without pulling: `git commit --allow-empty -m "Local"`
4. Try to push: `git push`
5. Verify you see the new error message instead of "Invalid revision range"
6. Delete the remote branch in 1.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
