### PR TITLE
Show adaptive pricing option in classic checkout

### DIFF
--- a/client/classic/upe/checkout-sessions.js
+++ b/client/classic/upe/checkout-sessions.js
@@ -1,0 +1,149 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import {
+	CheckoutProvider,
+	CurrencySelectorElement,
+	PaymentElement,
+	useCheckout,
+} from '@stripe/react-stripe-js/checkout';
+import { loadStripe } from '@stripe/stripe-js';
+import { getStripeServerData } from '../../stripe-utils';
+import { useState, useEffect } from '@wordpress/element';
+
+const stripePromise = ( async () => {
+	const stripeServerData = getStripeServerData();
+	if ( ! stripeServerData?.key ) {
+		return null;
+	}
+	return loadStripe( stripeServerData.key );
+} )();
+
+// Store checkout session ID and checkout instance globally so it can be accessed from payment-processing.js
+let globalCheckoutSessionId = null;
+let globalCheckoutInstance = null;
+
+const ClassicCheckoutForm = ( { api, onComplete, onError } ) => {
+	const checkoutState = useCheckout();
+	const [ isPaymentElementComplete, setIsPaymentElementComplete ] =
+		useState( false );
+	const [ checkoutSessionId, setCheckoutSessionId ] = useState( null );
+	const [ errorMessage, setErrorMessage ] = useState( null );
+
+	useEffect( () => {
+		if ( checkoutState.type === 'success' ) {
+			const sessionId = checkoutState.checkout.id;
+			if ( checkoutSessionId !== sessionId ) {
+				setCheckoutSessionId( sessionId );
+				globalCheckoutSessionId = sessionId;
+				// Store the checkout object which has the confirm method
+				globalCheckoutInstance = checkoutState.checkout;
+			}
+		}
+	}, [ checkoutState, checkoutSessionId ] );
+
+	const onSelectedPaymentMethodChange = ( { value, complete } ) => {
+		setIsPaymentElementComplete( complete );
+	};
+
+	const onLoadError = ( event ) => {
+		setErrorMessage( event.error?.message );
+		if ( onError ) {
+			onError( event );
+		}
+	};
+
+	if ( checkoutState.type === 'loading' ) {
+		return <div>Loading...</div>;
+	}
+
+	if ( checkoutState.type === 'error' ) {
+		return <div>Error: { checkoutState.error.message }</div>;
+	}
+
+	return (
+		<>
+			{ errorMessage && (
+				<div className="woocommerce-error" role="alert">
+					{ errorMessage }
+				</div>
+			) }
+			<CurrencySelectorElement />
+			<PaymentElement
+				options={ {
+					fields: {
+						billingDetails: {
+							name: 'never',
+							email: 'never',
+							phone: 'auto',
+							address: {
+								country: 'never',
+								line1: 'never',
+								line2: 'never',
+								city: 'never',
+								state: 'never',
+								postalCode: 'never',
+							},
+						},
+					},
+				} }
+				onChange={ onSelectedPaymentMethodChange }
+				onLoadError={ onLoadError }
+				className="wcstripe-payment-element"
+			/>
+		</>
+	);
+};
+
+export async function initializeCheckoutSessions( api, containerElement ) {
+	try {
+		const response = await api.checkoutSessionsCreateSession();
+		const clientSecret = response.data?.client_secret;
+
+		if ( ! clientSecret ) {
+			throw new Error( 'Failed to create checkout session' );
+		}
+
+		// Create React root and mount the checkout form
+		const root = createRoot( containerElement );
+
+		const providerOptions = {
+			clientSecret,
+			adaptivePricing: { allowed: true },
+		};
+
+		root.render(
+			<CheckoutProvider
+				stripe={ stripePromise }
+				options={ providerOptions }
+			>
+				<ClassicCheckoutForm api={ api } />
+			</CheckoutProvider>
+		);
+
+		return {
+			clientSecret,
+			root,
+		};
+	} catch ( error ) {
+		throw error;
+	}
+}
+
+/**
+ * Gets the checkout session ID from the checkout state.
+ * This is a helper function that can be called after the checkout is initialized.
+ *
+ * @return {string|null} The checkout session ID if available.
+ */
+export function getCheckoutSessionId() {
+	return globalCheckoutSessionId;
+}
+
+/**
+ * Gets the checkout instance.
+ *
+ * @return {Object|null} The checkout instance if available.
+ */
+export function getCheckoutInstance() {
+	return globalCheckoutInstance;
+}

--- a/client/classic/upe/payment-processing.js
+++ b/client/classic/upe/payment-processing.js
@@ -16,6 +16,11 @@ import {
 	validateBlikCode,
 } from '../../stripe-utils';
 import { getFontRulesFromPage } from '../../styles/upe';
+import {
+	initializeCheckoutSessions,
+	getCheckoutSessionId,
+	getCheckoutInstance,
+} from './checkout-sessions';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT,
@@ -44,6 +49,9 @@ export function initializeUPEComponents() {
 			elements: null,
 			upeElement: null,
 			hasLoadError: false,
+			isCheckoutSession: false,
+			checkoutSessionRoot: null,
+			checkoutSessionId: null,
 		};
 	}
 }
@@ -355,6 +363,36 @@ export async function mountStripePaymentElement( api, domElement ) {
 
 	if ( ! gatewayUPEComponents[ paymentMethodType ] ) {
 		return;
+	}
+
+	const useCheckoutSessions = getStripeServerData()?.isAPEnabled;
+
+	if ( useCheckoutSessions ) {
+		try {
+			// // Clear any existing content
+			// domElement.innerHTML = '';
+
+			// Initialize checkout sessions
+			const checkoutData = await initializeCheckoutSessions(
+				api,
+				domElement
+			);
+
+			gatewayUPEComponents[ paymentMethodType ].isCheckoutSession = true;
+			gatewayUPEComponents[ paymentMethodType ].checkoutSessionRoot =
+				checkoutData.root;
+			gatewayUPEComponents[ paymentMethodType ].clientSecret =
+				checkoutData.clientSecret;
+
+			return gatewayUPEComponents[ paymentMethodType ];
+		} catch ( error ) {
+			showErrorPaymentMethod(
+				error?.message ||
+					'Failed to initialize payment form. Please refresh the page and try again.',
+				domElement
+			);
+			// Continue and fall back to regular payment element if checkout sessions fail
+		}
 	}
 
 	const upeElement =
@@ -865,5 +903,36 @@ export const confirmWalletPayment = async ( api, jQueryForm ) => {
 		jQueryForm.removeClass( 'processing' ).unblock();
 		unblockBlockCheckout();
 		resetBlockCheckoutPaymentState();
+	}
+};
+
+/**
+ * Handles checkout session confirmation from URL hash.
+ *
+ * @param {Object} api        The API object.
+ * @param {Object} jQueryForm The jQuery form object.
+ */
+export const confirmCheckoutSessionsPayment = async ( api, jQueryForm ) => {
+	const partials = window.location.href.match(
+		/#wc-stripe-checkout-sessions-(.+):(.+)$/
+	);
+
+	if ( ! partials ) {
+		jQueryForm.removeClass( 'processing' ).unblock();
+		return;
+	}
+
+	// Remove the hash from the URL
+	history.replaceState(
+		'',
+		document.title,
+		window.location.pathname + window.location.search
+	);
+
+	const orderId = partials[ 1 ];
+	const returnUrl = decodeURIComponent( partials[ 2 ] );
+
+	if ( returnUrl ) {
+		window.location.href = returnUrl;
 	}
 };

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -454,7 +454,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 
 		wp_register_script(
 			'stripe',
-			'https://js.stripe.com/v3/',
+			'https://js.stripe.com/clover/stripe.js',
 			[],
 			'3.0',
 			true
@@ -566,6 +566,9 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 			$stripe_params['OCLayout']                     = $this->get_option( 'optimized_checkout_layout', self::OPTIMIZED_CHECKOUT_DEFAULT_LAYOUT );
 			$stripe_params['paymentMethodConfigurationId'] = WC_Stripe_Payment_Method_Configurations::get_configuration_id();
 		}
+
+		// Adaptive Pricing feature flag and setting.
+		$stripe_params['isAPEnabled'] = WC_Stripe_Feature_Flags::is_checkout_sessions_available() && 'yes' === $this->get_option( 'adaptive_pricing', 'no' );
 
 		// Checking for other BNPL extensions.
 		$stripe_params['hasAffirmGatewayPlugin'] = WC_Stripe_Helper::has_gateway_plugin_active( WC_Stripe_Helper::OFFICIAL_PLUGIN_ID_AFFIRM );


### PR DESCRIPTION
Towards STRIPE-919


## Changes proposed in this Pull Request:
- Creates a checkout session on classic checkout.
- Renders the currency selector.
- No checkout functionality implemented.


## Testing instructions
**Pre-requisite**
Needs to be tested with the following branches
- https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4977
- https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4993

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
