### PR TITLE
[Proof of concept] Defer express checkout nonce requirements

### DIFF
--- a/client/api/index.js
+++ b/client/api/index.js
@@ -6,6 +6,7 @@ import {
 	getCustomerNote,
 	getExpressCheckoutData,
 	getExpressCheckoutAjaxURL,
+	getExpressCheckoutNonce,
 } from 'wcstripe/express-checkout/utils';
 import { getStripeServerData } from 'wcstripe/stripe-utils';
 import {
@@ -478,11 +479,11 @@ export default class WCStripeAPI {
 	 * @param {Object} shippingAddress Shipping details.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutECECalculateShippingOptions( shippingAddress ) {
+	async expressCheckoutECECalculateShippingOptions( shippingAddress ) {
 		return this.request(
 			getExpressCheckoutAjaxURL( 'get_shipping_options' ),
 			{
-				security: getExpressCheckoutData( 'nonce' )?.shipping,
+				security: await getExpressCheckoutNonce( 'shipping' ),
 				is_product_page: getExpressCheckoutData( 'is_product_page' ),
 				...shippingAddress,
 			}
@@ -495,11 +496,11 @@ export default class WCStripeAPI {
 	 * @param {Object} shippingOption Shipping option.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutUpdateShippingDetails( shippingOption ) {
+	async expressCheckoutUpdateShippingDetails( shippingOption ) {
 		return this.request(
 			getExpressCheckoutAjaxURL( 'update_shipping_method' ),
 			{
-				security: getExpressCheckoutData( 'nonce' )?.update_shipping,
+				security: await getExpressCheckoutNonce( 'update_shipping' ),
 				shipping_method: [ shippingOption.id ],
 				is_product_page: getExpressCheckoutData( 'is_product_page' ),
 			}
@@ -513,9 +514,9 @@ export default class WCStripeAPI {
 	 * @param {Object} shippingAddress Shipping address.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutNormalizeAddress( billingAddress, shippingAddress ) {
+	async expressCheckoutNormalizeAddress( billingAddress, shippingAddress ) {
 		return this.request( getExpressCheckoutAjaxURL( 'normalize_address' ), {
-			security: getExpressCheckoutData( 'nonce' )?.normalize_address,
+			security: await getExpressCheckoutNonce( 'normalize_address' ),
 			data: {
 				billing_address: billingAddress,
 				shipping_address: shippingAddress,
@@ -528,11 +529,11 @@ export default class WCStripeAPI {
 	 *
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutGetCartDetails() {
+	async expressCheckoutGetCartDetails() {
 		return apiFetch( {
 			method: 'GET',
 			path: '/wc/store/v1/cart',
-			security: getExpressCheckoutData( 'nonce' )?.wc_store_api,
+			security: await getExpressCheckoutNonce( 'wc_store_api' ),
 		} );
 	}
 
@@ -543,9 +544,9 @@ export default class WCStripeAPI {
 	 *
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutGetCartDetailsLegacy() {
+	async expressCheckoutGetCartDetailsLegacy() {
 		return this.request( getExpressCheckoutAjaxURL( 'get_cart_details' ), {
-			security: getExpressCheckoutData( 'nonce' )?.get_cart_details,
+			security: await getExpressCheckoutNonce( 'get_cart_details' ),
 		} );
 	}
 
@@ -579,9 +580,9 @@ export default class WCStripeAPI {
 	 * @param {Object} productData Product data.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutAddToCartLegacy( productData ) {
+	async expressCheckoutAddToCartLegacy( productData ) {
 		return this.request( getExpressCheckoutAjaxURL( 'add_to_cart' ), {
-			security: getExpressCheckoutData( 'nonce' )?.add_to_cart,
+			security: await getExpressCheckoutNonce( 'add_to_cart' ),
 			...productData,
 		} );
 	}
@@ -598,7 +599,7 @@ export default class WCStripeAPI {
 				method: 'GET',
 				path: '/wc/store/v1/cart',
 				headers: {
-					Nonce: getExpressCheckoutData( 'nonce' )?.wc_store_api,
+					Nonce: await getExpressCheckoutNonce( 'wc_store_api' ),
 				},
 			} );
 			const removeItemsPromises = cartData.items.map( ( item ) => {
@@ -621,9 +622,9 @@ export default class WCStripeAPI {
 	 * @param {number} params.bookingId Booking ID.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutEmptyCartLegacy( { bookingId = null } ) {
+	async expressCheckoutEmptyCartLegacy( { bookingId = null } ) {
 		return this.request( getExpressCheckoutAjaxURL( 'clear_cart' ), {
-			security: getExpressCheckoutData( 'nonce' )?.clear_cart,
+			security: await getExpressCheckoutNonce( 'clear_cart' ),
 			...( bookingId ? { booking_id: bookingId } : {} ),
 		} );
 	}
@@ -634,7 +635,7 @@ export default class WCStripeAPI {
 	 * @param {Object} orderData Order data.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutECECreateOrder( orderData ) {
+	async expressCheckoutECECreateOrder( orderData ) {
 		return this.postToBlocksAPI(
 			'/wc/store/v1/checkout',
 			{
@@ -644,8 +645,9 @@ export default class WCStripeAPI {
 			{
 				'X-WCSTRIPE-EXPRESS-CHECKOUT': true,
 				'X-WCSTRIPE-EXPRESS-CHECKOUT-NONCE':
-					getExpressCheckoutData( 'nonce' )
-						?.wc_store_api_express_checkout,
+					await getExpressCheckoutNonce(
+						'wc_store_api_express_checkout'
+					),
 			}
 		);
 	}
@@ -675,12 +677,12 @@ export default class WCStripeAPI {
 	 * @param {Object} headers The headers for the request.
 	 * @return {Promise} The promise for the request to the server.
 	 */
-	postToBlocksAPI( path, data, headers = {} ) {
+	async postToBlocksAPI( path, data, headers = {} ) {
 		return apiFetch( {
 			method: 'POST',
 			path,
 			headers: {
-				Nonce: getExpressCheckoutData( 'nonce' )?.wc_store_api,
+				Nonce: await getExpressCheckoutNonce( 'wc_store_api' ),
 				...headers,
 			},
 			data,
@@ -693,13 +695,13 @@ export default class WCStripeAPI {
 	 * @param {Object} productData Product data.
 	 * @return {Promise} Promise for the request to the server.
 	 */
-	expressCheckoutGetSelectedProductData( productData ) {
+	async expressCheckoutGetSelectedProductData( productData ) {
 		return this.request(
 			getExpressCheckoutAjaxURL( 'get_selected_product_data' ),
 			{
-				security:
-					getExpressCheckoutData( 'nonce' )
-						?.get_selected_product_data,
+				security: await getExpressCheckoutNonce(
+					'get_selected_product_data'
+				),
 				...productData,
 			}
 		);

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -38,7 +38,7 @@ export const getErrorMessageFromNotice = ( notice ) => {
  */
 export const getExpressCheckoutData = ( key ) =>
 	// eslint-disable-next-line camelcase
-	wc_stripe_express_checkout_params[ key ] ?? null;
+	wc_stripe_express_checkout_params?.[ key ] ?? null;
 
 /**
  * Construct Express Checkout AJAX endpoint URL.
@@ -55,6 +55,47 @@ export const getExpressCheckoutAjaxURL = (
 		?.toString()
 		?.replace( '%%endpoint%%', prefix + endpoint );
 };
+
+/**
+ * Module-level nonce promise. Resolved once and cached for the page lifetime.
+ *
+ * @type {Promise<Object>|null}
+ */
+let expressCheckoutNoncePromise = null;
+
+/**
+ * Fetches all Express Checkout nonces from the server. This will create a WC customer session in the process.
+ * The result is cached so only one request is ever made per page load.
+ *
+ * @return {Promise<Object>} Promise that resolves to the nonce object.
+ */
+export const getAllExpressCheckoutNonces = () => {
+	if ( ! expressCheckoutNoncePromise ) {
+		expressCheckoutNoncePromise = fetch(
+			getExpressCheckoutAjaxURL( 'express_checkout_get_nonces' ),
+			{
+				method: 'POST',
+			}
+		)
+			.then( ( res ) => res.json() )
+			.then( ( data ) => data?.data ?? {} );
+	}
+	return expressCheckoutNoncePromise;
+};
+
+/**
+ * Fetches a single Express Checkout nonce by key.
+ *
+ * @param {string} key The nonce key to retrieve.
+ * @return {Promise<string|null>} Promise resolving to the nonce value.
+ */
+export const getExpressCheckoutNonce = async ( key ) => {
+	const nonces = await getAllExpressCheckoutNonces();
+	return nonces?.[ key ] ?? null;
+};
+
+// Prefetch nonces in the background as soon as the module loads.
+getAllExpressCheckoutNonces();
 
 /**
  * Displays a `confirm` dialog which leads to a redirect.

--- a/client/express-checkout/utils/index.js
+++ b/client/express-checkout/utils/index.js
@@ -64,12 +64,18 @@ export const getExpressCheckoutAjaxURL = (
 let expressCheckoutNoncePromise = null;
 
 /**
- * Fetches all Express Checkout nonces from the server. This will create a WC customer session in the process.
- * The result is cached so only one request is ever made per page load.
+ * Get all Express Checkout nonces.
+ * - If the express checkout nonces were sent in the page data, we will use the local values.
+ * - If we don't have that data, we'll fetch the nonces from the server, and use a single Promise to use only one request.
  *
  * @return {Promise<Object>} Promise that resolves to the nonce object.
  */
 export const getAllExpressCheckoutNonces = () => {
+	const nonceFromData = getExpressCheckoutData( 'nonce' );
+	if ( nonceFromData ) {
+		return Promise.resolve( nonceFromData );
+	}
+
 	if ( ! expressCheckoutNoncePromise ) {
 		expressCheckoutNoncePromise = fetch(
 			getExpressCheckoutAjaxURL( 'express_checkout_get_nonces' ),

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -32,6 +32,7 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 	 * @return void
 	 */
 	public function init() {
+		add_action( 'wc_ajax_wc_stripe_express_checkout_get_nonces', [ $this, 'ajax_get_express_checkout_nonces' ] );
 		add_action( 'wc_ajax_wc_stripe_get_cart_details', [ $this, 'ajax_get_cart_details' ] );
 		add_action( 'wc_ajax_wc_stripe_get_shipping_options', [ $this, 'ajax_get_shipping_options' ] );
 		add_action( 'wc_ajax_wc_stripe_normalize_address', [ $this, 'ajax_normalize_address' ] );
@@ -41,6 +42,38 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 		add_action( 'wc_ajax_wc_stripe_clear_cart', [ $this, 'ajax_clear_cart' ] );
 		add_action( 'wc_ajax_wc_stripe_log_errors', [ $this, 'ajax_log_errors' ] );
 		add_filter( 'woocommerce_get_country_locale', [ $this, 'modify_country_locale_for_express_checkout' ], 20 );
+	}
+
+	/**
+	 * Ensure that we have a WC customer session and return Express Checkout nonces.
+	 *
+	 * This is a public, nonce-free bootstrap endpoint that allows product pages to be cached
+	 * without any user-specific data, but still initiate Express Checkout.
+	 *
+	 * @return void
+	 */
+	public function ajax_get_express_checkout_nonces() {
+		if ( isset( WC()->session ) && ! WC()->session->has_session() ) {
+			WC()->session->set_customer_session_cookie( true );
+		}
+
+		wp_send_json_success(
+			[
+				'payment'                       => wp_create_nonce( 'wc-stripe-express-checkout' ),
+				'shipping'                      => wp_create_nonce( 'wc-stripe-express-checkout-shipping' ),
+				'normalize_address'             => wp_create_nonce( 'wc-stripe-express-checkout-normalize-address' ),
+				'get_cart_details'              => wp_create_nonce( 'wc-stripe-get-cart-details' ),
+				'update_shipping'               => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
+				'checkout'                      => wp_create_nonce( 'woocommerce-process_checkout' ),
+				'add_to_cart'                   => wp_create_nonce( 'wc-stripe-add-to-cart' ),
+				'get_selected_product_data'     => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
+				'log_errors'                    => wp_create_nonce( 'wc-stripe-log-errors' ),
+				'clear_cart'                    => wp_create_nonce( 'wc-stripe-clear-cart' ),
+				'pay_for_order'                 => wp_create_nonce( 'wc-stripe-pay-for-order' ),
+				'wc_store_api'                  => wp_create_nonce( 'wc_store_api' ),
+				'wc_store_api_express_checkout' => wp_create_nonce( 'wc_store_api_express_checkout' ),
+			]
+		);
 	}
 
 	/**

--- a/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-ajax-handler.php
@@ -53,26 +53,13 @@ class WC_Stripe_Express_Checkout_Ajax_Handler {
 	 * @return void
 	 */
 	public function ajax_get_express_checkout_nonces() {
-		if ( isset( WC()->session ) && ! WC()->session->has_session() ) {
+		// @phpstan-ignore isset.property
+		if ( isset( WC()->session ) && class_exists( 'WC_Session_Handler' ) && ( WC()->session instanceof WC_Session_Handler ) && ! WC()->session->has_session() ) {
 			WC()->session->set_customer_session_cookie( true );
 		}
 
 		wp_send_json_success(
-			[
-				'payment'                       => wp_create_nonce( 'wc-stripe-express-checkout' ),
-				'shipping'                      => wp_create_nonce( 'wc-stripe-express-checkout-shipping' ),
-				'normalize_address'             => wp_create_nonce( 'wc-stripe-express-checkout-normalize-address' ),
-				'get_cart_details'              => wp_create_nonce( 'wc-stripe-get-cart-details' ),
-				'update_shipping'               => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
-				'checkout'                      => wp_create_nonce( 'woocommerce-process_checkout' ),
-				'add_to_cart'                   => wp_create_nonce( 'wc-stripe-add-to-cart' ),
-				'get_selected_product_data'     => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
-				'log_errors'                    => wp_create_nonce( 'wc-stripe-log-errors' ),
-				'clear_cart'                    => wp_create_nonce( 'wc-stripe-clear-cart' ),
-				'pay_for_order'                 => wp_create_nonce( 'wc-stripe-pay-for-order' ),
-				'wc_store_api'                  => wp_create_nonce( 'wc_store_api' ),
-				'wc_store_api_express_checkout' => wp_create_nonce( 'wc_store_api_express_checkout' ),
-			]
+			$this->express_checkout_helper->get_express_checkout_nonces()
 		);
 	}
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -83,7 +83,6 @@ class WC_Stripe_Express_Checkout_Element {
 			return;
 		}
 
-		add_action( 'template_redirect', [ $this, 'set_session' ] );
 		add_action( 'template_redirect', [ $this, 'handle_express_checkout_redirect' ] );
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'scripts' ] );
@@ -199,21 +198,6 @@ class WC_Stripe_Express_Checkout_Element {
 				'is_express_checkout_enabled' => $this->express_checkout_helper->is_express_checkout_enabled(),
 				'is_amazon_pay_enabled'       => $this->express_checkout_helper->is_amazon_pay_enabled(),
 				'is_payment_request_enabled'  => $this->express_checkout_helper->is_payment_request_enabled(),
-			],
-			'nonce'                      => [
-				'payment'                       => wp_create_nonce( 'wc-stripe-express-checkout' ),
-				'shipping'                      => wp_create_nonce( 'wc-stripe-express-checkout-shipping' ),
-				'normalize_address'             => wp_create_nonce( 'wc-stripe-express-checkout-normalize-address' ),
-				'get_cart_details'              => wp_create_nonce( 'wc-stripe-get-cart-details' ),
-				'update_shipping'               => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
-				'checkout'                      => wp_create_nonce( 'woocommerce-process_checkout' ),
-				'add_to_cart'                   => wp_create_nonce( 'wc-stripe-add-to-cart' ),
-				'get_selected_product_data'     => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
-				'log_errors'                    => wp_create_nonce( 'wc-stripe-log-errors' ),
-				'clear_cart'                    => wp_create_nonce( 'wc-stripe-clear-cart' ),
-				'pay_for_order'                 => wp_create_nonce( 'wc-stripe-pay-for-order' ),
-				'wc_store_api'                  => wp_create_nonce( 'wc_store_api' ),
-				'wc_store_api_express_checkout' => wp_create_nonce( 'wc_store_api_express_checkout' ),
 			],
 			'i18n'                       => [
 				'no_prepaid_card'  => __( 'Sorry, we\'re not accepting prepaid cards at this time.', 'woocommerce-gateway-stripe' ),

--- a/includes/payment-methods/class-wc-stripe-express-checkout-element.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-element.php
@@ -124,10 +124,14 @@ class WC_Stripe_Express_Checkout_Element {
 	/**
 	 * Sets the WC customer session if one is not set.
 	 * This is needed so nonces can be verified by AJAX Request.
+	 * DEPRECATED: We now defer creation of sessions until the user actually interacts with the Express Checkout Element.
 	 *
+	 * @deprecated 10.5.0
 	 * @return void
 	 */
 	public function set_session() {
+		wc_deprecated_function( __FUNCTION__, '10.5.0' );
+
 		// Don't set session cookies on product pages to allow for caching when payment request
 		// buttons are disabled. But keep cookies if there is already an active WC session in place.
 		if (

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -357,6 +357,30 @@ class WC_Stripe_Express_Checkout_Helper {
 	}
 
 	/**
+	 * Get all the nonces needed for Express Checkout.
+	 *
+	 * @return array
+	 * @since 10.5.0
+	 */
+	public function get_express_checkout_nonces(): array {
+		return [
+			'payment'                       => wp_create_nonce( 'wc-stripe-express-checkout' ),
+			'shipping'                      => wp_create_nonce( 'wc-stripe-express-checkout-shipping' ),
+			'normalize_address'             => wp_create_nonce( 'wc-stripe-express-checkout-normalize-address' ),
+			'get_cart_details'              => wp_create_nonce( 'wc-stripe-get-cart-details' ),
+			'update_shipping'               => wp_create_nonce( 'wc-stripe-update-shipping-method' ),
+			'checkout'                      => wp_create_nonce( 'woocommerce-process_checkout' ),
+			'add_to_cart'                   => wp_create_nonce( 'wc-stripe-add-to-cart' ),
+			'get_selected_product_data'     => wp_create_nonce( 'wc-stripe-get-selected-product-data' ),
+			'log_errors'                    => wp_create_nonce( 'wc-stripe-log-errors' ),
+			'clear_cart'                    => wp_create_nonce( 'wc-stripe-clear-cart' ),
+			'pay_for_order'                 => wp_create_nonce( 'wc-stripe-pay-for-order' ),
+			'wc_store_api'                  => wp_create_nonce( 'wc_store_api' ),
+			'wc_store_api_express_checkout' => wp_create_nonce( 'wc_store_api_express_checkout' ),
+		];
+	}
+
+	/**
 	 * Default shipping option, used by product, cart and checkout pages.
 	 *
 	 * @return void|array


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR explores removing our current logic that forces the generation of a WooCommerce customer session when express checkout is enabled on the product page, which was originally instituted to allow for the generation of nonces in the page payload. Instead, we now have more nuanced logic:
 - If we already have a WooCommerce customer session, we keep the current logic where we send the nonce data in `wc_stripe_express_checkout_params`.
 - If we don't have a WooCommerce customer session yet, we no longer send the nonce details in the initial request.

In the client code, we can then request the nonces (and the creation of a customer session) later on. While this seems to be working for the most part, my current implementation is triggering the AJAX fetch of the nonces during page load, which means we'd only serve one cached product page, as we'd create a session when running the AJAX fetch. It would be better to trigger that logic when the user first interacts with the Express Checkout button. We will just need to ensure that we don't inject our logic synchronously, as most browsers prevent page events from being delayed too long from the initial interaction (e.g. opening a modal). I tripped over this earlier today when debugging some of the related code!

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
