### PR TITLE
Hide action buttons from order received page orders processed with checkout sessions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Add - Allow additional font domains to be included in Stripe fonts
 * Fix - Add order and payment method validation to prevent errors
+* Tweak - Hide pay and cancel actions for pending orders processed via Checkout Session in order received page and My Account orders list
 
 = 10.5.2 - 2026-03-13 =
 * Fix - Ensure that we enqueue all needed scripts on payment pages

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -3505,21 +3505,36 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 	/**
 	 * Hide "Pay" and "Cancel" action buttons for pending orders if they take a while to be confirmed.
 	 *
-	 * @param $actions array An array with the default actions.
-	 * @param $order WC_Order The order.
+	 * @param array     $actions An array with the default actions.
+	 * @param \WC_Order $order The order.
 	 * @return array
 	 */
-	public function filter_my_account_my_orders_actions( $actions, $order ) {
+	public function filter_my_account_my_orders_actions( $actions, $order ): array {
 		if ( ! $order || ! is_a( $order, 'WC_Order' ) ) {
+			return $actions;
+		}
+
+		if ( ! is_order_received_page() ) {
+			return $actions;
+		}
+
+		if ( ! $order->has_status( OrderStatus::PENDING ) ) {
 			return $actions;
 		}
 
 		$methods_with_delayed_confirmation = [
 			WC_Stripe_Payment_Methods::BACS_DEBIT_LABEL,
 		];
-		if ( is_order_received_page() && in_array( $order->get_payment_method_title(), $methods_with_delayed_confirmation, true ) && $order->has_status( OrderStatus::PENDING ) ) {
+		if ( in_array( $order->get_payment_method_title(), $methods_with_delayed_confirmation, true ) ) {
 			unset( $actions['pay'], $actions['cancel'] );
 		}
+
+		// If the order has a checkout session ID and is pending, hide the action buttons. The orders with checkout sessions take a while to be processed via webhooks.
+		$checkout_session_id = WC_Stripe_Order_Helper::get_instance()->get_stripe_checkout_session_id( $order );
+		if ( $checkout_session_id ) {
+			unset( $actions['pay'], $actions['cancel'] );
+		}
+
 		return $actions;
 	}
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4945,18 +4945,6 @@ parameters:
 			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
 
 		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:filter_my_account_my_orders_actions\(\) has parameter \$actions with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
-			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:filter_my_account_my_orders_actions\(\) has parameter \$order with no type specified\.$#'
-			identifier: missingType.parameter
-			count: 1
-			path: includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
-
-		-
 			message: '#^Method WC_Stripe_UPE_Payment_Gateway\:\:get_payment_method_data_from_intent\(\) has parameter \$intent with no type specified\.$#'
 			identifier: missingType.parameter
 			count: 1

--- a/readme.txt
+++ b/readme.txt
@@ -153,5 +153,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Add - Allow additional font domains to be included in Stripe fonts
 * Fix - Add order and payment method validation to prevent errors
+* Tweak - Hide pay and cancel actions for pending orders processed via Checkout Session in order received page and My Account orders list
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
+++ b/tests/phpunit/payment-methods/class-wc-stripe-upe-payment-gateway-test.php
@@ -3022,9 +3022,13 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	/**
 	 * Test for `filter_my_account_my_orders_actions`.
 	 *
-	 * @dataProvider payment_method_titles_provider
+	 * @param string $payment_method_title   The payment method title.
+	 * @param bool   $has_checkout_session   Whether the order has a Stripe checkout session ID (hides Pay/Cancel).
+	 * @param array  $expected_action_keys   The action keys that should remain after the filter.
+	 * @return void
+	 * @dataProvider filter_my_account_my_orders_actions_provider
 	 */
-	public function test_filter_my_account_my_orders_actions( $payment_method_title ) {
+	public function test_filter_my_account_my_orders_actions( $payment_method_title, $has_checkout_session, $expected_action_keys ) {
 		add_filter(
 			'woocommerce_is_order_received_page',
 			function () {
@@ -3035,6 +3039,10 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 		$order = WC_Helper_Order::create_order();
 		$order->set_payment_method_title( $payment_method_title );
 		$order->set_status( OrderStatus::PENDING );
+
+		if ( $has_checkout_session ) {
+			WC_Stripe_Order_Helper::get_instance()->update_stripe_checkout_session_id( $order, 'cs_test_123' );
+		}
 
 		$actions = [
 			'pay'    => [
@@ -3056,16 +3064,7 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 
 		$actual = $this->mock_gateway->filter_my_account_my_orders_actions( $actions, $order );
 
-		$this->assertEquals(
-			[
-				'view' => [
-					'url'        => $order->get_view_order_url(),
-					'name'       => 'View',
-					'aria-label' => sprintf( 'View order %s', $order->get_order_number() ),
-				],
-			],
-			$actual
-		);
+		$this->assertEquals( $expected_action_keys, array_keys( $actual ) );
 	}
 
 	/**
@@ -3073,9 +3072,28 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 *
 	 * @return array
 	 */
-	public function payment_method_titles_provider() {
+	public function filter_my_account_my_orders_actions_provider() {
 		return [
-			'Bacs' => [ WC_Stripe_Payment_Methods::BACS_DEBIT_LABEL ],
+			'Bacs (delayed confirmation)' => [
+				'payment_method_title' => WC_Stripe_Payment_Methods::BACS_DEBIT_LABEL,
+				'has_checkout_session' => false,
+				'expected_action_keys' => [ 'view' ],
+			],
+			'Bacs (delayed confirmation) with checkout session' => [
+				'payment_method_title' => WC_Stripe_Payment_Methods::BACS_DEBIT_LABEL,
+				'has_checkout_session' => true,
+				'expected_action_keys' => [ 'view' ],
+			],
+			'Card'                        => [
+				'payment_method_title' => WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+				'has_checkout_session' => false,
+				'expected_action_keys' => [ 'pay', 'view', 'cancel' ],
+			],
+			'Card with checkout session'  => [
+				'payment_method_title' => WC_Stripe_UPE_Payment_Method_CC::STRIPE_ID,
+				'has_checkout_session' => true,
+				'expected_action_keys' => [ 'view' ],
+			],
 		];
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Used the existing `filter_my_account_my_orders_actions` method to hide the actions button from order received page as well as the order details page in My Account. 
Orders via Stripe checkout sessions are dependent on the checkout session webhook events for the order status to change from `pending`. If we show the action buttons (`Pay` and `Cancel`) on the order received page for these orders, user may end up paying again for the already paid order. This PR is intended to prevent this possible double payment.

**Note:**
PHPStan errors are coming from the parent branch.

## Testing instructions
- Add the following filter to allow adaptive pricing and checkout sessions in your store
```
add_filter( 'wc_stripe_is_checkout_sessions_available', '__return_true' );
```
- Connect a US Stripe account
- Enable OCS in the Stripe settings page
- Enable adaptive pricing under the OCS settings
- Enable card and a couple more payment methods
- As a shopper, add a product to your cart and go to the block checkout page.
- Verify that the currency selector is displayed and the available currencies are USD and your local currency.
- Select your local currency and pay
- Wait to be redirected to the order received page.
- In `add/adaptive-pricing-info-in-order-received` branch, you should see the `Pay` and `Cancel` button on this page.
- In this branch, verify that you do not see these buttons on the order recieved page.


### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
