### PR TITLE
Add extensibility for font hosts

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 = 10.6.0 - xxxx-xx-xx =
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
+* Add - Allow additional font domains to be included in Stripe fonts
 
 = 10.5.0 - 2026-03-09 =
 * Update - Add missing metadata to checkout session objects when processing webhook events

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Update - Express Checkout button logging will only occur when verbose debug mode is enabled
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
+* Add - Allow additional font domains to be included in Stripe fonts
 
 = 10.5.2 - 2026-03-13 =
 * Fix - Ensure that we enqueue all needed scripts on payment pages
@@ -12,7 +13,6 @@
 * Fix - Reinstate custom appearance logic
 * Fix - Refactor some Amazon Pay helpers to prevent an infinite loop
 * Fix - Clear customer cache after saving a new payment method so the Stripe payment method list has correct data
-* Add - Allow additional font domains to be included in Stripe fonts
 
 = 10.5.0 - 2026-03-09 =
 * Update - Add missing metadata to checkout session objects when processing webhook events

--- a/client/styles/upe/__tests__/index.js
+++ b/client/styles/upe/__tests__/index.js
@@ -112,6 +112,102 @@ describe( 'Getting styles for automated theming', () => {
 		expect( fontRules ).toEqual( [] );
 	} );
 
+	it( 'getFontRulesFromPage returns font rules from fonts-api.wp.com by default', () => {
+		const mockStyleSheets = {
+			length: 1,
+			0: { href: 'https://fonts-api.wp.com/css?family=Lato' },
+		};
+		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
+			mockStyleSheets
+		);
+
+		const fontRules = upeStyles.getFontRulesFromPage();
+		expect( fontRules ).toEqual( [
+			{ cssSrc: 'https://fonts-api.wp.com/css?family=Lato' },
+		] );
+	} );
+
+	it( 'getFontRulesFromPage includes stylesheets from extra domains in permittedFontDomains', () => {
+		global.wc_stripe_upe_params = {
+			...global.wc_stripe_upe_params,
+			permittedFontDomains: [ 'custom-fonts.example.com' ],
+		};
+
+		const mockStyleSheets = {
+			length: 2,
+			0: { href: 'https://custom-fonts.example.com/style.css' },
+			1: { href: 'https://not-allowed.example.com/style.css' },
+		};
+		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
+			mockStyleSheets
+		);
+
+		const fontRules = upeStyles.getFontRulesFromPage();
+		expect( fontRules ).toEqual( [
+			{ cssSrc: 'https://custom-fonts.example.com/style.css' },
+		] );
+	} );
+
+	it( 'getFontRulesFromPage includes both default and extra domains when permittedFontDomains is set', () => {
+		global.wc_stripe_upe_params = {
+			...global.wc_stripe_upe_params,
+			permittedFontDomains: [ 'custom-fonts.example.com' ],
+		};
+
+		const mockStyleSheets = {
+			length: 2,
+			0: { href: 'https://fonts.googleapis.com/css?family=Roboto' },
+			1: { href: 'https://custom-fonts.example.com/style.css' },
+		};
+		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
+			mockStyleSheets
+		);
+
+		const fontRules = upeStyles.getFontRulesFromPage();
+		expect( fontRules ).toHaveLength( 2 );
+		expect( fontRules[ 0 ].cssSrc ).toContain( 'fonts.googleapis.com' );
+		expect( fontRules[ 1 ].cssSrc ).toContain( 'custom-fonts.example.com' );
+	} );
+
+	it( 'getFontRulesFromPage ignores permittedFontDomains when it is not an array', () => {
+		global.wc_stripe_upe_params = {
+			...global.wc_stripe_upe_params,
+			permittedFontDomains: 'custom-fonts.example.com',
+		};
+
+		const mockStyleSheets = {
+			length: 2,
+			0: { href: 'https://custom-fonts.example.com/style.css' },
+			1: { href: 'https://fonts.googleapis.com/css?family=Roboto' },
+		};
+		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
+			mockStyleSheets
+		);
+
+		const fontRules = upeStyles.getFontRulesFromPage();
+		expect( fontRules ).toEqual( [
+			{ cssSrc: 'https://fonts.googleapis.com/css?family=Roboto' },
+		] );
+	} );
+
+	it( 'getFontRulesFromPage uses only default domains when permittedFontDomains is not set', () => {
+		global.wc_stripe_upe_params = { shouldShowOptimizedCheckout: false };
+
+		const mockStyleSheets = {
+			length: 2,
+			0: { href: 'https://custom-fonts.example.com/style.css' },
+			1: { href: 'https://fonts.googleapis.com/css?family=Roboto' },
+		};
+		jest.spyOn( document, 'styleSheets', 'get' ).mockReturnValue(
+			mockStyleSheets
+		);
+
+		const fontRules = upeStyles.getFontRulesFromPage();
+		expect( fontRules ).toEqual( [
+			{ cssSrc: 'https://fonts.googleapis.com/css?family=Roboto' },
+		] );
+	} );
+
 	it( 'getAppearance returns the object with filtered CSS rules for UPE theming', () => {
 		global.wc_stripe_upe_params = { shouldShowOptimizedCheckout: false };
 

--- a/client/styles/upe/index.js
+++ b/client/styles/upe/index.js
@@ -1,3 +1,5 @@
+/* global wc_stripe_upe_params */
+
 import { upeRestrictedProperties } from './upe-styles';
 import {
 	generateHoverRules,
@@ -344,15 +346,37 @@ export const getFieldStyles = ( selector, upeElement ) => {
 	return filteredStyles;
 };
 
+/**
+ * Default font domains that support URLs that return text/css resources which include @font-face declarations.
+ */
+const DEFAULT_FONT_DOMAINS = [
+	'fonts.googleapis.com',
+	'fonts.gstatic.com',
+	'fast.fonts.com',
+	'use.typekit.net',
+	'fonts-api.wp.com',
+];
+
+/**
+ * Returns array of permitted font domains, which uses a default list.
+ * Additional font domains may be specified via the `wc_stripe_upe_permitted_font_domains` filter.
+ *
+ * @return {string[]} Array of permitted font domains.
+ */
+const getPermittedFontDomains = () => {
+	// eslint-disable-next-line camelcase
+	if ( Array.isArray( wc_stripe_upe_params?.permittedFontDomains ) ) {
+		return DEFAULT_FONT_DOMAINS.concat(
+			wc_stripe_upe_params.permittedFontDomains // eslint-disable-line camelcase
+		);
+	}
+	return DEFAULT_FONT_DOMAINS;
+};
+
 export const getFontRulesFromPage = () => {
 	const fontRules = [],
 		sheets = document.styleSheets,
-		fontDomains = [
-			'fonts.googleapis.com',
-			'fonts.gstatic.com',
-			'fast.fonts.com',
-			'use.typekit.net',
-		];
+		fontDomains = getPermittedFontDomains();
 	for ( let i = 0; i < sheets.length; i++ ) {
 		if ( ! sheets[ i ].href ) {
 			continue;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -552,6 +552,15 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		// Amazon Pay feature flag.
 		$stripe_params['isAmazonPayAvailable'] = WC_Stripe_Feature_Flags::is_amazon_pay_available();
 
+		/**
+		 * Filters the list of permitted font domains for the Stripe Payment Element.
+		 * These host names will be used in the client Javascript to identify additional domains
+		 * that return text/css resources which include @font-face declarations. Those stylesheets
+		 * can then be passed into the Stripe payment element.
+		 *
+		 * @param string[] $permitted_font_domains List of permitted font domains.
+		 * @since 10.6.0
+		 */
 		$permitted_font_domains = apply_filters( 'wc_stripe_upe_permitted_font_domains', [] );
 		if ( [] !== $permitted_font_domains && is_array( $permitted_font_domains ) ) {
 			$stripe_params['permittedFontDomains'] = $permitted_font_domains;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -552,6 +552,11 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		// Amazon Pay feature flag.
 		$stripe_params['isAmazonPayAvailable'] = WC_Stripe_Feature_Flags::is_amazon_pay_available();
 
+		$permitted_font_domains = apply_filters( 'wc_stripe_upe_permitted_font_domains', [] );
+		if ( [] !== $permitted_font_domains && is_array( $permitted_font_domains ) ) {
+			$stripe_params['permittedFontDomains'] = $permitted_font_domains;
+		}
+
 		// Optimized Checkout feature flag + setting + whether we are on any of the pages that should not show OC.
 		$should_show_optimized_checkout               = $this->oc_enabled && $this->is_valid_optimized_checkout_page();
 		$stripe_params['isOCEnabled']                 = $should_show_optimized_checkout;

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -563,20 +563,32 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		 */
 		$permitted_font_domains = apply_filters( 'wc_stripe_upe_permitted_font_domains', [] );
 		if ( is_array( $permitted_font_domains ) ) {
-			// Validate that we have unique, non-empty strings.
-			$permitted_font_domains = array_values(
-				array_unique(
-					array_filter(
-						array_map(
-							static function ( $domain ) {
-								// @phpstan-ignore-next-line function.alreadyNarrowedType (We need to validate that a filter is returning the expected types.)
-								return is_string( $domain ) ? strtolower( trim( $domain ) ) : '';
-							},
-							$permitted_font_domains
-						)
-					)
-				)
+			// Validate that we have unique, non-empty strings, that are also valid domain names.
+			$permitted_font_domains = array_map(
+				static function ( $domain ) {
+					// @phpstan-ignore-next-line function.alreadyNarrowedType (We need to validate that a filter is returning the expected types.)
+					if ( ! is_string( $domain ) ) {
+						return false;
+					}
+					$domain = strtolower( trim( $domain ) );
+					// FILTER_VALIDATE_DOMAIN allows host names without a domain, so add basic validation checks for . in the domain name.
+					$period_position = strpos( $domain, '.' );
+					// No . or . in the first position are both invalid.
+					if ( false === $period_position || 0 === $period_position ) {
+						return false;
+					}
+					// Make sure we don't have a . in the last two positions -- all TLDs are 2 or more letters.
+					if ( str_contains( substr( $domain, -2 ), '.' ) ) {
+						return false;
+					}
+
+					return filter_var( $domain, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME );
+				},
+				$permitted_font_domains
 			);
+			// Filter out false values and ensure we have unique values.
+			$permitted_font_domains = array_values( array_unique( array_filter( $permitted_font_domains ) ) );
+
 			if ( [] !== $permitted_font_domains ) {
 				$stripe_params['permittedFontDomains'] = $permitted_font_domains;
 			}

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -569,6 +569,7 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 					array_filter(
 						array_map(
 							static function ( $domain ) {
+								// @phpstan-ignore-next-line function.alreadyNarrowedType (We need to validate that a filter is returning the expected types.)
 								return is_string( $domain ) ? strtolower( trim( $domain ) ) : '';
 							},
 							$permitted_font_domains

--- a/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
+++ b/includes/payment-methods/class-wc-stripe-upe-payment-gateway.php
@@ -562,8 +562,23 @@ class WC_Stripe_UPE_Payment_Gateway extends WC_Stripe_Payment_Gateway {
 		 * @since 10.6.0
 		 */
 		$permitted_font_domains = apply_filters( 'wc_stripe_upe_permitted_font_domains', [] );
-		if ( [] !== $permitted_font_domains && is_array( $permitted_font_domains ) ) {
-			$stripe_params['permittedFontDomains'] = $permitted_font_domains;
+		if ( is_array( $permitted_font_domains ) ) {
+			// Validate that we have unique, non-empty strings.
+			$permitted_font_domains = array_values(
+				array_unique(
+					array_filter(
+						array_map(
+							static function ( $domain ) {
+								return is_string( $domain ) ? strtolower( trim( $domain ) ) : '';
+							},
+							$permitted_font_domains
+						)
+					)
+				)
+			);
+			if ( [] !== $permitted_font_domains ) {
+				$stripe_params['permittedFontDomains'] = $permitted_font_domains;
+			}
 		}
 
 		// Optimized Checkout feature flag + setting + whether we are on any of the pages that should not show OC.

--- a/readme.txt
+++ b/readme.txt
@@ -148,5 +148,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 = 10.6.0 - xxxx-xx-xx =
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
+* Add - Allow additional font domains to be included in Stripe fonts
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3819,6 +3819,104 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	}
 
 	/**
+	 * Build a minimal gateway mock suitable for exercising `javascript_params()`.
+	 *
+	 * All instance methods that reach out to Stripe or WooCommerce infrastructure are
+	 * stubbed; everything else (including `apply_filters`) runs for real so that
+	 * filter-based behaviour can be asserted.
+	 *
+	 * @return WC_Stripe_UPE_Payment_Gateway
+	 */
+	private function create_gateway_mock_for_javascript_params(): WC_Stripe_UPE_Payment_Gateway {
+		$gateway = $this->getMockBuilder( WC_Stripe_UPE_Payment_Gateway::class )
+			->setConstructorArgs( [] )
+			->onlyMethods(
+				[
+					'get_return_url',
+					'get_stripe_return_url',
+					'is_changing_payment_method_for_subscription',
+					'is_subscription_item_in_cart',
+					'is_valid_optimized_checkout_page',
+				]
+			)
+			->getMock();
+
+		$gateway->method( 'get_return_url' )->willReturn( '' );
+		$gateway->method( 'get_stripe_return_url' )->willReturn( '' );
+		$gateway->method( 'is_changing_payment_method_for_subscription' )->willReturn( false );
+		$gateway->method( 'is_subscription_item_in_cart' )->willReturn( false );
+		$gateway->method( 'is_valid_optimized_checkout_page' )->willReturn( false );
+
+		$this->set_stripe_account_data( [ 'country' => 'US' ] );
+
+		return $gateway;
+	}
+
+	/**
+	 * Tests that `javascript_params()` handles the `wc_stripe_upe_permitted_font_domains` filter correctly.
+	 *
+	 * @dataProvider provide_test_javascript_params_permitted_font_domains
+	 *
+	 * @param mixed|null $filter_return     Value returned by the filter, or null to skip adding the filter entirely.
+	 * @param bool       $expected_in_params Whether `permittedFontDomains` should be present in the params.
+	 * @param mixed      $expected_value    Expected value of `permittedFontDomains` when present.
+	 */
+	public function test_javascript_params_permitted_font_domains( $filter_return, bool $expected_in_params, $expected_value ): void {
+		$gateway = $this->create_gateway_mock_for_javascript_params();
+
+		$filter_callback = null;
+		if ( null !== $filter_return ) {
+			$filter_callback = function () use ( $filter_return ) {
+				return $filter_return;
+			};
+			add_filter( 'wc_stripe_upe_permitted_font_domains', $filter_callback );
+		}
+
+		$params = $gateway->javascript_params();
+
+		if ( null !== $filter_callback ) {
+			remove_filter( 'wc_stripe_upe_permitted_font_domains', $filter_callback );
+		}
+
+		if ( $expected_in_params ) {
+			$this->assertArrayHasKey( 'permittedFontDomains', $params );
+			$this->assertSame( $expected_value, $params['permittedFontDomains'] );
+		} else {
+			$this->assertArrayNotHasKey( 'permittedFontDomains', $params );
+		}
+	}
+
+	/**
+	 * Data provider for `test_javascript_params_permitted_font_domains`.
+	 *
+	 * @return array[]
+	 */
+	public function provide_test_javascript_params_permitted_font_domains(): array {
+		return [
+			'no filter hooked — key is omitted'                 => [
+				'filter_return'      => null,
+				'expected_in_params' => false,
+				'expected_value'     => null,
+			],
+			'filter returns empty array — key is omitted'       => [
+				'filter_return'      => [],
+				'expected_in_params' => false,
+				'expected_value'     => null,
+			],
+			'filter returns non-empty array — key is set'       => [
+				'filter_return'      => [ 'custom-fonts.example.com', 'fonts.mysite.com' ],
+				'expected_in_params' => true,
+				'expected_value'     => [ 'custom-fonts.example.com', 'fonts.mysite.com' ],
+			],
+			'filter returns non-array string — key is omitted'  => [
+				'filter_return'      => 'custom-fonts.example.com',
+				'expected_in_params' => false,
+				'expected_value'     => null,
+			],
+		];
+	}
+
+	/**
 	 * Data provider for `test_is_valid_optimized_checkout_page`.
 	 *
 	 * @return array[]

--- a/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
+++ b/tests/phpunit/PaymentMethods/WC_Stripe_UPE_Payment_Gateway_Test.php
@@ -3893,25 +3893,70 @@ class WC_Stripe_UPE_Payment_Gateway_Test extends WC_Mock_Stripe_API_Unit_Test_Ca
 	 */
 	public function provide_test_javascript_params_permitted_font_domains(): array {
 		return [
-			'no filter hooked — key is omitted'                 => [
+			'no filter hooked — key is omitted'                                         => [
 				'filter_return'      => null,
 				'expected_in_params' => false,
 				'expected_value'     => null,
 			],
-			'filter returns empty array — key is omitted'       => [
+			'filter returns empty array — key is omitted'                               => [
 				'filter_return'      => [],
 				'expected_in_params' => false,
 				'expected_value'     => null,
 			],
-			'filter returns non-empty array — key is set'       => [
+			'filter returns non-empty array — key is set'                               => [
 				'filter_return'      => [ 'custom-fonts.example.com', 'fonts.mysite.com' ],
 				'expected_in_params' => true,
 				'expected_value'     => [ 'custom-fonts.example.com', 'fonts.mysite.com' ],
 			],
-			'filter returns non-array string — key is omitted'  => [
+			'filter returns non-array string — key is omitted'                          => [
 				'filter_return'      => 'custom-fonts.example.com',
 				'expected_in_params' => false,
 				'expected_value'     => null,
+			],
+			'filter returns domain without dot (e.g. localhost) — key is omitted'      => [
+				'filter_return'      => [ 'localhost' ],
+				'expected_in_params' => false,
+				'expected_value'     => null,
+			],
+			'filter returns domain starting with dot — key is omitted'                 => [
+				'filter_return'      => [ '.example.com' ],
+				'expected_in_params' => false,
+				'expected_value'     => null,
+			],
+			'filter returns domain with single-char TLD — key is omitted'              => [
+				'filter_return'      => [ 'example.c' ],
+				'expected_in_params' => false,
+				'expected_value'     => null,
+			],
+			'filter returns domain with trailing dot — key is omitted'                 => [
+				'filter_return'      => [ 'example.' ],
+				'expected_in_params' => false,
+				'expected_value'     => null,
+			],
+			'filter returns array with non-string elements — non-strings are excluded' => [
+				'filter_return'      => [ 'fonts.example.com', 42, null, true, 'type.mysite.org' ],
+				'expected_in_params' => true,
+				'expected_value'     => [ 'fonts.example.com', 'type.mysite.org' ],
+			],
+			'filter returns mixed valid and invalid domains — only valid are included'  => [
+				'filter_return'      => [ 'fonts.example.com', 'localhost', '.bad.com', 'good.fonts.io', 'also.bad.' ],
+				'expected_in_params' => true,
+				'expected_value'     => [ 'fonts.example.com', 'good.fonts.io' ],
+			],
+			'filter returns uppercase domain — stored as lowercase'                    => [
+				'filter_return'      => [ 'Fonts.Example.COM' ],
+				'expected_in_params' => true,
+				'expected_value'     => [ 'fonts.example.com' ],
+			],
+			'filter returns domain with surrounding whitespace — stored trimmed'       => [
+				'filter_return'      => [ '  fonts.example.com  ' ],
+				'expected_in_params' => true,
+				'expected_value'     => [ 'fonts.example.com' ],
+			],
+			'filter returns duplicate valid domains — deduplicated'                    => [
+				'filter_return'      => [ 'fonts.example.com', 'fonts.example.com', 'FONTS.EXAMPLE.COM' ],
+				'expected_in_params' => true,
+				'expected_value'     => [ 'fonts.example.com' ],
 			],
 		];
 	}


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Related to https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5034.

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
The main goal of this PR is to make it possible for additional domains to be specified as eligible for custom fonts that will be passed to the Stripe elements. That is achieved by implementing a new `wc_stripe_upe_permitted_font_domains` filter that will then pass additional domains to the client.

This PR also adds `fonts-api.wp.com` to our default list of supported font domains.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [ ] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
