### PR TITLE
Endpoint to create Checkout Sessions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.4.0 - xxxx-xx-xx =
+* Add - Introduce an endpoint to create Checkout Sessions tokens
 * Update - Redirect merchants to the Stripe settings screen upon plugin activation
 * Fix - Fix Stripe client API calls with wrong amount when rendering the express checkout buttons in block
 * Fix - Validate product exists before accessing product methods in express checkout to prevent fatal errors

--- a/client/api/index.js
+++ b/client/api/index.js
@@ -691,4 +691,10 @@ export default class WCStripeAPI {
 			}
 		);
 	}
+
+	checkoutSessionsCreateSession() {
+		return this.request( this.getAjaxUrl( 'create_checkout_session' ), {
+			security: this.options?.createCheckoutSessionNonce,
+		} );
+	}
 }

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -1,0 +1,78 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC_Stripe_Checkout_Sessions_Controller class.
+ */
+class WC_Stripe_Checkout_Sessions_Controller {
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	public function init_hooks() {
+		add_action( 'wc_ajax_wc_stripe_create_checkout_session', [ $this, 'create_checkout_session' ] );
+	}
+
+	public function create_checkout_session() {
+		$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
+		if ( ! $is_nonce_valid ) {
+			throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
+		}
+
+		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
+			define( 'WOOCOMMERCE_CART', true );
+		}
+
+		$payment_method_type     = isset( $_POST['payment_method_type'] ) ? wc_clean( wp_unslash( $_POST['payment_method_type'] ) ) : '';
+		$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : [];
+
+		WC()->cart->calculate_totals();
+
+		$user     = wp_get_current_user();
+		$customer = new WC_Stripe_Customer( $user->ID );
+		$customer->update_or_create_customer();
+
+		// TODO: fix issue when customer does not have a billing address.
+		// Critical Uncaught WC_Stripe_Exception: missing_required_customer_field: name in includes/class-wc-stripe-customer.php:265
+
+		$currency   = get_woocommerce_currency();
+		$line_items = [];
+		foreach ( WC()->cart->get_cart() as $cart_item ) {
+			$product_name   = $cart_item['data']->get_name();
+			$line_items[] = [
+				'price_data' => [
+					'currency' => strtolower( $currency ),
+					'product_data' => [
+						'name' => $product_name,
+					],
+					'unit_amount' => WC_Stripe_Helper::get_stripe_amount( $cart_item['line_subtotal'] / $cart_item['quantity'], $currency ),
+				],
+				'quantity' => $cart_item['quantity'],
+			];
+		}
+
+		$request = [
+			'ui_mode'              => 'custom',
+			'customer'             => $customer->get_id(),
+			'line_items'           => $line_items,
+			'payment_method_types' => $enabled_payment_methods,
+			'payment_intent_data'  => [],
+			'mode'                 => 'payment',
+			'adaptive_pricing'     => [
+				'enabled' => 'true',
+			],
+		];
+
+		$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );
+
+		if ( ! empty( $checkout_session->error ) ) {
+			throw new Exception( $checkout_session->error->message );
+		}
+
+		wp_send_json( [ 'client_secret' => $checkout_session->client_secret ] );
+	}
+}

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -13,15 +13,22 @@ class WC_Stripe_Checkout_Sessions_Controller {
 	 *
 	 * @return void
 	 */
-	public function init_hooks() {
+	public function init_hooks(): void {
 		add_action( 'wc_ajax_wc_stripe_create_checkout_session', [ $this, 'create_checkout_session' ] );
 	}
 
-	public function create_checkout_session() {
-		$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
-		if ( ! $is_nonce_valid ) {
-			throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
-		}
+	/**
+	 * Create a Stripe Checkout Session and return the client secret.
+	 *
+	 * @return void
+	 * @throws WC_Stripe_Exception When unable to create the Checkout Session.
+	 */
+	public function create_checkout_session(): void {
+		// TODO: verify nonce
+		// $is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
+		// if ( ! $is_nonce_valid ) {
+		// throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
+		// }
 
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -36,11 +36,12 @@ class WC_Stripe_Checkout_Sessions_Controller {
 		$payment_method_type     = isset( $_POST['payment_method_type'] ) ? wc_clean( wp_unslash( $_POST['payment_method_type'] ) ) : '';
 		$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : [];
 
-		$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
-		$customer->maybe_create_customer();
-
-		// TODO: fix issue when customer does not have a billing address.
-		// Critical Uncaught WC_Stripe_Exception: missing_required_customer_field: name in includes/class-wc-stripe-customer.php:265
+		try {
+			$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
+			$customer->maybe_create_customer();
+		} catch ( Exception $e ) {
+			throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
+		}
 
 		if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
 			throw new Exception( __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
@@ -67,7 +68,7 @@ class WC_Stripe_Checkout_Sessions_Controller {
 			'customer'             => $customer->get_id(),
 			'line_items'           => $line_items,
 			'payment_method_types' => $enabled_payment_methods,
-			'payment_intent_data'  => [],
+			'payment_intent_data'  => [], // @todo Pass additional data if needed.
 			'mode'                 => 'payment',
 			'adaptive_pricing'     => [
 				'enabled' => 'true',

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -24,11 +24,10 @@ class WC_Stripe_Checkout_Sessions_Controller {
 	 * @throws WC_Stripe_Exception When unable to create the Checkout Session.
 	 */
 	public function create_checkout_session(): void {
-		// TODO: verify nonce
-		// $is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
-		// if ( ! $is_nonce_valid ) {
-		// throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
-		// }
+		$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
+		if ( ! $is_nonce_valid ) {
+			throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
+		}
 
 		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
 			define( 'WOOCOMMERCE_CART', true );
@@ -37,11 +36,8 @@ class WC_Stripe_Checkout_Sessions_Controller {
 		$payment_method_type     = isset( $_POST['payment_method_type'] ) ? wc_clean( wp_unslash( $_POST['payment_method_type'] ) ) : '';
 		$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : [];
 
-		WC()->cart->calculate_totals();
-
-		$user     = wp_get_current_user();
-		$customer = new WC_Stripe_Customer( $user->ID );
-		$customer->update_or_create_customer();
+		$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
+		$customer->maybe_create_customer();
 
 		// TODO: fix issue when customer does not have a billing address.
 		// Critical Uncaught WC_Stripe_Exception: missing_required_customer_field: name in includes/class-wc-stripe-customer.php:265

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -42,6 +42,10 @@ class WC_Stripe_Checkout_Sessions_Controller {
 		// TODO: fix issue when customer does not have a billing address.
 		// Critical Uncaught WC_Stripe_Exception: missing_required_customer_field: name in includes/class-wc-stripe-customer.php:265
 
+		if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
+			throw new Exception( __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
+		}
+
 		$currency   = get_woocommerce_currency();
 		$line_items = [];
 		foreach ( WC()->cart->get_cart() as $cart_item ) {

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -80,6 +80,10 @@ class WC_Stripe_Checkout_Sessions_Controller {
 			throw new Exception( $checkout_session->error->message );
 		}
 
+		if ( empty( $checkout_session->client_secret ) ) {
+			throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
+		}
+
 		wp_send_json( [ 'client_secret' => $checkout_session->client_secret ] );
 	}
 }

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -52,7 +52,7 @@ class WC_Stripe_Checkout_Sessions_Controller {
 			$currency   = get_woocommerce_currency();
 			$line_items = [];
 			foreach ( WC_Stripe_Helper::build_line_items() as $raw_line_item ) {
-				if ( 'total_discount' === $raw_line_item['key'] ) {
+				if ( 'total_discount' === ( $raw_line_item['key'] ?? '' ) ) {
 					// TODO: Stripe Checkout handles discounts/coupons differently. Skip for now.
 					continue;
 				}

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -83,7 +83,8 @@ class WC_Stripe_Checkout_Sessions_Controller {
 			$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );
 
 			if ( ! empty( $checkout_session->error ) ) {
-				throw new Exception( $checkout_session->error->message );
+				$message = empty( $checkout_session->error->message ) ? __( 'Checkout Sessions API returned an error', 'woocommerce-gateway-stripe' ) : $checkout_session->error->message;
+				throw new Exception( $message );
 			}
 
 			if ( empty( $checkout_session->client_secret ) ) {

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -38,8 +38,8 @@ class WC_Stripe_Checkout_Sessions_Controller {
 
 			// TODO: Test guest checkout flow.
 			try {
-				$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
-				$customer->maybe_create_customer();
+				$stripe_customer = new WC_Stripe_Customer( WC()->customer->get_id() );
+				$stripe_customer->maybe_create_customer();
 			} catch ( Exception $e ) {
 				throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
 			}
@@ -70,7 +70,7 @@ class WC_Stripe_Checkout_Sessions_Controller {
 
 			$request = [
 				'ui_mode'              => 'custom',
-				'customer'             => $customer->get_id(),
+				'customer'             => $stripe_customer->get_id(),
 				'line_items'           => $line_items,
 				'payment_method_types' => $enabled_payment_methods,
 				'payment_intent_data'  => [], // @todo Pass additional data if needed.

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -51,17 +51,16 @@ class WC_Stripe_Checkout_Sessions_Controller {
 
 			$currency   = get_woocommerce_currency();
 			$line_items = [];
-			foreach ( WC()->cart->get_cart() as $cart_item ) {
-				$product_name   = $cart_item['data']->get_name();
+			foreach ( WC_Stripe_Helper::build_line_items() as $raw_line_item ) {
 				$line_items[] = [
 					'price_data' => [
 						'currency' => strtolower( $currency ),
 						'product_data' => [
-							'name' => $product_name,
+							'name' => $raw_line_item['label'],
 						],
-						'unit_amount' => WC_Stripe_Helper::get_stripe_amount( $cart_item['line_subtotal'] / $cart_item['quantity'], $currency ),
+						'unit_amount' => $raw_line_item['amount'],
 					],
-					'quantity' => $cart_item['quantity'],
+					'quantity' => 1,
 				];
 			}
 

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -24,67 +24,72 @@ class WC_Stripe_Checkout_Sessions_Controller {
 	 * @throws WC_Stripe_Exception When unable to create the Checkout Session.
 	 */
 	public function create_checkout_session(): void {
-		$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
-		if ( ! $is_nonce_valid ) {
-			throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
-		}
-
-		if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
-			define( 'WOOCOMMERCE_CART', true );
-		}
-
-		$payment_method_type     = isset( $_POST['payment_method_type'] ) ? wc_clean( wp_unslash( $_POST['payment_method_type'] ) ) : '';
-		$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : [];
-
 		try {
-			$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
-			$customer->maybe_create_customer();
-		} catch ( Exception $e ) {
-			throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
-		}
+			$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
+			if ( ! $is_nonce_valid ) {
+				throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
+			}
 
-		if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
-			throw new Exception( __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
-		}
+			if ( ! defined( 'WOOCOMMERCE_CART' ) ) {
+				define( 'WOOCOMMERCE_CART', true );
+			}
 
-		$currency   = get_woocommerce_currency();
-		$line_items = [];
-		foreach ( WC()->cart->get_cart() as $cart_item ) {
-			$product_name   = $cart_item['data']->get_name();
-			$line_items[] = [
-				'price_data' => [
-					'currency' => strtolower( $currency ),
-					'product_data' => [
-						'name' => $product_name,
+			$payment_method_type     = isset( $_POST['payment_method_type'] ) ? wc_clean( wp_unslash( $_POST['payment_method_type'] ) ) : '';
+			$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : [];
+
+			try {
+				$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
+				$customer->maybe_create_customer();
+			} catch ( Exception $e ) {
+				throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
+			}
+
+			if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
+				throw new Exception( __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
+			}
+
+			$currency   = get_woocommerce_currency();
+			$line_items = [];
+			foreach ( WC()->cart->get_cart() as $cart_item ) {
+				$product_name   = $cart_item['data']->get_name();
+				$line_items[] = [
+					'price_data' => [
+						'currency' => strtolower( $currency ),
+						'product_data' => [
+							'name' => $product_name,
+						],
+						'unit_amount' => WC_Stripe_Helper::get_stripe_amount( $cart_item['line_subtotal'] / $cart_item['quantity'], $currency ),
 					],
-					'unit_amount' => WC_Stripe_Helper::get_stripe_amount( $cart_item['line_subtotal'] / $cart_item['quantity'], $currency ),
+					'quantity' => $cart_item['quantity'],
+				];
+			}
+
+			$request = [
+				'ui_mode'              => 'custom',
+				'customer'             => $customer->get_id(),
+				'line_items'           => $line_items,
+				'payment_method_types' => $enabled_payment_methods,
+				'payment_intent_data'  => [], // @todo Pass additional data if needed.
+				'mode'                 => 'payment',
+				'adaptive_pricing'     => [
+					'enabled' => 'true',
 				],
-				'quantity' => $cart_item['quantity'],
 			];
+
+			$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );
+
+			if ( ! empty( $checkout_session->error ) ) {
+				throw new Exception( $checkout_session->error->message );
+			}
+
+			if ( empty( $checkout_session->client_secret ) ) {
+				throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
+			}
+
+			wp_send_json_success( [ 'client_secret' => $checkout_session->client_secret ] );
+		} catch ( Exception $e ) {
+			WC_Stripe_Logger::error( 'Create checkout session error.', [ 'error_message' => $e->getMessage() ] );
+			wp_send_json_error( [ 'message' => $e->getMessage() ] );
 		}
-
-		$request = [
-			'ui_mode'              => 'custom',
-			'customer'             => $customer->get_id(),
-			'line_items'           => $line_items,
-			'payment_method_types' => $enabled_payment_methods,
-			'payment_intent_data'  => [], // @todo Pass additional data if needed.
-			'mode'                 => 'payment',
-			'adaptive_pricing'     => [
-				'enabled' => 'true',
-			],
-		];
-
-		$checkout_session = WC_Stripe_API::request( $request, 'checkout/sessions' );
-
-		if ( ! empty( $checkout_session->error ) ) {
-			throw new Exception( $checkout_session->error->message );
-		}
-
-		if ( empty( $checkout_session->client_secret ) ) {
-			throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
-		}
-
-		wp_send_json_success( [ 'client_secret' => $checkout_session->client_secret ] );
 	}
 }

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -65,7 +65,7 @@ class WC_Stripe_Checkout_Sessions_Controller {
 						],
 						'unit_amount' => $raw_line_item['amount'],
 					],
-					'quantity' => 1,
+					'quantity' => 1, // @TODO: Handle quantity properly if needed.
 				];
 			}
 

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -85,6 +85,6 @@ class WC_Stripe_Checkout_Sessions_Controller {
 			throw new Exception( __( 'Unable to create Stripe Checkout Session.', 'woocommerce-gateway-stripe' ) );
 		}
 
-		wp_send_json( [ 'client_secret' => $checkout_session->client_secret ] );
+		wp_send_json_success( [ 'client_secret' => $checkout_session->client_secret ] );
 	}
 }

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -44,7 +44,7 @@ class WC_Stripe_Checkout_Sessions_Controller {
 				throw new Exception( __( 'Unable to create or retrieve Stripe customer.', 'woocommerce-gateway-stripe' ) );
 			}
 
-			if ( is_null( WC()->cart ) || WC()->cart->is_empty() ) {
+			if ( ! WC()->cart || WC()->cart->is_empty() ) {
 				throw new Exception( __( 'Your cart is currently empty.', 'woocommerce-gateway-stripe' ) );
 			}
 

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -21,7 +21,6 @@ class WC_Stripe_Checkout_Sessions_Controller {
 	 * Create a Stripe Checkout Session and return the client secret.
 	 *
 	 * @return void
-	 * @throws WC_Stripe_Exception When unable to create the Checkout Session.
 	 */
 	public function create_checkout_session(): void {
 		try {

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -26,7 +26,7 @@ class WC_Stripe_Checkout_Sessions_Controller {
 		try {
 			$is_nonce_valid = check_ajax_referer( 'wc_stripe_create_checkout_session_nonce', false, false );
 			if ( ! $is_nonce_valid ) {
-				throw new Exception( __( "We're not able to process this payment. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
+				throw new Exception( __( "We're not able to process this request. Please refresh the page and try again.", 'woocommerce-gateway-stripe' ) );
 			}
 
 			if ( ! defined( 'WOOCOMMERCE_CART' ) ) {

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -52,6 +52,11 @@ class WC_Stripe_Checkout_Sessions_Controller {
 			$currency   = get_woocommerce_currency();
 			$line_items = [];
 			foreach ( WC_Stripe_Helper::build_line_items() as $raw_line_item ) {
+				if ( 'total_discount' === $raw_line_item['key'] ) {
+					// TODO: Stripe Checkout handles discounts/coupons differently. Skip for now.
+					continue;
+				}
+
 				$line_items[] = [
 					'price_data' => [
 						'currency' => strtolower( $currency ),

--- a/includes/class-wc-stripe-checkout-sessions-controller.php
+++ b/includes/class-wc-stripe-checkout-sessions-controller.php
@@ -37,6 +37,7 @@ class WC_Stripe_Checkout_Sessions_Controller {
 			$payment_method_type     = isset( $_POST['payment_method_type'] ) ? wc_clean( wp_unslash( $_POST['payment_method_type'] ) ) : '';
 			$enabled_payment_methods = $payment_method_type ? [ $payment_method_type ] : [];
 
+			// TODO: Test guest checkout flow.
 			try {
 				$customer = new WC_Stripe_Customer( wp_get_current_user()->ID );
 				$customer->maybe_create_customer();

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1931,4 +1931,91 @@ class WC_Stripe_Helper {
 		*/
 		return apply_filters( 'wc_stripe_is_verbose_debug_mode_enabled', false );
 	}
+
+	/**
+	 * Builds the line items to pass to express checkout elements and to checkout sessions creation request.
+	 *
+	 * @param bool $itemized_display_items Whether to force itemized display items.
+	 * @return array The display items.
+	 */
+	public static function build_line_items( bool $itemized_display_items = false ): array {
+		$items         = [];
+		$lines         = [];
+		$subtotal      = 0;
+		$discounts     = 0;
+		$has_deposits  = false;
+
+		if ( $itemized_display_items ) {
+			foreach ( WC()->cart->get_cart() as $cart_item ) {
+				// Hide itemization/subtotals for Apple Pay and Google Pay when deposits are present.
+				if ( ! empty( $cart_item['is_deposit'] ) ) {
+					$has_deposits = true;
+					continue;
+				}
+
+				$subtotal      += $cart_item['line_subtotal'];
+				$amount         = $cart_item['line_subtotal'];
+				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
+				$product_name   = $cart_item['data']->get_name();
+
+				$lines[] = [
+					'label'  => $product_name . $quantity_label,
+					'amount' => WC_Stripe_Helper::get_stripe_amount( $amount ),
+				];
+			}
+		} else {
+			$subtotal = WC()->cart->get_subtotal();
+		}
+
+		if ( $itemized_display_items && ! $has_deposits ) {
+			$items = array_merge( $items, $lines );
+		} elseif ( ! $has_deposits ) { // If the cart contains a deposit, the subtotal will be different to the cart total and will throw an error.
+			$items[] = [
+				'label'  => esc_html( __( 'Subtotal', 'woocommerce-gateway-stripe' ) ),
+				'amount' => WC_Stripe_Helper::get_stripe_amount( $subtotal ),
+			];
+		}
+
+		$applied_coupons = array_values( WC()->cart->get_coupon_discount_totals() );
+		foreach ( $applied_coupons as $amount ) {
+			$discounts += (float) $amount;
+		}
+
+		$discounts   = wc_format_decimal( $discounts, WC()->cart->dp );
+		$tax         = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
+		$shipping    = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
+
+		if ( wc_tax_enabled() ) {
+			$items[] = [
+				'label'  => esc_html( __( 'Tax', 'woocommerce-gateway-stripe' ) ),
+				'amount' => WC_Stripe_Helper::get_stripe_amount( $tax ),
+			];
+		}
+
+		if ( WC()->cart->needs_shipping() ) {
+			$items[] = [
+				'label'  => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
+				'amount' => WC_Stripe_Helper::get_stripe_amount( $shipping ),
+			];
+		}
+
+		if ( WC()->cart->has_discount() ) {
+			$items[] = [
+				'label'  => esc_html( __( 'Discount', 'woocommerce-gateway-stripe' ) ),
+				'amount' => WC_Stripe_Helper::get_stripe_amount( $discounts ),
+			];
+		}
+
+		$cart_fees = WC()->cart->get_fees();
+
+		// Include fees and taxes as display items.
+		foreach ( $cart_fees as $fee ) {
+			$items[] = [
+				'label'  => $fee->name,
+				'amount' => WC_Stripe_Helper::get_stripe_amount( $fee->amount ),
+			];
+		}
+
+		return $items;
+	}
 }

--- a/includes/class-wc-stripe-helper.php
+++ b/includes/class-wc-stripe-helper.php
@@ -1994,6 +1994,7 @@ class WC_Stripe_Helper {
 
 		if ( WC()->cart->needs_shipping() ) {
 			$items[] = [
+				'key'    => 'total_shipping',
 				'label'  => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
 				'amount' => WC_Stripe_Helper::get_stripe_amount( $shipping ),
 			];
@@ -2001,6 +2002,7 @@ class WC_Stripe_Helper {
 
 		if ( WC()->cart->has_discount() ) {
 			$items[] = [
+				'key'    => 'total_discount',
 				'label'  => esc_html( __( 'Discount', 'woocommerce-gateway-stripe' ) ),
 				'amount' => WC_Stripe_Helper::get_stripe_amount( $discounts ),
 			];

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -200,6 +200,7 @@ class WC_Stripe {
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/payment-tokens/class-wc-stripe-payment-tokens.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-customer.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-intent-controller.php';
+		require_once WC_STRIPE_PLUGIN_PATH . '/includes/class-wc-stripe-checkout-sessions-controller.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-inbox-notes.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-upe-compatibility-controller.php';
 		require_once WC_STRIPE_PLUGIN_PATH . '/includes/migrations/class-allowed-payment-request-button-types-update.php';
@@ -220,6 +221,9 @@ class WC_Stripe {
 
 		$intent_controller = new WC_Stripe_Intent_Controller();
 		$intent_controller->init_hooks();
+
+		$checkout_sessions_controller = new WC_Stripe_Checkout_Sessions_Controller();
+		$checkout_sessions_controller->init_hooks();
 
 		if ( is_admin() ) {
 			require_once WC_STRIPE_PLUGIN_PATH . '/includes/admin/class-wc-stripe-admin-notices.php';

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -1497,91 +1497,10 @@ class WC_Stripe_Express_Checkout_Helper {
 			define( 'WOOCOMMERCE_CART', true );
 		}
 
-		$items         = [];
-		$lines         = [];
-		$subtotal      = 0;
-		$discounts     = 0;
 		$display_items = ! apply_filters( 'wc_stripe_payment_request_hide_itemization', true ) || $itemized_display_items;
-		$has_deposits  = false;
-
-		if ( $display_items ) {
-			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-				// Hide itemization/subtotals for Apple Pay and Google Pay when deposits are present.
-				if ( ! empty( $cart_item['is_deposit'] ) ) {
-					$has_deposits = true;
-					continue;
-				}
-
-				$subtotal      += $cart_item['line_subtotal'];
-				$amount         = $cart_item['line_subtotal'];
-				$quantity_label = 1 < $cart_item['quantity'] ? ' (x' . $cart_item['quantity'] . ')' : '';
-				$product_name   = $cart_item['data']->get_name();
-
-				$lines[] = [
-					'label'  => $product_name . $quantity_label,
-					'amount' => WC_Stripe_Helper::get_stripe_amount( $amount ),
-				];
-			}
-		} else {
-			$subtotal = WC()->cart->get_subtotal();
-		}
-
-		if ( $display_items && ! $has_deposits ) {
-			$items = array_merge( $items, $lines );
-		} elseif ( ! $has_deposits ) { // If the cart contains a deposit, the subtotal will be different to the cart total and will throw an error.
-			$items[] = [
-				'label'  => 'Subtotal',
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $subtotal ),
-			];
-		}
-
-		$applied_coupons = array_values( WC()->cart->get_coupon_discount_totals() );
-
-		foreach ( $applied_coupons as $amount ) {
-			$discounts += (float) $amount;
-		}
-
-		$discounts   = wc_format_decimal( $discounts, WC()->cart->dp );
-		$tax         = wc_format_decimal( WC()->cart->tax_total + WC()->cart->shipping_tax_total, WC()->cart->dp );
-		$shipping    = wc_format_decimal( WC()->cart->shipping_total, WC()->cart->dp );
-		$items_total = wc_format_decimal( WC()->cart->cart_contents_total, WC()->cart->dp ) + $discounts;
-		$order_total = WC()->cart->get_total( false );
-
-		if ( wc_tax_enabled() ) {
-			$items[] = [
-				'label'  => esc_html( __( 'Tax', 'woocommerce-gateway-stripe' ) ),
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $tax ),
-			];
-		}
-
-		if ( WC()->cart->needs_shipping() ) {
-			$items[] = [
-				'key'    => 'total_shipping',
-				'label'  => esc_html( __( 'Shipping', 'woocommerce-gateway-stripe' ) ),
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $shipping ),
-			];
-		}
-
-		if ( WC()->cart->has_discount() ) {
-			$items[] = [
-				'key'    => 'total_discount',
-				'label'  => esc_html( __( 'Discount', 'woocommerce-gateway-stripe' ) ),
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $discounts ),
-			];
-		}
-
-		$cart_fees = WC()->cart->get_fees();
-
-		// Include fees and taxes as display items.
-		foreach ( $cart_fees as $key => $fee ) {
-			$items[] = [
-				'label'  => $fee->name,
-				'amount' => WC_Stripe_Helper::get_stripe_amount( $fee->amount ),
-			];
-		}
+		$order_total   = WC()->cart->get_total( false );
 
 		$calculated_total = WC_Stripe_Helper::get_stripe_amount( $order_total );
-
 		$calculated_total = apply_filters_deprecated(
 			'woocommerce_stripe_calculated_total',
 			[ $calculated_total, $order_total, WC()->cart ],
@@ -1602,7 +1521,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		$calculated_total = apply_filters( 'wc_stripe_calculated_total', $calculated_total, $order_total, WC()->cart );
 
 		return [
-			'displayItems' => $items,
+			'displayItems' => WC_Stripe_Helper::build_line_items( $display_items ),
 			'total'        => [
 				'label'   => $this->total_label,
 				'amount'  => max( 0, $calculated_total ),

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -535,6 +535,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['createSetupIntentNonce']            = wp_create_nonce( 'wc_stripe_create_setup_intent_nonce' );
 		$stripe_params['createAndConfirmSetupIntentNonce']  = wp_create_nonce( 'wc_stripe_create_and_confirm_setup_intent_nonce' );
 		$stripe_params['updateFailedOrderNonce']            = wp_create_nonce( 'wc_stripe_update_failed_order_nonce' );
+		$stripe_params['createCheckoutSessionNonce']        = wp_create_nonce( 'wc_stripe_create_checkout_session_nonce' );
 		$stripe_params['paymentMethodsConfig']              = $this->get_enabled_payment_method_config();
 		$stripe_params['genericErrorMessage']               = __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-gateway-stripe' );
 		$stripe_params['accountDescriptor']                 = $this->statement_descriptor;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3163,6 +3163,30 @@ parameters:
 			path: includes/class-wc-stripe-helper.php
 
 		-
+			message: '#^Access to an undefined property WC_Cart\:\:\$dp\.$#'
+			identifier: property.notFound
+			count: 3
+			path: includes/class-wc-stripe-helper.php
+
+		-
+			message: '#^Access to an undefined property WC_Cart\:\:\$shipping_tax_total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/class-wc-stripe-helper.php
+
+		-
+			message: '#^Access to an undefined property WC_Cart\:\:\$shipping_total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/class-wc-stripe-helper.php
+
+		-
+			message: '#^Access to an undefined property WC_Cart\:\:\$tax_total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: includes/class-wc-stripe-helper.php
+
+		-
 			message: '#^Access to an undefined property object\:\:\$currency\.$#'
 			identifier: property.notFound
 			count: 1
@@ -3394,6 +3418,12 @@ parameters:
 			message: '#^Parameter \#1 \$str of function trim expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 1
+			path: includes/class-wc-stripe-helper.php
+
+		-
+			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
+			identifier: argument.type
+			count: 3
 			path: includes/class-wc-stripe-helper.php
 
 		-
@@ -6085,36 +6115,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
-			message: '#^Access to an undefined property WC_Cart\:\:\$cart_contents_total\.$#'
-			identifier: property.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Access to an undefined property WC_Cart\:\:\$dp\.$#'
-			identifier: property.notFound
-			count: 4
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Access to an undefined property WC_Cart\:\:\$shipping_tax_total\.$#'
-			identifier: property.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Access to an undefined property WC_Cart\:\:\$shipping_total\.$#'
-			identifier: property.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Access to an undefined property WC_Cart\:\:\$tax_total\.$#'
-			identifier: property.notFound
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
 			message: '#^Access to an undefined property WooCommerce\:\:\$payment_gateways\.$#'
 			identifier: property.notFound
 			count: 1
@@ -6124,12 +6124,6 @@ parameters:
 			message: '#^Access to an undefined property WooCommerce\:\:\$shipping\.$#'
 			identifier: property.notFound
 			count: 3
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Binary operation "\+" between string and string results in an error\.$#'
-			identifier: binaryOp.invalid
-			count: 1
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-
@@ -6436,12 +6430,6 @@ parameters:
 			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, float\|string given\.$#'
 			identifier: argument.type
 			count: 1
-			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
-
-		-
-			message: '#^Parameter \#1 \$total of static method WC_Stripe_Helper\:\:get_stripe_amount\(\) expects float, string given\.$#'
-			identifier: argument.type
-			count: 3
 			path: includes/payment-methods/class-wc-stripe-express-checkout-helper.php
 
 		-

--- a/readme.txt
+++ b/readme.txt
@@ -140,6 +140,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.4.0 - xxxx-xx-xx =
+* Add - Introduce an endpoint to create Checkout Sessions tokens
 * Update - Redirect merchants to the Stripe settings screen upon plugin activation
 * Fix - Fix Stripe client API calls with wrong amount when rendering the express checkout buttons in blocks
 * Fix - Validate product exists before accessing product methods in express checkout to prevent fatal errors

--- a/tests/phpunit/Helpers/Ajax_Test_Helper.php
+++ b/tests/phpunit/Helpers/Ajax_Test_Helper.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests\Helpers;
+
+/**
+ * Provides useful methods to test logic related to AJAX requests.
+ */
+class Ajax_Test_Helper {
+	/**
+	 * Initialize hooks.
+	 *
+	 * @return void
+	 */
+	public static function init_hooks(): void {
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		add_filter( 'wp_die_ajax_handler', [ Ajax_Test_Helper::class, 'wp_ajax_halt_handler_filter' ] );
+	}
+
+	public static function remove_hooks(): void {
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+		remove_filter( 'wp_die_ajax_handler', [ Ajax_Test_Helper::class, 'wp_ajax_halt_handler_filter' ] );
+	}
+
+	/**
+	 * Filter to return a custom handler for AJAX requests.
+	 *
+	 * @return callable The custom handler function.
+	 */
+	public static function wp_ajax_halt_handler_filter(): callable {
+		return [ Ajax_Test_Helper::class, 'wp_ajax_print_handler' ];
+	}
+
+	/**
+	 * Custom handler function to output the message.
+	 *
+	 * @param string $message The message to print.
+	 */
+	public static function wp_ajax_print_handler( string $message ): void {
+		echo wp_kses_post( $message );
+	}
+}

--- a/tests/phpunit/Helpers/Ajax_Test_Helper.php
+++ b/tests/phpunit/Helpers/Ajax_Test_Helper.php
@@ -13,7 +13,7 @@ class Ajax_Test_Helper {
 	 */
 	public static function init_hooks(): void {
 		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter( 'wp_die_ajax_handler', [ Ajax_Test_Helper::class, 'wp_ajax_halt_handler_filter' ] );
+		add_filter( 'wp_die_ajax_handler', [ self::class, 'wp_ajax_halt_handler_filter' ] );
 	}
 
 	public static function remove_hooks(): void {

--- a/tests/phpunit/Helpers/Ajax_Test_Helper.php
+++ b/tests/phpunit/Helpers/Ajax_Test_Helper.php
@@ -18,7 +18,7 @@ class Ajax_Test_Helper {
 
 	public static function remove_hooks(): void {
 		remove_filter( 'wp_doing_ajax', '__return_true' );
-		remove_filter( 'wp_die_ajax_handler', [ Ajax_Test_Helper::class, 'wp_ajax_halt_handler_filter' ] );
+		remove_filter( 'wp_die_ajax_handler', [ self::class, 'wp_ajax_halt_handler_filter' ] );
 	}
 
 	/**
@@ -27,7 +27,7 @@ class Ajax_Test_Helper {
 	 * @return callable The custom handler function.
 	 */
 	public static function wp_ajax_halt_handler_filter(): callable {
-		return [ Ajax_Test_Helper::class, 'wp_ajax_print_handler' ];
+		return [ self::class, 'wp_ajax_print_handler' ];
 	}
 
 	/**

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -31,7 +31,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	 * Tests for the `create_checkout_session` method.
 	 *
 	 * @param bool        $is_valid_nonce             Whether the AJAX nonce is valid.
-	 * @param array       $cart_contents              The contents to add to the cart.
+	 * @param bool        $is_cart_empty              Whether the cart is empty.
 	 * @param object|null $checkout_session_response  The mocked response from Stripe when creating the Checkout Session.
 	 * @param string|null $expected_exception_message The expected exception message, if any.
 	 * @param string|null $expected_secret            The expected client secret, if any.
@@ -41,7 +41,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	public function test_create_checkout_session(
 		bool $is_valid_nonce,
 		array $customer_data = [],
-		array $cart_contents = [],
+		bool $is_cart_empty = true,
 		?object $checkout_session_response = null,
 		?string $expected_exception_message = null,
 		?string $expected_secret = null
@@ -59,7 +59,10 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		WC()->session->init();
 		WC()->cart->empty_cart();
 
-		foreach ( $cart_contents as $product ) {
+		if ( ! $is_cart_empty ) {
+			$product = WC_Helper_Product::create_simple_product();
+			$product->save();
+
 			WC()->cart->add_to_cart( $product->get_id(), 1 );
 		}
 
@@ -128,9 +131,6 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			'billing_country'    => 'US',
 		];
 
-		$product = WC_Helper_Product::create_simple_product();
-		$product->save();
-
 		$mocked_error_message = 'Simulated error for testing.';
 
 		$mocked_secret = 'cs_test_1234567890abcdef';
@@ -151,7 +151,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			'invalid nonce'            => [
 				'is valid nonce'             => false,
 				'customer data'              => [],
-				'cart contents'              => [],
+				'is cart empty'              => true,
 				'checkout session response'  => null,
 				'expected exception message' => "We're not able to process this payment. Please refresh the page and try again.",
 				'expected secret'            => null,
@@ -159,7 +159,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			'missing customer data'    => [
 				'is valid nonce'             => true,
 				'customer data'              => [],
-				'cart contents'              => [ $product ],
+				'is cart empty'              => true,
 				'checkout session response'  => null,
 				'expected exception message' => 'Unable to create or retrieve Stripe customer.',
 				'expected secret'            => null,
@@ -167,7 +167,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			'cart is empty'            => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
-				'cart contents'              => [],
+				'is cart empty'              => true,
 				'checkout session response'  => null,
 				'expected exception message' => 'Your cart is currently empty.',
 				'expected secret'            => null,
@@ -175,7 +175,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			'error creating session'   => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
-				'cart contents'              => [ $product ],
+				'is cart empty'              => false,
 				'checkout session response'  => $checkout_session_error,
 				'expected exception message' => $mocked_error_message,
 				'expected secret'            => null,
@@ -183,7 +183,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			'client secret is missing' => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
-				'cart contents'              => [ $product ],
+				'is cart empty'              => false,
 				'checkout session response'  => $checkout_session_missing_secret,
 				'expected exception message' => 'Unable to create Stripe Checkout Session.',
 				'expected secret'            => null,
@@ -191,7 +191,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			'successful creation'      => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
-				'cart contents'              => [ $product ],
+				'is cart empty'              => false,
 				'checkout session response'  => $checkout_session_success,
 				'expected exception message' => null,
 				'expected secret'            => $mocked_secret,

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -2,7 +2,9 @@
 
 namespace WooCommerce\Stripe\Tests;
 
+use Automattic\WooCommerce\Enums\ProductTaxStatus;
 use WooCommerce\Stripe\Tests\Helpers\Ajax_Test_Helper;
+use WooCommerce\Stripe\Tests\Helpers\WC_Helper_Product;
 use WP_UnitTestCase;
 use WC_Stripe_Checkout_Sessions_Controller;
 
@@ -29,6 +31,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	 * Tests for the `create_checkout_session` method.
 	 *
 	 * @param bool        $is_valid_nonce             Whether the AJAX nonce is valid.
+	 * @param array       $cart_contents              The contents to add to the cart.
 	 * @param object|null $checkout_session_response  The mocked response from Stripe when creating the Checkout Session.
 	 * @param string|null $expected_exception_message The expected exception message, if any.
 	 * @param string|null $expected_secret            The expected client secret, if any.
@@ -37,6 +40,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	 */
 	public function test_create_checkout_session(
 		bool $is_valid_nonce,
+		array $cart_contents = [],
 		?object $checkout_session_response = null,
 		?string $expected_exception_message = null,
 		?string $expected_secret = null
@@ -53,6 +57,14 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		update_user_meta( 1, 'billing_state', 'NY' );
 		update_user_meta( 1, 'billing_postcode', '10001' );
 		update_user_meta( 1, 'billing_country', 'US' );
+
+		// Set up the cart contents.
+		WC()->session->init();
+		WC()->cart->empty_cart();
+
+		foreach ( $cart_contents as $product ) {
+			WC()->cart->add_to_cart( $product->get_id(), 1 );
+		}
 
 		// Mock response from Stripe API.
 		$test_request = function ( $return_value, $parsed_args, $url ) use ( $checkout_session_response ) {
@@ -109,6 +121,9 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function provide_test_create_checkout_session(): array {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
 		$mocked_error_message = 'Simulated error for testing.';
 
 		$mocked_secret = 'cs_test_1234567890abcdef';
@@ -128,24 +143,35 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		return [
 			'invalid nonce'            => [
 				'is valid nonce'             => false,
+				'cart contents'              => [],
 				'checkout session response'  => null,
 				'expected exception message' => "We're not able to process this payment. Please refresh the page and try again.",
 				'expected secret'            => null,
 			],
+			'cart is empty'            => [
+				'is valid nonce'             => true,
+				'cart contents'              => [],
+				'checkout session response'  => null,
+				'expected exception message' => 'Your cart is currently empty.',
+				'expected secret'            => null,
+			],
 			'error creating session'   => [
 				'is valid nonce'             => true,
+				'cart contents'              => [ $product ],
 				'checkout session response'  => $checkout_session_error,
 				'expected exception message' => $mocked_error_message,
 				'expected secret'            => null,
 			],
 			'client secret is missing' => [
 				'is valid nonce'             => true,
+				'cart contents'              => [ $product ],
 				'checkout session response'  => $checkout_session_missing_secret,
 				'expected exception message' => 'Unable to create Stripe Checkout Session.',
 				'expected secret'            => null,
 			],
 			'successful creation'      => [
 				'is valid nonce'             => true,
+				'cart contents'              => [ $product ],
 				'checkout session response'  => $checkout_session_success,
 				'expected exception message' => null,
 				'expected secret'            => $mocked_secret,

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -40,6 +40,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	 */
 	public function test_create_checkout_session(
 		bool $is_valid_nonce,
+		array $customer_data = [],
 		array $cart_contents = [],
 		?object $checkout_session_response = null,
 		?string $expected_exception_message = null,
@@ -50,13 +51,9 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		// Set up a logged-in user with billing details.
 		wp_set_current_user( 1 );
 
-		update_user_meta( 1, 'billing_first_name', 'John' );
-		update_user_meta( 1, 'billing_last_name', 'Doe' );
-		update_user_meta( 1, 'billing_address_1', '123 Main St' );
-		update_user_meta( 1, 'billing_city', 'New York' );
-		update_user_meta( 1, 'billing_state', 'NY' );
-		update_user_meta( 1, 'billing_postcode', '10001' );
-		update_user_meta( 1, 'billing_country', 'US' );
+		foreach ( $customer_data as $key => $value ) {
+			update_user_meta( 1, $key, $value );
+		}
 
 		// Set up the cart contents.
 		WC()->session->init();
@@ -121,6 +118,16 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function provide_test_create_checkout_session(): array {
+		$customer_data = [
+			'billing_first_name' => 'John',
+			'billing_last_name'  => 'Doe',
+			'billing_address_1'  => '123 Main St',
+			'billing_city'       => 'New York',
+			'billing_state'      => 'NY',
+			'billing_postcode'   => '10001',
+			'billing_country'    => 'US',
+		];
+
 		$product = WC_Helper_Product::create_simple_product();
 		$product->save();
 
@@ -143,13 +150,23 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		return [
 			'invalid nonce'            => [
 				'is valid nonce'             => false,
+				'customer data'              => [],
 				'cart contents'              => [],
 				'checkout session response'  => null,
 				'expected exception message' => "We're not able to process this payment. Please refresh the page and try again.",
 				'expected secret'            => null,
 			],
+			'missing customer data'    => [
+				'is valid nonce'             => true,
+				'customer data'              => [],
+				'cart contents'              => [ $product ],
+				'checkout session response'  => null,
+				'expected exception message' => 'Unable to create or retrieve Stripe customer.',
+				'expected secret'            => null,
+			],
 			'cart is empty'            => [
 				'is valid nonce'             => true,
+				'customer data'              => $customer_data,
 				'cart contents'              => [],
 				'checkout session response'  => null,
 				'expected exception message' => 'Your cart is currently empty.',
@@ -157,6 +174,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			],
 			'error creating session'   => [
 				'is valid nonce'             => true,
+				'customer data'              => $customer_data,
 				'cart contents'              => [ $product ],
 				'checkout session response'  => $checkout_session_error,
 				'expected exception message' => $mocked_error_message,
@@ -164,6 +182,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			],
 			'client secret is missing' => [
 				'is valid nonce'             => true,
+				'customer data'              => $customer_data,
 				'cart contents'              => [ $product ],
 				'checkout session response'  => $checkout_session_missing_secret,
 				'expected exception message' => 'Unable to create Stripe Checkout Session.',
@@ -171,6 +190,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 			],
 			'successful creation'      => [
 				'is valid nonce'             => true,
+				'customer data'              => $customer_data,
 				'cart contents'              => [ $product ],
 				'checkout session response'  => $checkout_session_success,
 				'expected exception message' => null,

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace WooCommerce\Stripe\Tests;
+
+use WooCommerce\Stripe\Tests\Helpers\Ajax_Test_Helper;
+use WP_UnitTestCase;
+use WC_Stripe_Checkout_Sessions_Controller;
+
+/**
+ * These tests make assertions against the WC_Stripe_Checkout_Sessions_Controller class.
+ */
+class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
+	/**
+	 * Test that hooks are initialized correctly.
+	 */
+	public function test_init_hooks(): void {
+		$controller = new WC_Stripe_Checkout_Sessions_Controller();
+		$controller->init_hooks();
+
+		$this->assertTrue(
+			(bool) has_action(
+				'wc_ajax_wc_stripe_create_checkout_session',
+				[ $controller, 'create_checkout_session' ]
+			)
+		);
+	}
+
+	/**
+	 * Tests for the `create_checkout_session` method.
+	 *
+	 * @param bool        $is_valid_nonce             Whether the AJAX nonce is valid.
+	 * @param object|null $checkout_session_response  The mocked response from Stripe when creating the Checkout Session.
+	 * @param string|null $expected_exception_message The expected exception message, if any.
+	 * @param string|null $expected_secret            The expected client secret, if any.
+	 * @return void
+	 * @dataProvider provide_test_create_checkout_session
+	 */
+	public function test_create_checkout_session(
+		bool $is_valid_nonce,
+		?object $checkout_session_response = null,
+		?string $expected_exception_message = null,
+		?string $expected_secret = null
+	): void {
+		Ajax_Test_Helper::init_hooks();
+
+		// Set up a logged-in user with billing details.
+		wp_set_current_user( 1 );
+
+		update_user_meta( 1, 'billing_first_name', 'John' );
+		update_user_meta( 1, 'billing_last_name', 'Doe' );
+		update_user_meta( 1, 'billing_address_1', '123 Main St' );
+		update_user_meta( 1, 'billing_city', 'New York' );
+		update_user_meta( 1, 'billing_state', 'NY' );
+		update_user_meta( 1, 'billing_postcode', '10001' );
+		update_user_meta( 1, 'billing_country', 'US' );
+
+		// Mock response from Stripe API.
+		$test_request = function ( $return_value, $parsed_args, $url ) use ( $checkout_session_response ) {
+			// Mock the customer retrieval response.
+			if ( strpos( $url, '/v1/customers' ) !== false ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( (object) [ 'id' => 'cus_123' ] ),
+				];
+			}
+
+			return [
+				'response' => 200,
+				'headers'  => [ 'Content-Type' => 'application/json' ],
+				'body'     => json_encode( $checkout_session_response ),
+			];
+		};
+
+		add_filter( 'pre_http_request', $test_request, 10, 3 );
+
+		// Set up the AJAX request nonce.
+		$_REQUEST['_ajax_nonce'] = $is_valid_nonce ? wp_create_nonce( 'wc_stripe_create_checkout_session_nonce' ) : 'invalid_nonce_value';
+
+		$controller = new WC_Stripe_Checkout_Sessions_Controller();
+
+		if ( $expected_exception_message ) {
+			$this->expectException( \Exception::class );
+			$this->expectExceptionMessage( $expected_exception_message );
+		}
+
+		try {
+			ob_start();
+			$controller->create_checkout_session();
+			$output = ob_get_clean();
+		} catch ( \Exception $e ) {
+			ob_end_clean();
+			throw $e;
+		}
+
+		// Clean up.
+		remove_filter( 'pre_http_request', $test_request, 10, 3 );
+		Ajax_Test_Helper::remove_hooks();
+
+		if ( $expected_secret ) {
+			$response = json_decode( $output );
+			$this->assertEquals( $expected_secret, $response->client_secret );
+		}
+	}
+
+	/**
+	 * Data provider for `test_create_checkout_session`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_create_checkout_session(): array {
+		$mocked_error_message = 'Simulated error for testing.';
+
+		$mocked_secret = 'cs_test_1234567890abcdef';
+
+		$checkout_session_error = (object) [
+			'error' => (object) [
+				'message' => $mocked_error_message,
+			],
+		];
+
+		$checkout_session_missing_secret = (object) [];
+
+		$checkout_session_success = (object) [
+			'client_secret' => $mocked_secret,
+		];
+
+		return [
+			'invalid nonce'            => [
+				'is valid nonce'             => false,
+				'checkout session response'  => null,
+				'expected exception message' => "We're not able to process this payment. Please refresh the page and try again.",
+				'expected secret'            => null,
+			],
+			'error creating session'   => [
+				'is valid nonce'             => true,
+				'checkout session response'  => $checkout_session_error,
+				'expected exception message' => $mocked_error_message,
+				'expected secret'            => null,
+			],
+			'client secret is missing' => [
+				'is valid nonce'             => true,
+				'checkout session response'  => $checkout_session_missing_secret,
+				'expected exception message' => 'Unable to create Stripe Checkout Session.',
+				'expected secret'            => null,
+			],
+			'successful creation'      => [
+				'is valid nonce'             => true,
+				'checkout session response'  => $checkout_session_success,
+				'expected exception message' => null,
+				'expected secret'            => $mocked_secret,
+			],
+		];
+	}
+}

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -83,7 +83,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 					'body'     => json_encode( $checkout_session_response ),
 				];
 			}
-			
+
 			return $return_value;
 		};
 

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -101,11 +101,11 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		} catch ( \Exception $e ) {
 			ob_end_clean();
 			throw $e;
+		} finally {
+			// Clean up.
+			remove_filter( 'pre_http_request', $test_request, 10, 3 );
+			Ajax_Test_Helper::remove_hooks();
 		}
-
-		// Clean up.
-		remove_filter( 'pre_http_request', $test_request, 10, 3 );
-		Ajax_Test_Helper::remove_hooks();
 
 		$response = json_decode( $output );
 		$this->assertEquals( (object) $expected_response, $response );

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -76,11 +76,15 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 				];
 			}
 
-			return [
-				'response' => 200,
-				'headers'  => [ 'Content-Type' => 'application/json' ],
-				'body'     => json_encode( $checkout_session_response ),
-			];
+			if ( 'https://api.stripe.com/v1/checkout/sessions' === $url ) {
+				return [
+					'response' => 200,
+					'headers'  => [ 'Content-Type' => 'application/json' ],
+					'body'     => json_encode( $checkout_session_response ),
+				];
+			}
+			
+			return $return_value;
 		};
 
 		add_filter( 'pre_http_request', $test_request, 10, 3 );

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -152,7 +152,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 				'expected response'          => (object) [
 					'success' => false,
 					'data'    => (object) [
-						'message' => "We're not able to process this payment. Please refresh the page and try again.",
+						'message' => "We're not able to process this request. Please refresh the page and try again.",
 					],
 				],
 			],

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -48,7 +48,7 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		Ajax_Test_Helper::init_hooks();
 
 		// Set up a logged-in user with billing details.
-		wp_set_current_user( 1 );
+		WC()->customer = new \WC_Customer( 1 );
 
 		foreach ( $customer_data as $key => $value ) {
 			update_user_meta( 1, $key, $value );

--- a/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Checkout_Sessions_Controller_Test.php
@@ -32,19 +32,18 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 	 *
 	 * @param bool        $is_valid_nonce             Whether the AJAX nonce is valid.
 	 * @param bool        $is_cart_empty              Whether the cart is empty.
-	 * @param object|null $checkout_session_response  The mocked response from Stripe when creating the Checkout Session.
-	 * @param string|null $expected_exception_message The expected exception message, if any.
-	 * @param string|null $expected_secret            The expected client secret, if any.
+	 * @param array       $customer_data              The customer billing data to set.
+	 * @param object|null $checkout_session_response  The mocked response from the Stripe API.
+	 * @param object      $expected_response          The expected AJAX response, if any.
 	 * @return void
 	 * @dataProvider provide_test_create_checkout_session
 	 */
 	public function test_create_checkout_session(
 		bool $is_valid_nonce,
-		array $customer_data = [],
-		bool $is_cart_empty = true,
-		?object $checkout_session_response = null,
-		?string $expected_exception_message = null,
-		?string $expected_secret = null
+		array $customer_data,
+		bool $is_cart_empty,
+		?object $checkout_session_response,
+		object $expected_response
 	): void {
 		Ajax_Test_Helper::init_hooks();
 
@@ -91,11 +90,6 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 
 		$controller = new WC_Stripe_Checkout_Sessions_Controller();
 
-		if ( $expected_exception_message ) {
-			$this->expectException( \Exception::class );
-			$this->expectExceptionMessage( $expected_exception_message );
-		}
-
 		try {
 			ob_start();
 			$controller->create_checkout_session();
@@ -109,10 +103,8 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 		remove_filter( 'pre_http_request', $test_request, 10, 3 );
 		Ajax_Test_Helper::remove_hooks();
 
-		if ( $expected_secret ) {
-			$response = json_decode( $output );
-			$this->assertEquals( $expected_secret, $response->client_secret );
-		}
+		$response = json_decode( $output );
+		$this->assertEquals( (object) $expected_response, $response );
 	}
 
 	/**
@@ -153,48 +145,72 @@ class WC_Stripe_Checkout_Sessions_Controller_Test extends WP_UnitTestCase {
 				'customer data'              => [],
 				'is cart empty'              => true,
 				'checkout session response'  => null,
-				'expected exception message' => "We're not able to process this payment. Please refresh the page and try again.",
-				'expected secret'            => null,
+				'expected response'          => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => "We're not able to process this payment. Please refresh the page and try again.",
+					],
+				],
 			],
 			'missing customer data'    => [
 				'is valid nonce'             => true,
 				'customer data'              => [],
 				'is cart empty'              => true,
 				'checkout session response'  => null,
-				'expected exception message' => 'Unable to create or retrieve Stripe customer.',
-				'expected secret'            => null,
+				'expected response'          => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => 'Unable to create or retrieve Stripe customer.',
+					],
+				],
 			],
 			'cart is empty'            => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
 				'is cart empty'              => true,
 				'checkout session response'  => null,
-				'expected exception message' => 'Your cart is currently empty.',
-				'expected secret'            => null,
+				'expected response'          => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => 'Your cart is currently empty.',
+					],
+				],
 			],
 			'error creating session'   => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
 				'is cart empty'              => false,
 				'checkout session response'  => $checkout_session_error,
-				'expected exception message' => $mocked_error_message,
-				'expected secret'            => null,
+				'expected response'          => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => $mocked_error_message,
+					],
+				],
 			],
 			'client secret is missing' => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
 				'is cart empty'              => false,
 				'checkout session response'  => $checkout_session_missing_secret,
-				'expected exception message' => 'Unable to create Stripe Checkout Session.',
-				'expected secret'            => null,
+				'expected response'          => (object) [
+					'success' => false,
+					'data'    => (object) [
+						'message' => 'Unable to create Stripe Checkout Session.',
+					],
+				],
 			],
 			'successful creation'      => [
 				'is valid nonce'             => true,
 				'customer data'              => $customer_data,
 				'is cart empty'              => false,
 				'checkout session response'  => $checkout_session_success,
-				'expected exception message' => null,
-				'expected secret'            => $mocked_secret,
+				'expected response'          => (object) [
+					'success' => true,
+					'data'    => (object) [
+						'client_secret' => $mocked_secret,
+					],
+				],
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Helper_Test.php
+++ b/tests/phpunit/WC_Stripe_Helper_Test.php
@@ -1114,10 +1114,12 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 						'amount' => 0,
 					],
 					[
+						'key'    => 'total_shipping',
 						'label'  => 'Shipping',
 						'amount' => 0,
 					],
 					[
+						'key'    => 'total_discount',
 						'label'  => 'Discount',
 						'amount' => 100,
 					],
@@ -1136,6 +1138,7 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 							'amount' => 0,
 						],
 						[
+							'key'    => 'total_discount',
 							'label'  => 'Discount',
 							'amount' => 100,
 						],

--- a/tests/phpunit/WC_Stripe_Helper_Test.php
+++ b/tests/phpunit/WC_Stripe_Helper_Test.php
@@ -11,6 +11,7 @@ use WC_Stripe_Order_Helper;
 use WC_Stripe_Payment_Methods;
 use WooCommerce\Stripe\Tests\Helpers\UPE_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\WC_Helper_Order;
+use WooCommerce\Stripe\Tests\Helpers\WC_Helper_Product;
 
 /**
  * These tests make assertions against class WC_Stripe_Helper.
@@ -1053,6 +1054,93 @@ class WC_Stripe_Helper_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 					],
 				],
 				'expected_message' => '',
+			],
+		];
+	}
+
+	/**
+	 * Tests for `build_line_items`.
+	 *
+	 * @param bool  $itemized       Whether itemized line items are enabled.
+	 * @param array $expected_items The expected line items.
+	 * @return void
+	 * @dataProvider provide_test_build_line_items
+	 */
+	public function test_build_line_items( bool $itemized = false, array $expected_items = [] ): void {
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		$coupon = new \WC_Coupon();
+		$coupon->set_code( 'TESTDISCOUNT' );
+		$coupon->set_amount( 1 );
+		$coupon->set_discount_type( 'fixed_cart' );
+		$coupon->save();
+
+		WC()->session->init();
+		WC()->cart->empty_cart();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->add_discount( 'TESTDISCOUNT' );
+
+		$actual = WC_Stripe_Helper::build_line_items( $itemized );
+
+		// Clean up.
+		WC()->cart->empty_cart();
+		$product->delete( true );
+		$coupon->delete();
+		delete_option( 'woocommerce_calc_taxes' );
+
+		$this->assertSame( $expected_items, $actual );
+	}
+
+	/**
+	 * Data provider for `test_build_line_items`.
+	 *
+	 * @return array
+	 */
+	public function provide_test_build_line_items(): array {
+		return [
+			'itemized'   => [
+				'itemized'       => true,
+				'expected items' => [
+					[
+						'label'  => 'Dummy Product',
+						'amount' => 1000,
+					],
+					[
+						'label' => 'Tax',
+						'amount' => 0,
+					],
+					[
+						'label'  => 'Shipping',
+						'amount' => 0,
+					],
+					[
+						'label'  => 'Discount',
+						'amount' => 100,
+					],
+				],
+			],
+			'non-itemized'            => [
+				'itemized'       => false,
+				'expected items' => array_merge(
+					[
+						[
+							'label'  => 'Subtotal',
+							'amount' => 1000,
+						],
+						[
+							'label' => 'Tax',
+							'amount' => 0,
+						],
+						[
+							'label'  => 'Discount',
+							'amount' => 100,
+						],
+					],
+				),
 			],
 		];
 	}

--- a/tests/phpunit/WC_Stripe_Intent_Controller_Test.php
+++ b/tests/phpunit/WC_Stripe_Intent_Controller_Test.php
@@ -11,6 +11,7 @@ use WC_Stripe_UPE_Payment_Gateway;
 use WC_Subscription;
 use WC_Subscriptions_Switcher;
 use WC_Subscriptions_Helpers;
+use WooCommerce\Stripe\Tests\Helpers\Ajax_Test_Helper;
 use WooCommerce\Stripe\Tests\Helpers\WC_Helper_Order;
 use WP_UnitTestCase;
 
@@ -551,8 +552,7 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 	 * Test that rate limiting works after a failed attempt.
 	 */
 	public function test_rate_limiting_on_consecutive_failed_calls() {
-		add_filter( 'wp_doing_ajax', '__return_true' );
-		add_filter( 'wp_die_ajax_handler', [ $this, 'wp_ajax_halt_handler_filter' ] );
+		Ajax_Test_Helper::init_hooks();
 
 		wp_set_current_user( 1 );
 		$_POST['wc-stripe-payment-method'] = 'pm_test_123';
@@ -580,25 +580,6 @@ class WC_Stripe_Intent_Controller_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'error', $response['data'] );
 		$this->assertEquals( 'You cannot add a new payment method so soon after the previous one.', $response['data']['error']['message'] );
 
-		remove_filter( 'wp_die_ajax_handler', [ $this, 'wp_ajax_halt_handler_filter' ] );
-		remove_filter( 'wp_doing_ajax', '__return_true' );
-	}
-
-	/**
-	 * Filter to return a custom handler for AJAX requests.
-	 *
-	 * @return callable The custom handler function.
-	 */
-	public function wp_ajax_halt_handler_filter() {
-		return [ $this, 'wp_ajax_print_handler' ];
-	}
-
-	/**
-	 * Custom handler function to output the message.
-	 *
-	 * @param string $message The message to print.
-	 */
-	public function wp_ajax_print_handler( $message ) {
-		echo wp_kses_post( $message );
+		Ajax_Test_Helper::remove_hooks();
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-932
Fixes #4969
Doc https://docs.stripe.com/api/checkout/sessions/create

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

This PR introduces a new public (shopper-facing) AJAX endpoint that creates Checkout Sessions objects and returns the client secret for them. This secret is required to build the payment element on the frontend (both blocks and shortcode checkout).

The endpoint accepts the `payment_method_type` parameter to build the `payment_method_types` property. It builds the product information using the current cart session.

We are using `custom` as `ui_mode` so we can render the payment element following the existing standards for payment intents on the frontend. We are hardcoding `payment` as the `mode` since saving of payment methods won't be supported for now.

No payment intent data is currently being provided.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

It is a bit hard to test this new endpoint manually because it is not yet used by the frontend, and it would require adding session information to the cURL request. For now, a code review should be enough. Also, check if the tests are passing.

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
