### PR TITLE
Dev: Require changelog on push to develop

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,13 +5,25 @@ zero=$(git hash-object --stdin </dev/null | tr '[0-9a-f]' '0')
 
 while read local_ref local_oid remote_ref remote_oid
 do
-	range=""
-	if [ "$local_oid" != "$zero" ]
+	if [ "$local_oid" = "$zero" ]
 	then
-		if test "$remote_oid" != "$zero"
+		# Deleting a remote ref; skip changelog and PHPStan checks.
+		continue
+	fi
+
+	range=""
+	changed_files=""
+	if [ "$remote_oid" != "$zero" ]
+	then
+		# Update to existing branch - check all new commits.
+		range="$remote_oid..$local_oid"
+	else
+		# New remote ref - inspect commits not yet on any remote.
+		commits_to_push=$(git rev-list "$local_oid" --not --remotes)
+		if [ -n "$commits_to_push" ]
 		then
-				# Update to existing branch - check all new commits.
-				range="$remote_oid..$local_oid"
+			# Use awk as grep has a non-zero exit code when no matches exist, which causes the pre-push hook to fail.
+			changed_files=$(echo "$commits_to_push" | xargs git diff-tree --no-commit-id --name-only -r | awk '!seen[$0]++')
 		fi
 	fi
 
@@ -46,8 +58,9 @@ do
 			exit 1
 		fi
 
-		# Get the changed files.
+		# Get the changed files in the push.
 		changed_files=$(git diff --name-only "$range")
+
 		# Get the changed PHP files or directories in the push.
 		# Use awk as grep has a non-zero exit code when no matches exist, which causes the pre-push hook to fail.
 		changed_php_files=$(echo "$changed_files" | awk '/.*(\.php|\/)$/ {print $0;}')
@@ -63,6 +76,17 @@ do
 				run_phpstan='no'
 			fi
 		fi
+	fi
+
+	has_readme_update=$(echo "$changed_files" | awk '/^readme\.txt$/ { found=1 } END { print found+0 }')
+	has_changelog_update=$(echo "$changed_files" | awk '/^changelog\.txt$/ { found=1 } END { print found+0 }')
+
+	if [ "$has_readme_update" -ne 1 ] || [ "$has_changelog_update" -ne 1 ]
+	then
+		echo "Error: Missing changelog files in this push."
+		echo "Both readme.txt and changelog.txt must be updated before pushing."
+		echo "Run: npm run changelog"
+		exit 1
 	fi
 
 	if [ 'yes' = "$run_phpstan" ]

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -78,15 +78,21 @@ do
 		fi
 	fi
 
-	has_readme_update=$(echo "$changed_files" | awk '/^readme\.txt$/ { found=1 } END { print found+0 }')
-	has_changelog_update=$(echo "$changed_files" | awk '/^changelog\.txt$/ { found=1 } END { print found+0 }')
-
-	if [ "$has_readme_update" -ne 1 ] || [ "$has_changelog_update" -ne 1 ]
+	if [ "$remote_ref" = "refs/heads/develop" ] && [ -n "$range" ]
 	then
-		echo "Error: Missing changelog files in this push."
-		echo "Both readme.txt and changelog.txt must be updated before pushing."
-		echo "Run: npm run changelog"
-		exit 1
+		if [ -n "$changed_files" ]
+		then
+			has_readme_update=$(echo "$changed_files" | awk '/^readme\.txt$/ { found=1 } END { print found+0 }')
+			has_changelog_update=$(echo "$changed_files" | awk '/^changelog\.txt$/ { found=1 } END { print found+0 }')
+
+			if [ "$has_readme_update" -ne 1 ] || [ "$has_changelog_update" -ne 1 ]
+			then
+				echo "Error: Missing changelog files in this push to develop."
+				echo "Both readme.txt and changelog.txt must be updated before pushing to develop."
+				echo "Run: npm run changelog"
+				exit 1
+			fi
+		fi
 	fi
 
 	if [ 'yes' = "$run_phpstan" ]

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@
 * Add - Add the base CSV feed for agentic commerce
 * Dev - Add CodeRabbit configuration with Stripe-focused review guidance
 * Dev - Expand AI agent guidance with directory-level AGENTS and CLAUDE context files
+* Dev - Require changelogs on git push
 
 = 10.4.0 - 2026-02-09 =
 * Add - Introduce an endpoint to create Checkout Sessions tokens

--- a/readme.txt
+++ b/readme.txt
@@ -164,5 +164,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Add - Add the base CSV feed for agentic commerce
 * Dev - Add CodeRabbit configuration with Stripe-focused review guidance
 * Dev - Expand AI agent guidance with directory-level AGENTS and CLAUDE context files
+* Dev - Require changelogs on git push
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION

## Changes proposed in this Pull Request:

This PR adds a guard to the pre-push hook in `.husky/pre-push` so pushes are blocked when changelog files are missing.

- Checks the files in the commit(s) being pushed (both existing branch updates and first push of a new branch).
- Fails the push unless both `readme.txt` and `changelog.txt` are included.
- Shows a clear remediation message: `Run: npm run changelog`.
- Skips this check for branch deletion pushes.
- Keeps existing pre-push PHPStan behavior intact.

How can this code break?
- It may block pushes that intentionally do not need changelog updates.
- Edge cases in commit-range detection could cause false positives.

What are we doing to make sure this code doesn’t break?
- Validated shell syntax (`sh -n`).
- Simulated pre-push input and confirmed:
  - fails when `readme.txt`/`changelog.txt` are missing,
  - passes when both are included,
  - skips check for branch deletion pushes.

## Testing instructions

1. Create a commit that does not touch `readme.txt` or `changelog.txt`.
2. Run `git push origin <branch>`.
3. Confirm the push fails and shows:
   - `Error: Missing changelog files in this push.`
   - `Run: npm run changelog`
4. Run `npm run changelog` and commit the updates to `readme.txt` and `changelog.txt`.
5. Push again and confirm it succeeds.
6. Optional: run `git push origin --delete <branch>` and confirm deletion is not blocked by this check.

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [x] Tested on mobile (or does not apply)

### Changelog entry

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment

This is an internal developer workflow change (git hook only) and does not affect plugin runtime behavior.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added pre-push validation to enforce changelog and documentation file updates before code contributions

* **Documentation**
  * Updated release notes and changelog entries reflecting latest development workflow requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->