### PR TITLE
Making ECE debug logs optional

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Changelog ***
 
 = 10.6.0 - xxxx-xx-xx =
+* Update - Logging reasons for ECE buttons not showing only when verbose debug mode is enabled
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 
 = 10.5.0 - 2026-03-09 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Changelog ***
 
 = 10.6.0 - xxxx-xx-xx =
-* Update - Logging reasons for ECE buttons not showing only when verbose debug mode is enabled
+* Update - Express Checkout button logging will only occur when verbose debug mode is enabled
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -792,7 +792,7 @@ class WC_Stripe_Express_Checkout_Helper {
 				if ( $hide_based_on_tax !== $hide_based_on_tax_filtered ) {
 					WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to the tax setup being overridden by the filter.' );
 				} else {
-					WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
+					WC_Stripe_Logger::debug( "Stripe Express Checkout is hidden due to product/cart not requiring shipping and tax being based on customer's billing or shipping address." );
 				}
 			}
 			return false;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -693,7 +693,7 @@ class WC_Stripe_Express_Checkout_Helper {
 			&& ! $this->allowed_items_in_cart()
 		) {
 			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
-				WC_Stripe_Logger::debug( 'Some items in cart are not compatible with Stripe Express Checkout. ' );
+				WC_Stripe_Logger::debug( 'Some items in cart are not compatible with Stripe Express Checkout.' );
 			}
 			return false;
 		}
@@ -701,7 +701,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		// Don't show on cart if disabled.
 		if ( $this->is_cart() && ! $this->should_show_ece_on_cart_page() ) {
 			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
-				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on cart is disabled. ' );
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on cart is disabled.' );
 			}
 			return false;
 		}
@@ -711,7 +711,7 @@ class WC_Stripe_Express_Checkout_Helper {
 
 		if ( ( $this->is_checkout() || $is_one_page_checkout ) && ! $this->should_show_ece_on_checkout_page() ) {
 			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
-				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on checkout is disabled.' );
 			}
 			return false;
 		}
@@ -722,7 +722,7 @@ class WC_Stripe_Express_Checkout_Helper {
 		// Skip this check for One Page Checkout pages since they should be treated as checkout pages, not product pages.
 		if ( $is_product && ! $is_one_page_checkout && ! $this->should_show_ece_on_product_pages() ) {
 			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
-				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on product pages is disabled.' );
 			}
 			return false;
 		}

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -665,7 +665,6 @@ class WC_Stripe_Express_Checkout_Helper {
 					'https' => isset( $_SERVER['HTTPS'] ) ? wp_unslash( $_SERVER['HTTPS'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					'port'  => isset( $_SERVER['SERVER_PORT'] ) ? wp_unslash( $_SERVER['SERVER_PORT'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				];
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions
 				WC_Stripe_Logger::debug( 'Stripe Express Checkout live mode requires SSL', [ 'server_details' => $server_details ] );
 			}
 			return false;

--- a/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
+++ b/includes/payment-methods/class-wc-stripe-express-checkout-helper.php
@@ -651,31 +651,39 @@ class WC_Stripe_Express_Checkout_Helper {
 	public function should_show_express_checkout_button() {
 		// Bail if account is not connected.
 		if ( ! WC_Stripe::get_instance()->connect->is_connected() ) {
-			WC_Stripe_Logger::debug( 'Account is not connected.' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Account is not connected.' );
+			}
 			return false;
 		}
 
 		// If no SSL bail.
 		if ( ! $this->testmode && ! is_ssl() ) {
-			$server_details = [
-				'url'   => get_permalink(),
-				'https' => isset( $_SERVER['HTTPS'] ) ? wp_unslash( $_SERVER['HTTPS'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				'port'  => isset( $_SERVER['SERVER_PORT'] ) ? wp_unslash( $_SERVER['SERVER_PORT'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			];
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout live mode requires SSL', [ 'server_details' => $server_details ] );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				$server_details = [
+					'url'   => get_permalink(),
+					'https' => isset( $_SERVER['HTTPS'] ) ? wp_unslash( $_SERVER['HTTPS'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					'port'  => isset( $_SERVER['SERVER_PORT'] ) ? wp_unslash( $_SERVER['SERVER_PORT'] ) : '', // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				];
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout live mode requires SSL', [ 'server_details' => $server_details ] );
+			}
 			return false;
 		}
 
 		$available_gateways = WC()->payment_gateways->get_available_payment_gateways();
 		if ( ! isset( $available_gateways['stripe'] ) ) {
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout requires the Stripe gateway to be enabled.' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout requires the Stripe gateway to be enabled.' );
+			}
 			return false;
 		}
 
 		// Note that is_express_checkout_enabled() checks locations as well as the necessary express checkout methods being available.
 		if ( ! $this->is_express_checkout_enabled() ) {
-			WC_Stripe_Logger::debug( 'No Stripe Express Checkout options are enabled in the current context.' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'No Stripe Express Checkout options are enabled in the current context.' );
+			}
 			return false;
 		}
 
@@ -685,13 +693,17 @@ class WC_Stripe_Express_Checkout_Helper {
 			WC_Stripe_Helper::has_cart_or_checkout_on_current_page()
 			&& ! $this->allowed_items_in_cart()
 		) {
-			WC_Stripe_Logger::debug( 'Some items in cart are not compatible with Stripe Express Checkout. ' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Some items in cart are not compatible with Stripe Express Checkout. ' );
+			}
 			return false;
 		}
 
 		// Don't show on cart if disabled.
 		if ( $this->is_cart() && ! $this->should_show_ece_on_cart_page() ) {
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on cart is disabled. ' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on cart is disabled. ' );
+			}
 			return false;
 		}
 
@@ -699,7 +711,9 @@ class WC_Stripe_Express_Checkout_Helper {
 		$is_one_page_checkout = $this->is_one_page_checkout();
 
 		if ( ( $this->is_checkout() || $is_one_page_checkout ) && ! $this->should_show_ece_on_checkout_page() ) {
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on checkout is disabled. ' );
+			}
 			return false;
 		}
 
@@ -708,34 +722,44 @@ class WC_Stripe_Express_Checkout_Helper {
 		// Don't show if product page ECE is disabled.
 		// Skip this check for One Page Checkout pages since they should be treated as checkout pages, not product pages.
 		if ( $is_product && ! $is_one_page_checkout && ! $this->should_show_ece_on_product_pages() ) {
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons display on product pages is disabled. ' );
+			}
 			return false;
 		}
 
 		// On One Page Checkout pages, if we're in the product section and checkout buttons are enabled,
 		// skip rendering here because the button will render in the checkout section instead.
 		if ( $is_one_page_checkout && $is_product && doing_action( 'woocommerce_after_add_to_cart_form' ) && $this->should_show_ece_on_checkout_page() ) {
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons on One Page Checkout will be displayed in checkout section, not product section.' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout buttons on One Page Checkout will be displayed in checkout section, not product section.' );
+			}
 			return false;
 		}
 
 		$product = $this->get_product();
 
 		if ( $is_product && ! $product ) {
-			$request_uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
-			WC_Stripe_Logger::debug( 'Failed to identify product; not showing Stripe Express Checkout. Current URI: ' . $request_uri );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				$request_uri = sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ?? '' ) );
+				WC_Stripe_Logger::debug( 'Failed to identify product; not showing Stripe Express Checkout. Current URI: ' . $request_uri );
+			}
 			return false;
 		}
 
 		// Don't show if product on current page is not supported.
 		if ( $is_product && ! $this->is_product_supported( $product ) ) {
-			WC_Stripe_Logger::debug( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $product->get_id() );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Product is not supported by Stripe Express Checkout. Product ID: ' . $product->get_id() );
+			}
 			return false;
 		}
 
 		// Don't show in the product page if the product price is 0 and the product requires shipping.
 		if ( $is_product && $product && 0.0 === (float) $product->get_price() && $this->product_or_cart_needs_shipping() ) {
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout does not support free products that requires shipping.' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout does not support free products that requires shipping.' );
+			}
 			return false;
 		}
 
@@ -743,7 +767,9 @@ class WC_Stripe_Express_Checkout_Helper {
 			$stock_availability = array_column( $product->get_available_variations(), 'is_in_stock' );
 			// Don't show if all product variations are out-of-stock.
 			if ( ! in_array( true, $stock_availability, true ) ) {
-				WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to product variations being out of stock. Product ID: ' . $product->get_id() );
+				if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+					WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to product variations being out of stock. Product ID: ' . $product->get_id() );
+				}
 				return false;
 			}
 		}
@@ -753,7 +779,9 @@ class WC_Stripe_Express_Checkout_Helper {
 			! ( $this->is_payment_request_enabled() || $this->is_link_enabled() ) &&
 			( wc_tax_enabled() && 'billing' === get_option( 'woocommerce_tax_based_on' ) )
 		) {
-			WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to Amazon Pay being the only enabled method, but not available due to taxes being based on billing address.' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to Amazon Pay being the only enabled method, but not available due to taxes being based on billing address.' );
+			}
 			return false;
 		}
 
@@ -761,10 +789,12 @@ class WC_Stripe_Express_Checkout_Helper {
 		$hide_based_on_tax          = $this->should_hide_ece_based_on_tax_setup();
 		$hide_based_on_tax_filtered = apply_filters( 'wc_stripe_should_hide_express_checkout_button_based_on_tax_setup', $hide_based_on_tax );
 		if ( $hide_based_on_tax_filtered ) {
-			if ( $hide_based_on_tax !== $hide_based_on_tax_filtered ) {
-				WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to the tax setup being overridden by the filter.' );
-			} else {
-				WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
+			if ( WC_Stripe_Helper::is_verbose_debug_mode_enabled() ) {
+				if ( $hide_based_on_tax !== $hide_based_on_tax_filtered ) {
+					WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to the tax setup being overridden by the filter.' );
+				} else {
+					WC_Stripe_Logger::debug( 'Stripe Express Checkout is hidden due to product/cart not requiring shipping and tax being based on customer\'s billing or shipping address.' );
+				}
 			}
 			return false;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -146,7 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
-* Update - Logging reasons for ECE buttons not showing only when verbose debug mode is enabled
+* Update - Express Checkout button logging will only occur when verbose debug mode is enabled
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 

--- a/readme.txt
+++ b/readme.txt
@@ -146,6 +146,7 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 == Changelog ==
 
 = 10.6.0 - xxxx-xx-xx =
+* Update - Logging reasons for ECE buttons not showing only when verbose debug mode is enabled
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

See p1768294774721149-slack-C055WHLA98D / p1773142676536059-slack-C055WHLA98D

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

In this PR, I am making the existing ECE debug logs optional, being added only when verbose debug mode is enabled (using the `wc_stripe_is_verbose_debug_mode_enabled` filter). The goal is to reduce noise on merchants' log files.

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

- Checkout and build this branch on your test environment (`update/ece-debug-logs-optional`)
- Enable verbose debug logs with the filter:
```php
add_filter( 'wc_stripe_is_verbose_debug_mode_enabled', '__return_true' );
```
- Connect your Stripe account
- Enable ECE methods (Google Pay, Apple Pay, Amazon Pay)
- Disable ECE display in the cart page
- As a shopper, add a product to your cart
- Go to your cart. ECE buttons should not be shown
- As a merchant, go to your Stripe logs page
- Confirm the following entry is logged:
```
Stripe Express Checkout buttons display on cart is disabled.
```
- Remove the filter above
- Repeat the test steps
- Confirm the entry is no longer added to your Stripe logs

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
