### PR TITLE
Update PHPDoc in email notification classes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@
 * Dev - Automate release note creation PR
 * Dev - Introduce a feature flag for the Stripe checkout sessions feature
 * Dev - Improve the pre-push hook
+* Tweak - Update PHPDoc for email notification classes
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/includes/compat/class-wc-stripe-email-admin-failed-refund.php
+++ b/includes/compat/class-wc-stripe-email-admin-failed-refund.php
@@ -46,6 +46,7 @@ class WC_Stripe_Email_Admin_Failed_Refund extends WC_Stripe_Email_Failed_Refund 
 	 * Trigger.
 	 *
 	 * @inheritDoc
+	 * @return void
 	 */
 	public function trigger( $order_id, $order = false ) {
 		// Set before calling the parent trigger, so it is not override.

--- a/includes/compat/class-wc-stripe-email-customer-failed-refund.php
+++ b/includes/compat/class-wc-stripe-email-customer-failed-refund.php
@@ -48,6 +48,7 @@ class WC_Stripe_Email_Customer_Failed_Refund extends WC_Stripe_Email_Failed_Refu
 	 * Trigger.
 	 *
 	 * @inheritDoc
+	 * @return void
 	 */
 	public function trigger( $order_id, $order = false ) {
 		// Set before calling the parent trigger, so it is not override.

--- a/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication-retry.php
@@ -7,7 +7,6 @@
  *
  * @version     4.3.0
  * @package     WooCommerce_Stripe/Classes/WC_Stripe_Email_Failed_Authentication_Retry
- * @extends     WC_Email_Failed_Order
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -93,6 +92,8 @@ class WC_Stripe_Email_Failed_Authentication_Retry extends WC_Email_Failed_Order 
 	 *
 	 * @param int           $order_id The order ID.
 	 * @param WC_Order|null $order Order object.
+	 *
+	 * @return void
 	 */
 	public function trigger( $order_id, $order = null ) {
 		$this->object = $order;

--- a/includes/compat/class-wc-stripe-email-failed-authentication.php
+++ b/includes/compat/class-wc-stripe-email-failed-authentication.php
@@ -5,8 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Base for Failed Renewal/Pre-Order Authentication Notifications.
- *
- * @extends WC_Email
  */
 abstract class WC_Stripe_Email_Failed_Authentication extends WC_Email {
 	/**
@@ -74,6 +72,8 @@ abstract class WC_Stripe_Email_Failed_Authentication extends WC_Email {
 
 	/**
 	 * Uses specific fields from `WC_Email_Customer_Invoice` for this email.
+	 *
+	 * @return void
 	 */
 	public function init_form_fields() {
 		parent::init_form_fields();
@@ -97,6 +97,7 @@ abstract class WC_Stripe_Email_Failed_Authentication extends WC_Email {
 	 * Triggers the email.
 	 *
 	 * @param WC_Order $order The renewal order whose payment failed.
+	 * @return void
 	 */
 	public function trigger( $order ) {
 		if ( ! $this->is_enabled() ) {

--- a/includes/compat/class-wc-stripe-email-failed-preorder-authentication.php
+++ b/includes/compat/class-wc-stripe-email-failed-preorder-authentication.php
@@ -5,8 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Failed Renewal/Pre-Order Authentication Notification
- *
- * @extends WC_Stripe_Email_Failed_Authentication
  */
 class WC_Stripe_Email_Failed_Preorder_Authentication extends WC_Stripe_Email_Failed_Authentication {
 	/**
@@ -47,6 +45,7 @@ class WC_Stripe_Email_Failed_Preorder_Authentication extends WC_Stripe_Email_Fai
 	 * in order to send the authentication required email when the custom pre-orders message is available.
 	 *
 	 * @param WC_Order $order The order whose payment is failing.
+	 * @return void
 	 */
 	public function trigger( $order ) {
 		if ( class_exists( 'WC_Pre_Orders_Order' ) && WC_Pre_Orders_Order::order_contains_pre_order( $order->get_id() ) ) {
@@ -63,6 +62,7 @@ class WC_Stripe_Email_Failed_Preorder_Authentication extends WC_Stripe_Email_Fai
 	 *
 	 * @param WC_Order $order The order that is being paid.
 	 * @param string   $message The message, which should be added to the email.
+	 * @return void
 	 */
 	public function send_email( $order, $message ) {
 		$this->custom_message = $message;

--- a/includes/compat/class-wc-stripe-email-failed-refund.php
+++ b/includes/compat/class-wc-stripe-email-failed-refund.php
@@ -75,8 +75,9 @@ abstract class WC_Stripe_Email_Failed_Refund extends WC_Email_Failed_Order {
 	/**
 	 * Trigger.
 	 *
-	 * @param int $order_id The order ID.
-	 * @param WC_Order|false $order Order object.
+	 * @param int            $order_id The order ID.
+	 * @param WC_Order|false $order    Order object.
+	 * @return void
 	 */
 	public function trigger( $order_id, $order = false ) {
 		$this->object = $order;

--- a/includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
+++ b/includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
@@ -5,8 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Failed Renewal/Pre-Order Authentication Notification
- *
- * @extends WC_Email_Customer_Invoice
  */
 class WC_Stripe_Email_Failed_Renewal_Authentication extends WC_Stripe_Email_Failed_Authentication {
 	/**
@@ -39,6 +37,7 @@ class WC_Stripe_Email_Failed_Renewal_Authentication extends WC_Stripe_Email_Fail
 	 * Triggers the email while also disconnecting the original Subscriptions email.
 	 *
 	 * @param WC_Order $order The order that is being paid.
+	 * @return void
 	 */
 	public function trigger( $order ) {
 		if ( function_exists( 'wcs_order_contains_subscription' )

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4939,12 +4939,6 @@ parameters:
 			path: includes/class-wc-stripe.php
 
 		-
-			message: '#^Method WC_Stripe_Email_Admin_Failed_Refund\:\:trigger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-admin-failed-refund.php
-
-		-
 			message: '#^Parameter \#1 \$order of method WC_Stripe_Email_Failed_Refund\:\:get_reason\(\) expects object, bool\|object given\.$#'
 			identifier: argument.type
 			count: 1
@@ -4953,12 +4947,6 @@ parameters:
 		-
 			message: '#^Cannot access property \$billing_email on WC_Order\|false\.$#'
 			identifier: property.nonObject
-			count: 1
-			path: includes/compat/class-wc-stripe-email-customer-failed-refund.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Customer_Failed_Refund\:\:trigger\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/compat/class-wc-stripe-email-customer-failed-refund.php
 
@@ -4989,18 +4977,6 @@ parameters:
 		-
 			message: '#^Function wcs_get_human_time_diff not found\.$#'
 			identifier: function.notFound
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-authentication-retry.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Authentication_Retry\:\:trigger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-authentication-retry.php
-
-		-
-			message: '#^PHPDoc tag @extends has invalid value \(WC_Email_Failed_Order\)\: Unexpected token "\\n ", expected ''\<'' at offset 440 on line 9$#'
-			identifier: phpDoc.parseError
 			count: 1
 			path: includes/compat/class-wc-stripe-email-failed-authentication-retry.php
 
@@ -5047,24 +5023,6 @@ parameters:
 			path: includes/compat/class-wc-stripe-email-failed-authentication.php
 
 		-
-			message: '#^Method WC_Stripe_Email_Failed_Authentication\:\:init_form_fields\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-authentication.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Authentication\:\:trigger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-authentication.php
-
-		-
-			message: '#^PHPDoc tag @extends has invalid value \(WC_Email\)\: Unexpected token "\\n ", expected ''\<'' at offset 94 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-authentication.php
-
-		-
 			message: '#^Parameter \#1 \$date of function wc_format_datetime expects WC_DateTime, WC_DateTime\|null given\.$#'
 			identifier: argument.type
 			count: 1
@@ -5079,24 +5037,6 @@ parameters:
 		-
 			message: '#^Function remove_action invoked with 4 parameters, 2\-3 required\.$#'
 			identifier: arguments.count
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-preorder-authentication.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Preorder_Authentication\:\:send_email\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-preorder-authentication.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Preorder_Authentication\:\:trigger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-preorder-authentication.php
-
-		-
-			message: '#^PHPDoc tag @extends has invalid value \(WC_Stripe_Email_Failed_Authentication\)\: Unexpected token "\\n ", expected ''\<'' at offset 112 on line 4$#'
-			identifier: phpDoc.parseError
 			count: 1
 			path: includes/compat/class-wc-stripe-email-failed-preorder-authentication.php
 
@@ -5117,24 +5057,6 @@ parameters:
 			identifier: method.nonObject
 			count: 1
 			path: includes/compat/class-wc-stripe-email-failed-refund.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Refund\:\:trigger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-refund.php
-
-		-
-			message: '#^Method WC_Stripe_Email_Failed_Renewal_Authentication\:\:trigger\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
-
-		-
-			message: '#^PHPDoc tag @extends has invalid value \(WC_Email_Customer_Invoice\)\: Unexpected token "\\n ", expected ''\<'' at offset 100 on line 4$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/compat/class-wc-stripe-email-failed-renewal-authentication.php
 
 		-
 			message: '#^Property WC_Stripe_Email_Failed_Authentication\:\:\$original_email \(WC_Email\) in isset\(\) is not nullable\.$#'

--- a/readme.txt
+++ b/readme.txt
@@ -159,5 +159,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Automate release note creation PR
 * Dev - Introduce a feature flag for the Stripe checkout sessions feature
 * Dev - Improve the pre-push hook
+* Tweak - Update PHPDoc for email notification classes
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4955
Towards https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4905
Towards STRIPE-873

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates the PHPDoc for the email notification classes in `includes/compat/` to address a handful of PHPStan issues. In particular, it adds `@return void` to a number of methods, and removes `@extends` declarations that were triggering PHPStan parse issues.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->
* Code inspection should be sufficient, as this PR is only modifying PHPDoc.

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
