### PR TITLE
Add Coderabbit config

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -23,6 +23,7 @@ reviews:
     - "includes/**"
     - "client/**"
     - "tests/**"
+    - ".github/actions/**"
     - ".github/workflows/**"
     - "composer.json"
     - "composer.lock"
@@ -34,6 +35,40 @@ reviews:
     - "!**/*.map"
 
   path_instructions:
+    - path: "includes/payment-methods/**/*.php"
+      instructions: |
+        This is high-churn, payment-critical code.
+        Require null/empty guards before calling methods on orders, products, and tokens.
+        Require explicit state-transition checks for payment lifecycle updates.
+        Flag coupling risks between UPE gateway behavior and frontend checkout flows.
+    - path: "includes/class-wc-stripe-webhook-handler.php"
+      instructions: |
+        Require strict webhook signature validation and idempotent event handling.
+        Require safe handling for duplicate, delayed, or out-of-order events.
+        Require defensive payload/type checks to prevent fatal errors on unexpected data.
+    - path: "includes/class-wc-stripe-order-helper.php"
+      instructions: |
+        Treat order/refund metadata mapping as regression-prone.
+        Require consistency checks between Stripe IDs and Woo order/refund metadata.
+        Flag changes that can desynchronize refund or intent identifiers.
+    - path: "includes/admin/**/*.php"
+      instructions: |
+        For settings/admin changes, require capability and nonce checks.
+        Verify backward compatibility for existing options, defaults, and upgrade paths.
+    - path: "client/blocks/**/*.{js,jsx,ts,tsx}"
+      instructions: |
+        This area has repeated optimized/express checkout regressions.
+        Require robust async failure/retry handling and null-safe data access.
+        Flag frontend/backend contract mismatches with gateway/payment-method behavior.
+    - path: "client/classic/**/*.{js,jsx,ts,tsx}"
+      instructions: |
+        This area has repeated optimized/express checkout regressions.
+        Require robust async failure/retry handling and null-safe data access.
+        Flag frontend/backend contract mismatches with gateway/payment-method behavior.
+    - path: "client/settings/**/*.{js,jsx,ts,tsx}"
+      instructions: |
+        Ensure admin UI settings behavior remains in sync with backend settings semantics.
+        Flag changes that can desynchronize toggles/feature flags between UI and PHP.
     - path: "includes/**/*.php"
       instructions: |
         This is payment-critical backend code.

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "en-US"
+early_access: false
+
+reviews:
+  assess_linked_issues: false
+  collapse_walkthrough: true
+  high_level_summary: false
+  review_status: false
+  suggested_labels: false
+  suggested_reviewers: false
+  poem: false
+
+  profile: "assertive"
+
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "develop"
+
+  path_filters:
+    - "includes/**"
+    - "client/**"
+    - "tests/**"
+    - ".github/workflows/**"
+    - "composer.json"
+    - "composer.lock"
+    - "package.json"
+    - "package-lock.json"
+    - "!assets/**"
+    - "!build/**"
+    - "!**/*.min.js"
+    - "!**/*.map"
+
+  path_instructions:
+    - path: "includes/**/*.php"
+      instructions: |
+        This is payment-critical backend code.
+        Require capability/nonce checks on admin or REST entry points.
+        Require input validation/sanitization and proper output escaping.
+        For any order/subscription/customer mutation, require explicit state checks, ownership checks, and race-condition safety.
+        For webhooks, require signature verification and idempotent processing before mutating state.
+        Never expose secrets or sensitive payment/customer data in logs, notes, metadata, or errors.
+        Preserve backward compatibility for existing hooks/options and supported WordPress/WooCommerce versions.
+        Request PHPUnit coverage when behavior changes.
+    - path: "client/**/*.{js,jsx,ts,tsx}"
+      instructions: |
+        Ensure async checkout/admin payment flows handle failures and retries safely.
+        Ensure no secret keys or sensitive data are exposed client-side.
+        Request Jest/Playwright coverage for behavior changes.
+    - path: "tests/**/*.{php,js,ts,tsx}"
+      instructions: |
+        Prefer coverage of failure and edge cases: declines, duplicate webhooks, retry handling, partial refunds, stale order state.

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Dev - Upgrade @stripe/react-stripe-js to ^5.4.1 and @stripe/stripe-js to ^8.6.0 in JavaScript dependencies
 * Dev - Fix becs e2e tests
 * Add - Add the base CSV feed for agentic commerce
+* Dev - Add CodeRabbit configuration with Stripe-focused review guidance
 
 = 10.4.0 - 2026-02-09 = 
 * Add - Introduce an endpoint to create Checkout Sessions tokens

--- a/readme.txt
+++ b/readme.txt
@@ -162,5 +162,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Upgrade @stripe/react-stripe-js to ^5.4.1 and @stripe/stripe-js to ^8.6.0 in JavaScript dependencies
 * Dev - Fixes becs e2e tests
 * Add - Add the base CSV feed for agentic commerce
+* Dev - Add CodeRabbit configuration with Stripe-focused review guidance
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR adds a repository-level CodeRabbit configuration tailored for a Stripe payment gateway extension.

### What changed

- Added `/Users/ericbinnion/Repos/woocommerce-gateway-stripe/.worktrees/coderabbit-only/.coderabbit.yml` with:
  - Low-noise review defaults aligned with WooCommerce core style.
  - `assertive` review profile for payment/security-sensitive code.
  - Auto-review enabled for PRs targeting `develop`.
  - Path filters focused on source/config files, excluding generated/minified artifacts.
  - Stripe-specific review instructions for:
    - backend payment/webhook safety (`includes/**/*.php`)
    - frontend checkout/admin behavior (`client/**/*.{js,jsx,ts,tsx}`)
    - failure-path test expectations (`tests/**/*.{php,js,ts,tsx}`)

Summary of configuation:

| Setting | What it does | Practical effect in this repo |
|---|---|---|
| `# yaml-language-server: $schema=...` | Editor/schema hint for validation/autocomplete. | Helps catch invalid config keys/values while editing. |
| `language: "en-US"` | Sets review/chat language locale. | Comments are generated in US English. |
| `early_access: false` | Disables early-access features. | More stable behavior; fewer experimental features. |
| `reviews.assess_linked_issues: false` | Turns off “did this PR solve linked issues?” assessment in walkthrough. | Less walkthrough noise. |
| `reviews.collapse_walkthrough: true` | Wraps walkthrough in collapsible markdown. | Shorter PR comment footprint. |
| `reviews.high_level_summary: false` | Disables automatic high-level PR summary. | Review focuses on findings rather than summary prose. |
| `reviews.review_status: false` | Hides status/meta messages in walkthrough. | Fewer informational comments. |
| `reviews.suggested_labels: false` | Disables label suggestions. | No AI label proposals. |
| `reviews.suggested_reviewers: false` | Disables reviewer suggestions. | No AI reviewer assignment hints. |
| `reviews.poem: false` | Disables poem output. | Removes novelty output. |
| `reviews.profile: "assertive"` | Uses stricter/more nitpicky review style. | More feedback, especially edge cases and risks. |
| `reviews.auto_review.enabled: true` | Enables automatic PR reviews. | Reviews trigger without manual command. |
| `reviews.auto_review.drafts: false` | Excludes draft PRs from auto-review. | Reviews start once PR is ready (non-draft). |
| `reviews.auto_review.base_branches: ["develop"]` | Auto-review on additional base branches. | Targets `develop`; if `develop` is already default branch, this is effectively redundant/no-op. |
| `reviews.path_filters` | Include/exclude file globs for review scope. | Focuses review on `includes/**`, `client/**`, `tests/**`, workflow files, and dependency manifests; excludes generated/minified/map files and `assets`/`build`. |
| `reviews.path_instructions` | Adds path-specific review instructions (prompting guidance, not hard enforcement). | Makes CodeRabbit emphasize payment/webhook/security/test concerns where they matter most. |

For the targeted guidance, I asked Codex to look back at the last 6 months and it summarized the following recommendations:

| Targeted guidance (from `.coderabbit.yml`) | What this is trying to catch in review | PRs that showed this risk |
|---|---|---|
| `includes/payment-methods/**/*.php` | Missing null/empty guards, unsafe payment state transitions, and backend/frontend behavior drift in UPE/optimized checkout flows | [#4935](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4935), [#4932](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4932), [#4922](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4922), [#4814](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4814) |
| `includes/class-wc-stripe-webhook-handler.php` | Webhook signature/idempotency gaps, duplicate/out-of-order event handling bugs, and payload/type assumptions that can cause fatals | [#4866](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4866), [#4747](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4747), [#4660](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4660), [#4466](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4466) |
| `includes/class-wc-stripe-order-helper.php` | Metadata drift between Stripe IDs and Woo order/refund/intent meta keys; type/normalization inconsistencies | [#4693](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4693), [#4716](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4716), [#4652](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4652), [#4903](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4903) |
| `includes/admin/**/*.php` | Admin/settings security checks (capability/nonce) and backward-compatibility risks for existing settings/defaults | [#4985](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4985), [#4747](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4747) |
| `client/blocks/**/*.{js,jsx,ts,tsx}` and `client/classic/**/*.{js,jsx,ts,tsx}` | Async checkout failures, null-safe access issues, and optimized/express checkout behavior mismatches | [#4922](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4922), [#4754](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4754), [#4850](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4850), [#4788](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4788), [#4803](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4803) |
| `client/settings/**/*.{js,jsx,ts,tsx}` | UI toggle/feature-flag behavior drifting from backend semantics | [#4633](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4633), [#4683](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4683), [#4985](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4985) |
| `path_filters` addition: `.github/actions/**` | CI/review automation changes that can weaken test coverage or merge safety if unreviewed | [#4944](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4944), [#4953](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4953) |


### How can this code break?

- If path filters are too narrow, CodeRabbit could miss relevant files.
- If instructions are too strict, review noise could increase.

### What are we doing to make sure this code doesn't break?

- Filters include all primary source/test areas and workflow/config files.
- Exclusions only target generated/minified assets.
- Behavior can be validated immediately on this PR with `@coderabbitai review` and tuned iteratively.

## Testing instructions

No end-user checkout behavior is changed by this PR.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

N/A

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration settings.
  * Updated changelog and documentation entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->