### PR TITLE
Reinstate processing of custom appearance rules

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,7 @@
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Fix - Clear customer cache after saving a new payment method so the Stripe payment method list has correct data
+* Fix - Reinstate custom appearance logic
 
 = 10.5.0 - 2026-03-09 =
 * Update - Add missing metadata to checkout session objects when processing webhook events

--- a/client/stripe-utils/__tests__/utils.test.js
+++ b/client/stripe-utils/__tests__/utils.test.js
@@ -1,4 +1,13 @@
-import { getFontSizeBase, getDefaultValues } from '../utils';
+import {
+	getFontSizeBase,
+	getDefaultValues,
+	initializeUPEAppearance,
+} from '../utils';
+import { getAppearance } from '../../styles/upe';
+
+jest.mock( '../../styles/upe', () => ( {
+	getAppearance: jest.fn(),
+} ) );
 
 describe( 'utils', () => {
 	describe( 'getFontSizeBase', () => {
@@ -239,6 +248,255 @@ describe( 'utils', () => {
 							phone: '+1987654321',
 						},
 					},
+				} );
+			} );
+		} );
+	} );
+
+	describe( 'initializeUPEAppearance', () => {
+		const globalValues = global.wc_stripe_upe_params;
+
+		beforeEach( () => {
+			global.wc_stripe_upe_params = {};
+			getAppearance.mockReturnValue( { theme: 'computed' } );
+		} );
+
+		afterEach( () => {
+			global.wc_stripe_upe_params = globalValues;
+		} );
+
+		describe( 'returns server-provided appearance', () => {
+			it( 'returns classic appearance from server when isBlockCheckout is false', () => {
+				const serverAppearance = { theme: 'server-classic' };
+				global.wc_stripe_upe_params = { appearance: serverAppearance };
+
+				const result = initializeUPEAppearance( 'false' );
+
+				expect( result ).toBe( serverAppearance );
+				expect( getAppearance ).not.toHaveBeenCalled();
+			} );
+
+			it( 'returns blocks appearance from server when isBlockCheckout is true', () => {
+				const serverAppearance = { theme: 'server-blocks' };
+				global.wc_stripe_upe_params = {
+					blocksAppearance: serverAppearance,
+				};
+
+				const result = initializeUPEAppearance( 'true' );
+
+				expect( result ).toBe( serverAppearance );
+				expect( getAppearance ).not.toHaveBeenCalled();
+			} );
+
+			it( 'does not use classic server appearance when isBlockCheckout is true', () => {
+				// Only `appearance` is set, not `blocksAppearance`.
+				global.wc_stripe_upe_params = {
+					appearance: { theme: 'server-classic' },
+				};
+
+				initializeUPEAppearance( 'true' );
+
+				expect( getAppearance ).toHaveBeenCalledWith( true );
+			} );
+
+			it( 'falls through to computed appearance when server appearance is falsy', () => {
+				// The guard is `if (customAppearance)`, so null is ignored.
+				global.wc_stripe_upe_params = { appearance: null };
+
+				initializeUPEAppearance( 'false' );
+
+				expect( getAppearance ).toHaveBeenCalledWith( false );
+			} );
+
+			it( 'does not use server blocks appearance when isBlockCheckout is false', () => {
+				// Only `blocksAppearance` is set, not `appearance`.
+				global.wc_stripe_upe_params = {
+					blocksAppearance: { theme: 'server-blocks' },
+				};
+
+				initializeUPEAppearance( 'false' );
+
+				expect( getAppearance ).toHaveBeenCalledWith( false );
+			} );
+		} );
+
+		// Cache tests require a fresh module instance so the module-level
+		// `appearanceCache` starts empty. jest.isolateModules() and require() allow us
+		// to get both a fresh `initializeUPEAppearance` and the fresh mock instance
+		// that the isolated `utils.js` will actually use.
+		describe( 'computes and caches appearance', () => {
+			it( 'calls getAppearance with isBlocks=false for classic checkout', () => {
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'classic' } );
+
+					const result = init( 'false' );
+
+					expect( mockGetAppearance ).toHaveBeenCalledWith( false );
+					expect( result ).toEqual( { theme: 'classic' } );
+				} );
+			} );
+
+			it( 'calls getAppearance with isBlocks=true for blocks checkout', () => {
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'blocks' } );
+
+					const result = init( 'true' );
+
+					expect( mockGetAppearance ).toHaveBeenCalledWith( true );
+					expect( result ).toEqual( { theme: 'blocks' } );
+				} );
+			} );
+
+			it( 'defaults to classic checkout when isBlockCheckout argument is omitted', () => {
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'classic' } );
+
+					init();
+
+					expect( mockGetAppearance ).toHaveBeenCalledWith( false );
+				} );
+			} );
+
+			it( 'caches computed appearance for classic checkout', () => {
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'cached' } );
+					// Clear accumulated calls from earlier tests; keep the
+					// return-value implementation set above.
+					mockGetAppearance.mockClear();
+
+					init( 'false' );
+					init( 'false' );
+
+					expect( mockGetAppearance ).toHaveBeenCalledTimes( 1 );
+				} );
+			} );
+
+			it( 'caches computed appearance for blocks checkout', () => {
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'cached' } );
+					mockGetAppearance.mockClear();
+
+					init( 'true' );
+					init( 'true' );
+
+					expect( mockGetAppearance ).toHaveBeenCalledTimes( 1 );
+				} );
+			} );
+
+			it( 'returns the same cached object reference on subsequent calls', () => {
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'cached' } );
+					mockGetAppearance.mockClear();
+
+					const firstResult = init( 'false' );
+					const secondResult = init( 'false' );
+
+					expect( secondResult ).toBe( firstResult );
+				} );
+			} );
+
+			it( 'treats boolean true as classic checkout, not blocks', () => {
+				// isBlockCheckout uses string comparison (=== 'true'), so a
+				// boolean true is not equivalent and falls back to classic.
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'classic' } );
+
+					init( true );
+
+					expect( mockGetAppearance ).toHaveBeenCalledWith( false );
+				} );
+			} );
+
+			it( 'maintains separate caches for classic and blocks', () => {
+				jest.isolateModules( () => {
+					const classicAppearance = { theme: 'classic' };
+					const blocksAppearance = { theme: 'blocks' };
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockClear();
+					mockGetAppearance
+						.mockReturnValueOnce( classicAppearance )
+						.mockReturnValueOnce( blocksAppearance );
+
+					const classicResult = init( 'false' );
+					const blocksResult = init( 'true' );
+
+					expect( classicResult ).toBe( classicAppearance );
+					expect( blocksResult ).toBe( blocksAppearance );
+					expect( mockGetAppearance ).toHaveBeenCalledTimes( 2 );
+				} );
+			} );
+		} );
+
+		describe( 'server appearance takes priority over cache', () => {
+			it( 'returns server appearance even after cache is populated', () => {
+				jest.isolateModules( () => {
+					const {
+						initializeUPEAppearance: init,
+					} = require( '../utils' );
+					const {
+						getAppearance: mockGetAppearance,
+					} = require( '../../styles/upe' );
+					mockGetAppearance.mockReturnValue( { theme: 'computed' } );
+
+					// Populate the cache first.
+					init( 'false' );
+
+					// Then configure a server appearance.
+					const serverAppearance = { theme: 'server-override' };
+					global.wc_stripe_upe_params = {
+						appearance: serverAppearance,
+					};
+
+					const result = init( 'false' );
+
+					expect( result ).toBe( serverAppearance );
 				} );
 			} );
 		} );

--- a/client/stripe-utils/utils.js
+++ b/client/stripe-utils/utils.js
@@ -780,6 +780,13 @@ export const initializeUPEAppearance = ( isBlockCheckout = 'false' ) => {
 	const isBlocks = isBlockCheckout === 'true';
 	const location = isBlocks ? 'blocks' : 'classic';
 
+	// Check for custom appearance configuration from the server.
+	const customServerField = isBlocks ? 'blocksAppearance' : 'appearance';
+	const customAppearance = getStripeServerData()?.[ customServerField ];
+	if ( customAppearance ) {
+		return customAppearance;
+	}
+
 	if ( appearanceCache[ location ] ) {
 		return appearanceCache[ location ];
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -149,5 +149,6 @@ If you get stuck, you can ask for help in the [Plugin Forum](https://wordpress.o
 * Update - Disable the Optimized Checkout Suite in the "Add Payment Method" and "Change Subscription Payment Method" screens
 * Dev - Remove unused frontend code: legacy blocks payment request API helpers, related normalize utilities, and unused Stripe icon component
 * Fix - Clear customer cache after saving a new payment method so the Stripe payment method list has correct data
+* Fix - Reinstate custom appearance logic
 
 [See changelog for full details across versions](https://raw.githubusercontent.com/woocommerce/woocommerce-gateway-stripe/trunk/changelog.txt).


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/5114
Fixes STRIPE-982


## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
In a recent change, we stopped caching our dynamically detected styles on the server. However, our related client-side updates ignored the fact that our [appearance customisation docs](https://woocommerce.com/document/stripe/customization/style-payment-form/#elements-appearance-api) document that custom rules can be specified via the `blocksAppearance` or `appearance` fields in `wc_stripe_upe_params`.

This PR ensures that when we detect a value in the expected `blocksAppearance` or `appearance` field, we use that value.

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

* Set up a store using the code from `develop` and ensure that it is connected to Stripe
* On the server, add a filter as follows:
```php
function debug_set_stripe_custom_upe_appearance( $upe_params ) {
	$custom = (object) [ 'theme' => 'night' ]; // Choose a theme that would not be picked for your site -- 'stripe' or 'night' could also work

	$upe_params['appearance'] = $custom;
	$upe_params['blocksAppearance'] = $custom;

	return $upe_params;
}
add_filter( 'wc_stripe_upe_params', 'debug_set_stripe_custom_upe_appearance' );
```
* Navigate to block checkout, and verify that the custom theme is not being applied
* Navigate to classic checkout, and verify that the custom theme is not being applied
* Now switch to this branch and ensure the UI code is rebuilt: `git checkout fix/upe-customization-on-client && npm run build`
* Navigate to block checkout, and verify that the custom theme is applied
* Navigate to classic checkout, and verify that the custom theme is applied

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [ ] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [ ] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
