### PR TITLE
docs: expand agent guidance with directory context and CLAUDE links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,8 @@ Use the smallest command set needed for the task:
 | E2E run | `npm run test:e2e -- --base_url=...` | Supports Playwright CLI flags. |
 | PHP lint | `npm run lint:php` | Use `npm run lint:php-fix` when appropriate. |
 | JS lint | `npm run lint:js` | Use `npm run lint:js-fix` when appropriate. |
-| PHPStan | `npm run phpstan` | Level 8 static analysis. |
-| Refresh PHPStan baseline | `npm run phpstan:baseline` | Only after triaging `npm run phpstan` results. |
+| PHP static analysis | `npm run phpstan` | Level 8 static analysis for PHP files. |
+| Refresh PHP static analysis baseline | `npm run phpstan:baseline` | Only after triaging `npm run phpstan` results. |
 | Stripe webhook listener | `npm run listen` | For local webhook forwarding. |
 
 ## Common Pitfalls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Use the smallest command set needed for the task:
 
 | Task | Command | Notes |
 | --- | --- | --- |
-| Install dependencies | `npm install` | Runs Composer install and Playwright install. |
+| Install dependencies | `composer install && npm install` | Runs Composer install and npm install, which then installs all dependencies. |
 | Start local environment | `npm run up` | Docker-based site at `http://localhost:8072`. |
 | Stop local environment | `npm run down` | Preserves local Docker state. |
 | Build frontend assets | `npm run build:webpack` | Use when editing client-side sources that ship built assets. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,112 +1,152 @@
 # AGENTS.md
 
-This file provides guidance to AI coding assistants when working with code in this repository.
+This file provides guidance to coding agents working in this repository.
 
 ## Project Overview
 
-WooCommerce Stripe Payment Gateway - Official plugin for accepting Stripe payments on WooCommerce stores. Supports 20+ payment methods including credit cards, Apple Pay, Google Pay, Klarna, Affirm, SEPA, ACH, and regional methods like Alipay and Boleto.
+WooCommerce Stripe Payment Gateway is the official plugin for accepting Stripe payments on WooCommerce stores. It supports 20+ payment methods, including cards, Apple Pay, Google Pay, Klarna, Affirm, SEPA, ACH, Alipay, and Boleto.
 
 **Requirements:** PHP 7.4+, WordPress 6.7+, WooCommerce 9.9+, Node 20.18.1+, npm 10.2.3+
 
-## Common Commands
+## CRITICAL Rules
 
-```bash
-# Setup & Build
-npm install                  # Install all dependencies (runs composer install + playwright install)
-npm run build:webpack        # Build frontend assets
-npm start                    # Development mode with hot reload
+- **CRITICAL:** Do not edit WordPress core or WooCommerce core files in `docker/wordpress/` or `docker/wordpress_xdebug/`. Only edit plugin source in this repository.
+- **CRITICAL:** Do not commit credentials, API keys, webhook secrets, or `.env` values.
+- **CRITICAL:** Keep changes scoped. Do not perform broad refactors unless explicitly requested.
+- **CRITICAL:** If you change runtime behavior, run the smallest relevant test suite before claiming completion.
+- **CRITICAL:** Bugfixes for fatals, checkout failures, and payment regressions MUST include or update targeted automated tests; code review alone is not enough.
+- **CRITICAL:** If you update `phpstan-baseline.neon`, run `npm run phpstan` first, fix legitimate issues, then baseline only unavoidable items.
+- **CRITICAL:** Do not mix broad feature work with PHPStan baseline churn in a single commit unless explicitly requested.
+- **CRITICAL:** Changes to payment method availability/rendering MUST be validated across classic checkout, Blocks checkout, optimized checkout, and express checkout.
+- **CRITICAL:** Respect version support policy (WordPress strict L-2, WooCommerce loose L-2).
 
-# Docker Development Environment
-npm run up                   # Start Docker environment
-npm run down                 # Stop Docker
-npm run listen               # Start Stripe webhook listener (forward to localhost:8072)
-npm run xdebug:start         # Enable Xdebug in Docker
-npm run xdebug:stop          # Disable Xdebug in Docker
+## Task-to-Command Matrix
 
-# Testing
-npm run test:php             # Run PHPUnit tests (requires Docker running)
-npm run test:js              # Run Jest unit tests
-npm run test:js -- --watch   # Jest in watch mode
-npm run test:e2e             # Run E2E tests (default project)
-npm run test:e2e-setup       # Setup E2E environment first
+Use the smallest command set needed for the task:
 
-# Code Quality
-npm run lint:php             # PHP CodeSniffer
-npm run lint:php-fix         # Auto-fix PHP issues
-npm run lint:js              # ESLint
-npm run lint:js-fix          # Auto-fix ESLint issues
-npm run phpstan              # PHPStan static analysis (Level 8)
-npm run phpstan:baseline     # Update PHPStan baseline for new/changed errors
-```
+| Task | Command | Notes |
+| --- | --- | --- |
+| Install dependencies | `npm install` | Runs Composer install and Playwright install. |
+| Start local environment | `npm run up` | Docker-based site at `http://localhost:8072`. |
+| Stop local environment | `npm run down` | Preserves local Docker state. |
+| Build frontend assets | `npm run build:webpack` | Use when editing client-side sources that ship built assets. |
+| Dev hot reload | `npm start` | Webpack watch/dev mode. |
+| PHPUnit | `npm run test:php` | Requires Docker environment running. |
+| Jest unit tests | `npm run test:js` | Use `npm run test:js:watch` during iteration. |
+| E2E setup | `npm run test:e2e-setup -- --base_url=...` | Requires `tests/e2e/config/local.env`. |
+| E2E run | `npm run test:e2e -- --base_url=...` | Supports Playwright CLI flags. |
+| PHP lint | `npm run lint:php` | Use `npm run lint:php-fix` when appropriate. |
+| JS lint | `npm run lint:js` | Use `npm run lint:js-fix` when appropriate. |
+| PHPStan | `npm run phpstan` | Level 8 static analysis. |
+| Refresh PHPStan baseline | `npm run phpstan:baseline` | Only after triaging `npm run phpstan` results. |
+| Stripe webhook listener | `npm run listen` | For local webhook forwarding. |
+
+## Common Pitfalls
+
+- Running PHP tests without Docker: `npm run test:php` fails unless containers are up.
+- Missing E2E config: copy `tests/e2e/config/local.env.example` to `tests/e2e/config/local.env`.
+- Forgetting payment method registration: adding a `WC_Stripe_UPE_Payment_Method` class is not enough; it must also be registered in `WC_Stripe::init()` and constants updated.
+- Updating only backend or frontend for UPE changes: most payment method work spans PHP (`includes/payment-methods/`) and Blocks/UI (`client/blocks/upe/`, icons).
+- Treating PHPStan baseline as a blanket suppressor: fix real type/nullability issues first.
+- Skipping `@dataProvider` for multi-scenario PHPUnit tests: this repository standardizes on data providers for parameterized inputs.
+- Release metadata drift: version-related changes often require coordinated edits to `changelog.txt`, `readme.txt`, and release references.
 
 ## Architecture
 
 ### Backend Structure (`includes/`)
 
-- **Entry Point:** `woocommerce-gateway-stripe.php` → `WC_Stripe` singleton via `woocommerce_gateway_stripe()`
-- **Core Services:**
-  - `WC_Stripe_API` - Stripe API communication (singleton)
-  - `WC_Stripe_Webhook_Handler` - Processes Stripe webhooks
-  - `WC_Stripe_Intent_Controller` - Payment Intent lifecycle management
-  - `WC_Stripe_Customer` - WooCommerce-Stripe customer linking
+- **Entry point:** `woocommerce-gateway-stripe.php` loads `WC_Stripe` via `woocommerce_gateway_stripe()`.
+- **Core service:** `WC_Stripe_API` for Stripe API communication (singleton).
+- **Core service:** `WC_Stripe_Webhook_Handler` for webhook processing.
+- **Core service:** `WC_Stripe_Intent_Controller` for payment intent lifecycle.
+- **Core service:** `WC_Stripe_Customer` for WooCommerce-Stripe customer linking.
 
 ### Payment Gateway Hierarchy
 
 ```
 WC_Payment_Gateway_CC (WooCommerce)
     └── WC_Stripe_Payment_Gateway (abstract)
-            └── WC_Stripe_UPE_Payment_Gateway (main multi-method gateway)
+            └── WC_Stripe_UPE_Payment_Gateway
                     └── Uses WC_Stripe_UPE_Payment_Method subclasses
 
 WC_Stripe_UPE_Payment_Method (abstract)
-    ├── WC_Stripe_UPE_Payment_Method_CC (credit cards)
+    ├── WC_Stripe_UPE_Payment_Method_CC
     ├── WC_Stripe_UPE_Payment_Method_Klarna
     ├── WC_Stripe_UPE_Payment_Method_SEPA
-    └── ... (20+ payment methods)
+    └── ... (20+ methods)
 ```
 
-**Traits for subscriptions/pre-orders:**
-- `WC_Stripe_Subscriptions_Trait` - Subscription payment handling
-- `WC_Stripe_Pre_Orders_Trait` - Pre-order payment handling
+Traits:
+- `WC_Stripe_Subscriptions_Trait` for subscription flows.
+- `WC_Stripe_Pre_Orders_Trait` for pre-order flows.
 
 ### Frontend Structure (`client/`)
 
-- **React Admin UI:** `client/settings/`, `client/entrypoints/`
-- **WooCommerce Blocks:** `client/blocks/` (checkout integration)
-- **State Management:** Redux-style stores in `client/data/` (settings, account, payment-gateway, account-keys)
-- **Express Checkout:** `client/express-checkout/` (Apple Pay, Google Pay)
+- React admin UI: `client/settings/`, `client/entrypoints/`.
+- WooCommerce Blocks integration: `client/blocks/`.
+- Data stores: `client/data/` (`settings`, `account`, `payment-gateway`, `account-keys`).
+- Express checkout flows: `client/express-checkout/`.
 
 ### Key Patterns
 
-1. **Singleton Pattern:** `WC_Stripe::get_instance()`, `WC_Stripe_API::get_instance()`
-2. **Abstract Base Classes:** Payment methods extend `WC_Stripe_UPE_Payment_Method`
-3. **Settings Storage:** WordPress options `woocommerce_stripe_settings`, `woocommerce_stripe_{method}_settings`
-4. **REST Controllers:** `includes/admin/` - Settings, payment gateways, account keys endpoints
-5. **Database Caching:** `WC_Stripe_Database_Cache` provides TTL-based caching stored as WordPress options with in-memory per-request cache and async cleanup via Action Scheduler
+1. Singleton services (`WC_Stripe::get_instance()`, `WC_Stripe_API::get_instance()`).
+2. Payment methods inherit from `WC_Stripe_UPE_Payment_Method`.
+3. Settings stored in `woocommerce_stripe_settings` and `woocommerce_stripe_{method}_settings`.
+4. Admin REST controllers live in `includes/admin/`.
+5. `WC_Stripe_Database_Cache` uses WordPress options + in-memory cache + Action Scheduler cleanup.
 
-### Adding New Payment Methods
+### Adding a New Payment Method
 
-1. Create class extending `WC_Stripe_UPE_Payment_Method` in `includes/payment-methods/`
-2. Register in `WC_Stripe::init()`
-3. Add to `WC_Stripe_Payment_Methods` constants class
-4. Create icon in `client/payment-method-icons/`
-5. Add Blocks component in `client/blocks/upe/`
+1. Add class in `includes/payment-methods/` extending `WC_Stripe_UPE_Payment_Method`.
+2. Register method in `WC_Stripe::init()`.
+3. Add constants to `WC_Stripe_Payment_Methods`.
+4. Add icon in `client/payment-method-icons/`.
+5. Add Blocks support in `client/blocks/upe/`.
 
-## PHPStan Workflow
+## Testing Conventions
 
-PHPStan runs at Level 8 on every PR. When you see errors:
-- Fix legitimate issues (null checks, type mismatches)
-- For errors that can be ignored, update the baseline: `npm run phpstan:baseline`
-- Always commit baseline changes to avoid noise for other developers
+- PHPUnit tests live in `tests/phpunit/` (mirrors `includes/`).
+- Jest tests live in `tests/js/`.
+- E2E tests live in `tests/e2e/` (multiple Playwright projects).
+- Use `@dataProvider` for PHPUnit parameterized scenarios.
+- For behavior changes, prefer adding/updating tests nearest to touched code.
+- For checkout behavior or payment-method availability changes, verify at least one classic path and one Blocks/OC/ECE path.
 
-## Test Organization
+## Release Hygiene
 
-- **PHP Unit Tests:** `tests/phpunit/` - mirrors `includes/` structure
-- **Jest Tests:** `tests/js/` - React component tests
-- **E2E Tests:** `tests/e2e/` - Playwright with projects: default, legacy, acss, blik, becs, optimized-checkout
-
-**PHPUnit Convention:** Use `@dataProvider` for parameterized tests. This is the standard pattern in this codebase for testing multiple input/output scenarios.
+- For version/release changes, update `changelog.txt`, `readme.txt` stable tag, and related version references together.
+- For WooCommerce version resolution logic, include explicit cases for stable, RC, and beta semantics.
 
 ## Version Support
 
-Follows L-2 policy: supports current and two previous major versions of WordPress (strict) and WooCommerce (loose).
+This repository follows the L-2 policy:
+- WordPress: strict current and previous two major versions.
+- WooCommerce: loose current and previous two major versions.
+
+## Documentation and Context Sources
+
+- Root project docs: `README.md`
+- Docker setup: `docs/DOCKER.md`
+- E2E details: `tests/e2e/README.md`
+- API details: `docs/api/README.md`
+- Agentic Commerce feed context: `includes/agentic-commerce/README.md`
+
+## Directory-Specific Instructions
+
+Read these files when working in each area:
+
+- `includes/AGENTS.md` for backend/PHP changes.
+- `client/AGENTS.md` for frontend/Blocks/settings changes.
+- `tests/e2e/AGENTS.md` for Playwright E2E work.
+- `includes/agentic-commerce/AGENTS.md` for product feed integration work.
+
+## Agent Instruction Maintenance (MUST)
+
+Update this file when any of these occur:
+
+- An agent made an avoidable mistake due to missing project context.
+- A reviewer had to correct an assumption about architecture, commands, or conventions.
+- A new recurring pitfall appears in two or more PRs.
+- Build/test/lint workflows changed.
+
+When adding guidance, prefer concise, imperative rules with explicit priority words like **MUST** and **CRITICAL**.

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,8 +16,9 @@
 * Dev - Fix becs e2e tests
 * Add - Add the base CSV feed for agentic commerce
 * Dev - Add CodeRabbit configuration with Stripe-focused review guidance
+* Dev - Expand AI agent guidance with directory-level AGENTS and CLAUDE context files
 
-= 10.4.0 - 2026-02-09 = 
+= 10.4.0 - 2026-02-09 =
 * Add - Introduce an endpoint to create Checkout Sessions tokens
 * Add - New setting to control Adaptive Pricing
 * Add - Map Norwegian nb-NO to generic no-NO locale

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -1,0 +1,56 @@
+# client/AGENTS.md
+
+Scope: applies to frontend code under `client/`.
+
+For repository-wide rules, always read the root `AGENTS.md` first.
+
+## CRITICAL Rules
+
+- **CRITICAL:** Keep checkout behavior consistent across shortcode and Blocks flows unless the change is explicitly flow-specific.
+- **CRITICAL:** If you change user-facing behavior, add or update tests (Jest and/or E2E as appropriate).
+- **CRITICAL:** Keep payment method availability, labels, and icons aligned across UI surfaces.
+- **CRITICAL:** Payment method availability rules must come from a single source of truth shared across PHP config and frontend rendering.
+- **CRITICAL:** Use shared amount/minor-unit normalization utilities; do not compute Stripe-facing amounts ad hoc.
+- **CRITICAL:** Prefer incremental updates in existing modules over broad rewrites.
+
+## Structure and Ownership
+
+- Blocks integration: `client/blocks/`
+- Settings/admin UI: `client/settings/`, `client/entrypoints/`
+- Express checkout: `client/express-checkout/`
+- Shared data/state: `client/data/`
+- Shared utility logic: `client/utils/`, `client/stripe-utils/`
+- Payment method visuals: `client/payment-method-icons/`
+
+## Task-to-Command Matrix
+
+| Task | Command |
+| --- | --- |
+| Build frontend assets | `npm run build:webpack` |
+| Run dev watcher | `npm start` |
+| Run JS tests | `npm run test:js` |
+| Run JS lint | `npm run lint:js` |
+| Auto-fix JS lint | `npm run lint:js-fix` |
+| Run CSS/SCSS lint | `npm run lint:css` |
+
+## Frontend Conventions
+
+- Reuse existing shared utilities before adding new helpers.
+- Keep feature flags and payment-method gating logic centralized and explicit.
+- Preserve existing naming patterns and folder placement used by nearby files.
+- Keep dependencies minimal; avoid adding libraries for simple logic.
+
+## Common Pitfalls
+
+- Updating a payment method in one place only (for example settings but not blocks/icon map).
+- Introducing checkout-flow divergence accidentally between classic and blocks.
+- Changing state shape in `client/data/` without updating all consumers.
+- Forgetting to rebuild assets when source changes require refreshed build output.
+- Mixing display amounts and API minor-unit amounts in per-feature logic.
+
+## Test Mapping
+
+- JS unit tests and config: `tests/js/`
+- End-to-end checkout verification: `tests/e2e/`
+
+For behavior changes affecting checkout, pair unit-level checks with at least one relevant E2E path.

--- a/client/AGENTS.md
+++ b/client/AGENTS.md
@@ -10,7 +10,7 @@ For repository-wide rules, always read the root `AGENTS.md` first.
 - **CRITICAL:** If you change user-facing behavior, add or update tests (Jest and/or E2E as appropriate).
 - **CRITICAL:** Keep payment method availability, labels, and icons aligned across UI surfaces.
 - **CRITICAL:** Payment method availability rules must come from a single source of truth shared across PHP config and frontend rendering.
-- **CRITICAL:** Use shared amount/minor-unit normalization utilities; do not compute Stripe-facing amounts ad hoc.
+- **CRITICAL:** Use shared amount/minor-unit normalization utilities; do not compute Stripe-facing or user-facing amounts ad hoc.
 - **CRITICAL:** Prefer incremental updates in existing modules over broad rewrites.
 
 ## Structure and Ownership

--- a/client/CLAUDE.md
+++ b/client/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/docs/ai-readability-audit.md
+++ b/docs/ai-readability-audit.md
@@ -1,0 +1,48 @@
+# AI Readability Audit
+
+Date: 2026-02-13
+Source guidance: [Writing Guidelines for Coding Agents](https://fieldguide.automattic.com/coding-agents-guidelines/)
+
+## Scope
+
+This audit evaluates how easily coding agents can complete tasks correctly in this repository with minimal back-and-forth.
+
+Scoring scale:
+- `5` Excellent: likely correct first pass with minimal prompts.
+- `4` Strong: mostly correct, occasional prompt clarifications.
+- `3` Adequate: frequent clarifications needed.
+- `2` Weak: recurring incorrect assumptions.
+- `1` Poor: high failure risk without heavy human steering.
+
+## Current Scores
+
+| Category | Score | Evidence | Gap |
+| --- | --- | --- | --- |
+| Root agent instructions (`AGENTS.md` + `CLAUDE.md`) | 4 | Root file exists and `CLAUDE.md` points to it. | Needed stronger priority language and explicit pitfalls. |
+| Project knowledge and architecture context | 4 | Core architecture, hierarchy, and patterns already documented. | Needs sharper "do not violate" constraints and faster task routing. |
+| Commands and execution guidance | 4 | Common commands are present and useful. | Needed a task-to-command matrix for lowest-cost command selection. |
+| Conventions and testing expectations | 3 | PHPUnit `@dataProvider` convention documented. | Needed clearer behavior-change verification expectations. |
+| Architectural decisions that differ from defaults | 3 | Some rationale exists in subsystem READMEs (for example Blocks AJAX choices). | Rationale not yet mapped into agent-facing guardrails. |
+| Common pitfalls | 2 | Pitfalls were implicit, not centralized in root instructions. | Required a dedicated pitfalls section. |
+| Directory-specific context (progressive disclosure) | 4 | Subtree `AGENTS.md` files now exist for high-context areas. | Expand coverage if additional complex subsystems emerge. |
+| Instruction maintenance process | 2 | No explicit loop for updating instructions after failures. | Needed a mandatory update trigger list. |
+
+Overall score: `3.3` (strong baseline with improved context routing and safety guidance).
+
+## Improvements Implemented in This Pass
+
+1. Strengthened root instructions in `AGENTS.md` with explicit **CRITICAL** rules, a task-to-command matrix, a dedicated common pitfalls list, and mandatory instruction maintenance triggers.
+1. Added directory-level `AGENTS.md` files: `includes/AGENTS.md`, `client/AGENTS.md`, `tests/e2e/AGENTS.md`, and `includes/agentic-commerce/AGENTS.md`.
+1. Preserved `CLAUDE.md` single-source setup (`@AGENTS.md`).
+1. Added guidance informed by six-month repo history review (293 merged PRs, 390 commits): checkout parity gate, null/type guard emphasis, E2E iframe-readiness guidance, release hygiene, and feed contract checklist.
+
+## Next Improvements (Planned)
+
+1. Add benchmark prompts and measurement rubric by creating `docs/ai-benchmarks.md` with representative tasks and pass/fail criteria.
+2. Add process hooks, including a PR checklist item for instruction updates and a lightweight monthly review cadence.
+
+## Definition of Done for AI Readability Upgrade
+
+- Root and subdirectory agent instructions explicitly separate project-wide rules, subsystem-specific context, and critical pitfalls/verification expectations.
+- Benchmark prompts exist and can be rerun after instruction updates.
+- Team has a repeatable maintenance trigger for guidance quality.

--- a/includes/AGENTS.md
+++ b/includes/AGENTS.md
@@ -1,0 +1,78 @@
+# includes/AGENTS.md
+
+Scope: applies to all PHP code under `includes/`.
+
+For repository-wide rules, always read the root `AGENTS.md` first.
+
+## CRITICAL Rules
+
+- **CRITICAL:** Keep WooCommerce and WordPress L-2 compatibility in mind for new PHP features.
+- **CRITICAL:** Do not silently change option keys, action names, or filter names used externally.
+- **CRITICAL:** If behavior changes, update or add PHPUnit coverage in `tests/phpunit/`.
+- **CRITICAL:** Treat WordPress/WooCommerce and hook-derived values as untrusted (`null|false|mixed`) until validated.
+- **CRITICAL:** Prefer focused changes in existing classes over large cross-cutting refactors.
+
+## Structure and Ownership
+
+Core bootstrap and service wiring:
+
+- `includes/class-wc-stripe.php`
+- `includes/class-wc-stripe-api.php`
+- `includes/class-wc-stripe-intent-controller.php`
+- `includes/class-wc-stripe-webhook-handler.php`
+
+Admin REST and settings:
+
+- `includes/admin/`
+
+Payment method implementations:
+
+- `includes/payment-methods/`
+- `includes/payment-tokens/`
+- `includes/constants/class-wc-stripe-payment-methods.php`
+
+Compatibility layers (subscriptions, pre-orders, other integrations):
+
+- `includes/compat/`
+
+Agentic Commerce feed integration:
+
+- `includes/agentic-commerce/`
+
+## Task-to-Command Matrix
+
+| Task | Command |
+| --- | --- |
+| Run backend tests | `npm run test:php` |
+| Run PHP lint | `npm run lint:php` |
+| Auto-fix PHPCS issues | `npm run lint:php-fix` |
+| Run static analysis | `npm run phpstan` |
+| Refresh baseline after triage | `npm run phpstan:baseline` |
+
+## Backend Conventions
+
+- Follow existing class naming/file naming conventions (`class-wc-stripe-*.php`, `trait-wc-stripe-*.php`).
+- Use strict typing patterns that already exist in touched files.
+- Keep translation wrappers and escaping patterns consistent with neighboring code.
+- Keep hooks and side effects explicit. If adding hooks, ensure lifecycle placement is intentional.
+- Use data providers for parameterized PHPUnit coverage.
+- Define failure contracts for token/intent creation paths and handle failure explicitly at call sites.
+- For amount conversion paths, round before integer casting and test edge precision cases.
+
+## Common Pitfalls
+
+- Adding a payment method class without updating method registration/constants.
+- Updating only one layer of a flow (for example gateway logic without webhook/intent handling).
+- Treating PHPStan baseline updates as the first option instead of the last option.
+- Changing compatibility behavior (subscriptions/pre-orders) without targeted tests.
+- Calling methods on potential `null`/`false` token, order, or payment objects.
+- In recurring-payment capable methods, missing subscriptions/pre-orders initialization or regression coverage.
+
+## Test Mapping
+
+- General backend tests: `tests/phpunit/`
+- Admin controller tests: `tests/phpunit/Admin/`
+- Payment method tests: `tests/phpunit/PaymentMethods/`
+- Payment token tests: `tests/phpunit/PaymentTokens/`
+
+When adding a new backend class, add or update the closest mirrored test file.

--- a/includes/CLAUDE.md
+++ b/includes/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/includes/agentic-commerce/AGENTS.md
+++ b/includes/agentic-commerce/AGENTS.md
@@ -1,0 +1,63 @@
+# includes/agentic-commerce/AGENTS.md
+
+Scope: applies to Agentic Commerce integration code in `includes/agentic-commerce/`.
+
+For repository-wide rules, always read the root `AGENTS.md` first.
+
+## CRITICAL Rules
+
+- **CRITICAL:** Preserve streaming feed behavior. Do not introduce full-catalog in-memory processing.
+- **CRITICAL:** Keep `FeedInterface`/integration contracts compatible with WooCommerce Product Feed interfaces.
+- **CRITICAL:** Preserve scalar/null input constraints for CSV rows and existing normalization behavior.
+- **CRITICAL:** Keep scheduled sync lifecycle safe: schedule on activate, unschedule on deactivate.
+
+## Core Components
+
+- Feed writer: `class-wc-stripe-agentic-commerce-csv-feed.php`
+- Integration orchestration: `class-wc-stripe-agentic-commerce-integration.php`
+- Product mapping: `class-wc-stripe-agentic-commerce-product-mapper.php`
+- Feed validation: `class-wc-stripe-agentic-commerce-feed-validator.php`
+- Files API delivery: `class-wc-stripe-agentic-commerce-files-api-delivery.php`
+- Schema definition: `class-wc-stripe-agentic-commerce-feed-schema.php`
+- CLI hooks: `class-wc-stripe-agentic-commerce-cli.php`
+
+Read `README.md` in this directory for domain-specific feed requirements.
+
+## Behavior Invariants
+
+- Call sequence for feed generation: `set_columns()` -> `start()` -> `add_entry()` -> `end()` -> `get_file_url()`.
+- CSV entries must match header count.
+- Entry values must remain scalar or `null`; complex values must be serialized before `add_entry()`.
+- Keep logging and cleanup behavior on error paths intact.
+
+## Feed Contract Checklist (MUST)
+
+- Keep schema/header alignment intact when adding or removing fields.
+- Preserve unit normalization rules (for example prices, weights, dimensions) and update tests when changing format logic.
+- Preserve inventory and variant mapping consistency between mapper output and schema expectations.
+- Validate registration and delivery setup failure paths explicitly (including useful logs).
+
+## Task-to-Command Matrix
+
+| Task | Command |
+| --- | --- |
+| Run PHP tests | `npm run test:php` |
+| Run static analysis | `npm run phpstan` |
+| Run PHP lint | `npm run lint:php` |
+
+## Test Mapping
+
+Primary coverage is in:
+- `tests/phpunit/WC_Stripe_Agentic_Commerce_Csv_Feed_Test.php`
+- `tests/phpunit/WC_Stripe_Agentic_Commerce_Feed_Schema_Test.php`
+- `tests/phpunit/WC_Stripe_Agentic_Commerce_Feed_Validator_Test.php`
+- `tests/phpunit/WC_Stripe_Agentic_Commerce_Files_Api_Delivery_Test.php`
+- `tests/phpunit/WC_Stripe_Agentic_Commerce_Integration_Test.php`
+- `tests/phpunit/WC_Stripe_Agentic_Commerce_Product_Mapper_Test.php`
+
+## Common Pitfalls
+
+- Breaking feed column/schema alignment when adding fields.
+- Using array/object values directly in `add_entry()`.
+- Updating schedule constants/hook names without corresponding lifecycle/test updates.
+- Modifying delivery behavior without validating setup checks and failure logging.

--- a/includes/agentic-commerce/CLAUDE.md
+++ b/includes/agentic-commerce/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/readme.txt
+++ b/readme.txt
@@ -163,5 +163,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Fixes becs e2e tests
 * Add - Add the base CSV feed for agentic commerce
 * Dev - Add CodeRabbit configuration with Stripe-focused review guidance
+* Dev - Expand AI agent guidance with directory-level AGENTS and CLAUDE context files
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/e2e/AGENTS.md
+++ b/tests/e2e/AGENTS.md
@@ -1,0 +1,47 @@
+# tests/e2e/AGENTS.md
+
+Scope: applies to Playwright end-to-end tests in `tests/e2e/`.
+
+For repository-wide rules, always read the root `AGENTS.md` first.
+
+## CRITICAL Rules
+
+- **CRITICAL:** Treat `test:e2e-setup` against `--base_url` as destructive setup for a target site. Use only disposable/staging environments.
+- **CRITICAL:** Do not commit secrets from `tests/e2e/config/local.env`.
+- **CRITICAL:** Keep tests deterministic; avoid unnecessary sleeps and flaky selectors.
+- **CRITICAL:** For Stripe iframe interactions, do not rely on `networkidle`; use deterministic field readiness/visibility checks.
+- **CRITICAL:** Reuse existing setup/utility helpers before adding new setup logic.
+
+## Environment and Commands
+
+| Task | Command | Notes |
+| --- | --- | --- |
+| Full setup | `npm run test:e2e-setup -- --base_url=<url>` | Remote setup path. Can install/configure WooCommerce and Stripe settings. |
+| Run default project | `npm run test:e2e -- --base_url=<url>` | Uses `default` Playwright project. |
+| Run specific project | `npm run test:e2e-run -- --project=<name> --base_url=<url>` | Project names include `default`, `acss`, `becs`, `blik`, `optimized-checkout`. |
+| Debug run | `npm run test:e2e-debug -- --base_url=<url>` | Playwright debug mode. |
+| Docker setup/run | `npm run test:e2e-setup` then `npm run test:e2e` | Local Docker path (`http://localhost:8088`). |
+| Tear down Docker | `npm run test:e2e-down` | Stops E2E containers. |
+
+## File Layout
+
+- Runner scripts: `tests/e2e/bin/`
+- Environment and setup config: `tests/e2e/config/`, `tests/e2e/env/`
+- Test specs and setup files: `tests/e2e/tests/`
+- Shared helpers: `tests/e2e/utils/`
+- Fixture data: `tests/e2e/test-data/`
+
+## Common Pitfalls
+
+- Running against the wrong site because `--base_url` was omitted or incorrect.
+- Assuming setup is read-only: setup scripts actively configure plugins/options/pages.
+- Duplicating helper logic instead of extending `tests/e2e/utils/`.
+- Adding overly broad selectors that break with minor UI adjustments.
+
+## Authoring Guidance
+
+- Keep one test focused on one behavior.
+- Prefer existing annotations/tags and naming patterns.
+- For new payment-method coverage, mirror existing per-method setup/spec organization.
+- If a test is flaky, fix root cause before adding retries or sleeps.
+- When fixing flow-specific flakiness, verify the equivalent flow (classic vs blocks/OC/ECE) unless explicitly out of scope.

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Changes proposed in this Pull Request:

This PR improves AI-agent guidance for this repository and makes `CLAUDE.md` usage consistent with current guidance (`@AGENTS.md` file references, not symlinks).

### What changed

Updated root AGENTS.md after recent guidance. Add some AGENTS.md in subdirectories. Codex also made suggestons after reviewing past 6 months of commits and PRs.

### Why this is needed

Sets a new baseline for AI context following Field Guide guidance.

### How this could break

- Incorrect or stale guidance could steer future agent changes poorly.
- Directory-level instruction drift could introduce conflicting guidance.

### Mitigations

- Kept root guidance as source of truth for repo-wide rules.
- Scoped subdirectory guidance to local concerns only.
- Added explicit maintenance triggers in root `AGENTS.md`.
- Added an audit doc to make future updates intentional and reviewable.
- `AGENTS.md` is easily changeable.

## Testing instructions

Review guidance and verify that it makes sense. 

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment
This PR only updates internal AI guidance documentation (`AGENTS.md` / `CLAUDE.md`) and adds an internal audit doc. It does not change plugin runtime behavior or user-facing functionality.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)