### PR TITLE
Add GitHub Actions workflow to create GitHub issues from Linear labels

### DIFF
--- a/.github/workflows/create-github-issue-from-linear.yml
+++ b/.github/workflows/create-github-issue-from-linear.yml
@@ -1,0 +1,143 @@
+name: 'Create GitHub issue from Linear label'
+
+# Triggered by the Linear webhook relay (see docs/linear-webhook-relay/) when
+# the "create-github-issue" label is added to a Linear issue.
+on:
+  repository_dispatch:
+    types:
+      - linear_label_added
+
+permissions:
+  issues: write
+
+jobs:
+  create-issue:
+    name: 'Create GitHub issue from Linear issue'
+    runs-on: ubuntu-latest
+    if: ${{ github.repository == 'woocommerce/woocommerce-gateway-stripe' }}
+    steps:
+      - name: 'Create GitHub issue'
+        uses: actions/github-script@v7
+        env:
+          LINEAR_OAUTH_TOKEN: ${{ secrets.LINEAR_OAUTH_TOKEN }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { identifier, title, description, url } = context.payload.client_payload;
+
+            if (!identifier || !title) {
+              core.setFailed('Missing required fields in client_payload (identifier, title).');
+              return;
+            }
+
+            core.info(`Processing Linear issue ${identifier}: "${title}"`);
+
+            // ----------------------------------------------------------------
+            // 1. Guard against duplicates — search by exact title.
+            // ----------------------------------------------------------------
+            const searchResult = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue in:title "${title.replace(/"/g, '\\"')}"`,
+              per_page: 10,
+            });
+
+            const existing = searchResult.data.items.find(
+              item => item.title.trim().toLowerCase() === title.trim().toLowerCase()
+            );
+
+            if (existing) {
+              core.info(`GitHub issue #${existing.number} already exists for ${identifier}. Skipping.`);
+
+              // Still post the link back to Linear so the team knows.
+              await postLinearComment(identifier, existing.html_url);
+              return;
+            }
+
+            // ----------------------------------------------------------------
+            // 2. Create the GitHub issue.
+            // ----------------------------------------------------------------
+            const body = [
+              description ?? '',
+              '',
+              '---',
+              `_Synced from [${identifier}](${url})_`,
+            ].join('\n').trim();
+
+            const { data: newIssue } = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              title,
+              body,
+            });
+
+            core.info(`Created GitHub issue #${newIssue.number}: ${newIssue.html_url}`);
+
+            // ----------------------------------------------------------------
+            // 3. Comment on the Linear issue with the GitHub issue URL.
+            // ----------------------------------------------------------------
+            await postLinearComment(identifier, newIssue.html_url);
+
+            // ----------------------------------------------------------------
+            // Helpers
+            // ----------------------------------------------------------------
+            async function postLinearComment(issueIdentifier, githubIssueUrl) {
+              const token = process.env.LINEAR_OAUTH_TOKEN;
+              if (!token) {
+                core.warning('LINEAR_OAUTH_TOKEN not set — skipping Linear comment.');
+                return;
+              }
+
+              // Resolve the issue's internal UUID from its identifier (e.g. STRIPE-123).
+              const [teamKey, issueNumber] = issueIdentifier.split('-');
+              const resolveQuery = `
+                query GetIssueId($teamKey: String!, $number: Int!) {
+                  issue(filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }) {
+                    nodes { id }
+                  }
+                }
+              `;
+
+              const resolveRes = await fetch('https://api.linear.app/graphql', {
+                method:  'POST',
+                headers: {
+                  'Content-Type':  'application/json',
+                  'Authorization': `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                  query:     resolveQuery,
+                  variables: { teamKey, number: parseInt(issueNumber, 10) },
+                }),
+              });
+
+              const resolveData = await resolveRes.json();
+              const issueId = resolveData?.data?.issue?.nodes?.[0]?.id;
+
+              if (!issueId) {
+                core.warning(`Could not resolve Linear issue UUID for ${issueIdentifier}.`);
+                return;
+              }
+
+              const commentMutation = `
+                mutation CreateComment($issueId: String!, $body: String!) {
+                  commentCreate(input: { issueId: $issueId, body: $body }) {
+                    success
+                  }
+                }
+              `;
+
+              await fetch('https://api.linear.app/graphql', {
+                method:  'POST',
+                headers: {
+                  'Content-Type':  'application/json',
+                  'Authorization': `Bearer ${token}`,
+                },
+                body: JSON.stringify({
+                  query:     commentMutation,
+                  variables: {
+                    issueId,
+                    body: `GitHub issue created: ${githubIssueUrl}`,
+                  },
+                }),
+              });
+
+              core.info(`Posted GitHub issue link as a comment on ${issueIdentifier}.`);
+            }

--- a/docs/linear-webhook-relay/README.md
+++ b/docs/linear-webhook-relay/README.md
@@ -1,0 +1,66 @@
+# Linear → GitHub webhook relay
+
+A tiny Cloudflare Worker that bridges Linear webhooks to the GitHub Actions
+`repository_dispatch` API.
+
+## How it works
+
+```
+Linear issue labelled "create-github-issue"
+        │
+        ▼
+Cloudflare Worker  ← verifies HMAC-SHA256 signature
+        │
+        ▼  POST /repos/.../dispatches  { event_type: "linear_label_added" }
+GitHub Actions workflow: create-github-issue-from-linear.yml
+        │
+        ├─ searches for existing GitHub issue with same title
+        ├─ creates GitHub issue (if none found)
+        └─ comments back on the Linear issue with the GitHub issue URL
+```
+
+## Setup
+
+### 1. Deploy the Worker
+
+```bash
+npm install -g wrangler
+cd docs/linear-webhook-relay
+wrangler secret put LINEAR_WEBHOOK_SECRET   # from Linear › Settings › API › Webhooks
+wrangler secret put GITHUB_PAT              # GitHub PAT with `repo` scope
+wrangler deploy
+```
+
+The deploy command prints your Worker URL, e.g.:
+`https://linear-webhook-relay.<your-subdomain>.workers.dev`
+
+### 2. Register the webhook in Linear
+
+1. Go to **Linear › Settings › API › Webhooks › New webhook**.
+2. Set the URL to your Worker URL.
+3. Under **Data change events**, enable **Issue labels**.
+4. Copy the signing secret and use it for `LINEAR_WEBHOOK_SECRET` above.
+
+### 3. Create the label in Linear
+
+Create a label named exactly **`create-github-issue`** (or change
+`LINEAR_TRIGGER_LABEL` in `wrangler.toml`).
+
+### 4. Secrets in GitHub Actions
+
+The workflow (`create-github-issue-from-linear.yml`) uses:
+
+| Secret | Where to add |
+|---|---|
+| `LINEAR_OAUTH_TOKEN` | Org-level secret (already exists) |
+| `GITHUB_TOKEN` | Automatically provided by Actions |
+
+No additional GitHub secrets are needed for the workflow itself.
+The `GITHUB_PAT` secret lives only in the Cloudflare Worker.
+
+## Local development
+
+```bash
+wrangler dev
+# Then use a tool like ngrok or https://smee.io to expose localhost to Linear.
+```

--- a/docs/linear-webhook-relay/worker.js
+++ b/docs/linear-webhook-relay/worker.js
@@ -1,0 +1,138 @@
+/**
+ * Cloudflare Worker — Linear → GitHub repository_dispatch relay
+ *
+ * Receives Linear webhook events and forwards them to GitHub Actions via the
+ * repository_dispatch API when a specific label is added to a Linear issue.
+ *
+ * Required Worker secrets (set via `wrangler secret put <NAME>`):
+ *   LINEAR_WEBHOOK_SECRET   — found in Linear › Settings › API › Webhooks
+ *   GITHUB_PAT              — a GitHub Personal Access Token with `repo` scope
+ *
+ * Required Worker vars (set in wrangler.toml or the dashboard):
+ *   GITHUB_OWNER            — e.g. "woocommerce"
+ *   GITHUB_REPO             — e.g. "woocommerce-gateway-stripe"
+ *   LINEAR_TRIGGER_LABEL    — e.g. "create-github-issue"
+ */
+
+const GITHUB_DISPATCH_EVENT_TYPE = 'linear_label_added';
+
+export default {
+	async fetch( request, env ) {
+		if ( request.method !== 'POST' ) {
+			return new Response( 'Method not allowed', { status: 405 } );
+		}
+
+		const rawBody = await request.text();
+
+		// -------------------------------------------------------------------------
+		// 1. Verify the Linear webhook signature (HMAC-SHA256).
+		// -------------------------------------------------------------------------
+		const signature = request.headers.get( 'linear-signature' );
+		if ( ! signature ) {
+			return new Response( 'Missing signature', { status: 401 } );
+		}
+
+		const isValid = await verifySignature(
+			rawBody,
+			signature,
+			env.LINEAR_WEBHOOK_SECRET
+		);
+		if ( ! isValid ) {
+			return new Response( 'Invalid signature', { status: 401 } );
+		}
+
+		// -------------------------------------------------------------------------
+		// 2. Parse the payload.
+		// -------------------------------------------------------------------------
+		let payload;
+		try {
+			payload = JSON.parse( rawBody );
+		} catch {
+			return new Response( 'Invalid JSON', { status: 400 } );
+		}
+
+		// We only care about IssueLabel (label added) events.
+		if ( payload.type !== 'IssueLabel' || payload.action !== 'create' ) {
+			return new Response( 'Ignored', { status: 200 } );
+		}
+
+		const labelName = payload.data?.label?.name ?? '';
+		if (
+			labelName.toLowerCase() !==
+			( env.LINEAR_TRIGGER_LABEL ?? 'create-github-issue' ).toLowerCase()
+		) {
+			return new Response( 'Label not matched', { status: 200 } );
+		}
+
+		const issue = payload.data?.issue;
+		if ( ! issue ) {
+			return new Response( 'No issue in payload', { status: 400 } );
+		}
+
+		// -------------------------------------------------------------------------
+		// 3. Forward to GitHub Actions via repository_dispatch.
+		// -------------------------------------------------------------------------
+		const dispatchUrl = `https://api.github.com/repos/${ env.GITHUB_OWNER }/${ env.GITHUB_REPO }/dispatches`;
+
+		const dispatchRes = await fetch( dispatchUrl, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/vnd.github+json',
+				Authorization: `Bearer ${ env.GITHUB_PAT }`,
+				'Content-Type': 'application/json',
+				'X-GitHub-Api-Version': '2022-11-28',
+			},
+			body: JSON.stringify( {
+				event_type: GITHUB_DISPATCH_EVENT_TYPE,
+				client_payload: {
+					identifier: issue.identifier, // e.g. "STRIPE-123"
+					title: issue.title,
+					description: issue.description ?? '',
+					url: issue.url,
+				},
+			} ),
+		} );
+
+		if ( ! dispatchRes.ok ) {
+			const text = await dispatchRes.text();
+			console.error(
+				`GitHub dispatch failed: ${ dispatchRes.status } ${ text }`
+			);
+			return new Response( 'Failed to dispatch to GitHub', {
+				status: 502,
+			} );
+		}
+
+		return new Response( 'OK', { status: 200 } );
+	},
+};
+
+/**
+ * Verify the HMAC-SHA256 signature Linear sends with every webhook.
+ * @param {string} body       Raw request body string.
+ * @param {string} signature  Value of the `linear-signature` header.
+ * @param {string} secret     The webhook signing secret from Linear.
+ */
+async function verifySignature( body, signature, secret ) {
+	const encoder = new TextEncoder();
+	const key = await crypto.subtle.importKey(
+		'raw',
+		encoder.encode( secret ),
+		{ name: 'HMAC', hash: 'SHA-256' },
+		false,
+		[ 'sign' ]
+	);
+
+	const mac = await crypto.subtle.sign( 'HMAC', key, encoder.encode( body ) );
+	const hex = [ ...new Uint8Array( mac ) ]
+		.map( ( b ) => b.toString( 16 ).padStart( 2, '0' ) )
+		.join( '' );
+
+	// Constant-time comparison to prevent timing attacks.
+	if ( hex.length !== signature.length ) return false;
+	let diff = 0;
+	for ( let i = 0; i < hex.length; i++ ) {
+		diff |= hex.charCodeAt( i ) ^ signature.charCodeAt( i );
+	}
+	return diff === 0;
+}

--- a/docs/linear-webhook-relay/wrangler.toml
+++ b/docs/linear-webhook-relay/wrangler.toml
@@ -1,0 +1,12 @@
+name            = "linear-webhook-relay"
+main            = "worker.js"
+compatibility_date = "2024-01-01"
+
+[vars]
+GITHUB_OWNER         = "woocommerce"
+GITHUB_REPO          = "woocommerce-gateway-stripe"
+LINEAR_TRIGGER_LABEL = "create-github-issue"
+
+# Secrets — set these via the CLI, never commit them:
+#   wrangler secret put LINEAR_WEBHOOK_SECRET
+#   wrangler secret put GITHUB_PAT


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/create-github-issue-from-linear.yml`: a `repository_dispatch`-triggered workflow that creates a GitHub issue when the `create-github-issue` label is added to a Linear issue, deduplicates by title, and posts the resulting GitHub issue URL back as a comment on the Linear issue.
- Adds `docs/linear-webhook-relay/`: a Cloudflare Worker that acts as the bridge between Linear webhooks and the GitHub Actions `repository_dispatch` API, including HMAC-SHA256 signature verification, `wrangler.toml` config, and a setup README.

## How it works

```
Linear issue labelled "create-github-issue"
        │
        ▼
Cloudflare Worker (docs/linear-webhook-relay/worker.js)
  — verifies HMAC-SHA256 signature
  — filters for the trigger label
        │
        ▼  POST /repos/.../dispatches { event_type: "linear_label_added" }
GitHub Actions (create-github-issue-from-linear.yml)
  — deduplicates by title search
  — creates GitHub issue
  — comments GitHub issue URL back on the Linear issue
```

## Test plan

- [ ] Deploy the Cloudflare Worker (`wrangler deploy`) with `LINEAR_WEBHOOK_SECRET` and `GITHUB_PAT` secrets set
- [ ] Register the Worker URL as a webhook in Linear (Settings → API → Webhooks), enabling **Issue labels** events
- [ ] Create a label named `create-github-issue` in the Linear STRIPE team
- [ ] Add the label to a Linear issue and verify a GitHub issue is created with the correct title and description
- [ ] Add the label to a Linear issue that already has a matching GitHub issue and verify no duplicate is created
- [ ] Verify the Linear issue receives a comment with the GitHub issue URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)