### PR TITLE
Fix stale parameter set for initializeUPEAppearance()

### DIFF
--- a/client/blocks/checkout-sessions/checkout-container.js
+++ b/client/blocks/checkout-sessions/checkout-container.js
@@ -37,11 +37,11 @@ export const CheckoutContainer = ( props ) => {
 			clientSecret: checkoutSessionPromise,
 			adaptivePricing: { allowed: true },
 			elementsOptions: {
-				appearance: initializeUPEAppearance( api, 'true' ),
+				appearance: initializeUPEAppearance( 'true' ),
 				fonts: getFontRulesFromPage(),
 			},
 		} ),
-		[ checkoutSessionPromise, api ]
+		[ checkoutSessionPromise ]
 	);
 
 	return (


### PR DESCRIPTION
<!--
Did I add a title? A descriptive, yet concise, title.
-->

<!--
Issue: Link to the GitHub issue this PR addresses (if appropriate).
-->

## Changes proposed in this Pull Request:

<!--
Description: Write a brief summary about this PR. As you compose your summary, consider each of these questions and address them if appropriate. Why is this change needed? What does this change do? Were there other solutions you considered? Why did you choose to pursue this solution? Describe any trade-offs you might have had to make.
-->
This PR updates some code that was using an old set of parameters for the `initializeUPEAppearance()` function, which was missed due to the two sets of changes happening in separate branches. The `api` argument was removed as an argument, but this code was still supplying it.

The issue was flagged by CodeRabbit in [this comment](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/5116#pullrequestreview-3929053652).

<!--
Questions for the PR author:
- How can this code break?
- What are we doing to make sure this code doesn't break?
-->

<!--
Images or gifs: Include before and after screenshots or gifs/videos when it makes sense.
-->

## Testing instructions

Inspection should be sufficient.
<!--
Testing instructions: How should this be tested and how can a reviewer test the end-user functionality? Are there known issues that you plan to address in a future PR? Are there any side effects that readers should be aware of?
-->

<!--
Please follow the following guidelines when writing testing instructions:

- Include screenshots if there is no similar flow in the critical flows: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Critical-flows
- Assume instructions will be copied over to the Release Testing Instructions wiki page: https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions
- Assume instructions will be followed by external testers.
- Assume tester does not have intimate knowledge of Stripe.
-->

---

-   [x] Covered with tests (or have a good reason not to test in description ☝️)
-   [N/A] Tested on mobile (or does not apply)

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->
This is a truly minor tweak to unreleased code. I don't think it warrants a changelog entry.
</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
