### PR TITLE
Refactor Amazon Pay checks to prevent possible race conditions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,7 +5,7 @@
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Fix - Clear customer cache after saving a new payment method so the Stripe payment method list has correct data
 * Fix - Reinstate custom appearance logic
-* Dev - Refactor some Amazon Pay helpers to simplify bootstrap checks
+* Fix - Refactor some Amazon Pay helpers to prevent an infinite loop
 
 = 10.5.0 - 2026-03-09 =
 * Update - Add missing metadata to checkout session objects when processing webhook events

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Fix - Clear customer cache after saving a new payment method so the Stripe payment method list has correct data
+* Dev - Refactor some Amazon Pay helpers to simplify bootstrap checks
 
 = 10.5.0 - 2026-03-09 =
 * Update - Add missing metadata to checkout session objects when processing webhook events

--- a/includes/class-wc-stripe-payment-method-configurations.php
+++ b/includes/class-wc-stripe-payment-method-configurations.php
@@ -598,13 +598,9 @@ class WC_Stripe_Payment_Method_Configurations {
 				[ WC_Stripe_Payment_Methods::GOOGLE_PAY, WC_Stripe_Payment_Methods::APPLE_PAY ]
 			);
 
-			// If Amazon Pay is available and should be defaulted on, and the account country and currency are supported, enable Amazon Pay.
-			if ( WC_Stripe_Feature_Flags::is_amazon_pay_available() && 'yes' === get_option( 'wc_stripe_amazon_pay_default_on' ) ) {
-				$amazon_pay = new WC_Stripe_UPE_Payment_Method_Amazon_Pay();
-
-				if ( $amazon_pay->is_available_for_account_country() && in_array( get_woocommerce_currency(), $amazon_pay->get_supported_currencies(), true ) ) {
-					$enabled_payment_methods[] = WC_Stripe_Payment_Methods::AMAZON_PAY;
-				}
+			// If Amazon Pay should be defaulted on, and the account country and currency are supported, enable Amazon Pay.
+			if ( 'yes' === get_option( 'wc_stripe_amazon_pay_default_on' ) && WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_available_for_account_country() && in_array( get_woocommerce_currency(), WC_Stripe_UPE_Payment_Method_Amazon_Pay::get_amazon_pay_supported_currencies(), true ) ) {
+				$enabled_payment_methods[] = WC_Stripe_Payment_Methods::AMAZON_PAY;
 			}
 		}
 

--- a/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-method-amazon-pay.php
@@ -21,27 +21,40 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 	const STRIPE_ID = WC_Stripe_Payment_Methods::AMAZON_PAY;
 
 	/**
+	 * Supported countries for Amazon Pay.
+	 *
+	 * @var string[]
+	 */
+	private const SUPPORTED_COUNTRIES = [ 'AT', 'BE', 'CY', 'DK', 'FR', 'DE', 'HU', 'IE', 'IT', 'LU', 'NL', 'PT', 'ES', 'SE', 'CH', 'GB', 'US' ];
+
+	/**
+	 * Supported currencies for Amazon Pay.
+	 *
+	 * @var string[]
+	 */
+	private const SUPPORTED_CURRENCIES = [
+		WC_Stripe_Currency_Code::AUSTRALIAN_DOLLAR,
+		WC_Stripe_Currency_Code::SWISS_FRANC,
+		WC_Stripe_Currency_Code::DANISH_KRONE,
+		WC_Stripe_Currency_Code::EURO,
+		WC_Stripe_Currency_Code::POUND_STERLING,
+		WC_Stripe_Currency_Code::HONG_KONG_DOLLAR,
+		WC_Stripe_Currency_Code::JAPANESE_YEN,
+		WC_Stripe_Currency_Code::NORWEGIAN_KRONE,
+		WC_Stripe_Currency_Code::NEW_ZEALAND_DOLLAR,
+		WC_Stripe_Currency_Code::SWEDISH_KRONA,
+		WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
+		WC_Stripe_Currency_Code::SOUTH_AFRICAN_RAND,
+	];
+	/**
 	 * Constructor for Amazon Pay payment method
 	 */
 	public function __construct() {
 		parent::__construct();
 		$this->stripe_id            = self::STRIPE_ID;
 		$this->title                = __( 'Amazon Pay', 'woocommerce-gateway-stripe' );
-		$this->supported_currencies = [
-			WC_Stripe_Currency_Code::AUSTRALIAN_DOLLAR,
-			WC_Stripe_Currency_Code::SWISS_FRANC,
-			WC_Stripe_Currency_Code::DANISH_KRONE,
-			WC_Stripe_Currency_Code::EURO,
-			WC_Stripe_Currency_Code::POUND_STERLING,
-			WC_Stripe_Currency_Code::HONG_KONG_DOLLAR,
-			WC_Stripe_Currency_Code::JAPANESE_YEN,
-			WC_Stripe_Currency_Code::NORWEGIAN_KRONE,
-			WC_Stripe_Currency_Code::NEW_ZEALAND_DOLLAR,
-			WC_Stripe_Currency_Code::SWEDISH_KRONA,
-			WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR,
-			WC_Stripe_Currency_Code::SOUTH_AFRICAN_RAND,
-		];
-		$this->supported_countries  = [ 'AT', 'BE', 'CY', 'DK', 'FR', 'DE', 'HU', 'IE', 'IT', 'LU', 'NL', 'PT', 'ES', 'SE', 'CH', 'GB', 'US' ];
+		$this->supported_currencies = self::SUPPORTED_CURRENCIES;
+		$this->supported_countries  = self::SUPPORTED_COUNTRIES;
 		$this->is_reusable          = true;
 		$this->label                = __( 'Amazon Pay', 'woocommerce-gateway-stripe' );
 		$this->description          = __(
@@ -71,13 +84,22 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 	 * @return array Supported currencies.
 	 */
 	public function get_supported_currencies() {
+		return self::get_amazon_pay_supported_currencies();
+	}
+
+	/**
+	 * Returns the supported currencies for the current Stripe account.
+	 *
+	 * @return string[] Supported currencies.
+	 */
+	public static function get_amazon_pay_supported_currencies(): array {
 		$account_country = WC_Stripe::get_instance()->account->get_account_country();
 
 		if ( 'US' === $account_country ) {
 			return [ WC_Stripe_Currency_Code::UNITED_STATES_DOLLAR ];
 		}
 
-		return $this->supported_currencies;
+		return self::SUPPORTED_CURRENCIES;
 	}
 
 	/**
@@ -88,9 +110,20 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay extends WC_Stripe_UPE_Payment_Meth
 	 * @return bool True if the payment method is available for the account's country, false otherwise.
 	 */
 	public function is_available_for_account_country() {
+		return self::is_amazon_pay_available_for_account_country();
+	}
+
+	/**
+	 * Returns whether the payment method is available for the Stripe account's country.
+	 *
+	 * Amazon Pay is available for the following countries: AT, BE, CY, DK, FR, DE, HU, IE, IT, LU, NL, PT, ES, SE, CH, GB, US.
+	 *
+	 * @return bool True if the payment method is available for the account's country, false otherwise.
+	 */
+	public static function is_amazon_pay_available_for_account_country() {
 		$account_country = WC_Stripe::get_instance()->account->get_account_country();
 
-		return in_array( $account_country, $this->supported_countries, true );
+		return in_array( $account_country, self::SUPPORTED_COUNTRIES, true );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -149,5 +149,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Fix - Clear customer cache after saving a new payment method so the Stripe payment method list has correct data
+* Dev - Refactor some Amazon Pay helpers to simplify bootstrap checks
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Fix - Clear customer cache after saving a new payment method so the Stripe payment method list has correct data
 * Fix - Reinstate custom appearance logic
-* Dev - Refactor some Amazon Pay helpers to simplify bootstrap checks
+* Fix - Refactor some Amazon Pay helpers to prevent an infinite loop
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test.php
@@ -51,7 +51,7 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the supported currencies for the Amazon Pay payment method.
+	 * Test \WC_Stripe_UPE_Payment_Method_Amazon_Pay->get_supported_currencies().
 	 *
 	 * @param string   $account_country     The country code for the Stripe account.
 	 * @param string[] $expected_currencies The expected currencies.
@@ -69,6 +69,31 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test extends \WP_UnitTestCase {
 
 		$amazon_pay           = new \WC_Stripe_UPE_Payment_Method_Amazon_Pay();
 		$supported_currencies = $amazon_pay->get_supported_currencies();
+
+		// Reset account before asserting.
+		$stripe_instance->account = $initial_account;
+
+		$this->assertEquals( $expected_currencies, $supported_currencies );
+	}
+
+	/**
+	 * Test \WC_Stripe_UPE_Payment_Method_Amazon_Pay::get_amazon_pay_supported_currencies().
+	 *
+	 * @param string   $account_country     The country code for the Stripe account.
+	 * @param string[] $expected_currencies The expected currencies.
+	 * @dataProvider provide_test_supported_currencies
+	 */
+	public function test_get_amazon_pay_supported_currencies( string $account_country, array $expected_currencies ): void {
+		$mock_account = $this->createMock( \WC_Stripe_Account::class );
+
+		$mock_account->method( 'get_account_country' )
+			->willReturn( $account_country );
+
+		$stripe_instance = \WC_Stripe::get_instance();
+		$initial_account = $stripe_instance->account;
+		$stripe_instance->account = $mock_account;
+
+		$supported_currencies = \WC_Stripe_UPE_Payment_Method_Amazon_Pay::get_amazon_pay_supported_currencies();
 
 		// Reset account before asserting.
 		$stripe_instance->account = $initial_account;
@@ -119,6 +144,30 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test extends \WP_UnitTestCase {
 
 		$amazon_pay   = new \WC_Stripe_UPE_Payment_Method_Amazon_Pay();
 		$is_available = $amazon_pay->is_available_for_account_country();
+
+		// Reset account before asserting.
+		$stripe_instance->account = $initial_account;
+
+		$this->assertEquals( $expected_availability, $is_available );
+	}
+
+	/**
+	 * Test \WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_available_for_account_country().
+	 *
+	 * @param string $account_country       The country code for the Stripe account.
+	 * @param bool   $expected_availability The expected availability.
+	 * @dataProvider provide_test_is_available_for_account_country
+	 */
+	public function test_is_amazon_pay_available_for_account_country( string $account_country, bool $expected_availability ): void {
+		$mock_account = $this->createMock( \WC_Stripe_Account::class );
+		$mock_account->method( 'get_account_country' )
+			->willReturn( $account_country );
+
+		$stripe_instance = \WC_Stripe::get_instance();
+		$initial_account = $stripe_instance->account;
+		$stripe_instance->account = $mock_account;
+
+		$is_available = \WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_available_for_account_country();
 
 		// Reset account before asserting.
 		$stripe_instance->account = $initial_account;

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test.php
@@ -165,13 +165,15 @@ class WC_Stripe_UPE_Payment_Method_Amazon_Pay_Test extends \WP_UnitTestCase {
 
 		$stripe_instance = \WC_Stripe::get_instance();
 		$initial_account = $stripe_instance->account;
-		$stripe_instance->account = $mock_account;
 
-		$is_available = \WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_available_for_account_country();
+		try {
+			$stripe_instance->account = $mock_account;
 
-		// Reset account before asserting.
-		$stripe_instance->account = $initial_account;
+			$is_available = \WC_Stripe_UPE_Payment_Method_Amazon_Pay::is_amazon_pay_available_for_account_country();
 
-		$this->assertEquals( $expected_availability, $is_available );
+			$this->assertEquals( $expected_availability, $is_available );
+		} finally {
+			$stripe_instance->account = $initial_account;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR addresses a possible race condition that can occur when the `pmc_enabled` sub-option is empty, as the code in `WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()` creates an instance of `WC_Stripe_UPE_Payment_Method_Amazon_Pay`. However, that sets off the following chain that could lead to an infinite loop:
- `WC_Stripe_UPE_Payment_Method_Amazon_Pay::__construct()`
- `WC_Stripe_UPE_Payment_Method::__construct()`
- `WC_Stripe_UPE_Payment_Method->get_upe_enabled_payment_method_ids()`
- `WC_Stripe_Payment_Method_Configurations::get_upe_enabled_payment_method_ids()`
- `WC_Stripe_Payment_Method_Configurations::maybe_migrate_payment_methods_from_db_to_pmc()`

This PR refactors `WC_Stripe_UPE_Payment_Method_Amazon_Pay` to expose the relevant logic via static methods and capture the supported currencies and countries in private constants that are referenced from the static methods and the class constructor.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

I think code inspection should be enough for this PR, as the refactor is pretty straighforward, and I have the same set of underlying test cases running against both the new and old methods.

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
