### PR TITLE
Fix block editor incompatibility warning

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,7 +16,7 @@
 * Fix - Add validation to prevent fatal error when setting default payment token if token doesn't exist
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
-* Dev - Automate release note creation PR
+* Fix - Prevent incompatibility warnings for payment methods in block editor
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Add validation to prevent fatal error when setting default payment token if token doesn't exist
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
+* Dev - Automate release note creation PR
 * Fix - Prevent incompatibility warnings for payment methods in block editor
 
 = 10.3.1 - 2026-01-15 =

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -524,7 +524,7 @@ class WC_Stripe {
 
 					if ( $method instanceof WC_Stripe_UPE_Payment_Method ) {
 						$method_id = $method->get_id();
-						if ( isset( $upe_payment_methods[ $method_id ] ) && is_object( $upe_payment_methods[ $method_id ] ) ) {
+						if ( isset( $upe_payment_methods[ $method_id ] ) && $upe_payment_methods[ $method_id ] instanceof WC_Stripe_UPE_Payment_Method ) {
 							if ( ! $upe_payment_methods[ $method_id ]->is_enabled_at_checkout() ) {
 								return false;
 							}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -507,16 +507,30 @@ class WC_Stripe {
 
 		$methods = array_merge( $methods, $upe_payment_methods );
 
-		// When we are in an admin context, filter out Link and Amazon Pay, as they are only available as
-		// express checkout methods, and including them in the list results in warnings about block support
+		// When we are in an admin context,
+		// 1. Filter out Link and Amazon Pay, as they are only available as express checkout methods,
+		// and including them in the list results in warnings about block support
 		// when viewing the Express Checkout block in the editor for the cart and checkout pages.
+		// 2. Filter out UPE payment methods that are not enabled at checkout, as they are not available in the checkout block
+		// and including them in the list results in warnings about block support
+		// when viewing the payment methods block in the editor for the cart and checkout pages.
 		if ( is_admin() ) {
 			$methods = array_filter(
 				$methods,
-				function ( $method ) {
+				function ( $method ) use ( $upe_payment_methods ) {
 					if ( $method instanceof WC_Stripe_UPE_Payment_Method_Link || $method instanceof WC_Stripe_UPE_Payment_Method_Amazon_Pay ) {
 						return false;
 					}
+
+					if ( $method instanceof WC_Stripe_UPE_Payment_Method ) {
+						$method_id = $method->get_id();
+						if ( isset( $upe_payment_methods[ $method_id ] ) && is_object( $upe_payment_methods[ $method_id ] ) ) {
+							if ( ! $upe_payment_methods[ $method_id ]->is_enabled_at_checkout() ) {
+								return false;
+							}
+						}
+					}
+
 					return true;
 				}
 			);

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -527,7 +527,7 @@ class WC_Stripe {
 					}
 
 					if ( $method instanceof WC_Stripe_UPE_Payment_Method ) {
-						if ( $is_oc_enabled ) {
+						if ( 'yes' === $is_oc_enabled ) {
 							return false;
 						}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -523,11 +523,8 @@ class WC_Stripe {
 					}
 
 					if ( $method instanceof WC_Stripe_UPE_Payment_Method ) {
-						$method_id = $method->get_id();
-						if ( isset( $upe_payment_methods[ $method_id ] ) && $upe_payment_methods[ $method_id ] instanceof WC_Stripe_UPE_Payment_Method ) {
-							if ( ! $upe_payment_methods[ $method_id ]->is_enabled_at_checkout() ) {
-								return false;
-							}
+						if ( ! $method->is_enabled_at_checkout() ) {
+							return false;
 						}
 					}
 

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -498,8 +498,9 @@ class WC_Stripe {
 	 * @version 5.6.0
 	 */
 	public function add_gateways( $methods ) {
-		$main_gateway = $this->get_main_stripe_gateway();
-		$methods[]    = $main_gateway;
+		$main_gateway  = $this->get_main_stripe_gateway();
+		$methods[]     = $main_gateway;
+		$is_oc_enabled = $main_gateway->get_option( 'optimized_checkout_element', 'no' );
 
 		// The $main_gateway represents the card gateway so we don't want to include it in the list of UPE gateways.
 		$upe_payment_methods = $main_gateway->payment_methods;
@@ -511,18 +512,25 @@ class WC_Stripe {
 		// 1. Filter out Link and Amazon Pay, as they are only available as express checkout methods,
 		// and including them in the list results in warnings about block support
 		// when viewing the Express Checkout block in the editor for the cart and checkout pages.
-		// 2. Filter out UPE payment methods that are not enabled at checkout, as they are not available in the checkout block
+		// 2. Filter out Optimized Checkout payment methods, as they are only available as one payment element under the Stripe payment method block,
+		// and including them in the list results in warnings about block support
+		// when viewing the Optimized Checkout block in the editor for the cart and checkout pages.
+		// 3. Filter out UPE payment methods that are not enabled at checkout, as they are not available in the checkout block
 		// and including them in the list results in warnings about block support
 		// when viewing the payment methods block in the editor for the cart and checkout pages.
 		if ( is_admin() ) {
 			$methods = array_filter(
 				$methods,
-				function ( $method ) use ( $upe_payment_methods ) {
+				function ( $method ) use ( $is_oc_enabled ) {
 					if ( $method instanceof WC_Stripe_UPE_Payment_Method_Link || $method instanceof WC_Stripe_UPE_Payment_Method_Amazon_Pay ) {
 						return false;
 					}
 
 					if ( $method instanceof WC_Stripe_UPE_Payment_Method ) {
+						if ( $is_oc_enabled ) {
+							return false;
+						}
+
 						if ( ! $method->is_enabled_at_checkout() ) {
 							return false;
 						}

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -500,7 +500,7 @@ class WC_Stripe {
 	public function add_gateways( $methods ) {
 		$main_gateway  = $this->get_main_stripe_gateway();
 		$methods[]     = $main_gateway;
-		$is_oc_enabled = $main_gateway->get_option( 'optimized_checkout_element', 'no' );
+		$is_oc_enabled = 'yes' === $main_gateway->get_option( 'optimized_checkout_element', 'no' );
 
 		// The $main_gateway represents the card gateway so we don't want to include it in the list of UPE gateways.
 		$upe_payment_methods = $main_gateway->payment_methods;
@@ -527,7 +527,7 @@ class WC_Stripe {
 					}
 
 					if ( $method instanceof WC_Stripe_UPE_Payment_Method ) {
-						if ( 'yes' === $is_oc_enabled ) {
+						if ( $is_oc_enabled ) {
 							return false;
 						}
 

--- a/readme.txt
+++ b/readme.txt
@@ -156,5 +156,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Fix - Prevent incompatibility warnings for payment methods in block editor
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -372,6 +372,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			->getMock();
 
 		$mock_main_gateway->payment_methods = $payment_methods;
+		$mock_main_gateway->method( 'get_option' )
+			->with( 'optimized_checkout_element', 'no' )
+			->willReturn( 'no' );
 
 		$wc_stripe->method( 'get_main_stripe_gateway' )
 			->willReturn( $mock_main_gateway );
@@ -421,10 +424,12 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$klarna_gateway = $this->getMockBuilder( \WC_Stripe_UPE_Payment_Method_Klarna::class )
 			->disableOriginalConstructor()
 			->getMock();
+		$klarna_gateway->method( 'is_enabled_at_checkout' )->willReturn( true );
 
 		$afterpay_clearpay_gateway = $this->getMockBuilder( \WC_Stripe_UPE_Payment_Method_Afterpay_Clearpay::class )
 			->disableOriginalConstructor()
 			->getMock();
+		$afterpay_clearpay_gateway->method( 'is_enabled_at_checkout' )->willReturn( true );
 
 		return [
 			'none active' => [

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -358,10 +358,11 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @param array $payment_methods The payment methods to add.
 	 * @param array $expected_gateways The expected gateways.
 	 * @param bool $is_admin Whether the test is running in the admin.
+	 * @param bool $oc_enabled Whether the optimized checkout is enabled.
 	 * @return void
 	 * @dataProvider provide_test_add_gateways
 	 */
-	public function test_add_gateways( array $payment_methods, array $expected_gateways, bool $is_admin = false ): void {
+	public function test_add_gateways( array $payment_methods, array $expected_gateways, bool $is_admin = false, bool $oc_enabled = false ): void {
 		$wc_stripe = $this->getMockBuilder( WC_Stripe::class )
 			->disableOriginalConstructor()
 			->onlyMethods( [ 'get_main_stripe_gateway' ] )
@@ -374,7 +375,7 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$mock_main_gateway->payment_methods = $payment_methods;
 		$mock_main_gateway->method( 'get_option' )
 			->with( 'optimized_checkout_element', 'no' )
-			->willReturn( 'no' );
+			->willReturn( $oc_enabled ? 'yes' : 'no' );
 
 		$wc_stripe->method( 'get_main_stripe_gateway' )
 			->willReturn( $mock_main_gateway );
@@ -506,6 +507,18 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				],
 				'expected_gateways' => [ $afterpay_clearpay_gateway, $klarna_gateway ],
 				'is_admin'          => true,
+			],
+			'optimized checkout enabled admin' => [
+				'payment_methods'   => [
+					'card'              => $card_gateway,
+					'afterpay_clearpay' => $afterpay_clearpay_gateway,
+					'klarna'            => $klarna_gateway,
+					'amazon_pay'        => $amazon_pay_gateway,
+					'link'              => $link_gateway,
+				],
+				'expected_gateways' => [],
+				'is_admin'          => true,
+				'oc_enabled'        => true,
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -432,6 +432,11 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 			->getMock();
 		$afterpay_clearpay_gateway->method( 'is_enabled_at_checkout' )->willReturn( true );
 
+		$sepa_gateway = $this->getMockBuilder( \WC_Stripe_UPE_Payment_Method_Sepa::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$sepa_gateway->method( 'is_enabled_at_checkout' )->willReturn( false );
+
 		return [
 			'none active' => [
 				'payment_methods'   => [],
@@ -505,6 +510,19 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					'amazon_pay'        => $amazon_pay_gateway,
 					'link'              => $link_gateway,
 				],
+				'expected_gateways' => [ $afterpay_clearpay_gateway, $klarna_gateway ],
+				'is_admin'          => true,
+			],
+			'disabled at checkout payment methods are filtered out in admin' => [
+				'payment_methods'   => [
+					'card'              => $card_gateway,
+					'afterpay_clearpay' => $afterpay_clearpay_gateway,
+					'klarna'            => $klarna_gateway,
+					'amazon_pay'        => $amazon_pay_gateway,
+					'link'              => $link_gateway,
+					'sepa_debit'        => $sepa_gateway,
+				],
+				// sepa is disabled at checkout, so it should be filtered out.
 				'expected_gateways' => [ $afterpay_clearpay_gateway, $klarna_gateway ],
 				'is_admin'          => true,
 			],


### PR DESCRIPTION
Fixes STRIPE-913
Fixes #4949 

## Changes proposed in this Pull Request:

WooCommerce's block editor compares `globalPaymentMethods`  against `availablePaymentMethods` (JS methods registered via registerPaymentMethod()). If there is any mismatch, then the block editor shows this incompatibility notice.

In `add_gateways` method, we are adding all UPE methods irrespective of whether they are available on the checkout page or not. But in the frontend, we only [send the list ](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php#L538)that is enabled at checkout.

In this PR, I am filtering out the gateways that are not enabled at checkout from the `add_gateways` method so that both the list aligns.

## Testing instructions
- Connect to an US Stripe account.
- Set store currency to Euro and enable a few Euro supported payment methods like SEPA, iDeal etc.
- Switch store currency to USD enable a few other USD supported payment methods.
- Go to the checkout block editor and select the payment block.
- In `develop` notice that there are 'Incompatible with block-based checkout' beside some methods.
- In this branch, those incompatible methods should be hidden and for the displayed methods there should be no incompatibility notice.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
