### PR TITLE
Add method to call the ajax endpoint to create checkout session

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -691,4 +691,10 @@ export default class WCStripeAPI {
 			}
 		);
 	}
+
+	checkoutSessionsCreateSession() {
+		return this.request( this.getAjaxUrl( 'create_checkout_session' ), {
+			security: this.options?.createCheckoutSessionNonce,
+		} );
+	}
 }

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -535,6 +535,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		$stripe_params['createSetupIntentNonce']            = wp_create_nonce( 'wc_stripe_create_setup_intent_nonce' );
 		$stripe_params['createAndConfirmSetupIntentNonce']  = wp_create_nonce( 'wc_stripe_create_and_confirm_setup_intent_nonce' );
 		$stripe_params['updateFailedOrderNonce']            = wp_create_nonce( 'wc_stripe_update_failed_order_nonce' );
+		$stripe_params['createCheckoutSessionNonce']        = wp_create_nonce( 'wc_stripe_create_checkout_session_nonce' );
 		$stripe_params['paymentMethodsConfig']              = $this->get_enabled_payment_method_config();
 		$stripe_params['genericErrorMessage']               = __( 'There was a problem processing the payment. Please check your email inbox and refresh the page to try again.', 'woocommerce-gateway-stripe' );
 		$stripe_params['accountDescriptor']                 = $this->statement_descriptor;


### PR DESCRIPTION
Related to STRIPE-932
Fixes #4969

## Changes proposed in this Pull Request:
- Added `checkoutSessionsCreateSession` method in `WCStripeAPI` class to be used by both block and classic checkout.

## Testing instructions
Code review.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

This PR only adds a method to call the ajax endpoint added in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4968. The changelog statement in the other PR is enough to cover this one as well.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
