### PR TITLE
Remove strict param from existing public method

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -981,7 +981,7 @@ class WC_Stripe_Customer {
 	 * @return bool True if the default payment method was set successfully, false otherwise.
 	 * @throws WC_Stripe_Exception
 	 */
-	public function set_default_payment_method( $payment_method_id ) {
+	public function set_default_payment_method( $payment_method_id ): bool {
 		$response = WC_Stripe_API::request(
 			[
 				'invoice_settings' => [

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -953,7 +953,7 @@ class WC_Stripe_Customer {
 	 * @return bool True if the default source was set successfully, false otherwise.
 	 * @throws WC_Stripe_Exception
 	 */
-	public function set_default_source( $source_id ) {
+	public function set_default_source( $source_id ): bool {
 		$response = WC_Stripe_API::request(
 			[
 				'default_source' => sanitize_text_field( $source_id ),

--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -953,7 +953,7 @@ class WC_Stripe_Customer {
 	 * @return bool True if the default source was set successfully, false otherwise.
 	 * @throws WC_Stripe_Exception
 	 */
-	public function set_default_source( string $source_id ): bool {
+	public function set_default_source( $source_id ) {
 		$response = WC_Stripe_API::request(
 			[
 				'default_source' => sanitize_text_field( $source_id ),
@@ -981,7 +981,7 @@ class WC_Stripe_Customer {
 	 * @return bool True if the default payment method was set successfully, false otherwise.
 	 * @throws WC_Stripe_Exception
 	 */
-	public function set_default_payment_method( string $payment_method_id ): bool {
+	public function set_default_payment_method( $payment_method_id ) {
 		$response = WC_Stripe_API::request(
 			[
 				'invoice_settings' => [


### PR DESCRIPTION
## Changes proposed in this Pull Request:
Removed the strict param from the existing public methods.

## Testing instructions
- Code review

### Changelog entry

<!-- If no changelog entry is required for this PR, you can specify that below and provide a comment explaining why. This cannot be used if you selected the option to automatically create a changelog entry above. -->

-   [x] This Pull Request does not require a changelog entry. (Comment required below)

<details>

<summary>Changelog Entry Comment</summary>

#### Comment <!-- If your Pull Request doesn't require a changelog entry, a comment explaining why is required instead -->

Removed a strict param check which was added in another PR going in the same release. So reverting this part does not need a new changelog entry.

</details>

**Post merge**

-   [ ] Added testing instructions to the [Release Testing Instructions wiki page](https://github.com/woocommerce/woocommerce-gateway-stripe/wiki/Release-Testing-Instructions) (or does not apply)
-   [ ] Added the [needs docs label](https://github.com/woocommerce/woocommerce-gateway-stripe/labels?q=docs) (or does not apply)
-   [ ] Included this PR in the Release Thread scope (or does not apply)
