### PR TITLE
Update missing rebranding in settings

### DIFF
--- a/client/settings/payments-and-transactions-section/index.js
+++ b/client/settings/payments-and-transactions-section/index.js
@@ -96,11 +96,11 @@ const PaymentsAndTransactionsSection = () => {
 					checked={ isSepaTokensForIdealEnabled }
 					onChange={ setIsSepaTokensForIdealEnabled }
 					label={ __(
-						'Enable saved iDEAL payments for repeat payments',
+						'Enable saved iDEAL | Wero payments for repeat payments',
 						'woocommerce-gateway-stripe'
 					) }
 					help={ __(
-						'Let customers save iDEAL as a SEPA Direct Debit method for future purchases. Requires iDEAL to be enabled.',
+						'Let customers save iDEAL | Wero as a SEPA Direct Debit method for future purchases. Requires iDEAL | Wero to be enabled.',
 						'woocommerce-gateway-stripe'
 					) }
 				/>

--- a/includes/admin/class-wc-rest-stripe-settings-controller.php
+++ b/includes/admin/class-wc-rest-stripe-settings-controller.php
@@ -152,7 +152,7 @@ class WC_REST_Stripe_Settings_Controller extends WC_Stripe_REST_Base_Controller 
 						'validate_callback' => 'rest_validate_request_arg',
 					],
 					'is_sepa_tokens_for_ideal' => [
-						'description'       => __( 'If "SEPA tokens for iDEAL" should be enabled.', 'woocommerce-gateway-stripe' ),
+						'description'       => __( 'If "SEPA tokens for iDEAL | Wero" should be enabled.', 'woocommerce-gateway-stripe' ),
 						'type'              => 'boolean',
 						'validate_callback' => 'rest_validate_request_arg',
 					],

--- a/includes/admin/stripe-settings.php
+++ b/includes/admin/stripe-settings.php
@@ -227,10 +227,10 @@ return apply_filters(
 			'desc_tip'    => true,
 		],
 		'sepa_tokens_for_ideal'       => [
-			'title'       => __( 'SEPA Direct Debit tokens when saving iDEAL methods', 'woocommerce-gateway-stripe' ),
-			'label'       => __( 'Enable saved iDEAL payments for repeat payments', 'woocommerce-gateway-stripe' ),
+			'title'       => __( 'SEPA Direct Debit tokens when saving iDEAL | Wero methods', 'woocommerce-gateway-stripe' ),
+			'label'       => __( 'Enable saved iDEAL | Wero payments for repeat payments', 'woocommerce-gateway-stripe' ),
 			'type'        => 'checkbox',
-			'description' => __( 'If enabled, users will be able to pay with iDEAL and save the method as a SEPA Direct Debit method.', 'woocommerce-gateway-stripe' ),
+			'description' => __( 'If enabled, users will be able to pay with iDEAL | Wero and save the method as a SEPA Direct Debit method.', 'woocommerce-gateway-stripe' ),
 			'default'     => 'no',
 			'desc_tip'    => true,
 		],


### PR DESCRIPTION
Discussed in p1773069026120839-slack-C055WHLA98D

## Changes proposed in this Pull Request:
Updated missing iDeal rebranding in settings.

## Testing instructions
Go to the Stripe settings page and verify the following checkbox is showing `iDEAL | Wero` rebranding.

<img width="790" height="275" alt="Screenshot 2026-03-09 at 9 27 06 PM" src="https://github.com/user-attachments/assets/0a01666b-e3d0-4094-83ec-318b0334ba47" />


### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Previous changelog entry is sufficient.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)