### PR TITLE
Improve PHPDoc for migrations, notes, and two general classes and use current Woo Note

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 * Dev - Improve the pre-push hook
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
+* Tweak - Improve PHPDoc for migration and notes; minor notes refactor
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/includes/class-wc-stripe-logger.php
+++ b/includes/class-wc-stripe-logger.php
@@ -35,6 +35,12 @@ class WC_Stripe_Logger {
 	 * @deprecated 9.7.0 Use the shortcut methods for each log severity level: info(), error(), etc. instead.
 	 *
 	 * @since 4.0.0
+	 *
+	 * @param string   $message    The message to log.
+	 * @param int|null $start_time Optional start time timestamp.
+	 * @param int|null $end_time   Optional end time timestamp.
+	 *
+	 * @return void
 	 */
 	public static function log( $message, $start_time = null, $end_time = null ) {
 		if ( ! self::can_log() ) {

--- a/includes/class-wc-stripe-status.php
+++ b/includes/class-wc-stripe-status.php
@@ -53,6 +53,8 @@ class WC_Stripe_Status {
 
 	/**
 	 * Renders Stripe information on the status page.
+	 *
+	 * @return void
 	 */
 	public function render_status_report_section() {
 		$account_data            = $this->account->get_cached_account_data();
@@ -206,6 +208,8 @@ class WC_Stripe_Status {
 	 * Add Stripe tools to the Woo debug tools.
 	 *
 	 * @param array $tools List of current available tools.
+	 *
+	 * @return array
 	 */
 	public function debug_tools( $tools ) {
 		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {

--- a/includes/migrations/class-allowed-payment-request-button-types-update.php
+++ b/includes/migrations/class-allowed-payment-request-button-types-update.php
@@ -22,6 +22,8 @@ class Allowed_Payment_Request_Button_Types_Update {
 
 	/**
 	 * Only execute the migration if not applied yet.
+	 *
+	 * @return void
 	 */
 	public function maybe_migrate() {
 		// not compatible with older WC versions, due to the missing `update_option` method on the gateway class

--- a/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php
+++ b/includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php
@@ -22,6 +22,8 @@ class Migrate_Payment_Request_Data_To_Express_Checkout_Data {
 
 	/**
 	 * Only execute the migration if not applied yet.
+	 *
+	 * @return void
 	 */
 	public function maybe_migrate() {
 		$stripe_gateway = $this->get_gateway();
@@ -35,6 +37,8 @@ class Migrate_Payment_Request_Data_To_Express_Checkout_Data {
 
 	/**
 	 * Copies over Payment Request settings data to Express Checkout settings data.
+	 *
+	 * @return void
 	 */
 	private function migrate() {
 		$stripe_gateway = $this->get_gateway();

--- a/includes/migrations/class-sepa-tokens-for-other-methods-settings-update.php
+++ b/includes/migrations/class-sepa-tokens-for-other-methods-settings-update.php
@@ -22,6 +22,8 @@ class Sepa_Tokens_For_Other_Methods_Settings_Update {
 
 	/**
 	 * Only execute the migration if not applied yet.
+	 *
+	 * @return void
 	 */
 	public function maybe_migrate() {
 		$stripe_gateway = $this->get_gateway();

--- a/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
+++ b/includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
@@ -68,6 +68,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 * Don't run if either of these conditions are met:
 	 *    - The WooCommerce Subscriptions extension isn't active.
 	 *    - The Legacy checkout experience is enabled (aka UPE is disabled).
+	 *
+	 * @return void
 	 */
 	public function maybe_update() {
 		if (
@@ -94,6 +96,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 * This is the callback for the repair hook.
 	 *
 	 * @param int $subscription_id ID of the subscription to be processed.
+	 *
+	 * @return void
 	 */
 	public function repair_item( $subscription_id ) {
 		try {
@@ -119,6 +123,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 * 3. Delete the transient which stores the progress of the repair.
 	 *
 	 * @param int $item The ID of the subscription to migrate.
+	 *
+	 * @return void
 	 */
 	protected function update_item( $item ) {
 		if ( ! as_next_scheduled_action( $this->repair_hook, [ 'repair_object' => $item ] ) ) {
@@ -163,6 +169,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 * This function is a backstop to prevent subscription renewals from failing if we haven't ran the repair yet.
 	 *
 	 * @param int $subscription_id The subscription ID which is about to renew.
+	 *
+	 * @return void
 	 */
 	public function maybe_migrate_before_renewal( $subscription_id ) {
 		if ( ! class_exists( 'WC_Subscriptions' ) ) {
@@ -202,6 +210,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 	 *
 	 * This notice is displayed on the Subscriptions list table page and includes information about the progress of the repair.
 	 * What % of the repair is complete, or when the next scheduled action is expected to run.
+	 *
+	 * @return void
 	 */
 	public function display_admin_notice() {
 		if ( ! class_exists( 'WC_Subscriptions' ) ) {
@@ -379,6 +389,8 @@ class WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens extends \WCS_Backgroun
 
 	/**
 	 * Restarts the legacy token update process.
+	 *
+	 * @return void
 	 */
 	public function restart_update() {
 		// Clear the option to allow the update to be scheduled again.

--- a/includes/notes/class-wc-stripe-bnpl-promotion-note.php
+++ b/includes/notes/class-wc-stripe-bnpl-promotion-note.php
@@ -7,7 +7,6 @@
 
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -29,41 +28,29 @@ class WC_Stripe_BNPL_Promotion_Note {
 
 	/**
 	 * Get the note.
+	 *
+	 * @return Note
 	 */
 	public static function get_note() {
-		$note_class = self::get_note_class();
-		$note       = new $note_class();
+		$note = new Note();
 
 		$note->set_title( __( 'Offer more ways to pay with Buy Now, Pay Later', 'woocommerce-gateway-stripe' ) );
 		$message  = __( 'Flexible pay-over-time options can boost revenue by up to 14%.* Affirm and Klarna payments are auto-enabled with Stripe for eligible merchants.', 'woocommerce-gateway-stripe' );
 		$message .= '<br /><br />';
 		$message .= __( '*Source: Stripe 2024', 'woocommerce-gateway-stripe' );
 		$note->set_content( $message );
-		$note->set_type( $note_class::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Learn more', 'woocommerce-gateway-stripe' ),
 			self::LEARN_MORE_LINK,
-			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 
 		return $note;
-	}
-
-	/**
-	 * Get the class type to be used for the note.
-	 *
-	 * @return string
-	 */
-	private static function get_note_class() {
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
-			return Note::class;
-		} else {
-			return WC_Admin_Note::class;
-		}
 	}
 
 	/**

--- a/includes/notes/class-wc-stripe-oc-promotion-note.php
+++ b/includes/notes/class-wc-stripe-oc-promotion-note.php
@@ -7,7 +7,6 @@
 
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -29,38 +28,26 @@ final class WC_Stripe_OC_Promotion_Note {
 
 	/**
 	 * Get the note.
+	 *
+	 * @return Note
 	 */
 	public static function get_note() {
-		$note_class = self::get_note_class();
-		$note       = new $note_class();
+		$note = new Note();
 
 		$note->set_title( __( 'Increase conversions with Stripe\'s Optimized Checkout Suite', 'woocommerce-gateway-stripe' ) );
 		$note->set_content( __( 'Optimize your checkout for more sales by automatically displaying the most relevant payment methods for each customer.', 'woocommerce-gateway-stripe' ) );
-		$note->set_type( $note_class::E_WC_ADMIN_NOTE_MARKETING );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_MARKETING );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Activate now', 'woocommerce-gateway-stripe' ),
 			self::ACTIVATE_NOW_LINK,
-			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 
 		return $note;
-	}
-
-	/**
-	 * Get the class type to be used for the note.
-	 *
-	 * @return string
-	 */
-	private static function get_note_class() {
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
-			return Note::class;
-		} else {
-			return WC_Admin_Note::class;
-		}
 	}
 
 	/**
@@ -99,6 +86,8 @@ final class WC_Stripe_OC_Promotion_Note {
 	 * Should this note exist?
 	 *
 	 * @inheritDoc
+	 *
+	 * @return bool
 	 */
 	public static function is_applicable() {
 		return ! WC_Stripe::get_instance()->get_main_stripe_gateway()->is_oc_enabled();

--- a/includes/notes/class-wc-stripe-upe-availability-note.php
+++ b/includes/notes/class-wc-stripe-upe-availability-note.php
@@ -7,7 +7,6 @@
 
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -32,10 +31,11 @@ class WC_Stripe_UPE_Availability_Note {
 
 	/**
 	 * Get the note.
+	 *
+	 * @return Note
 	 */
 	public static function get_note() {
-		$note_class = self::get_note_class();
-		$note       = new $note_class();
+		$note = new Note();
 
 		$note->set_title( __( 'Boost your sales with the new payment experience in Stripe', 'woocommerce-gateway-stripe' ) );
 		$message = sprintf(
@@ -45,14 +45,14 @@ class WC_Stripe_UPE_Availability_Note {
 			'</a>'
 		);
 		$note->set_content( $message );
-		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Enable in your store', 'woocommerce-gateway-stripe' ),
 			self::ENABLE_IN_STORE_LINK,
-			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 
@@ -60,18 +60,10 @@ class WC_Stripe_UPE_Availability_Note {
 	}
 
 	/**
-	 * Get the class type to be used for the note.
+	 * Initialize the note.
 	 *
-	 * @return string
+	 * @return void
 	 */
-	private static function get_note_class() {
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
-			return Note::class;
-		} else {
-			return WC_Admin_Note::class;
-		}
-	}
-
 	public static function init() {
 		return;
 	}

--- a/includes/notes/class-wc-stripe-upe-stripelink-note.php
+++ b/includes/notes/class-wc-stripe-upe-stripelink-note.php
@@ -7,7 +7,6 @@
 
 use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 use Automattic\WooCommerce\Admin\Notes\Note;
-use Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -29,39 +28,27 @@ class WC_Stripe_UPE_StripeLink_Note {
 
 	/**
 	 * Get the note.
+	 *
+	 * @return Note
 	 */
 	public static function get_note() {
-		$note_class = self::get_note_class();
-		$note       = new $note_class();
+		$note = new Note();
 
 		$note->set_title( __( 'Increase conversion at checkout', 'woocommerce-gateway-stripe' ) );
 		$note->set_content( __( 'Reduce cart abandonment and create a frictionless checkout experience with Link by Stripe. Link autofills your customer’s payment and shipping details so they can check out in just six seconds with the Link optimized experience.', 'woocommerce-gateway-stripe' ) );
 
-		$note->set_type( $note_class::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_source( 'woocommerce-gateway-stripe' );
 		$note->add_action(
 			self::NOTE_NAME,
 			__( 'Set up now', 'woocommerce-gateway-stripe' ),
 			self::NOTE_DOCUMENTATION_URL,
-			$note_class::E_WC_ADMIN_NOTE_UNACTIONED,
+			Note::E_WC_ADMIN_NOTE_UNACTIONED,
 			true
 		);
 
 		return $note;
-	}
-
-	/**
-	 * Get the class type to be used for the note.
-	 *
-	 * @return string
-	 */
-	private static function get_note_class() {
-		if ( class_exists( 'Automattic\WooCommerce\Admin\Notes\Note' ) ) {
-			return Note::class;
-		} else {
-			return WC_Admin_Note::class;
-		}
 	}
 
 	/**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2269,12 +2269,6 @@ parameters:
 			path: includes/admin/class-wc-stripe-amazon-pay-controller.php
 
 		-
-			message: '#^Call to WC_Stripe_UPE_Availability_Note\:\:init\(\) on a separate line has no effect\.$#'
-			identifier: staticMethod.resultUnused
-			count: 1
-			path: includes/admin/class-wc-stripe-inbox-notes.php
-
-		-
 			message: '#^Call to an undefined method WC_Data_Store\:\:get_notes_with_name\(\)\.$#'
 			identifier: method.notFound
 			count: 3
@@ -3745,30 +3739,6 @@ parameters:
 			path: includes/class-wc-stripe-intent-controller.php
 
 		-
-			message: '#^Method WC_Stripe_Logger\:\:log\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:log\(\) has parameter \$end_time with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:log\(\) has parameter \$message with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
-			message: '#^Method WC_Stripe_Logger\:\:log\(\) has parameter \$start_time with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/class-wc-stripe-logger.php
-
-		-
 			message: '#^Static property WC_Stripe_Logger\:\:\$logger \(WC_Logger\) does not accept WC_Logger_Interface\.$#'
 			identifier: assign.propertyType
 			count: 9
@@ -4247,18 +4217,6 @@ parameters:
 			identifier: assign.propertyType
 			count: 1
 			path: includes/class-wc-stripe-payment-method-configurations.php
-
-		-
-			message: '#^Method WC_Stripe_Status\:\:debug_tools\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-status.php
-
-		-
-			message: '#^Method WC_Stripe_Status\:\:render_status_report_section\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/class-wc-stripe-status.php
 
 		-
 			message: '#^Method WC_Stripe_UPE_Compatibility\:\:is_wc_supported\(\) has no return type specified\.$#'
@@ -5395,30 +5353,6 @@ parameters:
 			path: includes/connect/class-wc-stripe-connect.php
 
 		-
-			message: '#^Method Allowed_Payment_Request_Button_Types_Update\:\:maybe_migrate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-allowed-payment-request-button-types-update.php
-
-		-
-			message: '#^Method Migrate_Payment_Request_Data_To_Express_Checkout_Data\:\:maybe_migrate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php
-
-		-
-			message: '#^Method Migrate_Payment_Request_Data_To_Express_Checkout_Data\:\:migrate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-migrate-payment-request-data-to-express-checkout-data.php
-
-		-
-			message: '#^Method Sepa_Tokens_For_Other_Methods_Settings_Update\:\:maybe_migrate\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-sepa-tokens-for-other-methods-settings-update.php
-
-		-
 			message: '#^Access to constant STATUS_COMPLETE on an unknown class ActionScheduler_Store\.$#'
 			identifier: class.notFound
 			count: 1
@@ -5497,44 +5431,8 @@ parameters:
 			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
 
 		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:display_admin_notice\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
 			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:get_items_to_repair\(\) should return array\<int\> but returns array\<WC_Order\>\|stdClass\.$#'
 			identifier: return.type
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:maybe_migrate_before_renewal\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:maybe_update\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:repair_item\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:restart_update\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
-
-		-
-			message: '#^Method WC_Stripe_Subscriptions_Repairer_Legacy_SEPA_Tokens\:\:update_item\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
 
@@ -5545,194 +5443,14 @@ parameters:
 			path: includes/migrations/class-wc-stripe-subscriptions-repairer-legacy-sepa-tokens.php
 
 		-
-			message: '#^Call to an undefined method object\:\:add_action\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-bnpl-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_content\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-bnpl-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-bnpl-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_source\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-bnpl-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_title\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-bnpl-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_type\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-bnpl-promotion-note.php
-
-		-
-			message: '#^Method WC_Stripe_BNPL_Promotion_Note\:\:get_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/notes/class-wc-stripe-bnpl-promotion-note.php
-
-		-
 			message: '#^Call to an undefined method WC_Stripe_Payment_Gateway\:\:is_oc_enabled\(\)\.$#'
 			identifier: method.notFound
 			count: 2
 			path: includes/notes/class-wc-stripe-oc-promotion-note.php
 
 		-
-			message: '#^Call to an undefined method object\:\:add_action\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_content\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_source\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_title\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_type\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Method WC_Stripe_OC_Promotion_Note\:\:get_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Method WC_Stripe_OC_Promotion_Note\:\:is_applicable\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/notes/class-wc-stripe-oc-promotion-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:add_action\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_content\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_source\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_title\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_type\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Availability_Note\:\:get_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Availability_Note\:\:init\(\) has no return type specified\.$#'
-			identifier: missingType.return
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-availability-note.php
-
-		-
 			message: '#^Call to an undefined method WC_Stripe_Payment_Gateway\:\:get_upe_enabled_at_checkout_payment_method_ids\(\)\.$#'
 			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:add_action\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_content\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_name\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_source\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_title\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
-
-		-
-			message: '#^Call to an undefined method object\:\:set_type\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_StripeLink_Note\:\:get_note\(\) has no return type specified\.$#'
-			identifier: missingType.return
 			count: 1
 			path: includes/notes/class-wc-stripe-upe-stripelink-note.php
 

--- a/readme.txt
+++ b/readme.txt
@@ -161,5 +161,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Improve the pre-push hook
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
+* Tweak - Improve PHPDoc for migration and notes; minor notes refactor
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4955
Towards https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4905
Towards STRIPE-873

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates the PHPDoc for our internal migrations classes, notes classes, and `WC_Stripe_Status` and `WC_Stripe_Logger` to reduce PHPStan errors. The PR also refactors the note classes to use the `Automattic\WooCommerce\Admin\Notes\Note` class directly, as the older `Automattic\WooCommerce\Admin\Notes\WC_Admin_Note` class was deprecated in WooCommerce 4.8.0.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

For the PHPDoc improvements, code inspection should be fine. I believe the notes refactor should also be fine for code inspection only, as it should appear in e2e tests and/or unit tests if it is truly failing.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
