### PR TITLE
Start new 10.5.0 sections and move changelog from #4974

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Changelog ***
 
+= 10.5.0 - xxxx-xx-xx =
+* Tweak - Update PHPDoc in admin REST controllers and related code
+
 = 10.4.0 - xxxx-xx-xx =
 * Add - Introduce an endpoint to create Checkout Sessions tokens
 * Add - New setting to control Adaptive Pricing
@@ -32,7 +35,6 @@
 * Add - Support Amazon Pay as an express checkout method
 * Add - Enable Amazon Pay for eligible new installs
 * Update - Stop auto-enabling Optimized Checkout Suite for new installs
-* Tweak - Update PHPDoc in admin REST controllers and related code
 
 = 10.3.1 - 2026-01-15 =
 * Fix - Fatal error when using express payment method with certain addresses

--- a/readme.txt
+++ b/readme.txt
@@ -141,38 +141,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 
 == Changelog ==
 
-= 10.4.0 - xxxx-xx-xx =
-* Add - Introduce an endpoint to create Checkout Sessions tokens
-* Add - New setting to control Adaptive Pricing
-* Add - Map Norwegian nb-NO to generic no-NO locale
-* Update - Redirect merchants to the Stripe settings screen upon plugin activation
-* Fix - Fix Stripe client API calls with wrong amount when rendering the express checkout buttons in blocks
-* Fix - Validate product exists before accessing product methods in express checkout to prevent fatal errors
-* Update - Ensure the `customer_name` metadata sent to Stripe does not have leading or trailing spaces
-* Update - Move all logic from WC_Gateway_Stripe to WC_Stripe_UPE_Payment_Gateway as part of deprecation
-* Update - Remove the main Payment Request Buttons backend class, WC_Stripe_Payment_Request, which was deprecated in 10.2.0
-* Dev - Replace deprecated logger method calls with severity specific methods
-* Dev - Ensure PHPStan runs when pushing changes
-* Dev - Add PHPStan stub for WC_Subscription class
-* Dev - Remove the deprecated WC_Stripe_Apple_Pay class
-* Fix - Prevent Optimized Checkout from showing unsupported payment methods
-* Dev - Unit tests to cover address normalization
-* Fix - Add order validation in Multibanco email instructions to prevent fatal error when order is invalid
-* Fix - Add validation to prevent fatal error when setting default payment token if token doesn't exist
-* Fix - Validate order object before accessing methods in my account orders actions to prevent fatal errors
-* Dev - Use WC_STRIPE_PLUGIN_PATH constant instead of __DIR__ for more reliable file path resolution
-* Dev - Automate release note creation PR
-* Fix - Prevent incompatibility warnings for payment methods in block editor
-* Dev - Introduce a feature flag for the Stripe checkout sessions feature
-* Dev - Improve the pre-push hook
-* Fix - Keep payment method details when toggling save payment method checkbox in classic checkout with Optimized Checkout enabled
-* Fix - Better error handling when token creation fails
-* Tweak - Improve PHPDoc for payment token code
-* Tweak - Update PHPDoc for email notification classes
-* Add - Admin notice for merchants potentially affected by the express checkout button location issue in versions 10.1.0 to 10.2.x
-* Add - Support Amazon Pay as an express checkout method
-* Add - Enable Amazon Pay for eligible new installs
-* Update - Stop auto-enabling Optimized Checkout Suite for new installs
+= 10.5.0 - xxxx-xx-xx =
 * Tweak - Update PHPDoc in admin REST controllers and related code
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to #4974

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR starts new 10.5.0 sections in `readme.txt` and `changelog.txt`, and moves the changelog entries from PR #4974 to the new 10.5.0 sections. I merged the PR and then realised that the changelog details were still in the 10.4.0 section.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Code inspection is all that is needed for this PR, as the only changes are to `changelog.txt` and `readme.txt`.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [N/A] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
