### PR TITLE
Bump @types/react version

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,7 @@
 * Dev - Upgrade @stripe/react-stripe-js to ^5.4.1 and @stripe/stripe-js to ^8.6.0 in JavaScript dependencies
 * Dev - Fix becs e2e tests
 * Add - Add the base CSV feed for agentic commerce
+* Dev - Upgrade @types/react to ^18.3.7 in JavaScript dependencies
 
 = 10.4.0 - 2026-02-09 = 
 * Add - Introduce an endpoint to create Checkout Sessions tokens

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "woocommerce-gateway-stripe",
-      "version": "10.3.1",
+      "version": "10.4.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
@@ -33,7 +33,7 @@
         "@testing-library/jest-dom": "^5.14.1",
         "@testing-library/react": "^14.3.1",
         "@testing-library/user-event": "^13.2.1",
-        "@types/react": "16.9.56",
+        "@types/react": "^18.3.7",
         "@types/react-dom": "^18.3.7",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -6413,13 +6413,14 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "16.9.56",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.56.tgz",
-      "integrity": "sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
@@ -8300,17 +8301,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@wordpress/components/node_modules/@types/react": {
-      "version": "18.3.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@wordpress/components/node_modules/@wordpress/a11y": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-3.58.0.tgz",
@@ -8856,6 +8846,18 @@
       "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
       "dev": true
     },
+    "node_modules/@wordpress/data/node_modules/@types/react": {
+      "version": "16.14.69",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.69.tgz",
+      "integrity": "sha512-NdnAamzkxLX9LBssSdt9Q0tQ3LR94hYxotI4/sRUs1vHKFXaDx9xDbK8S4wuw5bwrxiiXbTYyhKeITtFnwDvEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@wordpress/data/node_modules/@types/react-dom": {
       "version": "16.9.25",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.25.tgz",
@@ -9186,6 +9188,18 @@
         "react-dom": "^16.13.1"
       }
     },
+    "node_modules/@wordpress/element/node_modules/@types/react": {
+      "version": "16.14.69",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.69.tgz",
+      "integrity": "sha512-NdnAamzkxLX9LBssSdt9Q0tQ3LR94hYxotI4/sRUs1vHKFXaDx9xDbK8S4wuw5bwrxiiXbTYyhKeITtFnwDvEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@wordpress/element/node_modules/@types/react-dom": {
       "version": "16.9.25",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.25.tgz",
@@ -9436,17 +9450,6 @@
         "npm": ">=8.19.2"
       }
     },
-    "node_modules/@wordpress/icons/node_modules/@types/react": {
-      "version": "18.3.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/@wordpress/icons/node_modules/@wordpress/element": {
       "version": "6.31.0",
       "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.31.0.tgz",
@@ -9597,6 +9600,18 @@
         "@wordpress/a11y": "^2.15.3",
         "@wordpress/data": "^4.27.3",
         "lodash": "^4.17.19"
+      }
+    },
+    "node_modules/@wordpress/notices/node_modules/@types/react": {
+      "version": "16.14.69",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.69.tgz",
+      "integrity": "sha512-NdnAamzkxLX9LBssSdt9Q0tQ3LR94hYxotI4/sRUs1vHKFXaDx9xDbK8S4wuw5bwrxiiXbTYyhKeITtFnwDvEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "^0.16",
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@wordpress/notices/node_modules/@types/react-dom": {
@@ -9806,17 +9821,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/primitives/node_modules/@types/react": {
-      "version": "18.3.24",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
-      "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/prop-types": "*",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
@@ -14068,10 +14072,11 @@
       "license": "MIT"
     },
     "node_modules/csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA==",
-      "dev": true
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cwd": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^13.2.1",
-    "@types/react": "16.9.56",
+    "@types/react": "^18.3.7",
     "@types/react-dom": "^18.3.7",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/readme.txt
+++ b/readme.txt
@@ -162,5 +162,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Upgrade @stripe/react-stripe-js to ^5.4.1 and @stripe/stripe-js to ^8.6.0 in JavaScript dependencies
 * Dev - Fixes becs e2e tests
 * Add - Add the base CSV feed for agentic commerce
+* Dev - Upgrade @types/react to ^18.3.7 in JavaScript dependencies
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
Discovered in https://github.com/woocommerce/woocommerce-gateway-stripe/pull/4993#discussion_r2810932083


> @types/react is pinned to 16.9.56 (line 26), which is incompatible with react@18.3.1 (line 88) and @stripe/react-stripe-js@v5. 


## Changes proposed in this Pull Request:
- Updated `@types/react` to ^18.x to match React 18 and v5's type expectations.

## Testing instructions
- Code review
- All the tests should pass in this branch.

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)