### PR TITLE
Add extension compatibility activation tests workflow

### DIFF
--- a/.github/workflows/ci-extension-compat.yml
+++ b/.github/workflows/ci-extension-compat.yml
@@ -1,0 +1,112 @@
+name: Extension Compatibility
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      plugin-slug:
+        description: 'Test a specific plugin slug (leave empty to run the default matrix)'
+        type: string
+        default: ''
+      extension-set:
+        description: 'QIT extension set to test (e.g. "compatibility"). Mutually exclusive with plugin-slug.'
+        type: string
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+
+  setup-matrix:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        env:
+          PLUGIN_SLUG: ${{ inputs['plugin-slug'] }}
+          EXTENSION_SET: ${{ inputs['extension-set'] }}
+        run: |
+          if [[ -n "$PLUGIN_SLUG" && -n "$EXTENSION_SET" ]]; then
+            echo "::error::plugin-slug and extension-set are mutually exclusive"
+            exit 1
+          elif [[ -n "$PLUGIN_SLUG" ]]; then
+            matrix=$(jq -nc --arg slug "$PLUGIN_SLUG" \
+              '{"include":[{"name":$slug,"additional-plugins":$slug,"extension-set":""}]}')
+          elif [[ -n "$EXTENSION_SET" ]]; then
+            matrix=$(jq -nc --arg set "$EXTENSION_SET" \
+              '{"include":[{"name":$set,"additional-plugins":"","extension-set":$set}]}')
+          else
+            matrix=$(cat <<'MATRIX_EOF'
+          {"include":[
+            {"name":"compatibility-set","additional-plugins":"","extension-set":"compatibility"},
+            {"name":"subscriptions-for-woocommerce","additional-plugins":"subscriptions-for-woocommerce","extension-set":""},
+            {"name":"yith-woocommerce-subscription","additional-plugins":"yith-woocommerce-subscription","extension-set":""},
+            {"name":"funnel-builder","additional-plugins":"funnel-builder","extension-set":""},
+            {"name":"wp-fusion-lite","additional-plugins":"wp-fusion-lite","extension-set":""},
+          ]}
+          MATRIX_EOF
+            )
+          fi
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build-project:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    needs: [setup-matrix]
+    uses: ./.github/workflows/build-upload-zip.yml
+    with:
+      artifact: 'extension-compat-test-package'
+
+  activation-tests:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    name: "Activation: ${{ matrix['name'] }}"
+    needs: [setup-matrix, build-project]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
+    uses: ./.github/workflows/run-qit.yml
+    secrets: inherit
+    with:
+      extension: 'woocommerce-gateway-stripe'
+      artifact: 'extension-compat-test-package'
+      test-activation: 'true'
+      test-additional-plugins: ${{ matrix['additional-plugins'] }}
+      test-extension-set: ${{ matrix['extension-set'] }}
+      results-artifact: "qit-results-${{ matrix['name'] }}"
+
+  handle-error:
+    if: ${{ failure() }}
+    needs: [build-project, activation-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            icon: ":workflow-failed:"
+            status: "failed"
+            workflowName: "${{ github.workflow }} | ${{ github.head_ref || github.ref_name }}"
+            workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  handle-cancelled:
+    if: ${{ cancelled() }}
+    needs: [build-project, activation-tests]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: webhook-trigger
+          payload: |
+            icon: ":workflow-cancelled:"
+            status: "cancelled"
+            workflowName: "${{ github.workflow }} | ${{ github.head_ref || github.ref_name }}"
+            workflowUrl: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/ci-extension-compat.yml
+++ b/.github/workflows/ci-extension-compat.yml
@@ -58,14 +58,12 @@ jobs:
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
   build-project:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     needs: [setup-matrix]
     uses: ./.github/workflows/build-upload-zip.yml
     with:
       artifact: 'extension-compat-test-package'
 
   activation-tests:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     name: "Activation: ${{ matrix['name'] }}"
     needs: [setup-matrix, build-project]
     strategy:

--- a/.github/workflows/ci-extension-compat.yml
+++ b/.github/workflows/ci-extension-compat.yml
@@ -50,7 +50,7 @@ jobs:
             {"name":"subscriptions-for-woocommerce","additional-plugins":"subscriptions-for-woocommerce","extension-set":""},
             {"name":"yith-woocommerce-subscription","additional-plugins":"yith-woocommerce-subscription","extension-set":""},
             {"name":"funnel-builder","additional-plugins":"funnel-builder","extension-set":""},
-            {"name":"wp-fusion-lite","additional-plugins":"wp-fusion-lite","extension-set":""},
+            {"name":"wp-fusion-lite","additional-plugins":"wp-fusion-lite","extension-set":""}
           ]}
           MATRIX_EOF
             )

--- a/.github/workflows/run-qit.yml
+++ b/.github/workflows/run-qit.yml
@@ -44,6 +44,9 @@ on:
       test-additional-plugins:
         type: string
         default: ''
+      test-extension-set:
+        type: string
+        default: ''
       test-malware:
         type: string
         default: 'false'
@@ -53,6 +56,9 @@ on:
       test-validation:
         type: string
         default: 'false'
+      results-artifact:
+        type: string
+        default: 'qit-results'
       options:
         type: string
         default: ''
@@ -69,6 +75,8 @@ env:
   WC_VERSION: ${{ inputs.wc-version && inputs.wc-version || 'stable' }}
   PHP_VERSION: ${{ inputs.php-version && inputs.php-version || '8.4' }}
   ADDITIONAL_PLUGINS: ${{ inputs.test-additional-plugins && format( '--additional_plugins={0}', inputs.test-additional-plugins ) || '' }}
+  ACTIVATION_PLUGINS: ${{ inputs.test-additional-plugins && format( '-p {0}', inputs.test-additional-plugins ) || '' }}
+  EXTENSION_SET: ${{ inputs['test-extension-set'] && format( '--extension_set={0}', inputs['test-extension-set'] ) || '' }}
   WAIT_FLAG: ${{ inputs.wait && '--wait' || '' }}
   EXTRA_OPTIONS: ${{ inputs.options }}
 
@@ -122,6 +130,8 @@ jobs:
             --wp=${{ env.WP_VERSION }} \
             --woo=${{ env.WC_VERSION }} \
             --php_version=${{ env.PHP_VERSION }} \
+            ${{ env.ACTIVATION_PLUGINS }} \
+            ${{ env.EXTENSION_SET }} \
             ${{ env.EXTRA_OPTIONS }} \
             -n \
             > ${{ github.workspace }}/qit-results/qit-activation-results.txt
@@ -344,5 +354,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: qit-results
+          name: ${{ inputs.results-artifact }}
           path: ${{ github.workspace }}/qit-results/


### PR DESCRIPTION
## Changes proposed in this Pull Request:                                                                                                                                                                                                                                                                                                                             
   
Third-party plugins that integrate with Stripe can fatal when we remove or rename classes. QIT activation tests can catch these, but no workflow runs them today.                                                                              
                                                            
This adds a post-merge workflow (`ci-extension-compat.yml`) that runs QIT activation tests for Stripe paired with integrating extensions, with non-blocking Slack alerts on failure. It uses two complementary QIT mechanisms for testing plugin combinations:

- **`--extension_set=compatibility`** — QIT's built-in set of 16 major extensions (WC Subscriptions, WC Payments, Bookings, etc.). More details in our docs around [Extension Sets](https://qit.woo.com/docs/managed-tests/extension-sets).
- **`-p <slug>`** — Provide individual plugin slugs (WCCOM, WPORG) for specific plugins not in the extension set

Note: Changes to `run-qit.yml` are backwards-compatible — new inputs default to empty strings, and existing callers are unaffected.

## Testing instructions

This is a CI-only change with no runtime impact. More important is ensuring the GitHub action syntax looks correct.

Once this is merged, we can do the following steps to verify:

1. Trigger the workflow manually via Actions > Extension Compatibility > Run workflow
2. Verify full default matrix runs (compatibility set + individual plugins)
3. Confirm existing `ci-merge` and `ci-cron-qit` workflows are unaffected

  ---

  ### Changelog entry

  - [x] This Pull Request does not require a changelog entry. (Comment required below)

  <details>

  <summary>Changelog Entry Comment</summary>

  #### Comment

  CI workflow change only — no user-facing changes.

  </details>