### PR TITLE
Add an admin notice for merchants potentially affected by the express checkout button location issue

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
 * Tweak - Update PHPDoc for email notification classes
+* Add - Admin notice for merchants potentially affected by the express checkout button location issue in versions 10.1.0 to 10.2.x
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -625,6 +625,9 @@ class WC_Stripe_Admin_Notices {
 						wp_safe_redirect( remove_query_arg( [ 'wc-stripe-hide-notice', '_wc_stripe_notice_nonce' ], esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) ) );
 					}
 					break;
+				case 'ece_location':
+					update_option( 'wc_stripe_show_ece_location_notice', 'no' );
+					break;
 			}
 		}
 	}

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -668,7 +668,7 @@ class WC_Stripe_Admin_Notices {
 		// A bug in these versions reset express checkout button locations during upgrade.
 		$was_affected_version = ! empty( $previous_version )
 			&& version_compare( $previous_version, '10.1.0', '>=' )
-			&& version_compare( $previous_version, '10.3.0', '<' );
+			&& version_compare( $previous_version, '10.4.0', '<' );
 
 		if ( $was_affected_version && 'no' !== get_option( 'wc_stripe_show_ece_location_notice' ) ) {
 			update_option( 'wc_stripe_show_ece_location_notice', 'yes' );

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -407,7 +407,8 @@ class WC_Stripe_Admin_Notices {
 		$has_cart     = in_array( 'cart', $locations, true );
 		$has_checkout = in_array( 'checkout', $locations, true );
 
-		if ( ! $has_product || ! $has_cart || $has_checkout ) {
+		// We only need to show the notice if we have ( product + cart ) but not checkout, so return if we have anything else.
+		if ( ! ( $has_product && $has_cart && ! $has_checkout ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -390,7 +390,7 @@ class WC_Stripe_Admin_Notices {
 	public function check_express_checkout_location(): void {
 		$show_notice = get_option( 'wc_stripe_show_ece_location_notice' );
 
-		if ( 'no' === $show_notice ) {
+		if ( 'yes' !== $show_notice ) {
 			return;
 		}
 
@@ -664,13 +664,12 @@ class WC_Stripe_Admin_Notices {
 
 		// Set the ECE location notice flag if upgrading from the affected version range (10.1.0–10.2.x).
 		// A bug in these versions reset express checkout button locations during upgrade.
-		// For affected versions, don't overwrite — the flag may have been set by a previous upgrade.
 		$is_affected_version = ! empty( $previous_version )
 			&& version_compare( $previous_version, '10.1.0', '>=' )
 			&& version_compare( $previous_version, '10.3.0', '<' );
 
-		if ( ! $is_affected_version ) {
-			update_option( 'wc_stripe_show_ece_location_notice', 'no' );
+		if ( $is_affected_version && 'no' !== get_option( 'wc_stripe_show_ece_location_notice' ) ) {
+			update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
 		}
 	}
 

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -605,6 +605,17 @@ class WC_Stripe_Admin_Notices {
 		if ( empty( $previous_version ) || version_compare( $previous_version, '4.3.0', 'ge' ) ) {
 			update_option( 'wc_stripe_show_sca_notice', 'no' );
 		}
+
+		// Set the ECE location notice flag if upgrading from the affected version range (10.1.0–10.2.x).
+		// A bug in these versions reset express checkout button locations during upgrade.
+		// For affected versions, don't overwrite — the flag may have been set by a previous upgrade.
+		$is_affected_version = ! empty( $previous_version )
+			&& version_compare( $previous_version, '10.1.0', '>=' )
+			&& version_compare( $previous_version, '10.3.0', '<' );
+
+		if ( ! $is_affected_version ) {
+			update_option( 'wc_stripe_show_ece_location_notice', 'no' );
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -67,6 +67,7 @@ class WC_Stripe_Admin_Notices {
 		$this->payment_methods_check_environment();
 
 		// Check for merchants affected by ECE button location bug.
+		// https://github.com/woocommerce/woocommerce-gateway-stripe/issues/4861
 		$this->check_express_checkout_location();
 
 		// Check for subscriptions detached from the customer.

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -384,8 +384,10 @@ class WC_Stripe_Admin_Notices {
 	 * in versions 10.1.0–10.2.x and displays a notice if so.
 	 *
 	 * @since 10.4.0
+	 *
+	 * @return void
 	 */
-	public function check_express_checkout_location() {
+	public function check_express_checkout_location(): void {
 		$show_notice = get_option( 'wc_stripe_show_ece_location_notice' );
 
 		if ( 'no' === $show_notice ) {

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -416,7 +416,7 @@ class WC_Stripe_Admin_Notices {
 
 		$message = sprintf(
 			/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) HTML line break tag */
-			__( '%1$sAction Required: Review your express checkout settings.%2$s%3$sA recent update may have unintentionally changed where Apple Pay / Google Pay buttons appear. Currently, they are active on the product and cart pages but not on the checkout page. Please verify your settings to ensure your customers have the best checkout experience.', 'woocommerce-gateway-stripe' ),
+			__( '%1$sAction Required: Review your Stripe express checkout settings.%2$s%3$sA recent update to the Stripe plugin may have unintentionally changed where Apple Pay and/or Google Pay buttons appear. Currently, they are active on the product and cart pages but not on the checkout page. Please review your express checkout settings to ensure your customers have the best checkout experience.', 'woocommerce-gateway-stripe' ),
 			'<strong>',
 			'</strong>',
 			'<br>'

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -416,7 +416,7 @@ class WC_Stripe_Admin_Notices {
 
 		$message = sprintf(
 			/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) HTML line break tag */
-			__( '%1$sAction Required: Review your Stripe express checkout settings.%2$s%3$sA recent update to the Stripe plugin may have unintentionally changed where Apple Pay and/or Google Pay buttons appear. Currently, they are active on the product and cart pages but not on the checkout page. Please review your express checkout settings to ensure your customers have the best checkout experience.', 'woocommerce-gateway-stripe' ),
+			__( '%1$sAction Required: Review your Stripe express checkout settings.%2$s%3$sA recent update to the Stripe plugin may have unintentionally changed where Apple Pay and Google Pay buttons appear. Currently, they are active on the product and cart pages but not on the checkout page. Please review your express checkout settings to ensure your customers have the best checkout experience.', 'woocommerce-gateway-stripe' ),
 			'<strong>',
 			'</strong>',
 			'<br>'

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -66,6 +66,9 @@ class WC_Stripe_Admin_Notices {
 		// All other payment methods.
 		$this->payment_methods_check_environment();
 
+		// Check for merchants affected by ECE button location bug.
+		$this->check_express_checkout_location();
+
 		// Check for subscriptions detached from the customer.
 		if ( WC_Stripe_Subscriptions_Helper::is_subscriptions_enabled() ) {
 			$this->subscription_check_detachment();
@@ -374,6 +377,55 @@ class WC_Stripe_Admin_Notices {
 		if ( ! empty( $currency_messages ) && 'no' !== $show_notice ) {
 			$this->add_admin_notice( 'upe_payment_methods', 'notice notice-error', $currency_messages, true );
 		}
+	}
+
+	/**
+	 * Checks if the merchant may have been affected by the ECE button location bug
+	 * in versions 10.1.0–10.2.x and displays a notice if so.
+	 *
+	 * @since 10.4.0
+	 */
+	public function check_express_checkout_location() {
+		$show_notice = get_option( 'wc_stripe_show_ece_location_notice' );
+
+		if ( 'no' === $show_notice ) {
+			return;
+		}
+
+		$options   = WC_Stripe_Helper::get_stripe_settings();
+		$enabled   = isset( $options['express_checkout'] ) && 'yes' === $options['express_checkout'];
+		$locations = isset( $options['express_checkout_button_locations'] ) ? $options['express_checkout_button_locations'] : [];
+
+		if ( ! $enabled ) {
+			return;
+		}
+
+		$has_product  = in_array( 'product', $locations, true );
+		$has_cart     = in_array( 'cart', $locations, true );
+		$has_checkout = in_array( 'checkout', $locations, true );
+
+		if ( ! $has_product || ! $has_cart || $has_checkout ) {
+			return;
+		}
+
+		$settings_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings' );
+
+		$message = sprintf(
+			/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) HTML anchor open tag 4) HTML anchor closing tag */
+			__( '%1$sAction Required: Review your express checkout settings.%2$s A recent update may have unintentionally changed where Apple Pay / Google Pay buttons appear. Currently, they are active on the product and cart pages but not on the checkout page. Please %3$sreview your settings%4$s to ensure your customers have the best checkout experience.', 'woocommerce-gateway-stripe' ),
+			'<strong>',
+			'</strong>',
+			'<a href="' . esc_url( $settings_url ) . '">',
+			'</a>'
+		);
+
+		$review_action = sprintf(
+			'<a href="%s" style="display:inline-block;margin:4px 4px 4px 0;">%s</a>',
+			esc_url( $settings_url ),
+			__( 'Review Settings', 'woocommerce-gateway-stripe' )
+		);
+
+		$this->add_admin_notice( 'ece_location', 'notice notice-warning', $message, true, [ $review_action ] );
 	}
 
 	/**

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -410,15 +410,14 @@ class WC_Stripe_Admin_Notices {
 			return;
 		}
 
-		$settings_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=settings' );
+		$settings_url = admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe&panel=methods&area=express_checkout' );
 
 		$message = sprintf(
-			/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) HTML anchor open tag 4) HTML anchor closing tag */
-			__( '%1$sAction Required: Review your express checkout settings.%2$s A recent update may have unintentionally changed where Apple Pay / Google Pay buttons appear. Currently, they are active on the product and cart pages but not on the checkout page. Please %3$sreview your settings%4$s to ensure your customers have the best checkout experience.', 'woocommerce-gateway-stripe' ),
+			/* translators: 1) HTML strong open tag 2) HTML strong closing tag 3) HTML line break tag */
+			__( '%1$sAction Required: Review your express checkout settings.%2$s%3$sA recent update may have unintentionally changed where Apple Pay / Google Pay buttons appear. Currently, they are active on the product and cart pages but not on the checkout page. Please verify your settings to ensure your customers have the best checkout experience.', 'woocommerce-gateway-stripe' ),
 			'<strong>',
 			'</strong>',
-			'<a href="' . esc_url( $settings_url ) . '">',
-			'</a>'
+			'<br>'
 		);
 
 		$review_action = sprintf(

--- a/includes/admin/class-wc-stripe-admin-notices.php
+++ b/includes/admin/class-wc-stripe-admin-notices.php
@@ -665,11 +665,11 @@ class WC_Stripe_Admin_Notices {
 
 		// Set the ECE location notice flag if upgrading from the affected version range (10.1.0–10.2.x).
 		// A bug in these versions reset express checkout button locations during upgrade.
-		$is_affected_version = ! empty( $previous_version )
+		$was_affected_version = ! empty( $previous_version )
 			&& version_compare( $previous_version, '10.1.0', '>=' )
 			&& version_compare( $previous_version, '10.3.0', '<' );
 
-		if ( $is_affected_version && 'no' !== get_option( 'wc_stripe_show_ece_location_notice' ) ) {
+		if ( $was_affected_version && 'no' !== get_option( 'wc_stripe_show_ece_location_notice' ) ) {
 			update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -164,5 +164,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Fix - Better error handling when token creation fails
 * Tweak - Improve PHPDoc for payment token code
 * Tweak - Update PHPDoc for email notification classes
+* Add - Admin notice for merchants potentially affected by the express checkout button location issue in versions 10.1.0 to 10.2.x
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -878,7 +878,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that upgrading from an affected version (10.1.0-10.2.x) sets the flag.
+	 * Test that upgrading from an affected version (10.1.0–10.2.x) sets the flag to 'yes'.
 	 */
 	public function test_stripe_updated_sets_ece_location_flag_for_affected_versions() {
 		update_option( 'wc_stripe_version', '10.2.0' );
@@ -891,7 +891,25 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$notices->stripe_updated();
 
-		$this->assertNotEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+		$this->assertEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
+	}
+
+	/**
+	 * Test that upgrading from an affected version does not overwrite a previous dismissal.
+	 */
+	public function test_stripe_updated_does_not_overwrite_dismissed_ece_location_flag() {
+		update_option( 'wc_stripe_version', '10.2.0' );
+		update_option( 'wc_stripe_show_ece_location_notice', 'no' );
+
+		// Remove hooks to prevent side effects during construction.
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+
+		$notices->stripe_updated();
+
+		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
 
 	/**
@@ -908,7 +926,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$notices->stripe_updated();
 
-		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+		$this->assertNotEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
 
 	/**
@@ -925,7 +943,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$notices->stripe_updated();
 
-		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+		$this->assertNotEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
 
 	/**
@@ -942,7 +960,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$notices->stripe_updated();
 
-		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+		$this->assertNotEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
 
 	/**
@@ -950,7 +968,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function test_ece_location_notice_is_shown_when_all_criteria_met() {
 		// Flag set (merchant came through affected version).
-		delete_option( 'wc_stripe_show_ece_location_notice' );
+		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
 		// Express checkout enabled with only product+cart (not checkout).
 		update_option(
 			'woocommerce_stripe_settings',
@@ -974,7 +992,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * Test that the notice is NOT shown when express checkout is disabled.
 	 */
 	public function test_ece_location_notice_not_shown_when_express_checkout_disabled() {
-		delete_option( 'wc_stripe_show_ece_location_notice' );
+		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
 		update_option(
 			'woocommerce_stripe_settings',
 			[
@@ -997,7 +1015,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * Test that the notice is NOT shown when checkout is already in the locations.
 	 */
 	public function test_ece_location_notice_not_shown_when_checkout_in_locations() {
-		delete_option( 'wc_stripe_show_ece_location_notice' );
+		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
 		update_option(
 			'woocommerce_stripe_settings',
 			[
@@ -1020,7 +1038,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * Test that the notice is NOT shown when only cart is in locations (product missing).
 	 */
 	public function test_ece_location_notice_not_shown_when_product_not_in_locations() {
-		delete_option( 'wc_stripe_show_ece_location_notice' );
+		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
 		update_option(
 			'woocommerce_stripe_settings',
 			[
@@ -1090,7 +1108,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 * Test that the notice is NOT shown when flag was never set (no affected upgrade).
 	 */
 	public function test_ece_location_notice_not_shown_when_flag_not_set() {
-		update_option( 'wc_stripe_show_ece_location_notice', 'no' );
+		delete_option( 'wc_stripe_show_ece_location_notice' );
 		update_option(
 			'woocommerce_stripe_settings',
 			[

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -878,253 +878,154 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that upgrading from an affected version (10.1.0–10.2.x) sets the flag to 'yes'.
+	 * Creates a WC_Stripe_Admin_Notices instance with hooks removed to prevent side effects.
+	 *
+	 * @return WC_Stripe_Admin_Notices
 	 */
-	public function test_stripe_updated_sets_ece_location_flag_for_affected_versions() {
-		update_option( 'wc_stripe_version', '10.2.0' );
-
-		// Remove hooks to prevent side effects during construction.
+	private function create_admin_notices_instance(): WC_Stripe_Admin_Notices {
 		remove_all_actions( 'admin_notices' );
 		remove_all_actions( 'wp_loaded' );
 		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
+		return new WC_Stripe_Admin_Notices();
+	}
 
+	/**
+	 * Test that stripe_updated() sets the ECE location notice flag correctly based on the previous version.
+	 *
+	 * @param string|null $previous_version  Version to set as previous, or null to delete.
+	 * @param string|null $initial_flag      Initial value for the notice option, or null to delete.
+	 * @param string|false $expected         Expected option value after stripe_updated().
+	 *
+	 * @dataProvider provide_ece_location_flag_scenarios
+	 */
+	public function test_stripe_updated_sets_ece_location_flag( $previous_version, $initial_flag, $expected ) {
+		if ( null === $previous_version ) {
+			delete_option( 'wc_stripe_version' );
+		} else {
+			update_option( 'wc_stripe_version', $previous_version );
+		}
+
+		if ( null === $initial_flag ) {
+			delete_option( 'wc_stripe_show_ece_location_notice' );
+		} else {
+			update_option( 'wc_stripe_show_ece_location_notice', $initial_flag );
+		}
+
+		$notices = $this->create_admin_notices_instance();
 		$notices->stripe_updated();
 
-		$this->assertEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
+		$this->assertSame( $expected, get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
 
 	/**
-	 * Test that upgrading from an affected version does not overwrite a previous dismissal.
+	 * Data provider for test_stripe_updated_sets_ece_location_flag.
+	 *
+	 * @return array
 	 */
-	public function test_stripe_updated_does_not_overwrite_dismissed_ece_location_flag() {
-		update_option( 'wc_stripe_version', '10.2.0' );
-		update_option( 'wc_stripe_show_ece_location_notice', 'no' );
-
-		// Remove hooks to prevent side effects during construction.
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-
-		$notices->stripe_updated();
-
-		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+	public function provide_ece_location_flag_scenarios(): array {
+		return [
+			'affected version sets flag'                    => [ '10.2.0', null, 'yes' ],
+			'affected version does not overwrite dismissal' => [ '10.2.0', 'no', 'no' ],
+			'pre-affected version does not set flag'        => [ '10.0.0', null, false ],
+			'post-fix version does not set flag'            => [ '10.4.0', null, false ],
+			'fresh install does not set flag'               => [ null, null, false ],
+		];
 	}
 
 	/**
-	 * Test that upgrading from a version before the affected window does NOT set the flag.
+	 * Test that check_express_checkout_location() shows or hides the notice based on settings.
+	 *
+	 * @param string|null $flag_value       Value for the notice option, or null to delete.
+	 * @param array       $stripe_settings  Stripe settings to set.
+	 * @param bool        $expect_notice    Whether the notice should be present.
+	 *
+	 * @dataProvider provide_ece_location_notice_scenarios
 	 */
-	public function test_stripe_updated_does_not_set_ece_location_flag_for_pre_affected_versions() {
-		update_option( 'wc_stripe_version', '10.0.0' );
-		delete_option( 'wc_stripe_show_ece_location_notice' );
+	public function test_ece_location_notice_display( $flag_value, array $stripe_settings, bool $expect_notice ) {
+		if ( null === $flag_value ) {
+			delete_option( 'wc_stripe_show_ece_location_notice' );
+		} else {
+			update_option( 'wc_stripe_show_ece_location_notice', $flag_value );
+		}
 
-		// Remove hooks to prevent side effects during construction.
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
+		update_option( 'woocommerce_stripe_settings', $stripe_settings );
 
-		$notices->stripe_updated();
-
-		$this->assertFalse( get_option( 'wc_stripe_show_ece_location_notice' ) );
-	}
-
-	/**
-	 * Test that upgrading from a version after the fix does NOT set the flag.
-	 */
-	public function test_stripe_updated_does_not_set_ece_location_flag_for_post_fix_versions() {
-		update_option( 'wc_stripe_version', '10.3.0' );
-
-		// Remove hooks to prevent side effects during construction.
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-
-		$notices->stripe_updated();
-
-		$this->assertNotEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
-	}
-
-	/**
-	 * Test that a fresh install (no previous version) does NOT set the flag.
-	 */
-	public function test_stripe_updated_does_not_set_ece_location_flag_for_fresh_install() {
-		delete_option( 'wc_stripe_version' );
-
-		// Remove hooks to prevent side effects during construction.
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-
-		$notices->stripe_updated();
-
-		$this->assertNotEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
-	}
-
-	/**
-	 * Test that the notice is shown when all trigger criteria are met.
-	 */
-	public function test_ece_location_notice_is_shown_when_all_criteria_met() {
-		// Flag set (merchant came through affected version).
-		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
-		// Express checkout enabled with only product+cart (not checkout).
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled'                             => 'yes',
-				'express_checkout'                    => 'yes',
-				'express_checkout_button_locations'    => [ 'product', 'cart' ],
-			]
-		);
-
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
+		$notices = $this->create_admin_notices_instance();
 		$notices->check_express_checkout_location();
 
-		$this->assertArrayHasKey( 'ece_location', $notices->notices );
+		if ( $expect_notice ) {
+			$this->assertArrayHasKey( 'ece_location', $notices->notices );
+		} else {
+			$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
+		}
 	}
 
 	/**
-	 * Test that the notice is NOT shown when express checkout is disabled.
+	 * Data provider for test_ece_location_notice_display.
+	 *
+	 * @return array
 	 */
-	public function test_ece_location_notice_not_shown_when_express_checkout_disabled() {
-		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled'                             => 'yes',
-				'express_checkout'                    => 'no',
-				'express_checkout_button_locations'    => [ 'product', 'cart' ],
-			]
-		);
+	public function provide_ece_location_notice_scenarios(): array {
+		$base_settings = [
+			'enabled'          => 'yes',
+			'express_checkout' => 'yes',
+		];
 
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-		$notices->check_express_checkout_location();
-
-		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
-	}
-
-	/**
-	 * Test that the notice is NOT shown when checkout is already in the locations.
-	 */
-	public function test_ece_location_notice_not_shown_when_checkout_in_locations() {
-		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled'                             => 'yes',
-				'express_checkout'                    => 'yes',
-				'express_checkout_button_locations'    => [ 'product', 'cart', 'checkout' ],
-			]
-		);
-
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-		$notices->check_express_checkout_location();
-
-		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
-	}
-
-	/**
-	 * Test that the notice is NOT shown when only cart is in locations (product missing).
-	 */
-	public function test_ece_location_notice_not_shown_when_product_not_in_locations() {
-		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled'                             => 'yes',
-				'express_checkout'                    => 'yes',
-				'express_checkout_button_locations'    => [ 'cart' ],
-			]
-		);
-
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-		$notices->check_express_checkout_location();
-
-		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
-	}
-
-	/**
-	 * Test that the notice is NOT shown when notice has been dismissed.
-	 */
-	public function test_ece_location_notice_not_shown_when_dismissed() {
-		update_option( 'wc_stripe_show_ece_location_notice', 'no' );
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled'                             => 'yes',
-				'express_checkout'                    => 'yes',
-				'express_checkout_button_locations'    => [ 'product', 'cart' ],
-			]
-		);
-
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-		$notices->check_express_checkout_location();
-
-		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
+		return [
+			'shown when all criteria met (product+cart, no checkout)' => [
+				'yes',
+				array_merge( $base_settings, [ 'express_checkout_button_locations' => [ 'product', 'cart' ] ] ),
+				true,
+			],
+			'not shown when express checkout disabled' => [
+				'yes',
+				array_merge(
+					$base_settings,
+					[
+						'express_checkout'                 => 'no',
+						'express_checkout_button_locations' => [ 'product', 'cart' ],
+					]
+				),
+				false,
+			],
+			'not shown when checkout already in locations' => [
+				'yes',
+				array_merge( $base_settings, [ 'express_checkout_button_locations' => [ 'product', 'cart', 'checkout' ] ] ),
+				false,
+			],
+			'not shown when product not in locations' => [
+				'yes',
+				array_merge( $base_settings, [ 'express_checkout_button_locations' => [ 'cart' ] ] ),
+				false,
+			],
+			'not shown when notice dismissed' => [
+				'no',
+				array_merge( $base_settings, [ 'express_checkout_button_locations' => [ 'product', 'cart' ] ] ),
+				false,
+			],
+			'not shown when flag never set' => [
+				null,
+				array_merge( $base_settings, [ 'express_checkout_button_locations' => [ 'product', 'cart' ] ] ),
+				false,
+			],
+		];
 	}
 
 	/**
 	 * Test that dismissing the ece_location notice sets the option to 'no'.
 	 */
 	public function test_hide_notices_dismisses_ece_location_notice() {
-		// Set the current user to an admin.
 		$admin_user = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $admin_user );
 
-		// Simulate the dismiss request.
 		$_GET['wc-stripe-hide-notice']   = 'ece_location';
 		$_GET['_wc_stripe_notice_nonce'] = wp_create_nonce( 'wc_stripe_hide_notices_nonce' );
 
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
+		$notices = $this->create_admin_notices_instance();
 		$notices->hide_notices();
 
 		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
 
-		// Clean up.
 		unset( $_GET['wc-stripe-hide-notice'], $_GET['_wc_stripe_notice_nonce'] );
-	}
-
-	/**
-	 * Test that the notice is NOT shown when flag was never set (no affected upgrade).
-	 */
-	public function test_ece_location_notice_not_shown_when_flag_not_set() {
-		delete_option( 'wc_stripe_show_ece_location_notice' );
-		update_option(
-			'woocommerce_stripe_settings',
-			[
-				'enabled'                             => 'yes',
-				'express_checkout'                    => 'yes',
-				'express_checkout_button_locations'    => [ 'product', 'cart' ],
-			]
-		);
-
-		remove_all_actions( 'admin_notices' );
-		remove_all_actions( 'wp_loaded' );
-		remove_all_actions( 'woocommerce_stripe_updated' );
-		$notices = new WC_Stripe_Admin_Notices();
-		$notices->check_express_checkout_location();
-
-		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
 	}
 }

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -917,6 +917,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	 */
 	public function test_stripe_updated_does_not_set_ece_location_flag_for_pre_affected_versions() {
 		update_option( 'wc_stripe_version', '10.0.0' );
+		delete_option( 'wc_stripe_show_ece_location_notice' );
 
 		// Remove hooks to prevent side effects during construction.
 		remove_all_actions( 'admin_notices' );
@@ -926,7 +927,7 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$notices->stripe_updated();
 
-		$this->assertNotEquals( 'yes', get_option( 'wc_stripe_show_ece_location_notice' ) );
+		$this->assertFalse( get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
 
 	/**

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -1063,6 +1063,30 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that dismissing the ece_location notice sets the option to 'no'.
+	 */
+	public function test_hide_notices_dismisses_ece_location_notice() {
+		// Set the current user to an admin.
+		$admin_user = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_user );
+
+		// Simulate the dismiss request.
+		$_GET['wc-stripe-hide-notice']   = 'ece_location';
+		$_GET['_wc_stripe_notice_nonce'] = wp_create_nonce( 'wc_stripe_hide_notices_nonce' );
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+		$notices->hide_notices();
+
+		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+
+		// Clean up.
+		unset( $_GET['wc-stripe-hide-notice'], $_GET['_wc_stripe_notice_nonce'] );
+	}
+
+	/**
 	 * Test that the notice is NOT shown when flag was never set (no affected upgrade).
 	 */
 	public function test_ece_location_notice_not_shown_when_flag_not_set() {

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -77,6 +77,9 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 	public function tear_down() {
 		parent::tear_down();
 
+		delete_option( 'wc_stripe_version' );
+		delete_option( 'wc_stripe_show_ece_location_notice' );
+
 		// Restoring the original `WC_Stripe_Connect` instance.
 		woocommerce_gateway_stripe()->connect = $this->stripe_connect_original;
 	}
@@ -872,5 +875,73 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 				'expected content' => '',
 			],
 		];
+	}
+
+	/**
+	 * Test that upgrading from an affected version (10.1.0-10.2.x) sets the flag.
+	 */
+	public function test_stripe_updated_sets_ece_location_flag_for_affected_versions() {
+		update_option( 'wc_stripe_version', '10.2.0' );
+
+		// Remove hooks to prevent side effects during construction.
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+
+		$notices->stripe_updated();
+
+		$this->assertNotEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+	}
+
+	/**
+	 * Test that upgrading from a version before the affected window does NOT set the flag.
+	 */
+	public function test_stripe_updated_does_not_set_ece_location_flag_for_pre_affected_versions() {
+		update_option( 'wc_stripe_version', '10.0.0' );
+
+		// Remove hooks to prevent side effects during construction.
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+
+		$notices->stripe_updated();
+
+		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+	}
+
+	/**
+	 * Test that upgrading from a version after the fix does NOT set the flag.
+	 */
+	public function test_stripe_updated_does_not_set_ece_location_flag_for_post_fix_versions() {
+		update_option( 'wc_stripe_version', '10.3.0' );
+
+		// Remove hooks to prevent side effects during construction.
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+
+		$notices->stripe_updated();
+
+		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
+	}
+
+	/**
+	 * Test that a fresh install (no previous version) does NOT set the flag.
+	 */
+	public function test_stripe_updated_does_not_set_ece_location_flag_for_fresh_install() {
+		delete_option( 'wc_stripe_version' );
+
+		// Remove hooks to prevent side effects during construction.
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+
+		$notices->stripe_updated();
+
+		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
 }

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -944,4 +944,144 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 
 		$this->assertEquals( 'no', get_option( 'wc_stripe_show_ece_location_notice' ) );
 	}
+
+	/**
+	 * Test that the notice is shown when all trigger criteria are met.
+	 */
+	public function test_ece_location_notice_is_shown_when_all_criteria_met() {
+		// Flag set (merchant came through affected version).
+		delete_option( 'wc_stripe_show_ece_location_notice' );
+		// Express checkout enabled with only product+cart (not checkout).
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'                             => 'yes',
+				'express_checkout'                    => 'yes',
+				'express_checkout_button_locations'    => [ 'product', 'cart' ],
+			]
+		);
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+		$notices->check_express_checkout_location();
+
+		$this->assertArrayHasKey( 'ece_location', $notices->notices );
+	}
+
+	/**
+	 * Test that the notice is NOT shown when express checkout is disabled.
+	 */
+	public function test_ece_location_notice_not_shown_when_express_checkout_disabled() {
+		delete_option( 'wc_stripe_show_ece_location_notice' );
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'                             => 'yes',
+				'express_checkout'                    => 'no',
+				'express_checkout_button_locations'    => [ 'product', 'cart' ],
+			]
+		);
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+		$notices->check_express_checkout_location();
+
+		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
+	}
+
+	/**
+	 * Test that the notice is NOT shown when checkout is already in the locations.
+	 */
+	public function test_ece_location_notice_not_shown_when_checkout_in_locations() {
+		delete_option( 'wc_stripe_show_ece_location_notice' );
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'                             => 'yes',
+				'express_checkout'                    => 'yes',
+				'express_checkout_button_locations'    => [ 'product', 'cart', 'checkout' ],
+			]
+		);
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+		$notices->check_express_checkout_location();
+
+		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
+	}
+
+	/**
+	 * Test that the notice is NOT shown when only cart is in locations (product missing).
+	 */
+	public function test_ece_location_notice_not_shown_when_product_not_in_locations() {
+		delete_option( 'wc_stripe_show_ece_location_notice' );
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'                             => 'yes',
+				'express_checkout'                    => 'yes',
+				'express_checkout_button_locations'    => [ 'cart' ],
+			]
+		);
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+		$notices->check_express_checkout_location();
+
+		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
+	}
+
+	/**
+	 * Test that the notice is NOT shown when notice has been dismissed.
+	 */
+	public function test_ece_location_notice_not_shown_when_dismissed() {
+		update_option( 'wc_stripe_show_ece_location_notice', 'no' );
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'                             => 'yes',
+				'express_checkout'                    => 'yes',
+				'express_checkout_button_locations'    => [ 'product', 'cart' ],
+			]
+		);
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+		$notices->check_express_checkout_location();
+
+		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
+	}
+
+	/**
+	 * Test that the notice is NOT shown when flag was never set (no affected upgrade).
+	 */
+	public function test_ece_location_notice_not_shown_when_flag_not_set() {
+		update_option( 'wc_stripe_show_ece_location_notice', 'no' );
+		update_option(
+			'woocommerce_stripe_settings',
+			[
+				'enabled'                             => 'yes',
+				'express_checkout'                    => 'yes',
+				'express_checkout_button_locations'    => [ 'product', 'cart' ],
+			]
+		);
+
+		remove_all_actions( 'admin_notices' );
+		remove_all_actions( 'wp_loaded' );
+		remove_all_actions( 'woocommerce_stripe_updated' );
+		$notices = new WC_Stripe_Admin_Notices();
+		$notices->check_express_checkout_location();
+
+		$this->assertArrayNotHasKey( 'ece_location', $notices->notices );
+	}
 }

--- a/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
+++ b/tests/phpunit/Admin/WC_Stripe_Admin_Notices_Test.php
@@ -1018,6 +1018,8 @@ class WC_Stripe_Admin_Notices_Test extends WC_Mock_Stripe_API_Unit_Test_Case {
 		$admin_user = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $admin_user );
 
+		update_option( 'wc_stripe_show_ece_location_notice', 'yes' );
+
 		$_GET['wc-stripe-hide-notice']   = 'ece_location';
 		$_GET['_wc_stripe_notice_nonce'] = wp_create_nonce( 'wc_stripe_hide_notices_nonce' );
 


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes STRIPE-937

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->


In version 10.1.0, a regression caused express checkout button location settings to be reset during plugin upgrades — removing the checkout page location and keeping only product and cart pages. This was fixed in 10.3.0 (#4864), but merchants who upgraded through 10.1.0–10.2.x may still have incorrect settings without realizing it.

Since we can't distinguish between "the bug set this" and "the merchant intentionally set this," we can't auto-fix. Instead, this PR adds a dismissible admin notice that alerts potentially affected merchants to review their express checkout button location settings.

How it works:

1. During plugin upgrade, if the previous version is in the affected range (≥10.1.0, <10.3.0),
the `wc_stripe_show_ece_location_notice` option is set to 'yes'. Previously dismissed notices are not overwritten.
2. The notice is shown only when all of these conditions are met:
    - The flag option is 'yes' (merchant upgraded through affected versions)
    - Express checkout is enabled
    - Button locations include product and cart but not checkout
    - The notice hasn't been dismissed
3. Clicking dismiss sets the option to 'no', permanently hiding the notice.

## Testing instructions

#### Prerequisites
- Set up 3 JN sites with plugin versions [10.0.0](https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.10.0.0.zip), [10.2.0](https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.10.2.0.zip) and [10.3.1](https://downloads.wordpress.org/plugin/woocommerce-gateway-stripe.10.3.1.zip)
- Onboard to Stripe on all 3. 
- Change Apple Pay/Google Pay locations to cart and product only (uncheck checkout)
- Get a build from this branch

#### Upgrade from 10.2.0
- Upgrade a JN site running Stripe 10.2.0 with a build from this branch
- Go to WC -> Orders (or any WC admin page)
- Make sure there's an admin notice
<img width="3460" height="388" alt="CleanShot 2026-02-04 at 12 12 51@2x" src="https://github.com/user-attachments/assets/50874c56-6ee5-42ac-8a52-e075682e9511" />

- Clicking "Review settings" should take you to the express checkout settings page.
- Dismiss the notice. 
- Refresh the page, the notice should not reappear.

#### Upgrade from 10.3.0
- Upgrade a JN site running Stripe 10.3.0 with a build from this branch
- Notice should appear

#### Upgrade from 10.0.0
- Upgrade a JN site running Stripe 10.0.0 with a build from this branch
- Notice should not appear as the bug has not yet been introduced.

#### Upgrade from 10.3.1
- Upgrade a JN site running Stripe 10.3.1 with a build from this branch
- Notice should not appear as the bug has already been fixed.


<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
