### PR TITLE
Fix credit card input from being cleared in OCS when save payment method checkbox is selected

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Fix - Prevent credit card input from being cleared when toggling save payment method checkbox in classic checkout with Optimized Checkout enabled
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,7 +20,7 @@
 * Dev - Automate release note creation PR
 * Dev - Introduce a feature flag for the Stripe checkout sessions feature
 * Dev - Improve the pre-push hook
-* Fix - Prevent credit card input from being cleared when toggling save payment method checkbox in classic checkout with Optimized Checkout enabled
+* Fix - Keep payment method details when toggling save payment method checkbox in classic checkout with Optimized Checkout enabled
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
 * Tweak - Update PHPDoc for email notification classes

--- a/client/classic/upe/deferred-intent.js
+++ b/client/classic/upe/deferred-intent.js
@@ -14,6 +14,7 @@ import {
 	confirmVoucherPayment,
 	confirmWalletPayment,
 	createAndConfirmSetupIntent,
+	getMountedUPEComponent,
 	initializeUPEComponents,
 	mountStripePaymentElement,
 	processPayment,
@@ -137,16 +138,6 @@ jQuery( function ( $ ) {
 	} );
 
 	/**
-	 * Unmounts the Stripe Payment Elements from the page.
-	 */
-	function unmountStripePaymentElements() {
-		for ( const upeElement of $( '.wc-stripe-upe-element' ).toArray() ) {
-			$( upeElement ).children().remove();
-		}
-		initializeUPEComponents();
-	}
-
-	/**
 	 * Checks if the URL hash starts with #wc-stripe-voucher- or #wc-stripe-wallet- and whether we
 	 * should display the relevant confirmation modal.
 	 */
@@ -186,14 +177,25 @@ jQuery( function ( $ ) {
 
 	// Bind the handling of the setup future usage option to the saving checkbox when OC is enabled.
 	if ( getStripeServerData()?.isOCEnabled ) {
-		$( document ).on(
-			'change',
-			'#wc-stripe-new-payment-method',
-			async () => {
-				// Remove all children from the UPE elements to force a re-mount.
-				unmountStripePaymentElements();
-				await maybeMountStripePaymentElement();
+		$( document ).on( 'change', '#wc-stripe-new-payment-method', () => {
+			const selectedMethod = getSelectedUPEGatewayPaymentMethod();
+			const component = getMountedUPEComponent( selectedMethod );
+
+			if ( component && component.elements ) {
+				const isChecked = $( '#wc-stripe-new-payment-method' ).is(
+					':checked'
+				);
+				const cartContainsSubscription =
+					getStripeServerData()?.cartContainsSubscription;
+
+				// Update only the setupFutureUsage on the Elements object and preserve user input.
+				component.elements.update( {
+					setupFutureUsage:
+						cartContainsSubscription || isChecked
+							? 'off_session'
+							: null,
+				} );
 			}
-		);
+		} );
 	}
 } );

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -396,6 +396,30 @@ export async function mountStripePaymentElement( api, domElement ) {
 }
 
 /**
+ * Gets the mounted UPE element for a payment method type.
+ *
+ * @param {string} paymentMethodType The payment method type.
+ * @return {Object|null} The UPE element component object or null if not found.
+ */
+export function getMountedUPEComponent( paymentMethodType ) {
+	if ( ! gatewayUPEComponents[ paymentMethodType ] ) {
+		return null;
+	}
+
+	const component = gatewayUPEComponents[ paymentMethodType ];
+	const domElement = document.querySelector(
+		`.wc-stripe-upe-element[data-payment-method-type="${ paymentMethodType }"]`
+	);
+
+	// Only return if the Elements object exists and is mounted.
+	if ( component.elements && domElement && domElement.children.length > 0 ) {
+		return component;
+	}
+
+	return null;
+}
+
+/**
  * Handles the checkout process for the provided jQuery form and Stripe payment method type. The function blocks the
  * form UI to prevent duplicate submission and validates the Stripe elements. It then creates a Stripe payment method
  * object and appends the necessary data to the form for checkout completion. Finally, it submits the form and prevents

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -407,12 +407,17 @@ export function getMountedUPEComponent( paymentMethodType ) {
 	}
 
 	const component = gatewayUPEComponents[ paymentMethodType ];
+
+	if ( ! component.elements ) {
+		return null;
+	}
+
 	const domElement = document.querySelector(
 		`.wc-stripe-upe-element[data-payment-method-type="${ paymentMethodType }"]`
 	);
 
 	// Only return if the Elements object exists and is mounted.
-	if ( component.elements && domElement && domElement.children.length > 0 ) {
+	if ( domElement && domElement.children.length > 0 ) {
 		return component;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -156,5 +156,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Fix - Prevent credit card input from being cleared when toggling save payment method checkbox in classic checkout with Optimized Checkout enabled
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -159,7 +159,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Automate release note creation PR
 * Dev - Introduce a feature flag for the Stripe checkout sessions feature
 * Dev - Improve the pre-push hook
-* Fix - Prevent credit card input from being cleared when toggling save payment method checkbox in classic checkout with Optimized Checkout enabled
+* Fix - Keep payment method details when toggling save payment method checkbox in classic checkout with Optimized Checkout enabled
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
 * Tweak - Update PHPDoc for email notification classes


### PR DESCRIPTION
Fixes STRIPE-690
Fixes #4629 

## Changes proposed in this Pull Request:
When the save payment method checkbox is changed, we unmount and remount the payment element. This is done so that we can show the correct list of payments that support saving the method and hide that do not support it. As a side effect of this approach, the payment element gets refreshed when the checkbox is selected. If shopper adds any card info before selecting the checkbox, those info also disappears.

In this PR, I have removed the unmount/re-mount approach and using [elements.update](https://docs.stripe.com/js/elements_object/update) method to update the `setupFutureUsage` parameter of the element only so that Stripe correctly calculates and renders the supported method for saving. 

## Testing instructions
- As an admin, set up a classic checkout page if you already do not have one.
- Enable optimized checkout suite in **WooCommerce > Settings > Payments > Manage (Stripe) > Settings > Advanced Settings**.
- Enable payment via saved cards.
- As a shopper, add a simple product to your cart and go to the classic checkout page.
- Select Stripe as the payment method and input some credit card information
- After filling in credit card info, select the save payment method checkbox
- In `develop`, observe that the credit card details have been cleared and the Stripe payment element is refreshed.
- In this branch, verify that the credit card information still persists and the Stripe element is not refreshed.
    - Also verify that there is no regression related to the list of payment methods displayed based on setup future usage capability. For example, if you have card, CashApp, WeChat and AliPay available on the checkout page initially and you select the save payment method checkbox, it should hide WeChat and AliPay, keeping card and CashApp still on the page. 
    - Verify that there is no other regressions and OCS checkout works with different methods.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
