### PR TITLE
Setting to control Checkout Sessions + Adaptive Pricing

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,7 @@
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Dev - Introduce a feature flag for the Stripe checkout sessions feature
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.4.0 - xxxx-xx-xx =
+* Add - New setting to control Checkout Sessions with Adaptive Pricing feature availability
 * Fix - Fix Stripe client API calls with wrong amount when rendering the express checkout buttons in block
 * Fix - Validate product exists before accessing product methods in express checkout to prevent fatal errors
 * Update - Ensure the `customer_name` metadata sent to Stripe does not have leading or trailing spaces

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,7 +22,6 @@
 * Dev - Introduce a feature flag for the Stripe checkout sessions feature
 * Dev - Improve the pre-push hook
 * Fix - Better error handling when token creation fails
-* Dev - Introduce a feature flag for the Stripe checkout sessions feature
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.4.0 - xxxx-xx-xx =
-* Add - New setting to control Checkout Sessions with Adaptive Pricing feature availability
+* Add - New setting to control Adaptive Pricing
 * Add - Map Norwegian nb-NO to generic no-NO locale
 * Update - Redirect merchants to the Stripe settings screen upon plugin activation
 * Fix - Fix Stripe client API calls with wrong amount when rendering the express checkout buttons in block

--- a/client/data/settings/__tests__/hooks.test.js
+++ b/client/data/settings/__tests__/hooks.test.js
@@ -22,6 +22,7 @@ import {
 	useSepaTokensForIdeal,
 	useSepaTokensForBancontact,
 	useIsOCEnabled,
+	useIsAPEnabled,
 } from '../hooks';
 import { STORE_NAME } from '../../constants';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -283,6 +284,12 @@ describe( 'Settings hooks tests', () => {
 		useIsOCEnabledSettings: {
 			hook: useIsOCEnabled,
 			storeKey: 'is_oc_enabled',
+			testedValue: true,
+			fallbackValue: false,
+		},
+		useIsAPEnabledSettings: {
+			hook: useIsAPEnabled,
+			storeKey: 'is_ap_enabled',
 			testedValue: true,
 			fallbackValue: false,
 		},

--- a/client/data/settings/__tests__/hooks.test.js
+++ b/client/data/settings/__tests__/hooks.test.js
@@ -22,7 +22,7 @@ import {
 	useSepaTokensForIdeal,
 	useSepaTokensForBancontact,
 	useIsOCEnabled,
-	useIsAPEnabled,
+	useIsAdaptivePricingEnabled,
 } from '../hooks';
 import { STORE_NAME } from '../../constants';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -287,8 +287,8 @@ describe( 'Settings hooks tests', () => {
 			testedValue: true,
 			fallbackValue: false,
 		},
-		useIsAPEnabledSettings: {
-			hook: useIsAPEnabled,
+		useIsAdaptivePricingEnabledSettings: {
+			hook: useIsAdaptivePricingEnabled,
 			storeKey: 'is_ap_enabled',
 			testedValue: true,
 			fallbackValue: false,

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -167,6 +167,7 @@ export const useIsShortAccountStatementEnabled = makeSettingsHook(
 );
 export const useDebugLog = makeSettingsHook( 'is_debug_log_enabled' );
 export const useIsOCEnabled = makeSettingsHook( 'is_oc_enabled' );
+export const useIsAPEnabled = makeSettingsHook( 'is_ap_enabled' );
 export const useOCLayout = makeSettingsHook( 'oc_layout' );
 export const useIsPMCEnabled = makeReadOnlySettingsHook(
 	'is_pmc_enabled',

--- a/client/data/settings/hooks.js
+++ b/client/data/settings/hooks.js
@@ -167,7 +167,7 @@ export const useIsShortAccountStatementEnabled = makeSettingsHook(
 );
 export const useDebugLog = makeSettingsHook( 'is_debug_log_enabled' );
 export const useIsOCEnabled = makeSettingsHook( 'is_oc_enabled' );
-export const useIsAPEnabled = makeSettingsHook( 'is_ap_enabled' );
+export const useIsAdaptivePricingEnabled = makeSettingsHook( 'is_ap_enabled' );
 export const useOCLayout = makeSettingsHook( 'oc_layout' );
 export const useIsPMCEnabled = makeReadOnlySettingsHook(
 	'is_pmc_enabled',

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -7,12 +7,14 @@ import {
 	useGetSavingError,
 	useSettings,
 	useIsOCEnabled,
+	useIsAPEnabled,
 	useOCLayout,
 } from 'wcstripe/data';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useDebugLog: jest.fn(),
 	useIsOCEnabled: jest.fn(),
+	useIsAPEnabled: jest.fn(),
 	useOCLayout: jest.fn(),
 	useGetSavingError: jest.fn(),
 	useSettings: jest.fn(),
@@ -28,6 +30,7 @@ describe( 'AdvancedSettings', () => {
 
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
+		useIsAPEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );
 		useGetSavingError.mockReturnValue( null );
 
@@ -81,7 +84,7 @@ describe( 'AdvancedSettings', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should display the Optimized Checkout layout setting if the Optimized Checkout feature is enabled', () => {
+	it( 'should display the Optimized Checkout layout and the Adaptive Pricing settings if the Optimized Checkout feature is enabled', () => {
 		global.wc_stripe_settings_params = { is_oc_available: true };
 
 		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
@@ -94,5 +97,11 @@ describe( 'AdvancedSettings', () => {
 			)
 		).toBeInTheDocument();
 		expect( screen.queryByText( 'Layout' ) ).toBeInTheDocument();
+
+		expect(
+			screen.queryByText(
+				'Let customers pay in their local currency with Adaptive Pricing.'
+			)
+		).toBeInTheDocument();
 	} );
 } );

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -7,14 +7,14 @@ import {
 	useGetSavingError,
 	useSettings,
 	useIsOCEnabled,
-	useIsAPEnabled,
+	useIsAdaptivePricingEnabled,
 	useOCLayout,
 } from 'wcstripe/data';
 
 jest.mock( 'wcstripe/data', () => ( {
 	useDebugLog: jest.fn(),
 	useIsOCEnabled: jest.fn(),
-	useIsAPEnabled: jest.fn(),
+	useIsAdaptivePricingEnabled: jest.fn(),
 	useOCLayout: jest.fn(),
 	useGetSavingError: jest.fn(),
 	useSettings: jest.fn(),
@@ -30,7 +30,7 @@ describe( 'AdvancedSettings', () => {
 
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
-		useIsAPEnabled.mockReturnValue( [ false, jest.fn() ] );
+		useIsAdaptivePricingEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );
 		useGetSavingError.mockReturnValue( null );
 

--- a/client/settings/advanced-settings-section/__tests__/index.test.js
+++ b/client/settings/advanced-settings-section/__tests__/index.test.js
@@ -26,7 +26,10 @@ jest.mock( '@woocommerce/navigation', () => ( {
 
 describe( 'AdvancedSettings', () => {
 	beforeEach( () => {
-		global.wc_stripe_settings_params = { is_oc_available: false };
+		global.wc_stripe_settings_params = {
+			is_cs_available: false,
+			is_oc_available: false,
+		};
 
 		useDebugLog.mockReturnValue( [ true, jest.fn() ] );
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
@@ -84,8 +87,11 @@ describe( 'AdvancedSettings', () => {
 		).toBeInTheDocument();
 	} );
 
-	it( 'should display the Optimized Checkout layout and the Adaptive Pricing settings if the Optimized Checkout feature is enabled', () => {
-		global.wc_stripe_settings_params = { is_oc_available: true };
+	it( 'should display the Optimized Checkout layout and the Adaptive Pricing settings if the Optimized Checkout feature is enabled and checkout sessions available', () => {
+		global.wc_stripe_settings_params = {
+			is_cs_available: true,
+			is_oc_available: true,
+		};
 
 		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
 

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -2,12 +2,13 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import OptimizedCheckoutFeature from 'wcstripe/settings/advanced-settings-section/optimized-checkout-feature';
-import { useIsOCEnabled, useOCLayout } from 'wcstripe/data';
+import { useIsOCEnabled, useIsAPEnabled, useOCLayout } from 'wcstripe/data';
 
 jest.useFakeTimers();
 
 jest.mock( 'wcstripe/data', () => ( {
 	useIsOCEnabled: jest.fn(),
+	useIsAPEnabled: jest.fn(),
 	useOCLayout: jest.fn(),
 } ) );
 
@@ -18,6 +19,7 @@ jest.mock( '@woocommerce/navigation', () => ( {
 describe( 'Optimized Checkout Element feature setting', () => {
 	beforeEach( () => {
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
+		useIsAPEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );
 	} );
 
@@ -48,18 +50,25 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		} );
 	} );
 
-	it( 'layout setting should be available when OC is enabled', () => {
+	it( 'Adaptive pricing and layout settings should be available when OC is enabled', () => {
 		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
 
 		render( <OptimizedCheckoutFeature /> );
 
-		const label = screen.getByText( 'Layout' );
-		expect( label ).toBeInTheDocument();
+		// Layout settings.
+		expect( screen.getByText( 'Layout' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Choose between a vertical accordion layout and a horizontal tabs layout to display payment methods.'
+			)
+		).toBeInTheDocument();
 
-		const help = screen.getByText(
-			'Choose between a vertical accordion layout and a horizontal tabs layout to display payment methods.'
-		);
-		expect( help ).toBeInTheDocument();
+		// Adaptive pricing settings.
+		expect(
+			screen.getByText(
+				'Let customers pay in their local currency with Adaptive Pricing.'
+			)
+		).toBeInTheDocument();
 	} );
 
 	it( 'triggers the hook when changing the layout setting', async () => {
@@ -76,6 +85,27 @@ describe( 'Optimized Checkout Element feature setting', () => {
 
 		await waitFor( async () => {
 			expect( setLayoutMock ).toHaveBeenCalledWith( 'tabs' );
+		} );
+	} );
+
+	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {
+		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
+
+		const setAPEnabledMock = jest.fn();
+		useIsAPEnabled.mockReturnValue( [ false, setAPEnabledMock ] );
+
+		render( <OptimizedCheckoutFeature /> );
+
+		expect( setAPEnabledMock ).not.toHaveBeenCalled();
+
+		await userEvent.click(
+			screen.getByLabelText(
+				'Let customers pay in their local currency with Adaptive Pricing.'
+			)
+		);
+
+		await waitFor( async () => {
+			expect( setAPEnabledMock ).toHaveBeenCalledWith( true );
 		} );
 	} );
 } );

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -22,6 +22,8 @@ jest.mock( '@woocommerce/navigation', () => ( {
 
 describe( 'Optimized Checkout Element feature setting', () => {
 	beforeEach( () => {
+		global.wc_stripe_settings_params = { is_cs_available: false };
+
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useIsAdaptivePricingEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );
@@ -54,7 +56,9 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		} );
 	} );
 
-	it( 'Adaptive pricing and layout settings should be available when OC is enabled', () => {
+	it( 'Adaptive pricing and layout settings should be available when OC is enabled and checkout sessions is available', () => {
+		global.wc_stripe_settings_params = { is_cs_available: true };
+
 		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
 
 		render( <OptimizedCheckoutFeature /> );
@@ -93,6 +97,8 @@ describe( 'Optimized Checkout Element feature setting', () => {
 	} );
 
 	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {
+		global.wc_stripe_settings_params = { is_cs_available: true };
+
 		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
 
 		const setAdaptivePricingEnabledMock = jest.fn();

--- a/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
+++ b/client/settings/advanced-settings-section/__tests__/optimized-checkout-feature.test.js
@@ -2,13 +2,17 @@ import { render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import OptimizedCheckoutFeature from 'wcstripe/settings/advanced-settings-section/optimized-checkout-feature';
-import { useIsOCEnabled, useIsAPEnabled, useOCLayout } from 'wcstripe/data';
+import {
+	useIsOCEnabled,
+	useIsAdaptivePricingEnabled,
+	useOCLayout,
+} from 'wcstripe/data';
 
 jest.useFakeTimers();
 
 jest.mock( 'wcstripe/data', () => ( {
 	useIsOCEnabled: jest.fn(),
-	useIsAPEnabled: jest.fn(),
+	useIsAdaptivePricingEnabled: jest.fn(),
 	useOCLayout: jest.fn(),
 } ) );
 
@@ -19,7 +23,7 @@ jest.mock( '@woocommerce/navigation', () => ( {
 describe( 'Optimized Checkout Element feature setting', () => {
 	beforeEach( () => {
 		useIsOCEnabled.mockReturnValue( [ false, jest.fn() ] );
-		useIsAPEnabled.mockReturnValue( [ false, jest.fn() ] );
+		useIsAdaptivePricingEnabled.mockReturnValue( [ false, jest.fn() ] );
 		useOCLayout.mockReturnValue( [ 'accordion', jest.fn() ] );
 	} );
 
@@ -91,12 +95,15 @@ describe( 'Optimized Checkout Element feature setting', () => {
 	it( 'triggers the hook when changing the Adaptive Pricing setting', async () => {
 		useIsOCEnabled.mockReturnValue( [ true, jest.fn() ] );
 
-		const setAPEnabledMock = jest.fn();
-		useIsAPEnabled.mockReturnValue( [ false, setAPEnabledMock ] );
+		const setAdaptivePricingEnabledMock = jest.fn();
+		useIsAdaptivePricingEnabled.mockReturnValue( [
+			false,
+			setAdaptivePricingEnabledMock,
+		] );
 
 		render( <OptimizedCheckoutFeature /> );
 
-		expect( setAPEnabledMock ).not.toHaveBeenCalled();
+		expect( setAdaptivePricingEnabledMock ).not.toHaveBeenCalled();
 
 		await userEvent.click(
 			screen.getByLabelText(
@@ -105,7 +112,9 @@ describe( 'Optimized Checkout Element feature setting', () => {
 		);
 
 		await waitFor( async () => {
-			expect( setAPEnabledMock ).toHaveBeenCalledWith( true );
+			expect( setAdaptivePricingEnabledMock ).toHaveBeenCalledWith(
+				true
+			);
 		} );
 	} );
 } );

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -78,7 +78,6 @@ const OptimizedCheckoutFeature = () => {
 			/>
 			{ isOCEnabled && (
 				<AdaptivePricingCheckbox
-					data-testid="adaptive-pricing-checkbox"
 					label={ __(
 						'Let customers pay in their local currency with Adaptive Pricing.',
 						'woocommerce-gateway-stripe'

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { getQuery } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
-import { useIsOCEnabled, useOCLayout } from '../../data';
+import { useIsAPEnabled, useIsOCEnabled, useOCLayout } from '../../data';
 import {
 	CheckboxControl,
 	ExternalLink,
@@ -9,6 +9,10 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+const AdaptivePricingCheckbox = styled( CheckboxControl )`
+	margin-left: 24px;
+`;
 
 const StyledRadioControl = styled( RadioControl )`
 	legend {
@@ -22,6 +26,7 @@ const StyledRadioControl = styled( RadioControl )`
 
 const OptimizedCheckoutFeature = () => {
 	const [ isOCEnabled, setIsOCEnabled ] = useIsOCEnabled();
+	const [ isAPEnabled, setIsAPEnabled ] = useIsAPEnabled();
 	const [ OCLayout, setOCLayout ] = useOCLayout();
 	const headingRef = useRef( null );
 
@@ -71,6 +76,28 @@ const OptimizedCheckoutFeature = () => {
 				checked={ isOCEnabled }
 				onChange={ setIsOCEnabled }
 			/>
+			{ isOCEnabled && (
+				<AdaptivePricingCheckbox
+					data-testid="adaptive-pricing-checkbox"
+					label={ __(
+						'Let customers pay in their local currency with Adaptive Pricing.',
+						'woocommerce-gateway-stripe'
+					) }
+					help={ createInterpolateElement(
+						__(
+							"With Adaptive Pricing, Stripe detects the customer's currency via IP and automatically applies localized pricing and conversion. <learnMoreLink>Learn more</learnMoreLink>.",
+							'woocommerce-gateway-stripe'
+						),
+						{
+							learnMoreLink: (
+								<ExternalLink href="https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing" />
+							),
+						}
+					) }
+					checked={ isAPEnabled }
+					onChange={ setIsAPEnabled }
+				/>
+			) }
 			{ isOCEnabled && (
 				<StyledRadioControl
 					label={ __( 'Layout', 'woocommerce-gateway-stripe' ) }

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -1,3 +1,4 @@
+/* global wc_stripe_settings_params */
 import React, { useEffect, useRef } from 'react';
 import { getQuery } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
@@ -34,6 +35,8 @@ const OptimizedCheckoutFeature = () => {
 		useIsAdaptivePricingEnabled();
 	const [ OCLayout, setOCLayout ] = useOCLayout();
 	const headingRef = useRef( null );
+	const isCheckoutSessionsAvailable =
+		wc_stripe_settings_params.is_cs_available; // eslint-disable-line camelcase
 
 	useEffect( () => {
 		if ( ! headingRef.current ) {
@@ -81,7 +84,7 @@ const OptimizedCheckoutFeature = () => {
 				checked={ isOCEnabled }
 				onChange={ setIsOCEnabled }
 			/>
-			{ isOCEnabled && (
+			{ isOCEnabled && isCheckoutSessionsAvailable && (
 				<AdaptivePricingCheckbox
 					label={ __(
 						'Let customers pay in their local currency with Adaptive Pricing.',

--- a/client/settings/advanced-settings-section/optimized-checkout-feature.js
+++ b/client/settings/advanced-settings-section/optimized-checkout-feature.js
@@ -1,7 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 import { getQuery } from '@woocommerce/navigation';
 import styled from '@emotion/styled';
-import { useIsAPEnabled, useIsOCEnabled, useOCLayout } from '../../data';
+import {
+	useIsAdaptivePricingEnabled,
+	useIsOCEnabled,
+	useOCLayout,
+} from '../../data';
 import {
 	CheckboxControl,
 	ExternalLink,
@@ -26,7 +30,8 @@ const StyledRadioControl = styled( RadioControl )`
 
 const OptimizedCheckoutFeature = () => {
 	const [ isOCEnabled, setIsOCEnabled ] = useIsOCEnabled();
-	const [ isAPEnabled, setIsAPEnabled ] = useIsAPEnabled();
+	const [ isAdaptivePricingEnabled, setIsAdaptivePricingEnabled ] =
+		useIsAdaptivePricingEnabled();
 	const [ OCLayout, setOCLayout ] = useOCLayout();
 	const headingRef = useRef( null );
 
@@ -93,8 +98,8 @@ const OptimizedCheckoutFeature = () => {
 							),
 						}
 					) }
-					checked={ isAPEnabled }
-					onChange={ setIsAPEnabled }
+					checked={ isAdaptivePricingEnabled }
+					onChange={ setIsAdaptivePricingEnabled }
 				/>
 			) }
 			{ isOCEnabled && (

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -250,11 +250,12 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				'is_short_statement_descriptor_enabled'    => 'yes' === $this->gateway->get_option( 'is_short_statement_descriptor_enabled' ),
 
 				/* Settings > Advanced settings */
-				'is_debug_log_enabled'                     => 'yes' === $this->gateway->get_option( 'logging' ),
-				'is_upe_enabled'                           => true,
-				'is_oc_enabled'                            => 'yes' === $this->gateway->get_option( 'optimized_checkout_element' ),
-				'oc_layout'                                => $this->gateway->get_validated_option( 'optimized_checkout_layout' ),
-				'is_pmc_enabled'                           => 'yes' === $this->gateway->get_option( 'pmc_enabled' ),
+				'is_debug_log_enabled'                  => 'yes' === $this->gateway->get_option( 'logging' ),
+				'is_upe_enabled'                        => true,
+				'is_oc_enabled'                         => 'yes' === $this->gateway->get_option( 'optimized_checkout_element' ),
+				'is_ap_enabled'                         => 'yes' === $this->gateway->get_option( 'adaptive_pricing' ),
+				'oc_layout'                             => $this->gateway->get_validated_option( 'optimized_checkout_layout' ),
+				'is_pmc_enabled'                        => 'yes' === $this->gateway->get_option( 'pmc_enabled' ),
 			]
 		);
 	}
@@ -558,6 +559,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 	private function update_oc_settings( WP_REST_Request $request ) {
 		$attributes = [
 			'is_oc_enabled' => 'optimized_checkout_element',
+			'is_ap_enabled' => 'adaptive_pricing',
 			'oc_layout'     => 'optimized_checkout_layout',
 		];
 		foreach ( $attributes as $request_key => $attribute ) {
@@ -567,7 +569,8 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 				continue;
 			}
 
-			$value         = 'is_oc_enabled' === $request_key ? ( $value ? 'yes' : 'no' ) : $value;
+			// Special handling for boolean settings except for oc_layout.
+			$value         = 'oc_layout' === $request_key ? $value : ( $value ? 'yes' : 'no' );
 			$current_value = $this->gateway->get_option( $attribute );
 
 			$this->gateway->update_validated_option( $attribute, $value );

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -80,6 +80,11 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],
+					'is_ap_enabled'                    => [
+						'description'       => __( 'If Adaptive Pricing should be enabled.', 'woocommerce-gateway-stripe' ),
+						'type'              => 'boolean',
+						'validate_callback' => 'rest_validate_request_arg',
+					],
 					'oc_layout'                        => [
 						'description'       => __( 'The Optimized Checkout layout (accordion or tabs).', 'woocommerce-gateway-stripe' ),
 						'type'              => 'string',

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -575,7 +575,9 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 			}
 
 			// Special handling for boolean settings except for oc_layout.
-			$value         = 'oc_layout' === $request_key ? $value : ( $value ? 'yes' : 'no' );
+			if ( 'oc_layout' !== $request_key ) {
+				$value = $value ? 'yes' : 'no';
+			}
 			$current_value = $this->gateway->get_option( $attribute );
 
 			$this->gateway->update_validated_option( $attribute, $value );

--- a/includes/admin/class-wc-stripe-settings-controller.php
+++ b/includes/admin/class-wc-stripe-settings-controller.php
@@ -245,6 +245,7 @@ class WC_Stripe_Settings_Controller {
 			'is_amazon_pay_available'               => WC_Stripe_Feature_Flags::is_amazon_pay_available(),
 			'is_oc_available'                       => WC_Stripe_Feature_Flags::is_oc_available(),
 			'is_oc_enabled'                         => $is_oc_enabled,
+			'is_cs_available'                       => WC_Stripe_Feature_Flags::is_checkout_sessions_available(),
 			'oc_layout'                             => $this->get_gateway()->get_validated_option( 'optimized_checkout_layout' ),
 			'oauth_nonce'                           => wp_create_nonce( 'wc_stripe_get_oauth_url' ),
 			'is_sepa_tokens_for_ideal_enabled'      => 'yes' === $this->gateway->get_option( 'sepa_tokens_for_ideal', 'no' ),

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -30,7 +30,7 @@ class WC_Stripe_Feature_Flags {
 	 * Feature flag for Stripe Checkout Sessions.
 	 *
 	 * @var string
-	 * @since 10.5.0
+	 * @since 10.4.0
 	 */
 	const CHECKOUT_SESSIONS_FEATURE_FLAG_NAME = '_wcstripe_feature_stripe_checkout_sessions';
 
@@ -90,7 +90,7 @@ class WC_Stripe_Feature_Flags {
 	 * Feature flag to control the availability of Stripe Checkout Sessions.
 	 *
 	 * @return bool
-	 * @since 10.5.0
+	 * @since 10.4.0
 	 */
 	public static function is_checkout_sessions_available() {
 		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
@@ -112,7 +112,7 @@ class WC_Stripe_Feature_Flags {
 		/**
 		 * Filter to control the availability of the Stripe Checkout Sessions feature.
 		 *
-		 * @since 10.5.0
+		 * @since 10.4.0
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
 		 * @deprecated This filter will be removed when the feature rolls out.
 		 */

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -100,6 +100,7 @@ class WC_Stripe_Feature_Flags {
 		 *
 		 * @since 10.5.0
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
+		 * @deprecated This filter will be removed when the feature rolls out.
 		 */
 		return (bool) apply_filters( 'wc_stripe_is_checkout_session_available', $is_checkout_sessions_available );
 	}

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -116,7 +116,7 @@ class WC_Stripe_Feature_Flags {
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
 		 * @deprecated This filter will be removed when the feature rolls out.
 		 */
-		return (bool) apply_filters( 'wc_stripe_is_checkout_session_available', $is_checkout_sessions_available );
+		return (bool) apply_filters( 'wc_stripe_is_checkout_sessions_available', $is_checkout_sessions_available );
 	}
 
 	/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -113,8 +113,8 @@ class WC_Stripe_Feature_Flags {
 		 * Filter to control the availability of the Stripe Checkout Sessions feature.
 		 *
 		 * @since 10.4.0
+		 * Note: This filter will be removed when the feature rolls out.
 		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
-		 * @deprecated This filter will be removed when the feature rolls out.
 		 */
 		return (bool) apply_filters( 'wc_stripe_is_checkout_sessions_available', $is_checkout_sessions_available );
 	}

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -103,7 +103,7 @@ class WC_Stripe_Feature_Flags {
 		// - OC Suite is enabled
 		// - Automatic capture is enabled (i.e. manual capture or later capture is disabled)
 		// If any of the above conditions are not met, the feature is not available.
-		if ( 'no' === $is_pmc_enabled || 'no' === $is_oc_enabled || 'no' === $is_automatic_capture_enabled ) {
+		if ( 'yes' !== $is_pmc_enabled || 'yes' !== $is_oc_enabled || 'yes' !== $is_automatic_capture_enabled ) {
 			return false;
 		}
 

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -93,6 +93,20 @@ class WC_Stripe_Feature_Flags {
 	 * @since 10.5.0
 	 */
 	public static function is_checkout_sessions_available() {
+		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
+		$is_pmc_enabled               = $stripe_settings['pmc_enabled'] ?? 'no';
+		$is_oc_enabled                = $stripe_settings['optimized_checkout_element'] ?? 'no';
+		$is_automatic_capture_enabled = $stripe_settings['capture'] ?? 'yes';
+
+		// Stripe checkout sessions feature can only be available if:
+		// - PMC is enabled
+		// - OC Suite is enabled
+		// - Automatic capture is enabled (i.e. manual capture or later capture is disabled)
+		// If any of the above conditions are not met, the feature is not available.
+		if ( 'no' === $is_pmc_enabled || 'no' === $is_oc_enabled || 'no' === $is_automatic_capture_enabled ) {
+			return false;
+		}
+
 		$is_checkout_sessions_available = 'yes' === self::get_option_with_default( self::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME );
 
 		/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -27,15 +27,25 @@ class WC_Stripe_Feature_Flags {
 	const OC_FEATURE_FLAG_NAME = '_wcstripe_feature_oc';
 
 	/**
+	 * Feature flag for Stripe Checkout Sessions.
+	 *
+	 * @var string
+	 * @since 10.5.0
+	 */
+	const CHECKOUT_SESSIONS_FEATURE_FLAG_NAME = '_wcstripe_feature_stripe_checkout_sessions';
+
+
+	/**
 	 * Map of feature flag option names => their default "yes"/"no" value.
 	 * This single source of truth makes it easier to maintain our dev tools.
 	 *
 	 * @var array
 	 */
 	protected static $feature_flags = [
-		'_wcstripe_feature_upe'                => 'yes',
-		self::AMAZON_PAY_FEATURE_FLAG_NAME     => 'no',
-		self::OC_FEATURE_FLAG_NAME             => 'no',
+		'_wcstripe_feature_upe'                   => 'yes',
+		self::AMAZON_PAY_FEATURE_FLAG_NAME        => 'no',
+		self::OC_FEATURE_FLAG_NAME                => 'no',
+		self::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME => 'no',
 	];
 
 	/**
@@ -74,6 +84,24 @@ class WC_Stripe_Feature_Flags {
 		 * @param bool $enable_amazon_pay Whether Amazon Pay should be enabled.
 		 */
 		return (bool) apply_filters( 'wc_stripe_is_amazon_pay_available', $enable_amazon_pay );
+	}
+
+	/**
+	 * Feature flag to control the availability of Stripe Checkout Sessions.
+	 *
+	 * @return bool
+	 * @since 10.5.0
+	 */
+	public static function is_checkout_sessions_available() {
+		$is_checkout_sessions_available = 'yes' === self::get_option_with_default( self::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME );
+
+		/**
+		 * Filter to control the availability of the Stripe Checkout Sessions feature.
+		 *
+		 * @since 10.5.0
+		 * @param bool $is_checkout_sessions_available Whether Stripe Checkout Sessions should be available.
+		 */
+		return (bool) apply_filters( 'wc_stripe_is_checkout_session_available', $is_checkout_sessions_available );
 	}
 
 	/**

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -94,8 +94,6 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_checkout_sessions_available() {
 		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
-		$is_pmc_enabled               = $stripe_settings['pmc_enabled'] ?? 'no';
-		$is_oc_enabled                = $stripe_settings['optimized_checkout_element'] ?? 'no';
 		$is_automatic_capture_enabled = $stripe_settings['capture'] ?? 'yes';
 
 		// Stripe checkout sessions feature can only be available if:
@@ -103,7 +101,7 @@ class WC_Stripe_Feature_Flags {
 		// - OC Suite is enabled
 		// - Automatic capture is enabled (i.e. manual capture or later capture is disabled)
 		// If any of the above conditions are not met, the feature is not available.
-		if ( 'yes' !== $is_pmc_enabled || 'yes' !== $is_oc_enabled || 'yes' !== $is_automatic_capture_enabled ) {
+		if ( ! self::is_oc_available() || 'yes' !== $is_automatic_capture_enabled ) {
 			return false;
 		}
 

--- a/includes/class-wc-stripe-feature-flags.php
+++ b/includes/class-wc-stripe-feature-flags.php
@@ -94,6 +94,8 @@ class WC_Stripe_Feature_Flags {
 	 */
 	public static function is_checkout_sessions_available() {
 		$stripe_settings              = WC_Stripe_Helper::get_stripe_settings();
+		$is_pmc_enabled               = $stripe_settings['pmc_enabled'] ?? 'no';
+		$is_oc_enabled                = $stripe_settings['optimized_checkout_element'] ?? 'no';
 		$is_automatic_capture_enabled = $stripe_settings['capture'] ?? 'yes';
 
 		// Stripe checkout sessions feature can only be available if:
@@ -101,7 +103,7 @@ class WC_Stripe_Feature_Flags {
 		// - OC Suite is enabled
 		// - Automatic capture is enabled (i.e. manual capture or later capture is disabled)
 		// If any of the above conditions are not met, the feature is not available.
-		if ( ! self::is_oc_available() || 'yes' !== $is_automatic_capture_enabled ) {
+		if ( 'yes' !== $is_pmc_enabled || 'yes' !== $is_oc_enabled || 'yes' !== $is_automatic_capture_enabled ) {
 			return false;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -155,5 +155,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
 * Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
 * Dev - Automate release note creation PR
+* Dev - Introduce a feature flag for the Stripe checkout sessions feature
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.4.0 - xxxx-xx-xx =
+* Add - New setting to control Checkout Sessions with Adaptive Pricing feature availability
 * Fix - Fix Stripe client API calls with wrong amount when rendering the express checkout buttons in blocks
 * Fix - Validate product exists before accessing product methods in express checkout to prevent fatal errors
 * Update - Ensure the `customer_name` metadata sent to Stripe does not have leading or trailing spaces

--- a/readme.txt
+++ b/readme.txt
@@ -140,7 +140,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.4.0 - xxxx-xx-xx =
-* Add - New setting to control Checkout Sessions with Adaptive Pricing feature availability
+* Add - New setting to control Adaptive Pricing
 * Add - Map Norwegian nb-NO to generic no-NO locale
 * Update - Redirect merchants to the Stripe settings screen upon plugin activation
 * Fix - Fix Stripe client API calls with wrong amount when rendering the express checkout buttons in blocks

--- a/readme.txt
+++ b/readme.txt
@@ -161,6 +161,5 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Introduce a feature flag for the Stripe checkout sessions feature
 * Dev - Improve the pre-push hook
 * Fix - Better error handling when token creation fails
-* Dev - Introduce a feature flag for the Stripe checkout sessions feature
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
@@ -141,9 +141,12 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	/**
 	 * Tests for boolean fields.
 	 *
+	 * @param string $rest_key    REST API key.
+	 * @param string $option_name Option name.
+	 * @param bool   $inverse     Whether the option is inverse of the REST key.
 	 * @dataProvider boolean_field_provider
 	 */
-	public function test_boolean_fields( $rest_key, $option_name, $inverse = false ): void {
+	public function test_boolean_fields( string $rest_key, string $option_name, bool $inverse = false ): void {
 		// It returns option value under expected key with HTTP code 200.
 		$this->get_gateway()->update_option( $option_name, 'yes' );
 		$response = $this->rest_get_settings();

--- a/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
+++ b/tests/phpunit/Admin/WC_REST_Stripe_Settings_Controller_Test.php
@@ -139,9 +139,11 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 	}
 
 	/**
+	 * Tests for boolean fields.
+	 *
 	 * @dataProvider boolean_field_provider
 	 */
-	public function test_boolean_fields( $rest_key, $option_name, $inverse = false ) {
+	public function test_boolean_fields( $rest_key, $option_name, $inverse = false ): void {
 		// It returns option value under expected key with HTTP code 200.
 		$this->get_gateway()->update_option( $option_name, 'yes' );
 		$response = $this->rest_get_settings();
@@ -517,11 +519,17 @@ class WC_REST_Stripe_Settings_Controller_Test extends WC_Mock_Stripe_API_Unit_Te
 		];
 	}
 
-	public function boolean_field_provider() {
+	/**
+	 * Data provider for `test_boolean_fields`.
+	 *
+	 * @return array
+	 */
+	public function boolean_field_provider(): array {
 		return [
 			'is_stripe_enabled'                     => [ 'is_stripe_enabled', 'enabled' ],
 			'is_test_mode_enabled'                  => [ 'is_test_mode_enabled', 'testmode' ],
 			'is_oc_enabled'                         => [ 'is_oc_enabled', 'optimized_checkout_element' ],
+			'is_ap_enabled'                         => [ 'is_ap_enabled', 'adaptive_pricing' ],
 			'is_manual_capture_enabled'             => [ 'is_manual_capture_enabled', 'capture', true ],
 			'is_saved_cards_enabled'                => [ 'is_saved_cards_enabled', 'saved_cards' ],
 			'is_separate_card_form_enabled'         => [ 'is_separate_card_form_enabled', 'inline_cc_form', true ],

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -111,7 +111,14 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @return void
 	 * @dataProvider provide_test_is_checkout_sessions_available
 	 */
-	public function test_is_checkout_sessions_available( $pmc_enabled, $oc_enabled, $automatic_capture, $feature_flag_enabled, $filter_function, $expected ) {
+	public function test_is_checkout_sessions_available(
+		bool $pmc_enabled,
+		bool $oc_enabled,
+		bool $automatic_capture,
+		bool $feature_flag_enabled,
+		string $filter_function,
+		bool $expected
+	): void {
 		// Mock the payment method configuration for the test, to avoid it being disabled by default.
 		PMC_Test_Helper::cache_mocked_configuration();
 
@@ -159,7 +166,7 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 *
 	 * @return array
 	 */
-	public function provide_test_is_checkout_sessions_available() {
+	public function provide_test_is_checkout_sessions_available(): array {
 		return [
 			'All prerequisites met, feature flag enabled'  => [
 				'PMC enabled'       => true,

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -5,6 +5,7 @@ namespace WooCommerce\Stripe\Tests;
 use WC_Stripe_Feature_Flags;
 use WC_Stripe_Helper;
 use WC_Stripe_UPE_Payment_Gateway;
+use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\PMC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 use WP_UnitTestCase;
@@ -95,6 +96,151 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'PMC enabled'     => true,
 				'filter function' => '__return_false',
 				'expected'        => false,
+			],
+		];
+	}
+
+	/**
+	 * Test for `is_checkout_sessions_available`.
+	 *
+	 * @param bool   $pmc_enabled           Whether the Payment Method Configuration API is enabled.
+	 * @param bool   $oc_enabled             Whether the Optimized Checkout is enabled.
+	 * @param bool   $automatic_capture      Whether automatic capture is enabled.
+	 * @param bool   $feature_flag_enabled   Whether the checkout sessions feature flag is enabled.
+	 * @param string $filter_function        The filter function to apply.
+	 * @param bool   $expected               The expected result.
+	 * @return void
+	 * @dataProvider provide_test_is_checkout_sessions_available
+	 */
+	public function test_is_checkout_sessions_available( $pmc_enabled, $oc_enabled, $automatic_capture, $feature_flag_enabled, $filter_function, $expected ) {
+		// Mock the payment method configuration for the test, to avoid it being disabled by default.
+		PMC_Test_Helper::cache_mocked_configuration();
+
+		if ( $pmc_enabled ) {
+			PMC_Test_Helper::enable_pmc();
+		} else {
+			PMC_Test_Helper::disable_pmc();
+		}
+
+		if ( $oc_enabled ) {
+			OC_Test_Helper::enable_oc();
+		} else {
+			OC_Test_Helper::disable_oc();
+		}
+
+		$stripe_settings            = WC_Stripe_Helper::get_stripe_settings();
+		$stripe_settings['capture'] = $automatic_capture ? 'yes' : 'no';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		update_option( WC_Stripe_Feature_Flags::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME, $feature_flag_enabled ? 'yes' : 'no' );
+
+		if ( ! empty( $filter_function ) ) {
+			add_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+		}
+
+		$actual = WC_Stripe_Feature_Flags::is_checkout_sessions_available();
+
+		// Clean up
+		PMC_Test_Helper::disable_pmc();
+		PMC_Test_Helper::delete_cached_configuration();
+		OC_Test_Helper::disable_oc();
+		update_option( WC_Stripe_Feature_Flags::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME, 'no' );
+		$stripe_settings['capture'] = 'yes';
+		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
+
+		$this->assertSame( $expected, $actual );
+
+		if ( ! empty( $filter_function ) ) {
+			remove_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+		}
+	}
+
+	/**
+	 * Provider for `test_is_checkout_sessions_available`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_is_checkout_sessions_available() {
+		return [
+			'All prerequisites met, feature flag enabled'  => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => true,
+			],
+			'All prerequisites met, feature flag disabled' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => false,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'PMC disabled'                                 => [
+				'PMC enabled'       => false,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'OC disabled'                                  => [
+				'PMC enabled'       => true,
+				'OC enabled'        => false,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'Manual capture enabled'                       => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => false,
+				'feature flag'      => true,
+				'filter function'   => '',
+				'expected'          => false,
+			],
+			'PMC disabled, filter set to true (filter ignored)' => [
+				'PMC enabled'       => false,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => false,
+			],
+			'OC disabled, filter set to true (filter ignored)' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => false,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => false,
+			],
+			'Manual capture, filter set to true (filter ignored)' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => false,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => false,
+			],
+			'All prerequisites met, feature flag enabled, filter set to true' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_true',
+				'expected'          => true,
+			],
+			'All prerequisites met, feature flag enabled, filter set to false' => [
+				'PMC enabled'       => true,
+				'OC enabled'        => true,
+				'automatic capture' => true,
+				'feature flag'      => true,
+				'filter function'   => '__return_false',
+				'expected'          => false,
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -147,11 +147,11 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$stripe_settings['capture'] = 'yes';
 		WC_Stripe_Helper::update_main_stripe_settings( $stripe_settings );
 
-		$this->assertSame( $expected, $actual );
-
 		if ( ! empty( $filter_function ) ) {
 			remove_filter( 'wc_stripe_is_checkout_sessions_available', $filter_function );
 		}
+
+		$this->assertSame( $expected, $actual );
 	}
 
 	/**

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -135,7 +135,7 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		update_option( WC_Stripe_Feature_Flags::CHECKOUT_SESSIONS_FEATURE_FLAG_NAME, $feature_flag_enabled ? 'yes' : 'no' );
 
 		if ( ! empty( $filter_function ) ) {
-			add_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+			add_filter( 'wc_stripe_is_checkout_sessions_available', $filter_function );
 		}
 
 		$actual = WC_Stripe_Feature_Flags::is_checkout_sessions_available();
@@ -151,7 +151,7 @@ class WC_Stripe_Feature_Flags_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$this->assertSame( $expected, $actual );
 
 		if ( ! empty( $filter_function ) ) {
-			remove_filter( 'wc_stripe_is_checkout_session_available', $filter_function );
+			remove_filter( 'wc_stripe_is_checkout_sessions_available', $filter_function );
 		}
 	}
 

--- a/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
+++ b/tests/phpunit/WC_Stripe_Feature_Flags_Test.php
@@ -8,7 +8,6 @@ use WC_Stripe_UPE_Payment_Gateway;
 use WooCommerce\Stripe\Tests\Helpers\OC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\PMC_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
-use WP_UnitTestCase;
 
 /**
  * These tests make assertions against the class WC_Stripe_Feature_Flags


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-930
Fixes #4966 

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, I am introducing a new setting to control the availability of Checkout Sessions and Adaptive Pricing. This setting appears below the main Optimized Checkout setting because it depends on it. We won't have separate settings for Checkout Sessions, as Checkout Sessions without Adaptive Pricing offer no value to the merchant or the shopper.

Preview *:
<img width="776" height="317" alt="Screenshot 2026-01-29 at 16 38 31" src="https://github.com/user-attachments/assets/856e7293-65ba-40fb-b04d-3fb0d98ddf69" />

\* The setting title and description might change in the next iterations.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`add/setting-to-control-checkout-sessions`)
- Connect your Stripe account
- Go to the Stripe settings screen
- Make sure Optimized Checkout is enabled
- Confirm the new Adaptive Pricing setting is displayed
- Attempt to toggle it and confirm the value is persisted

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
