### PR TITLE
Process deferred webhook for on hold and cancelled orders

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 * Dev - Add CodeRabbit configuration with Stripe-focused review guidance
 * Dev - Expand AI agent guidance with directory-level AGENTS and CLAUDE context files
 * Fix - Prevent fatal error when order ID in webhook references a refund
+* Fix - Deferred payment_intent.succeeded webhook now processes cancelled or on-hold orders so they are updated with Stripe transaction data when payment succeeded in Stripe
 
 = 10.4.0 - 2026-02-09 =
 * Add - Introduce an endpoint to create Checkout Sessions tokens

--- a/includes/class-wc-stripe-webhook-handler.php
+++ b/includes/class-wc-stripe-webhook-handler.php
@@ -1316,7 +1316,14 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 					}
 
 					// Check if the order is still in a valid state to process the webhook.
-					if ( ! $order->has_status( apply_filters( 'wc_stripe_allowed_payment_processing_statuses', [ OrderStatus::PENDING, OrderStatus::FAILED ], $order ) ) ) {
+					// Include cancelled and on-hold: after 3DS the customer may cancel or the order may be on-hold,
+					// but if Stripe sends a payment_intent.succeeded webhook event we should still mark the order as paid.
+					$allowed_statuses = apply_filters(
+						'wc_stripe_allowed_payment_processing_statuses',
+						[ OrderStatus::PENDING, OrderStatus::FAILED, OrderStatus::CANCELLED, OrderStatus::ON_HOLD ],
+						$order
+					);
+					if ( ! $order->has_status( $allowed_statuses ) ) {
 						WC_Stripe_Logger::debug( "Skipped processing deferred webhook for Stripe PaymentIntent {$intent_id} for order {$order->get_id()} - payment already complete." );
 						return;
 					}
@@ -1375,8 +1382,18 @@ class WC_Stripe_Webhook_Handler extends WC_Stripe_Payment_Gateway {
 			'The wc_gateway_stripe_process_payment action is deprecated. Use wc_gateway_stripe_process_payment_charge instead.'
 		);
 
+		$should_update_status = false;
+		if ( OrderStatus::CANCELLED === $order->get_status() ) {
+			$should_update_status = true;
+		}
 		$charge->is_webhook_response = true;
 		$this->process_response( $charge, $order );
+
+		// process_response() will update the order status to 'processing' or 'completed'.
+		// If the order was cancelled, update the order status to on hold and add an order note.
+		if ( $should_update_status ) {
+			$order->update_status( OrderStatus::ON_HOLD, __( 'Payment was received via Stripe after it was cancelled. Please confirm with the customer whether to fulfill or refund.', 'woocommerce-gateway-stripe' ) );
+		}
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -169,5 +169,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Add CodeRabbit configuration with Stripe-focused review guidance
 * Dev - Expand AI agent guidance with directory-level AGENTS and CLAUDE context files
 * Fix - Prevent fatal error when order ID in webhook references a refund
+* Fix - Deferred payment_intent.succeeded webhook now processes cancelled or on-hold orders so they are updated with Stripe transaction data when payment succeeded in Stripe
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
+++ b/tests/phpunit/WC_Stripe_Webhook_Handler_Test.php
@@ -297,6 +297,91 @@ class WC_Stripe_Webhook_Handler_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that deferred webhook processes when order is in a valid status
+	 *
+	 * @param string $order_status Order status before deferred webhook runs.
+	 * @dataProvider provide_order_statuses_for_deferred_webhook
+	 */
+	public function test_deferred_webhook_processes_when_order_is_in_valid_status( $order_status ) {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( $order_status );
+		$order->save();
+
+		$data         = [
+			'order_id'  => $order->get_id(),
+			'intent_id' => self::MOCK_PAYMENT_INTENT['id'],
+		];
+		$notification = (object) [
+			'type' => 'payment_intent.succeeded',
+			'data' => (object) [
+				'object' => (object) self::MOCK_PAYMENT_INTENT,
+			],
+		];
+
+		$this->mock_webhook_handler( [ 'handle_deferred_payment_intent_succeeded' ] );
+
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'get_intent_from_order' )
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT );
+
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'get_latest_charge_from_intent' )
+			->willReturn( (object) self::MOCK_PAYMENT_INTENT['charges']['data'][0] );
+
+		$this->mock_webhook_handler->expects( $this->once() )
+			->method( 'process_response' )
+			->with(
+				$this->anything(),
+				$this->callback(
+					function ( $passed_order ) use ( $order ) {
+						return $passed_order instanceof WC_Order && $order->get_id() === $passed_order->get_id();
+					}
+				)
+			);
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+	}
+
+	/**
+	 * Data provider for test_deferred_webhook_processes_when_order_cancelled_or_on_hold.
+	 *
+	 * @return array[]
+	 */
+	public function provide_order_statuses_for_deferred_webhook() {
+		return [
+			'pending'   => [ OrderStatus::PENDING ],
+			'failed'    => [ OrderStatus::FAILED ],
+			'cancelled' => [ OrderStatus::CANCELLED ],
+			'on-hold'   => [ OrderStatus::ON_HOLD ],
+		];
+	}
+
+	/**
+	 * Test that deferred webhook is skipped when order is already paid (processing/completed).
+	 */
+	public function test_deferred_webhook_skipped_when_order_already_paid() {
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( OrderStatus::PROCESSING );
+		$order->save();
+
+		$data         = [
+			'order_id'  => $order->get_id(),
+			'intent_id' => self::MOCK_PAYMENT_INTENT['id'],
+		];
+		$notification = (object) [
+			'type' => 'payment_intent.succeeded',
+			'data' => (object) [
+				'object' => (object) self::MOCK_PAYMENT_INTENT,
+			],
+		];
+
+		$this->mock_webhook_handler->expects( $this->never() )
+			->method( 'handle_deferred_payment_intent_succeeded' );
+
+		$this->mock_webhook_handler->process_deferred_webhook( 'payment_intent.succeeded', $data, $notification );
+	}
+
+	/**
 	 * Test for `process_webhook_charge_failed`.
 	 *
 	 * @param string $order_status       The order status.


### PR DESCRIPTION
Fixes STRIPE-948

## Changes proposed in this Pull Request:

The deferred webhook processing only runs `handle_deferred_payment_intent_succeeded()` (which would call `payment_complete()` and store transaction data in order meta) when the order has status pending or failed. If the order has any other status, it skips and never marks the order as paid in this path.

There could be edge cases where this check end up ignoring the event and loses transaction data. For example, when a user takes some time instead of immediately approving the 3DS authentication, it may cause a nonce error on returning to the site. If the user then cancels the order the payment intent succeeded event is never processed for this order due to the above status check, while in the merchant's Stripe account, the payment is already received.

This PR handles this edge case.
- Now we process deferred webhook for on-hold and cancelled orders.
- After processing response, we move the order status to on-hold if it was cancelled before and add a order note for the merchant.

## Testing instructions
- To reproduce the edge case, throw hard coded nonce error from [update_order_status_ajax](https://github.com/woocommerce/woocommerce-gateway-stripe/blob/develop/includes/class-wc-stripe-intent-controller.php#L688) methods (`throw new WC_Stripe_Exception( 'missing-nonce', __( 'Verification failed.', 'woocommerce-gateway-stripe' ) );`)
- As a logged in shopper, add a product to your cart and go to the checkout page.
- Select card payment and use a [3DS card](https://docs.stripe.com/testing#regulatory-cards) to pay.
- Click the place order button.
- Approve the payment in the 3DS modal.
- The checkout should fail.
- Go to **My Account > Orders** and cancel the latest order (this should be in pending payment state at this point).
- Go to the order edit page as an admin. The order should be in the cancelled state.
- Wait for a couple of minutes and refresh the order edit page.
- Go to **WooCommerce > Status > Scheduled Actions > Pending** and confirm that there is no deferred intent webhook action in the pending state for this order. If there is one, then run the action.
- Check the status in the order edit page.
- In `develop` branch, the order should still be in the cancelled state and there should be no transaction ID or related order notes. Check the Stripe dashboard of the connected account and notice that the transaction was successful for this order.
- In this branch, the order should be in 'on-hold' state and there should be relevant order notes.

<img width="299" height="677" alt="Screenshot 2026-02-23 at 11 00 38 PM" src="https://github.com/user-attachments/assets/f2ae04ee-bd8f-4c14-9029-b44c7bff3d3c" />


### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
