### PR TITLE
Disable defaulting on of OCS for new installs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
 * Tweak - Update PHPDoc for email notification classes
+* Update - Stop auto-enabling Optimized Checkout Suite for new installs
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/includes/class-wc-stripe.php
+++ b/includes/class-wc-stripe.php
@@ -331,10 +331,15 @@ class WC_Stripe {
 				define( 'WC_STRIPE_INSTALLING', true );
 			}
 
-			// Mark optimized checkout as default on for new installs.
-			if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
-				update_option( 'wc_stripe_optimized_checkout_default_on', true );
-			}
+			/*
+			 * Pause defaulting on Optimized Checkout for the time being, as we want to make UX improvements.
+			 * @see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979
+			 *
+			 * // Mark optimized checkout as default on for new installs.
+			 * if ( false === get_option( 'wc_stripe_version' ) && false === get_option( 'wc_stripe_optimized_checkout_default_on' ) ) {
+			 *   update_option( 'wc_stripe_optimized_checkout_default_on', true );
+			 * }
+			 */
 
 			add_woocommerce_inbox_variant();
 			$this->update_plugin_version();

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,8 @@ Stripe is available for store owners and merchants in [46 countries worldwide](h
 
 The following items note specific versions that include important changes, features, or deprecations.
 
+* 10.4.0
+   - Optimized Checkout Suite no longer enabled by default for new installs
 * 10.2.0
    - Optimized Checkout Suite enabled by default for all new installations
    - Add minimum transaction amounts for BRL, INR, NZD, THB, CZK, HUF, AED, MYR, PLN, RON
@@ -162,5 +164,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
 * Tweak - Update PHPDoc for email notification classes
+* Update - Stop auto-enabling Optimized Checkout Suite for new installs
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -235,6 +235,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_install_sets_fresh_install_flag(): void {
+		// @see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979
+		$this->markTestSkipped( 'We are pausing OCS default on, so the flag is not being set on new installs' );
+
 		update_option( 'active_plugins', [ plugin_basename( WC_STRIPE_MAIN_FILE ) ] );
 
 		// Ensure the flag is not set.

--- a/tests/phpunit/WC_Stripe_Test.php
+++ b/tests/phpunit/WC_Stripe_Test.php
@@ -235,9 +235,6 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_install_sets_fresh_install_flag(): void {
-		// @see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979
-		$this->markTestSkipped( 'We are pausing OCS default on, so the flag is not being set on new installs' );
-
 		update_option( 'active_plugins', [ plugin_basename( WC_STRIPE_MAIN_FILE ) ] );
 
 		// Ensure the flag is not set.
@@ -256,7 +253,9 @@ class WC_Stripe_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$wc_stripe->install();
 
-		$this->assertEquals( 'yes', get_option( 'wc_stripe_optimized_checkout_default_on' ) );
+		// Test that we are NOT setting the flag for now.
+		// @see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979
+		$this->assertEquals( false, get_option( 'wc_stripe_optimized_checkout_default_on' ) );
 	}
 
 	/**


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-939
Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
As noted in https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4979, we plan to make some improvements to the Optimized Checkout Suite shopper UX, and we want to get those fixes in place before we continue to default on the experience for new merchants.

This PR comments out the code that sets the default on flag for new merchants, and updates the relevant unit test to ensure that the flag is not set for new installs.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Given that we are removing code that sets an option, and we are explicitly testing that is the case, I think code inspection and passing tests should be sufficient.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
